### PR TITLE
FormattedTextのパーサーを最適化

### DIFF
--- a/src/BeUtl.Graphics/Graphics/StackExtensions.cs
+++ b/src/BeUtl.Graphics/Graphics/StackExtensions.cs
@@ -13,4 +13,16 @@ internal static class StackExtensions
             return defaultValue;
         }
     }
+
+    public static T PopOrDefault<T>(this Stack<T> stack, T defaultValue)
+    {
+        if (stack.TryPop(out T? result))
+        {
+            return result;
+        }
+        else
+        {
+            return defaultValue;
+        }
+    }
 }

--- a/src/BeUtl.Graphics/Graphics/Thickness.cs
+++ b/src/BeUtl.Graphics/Graphics/Thickness.cs
@@ -194,6 +194,26 @@ public readonly struct Thickness : IEquatable<Thickness>
             return false;
         }
     }
+    
+    /// <summary>
+    /// Parses a <see cref="Thickness"/> string.
+    /// </summary>
+    /// <param name="s">The string.</param>
+    /// <param name="thickness">The <see cref="Thickness"/>.</param>
+    /// <returns>The status of the operation.</returns>
+    public static bool TryParse(ReadOnlySpan<char> s, out Thickness thickness)
+    {
+        try
+        {
+            thickness = Parse(s);
+            return true;
+        }
+        catch
+        {
+            thickness = default;
+            return false;
+        }
+    }
 
     /// <summary>
     /// Parses a <see cref="Thickness"/> string.
@@ -205,6 +225,34 @@ public readonly struct Thickness : IEquatable<Thickness>
         const string exceptionMessage = "Invalid Thickness.";
 
         using var tokenizer = new StringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage);
+        if (tokenizer.TryReadSingle(out float a))
+        {
+            if (tokenizer.TryReadSingle(out float b))
+            {
+                if (tokenizer.TryReadSingle(out float c))
+                {
+                    return new Thickness(a, b, c, tokenizer.ReadSingle());
+                }
+
+                return new Thickness(a, b);
+            }
+
+            return new Thickness(a);
+        }
+
+        throw new FormatException(exceptionMessage);
+    }
+    
+    /// <summary>
+    /// Parses a <see cref="Thickness"/> string.
+    /// </summary>
+    /// <param name="s">The string.</param>
+    /// <returns>The <see cref="Thickness"/>.</returns>
+    public static Thickness Parse(ReadOnlySpan<char> s)
+    {
+        const string exceptionMessage = "Invalid Thickness.";
+
+        using var tokenizer = new RefStringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage);
         if (tokenizer.TryReadSingle(out float a))
         {
             if (tokenizer.TryReadSingle(out float b))

--- a/src/BeUtl.Graphics/Media/TextFormatting/FormattedText.cs
+++ b/src/BeUtl.Graphics/Media/TextFormatting/FormattedText.cs
@@ -49,7 +49,7 @@ public class FormattedText : Drawable
 
     public static FormattedText Parse(string s, FormattedTextInfo info)
     {
-        var tokenizer = new FormattedTextTokenizer(s);
+        var tokenizer = new FormattedTextParser(s);
         List<TextLine> lines = tokenizer.ToLines(info);
 
         return new FormattedText(lines);
@@ -59,7 +59,7 @@ public class FormattedText : Drawable
     {
         _lines.Clear();
         IsDisposed = false;
-        var tokenizer = new FormattedTextTokenizer(s);
+        var tokenizer = new FormattedTextParser(s);
         List<TextLine> lines = tokenizer.ToLines(info);
 
         _lines.AddRange(lines);
@@ -70,7 +70,7 @@ public class FormattedText : Drawable
     {
         Initialize();
 
-        var tokenizer = new FormattedTextTokenizer(s);
+        var tokenizer = new FormattedTextParser(s);
         List<TextLine> lines = tokenizer.ToLines(info);
 
         _lines.AddRange(lines);

--- a/src/BeUtl.Graphics/Properties/AssemblyInfo.cs
+++ b/src/BeUtl.Graphics/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("BeUtl.Graphics.UnitTests")]
+[assembly: InternalsVisibleTo("BeUtl.Benchmarks")]

--- a/src/BeUtl.Utilities/RefStringTokenizer.cs
+++ b/src/BeUtl.Utilities/RefStringTokenizer.cs
@@ -1,0 +1,247 @@
+﻿using System.Globalization;
+
+namespace BeUtl.Utilities;
+
+public ref struct RefStringTokenizer
+{
+    private const char DefaultSeparatorChar = ',';
+
+    private readonly ReadOnlySpan<char> _s;
+    private readonly int _length;
+    private readonly char _separator;
+    private readonly string _exceptionMessage;
+    private readonly IFormatProvider _formatProvider;
+    private int _index;
+    private int _tokenIndex;
+    private int _tokenLength;
+
+    public RefStringTokenizer(ReadOnlySpan<char> s, IFormatProvider formatProvider, string exceptionMessage = "")
+        : this(s, GetSeparatorFromFormatProvider(formatProvider), exceptionMessage)
+    {
+        _formatProvider = formatProvider;
+    }
+
+    public RefStringTokenizer(ReadOnlySpan<char> s, char separator = DefaultSeparatorChar, string exceptionMessage = "")
+    {
+        _s = s;
+        _length = s.Length;
+        _separator = separator;
+        _exceptionMessage = exceptionMessage;
+        _formatProvider = CultureInfo.InvariantCulture;
+        _index = 0;
+        _tokenIndex = -1;
+        _tokenLength = 0;
+
+        while (_index < _length && char.IsWhiteSpace(_s[_index]))
+        {
+            _index++;
+        }
+    }
+
+    public ReadOnlySpan<char> CurrentToken => _tokenIndex < 0 ? default : _s.Slice(_tokenIndex, _tokenLength);
+
+    public void Dispose()
+    {
+        if (_index != _length)
+        {
+            throw GetFormatException();
+        }
+    }
+
+    public bool TryReadInt32(out int result, char? separator = null)
+    {
+        if (TryReadString(out ReadOnlySpan<char> stringResult, separator) &&
+            int.TryParse(stringResult, NumberStyles.Integer, _formatProvider, out result))
+        {
+            return true;
+        }
+        else
+        {
+            result = default;
+            return false;
+        }
+    }
+
+    public int ReadInt32(char? separator = null)
+    {
+        if (!TryReadInt32(out int result, separator))
+        {
+            throw GetFormatException();
+        }
+
+        return result;
+    }
+
+    public bool TryReadDouble(out double result, char? separator = null)
+    {
+        if (TryReadString(out ReadOnlySpan<char> stringResult, separator) &&
+            double.TryParse(stringResult, NumberStyles.Float, _formatProvider, out result))
+        {
+            return true;
+        }
+        else
+        {
+            result = default;
+            return false;
+        }
+    }
+
+    public double ReadDouble(char? separator = null)
+    {
+        if (!TryReadDouble(out double result, separator))
+        {
+            throw GetFormatException();
+        }
+
+        return result;
+    }
+
+    public bool TryReadSingle(out float result, char? separator = null)
+    {
+        if (TryReadString(out ReadOnlySpan<char> stringResult, separator) &&
+            float.TryParse(stringResult, NumberStyles.Float, _formatProvider, out result))
+        {
+            return true;
+        }
+        else
+        {
+            result = default;
+            return false;
+        }
+    }
+
+    public float ReadSingle(char? separator = null)
+    {
+        if (!TryReadSingle(out float result, separator))
+        {
+            throw GetFormatException();
+        }
+
+        return result;
+    }
+
+    public bool TryReadString(out ReadOnlySpan<char> result, char? separator = null)
+    {
+        bool success = TryReadToken(separator ?? _separator);
+
+        if (success)
+        {
+            result = _s.Slice(_tokenIndex, _tokenLength);
+        }
+        else
+        {
+            result = default;
+        }
+
+        return success;
+    }
+
+    public ReadOnlySpan<char> ReadString(char? separator = null)
+    {
+        if (!TryReadString(out ReadOnlySpan<char> result, separator))
+        {
+            throw GetFormatException();
+        }
+
+        return result;
+    }
+
+    private bool TryReadToken(char separator)
+    {
+        _tokenIndex = -1;
+
+        if (_index >= _length)
+        {
+            return false;
+        }
+
+        int index = _index;
+        int length = 0;
+
+        while (_index < _length)
+        {
+            char c = _s[_index];
+
+            if (char.IsWhiteSpace(c) || c == separator)
+            {
+                break;
+            }
+
+            _index++;
+            length++;
+        }
+
+        SkipToNextToken(separator);
+
+        _tokenIndex = index;
+        _tokenLength = length;
+
+        if (_tokenLength < 1)
+        {
+            throw GetFormatException();
+        }
+
+        return true;
+    }
+
+    private void SkipToNextToken(char separator)
+    {
+        if (_index < _length)
+        {
+            char c = _s[_index];
+
+            if (c != separator && !char.IsWhiteSpace(c))
+            {
+                throw GetFormatException();
+            }
+
+            int length = 0;
+
+            while (_index < _length)
+            {
+                c = _s[_index];
+
+                if (c == separator)
+                {
+                    length++;
+                    _index++;
+
+                    if (length > 1)
+                    {
+                        throw GetFormatException();
+                    }
+                }
+                else
+                {
+                    if (!char.IsWhiteSpace(c))
+                    {
+                        break;
+                    }
+
+                    _index++;
+                }
+            }
+
+            if (length > 0 && _index >= _length)
+            {
+                throw GetFormatException();
+            }
+        }
+    }
+
+    private FormatException GetFormatException() =>
+        _exceptionMessage != null ? new FormatException(_exceptionMessage) : new FormatException();
+
+    private static char GetSeparatorFromFormatProvider(IFormatProvider provider)
+    {
+        char c = DefaultSeparatorChar;
+
+        var formatInfo = NumberFormatInfo.GetInstance(provider);
+        if (formatInfo.NumberDecimalSeparator.Length > 0 && c == formatInfo.NumberDecimalSeparator[0])
+        {
+            c = ';';
+        }
+
+        return c;
+    }
+}

--- a/tests/BeUtl.Benchmarks/DictionaryBench.cs
+++ b/tests/BeUtl.Benchmarks/DictionaryBench.cs
@@ -1,0 +1,79 @@
+﻿
+using BenchmarkDotNet.Attributes;
+
+[MemoryDiagnoser]
+public class DictionaryBench
+{
+    private readonly Dictionary<int, int> _dictionary;
+
+    public DictionaryBench()
+    {
+        _dictionary = Enumerable.Range(0, 500).Select(i => new KeyValuePair<int, int>(i, i)).ToDictionary(i => i.Key, i => i.Value);
+    }
+
+    [Benchmark]
+    public void ForEach()
+    {
+        int sum = 0;
+        foreach (var item in _dictionary)
+        {
+            sum += item.Value;
+        }
+    }
+
+    [Benchmark]
+    public void ForEachArray()
+    {
+        KeyValuePair<int, int>[] array = new KeyValuePair<int, int>[_dictionary.Count];
+        (_dictionary as ICollection<KeyValuePair<int, int>>).CopyTo(array, 0);
+        int sum = 0;
+        foreach (var item in array)
+        {
+            sum += item.Value;
+        }
+    }
+
+    [Benchmark]
+    public void ForEachKey()
+    {
+        int sum = 0;
+        foreach (var item in _dictionary.Keys)
+        {
+            sum += _dictionary[item];
+        }
+    }
+
+    [Benchmark]
+    public void ForEachValue()
+    {
+        int sum = 0;
+        foreach (var item in _dictionary.Values)
+        {
+            sum += item;
+        }
+    }
+
+    [Benchmark]
+    public void ForEachKeysArray()
+    {
+        int[] array = new int[_dictionary.Count];
+        _dictionary.Keys.CopyTo(array, 0);
+        int sum = 0;
+        foreach (var item in array)
+        {
+            sum += _dictionary[item];
+        }
+    }
+
+    [Benchmark]
+    public void ForEachValuesArray()
+    {
+        int[] array = new int[_dictionary.Count];
+        _dictionary.Values.CopyTo(array, 0);
+        int sum = 0;
+        foreach (var item in array)
+        {
+            sum += item;
+        }
+    }
+}

--- a/tests/BeUtl.Benchmarks/FormattedTextBench.cs
+++ b/tests/BeUtl.Benchmarks/FormattedTextBench.cs
@@ -1,0 +1,31 @@
+﻿
+using BenchmarkDotNet.Attributes;
+
+using BeUtl.Benchmarks.Media.TextFormatting;
+using BeUtl.Media;
+using BeUtl.Media.TextFormatting;
+
+[MemoryDiagnoser]
+public class FormattedTextBench
+{
+    private const string Str = @"
+<b>吾輩</b><size=70>は</size><#ff0000>猫</#><size=70>である。</size>
+<i>名前</i><size=70>はまだ</size>無<size=70>い。</cspace>
+
+<font='Roboto'>Roboto</font>
+<noparse><font='Noto Sans JP'><bold>Noto Sans</font></bold></noparse>
+";
+    [Benchmark]
+    public void Old()
+    {
+        var tokenizer = new FormattedTextTokenizer(Str);
+        var tokens = tokenizer.Tokenize();
+    }
+
+    [Benchmark]
+    public void New()
+    {
+        var parser = new FormattedTextParser(Str);
+        var tokens = parser.Tokenize();
+    }
+}

--- a/tests/BeUtl.Benchmarks/ListBench.cs
+++ b/tests/BeUtl.Benchmarks/ListBench.cs
@@ -1,0 +1,54 @@
+﻿using System.Runtime.InteropServices;
+
+using BenchmarkDotNet.Attributes;
+
+public class ListBench
+{
+    private readonly List<int> _list;
+
+    public ListBench()
+    {
+        _list = Enumerable.Range(0, 500).ToList();
+    }
+
+    [Benchmark]
+    public void Foreach()
+    {
+        int sum = 0;
+        foreach (int item in _list)
+        {
+            sum += item;
+        }
+    }
+
+    [Benchmark]
+    public void For()
+    {
+        int sum = 0;
+        for (int i = 0; i < _list.Count; i++)
+        {
+            sum += _list[i];
+        }
+    }
+
+    [Benchmark]
+    public void SpanForeach()
+    {
+        int sum = 0;
+        foreach (int item in CollectionsMarshal.AsSpan(_list))
+        {
+            sum += item;
+        }
+    }
+
+    [Benchmark]
+    public void SpanFor()
+    {
+        int sum = 0;
+        Span<int> span = CollectionsMarshal.AsSpan(_list);
+        for (int i = 0; i < span.Length; i++)
+        {
+            sum += span[i];
+        }
+    }
+}

--- a/tests/BeUtl.Benchmarks/Program.cs
+++ b/tests/BeUtl.Benchmarks/Program.cs
@@ -1,136 +1,33 @@
-﻿using System.Linq;
-using System.Runtime.InteropServices;
-
+﻿
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 
-BenchmarkRunner.Run<DictionaryBench>();
+BenchmarkRunner.Run<FormattedTextBench>();
 
-
-[MemoryDiagnoser]
-public class DictionaryBench
+public class StartWithBench
 {
-    private readonly Dictionary<int, int> _dictionary;
-
-    public DictionaryBench()
-    {
-        _dictionary = Enumerable.Range(0, 500).Select(i => new KeyValuePair<int, int>(i, i)).ToDictionary(i => i.Key, i => i.Value);
-    }
+    private const string Str = "NOFenwknvV+mGあｄgwbtab;nbtrawaafうぇえ";
+    private const string Other = "NOFenwknvV+mGあｄgwbtabGEWｌｂｋｎあＦＶＥＷＢ";
 
     [Benchmark]
-    public void ForEach()
+    public void MemX_StartWith()
     {
-        int sum = 0;
-        foreach (var item in _dictionary)
+        ReadOnlySpan<char> str = Str.AsSpan();
+        ReadOnlySpan<char> other = Other.AsSpan();
+        for (int i = 0; i < 50000; i++)
         {
-            sum += item.Value;
+            str.StartsWith(other);
         }
     }
-
+    
     [Benchmark]
-    public void ForEachArray()
+    public void MemX_StartWith_Ordinal()
     {
-        KeyValuePair<int, int>[] array = new KeyValuePair<int, int>[_dictionary.Count];
-        (_dictionary as ICollection<KeyValuePair<int, int>>).CopyTo(array, 0);
-        int sum = 0;
-        foreach (var item in array)
+        ReadOnlySpan<char> str = Str.AsSpan();
+        ReadOnlySpan<char> other = Other.AsSpan();
+        for (int i = 0; i < 50000; i++)
         {
-            sum += item.Value;
-        }
-    }
-
-    [Benchmark]
-    public void ForEachKey()
-    {
-        int sum = 0;
-        foreach (var item in _dictionary.Keys)
-        {
-            sum += _dictionary[item];
-        }
-    }
-
-    [Benchmark]
-    public void ForEachValue()
-    {
-        int sum = 0;
-        foreach (var item in _dictionary.Values)
-        {
-            sum += item;
-        }
-    }
-
-    [Benchmark]
-    public void ForEachKeysArray()
-    {
-        int[] array = new int[_dictionary.Count];
-        _dictionary.Keys.CopyTo(array, 0);
-        int sum = 0;
-        foreach (var item in array)
-        {
-            sum += _dictionary[item];
-        }
-    }
-
-    [Benchmark]
-    public void ForEachValuesArray()
-    {
-        int[] array = new int[_dictionary.Count];
-        _dictionary.Values.CopyTo(array, 0);
-        int sum = 0;
-        foreach (var item in array)
-        {
-            sum += item;
-        }
-    }
-}
-
-public class ListBench
-{
-    private readonly List<int> _list;
-
-    public ListBench()
-    {
-        _list = Enumerable.Range(0, 500).ToList();
-    }
-
-    [Benchmark]
-    public void Foreach()
-    {
-        int sum = 0;
-        foreach (int item in _list)
-        {
-            sum += item;
-        }
-    }
-
-    [Benchmark]
-    public void For()
-    {
-        int sum = 0;
-        for (int i = 0; i < _list.Count; i++)
-        {
-            sum += _list[i];
-        }
-    }
-
-    [Benchmark]
-    public void SpanForeach()
-    {
-        int sum = 0;
-        foreach (int item in CollectionsMarshal.AsSpan(_list))
-        {
-            sum += item;
-        }
-    }
-
-    [Benchmark]
-    public void SpanFor()
-    {
-        int sum = 0;
-        Span<int> span = CollectionsMarshal.AsSpan(_list);
-        for (int i = 0; i < span.Length; i++)
-        {
-            sum += span[i];
+            str.StartsWith(other, StringComparison.Ordinal);
         }
     }
 }

--- a/tests/BeUtl.Benchmarks/StringCompareBench.cs
+++ b/tests/BeUtl.Benchmarks/StringCompareBench.cs
@@ -1,0 +1,64 @@
+﻿
+using BenchmarkDotNet.Attributes;
+
+[MemoryDiagnoser]
+public class StringCompareBench
+{
+    private const string Str = "NOFenwknvV+mGあｄgwbtab;nbtrawaafうぇえ";
+    private const string Other = "NOFenwknvV+mGあｄgwbtabGEWｌｂｋｎあＦＶＥＷＢ";
+
+    [Benchmark]
+    public void MemX_SequenceEqual()
+    {
+        ReadOnlySpan<char> str = Str.AsSpan();
+        ReadOnlySpan<char> other = Other.AsSpan();
+        for (int i = 0; i < 50000; i++)
+        {
+            str.SequenceEqual(other);
+        }
+    }
+
+    [Benchmark]
+    public void MemX_Equals_Ordinal()
+    {
+        ReadOnlySpan<char> str = Str.AsSpan();
+        ReadOnlySpan<char> other = Other.AsSpan();
+        for (int i = 0; i < 50000; i++)
+        {
+            str.Equals(other, StringComparison.Ordinal);
+        }
+    }
+
+    [Benchmark]
+    public void MemX_Equals_OrdinalIgnoreCase()
+    {
+        ReadOnlySpan<char> str = Str.AsSpan();
+        ReadOnlySpan<char> other = Other.AsSpan();
+        for (int i = 0; i < 50000; i++)
+        {
+            str.Equals(other, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Benchmark]
+    public void MemX_Equals_Invariant()
+    {
+        ReadOnlySpan<char> str = Str.AsSpan();
+        ReadOnlySpan<char> other = Other.AsSpan();
+        for (int i = 0; i < 50000; i++)
+        {
+            str.Equals(other, StringComparison.InvariantCulture);
+        }
+    }
+
+    [Benchmark]
+    public void MemX_Equals_Current()
+    {
+        ReadOnlySpan<char> str = Str.AsSpan();
+        ReadOnlySpan<char> other = Other.AsSpan();
+        for (int i = 0; i < 50000; i++)
+        {
+            str.Equals(other, StringComparison.CurrentCulture);
+        }
+    }
+}

--- a/tests/BeUtl.Graphics.UnitTests/FormattedTextTests.cs
+++ b/tests/BeUtl.Graphics.UnitTests/FormattedTextTests.cs
@@ -116,6 +116,7 @@ public class FormattedTextTests
         Typeface typeface = TypefaceProvider.Typeface();
         using var text = FormattedText.Parse(str, new FormattedTextInfo(typeface, 100, Colors.Black, 0, default));
 
+        text.IsVisible = true;
         text.Measure(Size.Infinity);
         Rect bounds = text.Bounds;
         using var graphics = new Canvas((int)bounds.Width, (int)bounds.Height);


### PR DESCRIPTION
## 概要
- FormattedTextTokenizer（パーサー）内でstring.Splitメソッドを多用していたり、
メモリの無駄な確保が多発していたのでReadOnlySpan<T>を使って最適化した
- RegexはReadOnlySpanに対応していないので、Regexを使わないようにした
- 文字列の比較にOrdinalを指定したり、SequenceEqualを使うようにした