### PR TITLE
RenderLayerSpan.Valueに親要素が設定されないのを修正

### DIFF
--- a/src/Beutl.Graphics/Rendering/RenderLayerSpan.cs
+++ b/src/Beutl.Graphics/Rendering/RenderLayerSpan.cs
@@ -9,7 +9,7 @@ public sealed class RenderLayerSpan : Element, IAffectsRender
     public static readonly CoreProperty<TimeSpan> DurationProperty;
     public static readonly CoreProperty<Renderables> ValueProperty;
     public static readonly CoreProperty<RenderLayer?> RenderLayerProperty;
-    private readonly Renderables _value = new();
+    private readonly Renderables _value;
     private TimeSpan _start;
     private TimeSpan _duration;
     private RenderLayer? _renderLayer;
@@ -36,12 +36,11 @@ public sealed class RenderLayerSpan : Element, IAffectsRender
             .Accessor(o => o.RenderLayer)
             .PropertyFlags(PropertyFlags.NotifyChanged)
             .Register();
-
-        LogicalChild<RenderLayerSpan>(ValueProperty);
     }
 
     public RenderLayerSpan()
     {
+        _value = new(this);
         _value.Invalidated += OnValueInvalidated;
     }
 

--- a/src/Beutl.Graphics/Rendering/Renderables.cs
+++ b/src/Beutl.Graphics/Rendering/Renderables.cs
@@ -6,9 +6,10 @@ using Beutl.Media;
 
 namespace Beutl.Rendering;
 
-public sealed class Renderables : CoreList<Renderable>, IAffectsRender
+public sealed class Renderables : LogicalList<Renderable>, IAffectsRender
 {
-    public Renderables()
+    public Renderables(ILogicalElement parent)
+        : base(parent)
     {
         ResetBehavior = ResetBehavior.Remove;
         CollectionChanged += OnCollectionChanged;


### PR DESCRIPTION
<!-- 2-4は省略可 -->
## このプルリクエストで何をやったのか？

## やらなかったこと

## できるようになること

## できなくなること

## 破壊的変更

## 廃止するApi
<!-- Obsolete属性を付けたApi -->

## リンクされたIsuues
