### PR TITLE
プロジェクトの名前の設定時、Ctrl+Zでスタックトレースが表示されないようにし、名前が空白の場合に「無効な文字列です」と表示するようにした。

### DIFF
--- a/src/Beutl/ViewModels/Dialogs/CreateNewProjectViewModel.cs
+++ b/src/Beutl/ViewModels/Dialogs/CreateNewProjectViewModel.cs
@@ -15,7 +15,11 @@ public sealed class CreateNewProjectViewModel
 
         Name.SetValidateNotifyError(n =>
         {
-            if (Directory.Exists(Path.Combine(Location.Value, n)))
+            if(n == string.Empty || n == null)
+            {
+                return Message.InvalidString;
+            }
+            else if (Directory.Exists(Path.Combine(Location.Value, n)))
             {
                 return Message.ItAlreadyExists;
             }
@@ -64,11 +68,15 @@ public sealed class CreateNewProjectViewModel
             {
                 (string name, string location, PixelSize size, int framerate, int samplerate) = t;
 
-                return !Directory.Exists(Path.Combine(location, name)) &&
-                    size.Width > 0 &&
-                    size.Height > 0 &&
-                    framerate > 0 &&
-                    samplerate > 0;
+                if (location != null && name != null)
+                {
+                    return !Directory.Exists(Path.Combine(location, name)) &&
+                        size.Width > 0 &&
+                        size.Height > 0 &&
+                        framerate > 0 &&
+                        samplerate > 0;
+                }
+                else return false;
             })
             .ToReadOnlyReactivePropertySlim();
         Create = new ReactiveCommand(CanCreate);


### PR DESCRIPTION
<!-- 2-4は省略可 -->
## このプルリクエストで何をやったのか？

プロジェクトの名前の設定時、Ctrl+Zでスタックトレースが表示されないようにした。
名前が空白の場合に「無効な文字列です」と表示するようにした。

## リンクされたIsuues
なし