### PR TITLE
プロジェクト/シーン作成時の名前の判定についての修正

### DIFF
--- a/src/Beutl/ViewModels/Dialogs/CreateNewProjectViewModel.cs
+++ b/src/Beutl/ViewModels/Dialogs/CreateNewProjectViewModel.cs
@@ -15,7 +15,7 @@ public sealed class CreateNewProjectViewModel
 
         Name.SetValidateNotifyError(n =>
         {
-            if(n == string.Empty || n == null || n.IndexOfAny(Path.GetInvalidFileNameChars()) > 0)
+            if(n == string.Empty || n == null || n.IndexOfAny(Path.GetInvalidFileNameChars()) > -1)
             {
                 return Message.InvalidString;
             }

--- a/src/Beutl/ViewModels/Dialogs/CreateNewProjectViewModel.cs
+++ b/src/Beutl/ViewModels/Dialogs/CreateNewProjectViewModel.cs
@@ -15,7 +15,7 @@ public sealed class CreateNewProjectViewModel
 
         Name.SetValidateNotifyError(n =>
         {
-            if(n == string.Empty || n == null)
+            if(n == string.Empty || n == null || n.IndexOfAny(Path.GetInvalidFileNameChars()) > 0)
             {
                 return Message.InvalidString;
             }

--- a/src/Beutl/ViewModels/Dialogs/CreateNewSceneViewModel.cs
+++ b/src/Beutl/ViewModels/Dialogs/CreateNewSceneViewModel.cs
@@ -23,7 +23,11 @@ public sealed class CreateNewSceneViewModel
 
         Name.SetValidateNotifyError(n =>
         {
-            if (Directory.Exists(Path.Combine(Location.Value, n)))
+            if (n == string.Empty || n == null || n.IndexOfAny(Path.GetInvalidFileNameChars()) > 0)
+            {
+                return Message.InvalidString;
+            }
+            else if (Directory.Exists(Path.Combine(Location.Value, n)))
             {
                 return Message.ItAlreadyExists;
             }

--- a/src/Beutl/ViewModels/Dialogs/CreateNewSceneViewModel.cs
+++ b/src/Beutl/ViewModels/Dialogs/CreateNewSceneViewModel.cs
@@ -55,9 +55,14 @@ public sealed class CreateNewSceneViewModel
             string location = t.Second;
             PixelSize size = t.Third;
 
-            return !Directory.Exists(Path.Combine(location, name)) &&
+            if (location != null && name != null)
+            {
+                return !Directory.Exists(Path.Combine(location, name)) &&
                 size.Width > 0 &&
                 size.Height > 0;
+            }
+            else return false;
+            
         }).ToReadOnlyReactivePropertySlim();
         Create = new ReactiveCommand(CanCreate);
         Create.Subscribe(() =>

--- a/src/Beutl/ViewModels/Dialogs/CreateNewSceneViewModel.cs
+++ b/src/Beutl/ViewModels/Dialogs/CreateNewSceneViewModel.cs
@@ -23,7 +23,7 @@ public sealed class CreateNewSceneViewModel
 
         Name.SetValidateNotifyError(n =>
         {
-            if (n == string.Empty || n == null || n.IndexOfAny(Path.GetInvalidFileNameChars()) > 0)
+            if (n == string.Empty || n == null || n.IndexOfAny(Path.GetInvalidFileNameChars()) > -1)
             {
                 return Message.InvalidString;
             }


### PR DESCRIPTION
<!-- 2-4は省略可 -->
## このプルリクエストで何をやったのか？

・プロジェクト作成時、システム上使えない文字がプロジェクト名に入っているか検出する機能を追加
・現在シーンの作成はそもそもダイアログが出ないため確認できないが、同様のコードはプロジェクト名のものと同じように修正

## やらなかったこと

ファイル名・ディレクトリ名がstring.Emptyの場合に「次へ」ボタンが押せてしまうことへの対策

## リンクされたIsuues
なし