### PR TITLE
ショートカットの動作を修正

### DIFF
--- a/src/Beutl.Controls/Player.cs
+++ b/src/Beutl.Controls/Player.cs
@@ -61,6 +61,7 @@ public class Player : RangeBase
     private Button _endButton;
     private Button _startButton;
     private Image _image;
+    private Slider _slider;
     private ICommand _playButtonCommand;
     private ICommand _nextButtonCommand;
     private ICommand _previousButtonCommand;
@@ -126,6 +127,14 @@ public class Player : RangeBase
         return _image;
     }
 
+    public void SetSeekBarOpacity(double opacity)
+    {
+        if (_slider != null)
+        {
+            _slider.Opacity = opacity;
+        }
+    }
+
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         base.OnApplyTemplate(e);
@@ -135,6 +144,7 @@ public class Player : RangeBase
         _endButton = e.NameScope.Find<Button>("PART_EndButton");
         _startButton = e.NameScope.Find<Button>("PART_StartButton");
         _image = e.NameScope.Find<Image>("PART_Image");
+        _slider = e.NameScope.Find<Slider>("PART_Slider");
 
         _playButton.Click += (s, e) => PlayButtonCommand?.Execute(null);
         _nextButton.Click += (s, e) => NextButtonCommand?.Execute(null);

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -1,5 +1,10 @@
 ﻿using System.Numerics;
 using System.Text.Json.Nodes;
+using System.Windows.Input;
+
+using Avalonia;
+using Avalonia.Input;
+using Avalonia.Input.Platform;
 
 using Beutl.Animation;
 using Beutl.Api.Services;
@@ -64,6 +69,8 @@ public sealed class EditViewModel : IEditorContext, ITimelineOptionsProvider, IS
                     newHierarchical.DetachedFromHierarchy += OnSelectedObjectDetachedFromHierarchy;
             })
             .DisposeWith(_disposables);
+
+        KeyBindings = CreateKeyBindings();
     }
 
     private void OnSelectedObjectDetachedFromHierarchy(object? sender, HierarchyAttachmentEventArgs e)
@@ -98,6 +105,8 @@ public sealed class EditViewModel : IEditorContext, ITimelineOptionsProvider, IS
     public IObservable<Vector2> Offset { get; }
 
     IReactiveProperty<bool> IEditorContext.IsEnabled => IsEnabled;
+
+    public List<KeyBinding> KeyBindings { get; }
 
     public void Dispose()
     {
@@ -446,6 +455,33 @@ public sealed class EditViewModel : IEditorContext, ITimelineOptionsProvider, IS
             BottomTabItems.Remove(item);
             item.Dispose();
         }
+    }
+
+    // Todo: 設定からショートカットを変更できるようにする。
+    private List<KeyBinding> CreateKeyBindings()
+    {
+        static KeyBinding KeyBinding(Key key, KeyModifiers modifiers, ICommand command)
+        {
+            return new KeyBinding
+            {
+                Gesture = new KeyGesture(key, modifiers),
+                Command = command
+            };
+        }
+
+        return new List<KeyBinding>
+        {
+            // PlayPause: Space
+            KeyBinding(Key.Space, KeyModifiers.None, Player.PlayPause),
+            // Next: Right
+            KeyBinding(Key.Right, KeyModifiers.None, Player.Next),
+            // Previous: Left
+            KeyBinding(Key.Left, KeyModifiers.None, Player.Previous),
+            // Start: Home
+            KeyBinding(Key.Home, KeyModifiers.None, Player.Start),
+            // End: End
+            KeyBinding(Key.End, KeyModifiers.None, Player.End),
+        };
     }
 
     private sealed class KnownCommandsImpl : IKnownEditorCommands

--- a/src/Beutl/ViewModels/ElementViewModel.cs
+++ b/src/Beutl/ViewModels/ElementViewModel.cs
@@ -119,6 +119,8 @@ public sealed class ElementViewModel : IDisposable
                 LayerHeader.Value = newLH;
             })
             .AddTo(_disposables);
+
+        KeyBindings = CreateKeyBinding();
     }
 
     ~ElementViewModel()
@@ -167,6 +169,8 @@ public sealed class ElementViewModel : IDisposable
     public ReactiveCommand FinishEditingAnimation { get; } = new();
 
     public ReactiveCommand BringAnimationToTop { get; } = new();
+
+    public List<KeyBinding> KeyBindings { get; }
 
     public void SetClipboard(IClipboard? clipboard)
     {
@@ -340,6 +344,30 @@ public sealed class ElementViewModel : IDisposable
 
         backwardLayer.Save(RandomFileNameGenerator.Generate(Path.GetDirectoryName(Scene.FileName)!, Constants.ElementFileExtension));
         Scene.AddChild(backwardLayer).DoAndRecord(CommandRecorder.Default);
+    }
+
+    private List<KeyBinding> CreateKeyBinding()
+    {
+        PlatformHotkeyConfiguration? config = Application.Current?.PlatformSettings?.HotkeyConfiguration;
+        KeyModifiers modifier = config?.CommandModifiers ?? KeyModifiers.Control;
+        var list = new List<KeyBinding>
+        {
+            new KeyBinding { Gesture = new(Key.Delete), Command = Exclude },
+            new KeyBinding { Gesture = new(Key.Delete, modifier), Command = Delete }
+        };
+
+        if (config != null)
+        {
+            list.AddRange(config.Cut.Select(x => new KeyBinding { Gesture = x, Command = Cut }));
+            list.AddRange(config.Copy.Select(x => new KeyBinding { Gesture = x, Command = Copy }));
+        }
+        else
+        {
+            list.Add(new KeyBinding { Gesture = new(Key.X, modifier), Command = Cut });
+            list.Add(new KeyBinding { Gesture = new(Key.C, modifier), Command = Copy });
+        }
+
+        return list;
     }
 
     public record struct PrepareAnimationContext(

--- a/src/Beutl/ViewModels/TimelineViewModel.cs
+++ b/src/Beutl/ViewModels/TimelineViewModel.cs
@@ -5,6 +5,8 @@ using System.Reactive.Subjects;
 using System.Text.Json.Nodes;
 
 using Avalonia;
+using Avalonia.Input;
+using Avalonia.Input.Platform;
 
 using Beutl.Animation;
 using Beutl.Models;
@@ -121,6 +123,26 @@ public sealed class TimelineViewModel : IToolContext
         editViewModel.Options.Select(x => x.MaxLayerCount)
             .DistinctUntilChanged()
             .Subscribe(TryApplyLayerCount);
+
+        // Todo: 設定からショートカットを変更できるようにする。
+        KeyBindings = new List<KeyBinding>();
+        PlatformHotkeyConfiguration? keyConf = Application.Current?.PlatformSettings?.HotkeyConfiguration;
+        if (keyConf != null)
+        {
+            KeyBindings.AddRange(keyConf.Paste.Select(i => new KeyBinding
+            {
+                Command = Paste,
+                Gesture = i
+            }));
+        }
+        else
+        {
+            KeyBindings.Add(new KeyBinding
+            {
+                Command = Paste,
+                Gesture = new KeyGesture(Key.V, keyConf?.CommandModifiers ?? KeyModifiers.Control)
+            });
+        }
     }
 
     public Scene Scene { get; private set; }
@@ -162,6 +184,8 @@ public sealed class TimelineViewModel : IToolContext
     public IObservable<LayerHeaderViewModel> LayerHeightChanged => _layerHeightChanged;
 
     public string Header => Strings.Timeline;
+
+    public List<KeyBinding> KeyBindings { get; }
 
     public void Dispose()
     {

--- a/src/Beutl/Views/EditView.axaml
+++ b/src/Beutl/Views/EditView.axaml
@@ -12,6 +12,7 @@
              d:DesignHeight="720"
              d:DesignWidth="1280"
              x:DataType="vm:EditViewModel"
+             Focusable="True"
              IsEnabled="{CompiledBinding IsEnabled.Value}"
              mc:Ignorable="d">
     <UserControl.Styles>

--- a/src/Beutl/Views/EditView.axaml.cs
+++ b/src/Beutl/Views/EditView.axaml.cs
@@ -43,6 +43,12 @@ public sealed partial class EditView : UserControl
         base.OnKeyDown(e);
         if (DataContext is EditViewModel viewModel)
         {
+            // TextBox.OnKeyDown で e.Handled が True に設定されないので
+            if (e.Key == Key.Space && e.Source is TextBox)
+            {
+                return;
+            }
+
             // KeyBindingsは変更してはならない。
             foreach (KeyBinding binding in viewModel.KeyBindings)
             {

--- a/src/Beutl/Views/EditView.axaml.cs
+++ b/src/Beutl/Views/EditView.axaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Specialized;
 
+using Avalonia;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -34,6 +35,9 @@ public sealed partial class EditView : UserControl
         // 右側のタブ
         RightTabView.ItemsSource = _rightTabItems;
         _rightTabItems.CollectionChanged += TabItems_CollectionChanged;
+
+        this.GetObservable(IsKeyboardFocusWithinProperty)
+            .Subscribe(v => Player.Opacity = v ? 1 : 0.8);
     }
 
     private Image Image => _image ??= Player.GetImage();
@@ -109,7 +113,7 @@ public sealed partial class EditView : UserControl
         }
     }
 
-    protected override void OnDetachedFromVisualTree(Avalonia.VisualTreeAttachmentEventArgs e)
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnDetachedFromVisualTree(e);
         if (DataContext is EditViewModel viewModel && viewModel.Player.IsPlaying.Value)

--- a/src/Beutl/Views/EditView.axaml.cs
+++ b/src/Beutl/Views/EditView.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
+using Avalonia.Input;
 using Avalonia.Threading;
 
 using Beutl.Controls;
@@ -36,6 +37,21 @@ public sealed partial class EditView : UserControl
     }
 
     private Image Image => _image ??= Player.GetImage();
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        if (DataContext is EditViewModel viewModel)
+        {
+            // KeyBindingsは変更してはならない。
+            foreach (KeyBinding binding in viewModel.KeyBindings)
+            {
+                if (e.Handled)
+                    break;
+                binding.TryHandle(e);
+            }
+        }
+    }
 
     private void TabItems_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {

--- a/src/Beutl/Views/EditView.axaml.cs
+++ b/src/Beutl/Views/EditView.axaml.cs
@@ -37,7 +37,7 @@ public sealed partial class EditView : UserControl
         _rightTabItems.CollectionChanged += TabItems_CollectionChanged;
 
         this.GetObservable(IsKeyboardFocusWithinProperty)
-            .Subscribe(v => Player.Opacity = v ? 1 : 0.8);
+            .Subscribe(v => Player.SetSeekBarOpacity(v ? 1 : 0.8));
     }
 
     private Image Image => _image ??= Player.GetImage();

--- a/src/Beutl/Views/ElementView.axaml
+++ b/src/Beutl/Views/ElementView.axaml
@@ -21,12 +21,6 @@
              Focusable="True"
              IsEnabled="{CompiledBinding IsEnabled.Value}"
              mc:Ignorable="d">
-    <UserControl.KeyBindings>
-        <KeyBinding Command="{Binding Cut}" Gesture="{DynamicResource CutKeyGesture}" />
-        <KeyBinding Command="{Binding Copy}" Gesture="{DynamicResource CopyKeyGesture}" />
-        <KeyBinding Command="{Binding Delete}" Gesture="{DynamicResource LayerDeleteKeyGesture}" />
-        <KeyBinding Command="{Binding Exclude}" Gesture="{DynamicResource DeleteKeyGesture}" />
-    </UserControl.KeyBindings>
     <Border x:Name="border"
             Width="{Binding Width.Value}"
             Margin="{Binding BorderMargin.Value}"

--- a/src/Beutl/Views/ElementView.axaml.cs
+++ b/src/Beutl/Views/ElementView.axaml.cs
@@ -46,6 +46,27 @@ public sealed partial class ElementView : UserControl
 
     private ElementViewModel ViewModel => (ElementViewModel)DataContext!;
 
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        if (DataContext is ElementViewModel viewModel)
+        {
+            if(e.Key== Key.F2)
+            {
+                Rename_Click(null, null!);
+                return;
+            }
+
+            // KeyBindingsは変更してはならない。
+            foreach (KeyBinding binding in viewModel.KeyBindings)
+            {
+                if (e.Handled)
+                    break;
+                binding.TryHandle(e);
+            }
+        }
+    }
+
     private void OnDataContextDetached(ElementViewModel obj)
     {
         obj.AnimationRequested = (_, _) => Task.CompletedTask;

--- a/src/Beutl/Views/MainView.axaml
+++ b/src/Beutl/Views/MainView.axaml
@@ -26,18 +26,6 @@
         <vm:MainViewModel />
     </Design.DataContext>
 
-    <!--<UserControl.KeyBindings>
-        <KeyBinding Command="{CompiledBinding CreateNewProject}" Gesture="{DynamicResource CreateNewProjectKeyGesture}" />
-        <KeyBinding Command="{CompiledBinding CreateNew}" Gesture="{DynamicResource CreateNewKeyGesture}" />
-        <KeyBinding Command="{CompiledBinding OpenProject}" Gesture="{DynamicResource OpenProjectKeyGesture}" />
-        <KeyBinding Command="{CompiledBinding OpenFile}" Gesture="{DynamicResource OpenKeyGesture}" />
-        <KeyBinding Command="{CompiledBinding Save}" Gesture="{DynamicResource SaveKeyGesture}" />
-        <KeyBinding Command="{CompiledBinding SaveAll}" Gesture="{DynamicResource SaveAllKeyGesture}" />
-        <KeyBinding Command="{CompiledBinding Exit}" Gesture="{DynamicResource ExitKeyGesture}" />
-        <KeyBinding Command="{CompiledBinding Undo}" Gesture="{DynamicResource UndoKeyGesture}" />
-        <KeyBinding Command="{CompiledBinding Redo}" Gesture="{DynamicResource RedoKeyGesture}" />
-    </UserControl.KeyBindings>-->
-
     <UserControl.Styles>
         <Style Selector="FlyoutPresenter.HiddenNotificationPadding0">
             <Setter Property="Padding" Value="0" />

--- a/src/Beutl/Views/MainView.axaml
+++ b/src/Beutl/Views/MainView.axaml
@@ -26,7 +26,7 @@
         <vm:MainViewModel />
     </Design.DataContext>
 
-    <UserControl.KeyBindings>
+    <!--<UserControl.KeyBindings>
         <KeyBinding Command="{CompiledBinding CreateNewProject}" Gesture="{DynamicResource CreateNewProjectKeyGesture}" />
         <KeyBinding Command="{CompiledBinding CreateNew}" Gesture="{DynamicResource CreateNewKeyGesture}" />
         <KeyBinding Command="{CompiledBinding OpenProject}" Gesture="{DynamicResource OpenProjectKeyGesture}" />
@@ -36,7 +36,7 @@
         <KeyBinding Command="{CompiledBinding Exit}" Gesture="{DynamicResource ExitKeyGesture}" />
         <KeyBinding Command="{CompiledBinding Undo}" Gesture="{DynamicResource UndoKeyGesture}" />
         <KeyBinding Command="{CompiledBinding Redo}" Gesture="{DynamicResource RedoKeyGesture}" />
-    </UserControl.KeyBindings>
+    </UserControl.KeyBindings>-->
 
     <UserControl.Styles>
         <Style Selector="FlyoutPresenter.HiddenNotificationPadding0">

--- a/src/Beutl/Views/MainView.axaml.cs
+++ b/src/Beutl/Views/MainView.axaml.cs
@@ -9,6 +9,7 @@ using Avalonia.Animation.Easings;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
@@ -17,6 +18,7 @@ using Avalonia.Media;
 using Avalonia.Platform.Storage;
 using Avalonia.Styling;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using Avalonia.Xaml.Interactivity;
 
 using Beutl.Controls;
@@ -126,6 +128,21 @@ public sealed partial class MainView : UserControl
 
         recentFiles.ItemsSource = _rawRecentFileItems;
         recentProjects.ItemsSource = _rawRecentProjItems;
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        if (DataContext is MainViewModel viewModel)
+        {
+            // KeyBindingsは変更してはならない。
+            foreach (KeyBinding binding in viewModel.KeyBindings)
+            {
+                if (e.Handled)
+                    break;
+                binding.TryHandle(e);
+            }
+        }
     }
 
     private void SceneSettings_Click(object? sender, RoutedEventArgs e)

--- a/src/Beutl/Views/Timeline.axaml
+++ b/src/Beutl/Views/Timeline.axaml
@@ -94,15 +94,6 @@
                    PointerMoved="TimelinePanel_PointerMoved"
                    PointerPressed="TimelinePanel_PointerPressed"
                    PointerReleased="TimelinePanel_PointerReleased">
-                <Panel.KeyBindings>
-                    <KeyBinding Command="{CompiledBinding Player.PlayPause}" Gesture="{DynamicResource PlayPauseKeyGesture}" />
-                    <KeyBinding Command="{CompiledBinding Player.Next}" Gesture="{DynamicResource NextKeyGesture}" />
-                    <KeyBinding Command="{CompiledBinding Player.Previous}" Gesture="{DynamicResource PreviousKeyGesture}" />
-                    <KeyBinding Command="{CompiledBinding Player.Start}" Gesture="{DynamicResource StartKeyGesture}" />
-                    <KeyBinding Command="{CompiledBinding Player.End}" Gesture="{DynamicResource EndKeyGesture}" />
-                    <KeyBinding Command="{CompiledBinding Paste}" Gesture="{DynamicResource PasteKeyGesture}" />
-                </Panel.KeyBindings>
-
                 <Panel.ContextFlyout>
                     <ui:FAMenuFlyout>
                         <ui:MenuFlyoutItem Click="AddElementClick" Text="{x:Static lang:Strings.AddElement}" />

--- a/src/Beutl/Views/Timeline.axaml.cs
+++ b/src/Beutl/Views/Timeline.axaml.cs
@@ -38,6 +38,7 @@ public sealed partial class Timeline : UserControl
     private readonly CompositeDisposable _disposables = new();
     private ElementView? _selectedLayer;
     private readonly List<(ElementViewModel Layer, bool IsSelectedOriginal)> _rangeSelection = new();
+
     public Timeline()
     {
         InitializeComponent();
@@ -52,6 +53,21 @@ public sealed partial class Timeline : UserControl
         DragDrop.SetAllowDrop(TimelinePanel, true);
 
         this.SubscribeDataContextChange<TimelineViewModel>(OnDataContextAttached, OnDataContextDetached);
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        if (DataContext is TimelineViewModel viewModel)
+        {
+            // KeyBindingsは変更してはならない。
+            foreach (KeyBinding binding in viewModel.KeyBindings)
+            {
+                if (e.Handled)
+                    break;
+                binding.TryHandle(e);
+            }
+        }
     }
 
     private void OnDataContextDetached(TimelineViewModel obj)


### PR DESCRIPTION
<!-- 2-4は省略可 -->
## このプルリクエストで何をやったのか？
- スペースキーで再生/一時停止ができない場合があるのを修正
- KeyBindingを使っているとき、意図しない動作をすることがあったため、KeyDownイベントを使うようにした
- エディタのショートカットが使えない場合、シークバーを半透明にしてわかりやすくした

## やらなかったこと

## できるようになること

## できなくなること

## 破壊的変更

## 廃止するApi
<!-- Obsolete属性を付けたApi -->

## リンクされたIsuues
- #674 
