### PR TITLE
Pcm.Compoundメソッドを修正

### DIFF
--- a/src/Beutl.Engine/Media/Music/Pcm.cs
+++ b/src/Beutl.Engine/Media/Music/Pcm.cs
@@ -131,7 +131,7 @@ public sealed unsafe class Pcm<T> : IPcm
     {
         if (sound.SampleRate != SampleRate) throw new Exception("Sounds with different SampleRates cannot be synthesized.");
 
-        Parallel.For(0, Math.Min(sound.NumSamples, NumSamples), i => DataSpan[i] = T.Compound(DataSpan[i], sound.DataSpan[i]));
+        Compound(0, sound);
     }
 
     public void Compound(int start, Pcm<T> sound)

--- a/src/Beutl.Engine/Media/Music/Pcm.cs
+++ b/src/Beutl.Engine/Media/Music/Pcm.cs
@@ -138,10 +138,14 @@ public sealed unsafe class Pcm<T> : IPcm
     {
         if (sound.SampleRate != SampleRate) throw new Exception("Sounds with different SampleRates cannot be synthesized.");
 
-        Parallel.For(
-            start,
-            Math.Min(sound.NumSamples, NumSamples),
-            i => DataSpan[i] = T.Compound(DataSpan[i], sound.DataSpan[i - start]));
+        Parallel.For(start, NumSamples, i =>
+        {
+            int j = i - start;
+            if (j < sound.NumSamples)
+            {
+                DataSpan[i] = T.Compound(DataSpan[i], sound.DataSpan[j]);
+            }
+        });
     }
 
     public Pcm<T> Resamples(int frequency)


### PR DESCRIPTION
<!-- 2-4は省略可 -->
## このプルリクエストで何をやったのか？
Pcm.Compoundメソッドでそれぞれのサンプル数が違うとき、
正常に処理できていなかったのを修正

## やらなかったこと

## できるようになること

## できなくなること

## 破壊的変更

## 廃止するApi
<!-- Obsolete属性を付けたApi -->

## リンクされたIsuues
