### PR TITLE
要素の配置処理を改善

### DIFF
--- a/src/Beutl/ViewModels/ElementViewModel.cs
+++ b/src/Beutl/ViewModels/ElementViewModel.cs
@@ -351,8 +351,6 @@ public sealed class ElementViewModel : IDisposable
             .DoAndRecord(CommandRecorder.Default);
     }
 
-    }
-
     private List<KeyBinding> CreateKeyBinding()
     {
         PlatformHotkeyConfiguration? config = Application.Current?.PlatformSettings?.HotkeyConfiguration;

--- a/src/Beutl/ViewModels/ElementViewModel.cs
+++ b/src/Beutl/ViewModels/ElementViewModel.cs
@@ -340,12 +340,17 @@ public sealed class ElementViewModel : IDisposable
 
         CoreObjectReborn.Reborn(Model, out Element backwardLayer);
 
-        Scene.MoveChild(Model.ZIndex, Model.Start, forwardLength, Model).DoAndRecord(CommandRecorder.Default);
+        IRecordableCommand command1 = Scene.MoveChild(Model.ZIndex, Model.Start, forwardLength, Model);
         backwardLayer.Start = absTime;
         backwardLayer.Length = backwardLength;
 
         backwardLayer.Save(RandomFileNameGenerator.Generate(Path.GetDirectoryName(Scene.FileName)!, Constants.ElementFileExtension));
-        Scene.AddChild(backwardLayer).DoAndRecord(CommandRecorder.Default);
+        IRecordableCommand command2 = Scene.AddChild(backwardLayer);
+
+        command1.Append(command2)
+            .DoAndRecord(CommandRecorder.Default);
+    }
+
     }
 
     private List<KeyBinding> CreateKeyBinding()


### PR DESCRIPTION
<!-- 2-4は省略可 -->
## このプルリクエストで何をやったのか？
- 要素を追加するとき、他の要素に被さる場合、長さや開始位置、ZIndexを調整するようにした。
- 要素をリサイズするとき、長さの最小値を一フレームにした

## やらなかったこと

## できるようになること

## できなくなること

## 破壊的変更

## 廃止するApi
<!-- Obsolete属性を付けたApi -->

## リンクされたIsuues
