### PR TITLE
要素のもともとの長さを使えるようにした

### DIFF
--- a/src/Beutl.Language/Strings.Designer.cs
+++ b/src/Beutl.Language/Strings.Designer.cs
@@ -403,6 +403,15 @@ namespace Beutl.Language {
         }
         
         /// <summary>
+        ///   Change to original length に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string ChangeToOriginalLength {
+            get {
+                return ResourceManager.GetString("ChangeToOriginalLength", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Channels に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string Channels {

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -946,4 +946,7 @@ b-editorがダウンロードURLを管理します。</value>
   <data name="ColorPallete" xml:space="preserve">
     <value>カラーパレット</value>
   </data>
+  <data name="ChangeToOriginalLength" xml:space="preserve">
+    <value>オリジナルの長さに変更</value>
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -946,4 +946,7 @@ and b-editor maintains the download URL.</value>
   <data name="ColorPallete" xml:space="preserve">
     <value>Color Pallete</value>
   </data>
+  <data name="ChangeToOriginalLength" xml:space="preserve">
+    <value>Change to original length</value>
+  </data>
 </root>

--- a/src/Beutl.Operators/Source/SourceSoundOperator.cs
+++ b/src/Beutl.Operators/Source/SourceSoundOperator.cs
@@ -35,4 +35,23 @@ public sealed class SourceSoundOperator : StyledSourcePublisher
             sound.BeginBatchUpdate();
         }
     }
+
+    public override bool HasOriginalLength()
+    {
+        return Source.Value?.IsDisposed == false;
+    }
+
+    public override bool TryGetOriginalLength(out TimeSpan timeSpan)
+    {
+        if (Source.Value?.IsDisposed == false)
+        {
+            timeSpan = Source.Value.Duration;
+            return true;
+        }
+        else
+        {
+            timeSpan = TimeSpan.Zero;
+            return false;
+        }
+    }
 }

--- a/src/Beutl.Operators/Source/SourceVideoOperator.cs
+++ b/src/Beutl.Operators/Source/SourceVideoOperator.cs
@@ -54,4 +54,23 @@ public sealed class SourceVideoOperator : DrawablePublishOperator<SourceVideo>
             setter.Value = videoSource;
         }
     }
+
+    public override bool HasOriginalLength()
+    {
+        return Source.Value?.IsDisposed == false;
+    }
+
+    public override bool TryGetOriginalLength(out TimeSpan timeSpan)
+    {
+        if (Source.Value?.IsDisposed == false)
+        {
+            timeSpan = Source.Value.Duration - OffsetPosition.Value;
+            return true;
+        }
+        else
+        {
+            timeSpan = TimeSpan.Zero;
+            return false;
+        }
+    }
 }

--- a/src/Beutl.ProjectSystem/Operation/SourceOperator.cs
+++ b/src/Beutl.ProjectSystem/Operation/SourceOperator.cs
@@ -86,6 +86,17 @@ public class SourceOperator : Hierarchical, ISourceOperator
     {
     }
 
+    public virtual bool HasOriginalLength()
+    {
+        return false;
+    }
+    
+    public virtual bool TryGetOriginalLength(out TimeSpan timeSpan)
+    {
+        timeSpan = default;
+        return false;
+    }
+
     protected void RaiseInvalidated(RenderInvalidatedEventArgs args)
     {
         Invalidated?.Invoke(this, args);

--- a/src/Beutl.ProjectSystem/TimeSpanExtensions.cs
+++ b/src/Beutl.ProjectSystem/TimeSpanExtensions.cs
@@ -6,6 +6,11 @@ public static class TimeSpanExtensions
     {
         return Math.Round(ts.ToFrameNumber(rate), MidpointRounding.AwayFromZero).ToTimeSpan(rate);
     }
+    
+    public static TimeSpan FloorToRate(this TimeSpan ts, double rate)
+    {
+        return Math.Floor(ts.ToFrameNumber(rate)).ToTimeSpan(rate);
+    }
 
     public static double ToFrameNumber(this TimeSpan ts, double rate)
     {

--- a/src/Beutl/ViewModels/TimelineViewModel.cs
+++ b/src/Beutl/ViewModels/TimelineViewModel.cs
@@ -427,7 +427,7 @@ public sealed class TimelineViewModel : IToolContext
     public void AttachInline(IAbstractAnimatableProperty property, Element layer)
     {
         if (!Inlines.Any(x => x.Layer.Model == layer && x.Property == property)
-            && Layers.FirstOrDefault(x => x.Model == layer) is { } viewModel)
+            && GetViewModelFor(layer) is { } viewModel)
         {
             // タイムラインのタブを開く
             Type type = typeof(InlineAnimationLayerViewModel<>).MakeGenericType(property.PropertyType);
@@ -557,6 +557,11 @@ public sealed class TimelineViewModel : IToolContext
     public object? GetService(Type serviceType)
     {
         return EditorContext.GetService(serviceType);
+    }
+
+    public ElementViewModel? GetViewModelFor(Element element)
+    {
+        return Layers.FirstOrDefault(x => x.Model == element);
     }
 
     private sealed class TrackedLayerTopObservable : LightweightObservableBase<double>, IDisposable

--- a/src/Beutl/Views/Editors/SoundSourceEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/SoundSourceEditor.axaml.cs
@@ -4,6 +4,8 @@ using Avalonia.Platform.Storage;
 using Beutl.Api.Services;
 using Beutl.Media.Decoding;
 using Beutl.Media.Source;
+using Beutl.ProjectSystem;
+using Beutl.ViewModels;
 using Beutl.ViewModels.Editors;
 
 using FluentAvalonia.UI.Controls;
@@ -85,7 +87,14 @@ public partial class SoundSourceEditor : UserControl
             {
                 ISoundSource? oldValue = vm.WrappedProperty.GetValue();
                 vm.SetValue(oldValue, soundSource);
-                oldValue?.Dispose();
+
+                if (vm.GetService<Element>() is Element element)
+                {
+                    TimelineViewModel? timeline = vm.GetService<EditViewModel>()?.FindToolTab<TimelineViewModel>();
+                    ElementViewModel? elmViewModel = timeline?.GetViewModelFor(element);
+
+                    elmViewModel?.ChangeToOriginalLength?.Execute();
+                }
             }
         }
     }

--- a/src/Beutl/Views/Editors/VideoSourceEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/VideoSourceEditor.axaml.cs
@@ -4,6 +4,8 @@ using Avalonia.Platform.Storage;
 using Beutl.Api.Services;
 using Beutl.Media.Decoding;
 using Beutl.Media.Source;
+using Beutl.ProjectSystem;
+using Beutl.ViewModels;
 using Beutl.ViewModels.Editors;
 
 using FluentAvalonia.UI.Controls;
@@ -85,7 +87,14 @@ public partial class VideoSourceEditor : UserControl
             {
                 IVideoSource? oldValue = vm.WrappedProperty.GetValue();
                 vm.SetValue(oldValue, videoSource);
-                oldValue?.Dispose();
+
+                if (vm.GetService<Element>() is Element element)
+                {
+                    TimelineViewModel? timeline = vm.GetService<EditViewModel>()?.FindToolTab<TimelineViewModel>();
+                    ElementViewModel? elmViewModel = timeline?.GetViewModelFor(element);
+
+                    elmViewModel?.ChangeToOriginalLength?.Execute();
+                }
             }
         }
     }

--- a/src/Beutl/Views/ElementView.axaml
+++ b/src/Beutl/Views/ElementView.axaml
@@ -84,6 +84,9 @@
                         <icons:SymbolIconSource Symbol="Rename" />
                     </ui:MenuFlyoutItem.IconSource>
                 </ui:MenuFlyoutItem>
+                <ui:MenuFlyoutItem x:Name="change2OriginalLength"
+                                   Command="{Binding ChangeToOriginalLength}"
+                                   Text="{x:Static lang:Strings.ChangeToOriginalLength}" />
                 <ui:MenuFlyoutItem Click="ChangeColor_Click" Text="{x:Static lang:Strings.ChangeColor}" />
                 <ui:MenuFlyoutSeparator />
                 <ui:MenuFlyoutSubItem Text="{x:Static lang:Strings.Animation}">

--- a/src/Beutl/Views/ElementView.axaml.cs
+++ b/src/Beutl/Views/ElementView.axaml.cs
@@ -41,6 +41,7 @@ public sealed partial class ElementView : UserControl
     {
         InitializeComponent();
 
+        (border.ContextFlyout as FAMenuFlyout)!.Opening += OnContextFlyoutOpening;
         textBox.LostFocus += OnTextBoxLostFocus;
         this.SubscribeDataContextChange<ElementViewModel>(OnDataContextAttached, OnDataContextDetached);
     }
@@ -73,6 +74,14 @@ public sealed partial class ElementView : UserControl
                     break;
                 binding.TryHandle(e);
             }
+        }
+    }
+
+    private void OnContextFlyoutOpening(object? sender, EventArgs e)
+    {
+        if (DataContext is ElementViewModel viewModel)
+        {
+            change2OriginalLength.IsEnabled = viewModel.HasOriginalLength();
         }
     }
 
@@ -369,8 +378,8 @@ public sealed partial class ElementView : UserControl
                             if (minWidth < newWidth)
                             {
                                 viewModel.Width.Value = newWidth;
-                            viewModel.BorderMargin.Value = new Thickness(x, 0, 0, 0);
-                        }
+                                viewModel.BorderMargin.Value = new Thickness(x, 0, 0, 0);
+                            }
                             else
                             {
                                 viewModel.Width.Value = minWidth;


### PR DESCRIPTION
<!-- 2-4は省略可 -->
## このプルリクエストで何をやったのか？
- 動画、音声などもともとの長さがある場合、その長さを使えるようにした

## やらなかったこと

## できるようになること

## できなくなること

## 破壊的変更

## 廃止するApi
<!-- Obsolete属性を付けたApi -->

## リンクされたIsuues
