### PR TITLE
要素の分割を改善

### DIFF
--- a/src/Beutl.Language/Strings.Designer.cs
+++ b/src/Beutl.Language/Strings.Designer.cs
@@ -2240,6 +2240,15 @@ namespace Beutl.Language {
         }
         
         /// <summary>
+        ///   Split by current frame に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SplitByCurrentFrame {
+            get {
+                return ResourceManager.GetString("SplitByCurrentFrame", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Spread Method に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string SpreadMethod {

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -949,4 +949,7 @@ b-editorがダウンロードURLを管理します。</value>
   <data name="ChangeToOriginalLength" xml:space="preserve">
     <value>オリジナルの長さに変更</value>
   </data>
+  <data name="SplitByCurrentFrame" xml:space="preserve">
+    <value>現在のフレームで分割</value>
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -949,4 +949,7 @@ and b-editor maintains the download URL.</value>
   <data name="ChangeToOriginalLength" xml:space="preserve">
     <value>Change to original length</value>
   </data>
+  <data name="SplitByCurrentFrame" xml:space="preserve">
+    <value>Split by current frame</value>
+  </data>
 </root>

--- a/src/Beutl.Operators/Source/SourceSoundOperator.cs
+++ b/src/Beutl.Operators/Source/SourceSoundOperator.cs
@@ -54,4 +54,16 @@ public sealed class SourceSoundOperator : StyledSourcePublisher
             return false;
         }
     }
+
+    public override IRecordableCommand? OnSplit(bool backward, TimeSpan startDelta, TimeSpan lengthDelta)
+    {
+        if (backward)
+        {
+            return new ChangeSetterValueCommand<TimeSpan>(OffsetPosition, OffsetPosition.Value, OffsetPosition.Value + startDelta);
+        }
+        else
+        {
+            return base.OnSplit(backward, startDelta, lengthDelta);
+        }
+    }
 }

--- a/src/Beutl.Operators/Source/SourceVideoOperator.cs
+++ b/src/Beutl.Operators/Source/SourceVideoOperator.cs
@@ -73,4 +73,16 @@ public sealed class SourceVideoOperator : DrawablePublishOperator<SourceVideo>
             return false;
         }
     }
+
+    public override IRecordableCommand? OnSplit(bool backward, TimeSpan startDelta, TimeSpan lengthDelta)
+    {
+        if (backward)
+        {
+            return new ChangeSetterValueCommand<TimeSpan>(OffsetPosition, OffsetPosition.Value, OffsetPosition.Value + startDelta);
+        }
+        else
+        {
+            return base.OnSplit(backward, startDelta, lengthDelta);
+        }
+    }
 }

--- a/src/Beutl.ProjectSystem/ChangeSetterValueCommand.cs
+++ b/src/Beutl.ProjectSystem/ChangeSetterValueCommand.cs
@@ -1,0 +1,29 @@
+﻿using Beutl.Styling;
+
+namespace Beutl;
+
+public sealed class ChangeSetterValueCommand<T> : IRecordableCommand
+{
+    private readonly Setter<T> _setter;
+    private readonly T _oldValue;
+    private readonly T _newValue;
+
+    public ChangeSetterValueCommand(Setter<T> setter, T oldValue, T newValue)
+    {
+        _setter = setter;
+        _oldValue = oldValue;
+        _newValue = newValue;
+    }
+
+    public void Do()
+    {
+        _setter.Value = _newValue;
+    }
+
+    public void Redo() => Do();
+
+    public void Undo()
+    {
+        _setter.Value = _oldValue;
+    }
+}

--- a/src/Beutl.ProjectSystem/Operation/SourceOperation.cs
+++ b/src/Beutl.ProjectSystem/Operation/SourceOperation.cs
@@ -40,6 +40,14 @@ public sealed class SourceOperation : Hierarchical, IAffectsRender
     [NotAutoSerialized]
     public ICoreList<SourceOperator> Children => _children;
 
+    public IRecordableCommand OnSplit(bool backward, TimeSpan startDelta,TimeSpan lengthDelta)
+    {
+        return _children.Select(v => v.OnSplit(backward, startDelta, lengthDelta))
+            .Where(v => v != null)
+            .ToArray()!
+            .ToCommand();
+    }
+
     public override void ReadFromJson(JsonObject json)
     {
         base.ReadFromJson(json);

--- a/src/Beutl.ProjectSystem/Operation/SourceOperator.cs
+++ b/src/Beutl.ProjectSystem/Operation/SourceOperator.cs
@@ -97,6 +97,11 @@ public class SourceOperator : Hierarchical, ISourceOperator
         return false;
     }
 
+    public virtual IRecordableCommand? OnSplit(bool backward, TimeSpan startDelta, TimeSpan lengthDelta)
+    {
+        return null;
+    }
+
     protected void RaiseInvalidated(RenderInvalidatedEventArgs args)
     {
         Invalidated?.Invoke(this, args);

--- a/src/Beutl/App.axaml
+++ b/src/Beutl/App.axaml
@@ -33,6 +33,7 @@
             <KeyGesture x:Key="CutKeyGesture">Ctrl+X</KeyGesture>
             <KeyGesture x:Key="CopyKeyGesture">Ctrl+C</KeyGesture>
             <KeyGesture x:Key="PasteKeyGesture">Ctrl+V</KeyGesture>
+            <KeyGesture x:Key="SplitKeyGesture">Ctrl+K</KeyGesture>
             <KeyGesture x:Key="PlayPauseKeyGesture">Space</KeyGesture>
             <KeyGesture x:Key="NextKeyGesture">Right</KeyGesture>
             <KeyGesture x:Key="PreviousKeyGesture">Left</KeyGesture>

--- a/src/Beutl/ViewModels/ElementViewModel.cs
+++ b/src/Beutl/ViewModels/ElementViewModel.cs
@@ -364,8 +364,12 @@ public sealed class ElementViewModel : IDisposable
 
         backwardLayer.Save(RandomFileNameGenerator.Generate(Path.GetDirectoryName(Scene.FileName)!, Constants.ElementFileExtension));
         IRecordableCommand command2 = Scene.AddChild(backwardLayer);
+        IRecordableCommand command3 = backwardLayer.Operation.OnSplit(true, forwardLength, -forwardLength);
+        IRecordableCommand command4 = Model.Operation.OnSplit(false, TimeSpan.Zero, -backwardLength);
 
         command1.Append(command2)
+            .Append(command3)
+            .Append(command4)
             .DoAndRecord(CommandRecorder.Default);
     }
 

--- a/src/Beutl/Views/ElementView.axaml
+++ b/src/Beutl/Views/ElementView.axaml
@@ -42,13 +42,15 @@
         </Border.Resources>
         <Border.ContextFlyout>
             <ui:FAMenuFlyout>
-                <ui:MenuFlyoutItem Command="{Binding Split}"
-                                   CommandParameter="{Binding #root.GetClickedTime, Mode=OneTime}"
-                                   Text="{x:Static lang:Strings.Split}">
+                <ui:MenuFlyoutItem Command="{Binding Split}" Text="{x:Static lang:Strings.Split}">
                     <ui:MenuFlyoutItem.IconSource>
                         <icons:SymbolIconSource Symbol="SplitVertical" />
                     </ui:MenuFlyoutItem.IconSource>
                 </ui:MenuFlyoutItem>
+                <ui:MenuFlyoutItem x:Name="splitByCurrent"
+                                   Command="{Binding SplitByCurrentFrame}"
+                                   InputGesture="{DynamicResource SplitKeyGesture}"
+                                   Text="{x:Static lang:Strings.SplitByCurrentFrame}" />
                 <ui:MenuFlyoutItem Command="{Binding Cut}"
                                    InputGesture="{DynamicResource CutKeyGesture}"
                                    Text="{x:Static lang:Strings.Cut}">

--- a/src/Beutl/Views/ElementView.axaml.cs
+++ b/src/Beutl/Views/ElementView.axaml.cs
@@ -46,8 +46,6 @@ public sealed partial class ElementView : UserControl
         this.SubscribeDataContextChange<ElementViewModel>(OnDataContextAttached, OnDataContextDetached);
     }
 
-    public Func<TimeSpan> GetClickedTime => () => _pointerPosition;
-
     private ElementViewModel ViewModel => (ElementViewModel)DataContext!;
 
     protected override void OnKeyDown(KeyEventArgs e)
@@ -82,12 +80,14 @@ public sealed partial class ElementView : UserControl
         if (DataContext is ElementViewModel viewModel)
         {
             change2OriginalLength.IsEnabled = viewModel.HasOriginalLength();
+            splitByCurrent.IsEnabled = viewModel.Model.Range.Contains(viewModel.Scene.CurrentFrame);
         }
     }
 
     private void OnDataContextDetached(ElementViewModel obj)
     {
         obj.AnimationRequested = (_, _) => Task.CompletedTask;
+        obj.GetClickedTime = null;
         _disposables.Clear();
     }
 
@@ -155,6 +155,7 @@ public sealed partial class ElementView : UserControl
                 await Task.WhenAll(task1, task2);
             });
         };
+        obj.GetClickedTime = () => _pointerPosition;
 
         obj.Model.GetObservable(Element.IsEnabledProperty)
             .ObserveOnUIDispatcher()


### PR DESCRIPTION
<!-- 2-4は省略可 -->
## このプルリクエストで何をやったのか？
- 要素を分割するショートカットにCtrl+Kを割り当てた
- 要素を分割したとき、動画、音声の開始位置も変更するようにした

## やらなかったこと

## できるようになること

## できなくなること

## 破壊的変更

## 廃止するApi
<!-- Obsolete属性を付けたApi -->

## リンクされたIsuues
