### PR TITLE
アニメーション機能の改善

### DIFF
--- a/src/Beutl.Controls/PropertyEditors/PropertyEditor.cs
+++ b/src/Beutl.Controls/PropertyEditors/PropertyEditor.cs
@@ -45,8 +45,8 @@ public class PropertyEditor : TemplatedControl, IPropertyEditorContextVisitor, I
     public static readonly StyledProperty<IDataTemplate> MenuContentTemplateProperty =
         AvaloniaProperty.Register<PropertyEditor, IDataTemplate>(nameof(MenuContentTemplate));
 
-    public static readonly StyledProperty<int> KeyFrameIndexProperty =
-        AvaloniaProperty.Register<PropertyEditor, int>(nameof(KeyFrameIndex), 0);
+    public static readonly StyledProperty<float> KeyFrameIndexProperty =
+        AvaloniaProperty.Register<PropertyEditor, float>(nameof(KeyFrameIndex), 0);
 
     public static readonly StyledProperty<int> KeyFrameCountProperty =
         AvaloniaProperty.Register<PropertyEditor, int>(nameof(KeyFrameCount), 0, coerce: (_, v) => Math.Max(v, 0));
@@ -103,7 +103,7 @@ public class PropertyEditor : TemplatedControl, IPropertyEditorContextVisitor, I
         set => SetValue(MenuContentTemplateProperty, value);
     }
 
-    public int KeyFrameIndex
+    public float KeyFrameIndex
     {
         get => GetValue(KeyFrameIndexProperty);
         set => SetValue(KeyFrameIndexProperty, value);
@@ -211,7 +211,7 @@ public class PropertyEditor : TemplatedControl, IPropertyEditorContextVisitor, I
 
     private void OnLeftButtonClick(object sender, RoutedEventArgs e)
     {
-        int value = KeyFrameIndex - 1;
+        float value = MathF.Ceiling(KeyFrameIndex) - 1;
         if (0 <= value)
         {
             KeyFrameIndex = value;
@@ -220,7 +220,7 @@ public class PropertyEditor : TemplatedControl, IPropertyEditorContextVisitor, I
 
     private void OnRightButtonClick(object sender, RoutedEventArgs e)
     {
-        int value = KeyFrameIndex + 1;
+        float value = MathF.Floor(KeyFrameIndex) + 1;
         if (value < KeyFrameCount)
         {
             KeyFrameIndex = value;

--- a/src/Beutl.Engine/Animation/AnimatorRegistry.cs
+++ b/src/Beutl.Engine/Animation/AnimatorRegistry.cs
@@ -40,6 +40,11 @@ public static class AnimatorRegistry
         (type => typeof(Graphics.Vector).IsAssignableFrom(type), typeof(VectorAnimator)),
     };
 
+    public static Animator<T> CreateAnimator<T>()
+    {
+        return (Activator.CreateInstance(GetAnimatorType(typeof(T))) as Animator<T>) ?? new _Animator<T>();
+    }
+
     public static Type GetAnimatorType(Type type)
     {
         foreach ((Func<Type, bool> condition, Type animator) in s_animators)

--- a/src/Beutl.Engine/Animation/Animator{T}.cs
+++ b/src/Beutl.Engine/Animation/Animator{T}.cs
@@ -4,8 +4,8 @@ public abstract class Animator<T> : Animator
 {
     public abstract T Interpolate(float progress, T oldValue, T newValue);
 
-    public virtual T DefaultValue()
+    public virtual T? DefaultValue()
     {
-        return default(T) ?? throw new InvalidOperationException();
+        return default;
     }
 }

--- a/src/Beutl.Engine/Animation/IAnimation.cs
+++ b/src/Beutl.Engine/Animation/IAnimation.cs
@@ -19,7 +19,7 @@ public interface IAnimation<T> : IAnimation
 
     CoreProperty IAnimation.Property => Property;
 
-    T GetAnimatedValue(IClock clock);
+    T? GetAnimatedValue(IClock clock);
 
-    T Interpolate(TimeSpan timeSpan);
+    T? Interpolate(TimeSpan timeSpan);
 }

--- a/src/Beutl.Engine/Animation/KeyFrameAnimation{T}.cs
+++ b/src/Beutl.Engine/Animation/KeyFrameAnimation{T}.cs
@@ -39,8 +39,8 @@ public class KeyFrameAnimation<T> : KeyFrameAnimation, IAnimation<T>
 
         if (next is KeyFrame<T> next2)
         {
-            T prevValue = prev is KeyFrame<T> prev2 ? prev2.Value : defaultValue;
             T nextValue = next2.Value;
+            T prevValue = prev is KeyFrame<T> prev2 ? prev2.Value : nextValue;
             TimeSpan prevTime = prev?.KeyTime ?? TimeSpan.Zero;
             TimeSpan nextTime = next.KeyTime;
             // Zero除算になるので

--- a/src/Beutl.Engine/Animation/KeyFrameAnimation{T}.cs
+++ b/src/Beutl.Engine/Animation/KeyFrameAnimation{T}.cs
@@ -27,20 +27,19 @@ public class KeyFrameAnimation<T> : KeyFrameAnimation, IAnimation<T>
         }
     }
 
-    public T GetAnimatedValue(IClock clock)
+    public T? GetAnimatedValue(IClock clock)
     {
         return Interpolate(UseGlobalClock ? clock.GlobalClock.CurrentTime : clock.CurrentTime);
     }
 
-    public T Interpolate(TimeSpan timeSpan)
+    public T? Interpolate(TimeSpan timeSpan)
     {
         (IKeyFrame? prev, IKeyFrame? next) = GetPreviousAndNextKeyFrame(timeSpan);
-        T defaultValue = KeyFrame<T>.s_animator.DefaultValue();
 
         if (next is KeyFrame<T> next2)
         {
-            T nextValue = next2.Value;
-            T prevValue = prev is KeyFrame<T> prev2 ? prev2.Value : nextValue;
+            T? nextValue = next2.Value;
+            T? prevValue = prev is KeyFrame<T> prev2 ? prev2.Value : nextValue;
             TimeSpan prevTime = prev?.KeyTime ?? TimeSpan.Zero;
             TimeSpan nextTime = next.KeyTime;
             // Zero除算になるので
@@ -51,7 +50,13 @@ public class KeyFrameAnimation<T> : KeyFrameAnimation, IAnimation<T>
 
             float progress = (float)((timeSpan - prevTime) / (nextTime - prevTime));
             float ease = next.Easing.Ease(progress);
-            T value = KeyFrame<T>.s_animator.Interpolate(ease, prevValue, nextValue);
+            // どちらかがnullの場合、片方を返す
+            if (prevValue == null)
+                return nextValue;
+            else if (nextValue == null)
+                return prevValue;
+
+            T? value = KeyFrame<T>.s_animator.Interpolate(ease, prevValue, nextValue);
 
             return value;
         }
@@ -61,7 +66,7 @@ public class KeyFrameAnimation<T> : KeyFrameAnimation, IAnimation<T>
         }
         else
         {
-            return defaultValue;
+            return KeyFrame<T>.s_animator.DefaultValue();
         }
     }
 

--- a/src/Beutl.Engine/Animation/KeyFrames.cs
+++ b/src/Beutl.Engine/Animation/KeyFrames.cs
@@ -115,4 +115,18 @@ public class KeyFrames : CoreList<IKeyFrame>
 
         return Count - 1;
     }
+
+    public int IndexAtOrCount(TimeSpan timeSpan)
+    {
+        for (int i = 0; i < Count; i++)
+        {
+            IKeyFrame next = this[i];
+            if (timeSpan <= next.KeyTime)
+            {
+                return i;
+            }
+        }
+
+        return Count;
+    }
 }

--- a/src/Beutl.Engine/Animation/KeyFrame{T}.cs
+++ b/src/Beutl.Engine/Animation/KeyFrame{T}.cs
@@ -7,9 +7,9 @@ namespace Beutl.Animation;
 
 public sealed class KeyFrame<T> : KeyFrame, IKeyFrame
 {
-    public static readonly CoreProperty<T> ValueProperty;
+    public static readonly CoreProperty<T?> ValueProperty;
     internal static readonly Animator<T> s_animator;
-    private T _value;
+    private T? _value;
     internal IValidator<T>? _validator;
     private IKeyFrameAnimation? _parent;
 
@@ -20,14 +20,14 @@ public sealed class KeyFrame<T> : KeyFrame, IKeyFrame
 
     static KeyFrame()
     {
-        s_animator = (Animator<T>)Activator.CreateInstance(AnimatorRegistry.GetAnimatorType(typeof(T)))!;
+        s_animator = AnimatorRegistry.CreateAnimator<T>();
 
-        ValueProperty = ConfigureProperty<T, KeyFrame<T>>(nameof(Value))
+        ValueProperty = ConfigureProperty<T?, KeyFrame<T>>(nameof(Value))
             .Accessor(o => o.Value, (o, v) => o.Value = v)
             .Register();
     }
 
-    public T Value
+    public T? Value
     {
         get => _value;
         set

--- a/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
@@ -75,13 +75,13 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
                 {
                     if (GetAnimation() is { } animation)
                     {
-                        (int oldIndex, _) = t.OldValue;
-                        (int newIndex, KeyFrames? keyframes) = t.NewValue;
+                        (float oldIndex, _) = t.OldValue;
+                        (float newIndex, KeyFrames? keyframes) = t.NewValue;
 
-                        if (_editViewModel != null && keyframes != null
-                            && 0 <= newIndex && newIndex < keyframes.Count)
+                        if (_editViewModel != null && keyframes != null)
                         {
-                            EditingKeyFrame.Value = keyframes[newIndex];
+                            int newCeiled = (int)Math.Clamp(MathF.Ceiling(newIndex), 0, keyframes.Count - 1);
+                            EditingKeyFrame.Value = keyframes[newCeiled];
 
                             if (!_skipKeyFrameIndexSubscription && newIndex != oldIndex)
                             {
@@ -136,7 +136,7 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
 
     public ReadOnlyReactivePropertySlim<int> KeyFrameCount { get; }
 
-    public ReactivePropertySlim<int> KeyFrameIndex { get; } = new();
+    public ReactivePropertySlim<float> KeyFrameIndex { get; } = new();
 
     public bool IsAnimatable => WrappedProperty is IAbstractAnimatableProperty;
 
@@ -199,7 +199,7 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
                         {
                             if (GetAnimation() is { } animation)
                             {
-                                int rate = _editViewModel?.Scene?.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
+                                int rate = _editViewModel?.Scene?.FindHierarchicalParent<Project>().GetFrameRate() ?? 30;
 
                                 TimeSpan globalkeyTime = t.First;
                                 TimeSpan localKeyTime = _layer != null ? globalkeyTime - _layer.Start : globalkeyTime;
@@ -209,7 +209,10 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
                                 IsSymbolIconFilled.Value = t.Second?.Any(obj => obj.KeyTime == keyTime) ?? false;
                                 if (t.Second != null)
                                 {
-                                    int kfIndex = t.Second.IndexAt(keyTime);
+                                    float kfIndex = t.Second.IndexAtOrCount(keyTime);
+                                    if (!IsSymbolIconFilled.Value)
+                                        kfIndex -= 0.5f;
+
                                     _skipKeyFrameIndexSubscription = KeyFrameIndex.Value != kfIndex;
                                     KeyFrameIndex.Value = kfIndex;
                                 }

--- a/src/Beutl/ViewModels/GraphEditorKeyFrameViewModel.cs
+++ b/src/Beutl/ViewModels/GraphEditorKeyFrameViewModel.cs
@@ -239,7 +239,11 @@ public sealed class GraphEditorKeyFrameViewModel : IDisposable
     {
         if (Model.Easing is SplineEasing splineEasing)
         {
-            var command = new SubmitControlPointCommand((oldX, oldY), (splineEasing.X1, splineEasing.Y1), splineEasing, true);
+            var oldValues = (oldX, oldY);
+            var newValues = (splineEasing.X1, splineEasing.Y1);
+            if (oldValues == newValues)
+                return;
+            var command = new SubmitControlPointCommand(oldValues, newValues, splineEasing, true);
             command.DoAndRecord(CommandRecorder.Default);
         }
     }
@@ -248,7 +252,11 @@ public sealed class GraphEditorKeyFrameViewModel : IDisposable
     {
         if (Model.Easing is SplineEasing splineEasing)
         {
-            var command = new SubmitControlPointCommand((oldX, oldY), (splineEasing.X2, splineEasing.Y2), splineEasing, false);
+            var oldValues = (oldX, oldY);
+            var newValues = (splineEasing.X2, splineEasing.Y2);
+            if (oldValues == newValues)
+                return;
+            var command = new SubmitControlPointCommand(oldValues, newValues, splineEasing, false);
             command.DoAndRecord(CommandRecorder.Default);
         }
     }

--- a/src/Beutl/Views/GraphEditorView.axaml
+++ b/src/Beutl/Views/GraphEditorView.axaml
@@ -222,7 +222,8 @@
                                                               StartPoint="{Binding ControlPoint2.Value}"
                                                               EndPoint="{Binding RightTop.Value}" />
 
-                                                        <Path HorizontalAlignment="Left"
+                                                        <Path Name="KeyTimeIcon"
+                                                              HorizontalAlignment="Left"
                                                               VerticalAlignment="Top"
                                                               Classes.decreasing="{Binding Decreasing.Value}"
                                                               Fill="{DynamicResource SystemFillColorCaution}"
@@ -274,7 +275,6 @@
                                                         </Path>
                                                     </Panel>
                                                 </Border>
-
                                             </Border>
                                         </DataTemplate>
                                     </ItemsControl.ItemTemplate>

--- a/src/Beutl/Views/GraphEditorView.axaml.cs
+++ b/src/Beutl/Views/GraphEditorView.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.LogicalTree;
 
 using Beutl.Animation;
 using Beutl.Animation.Easings;
@@ -14,6 +15,7 @@ using Beutl.ViewModels;
 using Reactive.Bindings.Extensions;
 
 using Path = Avalonia.Controls.Shapes.Path;
+using Shape = Avalonia.Controls.Shapes.Shape;
 
 namespace Beutl.Views;
 
@@ -300,7 +302,7 @@ public partial class GraphEditorView : UserControl
     private void OnControlPointPointerMoved(object? sender, PointerEventArgs e)
     {
         if (_cPointPressed
-            && sender is Path { DataContext: GraphEditorKeyFrameViewModel viewModel, Tag: string tag } shape)
+            && sender is Shape { DataContext: GraphEditorKeyFrameViewModel viewModel, Tag: string tag } shape)
         {
             Point position = new(e.GetPosition(views).X, e.GetPosition(grid).Y);
             position = position.WithX(Math.Clamp(position.X, viewModel.Left.Value, viewModel.Right.Value));
@@ -313,10 +315,10 @@ public partial class GraphEditorView : UserControl
                 _ => false,
             };
 
-            if (!result)
-            {
-                _cPointPressed = false;
-            }
+            //if (!result)
+            //{
+            //    _cPointPressed = false;
+            //}
 
             e.Handled = true;
         }
@@ -325,7 +327,7 @@ public partial class GraphEditorView : UserControl
     private void OnControlPointPointerPressed(object? sender, PointerPressedEventArgs e)
     {
         if (DataContext is GraphEditorViewModel viewModel
-            && sender is Path
+            && sender is Shape
             {
                 Tag: string tag,
                 DataContext: GraphEditorKeyFrameViewModel
@@ -334,6 +336,14 @@ public partial class GraphEditorView : UserControl
                 }
             } shape)
         {
+            if (!e.KeyModifiers.HasFlag(KeyModifiers.Alt)
+                && shape.GetLogicalSiblings().OfType<Path>().FirstOrDefault(v => v.Name == "KeyTimeIcon") is Path ki
+                && ki.InputHitTest(e.GetPosition(ki)) == ki)
+            {
+                ki.RaiseEvent(e);
+                return;
+            }
+
             PointerPoint point = e.GetCurrentPoint(grid);
 
             if (point.Properties.IsLeftButtonPressed)
@@ -355,7 +365,7 @@ public partial class GraphEditorView : UserControl
     private void OnControlPointPointerReleased(object? sender, PointerReleasedEventArgs e)
     {
         if (DataContext is GraphEditorViewModel viewModel
-            && sender is Path { DataContext: GraphEditorKeyFrameViewModel itemViewModel, Tag: string tag })
+            && sender is Shape { DataContext: GraphEditorKeyFrameViewModel itemViewModel, Tag: string tag })
         {
             switch (tag)
             {


### PR DESCRIPTION
<!-- 2-4は省略可 -->
## このプルリクエストで何をやったのか？
- アニメーションの編集を準備するとき、もともとの値が使われるようにした
- プロパティエディタのキーフレームに移動するボタンを改善
- 参照型でアニメーションを有効にしたとき、例外が発生しないようにした
- グラフエディタでキーフレームを移動するとき、コントロールポイントに当たるのを修正

## やらなかったこと

## できるようになること

## できなくなること

## 破壊的変更

## 廃止するApi
<!-- Obsolete属性を付けたApi -->

## リンクされたIsuues
