### PR TITLE
フレーム番号の決定を修正

### DIFF
--- a/src/Beutl/Views/Timeline.axaml.cs
+++ b/src/Beutl/Views/Timeline.axaml.cs
@@ -254,8 +254,14 @@ public sealed partial class Timeline : UserControl
     {
         TimelineViewModel viewModel = ViewModel;
         PointerPoint pointerPt = e.GetCurrentPoint(TimelinePanel);
-        _pointerFrame = pointerPt.Position.X.ToTimeSpan(viewModel.Options.Value.Scale)
-            .RoundToRate(viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30);
+        int rate = viewModel.Scene.FindHierarchicalParent<Project>().GetFrameRate();
+        _pointerFrame = pointerPt.Position.X.ToTimeSpan(viewModel.Options.Value.Scale).RoundToRate(rate);
+
+        if (_pointerFrame >= viewModel.Scene.Duration)
+        {
+            _pointerFrame = viewModel.Scene.Duration - TimeSpan.FromSeconds(1d / rate);
+            _pointerFrame = _pointerFrame.RoundToRate(rate);
+        }
 
         if (_mouseFlag == MouseFlags.SeekBarPressed)
         {


### PR DESCRIPTION
<!-- 2-4は省略可 -->
## このプルリクエストで何をやったのか？
本来、描画できるフレームとシーンの長さは同じになることはないが、
プレビュー時に同じになることがあった。
これを修正。

## やらなかったこと

## できるようになること

## できなくなること

## 破壊的変更

## 廃止するApi
<!-- Obsolete属性を付けたApi -->

## リンクされたIsuues
