### PR TITLE
要素を移動、追加したときシーンの長さを変更するようにした

### DIFF
--- a/src/Beutl.Configuration/EditorConfig.cs
+++ b/src/Beutl.Configuration/EditorConfig.cs
@@ -1,0 +1,30 @@
+﻿using System.ComponentModel;
+
+namespace Beutl.Configuration;
+
+public sealed class EditorConfig : ConfigurationBase
+{
+    public static readonly CoreProperty<bool> AutoAdjustSceneDurationProperty;
+
+    static EditorConfig()
+    {
+        AutoAdjustSceneDurationProperty = ConfigureProperty<bool, EditorConfig>(nameof(AutoAdjustSceneDuration))
+            .DefaultValue(true)
+            .Register();
+    }
+
+    public bool AutoAdjustSceneDuration
+    {
+        get => GetValue(AutoAdjustSceneDurationProperty);
+        set => SetValue(AutoAdjustSceneDurationProperty, value);
+    }
+
+    protected override void OnPropertyChanged(PropertyChangedEventArgs args)
+    {
+        base.OnPropertyChanged(args);
+        if (args.PropertyName is not (nameof(Id) or nameof(Name)))
+        {
+            OnChanged();
+        }
+    }
+}

--- a/src/Beutl.Configuration/GlobalConfiguration.cs
+++ b/src/Beutl.Configuration/GlobalConfiguration.cs
@@ -36,6 +36,8 @@ public sealed class GlobalConfiguration
     public BackupConfig BackupConfig { get; } = new();
     
     public TelemetryConfig TelemetryConfig { get; } = new();
+    
+    public EditorConfig EditorConfig { get; } = new();
 
     [AllowNull]
     public string LastStartedVersion { get; private set; } = GitVersionInformation.SemVer;
@@ -76,6 +78,10 @@ public sealed class GlobalConfiguration
             var telemetryNode = new JsonObject();
             TelemetryConfig.WriteToJson(telemetryNode);
             json["Telemetry"] = telemetryNode;
+            
+            var editorNode = new JsonObject();
+            EditorConfig.WriteToJson(editorNode);
+            json["Editor"] = editorNode;
 
             json.JsonSave(file);
         }
@@ -116,6 +122,9 @@ public sealed class GlobalConfiguration
                 
                 if (GetNode("telemetry", "Telemetry") is JsonObject telemetry)
                     TelemetryConfig.ReadFromJson(telemetry);
+                
+                if (json["Editor"] is JsonObject editor)
+                    EditorConfig.ReadFromJson(editor);
 
                 if (json["Version"] is JsonValue version)
                 {
@@ -144,6 +153,7 @@ public sealed class GlobalConfiguration
         ViewConfig.ConfigurationChanged += OnConfigurationChanged;
         ExtensionConfig.ConfigurationChanged += OnConfigurationChanged;
         TelemetryConfig.ConfigurationChanged += OnConfigurationChanged;
+        EditorConfig.ConfigurationChanged += OnConfigurationChanged;
     }
 
     private void RemoveHandlers()
@@ -153,6 +163,7 @@ public sealed class GlobalConfiguration
         ViewConfig.ConfigurationChanged -= OnConfigurationChanged;
         ExtensionConfig.ConfigurationChanged -= OnConfigurationChanged;
         TelemetryConfig.ConfigurationChanged -= OnConfigurationChanged;
+        EditorConfig.ConfigurationChanged -= OnConfigurationChanged;
     }
 
     private void OnConfigurationChanged(object? sender, EventArgs e)

--- a/src/Beutl.Language/SettingsPage.Designer.cs
+++ b/src/Beutl.Language/SettingsPage.Designer.cs
@@ -97,6 +97,24 @@ namespace Beutl.Language {
         }
         
         /// <summary>
+        ///   Automatically adjusts scene duration に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string AutoAdjustSceneDuration {
+            get {
+                return ResourceManager.GetString("AutoAdjustSceneDuration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   When elements are added, if the duration of the scene needs to be adjusted, it will automatically do so. に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string AutoAdjustSceneDuration_Description {
+            get {
+                return ResourceManager.GetString("AutoAdjustSceneDuration_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Change account settings に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string ChangeAccountSettings {

--- a/src/Beutl.Language/SettingsPage.ja.resx
+++ b/src/Beutl.Language/SettingsPage.ja.resx
@@ -273,4 +273,10 @@
   <data name="ShowExactBoundaries" xml:space="preserve">
     <value>正確な境界線を表示</value>
   </data>
+  <data name="AutoAdjustSceneDuration" xml:space="preserve">
+    <value>自動でシーンの長さを調整</value>
+  </data>
+  <data name="AutoAdjustSceneDuration_Description" xml:space="preserve">
+    <value>要素を追加したとき、シーンの長さを調整する必要がある場合、自動で調整します。</value>
+  </data>
 </root>

--- a/src/Beutl.Language/SettingsPage.resx
+++ b/src/Beutl.Language/SettingsPage.resx
@@ -273,4 +273,10 @@ Enabling this setting may make the border invisible.</value>
   <data name="ShowExactBoundaries" xml:space="preserve">
     <value>Display precise boundaries</value>
   </data>
+  <data name="AutoAdjustSceneDuration" xml:space="preserve">
+    <value>Automatically adjusts scene duration</value>
+  </data>
+  <data name="AutoAdjustSceneDuration_Description" xml:space="preserve">
+    <value>When elements are added, if the duration of the scene needs to be adjusted, it will automatically do so.</value>
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.Designer.cs
+++ b/src/Beutl.Language/Strings.Designer.cs
@@ -872,6 +872,15 @@ namespace Beutl.Language {
         }
         
         /// <summary>
+        ///   Editor に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string Editor {
+            get {
+                return ResourceManager.GetString("Editor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Editors に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string Editors {

--- a/src/Beutl.Language/Strings.Designer.cs
+++ b/src/Beutl.Language/Strings.Designer.cs
@@ -142,6 +142,24 @@ namespace Beutl.Language {
         }
         
         /// <summary>
+        ///   Adjust duration to current frame に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string AdjustDurationToCurrent {
+            get {
+                return ResourceManager.GetString("AdjustDurationToCurrent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Adjust duration to pointer position に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string AdjustDurationToPointer {
+            get {
+                return ResourceManager.GetString("AdjustDurationToPointer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Agree に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string Agree {

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -979,7 +979,7 @@ b-editorがダウンロードURLを管理します。</value>
   <data name="AdjustDurationToPointer" xml:space="preserve">
     <value>ポインターの位置に時間を調整</value>
   </data>
-  <data name="String1" xml:space="preserve">
-    <value />
+  <data name="Editor" xml:space="preserve">
+    <value>エディター</value>
   </data>
 </root>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -973,4 +973,13 @@ b-editorがダウンロードURLを管理します。</value>
   <data name="Hand" xml:space="preserve">
     <value>ハンド</value>
   </data>
+  <data name="AdjustDurationToCurrent" xml:space="preserve">
+    <value>現在の位置に時間を調整</value>
+  </data>
+  <data name="AdjustDurationToPointer" xml:space="preserve">
+    <value>ポインターの位置に時間を調整</value>
+  </data>
+  <data name="String1" xml:space="preserve">
+    <value />
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -973,4 +973,10 @@ and b-editor maintains the download URL.</value>
   <data name="Hand" xml:space="preserve">
     <value>Hand</value>
   </data>
+  <data name="AdjustDurationToCurrent" xml:space="preserve">
+    <value>Adjust duration to current frame</value>
+  </data>
+  <data name="AdjustDurationToPointer" xml:space="preserve">
+    <value>Adjust duration to pointer position</value>
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -979,4 +979,7 @@ and b-editor maintains the download URL.</value>
   <data name="AdjustDurationToPointer" xml:space="preserve">
     <value>Adjust duration to pointer position</value>
   </data>
+  <data name="Editor" xml:space="preserve">
+    <value>Editor</value>
+  </data>
 </root>

--- a/src/Beutl/Pages/SettingsPage.axaml.cs
+++ b/src/Beutl/Pages/SettingsPage.axaml.cs
@@ -89,6 +89,15 @@ public sealed partial class SettingsPage : UserControl
             },
             new NavigationViewItem()
             {
+                Content = Strings.Editor,
+                Tag = typeof(EditorSettingsPage),
+                IconSource = new SymbolIconSource
+                {
+                    Symbol = Symbol.Edit
+                }
+            },
+            new NavigationViewItem()
+            {
                 Content = Strings.Font,
                 Tag = typeof(FontSettingsPage),
                 IconSource = new SymbolIconSource
@@ -149,6 +158,7 @@ public sealed partial class SettingsPage : UserControl
             {
                 "AccountSettingsPage" => settingsPage.Account,
                 "ViewSettingsPage" => settingsPage.View,
+                "EditorSettingsPage" => settingsPage.Editor,
                 "FontSettingsPage" => settingsPage.Font,
                 "ExtensionsSettingsPage" => settingsPage.ExtensionsPage,
                 "StorageSettingsPage" => settingsPage.Storage,
@@ -186,6 +196,7 @@ public sealed partial class SettingsPage : UserControl
         {
             if (pagetype == typeof(AccountSettingsPage)
                 || pagetype == typeof(ViewSettingsPage)
+                || pagetype == typeof(EditorSettingsPage)
                 || pagetype == typeof(FontSettingsPage)
                 || pagetype == typeof(ExtensionsSettingsPage)
                 || pagetype == typeof(StorageSettingsPage)
@@ -212,10 +223,11 @@ public sealed partial class SettingsPage : UserControl
             {
                 "AccountSettingsPage" => 0,
                 "ViewSettingsPage" => 1,
-                "FontSettingsPage" => 2,
-                "ExtensionsSettingsPage" or "EditorExtensionPriorityPage" or "DecoderPriorityPage" => 3,
-                "StorageSettingsPage" or "StorageDetailPage" => 4,
-                "InfomationPage" or "TelemetrySettingsPage" => 5,
+                "EditorSettingsPage" => 2,
+                "FontSettingsPage" => 3,
+                "ExtensionsSettingsPage" or "EditorExtensionPriorityPage" or "DecoderPriorityPage" => 4,
+                "StorageSettingsPage" or "StorageDetailPage" => 5,
+                "InfomationPage" or "TelemetrySettingsPage" => 6,
                 _ => 0,
             };
         }
@@ -226,6 +238,7 @@ public sealed partial class SettingsPage : UserControl
             {
                 "AccountSettingsPageViewModel" => typeof(AccountSettingsPage),
                 "ViewSettingsPageViewModel" => typeof(ViewSettingsPage),
+                "EditorSettingsPageViewModel" => typeof(EditorSettingsPage),
                 "FontSettingsPageViewModel" => typeof(FontSettingsPage),
                 "ExtensionsSettingsPageViewModel" => typeof(ExtensionsSettingsPage),
                 "EditorExtensionPriorityPageViewModel" => typeof(EditorExtensionPriorityPage),

--- a/src/Beutl/Pages/SettingsPages/EditorSettingsPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/EditorSettingsPage.axaml
@@ -1,0 +1,37 @@
+<UserControl x:Class="Beutl.Pages.SettingsPages.EditorSettingsPage"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ctrls="using:Beutl.Controls"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:lang="using:Beutl.Language"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:ui="using:FluentAvalonia.UI.Controls"
+             xmlns:vm="using:Beutl.ViewModels.SettingsPages"
+             x:Name="root"
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             x:DataType="vm:EditorSettingsPageViewModel"
+             mc:Ignorable="d">
+    <Grid Margin="18" RowDefinitions="Auto,*">
+
+        <TextBlock Margin="10,8"
+                   Classes="breadcrumb"
+                   Text="{x:Static lang:Strings.Editor}" />
+
+        <ScrollViewer Grid.Row="1">
+            <StackPanel Margin="10,16,10,0"
+                        VerticalAlignment="Stretch"
+                        Orientation="Vertical"
+                        Spacing="4">
+                <ctrls:OptionsDisplayItem Description="{x:Static lang:SettingsPage.AutoAdjustSceneDuration_Description}" Header="{x:Static lang:SettingsPage.AutoAdjustSceneDuration}">
+                    <ctrls:OptionsDisplayItem.ActionButton>
+                        <ToggleSwitch Classes="left"
+                                      IsChecked="{CompiledBinding AutoAdjustSceneDuration.Value}"
+                                      Theme="{StaticResource CompactToggleSwitchStyle}" />
+                    </ctrls:OptionsDisplayItem.ActionButton>
+                </ctrls:OptionsDisplayItem>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+</UserControl>

--- a/src/Beutl/Pages/SettingsPages/EditorSettingsPage.axaml.cs
+++ b/src/Beutl/Pages/SettingsPages/EditorSettingsPage.axaml.cs
@@ -1,0 +1,16 @@
+﻿using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+using Beutl.ViewModels.SettingsPages;
+
+using FluentAvalonia.UI.Controls;
+
+namespace Beutl.Pages.SettingsPages;
+
+public sealed partial class EditorSettingsPage : UserControl
+{
+    public EditorSettingsPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Beutl/ViewModels/SettingsPageViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsPageViewModel.cs
@@ -12,6 +12,7 @@ public sealed class SettingsPageViewModel : IPageContext
     private readonly Lazy<AccountSettingsPageViewModel> _account;
     private readonly Lazy<StorageSettingsPageViewModel> _storage;
     private readonly Lazy<ViewSettingsPageViewModel> _view;
+    private readonly Lazy<EditorSettingsPageViewModel> _editor;
     private readonly Lazy<FontSettingsPageViewModel> _font;
     private readonly Lazy<ExtensionsSettingsPageViewModel> _extensionsPage;
     private readonly Lazy<InfomationPageViewModel> _infomation;
@@ -20,6 +21,7 @@ public sealed class SettingsPageViewModel : IPageContext
     {
         _account = new(() => new AccountSettingsPageViewModel(clients));
         _view = new(() => new ViewSettingsPageViewModel());
+        _editor = new(() => new EditorSettingsPageViewModel());
         _font = new(() => new FontSettingsPageViewModel());
         _extensionsPage = new(() => new ExtensionsSettingsPageViewModel());
         _storage = new(() => new StorageSettingsPageViewModel(clients.AuthorizedUser));
@@ -29,6 +31,8 @@ public sealed class SettingsPageViewModel : IPageContext
     public AccountSettingsPageViewModel Account => _account.Value;
 
     public ViewSettingsPageViewModel View => _view.Value;
+    
+    public EditorSettingsPageViewModel Editor => _editor.Value;
 
     public FontSettingsPageViewModel Font => _font.Value;
 

--- a/src/Beutl/ViewModels/SettingsPages/EditorSettingsPageViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsPages/EditorSettingsPageViewModel.cs
@@ -1,0 +1,20 @@
+﻿using Beutl.Configuration;
+
+using Reactive.Bindings;
+
+namespace Beutl.ViewModels.SettingsPages;
+
+public sealed class EditorSettingsPageViewModel
+{
+    private readonly EditorConfig _editorConfig;
+
+    public EditorSettingsPageViewModel()
+    {
+        _editorConfig = GlobalConfiguration.Instance.EditorConfig;
+
+        AutoAdjustSceneDuration = _editorConfig.GetObservable(EditorConfig.AutoAdjustSceneDurationProperty).ToReactiveProperty();
+        AutoAdjustSceneDuration.Subscribe(b => _editorConfig.AutoAdjustSceneDuration = b);
+    }
+
+    public ReactiveProperty<bool> AutoAdjustSceneDuration { get; }
+}

--- a/src/Beutl/ViewModels/TimelineViewModel.cs
+++ b/src/Beutl/ViewModels/TimelineViewModel.cs
@@ -9,6 +9,7 @@ using Avalonia.Input;
 using Avalonia.Input.Platform;
 
 using Beutl.Animation;
+using Beutl.Commands;
 using Beutl.Helpers;
 using Beutl.Media.Decoding;
 using Beutl.Media.Source;
@@ -111,6 +112,9 @@ public sealed class TimelineViewModel : IToolContext
             .DistinctUntilChanged()
             .Subscribe(TryApplyLayerCount);
 
+        AdjustDurationToPointer.Subscribe(OnAdjustDurationToPointer);
+        AdjustDurationToCurrent.Subscribe(OnAdjustDurationToCurrent);
+
         // Todo: 設定からショートカットを変更できるようにする。
         KeyBindings = new List<KeyBinding>();
         PlatformHotkeyConfiguration? keyConf = Application.Current?.PlatformSettings?.HotkeyConfiguration;
@@ -130,6 +134,24 @@ public sealed class TimelineViewModel : IToolContext
                 Gesture = new KeyGesture(Key.V, keyConf?.CommandModifiers ?? KeyModifiers.Control)
             });
         }
+    }
+
+    private void OnAdjustDurationToPointer()
+    {
+        int rate = Scene.FindHierarchicalParent<Project>().GetFrameRate();
+        TimeSpan time = ClickedFrame + TimeSpan.FromSeconds(1d / rate);
+
+        var command = new ChangePropertyCommand<TimeSpan>(Scene, Scene.DurationProperty, time, Scene.Duration);
+        command.DoAndRecord(CommandRecorder.Default);
+    }
+
+    private void OnAdjustDurationToCurrent()
+    {
+        int rate = Scene.FindHierarchicalParent<Project>().GetFrameRate();
+        TimeSpan time = Scene.CurrentFrame + TimeSpan.FromSeconds(1d / rate);
+
+        var command = new ChangePropertyCommand<TimeSpan>(Scene, Scene.DurationProperty, time, Scene.Duration);
+        command.DoAndRecord(CommandRecorder.Default);
     }
 
     public Scene Scene { get; private set; }
@@ -155,6 +177,10 @@ public sealed class TimelineViewModel : IToolContext
     public CoreList<LayerHeaderViewModel> LayerHeaders { get; } = new();
 
     public ReactiveCommand Paste { get; } = new();
+
+    public ReactiveCommandSlim AdjustDurationToPointer { get; } = new();
+
+    public ReactiveCommandSlim AdjustDurationToCurrent { get; } = new();
 
     public TimeSpan ClickedFrame { get; set; }
 

--- a/src/Beutl/ViewModels/TimelineViewModel.cs
+++ b/src/Beutl/ViewModels/TimelineViewModel.cs
@@ -10,6 +10,7 @@ using Avalonia.Input.Platform;
 
 using Beutl.Animation;
 using Beutl.Commands;
+using Beutl.Configuration;
 using Beutl.Helpers;
 using Beutl.Media.Decoding;
 using Beutl.Media.Source;
@@ -114,6 +115,10 @@ public sealed class TimelineViewModel : IToolContext
 
         AdjustDurationToPointer.Subscribe(OnAdjustDurationToPointer);
         AdjustDurationToCurrent.Subscribe(OnAdjustDurationToCurrent);
+        var editorConfig = GlobalConfiguration.Instance.EditorConfig;
+
+        AutoAdjustSceneDuration = editorConfig.GetObservable(EditorConfig.AutoAdjustSceneDurationProperty).ToReactiveProperty();
+        AutoAdjustSceneDuration.Subscribe(b => editorConfig.AutoAdjustSceneDuration = b);
 
         // Todo: 設定からショートカットを変更できるようにする。
         KeyBindings = new List<KeyBinding>();
@@ -181,6 +186,8 @@ public sealed class TimelineViewModel : IToolContext
     public ReactiveCommandSlim AdjustDurationToPointer { get; } = new();
 
     public ReactiveCommandSlim AdjustDurationToCurrent { get; } = new();
+
+    public ReactiveProperty<bool> AutoAdjustSceneDuration { get; }
 
     public TimeSpan ClickedFrame { get; set; }
 

--- a/src/Beutl/Views/ElementView.axaml
+++ b/src/Beutl/Views/ElementView.axaml
@@ -36,10 +36,6 @@
                 <Setter Property="BorderBrush" Value="{Binding RestBorderColor.Value, Converter={StaticResource ColorToBrushConverter}}" />
             </Style>
         </Border.Styles>
-        <Border.Resources>
-            <Thickness x:Key="MenuFlyoutItemPlaceholderThemeThickness">0,0,0,0</Thickness>
-            <Thickness x:Key="MenuFlyoutItemDoublePlaceholderThemeThickness">28,0,0,0</Thickness>
-        </Border.Resources>
         <Border.ContextFlyout>
             <ui:FAMenuFlyout>
                 <ui:MenuFlyoutItem Command="{Binding Split}" Text="{x:Static lang:Strings.Split}">

--- a/src/Beutl/Views/ElementView.axaml.cs
+++ b/src/Beutl/Views/ElementView.axaml.cs
@@ -505,7 +505,6 @@ public sealed partial class ElementView : UserControl
             if (AssociatedObject is { ViewModel: { } viewModel } view
                 && view._timeline is { } timeline && _pressed)
             {
-                Scene scene = viewModel.Scene;
                 Point point = e.GetPosition(view);
                 float scale = viewModel.Timeline.Options.Value.Scale;
                 TimeSpan pointerFrame = point.X.ToTimeSpan(scale);
@@ -514,7 +513,7 @@ public sealed partial class ElementView : UserControl
 
                 TimeSpan newframe = pointerFrame - _start.X.ToTimeSpan(scale);
 
-                newframe = TimeSpan.FromTicks(Math.Clamp(newframe.Ticks, TimeSpan.Zero.Ticks, scene.Duration.Ticks));
+                newframe = TimeSpan.FromTicks(Math.Max(newframe.Ticks, TimeSpan.Zero.Ticks));
 
                 var newTop = Math.Max(e.GetPosition(timeline.TimelinePanel).Y - _start.Y, 0);
                 var newLeft = newframe.ToPixel(scale);

--- a/src/Beutl/Views/Timeline.axaml
+++ b/src/Beutl/Views/Timeline.axaml
@@ -98,6 +98,8 @@
                     <ui:FAMenuFlyout>
                         <ui:MenuFlyoutItem Command="{Binding AdjustDurationToPointer}" Text="{x:Static lang:Strings.AdjustDurationToPointer}" />
                         <ui:MenuFlyoutItem Command="{Binding AdjustDurationToCurrent}" Text="{x:Static lang:Strings.AdjustDurationToCurrent}" />
+                        <ui:ToggleMenuFlyoutItem IsChecked="{Binding AutoAdjustSceneDuration.Value, Mode=TwoWay}" Text="{x:Static lang:SettingsPage.AutoAdjustSceneDuration}" />
+                        <ui:MenuFlyoutSeparator />
                         <ui:MenuFlyoutItem Click="AddElementClick" Text="{x:Static lang:Strings.AddElement}" />
                         <ui:MenuFlyoutItem Command="{CompiledBinding Paste}"
                                            InputGesture="{DynamicResource PasteKeyGesture}"

--- a/src/Beutl/Views/Timeline.axaml
+++ b/src/Beutl/Views/Timeline.axaml
@@ -96,6 +96,8 @@
                    PointerReleased="TimelinePanel_PointerReleased">
                 <Panel.ContextFlyout>
                     <ui:FAMenuFlyout>
+                        <ui:MenuFlyoutItem Command="{Binding AdjustDurationToPointer}" Text="{x:Static lang:Strings.AdjustDurationToPointer}" />
+                        <ui:MenuFlyoutItem Command="{Binding AdjustDurationToCurrent}" Text="{x:Static lang:Strings.AdjustDurationToCurrent}" />
                         <ui:MenuFlyoutItem Click="AddElementClick" Text="{x:Static lang:Strings.AddElement}" />
                         <ui:MenuFlyoutItem Command="{CompiledBinding Paste}"
                                            InputGesture="{DynamicResource PasteKeyGesture}"


### PR DESCRIPTION
<!-- 2-4は省略可 -->
## このプルリクエストで何をやったのか？
- 要素を移動、追加したときシーンの長さを変更するようにした
- コンテキストメニューから長さを変更できるようにした

## やらなかったこと

## できるようになること

## できなくなること

## 破壊的変更

## 廃止するApi
<!-- Obsolete属性を付けたApi -->

## リンクされたIsuues
- #734