### PR TITLE
Matrix.EqualsメソッドでSpanを使うかのベンチマークを追加

### DIFF
--- a/src/Beutl.Engine/Graphics/ColorMatrix.cs
+++ b/src/Beutl.Engine/Graphics/ColorMatrix.cs
@@ -47,17 +47,7 @@ public readonly struct ColorMatrix : IEquatable<ColorMatrix>
             0F, 0F, 1F, 0F, 0F,
             0F, 0F, 0F, 1F, 0F);
 
-    public bool IsIdentity
-    {
-        get
-        {
-            return
-                M11 == 1F && M12 == 0F && M13 == 0F && M14 == 0F && M15 == 0F &&
-                M21 == 0F && M22 == 1F && M23 == 0F && M24 == 0F && M25 == 0F &&
-                M31 == 0F && M32 == 0F && M33 == 1F && M34 == 0F && M35 == 0F &&
-                M41 == 0F && M42 == 0F && M43 == 0F && M44 == 1F && M45 == 0F;
-        }
-    }
+    public bool IsIdentity => Equals(Identity);
 
     public float M11 { get; }
 

--- a/src/Beutl.Engine/Graphics/Matrix.cs
+++ b/src/Beutl.Engine/Graphics/Matrix.cs
@@ -1,9 +1,6 @@
 ﻿using System.ComponentModel;
-using System.ComponentModel.Design;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
-using System.Runtime.CompilerServices;
-using System.Runtime.Intrinsics;
 using System.Text.Json.Serialization;
 
 using Beutl.Converters;
@@ -352,22 +349,17 @@ public readonly struct Matrix
     /// </summary>
     /// <param name="other">The other matrix to test equality against.</param>
     /// <returns>True if this matrix is equal to other; False otherwise.</returns>
-    public unsafe bool Equals(Matrix other)
+    public bool Equals(Matrix other)
     {
-        // Todo: Benchmark
-        var thisSpan = new Span<float>(Unsafe.AsPointer(ref Unsafe.AsRef(in this)), 9);
-        var otherSpan = new Span<float>(Unsafe.AsPointer(ref Unsafe.AsRef(in other)), 9);
-        return thisSpan.SequenceEqual(otherSpan);
-
-        //return M11 == other.M11 &&
-        //       M12 == other.M12 &&
-        //       M13 == other.M13 &&
-        //       M21 == other.M21 &&
-        //       M22 == other.M22 &&
-        //       M23 == other.M23 &&
-        //       M31 == other.M31 &&
-        //       M32 == other.M32 &&
-        //       M33 == other.M33;
+        return M11 == other.M11 &&
+               M12 == other.M12 &&
+               M13 == other.M13 &&
+               M21 == other.M21 &&
+               M22 == other.M22 &&
+               M23 == other.M23 &&
+               M31 == other.M31 &&
+               M32 == other.M32 &&
+               M33 == other.M33;
     }
 
     /// <summary>

--- a/tests/Beutl.Benchmarks/Beutl.Benchmarks.csproj
+++ b/tests/Beutl.Benchmarks/Beutl.Benchmarks.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Beutl.Benchmarks/MatrixEqualityCompareBench.cs
+++ b/tests/Beutl.Benchmarks/MatrixEqualityCompareBench.cs
@@ -1,0 +1,43 @@
+﻿
+using System.Runtime.CompilerServices;
+
+using BenchmarkDotNet.Attributes;
+
+using Beutl.Graphics;
+
+// Equalのほうが早い
+public class MatrixEqualityCompareBench
+{
+    [Benchmark]
+    public unsafe void SequenceEqual()
+    {
+        Matrix left = Matrix.Identity;
+        Matrix right = Matrix.Identity;
+        for (int i = 0; i < 50000; i++)
+        {
+            var leftSpan = new Span<float>(Unsafe.AsPointer(ref Unsafe.AsRef(in left)), 9);
+            var rightSpan = new Span<float>(Unsafe.AsPointer(ref Unsafe.AsRef(in right)), 9);
+            _ = leftSpan.SequenceEqual(rightSpan);
+        }
+    }
+
+    [Benchmark]
+    public void Equal()
+    {
+        Matrix left = Matrix.Identity;
+        Matrix right = Matrix.Identity;
+        for (int i = 0; i < 50000; i++)
+        {
+            _ = left.M11 == right.M11 &&
+                left.M12 == right.M12 &&
+                left.M13 == right.M13 &&
+                left.M21 == right.M21 &&
+                left.M22 == right.M22 &&
+                left.M23 == right.M23 &&
+                left.M31 == right.M31 &&
+                left.M32 == right.M32 &&
+                left.M33 == right.M33;
+        }
+    }
+
+}

--- a/tests/Beutl.Benchmarks/Program.cs
+++ b/tests/Beutl.Benchmarks/Program.cs
@@ -1,3 +1,3 @@
 ﻿using BenchmarkDotNet.Running;
 
-BenchmarkRunner.Run<EnumToStringBenchmark>();
+BenchmarkRunner.Run<MatrixEqualityCompareBench>();


### PR DESCRIPTION
<!-- 2-4は省略可 -->
## このプルリクエストで何をやったのか？
- Matrix.EqualsメソッドでSpanを使うかのベンチマークを追加
- Span.SequenceEqualを使わないほうが高速だったので、使わないようにした。

## やらなかったこと

## できるようになること

## できなくなること

## 破壊的変更

## 廃止するApi
<!-- Obsolete属性を付けたApi -->

## リンクされたIsuues
