### PR TITLE
MediaReaderを共有せずにそれぞれが所有するようにした

### DIFF
--- a/src/Beutl.Engine/Media/Source/BitmapSource.cs
+++ b/src/Beutl.Engine/Media/Source/BitmapSource.cs
@@ -1,5 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 
+using Beutl.Media.Pixel;
+
 namespace Beutl.Media.Source;
 
 public sealed class BitmapSource : ImageSource
@@ -18,6 +20,26 @@ public sealed class BitmapSource : ImageSource
     public override string Name { get; }
 
     public override bool IsGenerated => true;
+
+    public static BitmapSource Open(string fileName)
+    {
+        var bitmap = Bitmap<Bgra8888>.FromFile(fileName);
+        return new BitmapSource(Ref<IBitmap>.Create(bitmap), fileName);
+    }
+
+    public static bool TryOpen(string fileName, out BitmapSource? result)
+    {
+        try
+        {
+            result = Open(fileName);
+            return true;
+        }
+        catch
+        {
+            result = null;
+            return false;
+        }
+    }
 
     public override IImageSource Clone()
     {

--- a/src/Beutl.Engine/Media/Source/ImageSourceJsonConverter.cs
+++ b/src/Beutl.Engine/Media/Source/ImageSourceJsonConverter.cs
@@ -9,7 +9,7 @@ public sealed class ImageSourceJsonConverter : JsonConverter<IImageSource?>
     {
         string? s = reader.GetString();
 
-        return s != null && MediaSourceManager.Shared.OpenImageSource(s, out var imageSource)
+        return s != null && BitmapSource.TryOpen(s, out var imageSource)
             ? imageSource
             : null;
     }

--- a/src/Beutl.Engine/Media/Source/MediaSourceManager.cs
+++ b/src/Beutl.Engine/Media/Source/MediaSourceManager.cs
@@ -6,6 +6,8 @@ using Beutl.Media.Pixel;
 
 namespace Beutl.Media.Source;
 
+[EditorBrowsable(EditorBrowsableState.Never)]
+[Obsolete("Use the Open method of each MediaSource.")]
 public class MediaSourceManager
 {
     public static readonly MediaSourceManager Shared = new();
@@ -46,14 +48,12 @@ public class MediaSourceManager
         return value != null;
     }
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("Do not use.")]
     public bool TryGetMediaReader(string name, [NotNullWhen(true)] out Ref<MediaReader>? value)
     {
         return TryGetMediaReaderOrOpen(name, out value);
     }
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("Do not use.")]
     public bool TryGetMediaReaderOrOpen(string fileName, [NotNullWhen(true)] out Ref<MediaReader>? value)
     {
@@ -70,14 +70,12 @@ public class MediaSourceManager
         }
     }
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("Do not use.")]
     public bool TryGetBitmap(string name, [NotNullWhen(true)] out Ref<IBitmap>? value)
     {
         return TryGetBitmapOrOpen(name, out value);
     }
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("Do not use.")]
     public bool TryGetBitmapOrOpen(string fileName, [NotNullWhen(true)] out Ref<IBitmap>? value)
     {
@@ -96,7 +94,6 @@ public class MediaSourceManager
     }
 
     // 移譲する側は今後、valueを直接参照しない。
-    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("Do not use.")]
     public Ref<MediaReader>? TryTransferMediaReader(string name, MediaReader mediaReader)
     {
@@ -104,7 +101,6 @@ public class MediaSourceManager
     }
 
     // 移譲する側は今後、valueを直接参照しない。
-    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("Do not use.")]
     public Ref<IBitmap>? TryTransferBitmap(string name, IBitmap bitmap)
     {

--- a/src/Beutl.Engine/Media/Source/MediaSourceManager.cs
+++ b/src/Beutl.Engine/Media/Source/MediaSourceManager.cs
@@ -8,11 +8,9 @@ namespace Beutl.Media.Source;
 
 public class MediaSourceManager
 {
-    private readonly Dictionary<string, WeakReference<Ref<MediaReader>>> _mediaReaders = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, WeakReference<Ref<IBitmap>>> _bitmaps = new(StringComparer.Ordinal);
-
     public static readonly MediaSourceManager Shared = new();
 
+    [Obsolete("Use VideoSource.Open")]
     public bool OpenVideoSource(string name, [NotNullWhen(true)] out IVideoSource? value)
     {
         value = null;
@@ -24,6 +22,7 @@ public class MediaSourceManager
         return value != null;
     }
 
+    [Obsolete("Use SoundSource.Open")]
     public bool OpenSoundSource(string name, [NotNullWhen(true)] out ISoundSource? value)
     {
         value = null;
@@ -35,6 +34,7 @@ public class MediaSourceManager
         return value != null;
     }
 
+    [Obsolete("Use BitmapSource.Open")]
     public bool OpenImageSource(string name, [NotNullWhen(true)] out IImageSource? value)
     {
         value = null;
@@ -47,130 +47,79 @@ public class MediaSourceManager
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Do not use.")]
     public bool TryGetMediaReader(string name, [NotNullWhen(true)] out Ref<MediaReader>? value)
     {
-        value = null;
-        if (_mediaReaders.TryGetValue(name, out WeakReference<Ref<MediaReader>>? result)
-            && result.TryGetTarget(out Ref<MediaReader>? @ref)
-            && @ref.Value != null)
-        {
-            value = @ref.Clone();
-        }
-
-        return value != null;
+        return TryGetMediaReaderOrOpen(name, out value);
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Do not use.")]
     public bool TryGetMediaReaderOrOpen(string fileName, [NotNullWhen(true)] out Ref<MediaReader>? value)
     {
-        value = null;
-        if (_mediaReaders.TryGetValue(fileName, out WeakReference<Ref<MediaReader>>? result)
-            && result.TryGetTarget(out Ref<MediaReader>? @ref)
-            && @ref.Value != null)
+        try
         {
-            value = @ref.Clone();
+            var reader = MediaReader.Open(fileName);
+            value = Ref<MediaReader>.Create(reader);
+            return true;
         }
-        else
+        catch
         {
-            try
-            {
-                var reader = MediaReader.Open(fileName);
-
-                value = Ref<MediaReader>.Create(reader, () => _mediaReaders.Remove(fileName));
-                _mediaReaders[fileName] = new WeakReference<Ref<MediaReader>>(value);
-            }
-            catch
-            {
-            }
+            value = null;
+            return false;
         }
-
-        return value != null;
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Do not use.")]
     public bool TryGetBitmap(string name, [NotNullWhen(true)] out Ref<IBitmap>? value)
     {
-        value = null;
-        if (_bitmaps.TryGetValue(name, out WeakReference<Ref<IBitmap>>? result)
-            && result.TryGetTarget(out Ref<IBitmap>? @ref)
-            && @ref.Value != null)
-        {
-            value = @ref.Clone();
-        }
-
-        return value != null;
+        return TryGetBitmapOrOpen(name, out value);
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Do not use.")]
     public bool TryGetBitmapOrOpen(string fileName, [NotNullWhen(true)] out Ref<IBitmap>? value)
     {
-        value = null;
-        if (_bitmaps.TryGetValue(fileName, out WeakReference<Ref<IBitmap>>? result)
-            && result.TryGetTarget(out Ref<IBitmap>? @ref)
-            && @ref.Value != null)
+        try
         {
-            value = @ref.Clone();
+            var bitmap = Bitmap<Bgra8888>.FromFile(fileName);
+            value = Ref<IBitmap>.Create(bitmap);
+            return true;
         }
-        else
+        catch
         {
-            try
-            {
-                var bitmap = Bitmap<Bgra8888>.FromFile(fileName);
-
-                value = Ref<IBitmap>.Create(bitmap, () => _bitmaps.Remove(fileName));
-                _bitmaps[fileName] = new WeakReference<Ref<IBitmap>>(value);
-            }
-            catch
-            {
-            }
+            value = null;
+            return false;
         }
 
-        return value != null;
     }
 
     // 移譲する側は今後、valueを直接参照しない。
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Do not use.")]
     public Ref<MediaReader>? TryTransferMediaReader(string name, MediaReader mediaReader)
     {
-        if (mediaReader.IsDisposed
-            || _mediaReaders.ContainsKey(name)
-            || _mediaReaders.Values.Any(x => x.TryGetTarget(out Ref<MediaReader>? @ref) && @ref.RefCount > 0 && ReferenceEquals(@ref.Value, mediaReader)))
-        {
-            return null;
-        }
-        else
-        {
-            var @ref = Ref<MediaReader>.Create(mediaReader, () => _mediaReaders.Remove(name));
-            _mediaReaders[name] = new WeakReference<Ref<MediaReader>>(@ref);
-            return @ref;
-        }
+        return Ref<MediaReader>.Create(mediaReader);
     }
 
     // 移譲する側は今後、valueを直接参照しない。
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Do not use.")]
     public Ref<IBitmap>? TryTransferBitmap(string name, IBitmap bitmap)
     {
-        if (bitmap.IsDisposed
-            || _bitmaps.ContainsKey(name)
-            || _bitmaps.Values.Any(x => x.TryGetTarget(out Ref<IBitmap>? @ref) && @ref.RefCount > 0 && ReferenceEquals(@ref.Value, bitmap)))
-        {
-            return null;
-        }
-        else
-        {
-            var @ref = Ref<IBitmap>.Create(bitmap, () => _bitmaps.Remove(name));
-            _bitmaps[name] = new WeakReference<Ref<IBitmap>>(@ref);
-            return @ref;
-        }
+        return Ref<IBitmap>.Create(bitmap);
     }
 
+    [Obsolete("Do not use.")]
     public bool ContainsMediaReader(string name)
     {
-        return _mediaReaders.ContainsKey(name);
+        return false;
     }
 
+    [Obsolete("Do not use.")]
     public bool ContainsBitmap(string name)
     {
-        return _bitmaps.ContainsKey(name);
+        return false;
     }
 }

--- a/src/Beutl.Engine/Media/Source/SoundSource.cs
+++ b/src/Beutl.Engine/Media/Source/SoundSource.cs
@@ -33,6 +33,26 @@ public class SoundSource : ISoundSource
 
     public string Name { get; }
 
+    public static SoundSource Open(string fileName)
+    {
+        var reader = MediaReader.Open(fileName, new(MediaMode.Audio));
+        return new SoundSource(Ref<MediaReader>.Create(reader), fileName);
+    }
+
+    public static bool TryOpen(string fileName, out SoundSource? result)
+    {
+        try
+        {
+            result = Open(fileName);
+            return true;
+        }
+        catch
+        {
+            result = null;
+            return false;
+        }
+    }
+
     public void Dispose()
     {
         if (!IsDisposed)

--- a/src/Beutl.Engine/Media/Source/SoundSourceJsonConverter.cs
+++ b/src/Beutl.Engine/Media/Source/SoundSourceJsonConverter.cs
@@ -9,7 +9,7 @@ public sealed class SoundSourceJsonConverter : JsonConverter<ISoundSource?>
     {
         string? s = reader.GetString();
         
-        return s != null && MediaSourceManager.Shared.OpenSoundSource(s, out var soundSource)
+        return s != null && SoundSource.TryOpen(s, out var soundSource)
             ? soundSource
             : null;
     }

--- a/src/Beutl.Engine/Media/Source/VideoSource.cs
+++ b/src/Beutl.Engine/Media/Source/VideoSource.cs
@@ -25,7 +25,7 @@ public sealed class VideoSource : IVideoSource
     }
 
     public TimeSpan Duration { get; }
-    
+
     public Rational FrameRate { get; }
 
     public PixelSize FrameSize { get; }
@@ -33,6 +33,26 @@ public sealed class VideoSource : IVideoSource
     public bool IsDisposed { get; private set; }
 
     public string Name { get; }
+
+    public static VideoSource Open(string fileName)
+    {
+        var reader = MediaReader.Open(fileName, new(MediaMode.Video));
+        return new VideoSource(Ref<MediaReader>.Create(reader), fileName);
+    }
+
+    public static bool TryOpen(string fileName, out VideoSource? result)
+    {
+        try
+        {
+            result = Open(fileName);
+            return true;
+        }
+        catch
+        {
+            result = null;
+            return false;
+        }
+    }
 
     public void Dispose()
     {
@@ -63,7 +83,7 @@ public sealed class VideoSource : IVideoSource
         double frameNum = frame.TotalSeconds * _frameRate;
         return _mediaReader.Value.ReadVideo((int)frameNum, out bitmap);
     }
-    
+
     public bool Read(int frame, [NotNullWhen(true)] out IBitmap? bitmap)
     {
         if (IsDisposed)

--- a/src/Beutl.Engine/Media/Source/VideoSourceJsonConverter.cs
+++ b/src/Beutl.Engine/Media/Source/VideoSourceJsonConverter.cs
@@ -9,7 +9,7 @@ public sealed class VideoSourceJsonConverter : JsonConverter<IVideoSource?>
     {
         string? s = reader.GetString();
         
-        return s != null && MediaSourceManager.Shared.OpenVideoSource(s, out var videoSource)
+        return s != null && VideoSource.TryOpen(s, out var videoSource)
             ? videoSource
             : null;
     }

--- a/src/Beutl.Operators/Source/SourceImageOperator.cs
+++ b/src/Beutl.Operators/Source/SourceImageOperator.cs
@@ -43,7 +43,7 @@ public sealed class SourceImageOperator : DrawablePublishOperator<SourceImage>
         base.OnAttachedToHierarchy(args);
         if (Source is { Value: null } setter
             && _sourceName != null
-            && MediaSourceManager.Shared.OpenImageSource(_sourceName, out IImageSource? imageSource))
+            && BitmapSource.TryOpen(_sourceName, out BitmapSource? imageSource))
         {
             setter.Value = imageSource;
         }

--- a/src/Beutl.Operators/Source/SourceVideoOperator.cs
+++ b/src/Beutl.Operators/Source/SourceVideoOperator.cs
@@ -49,7 +49,7 @@ public sealed class SourceVideoOperator : DrawablePublishOperator<SourceVideo>
         base.OnAttachedToHierarchy(args);
         if (Source is { Value: null } setter
             && _sourceName != null
-            && MediaSourceManager.Shared.OpenVideoSource(_sourceName, out IVideoSource? videoSource))
+            && VideoSource.TryOpen(_sourceName, out VideoSource? videoSource))
         {
             setter.Value = videoSource;
         }

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -527,7 +527,7 @@ public sealed class EditViewModel : IEditorContext, ITimelineOptionsProvider, IS
             if (MatchFileImage(desc.FileName))
             {
                 Element element = CreateElementFor(out SourceImageOperator t);
-                MediaSourceManager.Shared.OpenImageSource(desc.FileName, out IImageSource? image);
+                BitmapSource.TryOpen(desc.FileName, out BitmapSource? image);
                 t.Source.Value = image;
 
                 element.Save(element.FileName);
@@ -538,8 +538,8 @@ public sealed class EditViewModel : IEditorContext, ITimelineOptionsProvider, IS
                 Element element1 = CreateElementFor(out SourceVideoOperator t1);
                 Element element2 = CreateElementFor(out SourceSoundOperator t2);
                 element2.ZIndex++;
-                MediaSourceManager.Shared.OpenVideoSource(desc.FileName, out IVideoSource? video);
-                MediaSourceManager.Shared.OpenSoundSource(desc.FileName, out ISoundSource? sound);
+                VideoSource.TryOpen(desc.FileName, out VideoSource? video);
+                SoundSource.TryOpen(desc.FileName, out SoundSource? sound);
                 t1.Source.Value = video;
                 t2.Source.Value = sound;
 
@@ -556,7 +556,7 @@ public sealed class EditViewModel : IEditorContext, ITimelineOptionsProvider, IS
             else if (MatchFileAudioOnly(desc.FileName))
             {
                 Element element = CreateElementFor(out SourceSoundOperator t);
-                MediaSourceManager.Shared.OpenSoundSource(desc.FileName, out ISoundSource? sound);
+                SoundSource.TryOpen(desc.FileName, out SoundSource? sound);
                 t.Source.Value = sound;
                 if (sound != null)
                 {

--- a/src/Beutl/ViewModels/Editors/ImageSourceEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/ImageSourceEditorViewModel.cs
@@ -53,7 +53,8 @@ public sealed class ImageSourceEditorViewModel : ValueEditorViewModel<IImageSour
         {
             if (_newValue == null && _newName != null)
             {
-                MediaSourceManager.Shared.OpenImageSource(_newName, out _newValue);
+                BitmapSource.TryOpen(_newName, out BitmapSource? newValue);
+                _newValue = newValue;
             }
 
             _keyframe.SetValue(KeyFrame<IImageSource?>.ValueProperty, _newValue);
@@ -70,7 +71,8 @@ public sealed class ImageSourceEditorViewModel : ValueEditorViewModel<IImageSour
         {
             if (_oldValue == null && _oldName != null)
             {
-                MediaSourceManager.Shared.OpenImageSource(_oldName, out _oldValue);
+                BitmapSource.TryOpen(_oldName, out BitmapSource? oldValue);
+                _oldValue = oldValue;
             }
 
             _keyframe.SetValue(KeyFrame<IImageSource?>.ValueProperty, _oldValue);
@@ -100,7 +102,8 @@ public sealed class ImageSourceEditorViewModel : ValueEditorViewModel<IImageSour
         {
             if (_newValue == null && _newName != null)
             {
-                MediaSourceManager.Shared.OpenImageSource(_newName, out _newValue);
+                BitmapSource.TryOpen(_newName, out BitmapSource? newValue);
+                _newValue = newValue;
             }
 
             _setter.SetValue(_newValue);
@@ -117,7 +120,8 @@ public sealed class ImageSourceEditorViewModel : ValueEditorViewModel<IImageSour
         {
             if (_oldValue == null && _oldName != null)
             {
-                MediaSourceManager.Shared.OpenImageSource(_oldName, out _oldValue);
+                BitmapSource.TryOpen(_oldName, out BitmapSource? oldValue);
+                _oldValue = oldValue;
             }
 
             _setter.SetValue(_oldValue);

--- a/src/Beutl/ViewModels/Editors/SoundSourceEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/SoundSourceEditorViewModel.cs
@@ -53,7 +53,8 @@ public sealed class SoundSourceEditorViewModel : ValueEditorViewModel<ISoundSour
         {
             if (_newValue == null && _newName != null)
             {
-                MediaSourceManager.Shared.OpenSoundSource(_newName, out _newValue);
+                SoundSource.TryOpen(_newName, out SoundSource? newValue);
+                _newValue = newValue;
             }
 
             _keyframe.SetValue(KeyFrame<ISoundSource?>.ValueProperty, _newValue);
@@ -70,7 +71,8 @@ public sealed class SoundSourceEditorViewModel : ValueEditorViewModel<ISoundSour
         {
             if (_oldValue == null && _oldName != null)
             {
-                MediaSourceManager.Shared.OpenSoundSource(_oldName, out _oldValue);
+                SoundSource.TryOpen(_oldName, out SoundSource? oldValue);
+                _oldValue = oldValue;
             }
 
             _keyframe.SetValue(KeyFrame<ISoundSource?>.ValueProperty, _oldValue);
@@ -100,7 +102,8 @@ public sealed class SoundSourceEditorViewModel : ValueEditorViewModel<ISoundSour
         {
             if (_newValue == null && _newName != null)
             {
-                MediaSourceManager.Shared.OpenSoundSource(_newName, out _newValue);
+                SoundSource.TryOpen(_newName, out SoundSource? newValue);
+                _newValue = newValue;
             }
 
             _setter.SetValue(_newValue);
@@ -117,7 +120,8 @@ public sealed class SoundSourceEditorViewModel : ValueEditorViewModel<ISoundSour
         {
             if (_oldValue == null && _oldName != null)
             {
-                MediaSourceManager.Shared.OpenSoundSource(_oldName, out _oldValue);
+                SoundSource.TryOpen(_oldName, out SoundSource? oldValue);
+                _oldValue = oldValue;
             }
 
             _setter.SetValue(_oldValue);

--- a/src/Beutl/ViewModels/Editors/VideoSourceEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/VideoSourceEditorViewModel.cs
@@ -53,7 +53,8 @@ public sealed class VideoSourceEditorViewModel : ValueEditorViewModel<IVideoSour
         {
             if (_newValue == null && _newName != null)
             {
-                MediaSourceManager.Shared.OpenVideoSource(_newName, out _newValue);
+                VideoSource.TryOpen(_newName, out VideoSource? newValue);
+                _newValue = newValue;
             }
 
             _keyframe.SetValue(KeyFrame<IVideoSource?>.ValueProperty, _newValue);
@@ -70,7 +71,8 @@ public sealed class VideoSourceEditorViewModel : ValueEditorViewModel<IVideoSour
         {
             if (_oldValue == null && _oldName != null)
             {
-                MediaSourceManager.Shared.OpenVideoSource(_oldName, out _oldValue);
+                VideoSource.TryOpen(_oldName, out VideoSource? oldValue);
+                _oldValue = oldValue;
             }
 
             _keyframe.SetValue(KeyFrame<IVideoSource?>.ValueProperty, _oldValue);
@@ -100,7 +102,8 @@ public sealed class VideoSourceEditorViewModel : ValueEditorViewModel<IVideoSour
         {
             if (_newValue == null && _newName != null)
             {
-                MediaSourceManager.Shared.OpenVideoSource(_newName, out _newValue);
+                VideoSource.TryOpen(_newName, out VideoSource? newValue);
+                _newValue = newValue;
             }
 
             _setter.SetValue(_newValue);
@@ -117,7 +120,8 @@ public sealed class VideoSourceEditorViewModel : ValueEditorViewModel<IVideoSour
         {
             if (_oldValue == null && _oldName != null)
             {
-                MediaSourceManager.Shared.OpenVideoSource(_oldName, out _oldValue);
+                VideoSource.TryOpen(_oldName, out VideoSource? oldValue);
+                _oldValue = oldValue;
             }
 
             _setter.SetValue(_oldValue);

--- a/src/Beutl/Views/Editors/ImageSourceEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/ImageSourceEditor.axaml.cs
@@ -21,7 +21,7 @@ public partial class ImageSourceEditor : UserControl
         IReadOnlyList<IStorageFile> result = await topLevel.StorageProvider.OpenFilePickerAsync(SharedFilePickerOptions.OpenImage());
         if (result.Count > 0
             && result[0].TryGetLocalPath() is string localPath
-            && MediaSourceManager.Shared.OpenImageSource(localPath, out IImageSource? imageSource))
+            && BitmapSource.TryOpen(localPath, out BitmapSource? imageSource))
         {
             IImageSource? oldValue = vm.WrappedProperty.GetValue();
             vm.SetValueAndDispose(oldValue, imageSource);

--- a/src/Beutl/Views/Editors/SoundSourceEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/SoundSourceEditor.axaml.cs
@@ -82,7 +82,7 @@ public partial class SoundSourceEditor : UserControl
             IReadOnlyList<IStorageFile> result = await topLevel.StorageProvider.OpenFilePickerAsync(options);
             if (result.Count > 0
                 && result[0].TryGetLocalPath() is string localPath
-                && MediaSourceManager.Shared.OpenSoundSource(localPath, out ISoundSource? soundSource))
+                && SoundSource.TryOpen(localPath, out SoundSource? soundSource))
             {
                 ISoundSource? oldValue = vm.WrappedProperty.GetValue();
                 vm.SetValueAndDispose(oldValue, soundSource);

--- a/src/Beutl/Views/Editors/VideoSourceEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/VideoSourceEditor.axaml.cs
@@ -82,7 +82,7 @@ public partial class VideoSourceEditor : UserControl
             IReadOnlyList<IStorageFile> result = await topLevel.StorageProvider.OpenFilePickerAsync(options);
             if (result.Count > 0
                 && result[0].TryGetLocalPath() is string localPath
-                && MediaSourceManager.Shared.OpenVideoSource(localPath, out IVideoSource? videoSource))
+                && VideoSource.TryOpen(localPath, out VideoSource? videoSource))
             {
                 IVideoSource? oldValue = vm.WrappedProperty.GetValue();
                 vm.SetValueAndDispose(oldValue, videoSource);


### PR DESCRIPTION
<!-- 2-4は省略可 -->
## このプルリクエストで何をやったのか？
同じファイルで既にMediaReaderを開いている場合、それを共有していた。

しかし、動画と音声を同時に再生すると音声は先行して読み取り、動画は一フレームずつ読み取るので、後ろ向きにシークする必要がある。

このシークが遅いので別々にMediaReaderを持つようにした。

## 廃止するApi
- MediaSourceManager

## リンクされたIsuues
- #733