### PR TITLE
`GradientStops`のエディタを改善

### DIFF
--- a/src/Beutl/Helpers/ColorGenerator.cs
+++ b/src/Beutl/Helpers/ColorGenerator.cs
@@ -1,7 +1,10 @@
-﻿using System.Security.Cryptography;
+﻿using System.Numerics;
+using System.Security.Cryptography;
 using System.Text;
 
 using Avalonia.Media;
+
+using Beutl.Utilities;
 
 namespace Beutl.Helpers;
 
@@ -48,5 +51,53 @@ public static class ColorGenerator
         }
 
         return color;
+    }
+
+    // https://github.com/google/skia/blob/0d39172f35d259b6ab888974177bc4e6d839d44c/src/effects/SkHighContrastFilter.cpp
+    public static Color GetTextColor(Color color)
+    {
+        static Vector3 Mix(Vector3 x, Vector3 y, float a)
+        {
+            return (x * (1 - a)) + (y * a);
+        }
+
+        static Vector3 Saturate(Vector3 a)
+        {
+            return Vector3.Clamp(a, new(0), new(1));
+        }
+
+        static Color ToColor(Vector3 vector)
+        {
+            return new(255, (byte)(vector.X * 255), (byte)(vector.Y * 255), (byte)(vector.Z * 255));
+        }
+
+        static Vector3 ToVector3(Color color)
+        {
+            return new Vector3(color.R / 255f, color.G / 255f, color.B / 255f);
+        }
+
+        // 計算機イプシロン
+        // 'float.Epsilon'は使わないで
+        const float Epsilon = MathUtilities.FloatEpsilon;
+        float contrast = 1.0f;
+        contrast = Math.Max(-1.0f + Epsilon, Math.Min(contrast, +1.0f - Epsilon));
+
+        contrast = (1.0f + contrast) / (1.0f - contrast);
+
+        Vector3 c = ToVector3(color);
+        float grayscale = Vector3.Dot(new(0.2126f, 0.7152f, 0.0722f), c);
+        c = new Vector3(grayscale);
+
+        // brightness
+        //c = Vector3.One - c;
+
+        //lightness
+        HslColor hsl = ToColor(c).ToHsl();
+        c = ToVector3(HslColor.ToRgb(hsl.H, hsl.S, 1 - hsl.L, hsl.A));
+
+        c = Mix(new Vector3(0.5f), c, contrast);
+        c = Saturate(c);
+
+        return ToColor(c);
     }
 }

--- a/src/Beutl/ViewModels/Editors/GradientStopsEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/GradientStopsEditorViewModel.cs
@@ -71,9 +71,26 @@ public class GradientStopsEditorViewModel : BaseEditorViewModel<GradientStops>
             }
 
             if (!MathUtilities.AreClose(model.Offset, oldOffset2))
-            //if (model.Offset != oldOffset2)
             {
                 var tmp = new ChangePropertyCommand<float>(model, GradientStop.OffsetProperty, newOffset, oldOffset2);
+                command = command == null ? tmp : command.Append(tmp);
+            }
+
+            GradientStop? prev = index > 0 ? Value.Value[index - 1] : null;
+            GradientStop? next = index + 1 < Value.Value.Count ? Value.Value[index + 1] : null;
+
+            if (prev != null && model.Offset < prev.Offset)
+            {
+                IRecordableCommand tmp = Value.Value.BeginRecord<GradientStop>()
+                    .Move(index, index - 1)
+                    .ToCommand();
+                command = command == null ? tmp : command.Append(tmp);
+            }
+            else if (next != null && next.Offset < model.Offset)
+            {
+                IRecordableCommand tmp = Value.Value.BeginRecord<GradientStop>()
+                    .Move(index, index + 1)
+                    .ToCommand();
                 command = command == null ? tmp : command.Append(tmp);
             }
 

--- a/src/Beutl/ViewModels/ElementViewModel.cs
+++ b/src/Beutl/ViewModels/ElementViewModel.cs
@@ -6,6 +6,7 @@ using Avalonia.Input;
 using Avalonia.Input.Platform;
 
 using Beutl.Commands;
+using Beutl.Helpers;
 using Beutl.Models;
 using Beutl.ProjectSystem;
 using Beutl.Services;
@@ -70,7 +71,7 @@ public sealed class ElementViewModel : IDisposable
         RestBorderColor = Color.Select(v => (Avalonia.Media.Color)((Color2)v).LightenPercent(-0.15f))
             .ToReadOnlyReactivePropertySlim()!;
 
-        TextColor = Color.Select(GetTextColor)
+        TextColor = Color.Select(ColorGenerator.GetTextColor)
             .ToReadOnlyReactivePropertySlim()
             .AddTo(_disposables);
 
@@ -424,54 +425,6 @@ public sealed class ElementViewModel : IDisposable
         }
 
         return list;
-    }
-
-    // https://github.com/google/skia/blob/0d39172f35d259b6ab888974177bc4e6d839d44c/src/effects/SkHighContrastFilter.cpp
-    private Avalonia.Media.Color GetTextColor(Avalonia.Media.Color color)
-    {
-        static Vector3 Mix(Vector3 x, Vector3 y, float a)
-        {
-            return (x * (1 - a)) + (y * a);
-        }
-
-        static Vector3 Saturate(Vector3 a)
-        {
-            return Vector3.Clamp(a, new(0), new(1));
-        }
-
-        static Avalonia.Media.Color ToColor(Vector3 vector)
-        {
-            return new(255, (byte)(vector.X * 255), (byte)(vector.Y * 255), (byte)(vector.Z * 255));
-        }
-
-        static Vector3 ToVector3(Avalonia.Media.Color color)
-        {
-            return new Vector3(color.R / 255f, color.G / 255f, color.B / 255f);
-        }
-
-        // 計算機イプシロン
-        // 'float.Epsilon'は使わないで
-        const float Epsilon = MathUtilities.FloatEpsilon;
-        float contrast = 1.0f;
-        contrast = Math.Max(-1.0f + Epsilon, Math.Min(contrast, +1.0f - Epsilon));
-
-        contrast = (1.0f + contrast) / (1.0f - contrast);
-
-        Vector3 c = ToVector3(color);
-        float grayscale = Vector3.Dot(new(0.2126f, 0.7152f, 0.0722f), c);
-        c = new Vector3(grayscale);
-
-        // brightness
-        //c = Vector3.One - c;
-
-        //lightness
-        HslColor hsl = ToColor(c).ToHsl();
-        c = ToVector3(HslColor.ToRgb(hsl.H, hsl.S, 1 - hsl.L, hsl.A));
-
-        c = Mix(new Vector3(0.5f), c, contrast);
-        c = Saturate(c);
-
-        return ToColor(c);
     }
 
     public bool HasOriginalLength()

--- a/src/Beutl/Views/Editors/GradientStopsEditor.axaml
+++ b/src/Beutl/Views/Editors/GradientStopsEditor.axaml
@@ -6,12 +6,13 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:vm="using:Beutl.ViewModels.Editors"
+             Padding="4,0"
              d:DesignWidth="300"
              x:CompileBindings="True"
              x:DataType="vm:GradientStopsEditorViewModel"
              mc:Ignorable="d">
     <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto,Auto">
-        <TextBlock Margin="8,0,0,0"
+        <TextBlock Margin="4,0,0,0"
                    HorizontalAlignment="Left"
                    VerticalAlignment="Top"
                    Text="{Binding Header}" />
@@ -19,7 +20,7 @@
         <Border x:Name="border"
                 Grid.Row="1"
                 Height="20"
-                Margin="8,0"
+                Margin="4,0"
                 CornerRadius="10">
             <Border.Background>
                 <LinearGradientBrush GradientStops="{Binding Stops}" StartPoint="0%,50%" EndPoint="100%,50%" />
@@ -28,7 +29,7 @@
         <ItemsControl x:Name="items"
                       Grid.Row="1"
                       Height="20"
-                      Margin="8,0"
+                      Margin="4,0"
                       ClipToBounds="False"
                       IsEnabled="{Binding CanEdit.Value}"
                       ItemsSource="{Binding Stops}">
@@ -75,8 +76,8 @@
                     IsEnabled="{Binding SelectedItem.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
                     Orientation="Horizontal"
                     Spacing="4">
-            <Button Width="35"
-                    Height="35"
+            <Button Width="37"
+                    Height="37"
                     Click="Delete_Click">
                 <ui:SymbolIcon FontSize="16" Symbol="Delete" />
             </Button>

--- a/src/Beutl/Views/Editors/GradientStopsEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/GradientStopsEditor.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia.Interactivity;
 using Avalonia.Media.Immutable;
 using Avalonia.Media.Transformation;
 
+using Beutl.Helpers;
 using Beutl.Utilities;
 using Beutl.ViewModels.Editors;
 
@@ -29,7 +30,7 @@ public sealed partial class GradientStopsEditor : UserControl
         Resources["ColorToBrush"] = new FuncValueConverter<AM.Color, ImmutableSolidColorBrush>(
             x => new ImmutableSolidColorBrush(x));
         Resources["ColorToBorderBrush"] = new FuncValueConverter<AM.Color, ImmutableSolidColorBrush>(
-            x => new ImmutableSolidColorBrush(((FAM.Color2)x).Lightnessf > 0.5f ? AM.Colors.Gray : AM.Colors.White));
+            x => new ImmutableSolidColorBrush(ColorGenerator.GetTextColor(x)));
         InitializeComponent();
 
         colorPicker.FlyoutConfirmed += ColorPicker_FlyoutConfirmed;


### PR DESCRIPTION
<!-- 2-4は省略可 -->
## このプルリクエストで何をやったのか？
GradientStopsEditorでグレーを選択したとき、ボーダーと同じ色になるのを防いだ。
Offsetが前後で順番通りに並んでいない場合、入れ替えるようにした。