### PR TITLE
`Vector4Editor`の操作中に例外が発生するのを修正

### DIFF
--- a/src/Beutl.Controls/PropertyEditors/Vector2Editor.cs
+++ b/src/Beutl.Controls/PropertyEditors/Vector2Editor.cs
@@ -121,7 +121,7 @@ public class Vector2Editor<TElement> : Vector2Editor
 
     private void OnTextBlockPointerMoved(object sender, PointerEventArgs e)
     {
-        if (!(InnerFirstTextBox.IsKeyboardFocusWithin || InnerSecondTextBox.IsKeyboardFocusWithin)
+        if (!(InnerFirstTextBox.IsKeyboardFocusWithin || InnerSecondTextBox?.IsKeyboardFocusWithin == true)
             && _headerPressed
             && sender is TextBlock headerText)
         {

--- a/src/Beutl.Controls/PropertyEditors/Vector3Editor.cs
+++ b/src/Beutl.Controls/PropertyEditors/Vector3Editor.cs
@@ -147,8 +147,8 @@ public class Vector3Editor<TElement> : Vector3Editor
     private void OnTextBlockPointerMoved(object sender, PointerEventArgs e)
     {
         if (!(InnerFirstTextBox.IsKeyboardFocusWithin
-            || InnerSecondTextBox.IsKeyboardFocusWithin
-            || InnerThirdTextBox.IsKeyboardFocusWithin)
+            || InnerSecondTextBox?.IsKeyboardFocusWithin == true
+            || InnerThirdTextBox?.IsKeyboardFocusWithin == true)
             && _headerPressed
             && sender is TextBlock headerText)
         {

--- a/src/Beutl.Controls/PropertyEditors/Vector4Editor.cs
+++ b/src/Beutl.Controls/PropertyEditors/Vector4Editor.cs
@@ -172,9 +172,9 @@ public class Vector4Editor<TElement> : Vector4Editor
     private void OnTextBlockPointerMoved(object sender, PointerEventArgs e)
     {
         if (!(InnerFirstTextBox.IsKeyboardFocusWithin
-            || InnerSecondTextBox.IsKeyboardFocusWithin
-            || InnerThirdTextBox.IsKeyboardFocusWithin
-            || InnerFourthTextBox.IsKeyboardFocusWithin)
+            || InnerSecondTextBox?.IsKeyboardFocusWithin == true
+            || InnerThirdTextBox?.IsKeyboardFocusWithin == true
+            || InnerFourthTextBox?.IsKeyboardFocusWithin == true)
             && _headerPressed)
         {
             Point point = e.GetPosition(_headerText);


### PR DESCRIPTION
<!-- 2-4は省略可 -->
## このプルリクエストで何をやったのか？
- `Vector4Editor`, `Vector3Editor`, `Vector2Editor` の操作中に例外が発生するのを修正

## やらなかったこと

## できるようになること

## できなくなること

## 破壊的変更

## 廃止するApi
<!-- Obsolete属性を付けたApi -->

## リンクされたIsuues
#868 