### PR TITLE
`AuthorizedUser.RefreshAsync`で`user.json`が変更されている場合、自動で再読み込みするようにした

### DIFF
--- a/src/Beutl.Api/Objects/AuthorizedUser.cs
+++ b/src/Beutl.Api/Objects/AuthorizedUser.cs
@@ -1,17 +1,25 @@
 ﻿using System.Diagnostics;
 using System.Net.Http.Headers;
 
+using Beutl.Api.Services;
+
 namespace Beutl.Api.Objects;
 
-public class AuthorizedUser(Profile profile, AuthResponse response, BeutlApiApplication clients, HttpClient httpClient)
+public class AuthorizedUser(
+    Profile profile, AuthResponse response,
+    BeutlApiApplication clients, HttpClient httpClient, DateTime writeTime)
 {
+    private AuthResponse _response = response;
+    // user.jsonに書き込まれた時間
+    internal DateTime _writeTime = writeTime;
+
     public Profile Profile { get; } = profile;
 
-    public string Token => response.Token;
+    public string Token => _response.Token;
 
-    public string RefreshToken => response.Refresh_token;
+    public string RefreshToken => _response.Refresh_token;
 
-    public DateTimeOffset Expiration => response.Expiration;
+    public DateTimeOffset Expiration => _response.Expiration;
 
     public bool IsExpired => Expiration < DateTimeOffset.UtcNow;
 
@@ -21,12 +29,41 @@ public class AuthorizedUser(Profile profile, AuthResponse response, BeutlApiAppl
     {
         using Activity? activity = clients.ActivitySource.StartActivity("AuthorizedUser.Refresh", ActivityKind.Client);
 
+        string fileName = Path.Combine(Helper.AppRoot, "user.json");
+        if (File.Exists(fileName))
+        {
+            DateTime lastWriteTime = File.GetLastWriteTimeUtc(fileName);
+            if (_writeTime < lastWriteTime)
+            {
+                AuthorizedUser? fileUser = await clients.ReadUserAsync();
+                if (fileUser?.Profile?.Id == Profile.Id)
+                {
+                    _response = fileUser._response;
+                    _writeTime = lastWriteTime;
+                }
+                else if (fileUser != null)
+                {
+                    clients.SignOut(false);
+                    throw new BeutlApiException<ApiErrorResponse>(
+                        message: "The user may have been changed in another process.",
+                        statusCode: 401,
+                        response: "",
+                        headers: new Dictionary<string, IEnumerable<string>>(),
+                        result: new ApiErrorResponse(
+                            documentation_url: "",
+                            error_code: ApiErrorCode.Unknown,
+                            message: "The user may have been changed in another process."),
+                        innerException: null);
+                }
+            }
+        }
+
         activity?.SetTag("force", force);
         activity?.SetTag("is_expired", IsExpired);
 
         if (force || IsExpired)
         {
-            response = await clients.Account.RefreshAsync(new RefeshTokenRequest(RefreshToken, Token))
+            _response = await clients.Account.RefreshAsync(new RefeshTokenRequest(RefreshToken, Token))
                 .ConfigureAwait(false);
             activity?.AddEvent(new("Refreshed"));
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);

--- a/src/Beutl/ViewModels/SettingsPages/AccountSettingsPageViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsPages/AccountSettingsPageViewModel.cs
@@ -62,7 +62,7 @@ public sealed class AccountSettingsPageViewModel : BasePageViewModel
             .DisposeWith(_disposables);
 
         SignOut = new ReactiveCommand(SignedIn);
-        SignOut.Subscribe(_clients.SignOut).DisposeWith(_disposables);
+        SignOut.Subscribe(() => _clients.SignOut()).DisposeWith(_disposables);
 
         OpenAccountSettings = new();
         OpenAccountSettings.Subscribe(BeutlApiApplication.OpenAccountSettings);


### PR DESCRIPTION
<!-- 2-4は省略可 -->
## このプルリクエストで何をやったのか？

## やらなかったこと

## できるようになること

## できなくなること

## 破壊的変更

## 廃止するApi
<!-- Obsolete属性を付けたApi -->

## リンクされたIsuues
- #897