### PR TITLE
Windowsでのメモリサイズの取得にSystem.Managementを使うようにした

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -73,6 +73,7 @@
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Interactive" Version="6.0.1" />
     <PackageVersion Include="System.Interactive.Async" Version="6.0.1" />
+    <PackageVersion Include="System.Management" Version="8.0.0" />
     <PackageVersion Include="System.Reactive" Version="6.0.0" />
     <PackageVersion Include="Vortice.XAudio2" Version="3.3.4" />
   </ItemGroup>

--- a/src/Beutl.Configuration/Beutl.Configuration.csproj
+++ b/src/Beutl.Configuration/Beutl.Configuration.csproj
@@ -1,5 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <PackageReference Include="System.Management" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Beutl.Core\Beutl.Core.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
<!-- 2-4は省略可 -->
## このプルリクエストで何をやったのか？
メモリサイズの取得に非推奨[^1]の`wmic`コマンドを使っていたので、`System.Management`を使うようにした

[^1]: [WMIC: WMI コマンド ライン ユーティリティ](https://learn.microsoft.com/ja-jp/windows/win32/wmisdk/wmic)

## やらなかったこと

## できるようになること

## できなくなること

## 破壊的変更

## 廃止するApi
<!-- Obsolete属性を付けたApi -->

## リンクされたIsuues
