### PR TITLE
描画品質を改善

### DIFF
--- a/src/Beutl.Core/Reactive/DisposableExtension.cs
+++ b/src/Beutl.Core/Reactive/DisposableExtension.cs
@@ -9,51 +9,51 @@ public static class DisposableExtension
         return disposable;
     }
 
-    public static void DisposeAll<T1, T2>(in this ValueTuple<T1, T2> tuple)
+    public static void DisposeAll<T1, T2>(in this ValueTuple<T1?, T2?> tuple)
         where T1 : IDisposable
         where T2 : IDisposable
     {
-        tuple.Item1.Dispose();
-        tuple.Item2.Dispose();
+        tuple.Item1?.Dispose();
+        tuple.Item2?.Dispose();
     }
 
-    public static void DisposeAll<T1, T2, T3>(in this ValueTuple<T1, T2, T3> tuple)
+    public static void DisposeAll<T1, T2, T3>(in this ValueTuple<T1?, T2?, T3?> tuple)
         where T1 : IDisposable
         where T2 : IDisposable
         where T3 : IDisposable
     {
-        tuple.Item1.Dispose();
-        tuple.Item2.Dispose();
-        tuple.Item3.Dispose();
+        tuple.Item1?.Dispose();
+        tuple.Item2?.Dispose();
+        tuple.Item3?.Dispose();
     }
 
-    public static void DisposeAll<T1, T2, T3, T4>(in this ValueTuple<T1, T2, T3, T4> tuple)
+    public static void DisposeAll<T1, T2, T3, T4>(in this ValueTuple<T1?, T2?, T3?, T4?> tuple)
         where T1 : IDisposable
         where T2 : IDisposable
         where T3 : IDisposable
         where T4 : IDisposable
     {
-        tuple.Item1.Dispose();
-        tuple.Item2.Dispose();
-        tuple.Item3.Dispose();
-        tuple.Item4.Dispose();
+        tuple.Item1?.Dispose();
+        tuple.Item2?.Dispose();
+        tuple.Item3?.Dispose();
+        tuple.Item4?.Dispose();
     }
 
-    public static void DisposeAll<T1, T2, T3, T4, T5>(in this ValueTuple<T1, T2, T3, T4, T5> tuple)
+    public static void DisposeAll<T1, T2, T3, T4, T5>(in this ValueTuple<T1?, T2?, T3?, T4?, T5?> tuple)
         where T1 : IDisposable
         where T2 : IDisposable
         where T3 : IDisposable
         where T4 : IDisposable
         where T5 : IDisposable
     {
-        tuple.Item1.Dispose();
-        tuple.Item2.Dispose();
-        tuple.Item3.Dispose();
-        tuple.Item4.Dispose();
-        tuple.Item5.Dispose();
+        tuple.Item1?.Dispose();
+        tuple.Item2?.Dispose();
+        tuple.Item3?.Dispose();
+        tuple.Item4?.Dispose();
+        tuple.Item5?.Dispose();
     }
 
-    public static void DisposeAll<T1, T2, T3, T4, T5, T6>(in this ValueTuple<T1, T2, T3, T4, T5, T6> tuple)
+    public static void DisposeAll<T1, T2, T3, T4, T5, T6>(in this ValueTuple<T1?, T2?, T3?, T4?, T5?, T6?> tuple)
         where T1 : IDisposable
         where T2 : IDisposable
         where T3 : IDisposable
@@ -61,15 +61,15 @@ public static class DisposableExtension
         where T5 : IDisposable
         where T6 : IDisposable
     {
-        tuple.Item1.Dispose();
-        tuple.Item2.Dispose();
-        tuple.Item3.Dispose();
-        tuple.Item4.Dispose();
-        tuple.Item5.Dispose();
-        tuple.Item6.Dispose();
+        tuple.Item1?.Dispose();
+        tuple.Item2?.Dispose();
+        tuple.Item3?.Dispose();
+        tuple.Item4?.Dispose();
+        tuple.Item5?.Dispose();
+        tuple.Item6?.Dispose();
     }
 
-    public static void DisposeAll<T1, T2, T3, T4, T5, T6, T7>(in this ValueTuple<T1, T2, T3, T4, T5, T6, T7> tuple)
+    public static void DisposeAll<T1, T2, T3, T4, T5, T6, T7>(in this ValueTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?> tuple)
         where T1 : IDisposable
         where T2 : IDisposable
         where T3 : IDisposable
@@ -78,12 +78,12 @@ public static class DisposableExtension
         where T6 : IDisposable
         where T7 : IDisposable
     {
-        tuple.Item1.Dispose();
-        tuple.Item2.Dispose();
-        tuple.Item3.Dispose();
-        tuple.Item4.Dispose();
-        tuple.Item5.Dispose();
-        tuple.Item6.Dispose();
-        tuple.Item7.Dispose();
+        tuple.Item1?.Dispose();
+        tuple.Item2?.Dispose();
+        tuple.Item3?.Dispose();
+        tuple.Item4?.Dispose();
+        tuple.Item5?.Dispose();
+        tuple.Item6?.Dispose();
+        tuple.Item7?.Dispose();
     }
 }

--- a/src/Beutl.Engine/Graphics/BrushConstructor.cs
+++ b/src/Beutl.Engine/Graphics/BrushConstructor.cs
@@ -22,6 +22,9 @@ public readonly struct BrushConstructor(Size targetSize, IBrush? brush, BlendMod
         float opacity = (Brush?.Opacity ?? 0) / 100f;
         paint.IsAntialias = true;
         paint.BlendMode = (SKBlendMode)BlendMode;
+        paint.HintingLevel = SKPaintHinting.Full;
+        paint.LcdRenderText = true;
+        paint.SubpixelText = true;
 
         paint.Color = new SKColor(255, 255, 255, (byte)(255 * opacity));
 

--- a/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
+++ b/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
@@ -379,22 +379,20 @@ public partial class ImmediateCanvas : ICanvas, IImmediateCanvasFactory
     {
         VerifyAccess();
 
-        var typeface = new Typeface(text.Font, text.Style, text.Weight);
-        SKTypeface sktypeface = typeface.ToSkia();
-        _sharedFillPaint.Reset();
-        _sharedFillPaint.TextSize = text.Size;
-        _sharedFillPaint.Typeface = sktypeface;
+        using SKFont font = text.ToSKFont();
 
-        using var shaper = new SKShaper(sktypeface);
+        using var shaper = new SKShaper(font.Typeface);
         using var buffer = new HarfBuzzSharp.Buffer();
         buffer.AddUtf16(text.Text.AsSpan());
         buffer.GuessSegmentProperties();
 
+        _sharedFillPaint.Reset();
+        _sharedFillPaint.TextSize = text.Size;
+        _sharedFillPaint.Typeface = font.Typeface;
         SKShaper.Result result = shaper.Shape(buffer, _sharedFillPaint);
 
         // create the text blob
         using var builder = new SKTextBlobBuilder();
-        using SKFont font = _sharedFillPaint.ToFont();
         SKPositionedRunBuffer run = builder.AllocatePositionedRun(font, result.Codepoints.Length);
 
         // copy the glyphs

--- a/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
+++ b/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
@@ -328,50 +328,32 @@ public partial class ImmediateCanvas : ICanvas, IImmediateCanvasFactory
         }
     }
 
-    private static SKPath CreateSKPathFromText(ReadOnlySpan<ushort> glyphs, ReadOnlySpan<SKPoint> positions, SKFont font)
+    private void DrawTextStroke(FormattedText text, IPen pen)
     {
-        var path = new SKPath();
+        ConfigureStrokePaint(new(text.Bounds.Size), pen!);
+        _sharedStrokePaint.IsStroke = false;
+        SKPath filled = text.GetFillPath()!;
+        SKPath stroke = text.GetStrokePath()!;
 
-        for (int i = 0; i < glyphs.Length; i++)
+        switch (pen!.StrokeAlignment)
         {
-            ushort glyph = glyphs[i];
-            SKPoint point = positions[i];
+            case StrokeAlignment.Center:
+                Canvas.DrawPath(stroke, _sharedStrokePaint);
+                break;
 
-            using SKPath glyphPath = font.GetGlyphPath(glyph);
-            path.AddPath(glyphPath, point.X, point.Y);
-        }
+            case StrokeAlignment.Inside:
+                Canvas.Save();
+                Canvas.ClipPath(filled, SKClipOperation.Intersect, true);
+                Canvas.DrawPath(stroke, _sharedStrokePaint);
+                Canvas.Restore();
+                break;
 
-        return path;
-    }
-
-    private void DrawTextStroke(FormattedText text, IPen pen, SKTextBlob textBlob,
-        ReadOnlySpan<ushort> glyphs, ReadOnlySpan<SKPoint> positions, SKFont font)
-    {
-        ConfigureStrokePaint(new(text.Bounds), pen!);
-        if (pen.StrokeAlignment == StrokeAlignment.Center)
-        {
-            Canvas.DrawText(textBlob, 0, 0, _sharedStrokePaint);
-        }
-        else
-        {
-            using SKPath path = CreateSKPathFromText(glyphs, positions, font);
-
-            switch (pen!.StrokeAlignment)
-            {
-                case StrokeAlignment.Inside:
-                    Canvas.Save();
-                    Canvas.ClipPath(path, SKClipOperation.Intersect, true);
-                    Canvas.DrawText(textBlob, 0, 0, _sharedStrokePaint);
-                    Canvas.Restore();
-                    break;
-
-                case StrokeAlignment.Outside:
-                    Canvas.Save();
-                    Canvas.ClipPath(path, SKClipOperation.Difference, true);
-                    Canvas.DrawText(textBlob, 0, 0, _sharedStrokePaint);
-                    Canvas.Restore();
-                    break;
-            }
+            case StrokeAlignment.Outside:
+                Canvas.Save();
+                Canvas.ClipPath(filled, SKClipOperation.Difference, true);
+                Canvas.DrawPath(stroke, _sharedStrokePaint);
+                Canvas.Restore();
+                break;
         }
     }
 
@@ -379,44 +361,16 @@ public partial class ImmediateCanvas : ICanvas, IImmediateCanvasFactory
     {
         VerifyAccess();
 
-        using SKFont font = text.ToSKFont();
-
-        using var shaper = new SKShaper(font.Typeface);
-        using var buffer = new HarfBuzzSharp.Buffer();
-        buffer.AddUtf16(text.Text.AsSpan());
-        buffer.GuessSegmentProperties();
-
-        _sharedFillPaint.Reset();
-        _sharedFillPaint.TextSize = text.Size;
-        _sharedFillPaint.Typeface = font.Typeface;
-        SKShaper.Result result = shaper.Shape(buffer, _sharedFillPaint);
-
-        // create the text blob
-        using var builder = new SKTextBlobBuilder();
-        SKPositionedRunBuffer run = builder.AllocatePositionedRun(font, result.Codepoints.Length);
-
-        // copy the glyphs
-        Span<ushort> glyphs = run.GetGlyphSpan();
-        Span<SKPoint> positions = run.GetPositionSpan();
-        for (int i = 0; i < result.Codepoints.Length; i++)
-        {
-            glyphs[i] = (ushort)result.Codepoints[i];
-            SKPoint point = result.Points[i];
-            point.X += i * text.Spacing;
-            positions[i] = point;
-        }
-
-        // build
-        using SKTextBlob textBlob = builder.Build();
+        SKPath filled = text.GetFillPath()!;
 
         // draw filled
-        ConfigureFillPaint(text.Bounds, fill);
-        Canvas.DrawText(textBlob, 0, 0, _sharedFillPaint);
+        ConfigureFillPaint(text.Bounds.Size, fill);
+        Canvas.DrawPath(filled, _sharedFillPaint);
 
         // draw stroke
-        if (pen != null && pen.Thickness != 0)
+        if (pen != null && pen.Thickness > 0)
         {
-            DrawTextStroke(text, pen, textBlob, glyphs, positions, font);
+            DrawTextStroke(text, pen);
         }
     }
 

--- a/src/Beutl.Engine/Graphics/Rendering/PenHelper.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/PenHelper.cs
@@ -1,6 +1,10 @@
 ﻿using Beutl.Media;
 using Beutl.Utilities;
 
+using SkiaSharp;
+
+using PathOptions = (float Thickness, Beutl.Media.StrokeAlignment Alignment, Beutl.Media.StrokeCap StrokeCap, Beutl.Media.StrokeJoin StrokeJoin, float MiterLimit);
+
 namespace Beutl.Graphics.Rendering;
 
 internal static class PenHelper
@@ -43,5 +47,133 @@ internal static class PenHelper
             StrokeCap.Square => rect.Inflate(pen.Thickness),
             _ => rect,
         };
+    }
+
+    public static void ConfigureStrokePaint(
+        IPen pen,
+        SKPaint paint, Size size)
+    {
+        float thickness = pen.Thickness;
+        switch (pen.StrokeAlignment)
+        {
+            case StrokeAlignment.Outside:
+                thickness *= 2;
+                break;
+
+            case StrokeAlignment.Inside:
+                thickness *= 2;
+                float maxAspect = Math.Max(size.Width, size.Height);
+                thickness = Math.Min(thickness, maxAspect);
+                break;
+
+            default:
+                break;
+        }
+
+        paint.IsStroke = true;
+        paint.StrokeWidth = thickness;
+        paint.StrokeCap = (SKStrokeCap)pen.StrokeCap;
+        paint.StrokeJoin = (SKStrokeJoin)pen.StrokeJoin;
+        paint.StrokeMiter = pen.MiterLimit;
+        if (pen.DashArray != null && pen.DashArray.Count > 0)
+        {
+            IReadOnlyList<float> srcDashes = pen.DashArray;
+
+            int count = srcDashes.Count % 2 == 0 ? srcDashes.Count : srcDashes.Count * 2;
+
+            float[] dashesArray = new float[count];
+
+            for (int i = 0; i < count; ++i)
+            {
+                dashesArray[i] = (float)srcDashes[i % srcDashes.Count] * thickness;
+            }
+
+            float offset = (float)(pen.DashOffset * thickness);
+
+            var pe = SKPathEffect.CreateDash(dashesArray, offset);
+
+            paint.PathEffect = pe;
+        }
+    }
+
+    public static SKPath CreateStrokePath(SKPath fillPath, IPen pen, Rect bounds)
+    {
+        var strokePath = new SKPath();
+
+        using (var paint = new SKPaint())
+        {
+            ConfigureStrokePaint(pen, paint, bounds.Size);
+
+            void CreateStrokePath(SKPath strokePath, SKPaint paint)
+            {
+                float thickness = paint.StrokeWidth;
+                float maxAspect = Math.Max(bounds.Width, bounds.Height);
+                if (maxAspect < thickness)
+                {
+                    paint.StrokeWidth = maxAspect;
+                    bool first = true;
+
+                    while (maxAspect < thickness)
+                    {
+                        using SKPath tmp = paint.GetFillPath(first ? fillPath : strokePath);
+                        if (!first)
+                        {
+                            using (var copy = new SKPath(strokePath))
+                                tmp.Op(copy, SKPathOp.Union, strokePath);
+                        }
+                        else
+                        {
+                            strokePath.AddPath(tmp);
+                            first = false;
+                        }
+
+                        thickness -= maxAspect;
+                    }
+
+                    if (thickness > 0)
+                    {
+                        paint.StrokeWidth = thickness;
+                        using SKPath tmp2 = paint.GetFillPath(strokePath);
+                        using var copy = new SKPath(strokePath);
+                        tmp2.Op(copy, SKPathOp.Union, strokePath);
+                    }
+                }
+                else
+                {
+                    paint.GetFillPath(fillPath, strokePath);
+                }
+            }
+
+            switch (pen.StrokeAlignment)
+            {
+                case StrokeAlignment.Center:
+                    CreateStrokePath(strokePath, paint);
+                    break;
+
+                case StrokeAlignment.Outside:
+                    CreateStrokePath(strokePath, paint);
+
+                    using (var strokePathCopy = new SKPath(strokePath))
+                    {
+                        strokePathCopy.Op(fillPath, SKPathOp.Difference, strokePath);
+                    }
+
+                    break;
+
+                case StrokeAlignment.Inside:
+                    paint.GetFillPath(fillPath, strokePath);
+
+                    using (var strokePathCopy = new SKPath(strokePath))
+                    {
+                        strokePathCopy.Op(fillPath, SKPathOp.Intersect, strokePath);
+                    }
+
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        return strokePath;
     }
 }

--- a/src/Beutl.Engine/Graphics/Rendering/TextNode.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/TextNode.cs
@@ -5,7 +5,7 @@ namespace Beutl.Graphics.Rendering;
 
 // Todo: bounds,HitTest
 public sealed class TextNode(FormattedText text, IBrush? fill, IPen? pen)
-    : BrushDrawNode(fill, pen, new(new Point(0, text.Metrics.Ascent), text.Bounds))
+    : BrushDrawNode(fill, pen, PenHelper.CalculateBoundsWithStrokeCap(PenHelper.GetBounds(new(new Point(0, text.Metrics.Ascent), text.Bounds), pen), pen))
 {
     public FormattedText Text { get; private set; } = text;
 

--- a/src/Beutl.Engine/Graphics/Rendering/TextNode.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/TextNode.cs
@@ -1,9 +1,10 @@
 ﻿using Beutl.Media;
 using Beutl.Media.TextFormatting;
 
+using SkiaSharp;
+
 namespace Beutl.Graphics.Rendering;
 
-// Todo: bounds,HitTest
 public sealed class TextNode(FormattedText text, IBrush? fill, IPen? pen)
     : BrushDrawNode(fill, pen, text.ActualBounds)
 {
@@ -23,6 +24,13 @@ public sealed class TextNode(FormattedText text, IBrush? fill, IPen? pen)
 
     public override bool HitTest(Point point)
     {
-        return Bounds.ContainsExclusive(point);
+        SKPath fill = Text.GetFillPath();
+        if (Fill != null && fill.Contains(point.X, point.Y))
+        {
+            return true;
+        }
+
+        SKPath? stroke = Text.GetStrokePath();
+        return stroke?.Contains(point.X, point.Y) == true;
     }
 }

--- a/src/Beutl.Engine/Graphics/Rendering/TextNode.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/TextNode.cs
@@ -5,7 +5,7 @@ namespace Beutl.Graphics.Rendering;
 
 // Todo: bounds,HitTest
 public sealed class TextNode(FormattedText text, IBrush? fill, IPen? pen)
-    : BrushDrawNode(fill, pen, PenHelper.CalculateBoundsWithStrokeCap(PenHelper.GetBounds(new(new Point(0, text.Metrics.Ascent), text.Bounds), pen), pen))
+    : BrushDrawNode(fill, pen, text.ActualBounds)
 {
     public FormattedText Text { get; private set; } = text;
 

--- a/src/Beutl.Engine/Graphics/Shapes/TextElement.cs
+++ b/src/Beutl.Engine/Graphics/Shapes/TextElement.cs
@@ -30,7 +30,6 @@ public class TextElement : Animatable, IAffectsRender
     private IBrush? _brush;
     private IPen? _pen = null;
     private bool _ignoreLineBreaks;
-    private FormattedText _formattedText;
 
     static TextElement()
     {
@@ -154,7 +153,7 @@ public class TextElement : Animatable, IAffectsRender
                     newBrush.Invalidated += OnAffectsRenderInvalidated;
 
                 goto RaiseInvalidated;
-                
+
             case nameof(Pen) when args is CorePropertyChangedEventArgs<IPen?> args2:
                 if (args2.OldValue is IAffectsRender oldPen)
                     oldPen.Invalidated -= OnAffectsRenderInvalidated;
@@ -201,8 +200,8 @@ public class TextElement : Animatable, IAffectsRender
 
             if (isReturnCode || isLast)
             {
-                ref FormattedText item = ref span[ii];
-                SetFields(ref item, new StringSpan(_text, prevIdx, (isReturnCode ? i : nextIdx) - prevIdx));
+                FormattedText item = span[ii];
+                SetFields(item, new StringSpan(_text, prevIdx, (isReturnCode ? i : nextIdx) - prevIdx));
                 item.BeginOnNewLine = nextReturn;
                 nextReturn = !_ignoreLineBreaks && isReturnCode;
 
@@ -237,7 +236,7 @@ public class TextElement : Animatable, IAffectsRender
             bool isReturnCode = c is '\n' or '\r';
             bool isLast = nextIdx == _text.Length;
 
-            if (isReturnCode | isLast)
+            if (isReturnCode || isLast)
             {
                 if (c is '\r'
                     && nextIdx < _text.Length
@@ -253,18 +252,16 @@ public class TextElement : Animatable, IAffectsRender
         return count;
     }
 
-    private void SetFields(ref FormattedText text, StringSpan s)
+    private void SetFields(FormattedText text, StringSpan s)
     {
-        _formattedText.Weight = _fontWeight;
-        _formattedText.Style = _fontStyle;
-        _formattedText.Font = _fontFamily;
-        _formattedText.Size = _size;
-        _formattedText.Spacing = _spacing;
-        _formattedText.Text = s;
-        _formattedText.Brush = Brush;
-        _formattedText.Pen = Pen;
-
-        text = _formattedText;
+        text.Weight = _fontWeight;
+        text.Style = _fontStyle;
+        text.Font = _fontFamily;
+        text.Size = _size;
+        text.Spacing = _spacing;
+        text.Text = s;
+        text.Brush = Brush;
+        text.Pen = Pen;
     }
 }
 

--- a/src/Beutl.Engine/Media/Font/FontExtensions.cs
+++ b/src/Beutl.Engine/Media/Font/FontExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Beutl.Graphics;
+using Beutl.Media.TextFormatting;
 
 using SkiaSharp;
 
@@ -9,6 +10,19 @@ internal static class FontExtensions
     public static SKTypeface ToSkia(this Typeface typeface)
     {
         return FontManager.Instance._fonts[typeface.FontFamily].Get(typeface);
+    }
+
+    public static SKFont ToSKFont(this FormattedText text)
+    {
+        var typeface = new Typeface(text.Font, text.Style, text.Weight);
+        var font = new SKFont(typeface.ToSkia(), text.Size)
+        {
+            Edging = SKFontEdging.Antialias,
+            Subpixel = true,
+            Hinting = SKFontHinting.Full
+        };
+
+        return font;
     }
 
     public static Typeface ToTypeface(this SKTypeface typeface)

--- a/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
+++ b/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
@@ -83,23 +83,22 @@ public struct FormattedText : IEquatable<FormattedText>
 
     internal Point AddToSKPath(SKPath path, Point point)
     {
-        SKTypeface typeface = new Typeface(Font, Style, Weight).ToSkia();
-        using SKPaint paint = new()
-        {
-            TextSize = Size,
-            Typeface = typeface
-        };
+        using SKFont font = this.ToSKFont();
 
-        using var shaper = new SKShaper(typeface);
+        using var shaper = new SKShaper(font.Typeface);
         using var buffer = new HarfBuzzSharp.Buffer();
         buffer.AddUtf16(Text.AsSpan());
         buffer.GuessSegmentProperties();
 
+        using SKPaint paint = new()
+        {
+            TextSize = Size,
+            Typeface = font.Typeface
+        };
         SKShaper.Result result = shaper.Shape(buffer, paint);
 
         // create the text blob
         using var builder = new SKTextBlobBuilder();
-        using SKFont font = paint.ToFont();
         SKPositionedRunBuffer run = builder.AllocatePositionedRun(font, result.Codepoints.Length);
 
         // copy the glyphs
@@ -130,21 +129,21 @@ public struct FormattedText : IEquatable<FormattedText>
 
     private (FontMetrics, Size) Measure()
     {
-        SKTypeface typeface = new Typeface(Font, Style, Weight).ToSkia();
-        using SKPaint paint = new()
-        {
-            TextSize = Size,
-            Typeface = typeface
-        };
+        using SKFont font = this.ToSKFont();
 
-        using var shaper = new SKShaper(typeface);
+        using var shaper = new SKShaper(font.Typeface);
         using var buffer = new HarfBuzzSharp.Buffer();
         buffer.AddUtf16(Text.AsSpan());
         buffer.GuessSegmentProperties();
 
+        using SKPaint paint = new()
+        {
+            TextSize = Size,
+            Typeface = font.Typeface
+        };
         SKShaper.Result result = shaper.Shape(buffer, paint);
 
-        FontMetrics fontMetrics = paint.FontMetrics.ToFontMetrics();
+        FontMetrics fontMetrics = font.Metrics.ToFontMetrics();
         float w = result.Width;
         var size = new Size(
             w + (buffer.Length - 1) * Spacing,

--- a/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
+++ b/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 
 using Beutl.Graphics;
+using Beutl.Reactive;
 
 using SkiaSharp;
 using SkiaSharp.HarfBuzz;
@@ -8,7 +9,7 @@ using SkiaSharp.HarfBuzz;
 namespace Beutl.Media.TextFormatting;
 
 [DebuggerDisplay("{Text}")]
-public struct FormattedText : IEquatable<FormattedText>
+public class FormattedText : IEquatable<FormattedText>
 {
     private FontWeight _weight = FontWeight.Regular;
     private FontStyle _style = FontStyle.Normal;
@@ -17,8 +18,13 @@ public struct FormattedText : IEquatable<FormattedText>
     private float _spacing = 0;
     private StringSpan _text = StringSpan.Empty;
     private FontMetrics _metrics = default;
-    private Size _bounds = default;
+    private Rect _bounds = default;
+    private Rect _actualBounds;
     private bool _isDirty = false;
+    private IPen? _pen;
+    private SKTextBlob? _textBlob;
+    private SKPath? _fillPath;
+    private SKPath? _strokePath;
 
     public FormattedText()
     {
@@ -75,12 +81,41 @@ public struct FormattedText : IEquatable<FormattedText>
 
     public IBrush? Brush { get; set; }
 
-    public IPen? Pen { get; set; }
+    public IPen? Pen
+    {
+        get => _pen;
+        set => SetProperty(ref _pen, value);
+    }
 
-    public FontMetrics Metrics => MeasureAndSetField().Metrics;
+    public FontMetrics Metrics
+    {
+        get
+        {
+            MeasureAndSetField();
+            return _metrics;
+        }
+    }
 
-    public Size Bounds => MeasureAndSetField().Bounds;
+    public Rect Bounds
+    {
+        get
+        {
+            MeasureAndSetField();
+            return _bounds;
+        }
+    }
 
+    // Strokeを含めた境界線
+    public Rect ActualBounds
+    {
+        get
+        {
+            MeasureAndSetField();
+            return _actualBounds;
+        }
+    }
+
+    // テスト用
     internal Point AddToSKPath(SKPath path, Point point)
     {
         using SKFont font = this.ToSKFont();
@@ -127,7 +162,25 @@ public struct FormattedText : IEquatable<FormattedText>
         return point;
     }
 
-    private (FontMetrics, Size) Measure()
+    internal SKPath GetFillPath()
+    {
+        MeasureAndSetField();
+        return _fillPath!;
+    }
+
+    internal SKPath? GetStrokePath()
+    {
+        MeasureAndSetField();
+        return _strokePath;
+    }
+
+    internal SKTextBlob GetTextBlob()
+    {
+        MeasureAndSetField();
+        return _textBlob!;
+    }
+
+    private void Measure()
     {
         using SKFont font = this.ToSKFont();
 
@@ -139,17 +192,148 @@ public struct FormattedText : IEquatable<FormattedText>
         using SKPaint paint = new()
         {
             TextSize = Size,
-            Typeface = font.Typeface
+            Typeface = font.Typeface,
         };
         SKShaper.Result result = shaper.Shape(buffer, paint);
 
-        FontMetrics fontMetrics = font.Metrics.ToFontMetrics();
-        float w = result.Width;
-        var size = new Size(
-            w + (buffer.Length - 1) * Spacing,
-            fontMetrics.Descent - fontMetrics.Ascent);
+        // create the text blob
+        using var builder = new SKTextBlobBuilder();
+        SKPositionedRunBuffer run = builder.AllocatePositionedRun(font, result.Codepoints.Length);
 
-        return (fontMetrics, size);
+        var fillPath = new SKPath();
+        Span<ushort> glyphs = run.GetGlyphSpan();
+        Span<SKPoint> positions = run.GetPositionSpan();
+        for (int i = 0; i < result.Codepoints.Length; i++)
+        {
+            glyphs[i] = (ushort)result.Codepoints[i];
+
+            SKPoint point = result.Points[i];
+            point.X += i * Spacing;
+            positions[i] = point;
+
+            using SKPath tmp = font.GetGlyphPath(glyphs[i]);
+            fillPath.AddPath(tmp, point.X, point.Y);
+        }
+
+        SKPath? strokePath = null;
+        Rect bounds = fillPath.TightBounds.ToGraphicsRect();
+        Rect actualBounds = bounds;
+        SKTextBlob textBlob = builder.Build();
+
+        if (result.Codepoints.Length > 0)
+        {
+            if (Pen != null && Pen.Thickness > 0)
+            {
+                ConfigureStrokePaint(paint, actualBounds.Size);
+                float maxAspect = Math.Max(actualBounds.Width, actualBounds.Height);
+                float thickness = Pen.Thickness;
+                if (Pen.StrokeAlignment == StrokeAlignment.Outside)
+                {
+                    thickness /= 2;
+                }
+                else if (Pen.StrokeAlignment == StrokeAlignment.Inside)
+                {
+                    thickness = paint.StrokeWidth;
+                }
+
+                if (maxAspect < thickness)
+                {
+                    strokePath = new SKPath();
+                    paint.StrokeWidth = maxAspect;
+                    SKPath? prev = null;
+                    try
+                    {
+                        while (maxAspect < thickness)
+                        {
+                            SKPath tmp = paint.GetFillPath(prev ?? fillPath);
+                            strokePath.AddPath(tmp);
+
+                            prev?.Dispose();
+                            prev = tmp;
+                            thickness -= maxAspect;
+                        }
+
+                        if (prev != null)
+                        {
+                            paint.StrokeWidth = thickness;
+                            using SKPath tmp2 = paint.GetFillPath(prev);
+                            strokePath.AddPath(tmp2);
+                        }
+
+                        paint.IsStroke = false;
+                        actualBounds = strokePath.TightBounds.ToGraphicsRect();
+                    }
+                    finally
+                    {
+                        prev?.Dispose();
+                    }
+                }
+                else
+                {
+                    strokePath = paint.GetFillPath(fillPath);
+                    if (Pen.StrokeAlignment != StrokeAlignment.Inside)
+                    {
+                        actualBounds = strokePath.TightBounds.ToGraphicsRect();
+                    }
+                }
+            }
+        }
+
+        (_metrics, _bounds, _actualBounds) = (font.Metrics.ToFontMetrics(), bounds, actualBounds);
+
+        (_textBlob, _fillPath, _strokePath).DisposeAll();
+        (_textBlob, _fillPath, _strokePath) = (textBlob, fillPath, strokePath);
+    }
+
+    private void ConfigureStrokePaint(SKPaint paint, Size size)
+    {
+        paint.Reset();
+
+        if (Pen != null && Pen.Thickness != 0)
+        {
+            float thickness = Pen.Thickness;
+
+            switch (Pen.StrokeAlignment)
+            {
+                case StrokeAlignment.Outside:
+                    thickness *= 2;
+                    break;
+
+                case StrokeAlignment.Inside:
+                    thickness *= 2;
+                    float maxAspect = Math.Max(size.Width, size.Height);
+                    thickness = Math.Min(thickness, maxAspect);
+                    break;
+
+                default:
+                    break;
+            }
+
+            paint.IsStroke = true;
+            paint.StrokeWidth = thickness;
+            paint.StrokeCap = (SKStrokeCap)Pen.StrokeCap;
+            paint.StrokeJoin = (SKStrokeJoin)Pen.StrokeJoin;
+            paint.StrokeMiter = Pen.MiterLimit;
+            if (Pen.DashArray != null && Pen.DashArray.Count > 0)
+            {
+                IReadOnlyList<float> srcDashes = Pen.DashArray;
+
+                int count = srcDashes.Count % 2 == 0 ? srcDashes.Count : srcDashes.Count * 2;
+
+                float[] dashesArray = new float[count];
+
+                for (int i = 0; i < count; ++i)
+                {
+                    dashesArray[i] = (float)srcDashes[i % srcDashes.Count] * thickness;
+                }
+
+                float offset = (float)(Pen.DashOffset * thickness);
+
+                var pe = SKPathEffect.CreateDash(dashesArray, offset);
+
+                paint.PathEffect = pe;
+            }
+        }
     }
 
     private void SetProperty<T>(ref T field, T value)
@@ -161,15 +345,13 @@ public struct FormattedText : IEquatable<FormattedText>
         }
     }
 
-    private (FontMetrics Metrics, Size Bounds) MeasureAndSetField()
+    private void MeasureAndSetField()
     {
         if (_isDirty)
         {
-            (_metrics, _bounds) = Measure();
+            Measure();
             _isDirty = false;
         }
-
-        return (_metrics, _bounds);
     }
 
     public override bool Equals(object? obj)
@@ -177,9 +359,17 @@ public struct FormattedText : IEquatable<FormattedText>
         return obj is FormattedText text && Equals(text);
     }
 
-    public bool Equals(FormattedText other)
+    public bool Equals(FormattedText? other)
     {
-        return Weight == other.Weight && Style == other.Style && Font.Equals(other.Font) && Size == other.Size && Spacing == other.Spacing && Text.Equals(other.Text) && BeginOnNewLine == other.BeginOnNewLine && EqualityComparer<IBrush>.Default.Equals(Brush, other.Brush);
+        return Weight == other?.Weight
+            && Style == other?.Style
+            && Font.Equals(other?.Font)
+            && Size == other?.Size
+            && Spacing == other?.Spacing
+            && Text.Equals(other?.Text)
+            && BeginOnNewLine == other?.BeginOnNewLine
+            && EqualityComparer<IBrush>.Default.Equals(Brush, other?.Brush)
+            && EqualityComparer<IPen>.Default.Equals(Pen, other?.Pen);
     }
 
     public override int GetHashCode()
@@ -193,6 +383,7 @@ public struct FormattedText : IEquatable<FormattedText>
         hash.Add(Text);
         hash.Add(BeginOnNewLine);
         hash.Add(Brush);
+        hash.Add(Pen);
         return hash.ToHashCode();
     }
 

--- a/src/Beutl.Engine/Rendering/Cache/RenderCacheContext.cs
+++ b/src/Beutl.Engine/Rendering/Cache/RenderCacheContext.cs
@@ -146,7 +146,9 @@ public sealed class RenderCacheContext : IDisposable
 
         // nodeをキャッシュ
         Rect bounds = (node as ISupportRenderCache)?.TransformBoundsForCache(cache) ?? node.Bounds;
-        PixelSize size = new((int)Math.Ceiling(bounds.Width), (int)Math.Ceiling(bounds.Height));
+        //bounds = bounds.Inflate(5);
+        PixelRect boundsInPixels = PixelRect.FromRect(bounds);
+        PixelSize size = boundsInPixels.Size;
         if (size.Width <= 0 || size.Height <= 0)
             return;
 
@@ -159,7 +161,7 @@ public sealed class RenderCacheContext : IDisposable
 
         using (ImmediateCanvas canvas = factory.CreateCanvas(surface, true))
         {
-            using (canvas.PushTransform(Matrix.CreateTranslation(-bounds.X, -bounds.Y)))
+            using (canvas.PushTransform(Matrix.CreateTranslation(-boundsInPixels.X, -boundsInPixels.Y)))
             {
                 if (node is ISupportRenderCache supportRenderCache)
                 {
@@ -174,7 +176,7 @@ public sealed class RenderCacheContext : IDisposable
 
         using (var surfaceRef = Ref<SKSurface>.Create(surface))
         {
-            cache.StoreCache(surfaceRef, bounds);
+            cache.StoreCache(surfaceRef, boundsInPixels.ToRect(1));
         }
 
         Debug.WriteLine($"[RenderCache:Created] '{node}'");


### PR DESCRIPTION
<!-- 2-4は省略可 -->
## このプルリクエストで何をやったのか？
**テキストの縁が滑らかになるように改善**
<details>
<summary>改善前</summary>

![改善前](https://github.com/b-editor/beutl/assets/66758394/67113f5a-eff3-455e-9632-bc42bf1c5b31)

</details>
<details>
<summary>改善後</summary>

![改善後](https://github.com/b-editor/beutl/assets/66758394/d0342875-3c77-4058-92f3-b2c9ed8a9183)

</details>

**元のサイズより大きい縁幅を設定すると、内側が空洞になるのを修正**
<details>
<summary>改善前</summary>

![改善前](https://github.com/b-editor/beutl/assets/66758394/be834786-dd8f-4938-8a8d-a46ed88b418e)

</details>
<details>
<summary>改善後</summary>

![改善後](https://github.com/b-editor/beutl/assets/66758394/01dfd493-0441-485d-9845-51fc86d8f5b6)

</details>

**描画キャッシュ (ノード) を使って描画するとき、1px以下分ずれることがあるのを修正**

## やらなかったこと

## できるようになること

## できなくなること

## 破壊的変更
- FormattedTextをclassに変更
- TextElements.Linesをclassに変更
- FormattedText.BoundsをSizeからRectに変更

## 廃止するApi
<!-- Obsolete属性を付けたApi -->

## リンクされたIsuues
- #918
- #745