### PR TITLE
複数のエフェクトターゲット

### DIFF
--- a/src/Beutl.Engine/Graphics/Drawable.cs
+++ b/src/Beutl.Engine/Graphics/Drawable.cs
@@ -79,6 +79,7 @@ public abstract class Drawable : Renderable
             BlendModeProperty);
     }
 
+    // DrawableBrushで使われる
     public Rect Bounds { get; protected set; }
 
     [Display(Name = nameof(Strings.ImageFilter), ResourceType = typeof(Strings), GroupName = nameof(Strings.ImageFilter))]

--- a/src/Beutl.Engine/Graphics/FilterEffects/Border.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/Border.cs
@@ -134,7 +134,7 @@ public class Border : FilterEffect
 
     public override void ApplyTo(FilterEffectContext context)
     {
-        context.Custom((Offset, Thickness, Color, MaskType, Style), Apply, TransformBounds);
+        context.CustomEffect((Offset, Thickness, Color, MaskType, Style), Apply, TransformBounds);
     }
 
     private static Rect TransformBounds((Point Offset, int Thickness, Color Color, MaskTypes MaskType, BorderStyles Style) data, Rect rect)
@@ -142,7 +142,7 @@ public class Border : FilterEffect
         return rect.Union(rect.Translate(new Vector(data.Offset.X, data.Offset.Y)).Inflate(data.Thickness / 2)).Inflate(8);
     }
 
-    private static void Apply((Point Offset, int Thickness, Color Color, MaskTypes MaskType, BorderStyles Style) data, FilterEffectCustomOperationContext context)
+    private static void Apply((Point Offset, int Thickness, Color Color, MaskTypes MaskType, BorderStyles Style) data, CustomFilterEffectContext context)
     {
         Point offset = data.Offset;
         Color color = data.Color;

--- a/src/Beutl.Engine/Graphics/FilterEffects/Border.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/Border.cs
@@ -177,16 +177,17 @@ public class Border : FilterEffect
             return border;
         }
 
-        if (context.Target.Surface != null)
+        for (int i = 0; i < context.Targets.Count; i++)
         {
-            using SKImage skimage = context.Target.Surface.Value.Snapshot();
+            EffectTarget target = context.Targets[i];
+            using SKImage skimage = target.Surface!.Value.Snapshot();
             using var src = skimage.ToBitmap();
             using var srcRef = Ref<IBitmap>.Create(src);
             using var srcBitmapSource = new BitmapSource(srcRef, "Temp");
 
             // 縁取りの画像を生成
             using Bitmap<Bgra8888> border = RenderBorderBitmap(src);
-            var rect = new Rect(0, 0, src.Width, src.Height);
+            var rect = target.Bounds;
             Rect borderBounds = rect.Translate(offset).Inflate(thicknessHalf);
             Rect canvasRect = rect.Union(borderBounds).Inflate(8);
             var borderRect = new Rect(0, 0, border.Width, border.Height);
@@ -197,7 +198,7 @@ public class Border : FilterEffect
                 maskBrush = new ImmutableImageBrush(srcBitmapSource, stretch: Stretch.None);
             }
 
-            using EffectTarget newTarget = context.CreateTarget((int)canvasRect.Width, (int)canvasRect.Height);
+            EffectTarget newTarget = context.CreateTarget(canvasRect);
             using (ImmediateCanvas canvas = context.Open(newTarget))
             using (canvas.PushTransform(Matrix.CreateTranslation(8, 8)))
             {
@@ -224,9 +225,10 @@ public class Border : FilterEffect
                     using (canvas.PushTransform(srcTranslate))
                         canvas.DrawBitmap(src, Brushes.White, null);
                 }
-
-                context.ReplaceTarget(newTarget);
             }
+
+            target.Dispose();
+            context.Targets[i] = newTarget;
         }
     }
     /* Contours to SKPath

--- a/src/Beutl.Engine/Graphics/FilterEffects/ChromaKey.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/ChromaKey.cs
@@ -88,13 +88,15 @@ public class ChromaKey : FilterEffect
 
     private unsafe void OnApplyTo((Hsv hsv, float hueRange, float satRange) data, FilterEffectCustomOperationContext context)
     {
-        if (context.Target.Surface?.Value is { } surface)
+        for (int i = 0; i < context.Targets.Count; i++)
         {
+            var target = context.Targets[i];
+            var surface = target.Surface!.Value;
             Accelerator accelerator = SharedGPUContext.Accelerator;
             var kernel = accelerator.LoadAutoGroupedStreamKernel<
                 Index1D, ArrayView<Bgra8888>, Hsv, float, float>(EffectKernel);
 
-            var size = PixelSize.FromSize(context.Target.Size, 1);
+            var size = PixelSize.FromSize(target.Bounds.Size, 1);
             var imgInfo = new SKImageInfo(size.Width, size.Height, SKColorType.Bgra8888);
 
             using var source = accelerator.Allocate1D<Bgra8888>(size.Width * size.Height);

--- a/src/Beutl.Engine/Graphics/FilterEffects/ChromaKey.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/ChromaKey.cs
@@ -63,7 +63,7 @@ public class ChromaKey : FilterEffect
 
     public override void ApplyTo(FilterEffectContext context)
     {
-        context.Custom((Color.ToHsv(), HueRange, SaturationRange), OnApplyTo, (_, r) => r);
+        context.CustomEffect((Color.ToHsv(), HueRange, SaturationRange), OnApplyTo, (_, r) => r);
     }
 
     private static unsafe void CopyFromCPU(MemoryBuffer1D<Bgra8888, Stride1D.Dense> source, SKSurface surface, SKImageInfo imageInfo)
@@ -86,7 +86,7 @@ public class ChromaKey : FilterEffect
         source.View.CopyToCPU(ref Unsafe.AsRef<Bgra8888>((void*)bitmap.GetPixels()), source.Length);
     }
 
-    private unsafe void OnApplyTo((Hsv hsv, float hueRange, float satRange) data, FilterEffectCustomOperationContext context)
+    private unsafe void OnApplyTo((Hsv hsv, float hueRange, float satRange) data, CustomFilterEffectContext context)
     {
         for (int i = 0; i < context.Targets.Count; i++)
         {

--- a/src/Beutl.Engine/Graphics/FilterEffects/Clipping.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/Clipping.cs
@@ -29,7 +29,7 @@ public sealed class Clipping : FilterEffect
 
     public override void ApplyTo(FilterEffectContext context)
     {
-        context.Custom(Thickness, Apply, TransformBounds);
+        context.CustomEffect(Thickness, Apply, TransformBounds);
     }
 
     public override Rect TransformBounds(Rect bounds)
@@ -42,7 +42,7 @@ public sealed class Clipping : FilterEffect
         return rect.Deflate(thickness).Normalize();
     }
 
-    private void Apply(Thickness thickness, FilterEffectCustomOperationContext context)
+    private void Apply(Thickness thickness, CustomFilterEffectContext context)
     {
         for (int i = 0; i < context.Targets.Count; i++)
         {

--- a/src/Beutl.Engine/Graphics/FilterEffects/ColorKey.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/ColorKey.cs
@@ -58,7 +58,7 @@ public class ColorKey : FilterEffect
         colorNtsc = Math.Clamp(colorNtsc, 0, 255);
         colorNtsc = MathF.Round(colorNtsc);
 
-        context.Custom((colorNtsc, Range), OnApplyTo, (_, r) => r);
+        context.CustomEffect((colorNtsc, Range), OnApplyTo, (_, r) => r);
     }
 
     private static unsafe void CopyFromCPU(MemoryBuffer1D<Bgra8888, Stride1D.Dense> source, SKSurface surface, SKImageInfo imageInfo)
@@ -81,7 +81,7 @@ public class ColorKey : FilterEffect
         source.View.CopyToCPU(ref Unsafe.AsRef<Bgra8888>((void*)bitmap.GetPixels()), source.Length);
     }
 
-    private unsafe void OnApplyTo((float colorNtsc, float range) data, FilterEffectCustomOperationContext context)
+    private unsafe void OnApplyTo((float colorNtsc, float range) data, CustomFilterEffectContext context)
     {
         for (int i = 0; i < context.Targets.Count; i++)
         {

--- a/src/Beutl.Engine/Graphics/FilterEffects/ColorKey.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/ColorKey.cs
@@ -51,7 +51,7 @@ public class ColorKey : FilterEffect
 
     public override void ApplyTo(FilterEffectContext context)
     {
-        var colorNtsc = 
+        var colorNtsc =
             (_color.R * 0.11448f) +
             (_color.G * 0.58661f) +
             (_color.B * 0.29891f);
@@ -83,13 +83,15 @@ public class ColorKey : FilterEffect
 
     private unsafe void OnApplyTo((float colorNtsc, float range) data, FilterEffectCustomOperationContext context)
     {
-        if (context.Target.Surface?.Value is { } surface)
+        for (int i = 0; i < context.Targets.Count; i++)
         {
+            var target = context.Targets[i];
+            var surface = target.Surface!.Value;
             Accelerator accelerator = SharedGPUContext.Accelerator;
             var kernel = accelerator.LoadAutoGroupedStreamKernel<
                 Index1D, ArrayView<Bgra8888>, float, float>(EffectKernel);
 
-            var size = PixelSize.FromSize(context.Target.Size, 1);
+            var size = PixelSize.FromSize(target.Bounds.Size, 1);
             var imgInfo = new SKImageInfo(size.Width, size.Height, SKColorType.Bgra8888);
 
             using var source = accelerator.Allocate1D<Bgra8888>(size.Width * size.Height);
@@ -119,7 +121,7 @@ public class ColorKey : FilterEffect
 
         ntsc = IntrinsicMath.Clamp(ntsc, 0, 255);
         ntsc = XMath.Round(ntsc);
-        
+
         if (IntrinsicMath.Abs(colorNtsc - ntsc) < range)
         {
             src[index] = default;

--- a/src/Beutl.Engine/Graphics/FilterEffects/CustomFilterEffectContext.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/CustomFilterEffectContext.cs
@@ -1,0 +1,91 @@
+﻿using System.Collections.Immutable;
+
+using Beutl.Media.Source;
+
+using SkiaSharp;
+
+namespace Beutl.Graphics.Effects;
+
+public class CustomFilterEffectContext
+{
+    internal readonly IImmediateCanvasFactory _factory;
+    internal readonly ImmutableArray<FEItemWrapper> _history;
+
+    internal CustomFilterEffectContext(
+        IImmediateCanvasFactory canvas,
+        EffectTargets targets,
+        ImmutableArray<FEItemWrapper> history)
+    {
+        Targets = targets;
+        _factory = canvas;
+        _history = history;
+    }
+
+    public EffectTargets Targets { get; }
+
+    public void ForEach(Action<int, EffectTarget> action)
+    {
+        for (int i = 0; i < Targets.Count; i++)
+        {
+            EffectTarget target = Targets[i];
+            action(i, target);
+        }
+    }
+
+    public void ForEach(Func<int, EffectTarget, EffectTarget> action)
+    {
+        for (int i = 0; i < Targets.Count; i++)
+        {
+            EffectTarget target = Targets[i];
+            EffectTarget newTarget = action(i, target);
+            if (newTarget != target)
+            {
+                target.Dispose();
+                Targets[i] = newTarget;
+            }
+        }
+    }
+
+    public void ForEach(Func<int, EffectTarget, EffectTargets> action)
+    {
+        for (int i = 0; i < Targets.Count; i++)
+        {
+            using EffectTarget target = Targets[i];
+            EffectTargets newTargets = action(i, target.Clone());
+
+            Targets.RemoveAt(i);
+            Targets.InsertRange(i, newTargets);
+            i += newTargets.Count - 1;
+        }
+    }
+
+    public EffectTarget CreateTarget(Rect bounds)
+    {
+        SKSurface? surface = _factory.CreateRenderTarget((int)bounds.Width, (int)bounds.Height);
+        if (surface != null)
+        {
+            using var surfaceRef = Ref<SKSurface>.Create(surface);
+            var obj = new EffectTarget(surfaceRef, bounds);
+
+            obj._history.AddRange(_history);
+            return obj;
+        }
+        else
+        {
+            var obj = new EffectTarget();
+
+            obj._history.AddRange(_history);
+            return obj;
+        }
+    }
+
+    public ImmediateCanvas Open(EffectTarget target)
+    {
+        if (target.Surface == null)
+        {
+            throw new InvalidOperationException("無効なEffectTarget");
+        }
+
+        return _factory.CreateCanvas(target.Surface.Value, true);
+    }
+}

--- a/src/Beutl.Engine/Graphics/FilterEffects/EffectTarget.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/EffectTarget.cs
@@ -1,4 +1,6 @@
-﻿using Beutl.Collections.Pooled;
+﻿using System.ComponentModel;
+
+using Beutl.Collections.Pooled;
 using Beutl.Graphics.Rendering;
 using Beutl.Media.Source;
 
@@ -36,6 +38,10 @@ public sealed class EffectTarget : IDisposable
     public Rect OriginalBounds { get; set; }
 
     public Rect Bounds { get; set; }
+
+    [Obsolete()]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public Size Size => Bounds.Size;
 
     public FilterEffectNode? Node => _target as FilterEffectNode;
 

--- a/src/Beutl.Engine/Graphics/FilterEffects/EffectTarget.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/EffectTarget.cs
@@ -14,20 +14,24 @@ public sealed class EffectTarget : IDisposable
     public EffectTarget(FilterEffectNode node)
     {
         _target = node;
-        Size = node.Bounds.Size;
+        OriginalBounds = node.OriginalBounds;
+        Bounds = node.OriginalBounds;
     }
 
-    public EffectTarget(Ref<SKSurface> surface, Size size)
+    public EffectTarget(Ref<SKSurface> surface, Rect originalBounds)
     {
         _target = surface.Clone();
-        Size = size;
+        OriginalBounds = originalBounds;
+        Bounds = originalBounds;
     }
 
     public EffectTarget()
     {
     }
 
-    public Size Size { get; private set; }
+    public Rect OriginalBounds { get; set; }
+
+    public Rect Bounds { get; set; }
 
     public FilterEffectNode? Node => _target as FilterEffectNode;
 
@@ -41,7 +45,10 @@ public sealed class EffectTarget : IDisposable
         }
         else if (Surface != null)
         {
-            return new EffectTarget(Surface, Size);
+            return new EffectTarget(Surface, OriginalBounds)
+            {
+                Bounds = Bounds
+            };
         }
         else
         {
@@ -53,7 +60,7 @@ public sealed class EffectTarget : IDisposable
     {
         Surface?.Dispose();
         _target = null;
-        Size = default;
+        OriginalBounds = default;
     }
 
     public void Draw(ImmediateCanvas canvas)

--- a/src/Beutl.Engine/Graphics/FilterEffects/EffectTargets.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/EffectTargets.cs
@@ -24,8 +24,13 @@ public sealed class EffectTargets : IList<EffectTarget>, IDisposable
 
     public bool IsReadOnly => ((ICollection<EffectTarget>)_targets).IsReadOnly;
 
+    public Rect CalculateBounds()
+    {
+        return this.Aggregate<EffectTarget, Rect>(default, (x, y) => x.Union(y.Bounds));
+    }
     public EffectTargets Clone() => new(this);
     public void Add(EffectTarget item) => ((ICollection<EffectTarget>)_targets).Add(item);
+    public void AddRange(IEnumerable<EffectTarget> collection) => _targets.AddRange(collection);
     public void Clear() => ((ICollection<EffectTarget>)_targets).Clear();
     public bool Contains(EffectTarget item) => ((ICollection<EffectTarget>)_targets).Contains(item);
     public void CopyTo(EffectTarget[] array, int arrayIndex) => ((ICollection<EffectTarget>)_targets).CopyTo(array, arrayIndex);

--- a/src/Beutl.Engine/Graphics/FilterEffects/EffectTargets.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/EffectTargets.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections;
+
+namespace Beutl.Graphics.Effects;
+
+public sealed class EffectTargets : IList<EffectTarget>, IDisposable
+{
+    private readonly List<EffectTarget> _targets = [];
+
+    public EffectTargets()
+    {
+    }
+    
+    public EffectTargets(EffectTargets obj)
+    {
+        foreach (EffectTarget item in obj)
+        {
+            Add(item.Clone());
+        }
+    }
+
+    public EffectTarget this[int index] { get => ((IList<EffectTarget>)_targets)[index]; set => ((IList<EffectTarget>)_targets)[index] = value; }
+
+    public int Count => ((ICollection<EffectTarget>)_targets).Count;
+
+    public bool IsReadOnly => ((ICollection<EffectTarget>)_targets).IsReadOnly;
+
+    public EffectTargets Clone() => new(this);
+    public void Add(EffectTarget item) => ((ICollection<EffectTarget>)_targets).Add(item);
+    public void Clear() => ((ICollection<EffectTarget>)_targets).Clear();
+    public bool Contains(EffectTarget item) => ((ICollection<EffectTarget>)_targets).Contains(item);
+    public void CopyTo(EffectTarget[] array, int arrayIndex) => ((ICollection<EffectTarget>)_targets).CopyTo(array, arrayIndex);
+    public IEnumerator<EffectTarget> GetEnumerator() => ((IEnumerable<EffectTarget>)_targets).GetEnumerator();
+    public int IndexOf(EffectTarget item) => ((IList<EffectTarget>)_targets).IndexOf(item);
+    public void Insert(int index, EffectTarget item) => _targets.Insert(index, item);
+    public void InsertRange(int index, IEnumerable<EffectTarget> collection) => _targets.InsertRange(index, collection);
+    public bool Remove(EffectTarget item) => ((ICollection<EffectTarget>)_targets).Remove(item);
+    public void RemoveAt(int index) => ((IList<EffectTarget>)_targets).RemoveAt(index);
+    IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_targets).GetEnumerator();
+    public void Dispose()
+    {
+        for (int i = _targets.Count - 1; i >= 0; i--)
+        {
+            _targets[i].Dispose();
+            _targets.RemoveAt(i);
+        }
+    }
+}

--- a/src/Beutl.Engine/Graphics/FilterEffects/FEImpl.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FEImpl.cs
@@ -1,4 +1,6 @@
-﻿using SkiaSharp;
+﻿using System.Collections.Immutable;
+
+using SkiaSharp;
 
 namespace Beutl.Graphics.Effects;
 
@@ -40,11 +42,32 @@ internal interface IFEItem_Skia
     void Accepts(FilterEffectActivator activator, SKImageFilterBuilder builder);
 }
 
+[Obsolete]
 internal record FEItem_Custom<T>(
-    T Data, Action<T, FilterEffectCustomOperationContext> Action, Func<T, Rect, Rect>? TransformBounds)
+    T Data, Action<T, FilterEffectCustomOperationContext> Action, Func<T, Rect, Rect> TransformBounds)
     : FEItem<T>(Data, TransformBounds), IFEItem_Custom
 {
-    public void Accepts(FilterEffectCustomOperationContext context)
+    public void Accepts(CustomFilterEffectContext context)
+    {
+        context.ForEach((_, target) =>
+        {
+            using (target)
+            {
+                var innerContext = new FilterEffectCustomOperationContext(context._factory, target, [.. target._history]);
+                Action.Invoke(Data, innerContext);
+
+                innerContext.Target.Bounds = TransformBounds!(Data, innerContext.Target.Bounds);
+                return innerContext.Target;
+            }
+        });
+    }
+}
+
+internal record FEItem_CustomEffect<T>(
+    T Data, Action<T, CustomFilterEffectContext> Action, Func<T, Rect, Rect>? TransformBounds)
+    : FEItem<T>(Data, TransformBounds), IFEItem_Custom
+{
+    public void Accepts(CustomFilterEffectContext context)
     {
         Action.Invoke(Data, context);
     }
@@ -52,5 +75,5 @@ internal record FEItem_Custom<T>(
 
 internal interface IFEItem_Custom
 {
-    void Accepts(FilterEffectCustomOperationContext context);
+    void Accepts(CustomFilterEffectContext context);
 }

--- a/src/Beutl.Engine/Graphics/FilterEffects/FEImpl.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FEImpl.cs
@@ -7,11 +7,11 @@ internal interface IFEItem
     Rect TransformBounds(Rect bounds);
 }
 
-internal abstract record FEItem<T>(T Data, Func<T, Rect, Rect> TransformBounds) : IFEItem
+internal abstract record FEItem<T>(T Data, Func<T, Rect, Rect>? TransformBounds) : IFEItem
 {
     Rect IFEItem.TransformBounds(Rect bounds)
     {
-        return TransformBounds(Data, bounds);
+        return TransformBounds?.Invoke(Data, bounds) ?? Rect.Invalid;
     }
 }
 
@@ -41,7 +41,7 @@ internal interface IFEItem_Skia
 }
 
 internal record FEItem_Custom<T>(
-    T Data, Action<T, FilterEffectCustomOperationContext> Action, Func<T, Rect, Rect> TransformBounds)
+    T Data, Action<T, FilterEffectCustomOperationContext> Action, Func<T, Rect, Rect>? TransformBounds)
     : FEItem<T>(Data, TransformBounds), IFEItem_Custom
 {
     public void Accepts(FilterEffectCustomOperationContext context)

--- a/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectActivator.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectActivator.cs
@@ -1,17 +1,10 @@
-﻿using System.Collections.Immutable;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
-using Beutl.Collections.Pooled;
 using Beutl.Media.Source;
 
 using SkiaSharp;
 
 namespace Beutl.Graphics.Effects;
-
-/*
- * 本当にひどいコードです。
- * 読む際は注意してください。
- */
 
 public sealed class FilterEffectActivator(EffectTargets targets, SKImageFilterBuilder builder, IImmediateCanvasFactory factory) : IDisposable
 {
@@ -125,13 +118,9 @@ public sealed class FilterEffectActivator(EffectTargets targets, SKImageFilterBu
         {
             count = count.Value - takeCount;
         }
-        //if (takeCount > 0)
-        {
-            offset = Math.Max(offset - context._items.Count, 0);
-        }
-        //offset -= takeCount;
 
-        // NOTE: 一旦ノードキャッシュ無しで考えるので、rangeは無視
+        offset = Math.Max(offset - context._items.Count, 0);
+
         if (context._renderTimeItems.Count > 0)
         {
             Flush(false);

--- a/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectActivator.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectActivator.cs
@@ -226,12 +226,18 @@ public sealed class FilterEffectActivator(EffectTargets targets, SKImageFilterBu
 
                             if (i == 0)
                             {
-                                int takeCount_ = count ?? ctx._items.Count - offset;
-                                if (count_.HasValue)
+                                int takeCount_;
+                                if (count.HasValue)
                                 {
-                                    count_ = count_.Value - takeCount_;
+                                    takeCount_ = Math.Min(count.Value, ctx._items.Count);
+                                    count_ = count.Value - takeCount_;
                                 }
-                                offset_ -= takeCount_;
+                                else
+                                {
+                                    takeCount_ = Math.Max(ctx._items.Count - offset, 0);
+                                }
+
+                                offset_ = Math.Max(offset - ctx._items.Count, 0);
                             }
                         }
                     }
@@ -269,7 +275,7 @@ public sealed class FilterEffectActivator(EffectTargets targets, SKImageFilterBu
 
                 using (var builder = new SKImageFilterBuilder())
                 using (var activator = new FilterEffectActivator(CurrentTargets, builder, _factory))
-                using (var ctx = new FilterEffectContext(CurrentTargets.CalculateBounds()))
+                using (var ctx = new FilterEffectContext(Rect.Invalid))
                 {
                     foreach (object item in deferralItems!)
                     {

--- a/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectActivator.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectActivator.cs
@@ -77,6 +77,8 @@ public sealed class FilterEffectActivator(EffectTargets targets, SKImageFilterBu
     // 最小単位である'IFEItem'の数がわからないので 'count'は'nullable'
     public void Apply(FilterEffectContext context, int offset, int? count)
     {
+        if (CurrentTargets.Count == 0) return;
+
         int takeCount;
         if (count.HasValue)
         {
@@ -101,6 +103,8 @@ public sealed class FilterEffectActivator(EffectTargets targets, SKImageFilterBu
             else if (item.Item is IFEItem_Custom custom)
             {
                 Flush(true);
+                if (CurrentTargets.Count == 0) return;
+
                 var customContext = new FilterEffectCustomOperationContext(
                     _factory,
                     CurrentTargets,
@@ -131,6 +135,7 @@ public sealed class FilterEffectActivator(EffectTargets targets, SKImageFilterBu
         if (context._renderTimeItems.Count > 0)
         {
             Flush(false);
+            if (CurrentTargets.Count == 0) return;
 
             FEItemWrapper? deferral = null;
             object[]? deferralItems = null;
@@ -247,7 +252,7 @@ public sealed class FilterEffectActivator(EffectTargets targets, SKImageFilterBu
             offset = offset_;
             count = count_;
 
-            if (deferred && (!count.HasValue || count > 0))
+            if (deferred && (!count.HasValue || count > 0) && CurrentTargets.Count > 0)
             {
                 if (offset == 0)
                 {

--- a/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectActivator.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectActivator.cs
@@ -106,7 +106,7 @@ public sealed class FilterEffectActivator(EffectTargets targets, SKImageFilterBu
             Flush(false);
 
             IFEItem_Custom? deferral = null;
-            FilterEffect[]? deferralItems = null;
+            object[]? deferralItems = null;
             bool deferred = false;
 
             for (int i = 0; i < CurrentTargets.Count; i++)
@@ -115,9 +115,16 @@ public sealed class FilterEffectActivator(EffectTargets targets, SKImageFilterBu
 
                 using (var ctx = new FilterEffectContext(t.Bounds))
                 {
-                    foreach (FilterEffect fe in context._renderTimeItems)
+                    foreach (object item in context._renderTimeItems)
                     {
-                        ctx.Apply(fe);
+                        if (item is FilterEffect fe)
+                        {
+                            ctx.Apply(fe);
+                        }
+                        else if (item is IFEItem feitem)
+                        {
+                            ctx._items.Add(feitem);
+                        }
                     }
 
                     if (i == 0)
@@ -187,9 +194,16 @@ public sealed class FilterEffectActivator(EffectTargets targets, SKImageFilterBu
                 using (var activator = new FilterEffectActivator(CurrentTargets, builder, _canvas))
                 using (var ctx = new FilterEffectContext(CurrentTargets.CalculateBounds()))
                 {
-                    foreach (FilterEffect fe in deferralItems!)
+                    foreach (object item in deferralItems!)
                     {
-                        ctx.Apply(fe);
+                        if (item is FilterEffect fe)
+                        {
+                            ctx.Apply(fe);
+                        }
+                        else if (item is IFEItem feitem)
+                        {
+                            ctx._items.Add(feitem);
+                        }
                     }
 
                     activator.Apply(ctx, Range.All);

--- a/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectActivator.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectActivator.cs
@@ -98,7 +98,7 @@ public sealed class FilterEffectActivator(EffectTargets targets, SKImageFilterBu
                 Flush(true);
                 if (CurrentTargets.Count == 0) return;
 
-                var customContext = new FilterEffectCustomOperationContext(
+                var customContext = new CustomFilterEffectContext(
                     _factory,
                     CurrentTargets,
                     [.. CurrentTargets[0]._history.Select(v => v.Inherit())]);
@@ -247,7 +247,7 @@ public sealed class FilterEffectActivator(EffectTargets targets, SKImageFilterBu
                 {
                     Flush(false);
 
-                    var customContext = new FilterEffectCustomOperationContext(
+                    var customContext = new CustomFilterEffectContext(
                         _factory,
                         CurrentTargets,
                         [.. CurrentTargets[0]._history.Select(v => v.Inherit())]);

--- a/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectCustomOperationContext.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectCustomOperationContext.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
-using Beutl.Media.Source;
+﻿using Beutl.Media.Source;
 
 using SkiaSharp;
 
@@ -9,38 +7,22 @@ namespace Beutl.Graphics.Effects;
 public class FilterEffectCustomOperationContext
 {
     private readonly ImmediateCanvas _canvas;
-    private EffectTarget _target;
 
-    public FilterEffectCustomOperationContext(ImmediateCanvas canvas, EffectTarget target)
+    public FilterEffectCustomOperationContext(ImmediateCanvas canvas, EffectTargets targets)
     {
-        Target = target.Clone();
+        Targets = targets;
         _canvas = canvas;
     }
 
-    public EffectTarget Target
-    {
-        get => _target;
-        [MemberNotNull(nameof(_target))]
-        set
-        {
-            ArgumentNullException.ThrowIfNull(value);
-            _target = value;
-        }
-    }
+    public EffectTargets Targets { get; }
 
-    public void ReplaceTarget(EffectTarget target)
+    public EffectTarget CreateTarget(Rect bounds)
     {
-        _target.Dispose();
-        Target = target.Clone();
-    }
-
-    public EffectTarget CreateTarget(int width, int height)
-    {
-        SKSurface? surface = _canvas.CreateRenderTarget(width, height);
+        SKSurface? surface = _canvas.CreateRenderTarget((int)bounds.Width, (int)bounds.Height);
         if (surface != null)
         {
             using var surfaceRef = Ref<SKSurface>.Create(surface);
-            return new EffectTarget(surfaceRef, new Size(width, height));
+            return new EffectTarget(surfaceRef, bounds);
         }
         else
         {

--- a/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectNodeComparer.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectNodeComparer.cs
@@ -8,6 +8,7 @@ namespace Beutl.Graphics.Effects;
 
 public class FilterEffectNodeComparer
 {
+    // Todo: すべてのEffectTargetのhistoryを記録
     private ImmutableArray<FEItemWrapper> _current = [];
     private int? _prevVersion;
 

--- a/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectNodeComparer.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectNodeComparer.cs
@@ -71,8 +71,9 @@ public class FilterEffectNodeComparer
                             }
                             else
                             {
+                                // エフェクトが追加されたとき
                                 d = CountEquals(_current, context._items);
-                                cache.ReportSameNumber(d, context._items.Count);
+                                cache.ReportSameNumber(d, context._items.Count + 1);
                                 _prevVersion = Node.FilterEffect.Version;
                                 return;
                             }

--- a/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectNodeComparer.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectNodeComparer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Immutable;
+using System.Diagnostics;
 
 using Beutl.Collections;
 using Beutl.Graphics.Rendering;
@@ -39,6 +40,35 @@ public class FilterEffectNodeComparer
         {
             var captured = activator.CurrentTargets[0]._history.ToImmutableArray();
             _current = captured;
+        }
+        else
+        {
+            _current = [];
+        }
+    }
+
+    public void OnRender(FilterEffectActivator activator, int offset, int? count)
+    {
+        if (activator.CurrentTargets.Count > 0)
+        {
+            if (!count.HasValue)
+            {
+                if (offset == 0)
+                {
+                    _current = [.. activator.CurrentTargets[0]._history];
+                }
+                else
+                {
+                    if (_current.Length < offset)
+                    {
+                        Debug.Fail("_current.Length < offset");
+                        return;
+                    }
+
+                    ReadOnlySpan<FEItemWrapper> old = _current.AsSpan().Slice(0, offset);
+                    _current = [.. old, .. activator.CurrentTargets[0]._history];
+                }
+            }
         }
         else
         {

--- a/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectNodeComparer.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectNodeComparer.cs
@@ -1,0 +1,106 @@
+﻿using System.Collections.Immutable;
+
+using Beutl.Collections;
+using Beutl.Graphics.Rendering;
+using Beutl.Rendering.Cache;
+
+namespace Beutl.Graphics.Effects;
+
+public class FilterEffectNodeComparer
+{
+    private ImmutableArray<FEItemWrapper> _current = [];
+    private int? _prevVersion;
+
+    public FilterEffectNodeComparer(FilterEffectNode node)
+    {
+        Node = node;
+    }
+
+    public FilterEffectNode Node { get; }
+
+    private static int CountEquals(IReadOnlyList<FEItemWrapper> left, IReadOnlyList<FEItemWrapper> right)
+    {
+        int minLength = Math.Min(left.Count, right.Count);
+        for (int i = 0; i < minLength; i++)
+        {
+            if (!left[i].Item.Equals(right[i].Item))
+            {
+                return i;
+            }
+        }
+
+        return minLength;
+    }
+
+    public void OnRender(FilterEffectActivator activator)
+    {
+        if (activator.CurrentTargets.Count > 0)
+        {
+            var captured = activator.CurrentTargets[0]._history.ToImmutableArray();
+            _current = captured;
+        }
+        else
+        {
+            _current = [];
+        }
+    }
+
+    public void Accepts(RenderCache cache)
+    {
+        if (_prevVersion != Node.FilterEffect.Version)
+        {
+            using (var context = new FilterEffectContext(Node.OriginalBounds))
+            {
+                context.Apply(Node.FilterEffect);
+
+            Compare:
+                int minLength = Math.Min(_current.Length, context._items.Count);
+                int d = CountEquals(_current, context._items);
+
+                if (context._renderTimeItems.Count > 0)
+                {
+                    object[] items = [.. context._renderTimeItems];
+                    context._renderTimeItems.Clear();
+                    foreach (object item in items)
+                    {
+                        if (context.Bounds.IsInvalid)
+                        {
+                            if (context._items.Count < _current.Length)
+                            {
+                                context.Bounds = _current[context._items.Count].SourceBounds;
+                            }
+                            else
+                            {
+                                d = CountEquals(_current, context._items);
+                                cache.ReportSameNumber(d, context._items.Count);
+                                _prevVersion = Node.FilterEffect.Version;
+                                return;
+                            }
+                        }
+
+                        if (item is FilterEffect fe)
+                        {
+                            context.Apply(fe);
+                        }
+                        else if (item is FEItemWrapper feitem)
+                        {
+                            context._items.Add(feitem);
+                        }
+                    }
+
+                    goto Compare;
+                }
+                else
+                {
+                    cache.ReportSameNumber(d, context._items.Count);
+                }
+            }
+        }
+        else
+        {
+            cache.ReportSameNumber(_current.Length, _current.Length);
+        }
+
+        _prevVersion = Node.FilterEffect.Version;
+    }
+}

--- a/src/Beutl.Engine/Graphics/FilterEffects/FlatShadow.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FlatShadow.cs
@@ -85,7 +85,7 @@ public class FlatShadow : FilterEffect
 
     public override void ApplyTo(FilterEffectContext context)
     {
-        context.Custom((Angle, Length, (Brush as IMutableBrush)?.ToImmutable(), ShadowOnly), Apply, TransformBounds);
+        context.CustomEffect((Angle, Length, (Brush as IMutableBrush)?.ToImmutable(), ShadowOnly), Apply, TransformBounds);
     }
 
     public override Rect TransformBounds(Rect bounds)
@@ -108,7 +108,7 @@ public class FlatShadow : FilterEffect
         return new Rect(rect.X - (xAbs - x) / 2, rect.Y - (yAbs - y) / 2, width, height);
     }
 
-    private static void Apply((float Angle, float Length, IBrush? Brush, bool ShadowOnly) data, FilterEffectCustomOperationContext context)
+    private static void Apply((float Angle, float Length, IBrush? Brush, bool ShadowOnly) data, CustomFilterEffectContext context)
     {
         static Cv.Point[][] FindPoints(Bitmap<Bgra8888> src)
         {

--- a/src/Beutl.Engine/Graphics/FilterEffects/FlatShadow.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FlatShadow.cs
@@ -85,7 +85,7 @@ public class FlatShadow : FilterEffect
 
     public override void ApplyTo(FilterEffectContext context)
     {
-        context.Custom((Angle, Length, Brush, ShadowOnly), Apply, TransformBounds);
+        context.Custom((Angle, Length, (Brush as IMutableBrush)?.ToImmutable(), ShadowOnly), Apply, TransformBounds);
     }
 
     public override Rect TransformBounds(Rect bounds)

--- a/src/Beutl.Engine/Graphics/FilterEffects/LutEffect.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/LutEffect.cs
@@ -102,13 +102,15 @@ public sealed class LutEffect : FilterEffect
 
     private unsafe void OnApply3DLUT_GPU((CubeFile, float) data, FilterEffectCustomOperationContext context)
     {
-        if (context.Target.Surface?.Value is { } surface)
+        for (int i = 0; i < context.Targets.Count; i++)
         {
+            var target= context.Targets[i];
+            var surface = target.Surface!.Value;
             Accelerator accelerator = SharedGPUContext.Accelerator;
             var kernel = accelerator.LoadAutoGroupedStreamKernel<
                 Index1D, ArrayView<Vec4b>, ArrayView<Vector3>, int, float>(Apply3DLUTKernel);
 
-            var size = PixelSize.FromSize(context.Target.Size, 1);
+            var size = PixelSize.FromSize(target.Bounds.Size, 1);
             var imgInfo = new SKImageInfo(size.Width, size.Height, SKColorType.Bgra8888);
 
             using var source = accelerator.Allocate1D<Vec4b>(size.Width * size.Height);

--- a/src/Beutl.Engine/Graphics/FilterEffects/LutEffect.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/LutEffect.cs
@@ -95,12 +95,12 @@ public sealed class LutEffect : FilterEffect
             }
             else
             {
-                context.Custom((_cube, _strength / 100), OnApply3DLUT_GPU, (_, r) => r);
+                context.CustomEffect((_cube, _strength / 100), OnApply3DLUT_GPU, (_, r) => r);
             }
         }
     }
 
-    private unsafe void OnApply3DLUT_GPU((CubeFile, float) data, FilterEffectCustomOperationContext context)
+    private unsafe void OnApply3DLUT_GPU((CubeFile, float) data, CustomFilterEffectContext context)
     {
         for (int i = 0; i < context.Targets.Count; i++)
         {

--- a/src/Beutl.Engine/Graphics/FilterEffects/OpenCv/Blur.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/OpenCv/Blur.cs
@@ -56,8 +56,16 @@ public class Blur : FilterEffect
     {
         if (!data.FixImageSize)
         {
-            int halfWidth = data.KernelSize.Width / 2;
-            int halfHeight = data.KernelSize.Height / 2;
+            int kwidth = data.KernelSize.Width;
+            int kheight = data.KernelSize.Height;
+
+            if (kwidth % 2 == 0)
+                kwidth++;
+            if (kheight % 2 == 0)
+                kheight++;
+
+            int halfWidth = kwidth / 2;
+            int halfHeight = kheight / 2;
             rect = rect.Inflate(new Thickness(halfWidth, halfHeight));
         }
         return rect;
@@ -65,8 +73,11 @@ public class Blur : FilterEffect
 
     private static void Apply((PixelSize KernelSize, bool FixImageSize) data, FilterEffectCustomOperationContext context)
     {
-        if (context.Target.Surface is { } surface)
+        for (int i = 0; i < context.Targets.Count; i++)
         {
+            var target = context.Targets[i];
+            var surface = target.Surface!;
+
             int kwidth = data.KernelSize.Width;
             int kheight = data.KernelSize.Height;
             if (kwidth <= 0 || kheight <= 0)
@@ -97,9 +108,10 @@ public class Blur : FilterEffect
                 using var mat = dst.ToMat();
                 Cv2.Blur(mat, mat, new(kwidth, kheight));
 
-                using EffectTarget target = context.CreateTarget(dst.Width, dst.Height);
-                target.Surface!.Value.Canvas.DrawBitmap(dst.ToSKBitmap(), 0, 0);
-                context.ReplaceTarget(target);
+                EffectTarget newtarget = context.CreateTarget(TransformBounds(data, target.Bounds));
+                newtarget.Surface!.Value.Canvas.DrawBitmap(dst.ToSKBitmap(), 0, 0);
+                target.Dispose();
+                context.Targets[i] = newtarget;
             }
             finally
             {

--- a/src/Beutl.Engine/Graphics/FilterEffects/OpenCv/Blur.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/OpenCv/Blur.cs
@@ -49,7 +49,7 @@ public class Blur : FilterEffect
 
     public override void ApplyTo(FilterEffectContext context)
     {
-        context.Custom((KernelSize, FixImageSize), Apply, TransformBounds);
+        context.CustomEffect((KernelSize, FixImageSize), Apply, TransformBounds);
     }
 
     private static Rect TransformBounds((PixelSize KernelSize, bool FixImageSize) data, Rect rect)
@@ -71,7 +71,7 @@ public class Blur : FilterEffect
         return rect;
     }
 
-    private static void Apply((PixelSize KernelSize, bool FixImageSize) data, FilterEffectCustomOperationContext context)
+    private static void Apply((PixelSize KernelSize, bool FixImageSize) data, CustomFilterEffectContext context)
     {
         for (int i = 0; i < context.Targets.Count; i++)
         {

--- a/src/Beutl.Engine/Graphics/FilterEffects/OpenCv/GaussianBlur.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/OpenCv/GaussianBlur.cs
@@ -65,7 +65,7 @@ public class GaussianBlur : FilterEffect
 
     public override void ApplyTo(FilterEffectContext context)
     {
-        context.Custom((KernelSize, Sigma, FixImageSize), Apply, TransformBounds);
+        context.CustomEffect((KernelSize, Sigma, FixImageSize), Apply, TransformBounds);
     }
 
     private static Rect TransformBounds((PixelSize KernelSize, Size Sigma, bool FixImageSize) data, Rect rect)
@@ -87,7 +87,7 @@ public class GaussianBlur : FilterEffect
         return rect;
     }
 
-    private static void Apply((PixelSize KernelSize, Size Sigma, bool FixImageSize) data, FilterEffectCustomOperationContext context)
+    private static void Apply((PixelSize KernelSize, Size Sigma, bool FixImageSize) data, CustomFilterEffectContext context)
     {
         for (int i = 0; i < context.Targets.Count; i++)
         {

--- a/src/Beutl.Engine/Graphics/FilterEffects/OpenCv/GaussianBlur.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/OpenCv/GaussianBlur.cs
@@ -72,8 +72,16 @@ public class GaussianBlur : FilterEffect
     {
         if (!data.FixImageSize)
         {
-            int halfWidth = data.KernelSize.Width / 2;
-            int halfHeight = data.KernelSize.Height / 2;
+            int kwidth = data.KernelSize.Width;
+            int kheight = data.KernelSize.Height;
+
+            if (kwidth % 2 == 0)
+                kwidth++;
+            if (kheight % 2 == 0)
+                kheight++;
+
+            int halfWidth = kwidth / 2;
+            int halfHeight = kheight / 2;
             rect = rect.Inflate(new Thickness(halfWidth, halfHeight));
         }
         return rect;
@@ -81,8 +89,11 @@ public class GaussianBlur : FilterEffect
 
     private static void Apply((PixelSize KernelSize, Size Sigma, bool FixImageSize) data, FilterEffectCustomOperationContext context)
     {
-        if (context.Target.Surface is { } surface)
+        for (int i = 0; i < context.Targets.Count; i++)
         {
+            var target = context.Targets[i];
+            var surface = target.Surface!;
+
             int kwidth = data.KernelSize.Width;
             int kheight = data.KernelSize.Height;
             if (kwidth <= 0 || kheight <= 0)
@@ -113,9 +124,10 @@ public class GaussianBlur : FilterEffect
                 using var mat = dst.ToMat();
                 Cv2.GaussianBlur(mat, mat, new(kwidth, kheight), data.Sigma.Width, data.Sigma.Height);
 
-                using EffectTarget target = context.CreateTarget(dst.Width, dst.Height);
-                target.Surface!.Value.Canvas.DrawBitmap(dst.ToSKBitmap(), 0, 0);
-                context.ReplaceTarget(target);
+                EffectTarget newtarget = context.CreateTarget(TransformBounds(data, target.Bounds));
+                newtarget.Surface!.Value.Canvas.DrawBitmap(dst.ToSKBitmap(), 0, 0);
+                target.Dispose();
+                context.Targets[i] = newtarget;
             }
             finally
             {

--- a/src/Beutl.Engine/Graphics/FilterEffects/OpenCv/MedianBlur.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/OpenCv/MedianBlur.cs
@@ -55,17 +55,22 @@ public class MedianBlur : FilterEffect
     {
         if (!data.FixImageSize)
         {
-            int halfWidth = data.KernelSize / 2;
-            int halfHeight = data.KernelSize / 2;
-            rect = rect.Inflate(new Thickness(halfWidth, halfHeight));
+            int ksize = data.KernelSize;
+            if (ksize % 2 == 0)
+                ksize++;
+
+            int half = ksize / 2;
+            rect = rect.Inflate(half);
         }
         return rect;
     }
 
     private static void Apply((int KernelSize, bool FixImageSize) data, FilterEffectCustomOperationContext context)
     {
-        if (context.Target.Surface is { } surface)
+        for (int i = 0; i < context.Targets.Count; i++)
         {
+            var target = context.Targets[i];
+            var surface = target.Surface!;
             int ksize = data.KernelSize;
             if (ksize % 2 == 0)
                 ksize++;
@@ -90,9 +95,10 @@ public class MedianBlur : FilterEffect
                 using var mat = dst.ToMat();
                 Cv2.MedianBlur(mat, mat, ksize);
 
-                using EffectTarget target = context.CreateTarget(dst.Width, dst.Height);
-                target.Surface!.Value.Canvas.DrawBitmap(dst.ToSKBitmap(), 0, 0);
-                context.ReplaceTarget(target);
+                EffectTarget newtarget = context.CreateTarget(TransformBounds(data, target.Bounds));
+                newtarget.Surface!.Value.Canvas.DrawBitmap(dst.ToSKBitmap(), 0, 0);
+                target.Dispose();
+                context.Targets[i] = newtarget;
             }
             finally
             {

--- a/src/Beutl.Engine/Graphics/FilterEffects/OpenCv/MedianBlur.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/OpenCv/MedianBlur.cs
@@ -48,7 +48,7 @@ public class MedianBlur : FilterEffect
 
     public override void ApplyTo(FilterEffectContext context)
     {
-        context.Custom((KernelSize, FixImageSize), Apply, TransformBounds);
+        context.CustomEffect((KernelSize, FixImageSize), Apply, TransformBounds);
     }
 
     private static Rect TransformBounds((int KernelSize, bool FixImageSize) data, Rect rect)
@@ -65,7 +65,7 @@ public class MedianBlur : FilterEffect
         return rect;
     }
 
-    private static void Apply((int KernelSize, bool FixImageSize) data, FilterEffectCustomOperationContext context)
+    private static void Apply((int KernelSize, bool FixImageSize) data, CustomFilterEffectContext context)
     {
         for (int i = 0; i < context.Targets.Count; i++)
         {

--- a/src/Beutl.Engine/Graphics/FilterEffects/PartsSplitEffect.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/PartsSplitEffect.cs
@@ -10,10 +10,10 @@ public class PartsSplitEffect : FilterEffect
 {
     public override void ApplyTo(FilterEffectContext context)
     {
-        context.Custom(Unit.Default, ApplyCore);
+        context.CustomEffect(Unit.Default, ApplyCore);
     }
 
-    private void ApplyCore(Unit unit, FilterEffectCustomOperationContext context)
+    private void ApplyCore(Unit unit, CustomFilterEffectContext context)
     {
         for (int i = 0; i < context.Targets.Count; i++)
         {

--- a/src/Beutl.Engine/Graphics/FilterEffects/PartsSplitEffect.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/PartsSplitEffect.cs
@@ -1,0 +1,88 @@
+﻿using System.Reactive;
+
+using SkiaSharp;
+
+using Cv = OpenCvSharp;
+
+namespace Beutl.Graphics.Effects;
+
+public class PartsSplitEffect : FilterEffect
+{
+    public override void ApplyTo(FilterEffectContext context)
+    {
+        context.Custom(Unit.Default, ApplyCore);
+    }
+
+    private void ApplyCore(Unit unit, FilterEffectCustomOperationContext context)
+    {
+        for (int i = 0; i < context.Targets.Count; i++)
+        {
+            EffectTarget target = context.Targets[i];
+            Media.Source.Ref<SKSurface> srcSurface = target.Surface!;
+            using SKImage skimage = srcSurface.Value.Snapshot();
+            using var src = skimage.ToBitmap();
+            using Cv.Mat srcMat = src.ToMat();
+            using Cv.Mat alphaMat = srcMat.ExtractChannel(3);
+
+            // 輪郭検出
+            alphaMat.FindContours(
+                out Cv.Point[][] points,
+                out Cv.HierarchyIndex[] h,
+                Cv.RetrievalModes.List,
+                Cv.ContourApproximationModes.ApproxSimple);
+
+            var newTargets = new EffectTargets();
+
+            try
+            {
+                using var skpath = new SKPath();
+                foreach (Cv.Point[] inner in points)
+                {
+                    bool first = true;
+                    foreach (Cv.Point item in inner)
+                    {
+                        if (first)
+                        {
+                            skpath.MoveTo(item.X, item.Y);
+                            first = false;
+                        }
+                        else
+                        {
+                            skpath.LineTo(item.X, item.Y);
+                        }
+                    }
+
+                    skpath.Close();
+
+                    SKRect pathBounds = skpath.TightBounds;
+                    var bounds = new Rect(
+                        target.Bounds.X + pathBounds.Left,
+                        target.Bounds.Y + pathBounds.Top,
+                        pathBounds.Width,
+                        pathBounds.Height);
+                    EffectTarget newTarget = context.CreateTarget(bounds);
+                    using (ImmediateCanvas newCanvas = context.Open(newTarget))
+                    using (newCanvas.PushTransform(Matrix.CreateTranslation(-pathBounds.Left, -pathBounds.Top)))
+                    {
+                        newCanvas.Canvas.ClipPath(skpath, antialias: true);
+
+                        newCanvas.DrawSurface(srcSurface.Value, default);
+                    }
+
+                    newTargets.Add(newTarget);
+
+                    skpath.Reset();
+                }
+
+                srcSurface.Dispose();
+                context.Targets.RemoveAt(i);
+                context.Targets.InsertRange(i, newTargets);
+                i += newTargets.Count - 1;
+            }
+            catch
+            {
+                newTargets.Dispose();
+            }
+        }
+    }
+}

--- a/src/Beutl.Engine/Graphics/FilterEffects/SplitEffect.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/SplitEffect.cs
@@ -70,7 +70,7 @@ public class SplitEffect : FilterEffect
 
     public override void ApplyTo(FilterEffectContext context)
     {
-        context.Custom((HorizontalDivisions, VerticalDivisions, HorizontalSpacing, VerticalSpacing), (d, context) =>
+        context.CustomEffect((HorizontalDivisions, VerticalDivisions, HorizontalSpacing, VerticalSpacing), (d, context) =>
         {
             for (int i = 0; i < context.Targets.Count; i++)
             {

--- a/src/Beutl.Engine/Graphics/FilterEffects/SplitEffect.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/SplitEffect.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reactive;
+using System.Text;
+using System.Threading.Tasks;
+
+using SkiaSharp;
+
+namespace Beutl.Graphics.Effects;
+
+public class SplitEffect : FilterEffect
+{
+    public static readonly CoreProperty<int> HorizontalDivisionsProperty;
+    public static readonly CoreProperty<int> VerticalDivisionsProperty;
+    public static readonly CoreProperty<float> HorizontalSpacingProperty;
+    public static readonly CoreProperty<float> VerticalSpacingProperty;
+
+    static SplitEffect()
+    {
+        HorizontalDivisionsProperty = ConfigureProperty<int, SplitEffect>(nameof(HorizontalDivisions))
+            .DefaultValue(2)
+            .Register();
+
+        VerticalDivisionsProperty = ConfigureProperty<int, SplitEffect>(nameof(VerticalDivisions))
+            .DefaultValue(2)
+            .Register();
+
+        HorizontalSpacingProperty = ConfigureProperty<float, SplitEffect>(nameof(HorizontalSpacing))
+            .DefaultValue(0)
+            .Register();
+
+        VerticalSpacingProperty = ConfigureProperty<float, SplitEffect>(nameof(VerticalSpacing))
+            .DefaultValue(0)
+            .Register();
+
+        AffectsRender<SplitEffect>(
+            HorizontalDivisionsProperty,
+            VerticalDivisionsProperty,
+            HorizontalSpacingProperty,
+            VerticalSpacingProperty);
+    }
+
+    [Range(1, int.MaxValue)]
+    public int HorizontalDivisions
+    {
+        get => GetValue(HorizontalDivisionsProperty);
+        set => SetValue(HorizontalDivisionsProperty, value);
+    }
+
+    [Range(1, int.MaxValue)]
+    public int VerticalDivisions
+    {
+        get => GetValue(VerticalDivisionsProperty);
+        set => SetValue(VerticalDivisionsProperty, value);
+    }
+
+    public float HorizontalSpacing
+    {
+        get => GetValue(HorizontalSpacingProperty);
+        set => SetValue(HorizontalSpacingProperty, value);
+    }
+
+    public float VerticalSpacing
+    {
+        get => GetValue(VerticalSpacingProperty);
+        set => SetValue(VerticalSpacingProperty, value);
+    }
+
+    public override void ApplyTo(FilterEffectContext context)
+    {
+        context.Custom((HorizontalDivisions, VerticalDivisions, HorizontalSpacing, VerticalSpacing), (d, context) =>
+        {
+            for (int i = 0; i < context.Targets.Count; i++)
+            {
+                EffectTarget t = context.Targets[i];
+                SKSurface surface = t.Surface!.Value;
+
+                float divWidth = t.Bounds.Width / d.HorizontalDivisions;
+                float divHeight = t.Bounds.Height / d.VerticalDivisions;
+
+                if ((int)divWidth <= 0 || (int)divHeight <= 0)
+                {
+                    t.Dispose();
+                    context.Targets.RemoveAt(i);
+                    i--;
+                }
+                else
+                {
+                    var newBounds = new Rect(
+                        0,
+                        0,
+                        t.Bounds.Width + (d.HorizontalSpacing * (d.HorizontalDivisions - 1)),
+                        t.Bounds.Height + (d.VerticalSpacing * (d.VerticalDivisions - 1)));
+                    newBounds = t.Bounds.CenterRect(newBounds);
+
+                    var newTargets = new EffectTarget[d.HorizontalDivisions * d.VerticalDivisions];
+
+                    for (int v = 0; v < d.VerticalDivisions; v++)
+                    {
+                        for (int h = 0; h < d.HorizontalDivisions; h++)
+                        {
+                            float hh = t.Bounds.Width / -d.VerticalDivisions;
+                            float vv = t.Bounds.Height / -d.HorizontalDivisions;
+                            EffectTarget newTarget = context.CreateTarget(
+                                new Rect(
+                                    newBounds.X + (divWidth + d.HorizontalSpacing) * h,
+                                    newBounds.Y + (divHeight + d.VerticalSpacing) * v,
+                                    divWidth,
+                                    divHeight));
+
+                            using (ImmediateCanvas canvas = context.Open(newTarget))
+                            {
+                                canvas.DrawSurface(surface, new Point(-divWidth * h, -divHeight * v));
+                            }
+
+                            newTargets[v * d.HorizontalDivisions + h] = newTarget;
+                        }
+                    }
+
+                    t.Dispose();
+                    context.Targets.RemoveAt(i);
+                    context.Targets.InsertRange(i, newTargets);
+                    i += newTargets.Length;
+                }
+            }
+        });
+    }
+}

--- a/src/Beutl.Engine/Graphics/FilterEffects/SplitEffect.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/SplitEffect.cs
@@ -122,7 +122,7 @@ public class SplitEffect : FilterEffect
                     t.Dispose();
                     context.Targets.RemoveAt(i);
                     context.Targets.InsertRange(i, newTargets);
-                    i += newTargets.Length;
+                    i += newTargets.Length - 1;
                 }
             }
         });

--- a/src/Beutl.Engine/Graphics/FilterEffects/StrokeEffect.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/StrokeEffect.cs
@@ -84,7 +84,7 @@ public class StrokeEffect : FilterEffect
 
     public override void ApplyTo(FilterEffectContext context)
     {
-        context.Custom((Offset, Pen, Style), Apply, TransformBounds);
+        context.Custom((Offset, (Pen as IMutablePen)?.ToImmutable(), Style), Apply, TransformBounds);
     }
 
     private static Rect TransformBounds((Point Offset, IPen? Pen, Border.BorderStyles Style) data, Rect rect)

--- a/src/Beutl.Engine/Graphics/FilterEffects/StrokeEffect.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/StrokeEffect.cs
@@ -84,7 +84,7 @@ public class StrokeEffect : FilterEffect
 
     public override void ApplyTo(FilterEffectContext context)
     {
-        context.Custom((Offset, (Pen as IMutablePen)?.ToImmutable(), Style), Apply, TransformBounds);
+        context.CustomEffect((Offset, (Pen as IMutablePen)?.ToImmutable(), Style), Apply, TransformBounds);
     }
 
     private static Rect TransformBounds((Point Offset, IPen? Pen, Border.BorderStyles Style) data, Rect rect)
@@ -93,7 +93,7 @@ public class StrokeEffect : FilterEffect
         return rect.Union(borderBounds.Translate(new Vector(data.Offset.X, data.Offset.Y)));
     }
 
-    private static void Apply((Point Offset, IPen? Pen, Border.BorderStyles Style) data, FilterEffectCustomOperationContext context)
+    private static void Apply((Point Offset, IPen? Pen, Border.BorderStyles Style) data, CustomFilterEffectContext context)
     {
         static SKPath CreateBorderPath(Bitmap<Bgra8888> src)
         {

--- a/src/Beutl.Engine/Graphics/Rect.cs
+++ b/src/Beutl.Engine/Graphics/Rect.cs
@@ -35,6 +35,11 @@ public readonly struct Rect
     public static readonly Rect Empty;
 
     /// <summary>
+    /// All values are NaN rectangles.
+    /// </summary>
+    public static readonly Rect Invalid = new(float.NaN, float.NaN, float.NaN, float.NaN);
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="Rect"/> structure.
     /// </summary>
     /// <param name="x">The X position.</param>
@@ -166,6 +171,11 @@ public readonly struct Rect
     /// Gets a value that indicates whether the rectangle is empty.
     /// </summary>
     public bool IsEmpty => Width == 0 && Height == 0;
+
+    /// <summary>
+    /// Gets the value of whether any of the properties are NaN.
+    /// </summary>
+    public bool IsInvalid => float.IsNaN(Width) || float.IsNaN(Height) || float.IsNaN(X) || float.IsNaN(Y);
 
     static int ITupleConvertible<Rect, float>.TupleLength => 4;
 

--- a/src/Beutl.Engine/Graphics/Rendering/BlendModeNode.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/BlendModeNode.cs
@@ -34,12 +34,12 @@ public sealed class BlendModeNode(BlendMode blendMode) : ContainerNode, ISupport
         }
     }
 
-    void ISupportRenderCache.RenderForCache(ImmediateCanvas canvas, RenderCache cache)
+    void ISupportRenderCache.CreateCache(IImmediateCanvasFactory factory, RenderCache cache, RenderCacheContext context)
     {
         if (BlendMode != BlendMode.SrcOver)
             throw new InvalidOperationException("SrcOver以外のブレンドモードはキャッシュ用に描画できません");
 
-        Render(canvas);
+        context.CreateDefaultCache(this, cache, factory);
     }
 
     void ISupportRenderCache.RenderWithCache(ImmediateCanvas canvas, RenderCache cache)
@@ -51,10 +51,5 @@ public sealed class BlendModeNode(BlendMode blendMode) : ContainerNode, ISupport
                 canvas.DrawSurface(surface.Value, cacheBounds.Position);
             }
         }
-    }
-
-    Rect ISupportRenderCache.TransformBoundsForCache(RenderCache cache)
-    {
-        return Bounds;
     }
 }

--- a/src/Beutl.Engine/Graphics/Rendering/FilterEffectNode.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/FilterEffectNode.cs
@@ -101,7 +101,7 @@ public sealed class FilterEffectNode : ContainerNode, ISupportRenderCache
                     paint.BlendMode = (SKBlendMode)canvas.BlendMode;
                     paint.ImageFilter = builder.GetFilter();
 
-                    foreach (var t in activator.CurrentTargets)
+                    foreach (EffectTarget t in activator.CurrentTargets)
                     {
                         using (canvas.PushBlendMode(BlendMode.SrcOver))
                         using (canvas.PushTransform(Matrix.CreateTranslation(t.Bounds.X - t.OriginalBounds.X, t.Bounds.Y - t.OriginalBounds.Y)))
@@ -130,12 +130,7 @@ public sealed class FilterEffectNode : ContainerNode, ISupportRenderCache
 
             _rect = activator.CurrentTargets.CalculateBounds();
 
-            // Todo: [0..1]までキャッシュされていたが、[0..2]までキャッシュできるようになったとき、キャッシュされない。
-            // なので、FilterEffectNodeComparer._currentから、キャッシュされた部分までのhistoryを付け加えたものを記録する。
-            if (offset == 0 && !count.HasValue)
-            {
-                _comparer.OnRender(activator);
-            }
+            _comparer.OnRender(activator, offset, count);
         }
     }
 

--- a/src/Beutl.Engine/Graphics/Rendering/FilterEffectNode.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/FilterEffectNode.cs
@@ -79,7 +79,6 @@ public sealed class FilterEffectNode(FilterEffect filterEffect) : ContainerNode,
         {
             activator.Apply(context, range);
 
-
             if (builder.HasFilter())
             {
                 using (var paint = new SKPaint())
@@ -114,7 +113,7 @@ public sealed class FilterEffectNode(FilterEffect filterEffect) : ContainerNode,
                 }
             }
 
-            _rect = activator.CurrentTargets.Aggregate<EffectTarget, Rect>(default, (x, y) => x.Union(y.Bounds));
+            _rect = activator.CurrentTargets.CalculateBounds();
         }
     }
 

--- a/src/Beutl.Engine/Rendering/Cache/ISupportRenderCache.cs
+++ b/src/Beutl.Engine/Rendering/Cache/ISupportRenderCache.cs
@@ -6,9 +6,7 @@ public interface ISupportRenderCache
 {
     void Accepts(RenderCache cache);
 
-    Rect TransformBoundsForCache(RenderCache cache);
-
-    void RenderForCache(ImmediateCanvas canvas, RenderCache cache);
-
     void RenderWithCache(ImmediateCanvas canvas, RenderCache cache);
+
+    void CreateCache(IImmediateCanvasFactory factory, RenderCache cache, RenderCacheContext context);
 }

--- a/src/Beutl.Engine/Rendering/Cache/RenderCache.cs
+++ b/src/Beutl.Engine/Rendering/Cache/RenderCache.cs
@@ -14,8 +14,7 @@ namespace Beutl.Rendering.Cache;
 public sealed class RenderCache(IGraphicNode node) : IDisposable
 {
     private readonly WeakReference<IGraphicNode> _node = new(node);
-    private Ref<SKSurface>? _cache;
-    private Rect _cacheBounds;
+    private readonly List<(Ref<SKSurface>, Rect)> _cache = new(1);
 
     private int _count;
 
@@ -33,7 +32,9 @@ public sealed class RenderCache(IGraphicNode node) : IDisposable
 
     private FixedArrayAccessor Accessor => _accessor ??= new();
 
-    public bool IsCached => _cache != null;
+    public bool IsCached => _cache.Count != 0;
+
+    public int CacheCount => _cache.Count;
 
     public DateTime LastAccessedTime { get; private set; }
 
@@ -174,15 +175,17 @@ public sealed class RenderCache(IGraphicNode node) : IDisposable
     {
         RenderThread.Dispatcher.CheckAccess();
 #if DEBUG
-        if (_cache != null)
+        if (_cache.Count != 0)
         {
             Debug.WriteLine($"[RenderCache:Invalildated] '{(_node.TryGetTarget(out IGraphicNode? node) ? node : null)}'");
         }
 #endif
 
-        _cache?.Dispose();
-        _cache = null;
-        _cacheBounds = Rect.Empty;
+        foreach ((Ref<SKSurface>, Rect) item in _cache)
+        {
+            item.Item1.Dispose();
+        }
+        _cache.Clear();
         _cachedAt = -1;
     }
 
@@ -190,13 +193,18 @@ public sealed class RenderCache(IGraphicNode node) : IDisposable
     {
         void DisposeOnRenderThread()
         {
-            if (_cache != null)
+            if (_cache.Count != 0)
             {
-                Ref<SKSurface> tmp = _cache;
-                _cache = null;
-                _cacheBounds = Rect.Empty;
+                (Ref<SKSurface>, Rect)[] tmp = [.. _cache];
+                _cache.Clear();
 
-                RenderThread.Dispatcher.Dispatch(tmp.Dispose, DispatchPriority.Low);
+                RenderThread.Dispatcher.Dispatch(() =>
+                {
+                    foreach ((Ref<SKSurface>, Rect) item in tmp)
+                    {
+                        item.Item1.Dispose();
+                    }
+                }, DispatchPriority.Low);
             }
 
             IsDisposed = true;
@@ -206,9 +214,11 @@ public sealed class RenderCache(IGraphicNode node) : IDisposable
         {
             if (RenderThread.Dispatcher.CheckAccess())
             {
-                _cache?.Dispose();
-                _cache = null;
-                _cacheBounds = Rect.Empty;
+                foreach ((Ref<SKSurface>, Rect) item in _cache)
+                {
+                    item.Item1.Dispose();
+                }
+                _cache.Clear();
                 IsDisposed = true;
             }
             else
@@ -222,27 +232,55 @@ public sealed class RenderCache(IGraphicNode node) : IDisposable
 
     public Ref<SKSurface> UseCache(out Rect bounds)
     {
-        if (_cache == null)
+        if (_cache.Count == 0)
         {
             throw new Exception("キャッシュはありません");
         }
 
-        bounds = _cacheBounds;
+        (Ref<SKSurface>, Rect) c = _cache[0];
+        bounds = c.Item2;
         LastAccessedTime = DateTime.UtcNow;
-        return _cache.Clone();
+        return c.Item1.Clone();
     }
 
     public void StoreCache(Ref<SKSurface> surface, Rect bounds)
     {
         Invalidate();
 
-        _cache = surface.Clone();
-        _cacheBounds = bounds;
+        _cache.Add((surface.Clone(), bounds));
 
         if (_accessor != null)
         {
             const int Count = FixedArray.Count;
-            _cachedAt = (_accessor.Index + (Count - 1)) % Count;
+            _cachedAt = _accessor.Get((_accessor.Index + (Count - 1)) % Count);
+        }
+        else
+        {
+            _cachedAt = 0;
+        }
+
+        LastAccessedTime = DateTime.UtcNow;
+    }
+
+    public (Ref<SKSurface> Surface, Rect Bounds)[] UseCache()
+    {
+        LastAccessedTime = DateTime.UtcNow;
+        return _cache.Select(i => (i.Item1.Clone(), i.Item2)).ToArray();
+    }
+
+    public void StoreCache(ReadOnlySpan<(Ref<SKSurface> Surface, Rect Bounds)> items)
+    {
+        Invalidate();
+
+        foreach ((Ref<SKSurface> surface, Rect bounds) in items)
+        {
+            _cache.Add((surface.Clone(), bounds));
+        }
+
+        if (_accessor != null)
+        {
+            const int Count = FixedArray.Count;
+            _cachedAt = _accessor.Get((_accessor.Index + (Count - 1)) % Count);
         }
         else
         {

--- a/src/Beutl.Engine/Rendering/Cache/RenderCacheContext.cs
+++ b/src/Beutl.Engine/Rendering/Cache/RenderCacheContext.cs
@@ -140,9 +140,9 @@ public sealed class RenderCacheContext : IDisposable
         }
     }
 
-    private void MakeCacheCore(IGraphicNode node, RenderCache cache, IImmediateCanvasFactory factory)
+    public void CreateDefaultCache(IGraphicNode node, RenderCache cache, IImmediateCanvasFactory factory)
     {
-        Rect bounds = (node as ISupportRenderCache)?.TransformBoundsForCache(cache) ?? node.Bounds;
+        Rect bounds = node.Bounds;
         //bounds = bounds.Inflate(5);
         PixelRect boundsInPixels = PixelRect.FromRect(bounds);
         PixelSize size = boundsInPixels.Size;
@@ -164,14 +164,7 @@ public sealed class RenderCacheContext : IDisposable
         {
             using (canvas.PushTransform(Matrix.CreateTranslation(-boundsInPixels.X, -boundsInPixels.Y)))
             {
-                if (node is ISupportRenderCache supportRenderCache)
-                {
-                    supportRenderCache.RenderForCache(canvas, cache);
-                }
-                else
-                {
-                    node.Render(canvas);
-                }
+                node.Render(canvas);
             }
         }
 
@@ -181,6 +174,18 @@ public sealed class RenderCacheContext : IDisposable
         }
 
         Debug.WriteLine($"[RenderCache:Created] '{node}'");
+    }
+
+    private void MakeCacheCore(IGraphicNode node, RenderCache cache, IImmediateCanvasFactory factory)
+    {
+        if (node is ISupportRenderCache supportRenderCache)
+        {
+            supportRenderCache.CreateCache(factory, cache, this);
+        }
+        else
+        {
+            CreateDefaultCache(node, cache, factory);
+        }
     }
 
     public void Dispose()

--- a/src/Beutl.Operators/Configure/Effects/EffectsOperator.cs
+++ b/src/Beutl.Operators/Configure/Effects/EffectsOperator.cs
@@ -148,3 +148,18 @@ public sealed class FlatShadowOperator : FilterEffectOperator<FlatShadow>
 
     public Setter<bool> ShadowOnly { get; set; } = new(FlatShadow.ShadowOnlyProperty);
 }
+
+public sealed class SplitEffectOperator : FilterEffectOperator<SplitEffect>
+{
+    public Setter<int> HorizontalDivisions { get; set; } = new(SplitEffect.HorizontalDivisionsProperty, 2);
+
+    public Setter<int> VerticalDivisions { get; set; } = new(SplitEffect.VerticalDivisionsProperty, 2);
+
+    public Setter<float> HorizontalSpacing { get; set; } = new(SplitEffect.HorizontalSpacingProperty);
+
+    public Setter<float> VerticalSpacing { get; set; } = new(SplitEffect.VerticalSpacingProperty);
+}
+
+public sealed class PartsSplitEffectOperator : FilterEffectOperator<PartsSplitEffect>
+{
+}

--- a/src/Beutl.Operators/LibraryRegistrar.cs
+++ b/src/Beutl.Operators/LibraryRegistrar.cs
@@ -16,6 +16,11 @@ public static class LibraryRegistrar
     public static void RegisterAll()
     {
         LibraryService.Current
+            .AddMultiple("SplitEffect", m => m
+                .BindFilterEffect<SplitEffect>()
+            );
+        
+        LibraryService.Current
             .AddMultiple(Strings.Ellipse, m => m
                 .BindSourceOperator<Source.EllipseOperator>()
                 .BindDrawable<Graphics.Shapes.EllipseShape>()

--- a/src/Beutl.Operators/LibraryRegistrar.cs
+++ b/src/Beutl.Operators/LibraryRegistrar.cs
@@ -21,6 +21,11 @@ public static class LibraryRegistrar
             );
         
         LibraryService.Current
+            .AddMultiple("PartsSplitEffect", m => m
+                .BindFilterEffect<PartsSplitEffect>()
+            );
+        
+        LibraryService.Current
             .AddMultiple(Strings.Ellipse, m => m
                 .BindSourceOperator<Source.EllipseOperator>()
                 .BindDrawable<Graphics.Shapes.EllipseShape>()


### PR DESCRIPTION
<!-- 2-4は省略可 -->
## このプルリクエストで何をやったのか？
- 複数のエフェクトターゲットに対応。
- 事前に境界線が確定しないエフェクトに対応。

## やらなかったこと

## できるようになること
- パーツ分解
- 分割

## できなくなること
- 境界線が確定しないエフェクトを使っている場合、描画前に境界線を取得できない

## 破壊的変更
- FilterEffectActivator
- ISupportRenderCache

## 廃止するApi
<!-- Obsolete属性を付けたApi -->

## リンクされたIsuues
- #935