### PR TITLE
Preferenceクラスを追加

### DIFF
--- a/src/Beutl.Configuration/DefaultPreferences.cs
+++ b/src/Beutl.Configuration/DefaultPreferences.cs
@@ -1,0 +1,128 @@
+﻿// https://github.com/AvaloniaUI/Avalonia.Essentials/blob/main/src/Preferences/Preferences.uwp.cs
+
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text.Json;
+
+namespace Beutl.Configuration;
+
+public sealed class DefaultPreferences : IPreferences
+{
+    private static readonly Type[] s_supportedTypes =
+    [
+        typeof(bool),
+        typeof(char),
+        typeof(sbyte),
+        typeof(byte),
+        typeof(short),
+        typeof(ushort),
+        typeof(int),
+        typeof(uint),
+        typeof(long),
+        typeof(ulong),
+        typeof(float),
+        typeof(double),
+        typeof(decimal),
+        typeof(DateTime),
+        typeof(string),
+    ];
+
+    private readonly ConcurrentDictionary<string, string> _preferences = new();
+    private readonly string _filePath;
+
+    public DefaultPreferences(string filePath)
+    {
+        _filePath = filePath;
+        Load();
+    }
+
+    public bool ContainsKey(string key)
+    {
+        return _preferences.ContainsKey(key);
+    }
+
+    public void Remove(string key)
+    {
+        _preferences.TryRemove(key, out _);
+        Save();
+    }
+
+    public void Clear()
+    {
+        _preferences.Clear();
+        Save();
+    }
+
+    public void Set<T>(string key, T value)
+    {
+        CheckIsSupportedType<T>();
+
+        if (value is null)
+            _preferences.TryRemove(key, out _);
+        else
+            _preferences[key] = string.Format(CultureInfo.InvariantCulture, "{0}", value);
+
+        Save();
+    }
+
+    public T Get<T>(string key, T defaultValue)
+    {
+        CheckIsSupportedType<T>();
+
+        if (_preferences.TryGetValue(key, out string? value) && value is not null)
+        {
+            try
+            {
+                return (T)Convert.ChangeType(value, typeof(T), CultureInfo.InvariantCulture);
+            }
+            catch (FormatException)
+            {
+                // bad get, fall back to default
+            }
+        }
+
+        return defaultValue;
+    }
+
+    private void Load()
+    {
+        if (!File.Exists(_filePath))
+            return;
+
+        try
+        {
+            using FileStream stream = File.OpenRead(_filePath);
+
+            Dictionary<string, string>? readPreferences = JsonSerializer.Deserialize<Dictionary<string, string>>(stream);
+
+            if (readPreferences != null)
+            {
+                _preferences.Clear();
+                foreach (KeyValuePair<string, string> pair in readPreferences)
+                    _preferences.TryAdd(pair.Key, pair.Value);
+            }
+        }
+        catch (JsonException)
+        {
+            // if deserialization fails proceed with empty settings
+        }
+    }
+
+    private void Save()
+    {
+        string? dir = Path.GetDirectoryName(_filePath);
+        Directory.CreateDirectory(dir!);
+
+        using FileStream stream = File.Create(_filePath);
+        JsonSerializer.Serialize(stream, _preferences);
+    }
+
+    internal static void CheckIsSupportedType<T>()
+    {
+        Type type = typeof(T);
+        if (!s_supportedTypes.Contains(type))
+        {
+            throw new NotSupportedException($"Preferences using '{type}' type is not supported");
+        }
+    }
+}

--- a/src/Beutl.Configuration/IPreferences.cs
+++ b/src/Beutl.Configuration/IPreferences.cs
@@ -1,0 +1,16 @@
+﻿// https://github.com/AvaloniaUI/Avalonia.Essentials/blob/main/src/Preferences/Preferences.uwp.cs
+
+namespace Beutl.Configuration;
+
+public interface IPreferences
+{
+    bool ContainsKey(string key);
+
+    void Remove(string key);
+
+    void Clear();
+
+    void Set<T>(string key, T value);
+
+    T Get<T>(string key, T defaultValue);
+}

--- a/src/Beutl.Configuration/Preference.cs
+++ b/src/Beutl.Configuration/Preference.cs
@@ -1,0 +1,13 @@
+﻿// https://github.com/AvaloniaUI/Avalonia.Essentials/blob/main/src/Preferences/Preferences.uwp.cs
+
+namespace Beutl.Configuration;
+
+public static class Preferences
+{
+    static Preferences()
+    {
+        Default = new DefaultPreferences(Path.Combine(BeutlEnvironment.HomeVariable, "preferences.json"));
+    }
+
+    public static IPreferences Default { get; }
+}


### PR DESCRIPTION
<!-- 2-4は省略可 -->
## このプルリクエストで何をやったのか？
GlobalConfigurationクラスを使わない設定APIの追加
(WebのlocalStorageのような機能)

## できるようになること
```cs
var fonts = Preferences.Default.Get("favorite.fonts", Array.Empty<string>());

fonts = fonts.Append("Inter").ToArray();
Preferences.Default.Set("fovorite.fonts", fonts);
```