### PR TITLE
Added Opacity property to Drawable class

### DIFF
--- a/src/Beutl.Engine/Graphics/CanvasPushedState.cs
+++ b/src/Beutl.Engine/Graphics/CanvasPushedState.cs
@@ -42,6 +42,26 @@ public partial class ImmediateCanvas
             }
         }
 
+        internal record OpacityPushedState(float Opacity, int Count, SKPaint Paint) : CanvasPushedState
+        {
+            public override void Pop(ImmediateCanvas canvas)
+            {
+                canvas._sharedFillPaint.Reset();
+                canvas._sharedFillPaint.BlendMode = SKBlendMode.DstIn;
+
+                canvas.Canvas.SaveLayer(canvas._sharedFillPaint);
+                using (SKPaint maskPaint = Paint)
+                {
+                    canvas.Canvas.DrawPaint(maskPaint);
+                }
+
+                canvas.Canvas.Restore();
+
+                canvas.Canvas.RestoreToCount(Count);
+                canvas.Opacity = Opacity;
+            }
+        }
+
         public abstract void Pop(ImmediateCanvas canvas);
     }
 }

--- a/src/Beutl.Engine/Graphics/ICanvas.cs
+++ b/src/Beutl.Engine/Graphics/ICanvas.cs
@@ -55,6 +55,8 @@ public interface ICanvas : IDisposable
 
     PushedState PushClip(Geometry geometry, ClipOperation operation = ClipOperation.Intersect);
 
+    PushedState PushOpacity(float opacity);
+
     PushedState PushOpacityMask(IBrush mask, Rect bounds, bool invert = false);
 
     PushedState PushFilterEffect(FilterEffect effect);

--- a/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
+++ b/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
@@ -45,6 +45,8 @@ public partial class ImmediateCanvas : ICanvas, IImmediateCanvasFactory
 
     public BlendMode BlendMode { get; set; } = BlendMode.SrcOver;
 
+    public float Opacity { get; set; } = 1;
+
     public PixelSize Size { get; }
 
     public Matrix Transform
@@ -481,6 +483,19 @@ public partial class ImmediateCanvas : ICanvas, IImmediateCanvasFactory
         ClipPath(geometry, operation);
 
         _states.Push(new CanvasPushedState.SKCanvasPushedState(count));
+        return new PushedState(this, _states.Count);
+    }
+
+    public PushedState PushOpacity(float opacity)
+    {
+        VerifyAccess();
+        float oldOpacity = Opacity;
+        Opacity *= opacity;
+        var paint = new SKPaint();
+
+        int count = Canvas.SaveLayer(paint);
+        paint.Color = new SKColor(0, 0, 0, (byte)(Opacity * 255));
+        _states.Push(new CanvasPushedState.OpacityPushedState(oldOpacity, count, paint));
         return new PushedState(this, _states.Count);
     }
 

--- a/src/Beutl.Engine/Graphics/Rendering/DeferradCanvas.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/DeferradCanvas.cs
@@ -350,6 +350,22 @@ public sealed class DeferradCanvas(ContainerNode container, PixelSize canvasSize
         return new(this, _nodes.Count);
     }
 
+    public PushedState PushOpacity(float opacity)
+    {
+        OpacityNode? next = Next<OpacityNode>();
+
+        if (next == null || !next.Equals(opacity))
+        {
+            AddAndPush(new OpacityNode(opacity), next);
+        }
+        else
+        {
+            Push(next);
+        }
+
+        return new(this, _nodes.Count);
+    }
+
     public PushedState PushFilterEffect(FilterEffect effect)
     {
         FilterEffectNode? next = Next<FilterEffectNode>();

--- a/src/Beutl.Engine/Graphics/Rendering/OpacityNode.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/OpacityNode.cs
@@ -1,0 +1,19 @@
+﻿namespace Beutl.Graphics.Rendering;
+
+public sealed class OpacityNode(float opacity) : ContainerNode
+{
+    public float Opacity { get; } = opacity;
+
+    public bool Equals(float opacity)
+    {
+        return Opacity == opacity;
+    }
+
+    public override void Render(ImmediateCanvas canvas)
+    {
+        using (canvas.PushOpacity(Opacity))
+        {
+            base.Render(canvas);
+        }
+    }
+}

--- a/src/Beutl.Operators/Source/EllipseOperation.cs
+++ b/src/Beutl.Operators/Source/EllipseOperation.cs
@@ -28,4 +28,6 @@ public sealed class EllipseOperator : DrawablePublishOperator<EllipseShape>
     public Setter<FilterEffect?> FilterEffect { get; set; } = new(Drawable.FilterEffectProperty, new FilterEffectGroup());
 
     public Setter<BlendMode> BlendMode { get; set; } = new Setter<BlendMode>(Drawable.BlendModeProperty, Graphics.BlendMode.SrcOver);
+
+    public Setter<float> Opacity { get; set; } = new Setter<float>(Drawable.OpacityProperty, 100);
 }

--- a/src/Beutl.Operators/Source/GeometryOperator.cs
+++ b/src/Beutl.Operators/Source/GeometryOperator.cs
@@ -28,4 +28,6 @@ public sealed class GeometryOperator : DrawablePublishOperator<GeometryShape>
     public Setter<FilterEffect?> FilterEffect { get; set; } = new(Drawable.FilterEffectProperty, new FilterEffectGroup());
 
     public Setter<BlendMode> BlendMode { get; set; } = new Setter<BlendMode>(Drawable.BlendModeProperty, Graphics.BlendMode.SrcOver);
+
+    public Setter<float> Opacity { get; set; } = new Setter<float>(Drawable.OpacityProperty, 100);
 }

--- a/src/Beutl.Operators/Source/RectOperator.cs
+++ b/src/Beutl.Operators/Source/RectOperator.cs
@@ -28,4 +28,6 @@ public sealed class RectOperator : DrawablePublishOperator<RectShape>
     public Setter<FilterEffect?> FilterEffect { get; set; } = new(Drawable.FilterEffectProperty, new FilterEffectGroup());
 
     public Setter<BlendMode> BlendMode { get; set; } = new Setter<BlendMode>(Drawable.BlendModeProperty, Graphics.BlendMode.SrcOver);
+
+    public Setter<float> Opacity { get; set; } = new Setter<float>(Drawable.OpacityProperty, 100);
 }

--- a/src/Beutl.Operators/Source/RoundedRectOperator.cs
+++ b/src/Beutl.Operators/Source/RoundedRectOperator.cs
@@ -30,4 +30,6 @@ public sealed class RoundedRectOperator : DrawablePublishOperator<RoundedRectSha
     public Setter<FilterEffect?> FilterEffect { get; set; } = new(Drawable.FilterEffectProperty, new FilterEffectGroup());
 
     public Setter<BlendMode> BlendMode { get; set; } = new Setter<BlendMode>(Drawable.BlendModeProperty, Graphics.BlendMode.SrcOver);
+
+    public Setter<float> Opacity { get; set; } = new Setter<float>(Drawable.OpacityProperty, 100);
 }

--- a/src/Beutl.Operators/Source/SourceBackdropOperator.cs
+++ b/src/Beutl.Operators/Source/SourceBackdropOperator.cs
@@ -21,4 +21,6 @@ public sealed class SourceBackdropOperator : DrawablePublishOperator<SourceBackd
     public Setter<FilterEffect?> FilterEffect { get; set; } = new(Drawable.FilterEffectProperty, new FilterEffectGroup());
 
     public Setter<BlendMode> BlendMode { get; set; } = new Setter<BlendMode>(Drawable.BlendModeProperty, Graphics.BlendMode.SrcOver);
+
+    public Setter<float> Opacity { get; set; } = new Setter<float>(Drawable.OpacityProperty, 100);
 }

--- a/src/Beutl.Operators/Source/SourceImageOperator.cs
+++ b/src/Beutl.Operators/Source/SourceImageOperator.cs
@@ -21,11 +21,11 @@ public sealed class SourceImageOperator : DrawablePublishOperator<SourceImage>
 
     public Setter<RelativePoint> TransformOrigin { get; set; } = new(Drawable.TransformOriginProperty, RelativePoint.Center);
 
-    public Setter<IBrush?> Fill { get; set; } = new(Drawable.FillProperty, new SolidColorBrush(Colors.White));
-
     public Setter<FilterEffect?> FilterEffect { get; set; } = new(Drawable.FilterEffectProperty, new FilterEffectGroup());
 
     public Setter<BlendMode> BlendMode { get; set; } = new Setter<BlendMode>(Drawable.BlendModeProperty, Graphics.BlendMode.SrcOver);
+
+    public Setter<float> Opacity { get; set; } = new Setter<float>(Drawable.OpacityProperty, 100);
 
     protected override void OnDetachedFromHierarchy(in HierarchyAttachmentEventArgs args)
     {

--- a/src/Beutl.Operators/Source/SourceVideoOperator.cs
+++ b/src/Beutl.Operators/Source/SourceVideoOperator.cs
@@ -27,11 +27,11 @@ public sealed class SourceVideoOperator : DrawablePublishOperator<SourceVideo>
 
     public Setter<RelativePoint> TransformOrigin { get; set; } = new(Drawable.TransformOriginProperty, RelativePoint.Center);
 
-    public Setter<IBrush?> Fill { get; set; } = new(Drawable.FillProperty, new SolidColorBrush(Colors.White));
-
     public Setter<FilterEffect?> FilterEffect { get; set; } = new(Drawable.FilterEffectProperty, new FilterEffectGroup());
 
     public Setter<BlendMode> BlendMode { get; set; } = new Setter<BlendMode>(Drawable.BlendModeProperty, Graphics.BlendMode.SrcOver);
+
+    public Setter<float> Opacity { get; set; } = new Setter<float>(Drawable.OpacityProperty, 100);
 
     protected override void OnDetachedFromHierarchy(in HierarchyAttachmentEventArgs args)
     {

--- a/src/Beutl.Operators/Source/TextBlockOperator.cs
+++ b/src/Beutl.Operators/Source/TextBlockOperator.cs
@@ -18,7 +18,7 @@ public sealed class TextBlockOperator : DrawablePublishOperator<TextBlock>
     public Setter<FontWeight> FontWeight { get; set; } = new Setter<FontWeight>(TextBlock.FontWeightProperty, Media.FontWeight.Regular);
 
     public Setter<float> Spacing { get; set; } = new Setter<float>(TextBlock.SpacingProperty, 0);
-    
+
     public Setter<bool> SplitByCharacters { get; set; } = new Setter<bool>(TextBlock.SplitByCharactersProperty);
 
     public Setter<string?> Text { get; set; } = new Setter<string?>(TextBlock.TextProperty, string.Empty);
@@ -38,4 +38,6 @@ public sealed class TextBlockOperator : DrawablePublishOperator<TextBlock>
     public Setter<FilterEffect?> FilterEffect { get; set; } = new(Drawable.FilterEffectProperty, new FilterEffectGroup());
 
     public Setter<BlendMode> BlendMode { get; set; } = new Setter<BlendMode>(Drawable.BlendModeProperty, Graphics.BlendMode.SrcOver);
+
+    public Setter<float> Opacity { get; set; } = new Setter<float>(Drawable.OpacityProperty, 100);
 }


### PR DESCRIPTION
## Description
Previously, opacity could only be set using effects. This update adds an opacity property to the Drawable class, allowing for direct opacity adjustments.

## Breaking changes

## Fixed issues
- #980