### PR TITLE
Enable Object Resolution by Id During Deserialization

### DIFF
--- a/src/Beutl.Core/Collections/HierarchicalList.cs
+++ b/src/Beutl.Core/Collections/HierarchicalList.cs
@@ -11,5 +11,10 @@ public class HierarchicalList<T> : CoreList<T>
         Detached += item => parent.RemoveChild(item);
     }
 
-    public IModifiableHierarchical Parent { get; }
+    public HierarchicalList()
+    {
+        ResetBehavior = ResetBehavior.Remove;
+    }
+
+    public IModifiableHierarchical? Parent { get; }
 }

--- a/src/Beutl.Core/CoreObject.cs
+++ b/src/Beutl.Core/CoreObject.cs
@@ -456,6 +456,12 @@ public abstract class CoreObject : ICoreObject
             Optional<object?> value = item.RouteDeserialize(context);
             if (value.HasValue)
             {
+                if (value.Value is IReference { IsNull: false } reference)
+                {
+                    context.Resolve(reference.Id,
+                        resolved => SetValue(item, reference.Resolved((CoreObject)resolved)));
+                }
+
                 SetValue(item, value.Value);
             }
         }

--- a/src/Beutl.Core/Hierarchy/Hierarchical.cs
+++ b/src/Beutl.Core/Hierarchy/Hierarchical.cs
@@ -5,6 +5,7 @@ using Beutl.Collections;
 
 namespace Beutl;
 
+// TODO: 複数の親要素（参照元）を持てるようにする
 public abstract class Hierarchical : CoreObject, IHierarchical, IModifiableHierarchical
 {
     public static readonly CoreProperty<IHierarchical?> HierarchicalParentProperty;

--- a/src/Beutl.Core/JsonHelper.cs
+++ b/src/Beutl.Core/JsonHelper.cs
@@ -87,6 +87,7 @@ public static class JsonHelper
             using (ThreadLocalSerializationContext.Enter(context))
             {
                 serializable.Deserialize(context);
+                context.AfterDeserialized(serializable);
             }
         }
     }

--- a/src/Beutl.Core/OptionalJsonConverter.cs
+++ b/src/Beutl.Core/OptionalJsonConverter.cs
@@ -45,6 +45,7 @@ public sealed class OptionalJsonConverter : JsonConverter<IOptional>
                         using (ThreadLocalSerializationContext.Enter(context))
                         {
                             serializable.Deserialize(context);
+                            context.AfterDeserialized(serializable);
                         }
 
                         instance = serializable;

--- a/src/Beutl.Core/ProjectItemContainer.cs
+++ b/src/Beutl.Core/ProjectItemContainer.cs
@@ -93,7 +93,6 @@ public sealed class ProjectItemContainer
 
     public void Add(ProjectItem item)
     {
-        _app.Items.Add(item);
         foreach (WeakReference<ProjectItem> wref in _items)
         {
             if (!wref.TryGetTarget(out _))

--- a/src/Beutl.Core/Reference.cs
+++ b/src/Beutl.Core/Reference.cs
@@ -1,0 +1,83 @@
+﻿namespace Beutl;
+
+public interface IReference
+{
+    Guid Id { get; }
+
+    CoreObject? Value { get; }
+
+    bool IsNull { get; }
+
+    Type ObjectType { get; }
+
+    IReference Resolved(CoreObject obj);
+}
+
+public readonly struct Reference<TObject> : IEquatable<Reference<TObject>>, IReference
+    where TObject : notnull, CoreObject
+{
+    private readonly TObject? _value;
+    private readonly Guid _id;
+
+    public Reference(Guid id) : this(id, null)
+    {
+    }
+
+    public Reference(TObject value) : this(value.Id, value)
+    {
+    }
+
+    public Reference(Guid id, TObject? value)
+    {
+        _id = id;
+        _value = value;
+    }
+
+    public Reference()
+    {
+    }
+
+    public Guid Id => _value?.Id ?? _id;
+
+    public TObject? Value => _value;
+
+    public bool IsNull => _id == Guid.Empty;
+
+    CoreObject? IReference.Value => Value;
+
+    Type IReference.ObjectType => typeof(TObject);
+
+    public Reference<TObject> Resolved(TObject obj)
+    {
+        return new Reference<TObject>(obj);
+    }
+
+    IReference IReference.Resolved(CoreObject obj)
+    {
+        return Resolved((TObject)obj);
+    }
+
+    public void Deconstruct(out Guid Id, out TObject? Value)
+    {
+        Id = this.Id;
+        Value = this.Value;
+    }
+
+    public bool Equals(Reference<TObject> other) => Id.Equals(other.Id);
+
+    public override bool Equals(object? obj) => obj is Reference<TObject> other && Equals(other);
+
+    public override int GetHashCode() => HashCode.Combine(_value, _id);
+
+    public static implicit operator Guid(Reference<TObject> reference) => reference.Id;
+
+    public static implicit operator Reference<TObject>(Guid id) => new(id);
+
+    public static implicit operator TObject?(Reference<TObject> reference) => reference.Value;
+
+    public static implicit operator Reference<TObject>(TObject value) => new(value.Id, value);
+
+    public static bool operator ==(Reference<TObject> left, Reference<TObject> right) => left.Equals(right);
+
+    public static bool operator !=(Reference<TObject> left, Reference<TObject> right) => !left.Equals(right);
+}

--- a/src/Beutl.Core/Serialization/CoreSerializableJsonConverter.cs
+++ b/src/Beutl.Core/Serialization/CoreSerializableJsonConverter.cs
@@ -26,6 +26,7 @@ public sealed class CoreSerializableJsonConverter : JsonConverter<ICoreSerializa
                 using (ThreadLocalSerializationContext.Enter(context))
                 {
                     instance.Deserialize(context);
+                    context.AfterDeserialized(instance);
                 }
 
                 return instance;

--- a/src/Beutl.Core/Serialization/ICoreSerializationContext.cs
+++ b/src/Beutl.Core/Serialization/ICoreSerializationContext.cs
@@ -15,4 +15,6 @@ public interface ICoreSerializationContext
     bool Contains(string name);
 
     void Populate(string name, ICoreSerializable obj);
+
+    void Resolve(Guid id, Action<ICoreSerializable> callback);
 }

--- a/src/Beutl.Core/Serialization/JsonSerializationContext.Deserialize.cs
+++ b/src/Beutl.Core/Serialization/JsonSerializationContext.Deserialize.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -100,6 +101,12 @@ public partial class JsonSerializationContext
 
                     return ArrayTypeHelpers.ConvertArrayType(output, baseType, elementType);
                 }
+            }
+            else if (node is JsonValue jsonValue
+                     && jsonValue.TryGetValue(out Guid id)
+                     && baseType.IsAssignableTo(typeof(IReference)))
+            {
+                return Activator.CreateInstance(baseType, id);
             }
         }
 

--- a/src/Beutl.Core/Serialization/JsonSerializationContext.Deserialize.cs
+++ b/src/Beutl.Core/Serialization/JsonSerializationContext.Deserialize.cs
@@ -25,7 +25,8 @@ public partial class JsonSerializationContext
             else
             {
                 string name = index.ToString();
-                output.Add(Deserialize(item, elementType, name, new RelaySerializationErrorNotifier(errorNotifier, name), parent));
+                output.Add(Deserialize(item, elementType, name,
+                    new RelaySerializationErrorNotifier(errorNotifier, name), parent));
             }
 
             index++;
@@ -78,6 +79,7 @@ public partial class JsonSerializationContext
                         if (Activator.CreateInstance(actualType) is ICoreSerializable instance)
                         {
                             instance.Deserialize(context);
+                            context.AfterDeserialized(instance);
 
                             return instance;
                         }

--- a/src/Beutl.Core/Serialization/JsonSerializationContext.Serialize.cs
+++ b/src/Beutl.Core/Serialization/JsonSerializationContext.Serialize.cs
@@ -36,6 +36,10 @@ public partial class JsonSerializationContext
 
             return obj;
         }
+        else if (value is IReference reference)
+        {
+            return reference.Id;
+        }
         else if (value is JsonNode jsonNode)
         {
             return jsonNode;
@@ -115,7 +119,7 @@ public partial class JsonSerializationContext
         else
         {
             Type actualType = value.GetType();
-            if (value is ICoreSerializable or IEnumerable)
+            if (value is ICoreSerializable or IEnumerable or IReference)
             {
                 _json[name] = Serialize(name, value, actualType, typeof(T), ErrorNotifier, this);
             }

--- a/src/Beutl.Core/Serialization/JsonSerializationContext.cs
+++ b/src/Beutl.Core/Serialization/JsonSerializationContext.cs
@@ -71,29 +71,39 @@ public partial class JsonSerializationContext(
     {
         if (obj is CoreObject coreObject)
         {
+            SetObjectAndId(coreObject);
+
             if (IsRoot)
             {
-                _objects ??= new();
-                _objects[coreObject.Id] = coreObject;
-
                 // Resolve references
                 if (_resolvers == null)
                     return;
 
-                foreach (var (id, callback) in _resolvers)
+                for (int i = _resolvers.Count - 1; i >= 0; i--)
                 {
+                    var (id, callback) = _resolvers[i];
                     if (_objects.TryGetValue(id, out var resolved))
                     {
                         callback(resolved);
                     }
-                }
 
-                _resolvers.Clear();
+                    _resolvers.RemoveAt(i);
+                }
             }
-            else
-            {
-                Root.AfterDeserialized(obj);
-            }
+        }
+    }
+
+    [MemberNotNull(nameof(_objects))]
+    private void SetObjectAndId(CoreObject coreObject)
+    {
+        if (IsRoot)
+        {
+            _objects ??= new();
+            _objects[coreObject.Id] = coreObject;
+        }
+        else
+        {
+            Root.SetObjectAndId(coreObject);
         }
     }
 

--- a/src/Beutl.Core/Serialization/JsonSerializationContext.cs
+++ b/src/Beutl.Core/Serialization/JsonSerializationContext.cs
@@ -89,6 +89,9 @@ public partial class JsonSerializationContext(
 
                     _resolvers.RemoveAt(i);
                 }
+
+                // TODO: アプリケーション全体から解決できるようになれば、
+                // ここにそのコードを追加する。
             }
         }
     }

--- a/src/Beutl.Engine/Animation/AnimationSerializer.cs
+++ b/src/Beutl.Engine/Animation/AnimationSerializer.cs
@@ -42,6 +42,7 @@ internal static class AnimationSerializer
                 using (ThreadLocalSerializationContext.Enter(innerContext))
                 {
                     animation.Deserialize(innerContext);
+                    innerContext.AfterDeserialized(animation);
                 }
                 return animation;
             }

--- a/src/Beutl.Engine/Converters/BrushJsonConverter.cs
+++ b/src/Beutl.Engine/Converters/BrushJsonConverter.cs
@@ -30,6 +30,7 @@ internal sealed class BrushJsonConverter : JsonConverter<IBrush>
                 using (ThreadLocalSerializationContext.Enter(context))
                 {
                     instance.Deserialize(context);
+                    context.AfterDeserialized(instance);
                 }
 
                 return brush;

--- a/src/Beutl.Engine/Converters/KeyFrameJsonConverter.cs
+++ b/src/Beutl.Engine/Converters/KeyFrameJsonConverter.cs
@@ -57,6 +57,7 @@ internal sealed class KeyFrameJsonConverter : JsonConverter<IKeyFrame>
                 using (ThreadLocalSerializationContext.Enter(context))
                 {
                     instance.Deserialize(context);
+                    context.AfterDeserialized(instance);
                 }
 
                 return instance;

--- a/src/Beutl.Engine/Converters/PenJsonConverter.cs
+++ b/src/Beutl.Engine/Converters/PenJsonConverter.cs
@@ -26,6 +26,7 @@ internal sealed class PenJsonConverter : JsonConverter<IPen>
             using (ThreadLocalSerializationContext.Enter(context))
             {
                 pen.Deserialize(context);
+                context.AfterDeserialized(pen);
             }
 
             return pen;

--- a/src/Beutl.Engine/Converters/TransformJsonConverter.cs
+++ b/src/Beutl.Engine/Converters/TransformJsonConverter.cs
@@ -30,6 +30,7 @@ internal sealed class TransformJsonConverter : JsonConverter<ITransform>
                 using (ThreadLocalSerializationContext.Enter(context))
                 {
                     instance.Deserialize(context);
+                    context.AfterDeserialized(instance);
                 }
 
                 return transform;

--- a/src/Beutl.ProjectSystem/NodeTree/Node.cs
+++ b/src/Beutl.ProjectSystem/NodeTree/Node.cs
@@ -450,6 +450,7 @@ public abstract class Node : Hierarchical
                         using (ThreadLocalSerializationContext.Enter(innerContext))
                         {
                             serializable.Deserialize(innerContext);
+                            innerContext.AfterDeserialized(serializable);
                         }
                     }
                 }

--- a/src/Beutl.ProjectSystem/NodeTree/Nodes/Group/GroupInput.cs
+++ b/src/Beutl.ProjectSystem/NodeTree/Nodes/Group/GroupInput.cs
@@ -95,6 +95,7 @@ public class GroupInput : Node, ISocketsCanBeAdded
                         using (ThreadLocalSerializationContext.Enter(innerContext))
                         {
                             serializable.Deserialize(innerContext);
+                            innerContext.AfterDeserialized(serializable);
                         }
                     }
 

--- a/src/Beutl.ProjectSystem/NodeTree/Nodes/Group/GroupNode.cs
+++ b/src/Beutl.ProjectSystem/NodeTree/Nodes/Group/GroupNode.cs
@@ -337,6 +337,7 @@ public class GroupNode : Node
                     using (ThreadLocalSerializationContext.Enter(innerContext))
                     {
                         nodeItem.Deserialize(innerContext);
+                        innerContext.AfterDeserialized(nodeItem);
                     }
 
                     ((NodeItem)nodeItem).LocalId = index;

--- a/src/Beutl.ProjectSystem/NodeTree/Nodes/Group/GroupOutput.cs
+++ b/src/Beutl.ProjectSystem/NodeTree/Nodes/Group/GroupOutput.cs
@@ -95,6 +95,7 @@ public class GroupOutput : Node, ISocketsCanBeAdded
                         using (ThreadLocalSerializationContext.Enter(innerContext))
                         {
                             serializable.Deserialize(innerContext);
+                            innerContext.AfterDeserialized(serializable);
                         }
                     }
 

--- a/src/Beutl.ProjectSystem/NodeTree/Nodes/LayerInputNode.cs
+++ b/src/Beutl.ProjectSystem/NodeTree/Nodes/LayerInputNode.cs
@@ -160,6 +160,7 @@ public class LayerInputNode : Node, ISocketsCanBeAdded
                         using (ThreadLocalSerializationContext.Enter(innerContext))
                         {
                             serializable.Deserialize(innerContext);
+                            innerContext.AfterDeserialized(serializable);
                         }
                     }
 

--- a/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
@@ -686,6 +686,7 @@ public class Scene : ProjectItem, IAffectsRender
             using (ThreadLocalSerializationContext.Enter(context))
             {
                 _element.Deserialize(context);
+                context.AfterDeserialized(_element);
             }
 
             _element.Save(_fileName);

--- a/src/Beutl/Services/ProjectService.cs
+++ b/src/Beutl/Services/ProjectService.cs
@@ -40,13 +40,14 @@ public sealed class ProjectService
         using Activity? activity = Telemetry.StartActivity("OpenProject");
         try
         {
+            CloseProject();
+
             var project = new Project();
             project.Restore(file);
 
-            Project? old = _app.Project;
             _app.Project = project;
             // 値を発行
-            _projectObservable.OnNext((New: project, old));
+            _projectObservable.OnNext((New: project, null));
 
             AddToRecentProjects(file);
 
@@ -80,6 +81,8 @@ public sealed class ProjectService
         activity?.SetTag(nameof(samplerate), samplerate);
         try
         {
+            CloseProject();
+
             location = Path.Combine(location, name);
             var scene = new Scene(width, height, name);
             ProjectItemContainer.Current.Add(scene);
@@ -101,7 +104,7 @@ public sealed class ProjectService
             project.Save(projectFile);
 
             // 値を発行
-            _projectObservable.OnNext((New: project, _app.Project));
+            _projectObservable.OnNext((New: project, null));
             _app.Project = project;
 
             AddToRecentProjects(projectFile);

--- a/tests/Beutl.UnitTests/Core/JsonSerializationTest.cs
+++ b/tests/Beutl.UnitTests/Core/JsonSerializationTest.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.Graphics;
+﻿using System.Text.Json.Nodes;
+using Beutl.Graphics;
 using Beutl.Graphics.Shapes;
 using Beutl.Logging;
 using Beutl.Media;
@@ -8,12 +9,38 @@ using Beutl.NodeTree.Nodes.Geometry;
 using Beutl.Operation;
 using Beutl.Operators.Source;
 using Beutl.ProjectSystem;
+using Beutl.Serialization;
 using Microsoft.Extensions.Logging;
 
 namespace Beutl.UnitTests.Core;
 
 public class JsonSerializationTest
 {
+    private class TestSerializable : CoreObject
+    {
+        public TestSerializable? Instance { get; set; }
+
+        public TestSerializable? Reference { get; set; }
+
+        public override void Serialize(ICoreSerializationContext context)
+        {
+            base.Serialize(context);
+            context.SetValue(nameof(Instance), Instance);
+            context.SetValue(nameof(Reference), Reference?.Id);
+        }
+
+        public override void Deserialize(ICoreSerializationContext context)
+        {
+            base.Deserialize(context);
+            Instance = context.GetValue<TestSerializable?>(nameof(Instance));
+            var id = context.GetValue<Guid?>(nameof(Reference));
+            if (id.HasValue)
+            {
+                context.Resolve(id.Value, o => Reference = o as TestSerializable);
+            }
+        }
+    }
+
     [SetUp]
     public void Setup()
     {
@@ -50,5 +77,40 @@ public class JsonSerializationTest
 
         Assert.That(((OutputSocket<RectGeometry>)rectNode.Items[0]).TryConnect((InputSocket<Geometry?>)shapeNode.Items[1]));
         Assert.That(((OutputSocket<GeometryShape>)shapeNode.Items[0]).TryConnect((InputSocket<Drawable?>)outNode.Items[0]));
+    }
+
+    [Test]
+    public void Resolve()
+    {
+        var original1 = new TestSerializable();
+        var original2 = new TestSerializable();
+        var original3 = new TestSerializable();
+        original1.Instance = original2;
+        original2.Reference = original3;
+        original3.Instance = original1;
+        var json = new JsonObject();
+
+        var context1 = new JsonSerializationContext(original3.GetType(), NullSerializationErrorNotifier.Instance, json: json);
+        using (ThreadLocalSerializationContext.Enter(context1))
+        {
+            original3.Serialize(context1);
+        }
+
+        var restored = new TestSerializable();
+        var context2 = new JsonSerializationContext(original3.GetType(), NullSerializationErrorNotifier.Instance, json: json);
+        using (ThreadLocalSerializationContext.Enter(context2))
+        {
+            restored.Deserialize(context2);
+            context2.AfterDeserialized(restored);
+        }
+
+        Assert.That(restored.Id, Is.EqualTo(original3.Id));
+        Assert.That(restored.Instance, Is.Not.Null);
+        Assert.That(restored.Instance!.Id, Is.EqualTo(original1.Id));
+        Assert.That(restored.Instance.Reference, Is.Null);
+        Assert.That(restored.Instance.Instance, Is.Not.Null);
+        Assert.That(restored.Instance.Instance!.Id, Is.EqualTo(original2.Id));
+        Assert.That(restored.Instance.Instance.Reference, Is.Not.Null);
+        Assert.That(restored.Instance.Instance.Reference!.Id, Is.EqualTo(original3.Id));
     }
 }


### PR DESCRIPTION
## Description
Implemented functionality to resolve objects by their Id during deserialization.
This allows the deserialization process to automatically map references to existing objects using their unique identifiers.

## Breaking changes

## Fixed issues
- #1055
