### PR TITLE
chore(deps): bump Vortice.XAudio2 from 3.5.0 to 3.6.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -82,6 +82,6 @@
     <PackageVersion Include="System.Interactive.Async" Version="6.0.1" />
     <PackageVersion Include="System.Management" Version="8.0.0" />
     <PackageVersion Include="System.Reactive" Version="6.0.1" />
-    <PackageVersion Include="Vortice.XAudio2" Version="3.5.0" />
+    <PackageVersion Include="Vortice.XAudio2" Version="3.6.2" />
   </ItemGroup>
 </Project>

--- a/src/Beutl.Engine/Audio/Platforms/XAudio2/XAudioBuffer.cs
+++ b/src/Beutl.Engine/Audio/Platforms/XAudio2/XAudioBuffer.cs
@@ -45,7 +45,7 @@ public sealed unsafe class XAudioBuffer : IDisposable
         Format = format;
         SizeInBytes = sizeInBytes;
         Buffer.AudioDataPointer = (nint)_stream;
-        Buffer.AudioBytes = SizeInBytes;
+        Buffer.AudioBytes = (uint)SizeInBytes;
     }
 
     public void Dispose()

--- a/src/Beutl.Engine/Audio/Platforms/XAudio2/XAudioSource.cs
+++ b/src/Beutl.Engine/Audio/Platforms/XAudio2/XAudioSource.cs
@@ -6,7 +6,7 @@ public sealed class XAudioSource(XAudioContext context) : IDisposable
 {
     private IXAudio2SourceVoice? _sourceVoice;
 
-    public int BuffersQueued => _sourceVoice?.State.BuffersQueued ?? -1;
+    public int BuffersQueued => (int?)_sourceVoice?.State.BuffersQueued ?? -1;
 
     public void Dispose()
     {


### PR DESCRIPTION
## Description

## Breaking changes

## Fixed issues
