### PR TITLE
Fix crash when editing properties in Node Editor

### DIFF
--- a/src/Beutl/ViewModels/NodeTree/NodeViewModel.cs
+++ b/src/Beutl/ViewModels/NodeTree/NodeViewModel.cs
@@ -17,7 +17,7 @@ using Reactive.Bindings;
 
 namespace Beutl.ViewModels.NodeTree;
 
-public sealed class NodeViewModel : IDisposable, IJsonSerializable
+public sealed class NodeViewModel : IDisposable, IJsonSerializable, IPropertyEditorContextVisitor, IServiceProvider
 {
     private readonly CompositeDisposable _disposables = [];
     private readonly string _defaultName;
@@ -178,7 +178,7 @@ public sealed class NodeViewModel : IDisposable, IJsonSerializable
             (_, PropertyEditorExtension ext) = PropertyEditorService.MatchProperty(atmp);
             ext?.TryCreateContextForNode(atmp, out context);
         }
-
+        context?.Accept(this);
         return CreateNodeItemViewModelCore(item, context);
     }
 
@@ -251,5 +251,19 @@ public sealed class NodeViewModel : IDisposable, IJsonSerializable
                 item.PropertyEditorContext.ReadFromJson(itemJson!.AsObject());
             }
         }
+    }
+
+    public void Visit(IPropertyEditorContext context)
+    {
+    }
+
+    public object? GetService(Type serviceType)
+    {
+        if (serviceType == typeof(Node))
+        {
+            return Node;
+        }
+
+        return EditorContext.GetService(serviceType);
     }
 }


### PR DESCRIPTION
## Description
This fix addresses a `System.InvalidOperationException` that occurred in the Node Editor when editing properties. The crash was due to a failure in retrieving a required service in the `SetValue` method of `BaseEditorViewModel`. The update ensures that services are correctly initialized and accessible during property editing, preventing the application from crashing when properties are modified.

## Breaking changes

## Fixed issues
