### PR TITLE
Fix handling of invalid Bounds cases

### DIFF
--- a/src/Beutl.Engine/Graphics/Drawable.cs
+++ b/src/Beutl.Engine/Graphics/Drawable.cs
@@ -168,7 +168,7 @@ public abstract class Drawable : Renderable
             rect = _filterEffect.TransformBounds(rect);
         }
 
-        Bounds = rect.TransformToAABB(transform);
+        Bounds = rect.IsInvalid ? rect : rect.TransformToAABB(transform);
     }
 
     protected abstract Size MeasureCore(Size availableSize);
@@ -201,13 +201,13 @@ public abstract class Drawable : Renderable
             Size availableSize = canvas.Size.ToSize(1);
             Size size = MeasureCore(availableSize);
             var rect = new Rect(size);
-            if (_filterEffect != null)
+            if (_filterEffect != null && !rect.IsInvalid)
             {
                 rect = _filterEffect.TransformBounds(rect);
             }
 
             Matrix transform = GetTransformMatrix(availableSize, size);
-            Rect transformedBounds = rect.TransformToAABB(transform);
+            Rect transformedBounds = rect.IsInvalid ? Rect.Invalid : rect.TransformToAABB(transform);
             using (canvas.PushBlendMode(BlendMode))
             using (canvas.PushTransform(transform))
             using (canvas.PushOpacity(Opacity / 100f))

--- a/src/Beutl.Engine/Graphics/DrawableGroup.cs
+++ b/src/Beutl.Engine/Graphics/DrawableGroup.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.Json.Nodes;
-
 using Beutl.Graphics.Effects;
 using Beutl.Serialization;
 
@@ -77,16 +76,16 @@ public sealed class DrawableGroup : Drawable
         {
             Size availableSize = canvas.Size.ToSize(1);
             Rect rect = PrivateMeasureCore(availableSize);
-            if (FilterEffect != null)
+            if (FilterEffect != null && !rect.IsInvalid)
             {
                 rect = FilterEffect.TransformBounds(rect);
             }
 
             Matrix transform = GetTransformMatrix(availableSize);
-            Rect transformedBounds = rect.TransformToAABB(transform);
+            Rect transformedBounds = rect.IsInvalid ? Rect.Invalid : rect.TransformToAABB(transform);
 
             using (canvas.PushBlendMode(BlendMode))
-            using (canvas.PushLayer(transformedBounds))
+            using (canvas.PushLayer(transformedBounds.IsInvalid ? default : transformedBounds))
             using (canvas.PushTransform(transform))
             using (FilterEffect == null ? new() : canvas.PushFilterEffect(FilterEffect))
             using (OpacityMask == null ? new() : canvas.PushOpacityMask(OpacityMask, new Rect(rect.Size)))


### PR DESCRIPTION
Handle scenarios where Bounds are invalid to prevent errors during rendering and measurement processes. This ensures that invalid rectangles do not lead to incorrect transformations or rendering issues.