### PR TITLE
Remove inverse PathFillType enum values

### DIFF
--- a/src/Beutl.Engine/Media/Geometry/PathFillType.cs
+++ b/src/Beutl.Engine/Media/Geometry/PathFillType.cs
@@ -4,6 +4,4 @@ public enum PathFillType
 {
     Winding = 0,
     EvenOdd = 1,
-    InverseWinding = 2,
-    InverseEvenOdd = 3
 }


### PR DESCRIPTION
Eliminate the InverseWinding and InverseEvenOdd values from the PathFillType enum.

Close #1171