### PR TITLE
Add IPublishOperator interface and update related classes

### DIFF
--- a/src/Beutl.ProjectSystem/Operation/IPublishOperator.cs
+++ b/src/Beutl.ProjectSystem/Operation/IPublishOperator.cs
@@ -1,0 +1,8 @@
+﻿using Beutl.Graphics.Rendering;
+
+namespace Beutl.Operation;
+
+public interface IPublishOperator
+{
+    Renderable Value { get; }
+}

--- a/src/Beutl.ProjectSystem/Operation/PublishOperator.cs
+++ b/src/Beutl.ProjectSystem/Operation/PublishOperator.cs
@@ -31,7 +31,7 @@ public record struct PropertyWithDefaultValue(CoreProperty Property, Func<Option
     }
 }
 
-public abstract class PublishOperator<T> : SourceOperator
+public abstract class PublishOperator<T> : SourceOperator, IPublishOperator
     where T : Renderable, new()
 {
     public static readonly CoreProperty<T> ValueProperty;
@@ -63,6 +63,8 @@ public abstract class PublishOperator<T> : SourceOperator
         get => _value;
         set => SetAndRaise(ValueProperty, ref _value, value);
     }
+
+    Renderable IPublishOperator.Value => Value;
 
     public override EvaluationTarget GetEvaluationTarget() => _evaluationTarget;
 
@@ -166,7 +168,8 @@ public abstract class PublishOperator<T> : SourceOperator
                                 }
                                 catch
                                 {
-                                    value = TypeDescriptor.GetConverter(value!.GetType()).ConvertTo(value, propertyType);
+                                    value = TypeDescriptor.GetConverter(value!.GetType())
+                                        .ConvertTo(value, propertyType);
                                 }
                             }
 

--- a/src/Beutl/ViewModels/PathEditorViewModel.cs
+++ b/src/Beutl/ViewModels/PathEditorViewModel.cs
@@ -43,10 +43,10 @@ public sealed class PathEditorViewModel : IDisposable, IPathEditorViewModel
         Element = Context.Select(v => v?.GetService<Element>())
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
-        SourceOperator = Context.Select(v => v?.GetService<SourceOperator>() as StyledSourcePublisher)
+        SourceOperator = Context.Select(v => v?.GetService<SourceOperator>() as IPublishOperator)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
-        Drawable = SourceOperator.Select(v => v?.Instance?.Target as Drawable)
+        Drawable = SourceOperator.Select(v => v?.Value as Drawable)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
 
@@ -129,7 +129,7 @@ public sealed class PathEditorViewModel : IDisposable, IPathEditorViewModel
 
     public IReadOnlyReactiveProperty<Element?> Element { get; }
 
-    public ReadOnlyReactivePropertySlim<StyledSourcePublisher?> SourceOperator { get; }
+    public ReadOnlyReactivePropertySlim<IPublishOperator?> SourceOperator { get; }
 
     public ReadOnlyReactivePropertySlim<Drawable?> Drawable { get; }
 

--- a/src/Beutl/ViewModels/Tools/PathEditorTabViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/PathEditorTabViewModel.cs
@@ -38,7 +38,7 @@ public sealed class PathEditorTabViewModel : IDisposable, IPathEditorViewModel, 
         Element = Context.Select(v => v?.GetService<Element>())
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
-        SourceOperator = Context.Select(v => v?.GetService<SourceOperator>() as StyledSourcePublisher)
+        SourceOperator = Context.Select(v => v?.GetService<SourceOperator>() as IPublishOperator)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
 
@@ -63,7 +63,7 @@ public sealed class PathEditorTabViewModel : IDisposable, IPathEditorViewModel, 
 
     public IReadOnlyReactiveProperty<Element?> Element { get; }
 
-    public ReadOnlyReactivePropertySlim<StyledSourcePublisher?> SourceOperator { get; }
+    public ReadOnlyReactivePropertySlim<IPublishOperator?> SourceOperator { get; }
 
     public IReactiveProperty<PathSegment?> SelectedOperation { get; } = new ReactiveProperty<PathSegment?>();
 


### PR DESCRIPTION
Introduce the IPublishOperator interface and implement it in the PublishOperator class. Update the PathEditorViewModel and PathEditorTabViewModel to use IPublishOperator instead of SourceOperator.