### PR TITLE
Enhance unit tests for filter effects

### DIFF
--- a/src/Beutl.Engine/Graphics/FilterEffects/DisplacementMap.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/DisplacementMap.cs
@@ -12,7 +12,7 @@ public sealed class DisplacementMap : FilterEffect
     public static readonly CoreProperty<FilterEffect?> DisplacementProperty;
     private SKColorChannel _xChannelSelector = SKColorChannel.A;
     private SKColorChannel _yChannelSelector = SKColorChannel.A;
-    private float _scale;
+    private float _scale = 1;
     private FilterEffect? _displacement;
 
     static DisplacementMap()

--- a/src/Beutl.Engine/Graphics/Rendering/Cache/RenderNodeCacheContext.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/Cache/RenderNodeCacheContext.cs
@@ -70,19 +70,6 @@ public sealed class RenderNodeCacheContext(RenderScene scene)
         return true;
     }
 
-    public static void ClearCache(RenderNode node, RenderNodeCache cache)
-    {
-        cache.Invalidate();
-
-        if (node is ContainerRenderNode containerNode)
-        {
-            foreach (RenderNode item in containerNode.Children)
-            {
-                ClearCache(item);
-            }
-        }
-    }
-
     public static void ClearCache(RenderNode node)
     {
         node.Cache.Invalidate();
@@ -108,7 +95,7 @@ public sealed class RenderNodeCacheContext(RenderScene scene)
         {
             if (!cache.IsCached)
             {
-                CreateDefaultCache(node, cache);
+                CreateDefaultCache(node);
             }
         }
         else if (node is ContainerRenderNode containerNode)
@@ -121,7 +108,7 @@ public sealed class RenderNodeCacheContext(RenderScene scene)
         }
     }
 
-    public void CreateDefaultCache(RenderNode node, RenderNodeCache cache)
+    public void CreateDefaultCache(RenderNode node)
     {
         var processor = new RenderNodeProcessor(node, false);
         var list = processor.RasterizeToRenderTargets();
@@ -134,10 +121,10 @@ public sealed class RenderNodeCacheContext(RenderScene scene)
             return;
 
         // nodeの子要素のキャッシュをすべて削除
-        ClearCache(node, cache);
+        ClearCache(node);
 
         var arr = list.Select(i => (i.RenderTarget, i.Bounds)).ToArray();
-        cache.StoreCache(arr);
+        node.Cache.StoreCache(arr);
 
         Debug.WriteLine($"[RenderCache:Created] '{node}'");
     }

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/BlendEffectTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/BlendEffectTest.cs
@@ -1,0 +1,72 @@
+using Beutl.Animation;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Media;
+using Moq;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class BlendEffectTest
+{
+    [Test]
+    public void BlendEffect_ShouldHaveDefaultValues()
+    {
+        var blendEffect = new BlendEffect();
+
+        Assert.That(blendEffect.Brush, Is.Not.Null);
+        Assert.That(blendEffect.Brush, Is.TypeOf<SolidColorBrush>());
+        Assert.That(((SolidColorBrush)blendEffect.Brush!).Color, Is.EqualTo(Colors.White));
+        Assert.That(blendEffect.BlendMode, Is.EqualTo(BlendMode.SrcIn));
+    }
+
+    [Test]
+    public void BlendEffect_ShouldUpdateBrushProperty()
+    {
+        var blendEffect = new BlendEffect();
+        var newBrush = new SolidColorBrush(Colors.Red);
+
+        blendEffect.Brush = newBrush;
+
+        Assert.That(blendEffect.Brush, Is.EqualTo(newBrush));
+    }
+
+    [Test]
+    public void BlendEffect_ShouldUpdateBlendModeProperty()
+    {
+        var blendEffect = new BlendEffect();
+        var newBlendMode = BlendMode.Multiply;
+
+        blendEffect.BlendMode = newBlendMode;
+
+        Assert.That(blendEffect.BlendMode, Is.EqualTo(newBlendMode));
+    }
+
+    [Test]
+    public void BlendEffect_ShouldApplyToContext()
+    {
+        var blendEffect = new BlendEffect();
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(blendEffect);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(blendEffect));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Custom>());
+    }
+
+    [Test]
+    public void BlendEffect_ShouldApplyAnimations()
+    {
+        var brush = new Mock<IBrush>();
+        brush.As<IAnimatable>().Setup(b => b.ApplyAnimations(It.IsAny<IClock>()));
+        var blendEffect = new BlendEffect()
+        {
+            Brush = brush.Object
+        };
+        var clock = new ZeroClock();
+
+        blendEffect.ApplyAnimations(clock);
+
+        brush.As<IAnimatable>().Verify(b => b.ApplyAnimations(clock), Times.Once);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/BlurTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/BlurTest.cs
@@ -1,0 +1,54 @@
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class BlurTest
+{
+    [Test]
+    public void Blur_ShouldHaveDefaultValues()
+    {
+        var blur = new Blur();
+
+        Assert.That(blur.Sigma, Is.EqualTo(Size.Empty));
+    }
+
+    [Test]
+    public void Blur_ShouldUpdateSigmaProperty()
+    {
+        var blur = new Blur();
+        var newSigma = new Size(5, 5);
+
+        blur.Sigma = newSigma;
+
+        Assert.That(blur.Sigma, Is.EqualTo(newSigma));
+    }
+
+    [Test]
+    public void Blur_ShouldApplyToContext()
+    {
+        var blur = new Blur();
+        var sigma = new Size(5, 5);
+        blur.Sigma = sigma;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(blur);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(blur));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Skia>());
+    }
+
+    [Test]
+    public void Blur_ShouldTransformBounds()
+    {
+        var blur = new Blur();
+        var sigma = new Size(5, 5);
+        blur.Sigma = sigma;
+        var bounds = new Rect(0, 0, 100, 100);
+
+        var transformedBounds = blur.TransformBounds(bounds);
+
+        Assert.That(transformedBounds, Is.EqualTo(bounds.Inflate(new Thickness(sigma.Width * 3, sigma.Height * 3))));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/BrightnessTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/BrightnessTest.cs
@@ -1,0 +1,42 @@
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class BrightnessTest
+{
+    [Test]
+    public void Brightness_ShouldHaveDefaultValues()
+    {
+        var brightness = new Brightness();
+
+        Assert.That(brightness.Amount, Is.EqualTo(100));
+    }
+
+    [Test]
+    public void Brightness_ShouldUpdateAmountProperty()
+    {
+        var brightness = new Brightness();
+        var newAmount = 150f;
+
+        brightness.Amount = newAmount;
+
+        Assert.That(brightness.Amount, Is.EqualTo(newAmount));
+    }
+
+    [Test]
+    public void Brightness_ShouldApplyToContext()
+    {
+        var brightness = new Brightness();
+        var amount = 150f;
+        brightness.Amount = amount;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(brightness);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(brightness));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Skia>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/ChromaKeyTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/ChromaKeyTest.cs
@@ -1,0 +1,55 @@
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class ChromaKeyTest
+{
+    [Test]
+    public void ChromaKey_ShouldHaveDefaultValues()
+    {
+        var chromaKey = new ChromaKey();
+
+        Assert.That(chromaKey.Color, Is.EqualTo((Color)default));
+        Assert.That(chromaKey.HueRange, Is.EqualTo(0));
+        Assert.That(chromaKey.SaturationRange, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void ChromaKey_ShouldUpdateProperties()
+    {
+        var chromaKey = new ChromaKey();
+        var newColor = Colors.Green;
+        var newHueRange = 10f;
+        var newSaturationRange = 20f;
+
+        chromaKey.Color = newColor;
+        chromaKey.HueRange = newHueRange;
+        chromaKey.SaturationRange = newSaturationRange;
+
+        Assert.That(chromaKey.Color, Is.EqualTo(newColor));
+        Assert.That(chromaKey.HueRange, Is.EqualTo(newHueRange));
+        Assert.That(chromaKey.SaturationRange, Is.EqualTo(newSaturationRange));
+    }
+
+    [Test]
+    public void ChromaKey_ShouldApplyToContext()
+    {
+        var chromaKey = new ChromaKey();
+        var color = Colors.Green;
+        var hueRange = 10f;
+        var saturationRange = 20f;
+        chromaKey.Color = color;
+        chromaKey.HueRange = hueRange;
+        chromaKey.SaturationRange = saturationRange;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(chromaKey);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(chromaKey));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Custom>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/ClippingTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/ClippingTest.cs
@@ -1,0 +1,120 @@
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class ClippingTest
+{
+    [Test]
+    public void Clipping_ShouldHaveDefaultValues()
+    {
+        var clipping = new Clipping();
+
+        Assert.That(clipping.Left, Is.EqualTo(0));
+        Assert.That(clipping.Top, Is.EqualTo(0));
+        Assert.That(clipping.Right, Is.EqualTo(0));
+        Assert.That(clipping.Bottom, Is.EqualTo(0));
+        Assert.That(clipping.AutoCenter, Is.False);
+        Assert.That(clipping.AutoClip, Is.False);
+    }
+
+    [Test]
+    public void Clipping_ShouldUpdateProperties()
+    {
+        var clipping = new Clipping();
+        var newLeft = 10f;
+        var newTop = 10f;
+        var newRight = 10f;
+        var newBottom = 10f;
+        var newAutoCenter = true;
+        var newAutoClip = true;
+
+        clipping.Left = newLeft;
+        clipping.Top = newTop;
+        clipping.Right = newRight;
+        clipping.Bottom = newBottom;
+        clipping.AutoCenter = newAutoCenter;
+        clipping.AutoClip = newAutoClip;
+
+        Assert.That(clipping.Left, Is.EqualTo(newLeft));
+        Assert.That(clipping.Top, Is.EqualTo(newTop));
+        Assert.That(clipping.Right, Is.EqualTo(newRight));
+        Assert.That(clipping.Bottom, Is.EqualTo(newBottom));
+        Assert.That(clipping.AutoCenter, Is.EqualTo(newAutoCenter));
+        Assert.That(clipping.AutoClip, Is.EqualTo(newAutoClip));
+    }
+
+    [Test]
+    public void Clipping_ShouldApplyToContext()
+    {
+        var clipping = new Clipping
+        {
+            Left = 10f,
+            Top = 10f,
+            Right = 10f,
+            Bottom = 10f
+        };
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(clipping);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(clipping));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Custom>());
+    }
+
+    [Test]
+    public void Clipping_TransformBounds_ShouldReturnCorrectBounds()
+    {
+        var clipping = new Clipping
+        {
+            Left = 10f,
+            Top = 10f,
+            Right = 10f,
+            Bottom = 10f
+        };
+        var originalBounds = new Rect(0, 0, 100, 100);
+        var expectedBounds = new Rect(10, 10, 80, 80);
+
+        var transformedBounds = clipping.TransformBounds(originalBounds);
+
+        Assert.That(transformedBounds, Is.EqualTo(expectedBounds));
+    }
+
+    [Test]
+    public void Clipping_TransformBounds_WithAutoCenter_ShouldReturnCenteredBounds()
+    {
+        var clipping = new Clipping
+        {
+            Left = 10f,
+            Top = 10f,
+            Right = 10f,
+            Bottom = 10f,
+            AutoCenter = true
+        };
+        var originalBounds = new Rect(0, 0, 100, 100);
+        var expectedBounds = originalBounds.CenterRect(new Rect(10, 10, 80, 80));
+
+        var transformedBounds = clipping.TransformBounds(originalBounds);
+
+        Assert.That(transformedBounds, Is.EqualTo(expectedBounds));
+    }
+
+    [Test]
+    public void Clipping_TransformBounds_WithAutoClip_ShouldReturnInvalidBounds()
+    {
+        var clipping = new Clipping
+        {
+            Left = 10f,
+            Top = 10f,
+            Right = 10f,
+            Bottom = 10f,
+            AutoClip = true
+        };
+        var originalBounds = new Rect(0, 0, 100, 100);
+
+        var transformedBounds = clipping.TransformBounds(originalBounds);
+
+        Assert.That(transformedBounds.IsInvalid, Is.True);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/ColorKeyTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/ColorKeyTest.cs
@@ -1,0 +1,43 @@
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class ColorKeyTest
+{
+    [Test]
+    public void ColorKey_ShouldHaveDefaultValues()
+    {
+        var colorKey = new ColorKey();
+
+        Assert.That(colorKey.Color, Is.EqualTo((Color)default));
+        Assert.That(colorKey.Range, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void ColorKey_ShouldUpdateProperties()
+    {
+        var colorKey = new ColorKey();
+        colorKey.Color = Colors.Red;
+        colorKey.Range = 50;
+
+        Assert.That(colorKey.Color, Is.EqualTo(Colors.Red));
+        Assert.That(colorKey.Range, Is.EqualTo(50));
+    }
+
+    [Test]
+    public void ColorKey_ShouldApplyToContext()
+    {
+        var colorKey = new ColorKey();
+        colorKey.Color = Colors.Red;
+        colorKey.Range = 50;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(colorKey);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(colorKey));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Custom>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/ColorShiftTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/ColorShiftTest.cs
@@ -1,0 +1,52 @@
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class ColorShiftTest
+{
+    [Test]
+    public void ColorShift_ShouldHaveDefaultValues()
+    {
+        var colorShift = new ColorShift();
+
+        Assert.That(colorShift.RedOffset, Is.EqualTo(new PixelPoint()));
+        Assert.That(colorShift.GreenOffset, Is.EqualTo(new PixelPoint()));
+        Assert.That(colorShift.BlueOffset, Is.EqualTo(new PixelPoint()));
+        Assert.That(colorShift.AlphaOffset, Is.EqualTo(new PixelPoint()));
+    }
+
+    [Test]
+    public void ColorShift_ShouldUpdateProperties()
+    {
+        var colorShift = new ColorShift();
+        colorShift.RedOffset = new PixelPoint(10, 10);
+        colorShift.GreenOffset = new PixelPoint(20, 20);
+        colorShift.BlueOffset = new PixelPoint(30, 30);
+        colorShift.AlphaOffset = new PixelPoint(40, 40);
+
+        Assert.That(colorShift.RedOffset, Is.EqualTo(new PixelPoint(10, 10)));
+        Assert.That(colorShift.GreenOffset, Is.EqualTo(new PixelPoint(20, 20)));
+        Assert.That(colorShift.BlueOffset, Is.EqualTo(new PixelPoint(30, 30)));
+        Assert.That(colorShift.AlphaOffset, Is.EqualTo(new PixelPoint(40, 40)));
+    }
+
+    [Test]
+    public void ColorShift_ShouldApplyToContext()
+    {
+        var colorShift = new ColorShift();
+        colorShift.RedOffset = new PixelPoint(10, 10);
+        colorShift.GreenOffset = new PixelPoint(20, 20);
+        colorShift.BlueOffset = new PixelPoint(30, 30);
+        colorShift.AlphaOffset = new PixelPoint(40, 40);
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(colorShift);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(colorShift));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Custom>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/DilateTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/DilateTest.cs
@@ -1,0 +1,43 @@
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class DilateTest
+{
+    [Test]
+    public void Dilate_ShouldHaveDefaultValues()
+    {
+        var dilate = new Dilate();
+
+        Assert.That(dilate.RadiusX, Is.EqualTo(0));
+        Assert.That(dilate.RadiusY, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Dilate_ShouldUpdateProperties()
+    {
+        var dilate = new Dilate();
+        dilate.RadiusX = 5;
+        dilate.RadiusY = 5;
+
+        Assert.That(dilate.RadiusX, Is.EqualTo(5));
+        Assert.That(dilate.RadiusY, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void Dilate_ShouldApplyToContext()
+    {
+        var dilate = new Dilate();
+        dilate.RadiusX = 5;
+        dilate.RadiusY = 5;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(dilate);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(dilate));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Skia>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/DisplacementMapTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/DisplacementMapTest.cs
@@ -1,0 +1,52 @@
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class DisplacementMapTest
+{
+    [Test]
+    public void DisplacementMap_ShouldHaveDefaultValues()
+    {
+        var displacementMap = new DisplacementMap();
+
+        Assert.That(displacementMap.XChannelSelector, Is.EqualTo(SKColorChannel.A));
+        Assert.That(displacementMap.YChannelSelector, Is.EqualTo(SKColorChannel.A));
+        Assert.That(displacementMap.Scale, Is.EqualTo(1f));
+        Assert.That(displacementMap.Displacement, Is.Null);
+    }
+
+    [Test]
+    public void DisplacementMap_ShouldUpdateProperties()
+    {
+        var displacementMap = new DisplacementMap();
+        displacementMap.XChannelSelector = SKColorChannel.R;
+        displacementMap.YChannelSelector = SKColorChannel.G;
+        displacementMap.Scale = 2f;
+        displacementMap.Displacement = new Blur();
+
+        Assert.That(displacementMap.XChannelSelector, Is.EqualTo(SKColorChannel.R));
+        Assert.That(displacementMap.YChannelSelector, Is.EqualTo(SKColorChannel.G));
+        Assert.That(displacementMap.Scale, Is.EqualTo(2f));
+        Assert.That(displacementMap.Displacement, Is.InstanceOf<Blur>());
+    }
+
+    [Test]
+    public void DisplacementMap_ShouldApplyToContext()
+    {
+        var displacementMap = new DisplacementMap();
+        displacementMap.XChannelSelector = SKColorChannel.R;
+        displacementMap.YChannelSelector = SKColorChannel.G;
+        displacementMap.Scale = 2f;
+        displacementMap.Displacement = new Blur();
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(displacementMap);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(displacementMap));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Skia>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/DropShadowTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/DropShadowTest.cs
@@ -1,0 +1,89 @@
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class DropShadowTest
+{
+    [Test]
+    public void DropShadow_ShouldHaveDefaultValues()
+    {
+        var dropShadow = new DropShadow();
+
+        Assert.That(dropShadow.Position, Is.EqualTo(new Point()));
+        Assert.That(dropShadow.Sigma, Is.EqualTo(Size.Empty));
+        Assert.That(dropShadow.Color, Is.EqualTo((Color)default));
+        Assert.That(dropShadow.ShadowOnly, Is.False);
+    }
+
+    [Test]
+    public void DropShadow_ShouldUpdateProperties()
+    {
+        var dropShadow = new DropShadow();
+        dropShadow.Position = new Point(10, 10);
+        dropShadow.Sigma = new Size(5, 5);
+        dropShadow.Color = Colors.Black;
+        dropShadow.ShadowOnly = true;
+
+        Assert.That(dropShadow.Position, Is.EqualTo(new Point(10, 10)));
+        Assert.That(dropShadow.Sigma, Is.EqualTo(new Size(5, 5)));
+        Assert.That(dropShadow.Color, Is.EqualTo(Colors.Black));
+        Assert.That(dropShadow.ShadowOnly, Is.True);
+    }
+
+    [Test]
+    public void DropShadow_ShouldApplyToContext()
+    {
+        var dropShadow = new DropShadow();
+        dropShadow.Position = new Point(10, 10);
+        dropShadow.Sigma = new Size(5, 5);
+        dropShadow.Color = Colors.Black;
+        dropShadow.ShadowOnly = true;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(dropShadow);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(dropShadow));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Skia>());
+    }
+
+    [Test]
+    public void DropShadow_TransformBounds_ShouldInflateBounds()
+    {
+        var dropShadow = new DropShadow();
+        dropShadow.Position = new Point(10, 10);
+        dropShadow.Sigma = new Size(5, 5);
+        dropShadow.ShadowOnly = false;
+
+        var originalBounds = new Rect(0, 0, 100, 100);
+        var transformedBounds = dropShadow.TransformBounds(originalBounds);
+
+        var expectedBounds = originalBounds
+            .Translate(dropShadow.Position)
+            .Inflate(new Thickness(dropShadow.Sigma.Width * 3, dropShadow.Sigma.Height * 3))
+            .Union(originalBounds);
+
+        Assert.That(transformedBounds, Is.EqualTo(expectedBounds));
+    }
+
+    [Test]
+    public void DropShadow_TransformBounds_ShouldReturnShadowBoundsWhenShadowOnly()
+    {
+        var dropShadow = new DropShadow();
+        dropShadow.Position = new Point(10, 10);
+        dropShadow.Sigma = new Size(5, 5);
+        dropShadow.ShadowOnly = true;
+
+        var originalBounds = new Rect(0, 0, 100, 100);
+        var transformedBounds = dropShadow.TransformBounds(originalBounds);
+
+        var expectedBounds = originalBounds
+            .Translate(dropShadow.Position)
+            .Inflate(new Thickness(dropShadow.Sigma.Width * 3, dropShadow.Sigma.Height * 3));
+
+        Assert.That(transformedBounds, Is.EqualTo(expectedBounds));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/ErodeTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/ErodeTest.cs
@@ -1,0 +1,43 @@
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class ErodeTest
+{
+    [Test]
+    public void Erode_ShouldHaveDefaultValues()
+    {
+        var erode = new Erode();
+
+        Assert.That(erode.RadiusX, Is.EqualTo(0));
+        Assert.That(erode.RadiusY, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Erode_ShouldUpdateProperties()
+    {
+        var erode = new Erode();
+        erode.RadiusX = 5;
+        erode.RadiusY = 5;
+
+        Assert.That(erode.RadiusX, Is.EqualTo(5));
+        Assert.That(erode.RadiusY, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void Erode_ShouldApplyToContext()
+    {
+        var erode = new Erode();
+        erode.RadiusX = 5;
+        erode.RadiusY = 5;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(erode);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(erode));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Skia>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/FlatShadowTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/FlatShadowTest.cs
@@ -1,0 +1,52 @@
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class FlatShadowTest
+{
+    [Test]
+    public void FlatShadow_ShouldHaveDefaultValues()
+    {
+        var flatShadow = new FlatShadow();
+
+        Assert.That(flatShadow.Angle, Is.EqualTo(0));
+        Assert.That(flatShadow.Length, Is.EqualTo(0));
+        Assert.That(flatShadow.Brush, Is.InstanceOf<SolidColorBrush>());
+        Assert.That(flatShadow.ShadowOnly, Is.False);
+    }
+
+    [Test]
+    public void FlatShadow_ShouldUpdateProperties()
+    {
+        var flatShadow = new FlatShadow();
+        flatShadow.Angle = 45;
+        flatShadow.Length = 10;
+        flatShadow.Brush = new SolidColorBrush(Colors.Red);
+        flatShadow.ShadowOnly = true;
+
+        Assert.That(flatShadow.Angle, Is.EqualTo(45));
+        Assert.That(flatShadow.Length, Is.EqualTo(10));
+        Assert.That(flatShadow.Brush, Is.InstanceOf<SolidColorBrush>());
+        Assert.That(flatShadow.ShadowOnly, Is.True);
+    }
+
+    [Test]
+    public void FlatShadow_ShouldApplyToContext()
+    {
+        var flatShadow = new FlatShadow();
+        flatShadow.Angle = 45;
+        flatShadow.Length = 10;
+        flatShadow.Brush = new SolidColorBrush(Colors.Red);
+        flatShadow.ShadowOnly = true;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(flatShadow);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(flatShadow));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Custom>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/GammaTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/GammaTest.cs
@@ -1,0 +1,43 @@
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class GammaTest
+{
+    [Test]
+    public void Gamma_ShouldHaveDefaultValues()
+    {
+        var gamma = new Gamma();
+
+        Assert.That(gamma.Amount, Is.EqualTo(100));
+        Assert.That(gamma.Strength, Is.EqualTo(100));
+    }
+
+    [Test]
+    public void Gamma_ShouldUpdateProperties()
+    {
+        var gamma = new Gamma();
+        gamma.Amount = 150;
+        gamma.Strength = 80;
+
+        Assert.That(gamma.Amount, Is.EqualTo(150));
+        Assert.That(gamma.Strength, Is.EqualTo(80));
+    }
+
+    [Test]
+    public void Gamma_ShouldApplyToContext()
+    {
+        var gamma = new Gamma();
+        gamma.Amount = 150;
+        gamma.Strength = 80;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(gamma);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(gamma));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Skia>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/HighContrastTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/HighContrastTest.cs
@@ -1,0 +1,47 @@
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class HighContrastTest
+{
+    [Test]
+    public void HighContrast_ShouldHaveDefaultValues()
+    {
+        var highContrast = new HighContrast();
+
+        Assert.That(highContrast.Grayscale, Is.False);
+        Assert.That(highContrast.InvertStyle, Is.EqualTo(HighContrastInvertStyle.NoInvert));
+        Assert.That(highContrast.Contrast, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void HighContrast_ShouldUpdateProperties()
+    {
+        var highContrast = new HighContrast();
+        highContrast.Grayscale = true;
+        highContrast.InvertStyle = HighContrastInvertStyle.InvertLightness;
+        highContrast.Contrast = 50;
+
+        Assert.That(highContrast.Grayscale, Is.True);
+        Assert.That(highContrast.InvertStyle, Is.EqualTo(HighContrastInvertStyle.InvertLightness));
+        Assert.That(highContrast.Contrast, Is.EqualTo(50));
+    }
+
+    [Test]
+    public void HighContrast_ShouldApplyToContext()
+    {
+        var highContrast = new HighContrast();
+        highContrast.Grayscale = true;
+        highContrast.InvertStyle = HighContrastInvertStyle.InvertBrightness;
+        highContrast.Contrast = 50;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(highContrast);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(highContrast));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Skia>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/HueRotateTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/HueRotateTest.cs
@@ -1,0 +1,40 @@
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class HueRotateTest
+{
+    [Test]
+    public void HueRotate_ShouldHaveDefaultValues()
+    {
+        var hueRotate = new HueRotate();
+
+        Assert.That(hueRotate.Angle, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void HueRotate_ShouldUpdateProperties()
+    {
+        var hueRotate = new HueRotate();
+        hueRotate.Angle = 180;
+
+        Assert.That(hueRotate.Angle, Is.EqualTo(180));
+    }
+
+    [Test]
+    public void HueRotate_ShouldApplyToContext()
+    {
+        var hueRotate = new HueRotate();
+        hueRotate.Angle = 180;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(hueRotate);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(hueRotate));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Skia>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/InnerShadowTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/InnerShadowTest.cs
@@ -1,0 +1,52 @@
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class InnerShadowTest
+{
+    [Test]
+    public void InnerShadow_ShouldHaveDefaultValues()
+    {
+        var innerShadow = new InnerShadow();
+
+        Assert.That(innerShadow.Position, Is.EqualTo(new Point()));
+        Assert.That(innerShadow.Sigma, Is.EqualTo(Size.Empty));
+        Assert.That(innerShadow.Color, Is.EqualTo((Color)default));
+        Assert.That(innerShadow.ShadowOnly, Is.False);
+    }
+
+    [Test]
+    public void InnerShadow_ShouldUpdateProperties()
+    {
+        var innerShadow = new InnerShadow();
+        innerShadow.Position = new Point(10, 10);
+        innerShadow.Sigma = new Size(5, 5);
+        innerShadow.Color = Colors.Black;
+        innerShadow.ShadowOnly = true;
+
+        Assert.That(innerShadow.Position, Is.EqualTo(new Point(10, 10)));
+        Assert.That(innerShadow.Sigma, Is.EqualTo(new Size(5, 5)));
+        Assert.That(innerShadow.Color, Is.EqualTo(Colors.Black));
+        Assert.That(innerShadow.ShadowOnly, Is.True);
+    }
+
+    [Test]
+    public void InnerShadow_ShouldApplyToContext()
+    {
+        var innerShadow = new InnerShadow();
+        innerShadow.Position = new Point(10, 10);
+        innerShadow.Sigma = new Size(5, 5);
+        innerShadow.Color = Colors.Black;
+        innerShadow.ShadowOnly = true;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(innerShadow);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(innerShadow));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Custom>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/InvertTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/InvertTest.cs
@@ -1,0 +1,44 @@
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class InvertTest
+{
+    [Test]
+    public void Invert_ShouldHaveDefaultValues()
+    {
+        var invert = new Invert();
+
+        Assert.That(invert.Amount, Is.EqualTo(100));
+        Assert.That(invert.ExcludeAlphaChannel, Is.True);
+    }
+
+    [Test]
+    public void Invert_ShouldUpdateProperties()
+    {
+        var invert = new Invert();
+        invert.Amount = 50;
+        invert.ExcludeAlphaChannel = false;
+
+        Assert.That(invert.Amount, Is.EqualTo(50));
+        Assert.That(invert.ExcludeAlphaChannel, Is.False);
+    }
+
+    [Test]
+    public void Invert_ShouldApplyToContext()
+    {
+        var invert = new Invert();
+        invert.Amount = 50;
+        invert.ExcludeAlphaChannel = false;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(invert);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(invert));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Skia>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/LightingTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/LightingTest.cs
@@ -1,0 +1,44 @@
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class LightingTest
+{
+    [Test]
+    public void Lighting_ShouldHaveDefaultValues()
+    {
+        var lighting = new Lighting();
+
+        Assert.That(lighting.Multiply, Is.EqualTo(Colors.White));
+        Assert.That(lighting.Add, Is.EqualTo((Color)default));
+    }
+
+    [Test]
+    public void Lighting_ShouldUpdateProperties()
+    {
+        var lighting = new Lighting();
+        lighting.Multiply = Colors.Red;
+        lighting.Add = Colors.Blue;
+
+        Assert.That(lighting.Multiply, Is.EqualTo(Colors.Red));
+        Assert.That(lighting.Add, Is.EqualTo(Colors.Blue));
+    }
+
+    [Test]
+    public void Lighting_ShouldApplyToContext()
+    {
+        var lighting = new Lighting();
+        lighting.Multiply = Colors.Red;
+        lighting.Add = Colors.Blue;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(lighting);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(lighting));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Skia>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/LumaColorTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/LumaColorTest.cs
@@ -1,0 +1,22 @@
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class LumaColorTest
+{
+    [Test]
+    public void LumaColor_ShouldApplyToContext()
+    {
+        var lumaColor = new LumaColor();
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(lumaColor);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(lumaColor));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Skia>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/MosaicTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/MosaicTest.cs
@@ -1,0 +1,48 @@
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class MosaicTest
+{
+    [Test]
+    public void Mosaic_ShouldHaveDefaultValues()
+    {
+        var mosaic = new Mosaic();
+
+        Assert.That(mosaic.Scale, Is.EqualTo(1));
+        Assert.That(mosaic.ScaleX, Is.EqualTo(1));
+        Assert.That(mosaic.ScaleY, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Mosaic_ShouldUpdateProperties()
+    {
+        var mosaic = new Mosaic();
+        mosaic.Scale = 2;
+        mosaic.ScaleX = 1.5f;
+        mosaic.ScaleY = 1.5f;
+
+        Assert.That(mosaic.Scale, Is.EqualTo(2));
+        Assert.That(mosaic.ScaleX, Is.EqualTo(1.5f));
+        Assert.That(mosaic.ScaleY, Is.EqualTo(1.5f));
+    }
+
+    [Test]
+    public void Mosaic_ShouldApplyToContext()
+    {
+        var mosaic = new Mosaic();
+        mosaic.Scale = 2;
+        mosaic.ScaleX = 1.5f;
+        mosaic.ScaleY = 1.5f;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(mosaic);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(mosaic));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Custom>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/NegaposiTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/NegaposiTest.cs
@@ -1,0 +1,52 @@
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class NegaposiTest
+{
+    [Test]
+    public void Negaposi_ShouldHaveDefaultValues()
+    {
+        var negaposi = new Negaposi();
+
+        Assert.That(negaposi.Red, Is.EqualTo(0));
+        Assert.That(negaposi.Green, Is.EqualTo(0));
+        Assert.That(negaposi.Blue, Is.EqualTo(0));
+        Assert.That(negaposi.Strength, Is.EqualTo(100));
+    }
+
+    [Test]
+    public void Negaposi_ShouldUpdateProperties()
+    {
+        var negaposi = new Negaposi();
+        negaposi.Red = 255;
+        negaposi.Green = 128;
+        negaposi.Blue = 64;
+        negaposi.Strength = 50;
+
+        Assert.That(negaposi.Red, Is.EqualTo(255));
+        Assert.That(negaposi.Green, Is.EqualTo(128));
+        Assert.That(negaposi.Blue, Is.EqualTo(64));
+        Assert.That(negaposi.Strength, Is.EqualTo(50));
+    }
+
+    [Test]
+    public void Negaposi_ShouldApplyToContext()
+    {
+        var negaposi = new Negaposi();
+        negaposi.Red = 255;
+        negaposi.Green = 128;
+        negaposi.Blue = 64;
+        negaposi.Strength = 50;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(negaposi);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(negaposi));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Skia>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/PartsSplitEffectTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/PartsSplitEffectTest.cs
@@ -1,0 +1,21 @@
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class PartsSplitEffectTest
+{
+    [Test]
+    public void PartsSplitEffect_ShouldApplyToContext()
+    {
+        var effect = new PartsSplitEffect();
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(effect);
+
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(effect));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Custom>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/SaturateTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/SaturateTest.cs
@@ -1,0 +1,41 @@
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class SaturateTest
+{
+    [Test]
+    public void Saturate_ShouldHaveDefaultValues()
+    {
+        var saturate = new Saturate();
+
+        Assert.That(saturate.Amount, Is.EqualTo(100F));
+    }
+
+    [Test]
+    public void Saturate_ShouldUpdateProperties()
+    {
+        var saturate = new Saturate();
+        saturate.Amount = 75F;
+
+        Assert.That(saturate.Amount, Is.EqualTo(75F));
+    }
+
+    [Test]
+    public void Saturate_ShouldApplyToContext()
+    {
+        var saturate = new Saturate();
+        saturate.Amount = 75F;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(saturate);
+
+        // 適用結果の検証
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(saturate));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Skia>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/ShakeEffectTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/ShakeEffectTest.cs
@@ -1,0 +1,47 @@
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class ShakeEffectTest
+{
+    [Test]
+    public void ShakeEffect_ShouldHaveDefaultValues()
+    {
+        var effect = new ShakeEffect();
+
+        Assert.That(effect.StrengthX, Is.EqualTo(50));
+        Assert.That(effect.StrengthY, Is.EqualTo(50));
+        Assert.That(effect.Speed, Is.EqualTo(100));
+    }
+
+    [Test]
+    public void ShakeEffect_ShouldUpdateProperties()
+    {
+        var effect = new ShakeEffect();
+        effect.StrengthX = 75;
+        effect.StrengthY = 25;
+        effect.Speed = 50;
+
+        Assert.That(effect.StrengthX, Is.EqualTo(75));
+        Assert.That(effect.StrengthY, Is.EqualTo(25));
+        Assert.That(effect.Speed, Is.EqualTo(50));
+    }
+
+    [Test]
+    public void ShakeEffect_ShouldApplyToContext()
+    {
+        var effect = new ShakeEffect();
+        effect.StrengthX = 75;
+        effect.StrengthY = 25;
+        effect.Speed = 50;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(effect);
+
+        // 適用結果の検証
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(effect));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Custom>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/SplitEffectTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/SplitEffectTest.cs
@@ -1,0 +1,51 @@
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class SplitEffectTest
+{
+    [Test]
+    public void SplitEffect_ShouldHaveDefaultValues()
+    {
+        var effect = new SplitEffect();
+
+        Assert.That(effect.HorizontalDivisions, Is.EqualTo(2));
+        Assert.That(effect.VerticalDivisions, Is.EqualTo(2));
+        Assert.That(effect.HorizontalSpacing, Is.EqualTo(0));
+        Assert.That(effect.VerticalSpacing, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void SplitEffect_ShouldUpdateProperties()
+    {
+        var effect = new SplitEffect();
+        effect.HorizontalDivisions = 3;
+        effect.VerticalDivisions = 4;
+        effect.HorizontalSpacing = 5;
+        effect.VerticalSpacing = 6;
+
+        Assert.That(effect.HorizontalDivisions, Is.EqualTo(3));
+        Assert.That(effect.VerticalDivisions, Is.EqualTo(4));
+        Assert.That(effect.HorizontalSpacing, Is.EqualTo(5));
+        Assert.That(effect.VerticalSpacing, Is.EqualTo(6));
+    }
+
+    [Test]
+    public void SplitEffect_ShouldApplyToContext()
+    {
+        var effect = new SplitEffect();
+        effect.HorizontalDivisions = 3;
+        effect.VerticalDivisions = 4;
+        effect.HorizontalSpacing = 5;
+        effect.VerticalSpacing = 6;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(effect);
+
+        // 適用結果の検証
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(effect));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Custom>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/StrokeEffectTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/StrokeEffectTest.cs
@@ -1,0 +1,50 @@
+#pragma warning disable CS0618
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class StrokeEffectTest
+{
+    [Test]
+    public void StrokeEffect_ShouldHaveDefaultValues()
+    {
+        var effect = new StrokeEffect();
+
+        Assert.That(effect.Pen, Is.Not.Null);
+        Assert.That(effect.Offset, Is.EqualTo(new Point()));
+        Assert.That(effect.Style, Is.EqualTo(Border.BorderStyles.Background));
+    }
+
+    [Test]
+    public void StrokeEffect_ShouldUpdateProperties()
+    {
+        var effect = new StrokeEffect();
+        effect.Pen = new Pen { Brush = Brushes.Red, Thickness = 2 };
+        effect.Offset = new Point(10, 10);
+        effect.Style = Border.BorderStyles.Foreground;
+
+        Assert.That(effect.Pen, Is.Not.Null);
+        Assert.That(effect.Offset, Is.EqualTo(new Point(10, 10)));
+        Assert.That(effect.Style, Is.EqualTo(Border.BorderStyles.Foreground));
+    }
+
+    [Test]
+    public void StrokeEffect_ShouldApplyToContext()
+    {
+        var effect = new StrokeEffect();
+        effect.Pen = new Pen { Brush = Brushes.Red, Thickness = 2 };
+        effect.Offset = new Point(10, 10);
+        effect.Style = Border.BorderStyles.Foreground;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(effect);
+
+        // 適用結果の検証
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(effect));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Custom>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/ThresholdTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/ThresholdTest.cs
@@ -1,0 +1,46 @@
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class ThresholdTest
+{
+    [Test]
+    public void Threshold_ShouldHaveDefaultValues()
+    {
+        var threshold = new Threshold();
+
+        Assert.That(threshold.Value, Is.EqualTo(50));
+        Assert.That(threshold.Strength, Is.EqualTo(100));
+    }
+
+    [Test]
+    public void Threshold_ShouldUpdateProperties()
+    {
+        var threshold = new Threshold();
+        threshold.Value = 75;
+        threshold.Strength = 50;
+
+        Assert.That(threshold.Value, Is.EqualTo(75));
+        Assert.That(threshold.Strength, Is.EqualTo(50));
+    }
+
+    [Test]
+    public void Threshold_ShouldApplyToContext()
+    {
+        var threshold = new Threshold();
+        threshold.Value = 75;
+        threshold.Strength = 50;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(threshold);
+
+        // 適用結果の検証
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(threshold));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Skia>());
+        Assert.That(context._items[1].FilterEffect, Is.EqualTo(threshold));
+        Assert.That(context._items[1].Item, Is.InstanceOf<IFEItem_Skia>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Effects/TransformEffectTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Effects/TransformEffectTest.cs
@@ -1,0 +1,54 @@
+
+using Beutl.Graphics.Effects;
+using Beutl.Media;
+using Beutl.Graphics.Transformation;
+using Beutl.Graphics;
+
+namespace Beutl.UnitTests.Engine.Graphics.Effects;
+
+public class TransformEffectTest
+{
+    [Test]
+    public void TransformEffect_ShouldHaveDefaultValues()
+    {
+        var effect = new TransformEffect();
+
+        Assert.That(effect.Transform, Is.Null);
+        Assert.That(effect.TransformOrigin, Is.EqualTo(RelativePoint.Center));
+        Assert.That(effect.BitmapInterpolationMode, Is.EqualTo(BitmapInterpolationMode.Default));
+        Assert.That(effect.ApplyToTarget, Is.False);
+    }
+
+    [Test]
+    public void TransformEffect_ShouldUpdateProperties()
+    {
+        var effect = new TransformEffect();
+        effect.Transform = new RotationTransform { Rotation = 45 };
+        effect.TransformOrigin = RelativePoint.TopLeft;
+        effect.BitmapInterpolationMode = BitmapInterpolationMode.HighQuality;
+        effect.ApplyToTarget = false;
+
+        Assert.That(effect.Transform, Is.Not.Null);
+        Assert.That(effect.TransformOrigin, Is.EqualTo(RelativePoint.TopLeft));
+        Assert.That(effect.BitmapInterpolationMode, Is.EqualTo(BitmapInterpolationMode.HighQuality));
+        Assert.That(effect.ApplyToTarget, Is.False);
+    }
+
+    [Test]
+    public void TransformEffect_ShouldApplyToContext()
+    {
+        var effect = new TransformEffect();
+        effect.Transform = new RotationTransform { Rotation = 45 };
+        effect.TransformOrigin = RelativePoint.TopLeft;
+        effect.BitmapInterpolationMode = BitmapInterpolationMode.HighQuality;
+        effect.ApplyToTarget = false;
+        using var context = new FilterEffectContext(new Rect(0, 0, 100, 100));
+
+        context.Apply(effect);
+
+        // 適用結果の検証
+        Assert.That(context._items, Is.Not.Empty);
+        Assert.That(context._items[0].FilterEffect, Is.EqualTo(effect));
+        Assert.That(context._items[0].Item, Is.InstanceOf<IFEItem_Skia>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/RenderCacheRulesTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/RenderCacheRulesTest.cs
@@ -1,0 +1,92 @@
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Cache;
+
+[TestFixture]
+public class RenderCacheRulesTest
+{
+    [Test]
+    public void Match_ShouldReturnTrue_WhenPixelsWithinRange()
+    {
+        // Arrange
+        var rules = new RenderCacheRules(10000, 100);
+        var size = new PixelSize(50, 50); // 2500 pixels
+
+        // Act
+        bool result = rules.Match(size);
+
+        // Assert
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Match_ShouldReturnFalse_WhenPixelsBelowMin()
+    {
+        // Arrange
+        var rules = new RenderCacheRules(10000, 100);
+        var size = new PixelSize(5, 5); // 25 pixels
+
+        // Act
+        bool result = rules.Match(size);
+
+        // Assert
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Match_ShouldReturnFalse_WhenPixelsAboveMax()
+    {
+        // Arrange
+        var rules = new RenderCacheRules(10000, 100);
+        var size = new PixelSize(200, 200); // 40000 pixels
+
+        // Act
+        bool result = rules.Match(size);
+
+        // Assert
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Match_ShouldReturnTrue_WhenPixelsWithinRange_Int()
+    {
+        // Arrange
+        var rules = new RenderCacheRules(10000, 100);
+        int pixels = 2500;
+
+        // Act
+        bool result = rules.Match(pixels);
+
+        // Assert
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Match_ShouldReturnFalse_WhenPixelsBelowMin_Int()
+    {
+        // Arrange
+        var rules = new RenderCacheRules(10000, 100);
+        int pixels = 25;
+
+        // Act
+        bool result = rules.Match(pixels);
+
+        // Assert
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Match_ShouldReturnFalse_WhenPixelsAboveMax_Int()
+    {
+        // Arrange
+        var rules = new RenderCacheRules(10000, 100);
+        int pixels = 40000;
+
+        // Act
+        bool result = rules.Match(pixels);
+
+        // Assert
+        Assert.That(result, Is.False);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/RenderNodeCacheContextTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/RenderNodeCacheContextTest.cs
@@ -1,0 +1,280 @@
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Cache;
+
+public class RenderNodeCacheContextTest
+{
+    private RenderScene? _scene;
+    private RenderNodeCacheContext? _context;
+
+    [SetUp]
+    public void Setup()
+    {
+        _scene = new RenderScene(new PixelSize(100, 100));
+        _context = new RenderNodeCacheContext(_scene);
+    }
+
+    [Test]
+    public void CacheOptions_Setter_ShouldClearCache()
+    {
+        // Arrange
+        var newCacheOptions = new RenderCacheOptions(true, RenderCacheRules.Default);
+
+        // Act
+        _context!.CacheOptions = newCacheOptions;
+
+        // Assert
+        Assert.That(_context.CacheOptions, Is.EqualTo(newCacheOptions));
+    }
+
+    [Test]
+    public void CanCacheRecursive_ShouldReturnFalse_WhenCacheCannotCache()
+    {
+        // Arrange
+        var childNode = new EllipseRenderNode(new Rect(0, 0, 100, 100), Brushes.White, null);
+        var containerNode = new ContainerRenderNode();
+        containerNode.AddChild(childNode);
+
+        // Act
+        bool result = RenderNodeCacheContext.CanCacheRecursive(containerNode);
+
+        // Assert
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void CanCacheRecursive_ShouldReturnTrue_WhenCacheCanCache()
+    {
+        // Arrange
+        var childNode = new EllipseRenderNode(new Rect(0, 0, 100, 100), Brushes.White, null);
+        var containerNode = new ContainerRenderNode();
+        containerNode.AddChild(childNode);
+        childNode.Cache.ReportRenderCount(3);
+        containerNode.Cache.ReportRenderCount(3);
+        containerNode.Cache.CaptureChildren();
+
+        // Act
+        bool result = RenderNodeCacheContext.CanCacheRecursive(containerNode);
+
+        // Assert
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void CanCacheRecursive_ShouldReturnFalse_WhenChildCountIsDifferent()
+    {
+        // Arrange
+        var childNode = new EllipseRenderNode(new Rect(0, 0, 100, 100), Brushes.White, null);
+        var containerNode = new ContainerRenderNode();
+        containerNode.AddChild(childNode);
+        childNode.Cache.ReportRenderCount(3);
+        containerNode.Cache.ReportRenderCount(3);
+        containerNode.Cache.CaptureChildren();
+        containerNode.AddChild(new EllipseRenderNode(new Rect(0, 0, 100, 100), Brushes.White, null));
+
+        // Act
+        bool result = RenderNodeCacheContext.CanCacheRecursive(containerNode);
+
+        // Assert
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void CanCacheRecursive_ShouldReturnFalse_WhenChildIsDifferent()
+    {
+        // Arrange
+        var childNode = new EllipseRenderNode(new Rect(0, 0, 100, 100), Brushes.White, null);
+        var containerNode = new ContainerRenderNode();
+        containerNode.AddChild(childNode);
+        childNode.Cache.ReportRenderCount(3);
+        containerNode.Cache.ReportRenderCount(3);
+        containerNode.Cache.CaptureChildren();
+        containerNode.SetChild(0, new EllipseRenderNode(new Rect(0, 0, 100, 100), Brushes.White, null));
+
+        // Act
+        bool result = RenderNodeCacheContext.CanCacheRecursive(containerNode);
+
+        // Assert
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void CanCacheRecursive_ShouldReturnFalse_WhenNotCaptured()
+    {
+        // Arrange
+        var childNode = new EllipseRenderNode(new Rect(0, 0, 100, 100), Brushes.White, null);
+        var containerNode = new ContainerRenderNode();
+        containerNode.AddChild(childNode);
+        childNode.Cache.ReportRenderCount(3);
+        containerNode.Cache.ReportRenderCount(3);
+
+        // Act
+        bool result = RenderNodeCacheContext.CanCacheRecursive(containerNode);
+
+        // Assert
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void CanCacheRecursiveChildrenOnly_ShouldReturnFalse_WhenAnyChildCannotCache()
+    {
+        // Arrange
+        var childNode = new EllipseRenderNode(new Rect(0, 0, 100, 100), Brushes.White, null);
+        var containerNode = new ContainerRenderNode();
+        containerNode.AddChild(childNode);
+        containerNode.Cache.ReportRenderCount(3);
+        containerNode.Cache.CaptureChildren();
+
+        // Act
+        var result = RenderNodeCacheContext.CanCacheRecursiveChildrenOnly(containerNode);
+
+        // Assert
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void CanCacheRecursiveChildrenOnly_ShouldReturnTrue_WhenAllChildrenCanCache()
+    {
+        // Arrange
+        var childNode = new EllipseRenderNode(new Rect(0, 0, 100, 100), Brushes.White, null);
+        var containerNode = new ContainerRenderNode();
+        containerNode.AddChild(childNode);
+        childNode.Cache.ReportRenderCount(3);
+
+        // Act
+        bool result = RenderNodeCacheContext.CanCacheRecursiveChildrenOnly(containerNode);
+
+        // Assert
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void ClearCache_ShouldInvalidateCache()
+    {
+        // Arrange
+        using var node = new EllipseRenderNode(new Rect(0, 0, 100, 100), Brushes.White, null);
+        using (var renderTarget = RenderTarget.CreateNull(100, 100))
+        {
+            node.Cache.StoreCache(renderTarget, new Rect(0, 0, 100, 100));
+        }
+
+        // Act
+        RenderNodeCacheContext.ClearCache(node);
+
+        // Assert
+        Assert.That(node.Cache.IsCached, Is.False);
+    }
+
+    [Test]
+    public void ClearCache_ShouldInvalidateCache_WhenNodeIsContainerRenderNode()
+    {
+        // Arrange
+        using var node = new ContainerRenderNode();
+        using var childNode = new EllipseRenderNode(new Rect(0, 0, 100, 100), Brushes.White, null);
+        using (var renderTarget = RenderTarget.CreateNull(100, 100))
+        {
+            childNode.Cache.StoreCache(renderTarget, new Rect(0, 0, 100, 100));
+        }
+        node.AddChild(childNode);
+
+        // Act
+        RenderNodeCacheContext.ClearCache(node);
+
+        // Assert
+        Assert.That(childNode.Cache.IsCached, Is.False);
+    }
+
+    [Test]
+    public void MakeCache_ShouldCreateCache_WhenCacheIsEnabledAndCanCache()
+    {
+        // Arrange
+        var childNode = new EllipseRenderNode(new Rect(0, 0, 100, 100), Brushes.White, null);
+        var containerNode = new ContainerRenderNode();
+        containerNode.AddChild(childNode);
+        childNode.Cache.ReportRenderCount(3);
+        containerNode.Cache.ReportRenderCount(3);
+        containerNode.Cache.CaptureChildren();
+        _context!.CacheOptions = new RenderCacheOptions(true, RenderCacheRules.Default);
+
+        // Act
+        _context.MakeCache(containerNode);
+
+        // Assert
+        Assert.That(containerNode.Cache.IsCached, Is.True);
+    }
+
+    [Test]
+    public void MakeCache_ShouldNotCreateCache_WhenCacheIsDisabled()
+    {
+        // Arrange
+        var childNode = new EllipseRenderNode(new Rect(0, 0, 100, 100), Brushes.White, null);
+        var containerNode = new ContainerRenderNode();
+        containerNode.AddChild(childNode);
+        childNode.Cache.ReportRenderCount(3);
+        containerNode.Cache.ReportRenderCount(3);
+        containerNode.Cache.CaptureChildren();
+        _context!.CacheOptions = new RenderCacheOptions(false, RenderCacheRules.Default);
+
+        // Act
+        _context.MakeCache(containerNode);
+
+        // Assert
+        Assert.That(containerNode.Cache.IsCached, Is.False);
+    }
+
+    [Test]
+    public void MakeCache_ShouldNotCreateCache_WhenCannotCacheChildren()
+    {
+        // Arrange
+        var childNode = new EllipseRenderNode(new Rect(0, 0, 100, 100), Brushes.White, null);
+        var containerNode = new ContainerRenderNode();
+        containerNode.AddChild(childNode);
+        containerNode.Cache.ReportRenderCount(3);
+        containerNode.Cache.CaptureChildren();
+        _context!.CacheOptions = new RenderCacheOptions(true, RenderCacheRules.Default);
+
+        // Act
+        _context.MakeCache(containerNode);
+
+        // Assert
+        Assert.That(containerNode.Cache.IsCached, Is.False);
+    }
+
+    [Test]
+    public void CreateDefaultCache_ShouldStoreCache_WhenCacheRulesMatch()
+    {
+        // Arrange
+        var childNode = new EllipseRenderNode(new Rect(0, 0, 100, 100), Brushes.White, null);
+        var containerNode = new ContainerRenderNode();
+        containerNode.AddChild(childNode);
+        childNode.Cache.ReportRenderCount(3);
+        containerNode.Cache.ReportRenderCount(3);
+        containerNode.Cache.CaptureChildren();
+        _context!.CacheOptions = new RenderCacheOptions(true, new RenderCacheRules(10000, 1));
+
+        // Act
+        _context.CreateDefaultCache(containerNode);
+
+        // Assert
+        Assert.That(containerNode.Cache.IsCached, Is.True);
+    }
+
+    [Test]
+    public void CreateDefaultCache_ShouldNotStoreCache_WhenCacheRulesDoNotMatch()
+    {
+        // Arrange
+        var childNode = new EllipseRenderNode(new Rect(0, 0, 100, 100), Brushes.White, null);
+        var containerNode = new ContainerRenderNode();
+        containerNode.AddChild(childNode);
+        _context!.CacheOptions = new RenderCacheOptions(true, new RenderCacheRules(1, 1));
+
+        // Act
+        _context.CreateDefaultCache(containerNode);
+
+        // Assert
+        Assert.That(containerNode.Cache.IsCached, Is.False);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/ImageSourceRenderNodeTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/ImageSourceRenderNodeTest.cs
@@ -1,0 +1,124 @@
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+using Beutl.Media.Source;
+using Moq;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+[TestFixture]
+public class ImageSourceRenderNodeTest
+{
+    public IImageSource CreateMockImageSource()
+    {
+        var source = new Mock<IImageSource>();
+        source.Setup(x => x.FrameSize).Returns(new PixelSize(100, 100));
+        source.Setup(x => x.Clone()).Returns(() => source.Object);
+
+        return source.Object;
+    }
+
+    [Test]
+    public void Equals_ShouldReturnTrue_WhenAllPropertiesMatch()
+    {
+        IImageSource source = CreateMockImageSource();
+        IBrush fill = Brushes.White;
+        IPen pen = new Pen { Brush = Brushes.Black, Thickness = 1 };
+        var node = new ImageSourceRenderNode(source, fill, pen);
+
+        Assert.That(node.Equals(source, fill, pen), Is.True);
+    }
+
+    [Test]
+    public void Equals_ShouldReturnFalse_WhenPropertiesDoNotMatch()
+    {
+        IImageSource source = CreateMockImageSource();
+        IBrush fill = Brushes.White;
+        IPen pen = new Pen { Brush = Brushes.Black, Thickness = 1 };
+        var node = new ImageSourceRenderNode(source, fill, pen);
+
+        Assert.That(node.Equals(Mock.Of<IImageSource>(), fill, pen), Is.False);
+    }
+
+    [Test]
+    public void Process_WithoutInput_ShouldReturnEmptyRenderNodeOperation()
+    {
+        var context = new RenderNodeContext([]);
+
+        IImageSource source = CreateMockImageSource();
+        var node = new ImageSourceRenderNode(source, null, null);
+        var operations = node.Process(context);
+
+        Assert.That(operations, Is.Not.Empty);
+    }
+
+    [Test]
+    public void Process_WithInput_ShouldReturnExpectedRenderNodeOperation()
+    {
+        var context = new RenderNodeContext([
+            RenderNodeOperation.CreateLambda(default, _ => {  })
+        ]);
+
+        IImageSource source = CreateMockImageSource();
+        var node = new ImageSourceRenderNode(source, null, null);
+        var operations = node.Process(context);
+
+        Assert.That(operations, Is.Not.Empty);
+    }
+
+    [Test]
+    public void HitTest_ShouldReturnTrue_WhenPointIsInsideStroke()
+    {
+        IImageSource source = CreateMockImageSource();
+        IPen pen = new Pen { Brush = Brushes.Black, Thickness = 50 };
+        var context = new RenderNodeContext([]);
+
+        var node = new ImageSourceRenderNode(source, null, pen);
+        var operations = node.Process(context);
+        var point = new Point(-10, -10);
+
+        Assert.That(operations[0].HitTest(point), Is.True);
+    }
+
+    [Test]
+    public void HitTest_ShouldReturnFalse_WhenPointIsOutsideStroke()
+    {
+        IImageSource source = CreateMockImageSource();
+        IPen pen = new Pen { Brush = Brushes.Black, Thickness = 50 };
+        var context = new RenderNodeContext([]);
+
+        var node = new ImageSourceRenderNode(source, null, pen);
+        var operations = node.Process(context);
+        var point = new Point(60, 60);
+
+        Assert.That(operations[0].HitTest(point), Is.False);
+    }
+
+    [Test]
+    public void HitTest_ShouldReturnTrue_WhenPointIsInsideFill()
+    {
+        IImageSource source = CreateMockImageSource();
+        IBrush fill = Brushes.White;
+        var context = new RenderNodeContext([]);
+
+        var node = new ImageSourceRenderNode(source, fill, null);
+        var operations = node.Process(context);
+        var point = new Point(50, 50);
+
+        Assert.That(operations[0].HitTest(point), Is.True);
+    }
+
+    [Test]
+    public void HitTest_ShouldReturnFalse_WhenPointIsOutsideFill()
+    {
+        IImageSource source = CreateMockImageSource();
+        IBrush fill = Brushes.White;
+        var context = new RenderNodeContext([]);
+
+        var node = new ImageSourceRenderNode(source, fill, null);
+        var operations = node.Process(context);
+        var point = new Point(150, 150);
+
+        Assert.That(operations[0].HitTest(point), Is.False);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/SizeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/SizeTests.cs
@@ -1,70 +1,71 @@
 ﻿using System.Globalization;
 using System.Text;
 using Beutl.Graphics;
-using NUnit.Framework.Legacy;
+using Beutl.Media;
+using NUnit.Framework;
 
 namespace Beutl.UnitTests.Engine;
 
 public class SizeTests
 {
     [Test]
-    public void Parse()
+    public void Parse_CommaSeparatedString_ReturnsCorrectSize()
     {
         const string str = "1920,1080";
         var size = Size.Parse(str);
 
-        ClassicAssert.AreEqual(new Size(1920, 1080), size);
+        Assert.That(size, Is.EqualTo(new Size(1920, 1080)));
     }
 
     [Test]
-    public void ParseSpan()
+    public void ParseSpan_CommaSeparatedString_ReturnsCorrectSize()
     {
         const string str = "1920,1080";
         var size = Size.Parse(str.AsSpan());
 
-        ClassicAssert.AreEqual(new Size(1920, 1080), size);
+        Assert.That(size, Is.EqualTo(new Size(1920, 1080)));
     }
 
     [Test]
-    public void ParseWithProvider()
+    public void ParseWithProvider_SemicolonSeparatedString_ReturnsCorrectSize()
     {
         const string str = "1920;1080";
         var size = Size.Parse(str, CultureInfo.GetCultureInfo("fr"));
 
-        ClassicAssert.AreEqual(new Size(1920, 1080), size);
+        Assert.That(size, Is.EqualTo(new Size(1920, 1080)));
     }
 
     [Test]
-    public void ParseUtf8()
+    public void ParseUtf8_CommaSeparatedUtf8String_ReturnsCorrectSize()
     {
         ReadOnlySpan<byte> str = "1920,1080"u8;
         var size = Size.Parse(str);
 
-        ClassicAssert.AreEqual(new Size(1920, 1080), size);
+        Assert.That(size, Is.EqualTo(new Size(1920, 1080)));
     }
 
     [Test]
-    public void ParseUtf8WithProvider()
+    public void ParseUtf8WithProvider_SemicolonSeparatedUtf8String_ReturnsCorrectSize()
     {
         ReadOnlySpan<byte> str = "1920;1080"u8;
         var size = Size.Parse(str, CultureInfo.GetCultureInfo("fr"));
 
-        ClassicAssert.AreEqual(new Size(1920, 1080), size);
+        Assert.That(size, Is.EqualTo(new Size(1920, 1080)));
     }
 
     [Test]
-    public void FormatToSpan()
+    public void FormatToSpan_SizeFormattedToSpan_ReturnsCorrectString()
     {
         const string str = "1920, 1080";
         var size = new Size(1920, 1080);
         Span<char> s = stackalloc char[64];
 
         size.TryFormat(s, out int written);
-        ClassicAssert.AreEqual(str, s.Slice(0, written).ToString());
+        Assert.That(s.Slice(0, written).ToString(), Is.EqualTo(str));
     }
 
     [Test]
-    public void FormatToUtf8()
+    public void FormatToUtf8_SizeFormattedToUtf8_ReturnsCorrectString()
     {
         const string str = "1920, 1080";
         var size = new Size(1920, 1080);
@@ -72,28 +73,143 @@ public class SizeTests
 
         size.TryFormat(s, out int written);
 
-        ClassicAssert.AreEqual(str, Encoding.UTF8.GetString(s.Slice(0, written)));
+        Assert.That(Encoding.UTF8.GetString(s.Slice(0, written)), Is.EqualTo(str));
     }
 
     [Test]
-    public void Deflate()
+    public void Deflate_SizeDeflatedByThickness_ReturnsCorrectSize()
     {
         var size = new Size(1920, 1080);
         var thickness = new Thickness(10, 15);
 
         size = size.Deflate(thickness);
 
-        ClassicAssert.AreEqual(new Size(1900, 1050), size);
+        Assert.That(size, Is.EqualTo(new Size(1900, 1050)));
     }
 
     [Test]
-    public void Inflate()
+    public void Inflate_SizeInflatedByThickness_ReturnsCorrectSize()
     {
         var size = new Size(1920, 1080);
         var thickness = new Thickness(15, 10);
 
         size = size.Inflate(thickness);
 
-        ClassicAssert.AreEqual(new Size(1950, 1100), size);
+        Assert.That(size, Is.EqualTo(new Size(1950, 1100)));
+    }
+
+
+    [Test]
+    public void AspectRatio_ReturnsCorrectRatio()
+    {
+        var size = new Size(1920, 1080);
+        Assert.That(size.AspectRatio, Is.EqualTo(16.0f / 9.0f));
+    }
+
+    [Test]
+    public void IsDefault_ReturnsTrueForDefaultSize()
+    {
+        var size = new Size();
+        Assert.That(size.IsDefault, Is.True);
+    }
+
+    [Test]
+    public void EqualityOperator_ReturnsTrueForEqualSizes()
+    {
+        var size1 = new Size(1920, 1080);
+        var size2 = new Size(1920, 1080);
+        Assert.That(size1 == size2, Is.True);
+    }
+
+    [Test]
+    public void InequalityOperator_ReturnsTrueForDifferentSizes()
+    {
+        var size1 = new Size(1920, 1080);
+        var size2 = new Size(1280, 720);
+        Assert.That(size1 != size2, Is.True);
+    }
+
+    [Test]
+    public void MultiplicationOperator_ReturnsScaledSize()
+    {
+        var size = new Size(1920, 1080);
+        var scaledSize = size * 2;
+        Assert.That(scaledSize, Is.EqualTo(new Size(3840, 2160)));
+    }
+
+    [Test]
+    public void DivisionOperator_ReturnsScaledSize()
+    {
+        var size = new Size(1920, 1080);
+        var scaledSize = size / 2;
+        Assert.That(scaledSize, Is.EqualTo(new Size(960, 540)));
+    }
+
+    [Test]
+    public void AdditionOperator_ReturnsSummedSize()
+    {
+        var size1 = new Size(1920, 1080);
+        var size2 = new Size(1280, 720);
+        var summedSize = size1 + size2;
+        Assert.That(summedSize, Is.EqualTo(new Size(3200, 1800)));
+    }
+
+    [Test]
+    public void SubtractionOperator_ReturnsDifferenceSize()
+    {
+        var size1 = new Size(1920, 1080);
+        var size2 = new Size(1280, 720);
+        var diffSize = size1 - size2;
+        Assert.That(diffSize, Is.EqualTo(new Size(640, 360)));
+    }
+
+    [Test]
+    public void TryParse_ValidString_ReturnsTrueAndCorrectSize()
+    {
+        const string str = "1920,1080";
+        var result = Size.TryParse(str, out var size);
+        Assert.That(result, Is.True);
+        Assert.That(size, Is.EqualTo(new Size(1920, 1080)));
+    }
+
+    [Test]
+    public void Constrain_SizeConstrainedByMaxSize_ReturnsCorrectSize()
+    {
+        var size = new Size(1920, 1080);
+        var maxSize = new Size(1280, 720);
+        var constrainedSize = size.Constrain(maxSize);
+        Assert.That(constrainedSize, Is.EqualTo(maxSize));
+    }
+
+    [Test]
+    public void NearlyEquals_SizesWithinTolerance_ReturnsTrue()
+    {
+        var size1 = new Size(1920, 1080);
+        var size2 = new Size(1920.0001f, 1080.0001f);
+        Assert.That(size1.NearlyEquals(size2), Is.True);
+    }
+
+    [Test]
+    public void WithWidth_ReturnsSizeWithNewWidth()
+    {
+        var size = new Size(1920, 1080);
+        var newSize = size.WithWidth(1280);
+        Assert.That(newSize, Is.EqualTo(new Size(1280, 1080)));
+    }
+
+    [Test]
+    public void WithHeight_ReturnsSizeWithNewHeight()
+    {
+        var size = new Size(1920, 1080);
+        var newSize = size.WithHeight(720);
+        Assert.That(newSize, Is.EqualTo(new Size(1920, 720)));
+    }
+
+    [Test]
+    public void Ceiling_ReturnsSizeWithCeilingValues()
+    {
+        var size = new Size(1920.5f, 1080.5f);
+        var ceilingSize = size.Ceiling();
+        Assert.That(ceilingSize, Is.EqualTo(new PixelSize(1921, 1081)));
     }
 }


### PR DESCRIPTION
Simplify the `ClearCache` method and remove unnecessary parameters. Add comprehensive unit tests for various filter effects to ensure proper functionality and context application.