### PR TITLE
Update HarfBuzzSharp and SkiaSharp packages, improve bitmap interpolation handling, and simplify text shaping

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,8 +32,8 @@
     <PackageVersion Include="MonoMac.NetStandard" Version="0.0.4" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NAudio.Wasapi" Version="2.2.1" />
-    <PackageVersion Include="HarfBuzzSharp" Version="7.3.0.3" />
-    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0.3" />
+    <PackageVersion Include="HarfBuzzSharp" Version="8.3.0.1" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.0.1" />
     <PackageVersion Include="ILGPU" Version="1.5.1" />
     <PackageVersion Include="Kokuban" Version="0.2.0" />
     <PackageVersion Include="Kurukuru" Version="1.4.2" />
@@ -72,9 +72,9 @@
     <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="1.2.0" />
     <PackageVersion Include="Sharprompt" Version="2.4.5" />
-    <PackageVersion Include="SkiaSharp" Version="2.88.9" />
-    <PackageVersion Include="SkiaSharp.HarfBuzz" Version="2.88.9" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.9" />
+    <PackageVersion Include="SkiaSharp" Version="3.116.1" />
+    <PackageVersion Include="SkiaSharp.HarfBuzz" Version="3.116.1" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Interactive" Version="6.0.1" />
     <PackageVersion Include="System.Interactive.Async" Version="6.0.1" />

--- a/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectContext.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectContext.cs
@@ -298,7 +298,7 @@ public sealed class FilterEffectContext : IDisposable
     {
         AppendSkiaFilter(
             (matrix, bitmapInterpolationMode),
-            (data, input, _) => SKImageFilter.CreateMatrix(data.matrix.ToSKMatrix(), data.bitmapInterpolationMode.ToSKFilterQuality(), input),
+            (data, input, _) => SKImageFilter.CreateMatrix(data.matrix.ToSKMatrix(), data.bitmapInterpolationMode.ToSKSamplingOptions(), input),
             (data, rect) => rect.TransformToAABB(data.matrix));
     }
 

--- a/src/Beutl.Engine/Graphics/SkiaSharpExtensions.cs
+++ b/src/Beutl.Engine/Graphics/SkiaSharpExtensions.cs
@@ -18,6 +18,18 @@ internal static class SkiaSharpExtensions
         };
     }
 
+    public static SKSamplingOptions ToSKSamplingOptions(this BitmapInterpolationMode interpolationMode)
+    {
+        return interpolationMode switch
+        {
+            BitmapInterpolationMode.Default => new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None),
+            BitmapInterpolationMode.LowQuality => new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.None),
+            BitmapInterpolationMode.MediumQuality => new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.Linear),
+            BitmapInterpolationMode.HighQuality => new SKSamplingOptions(SKCubicResampler.Mitchell),
+            _ => throw new ArgumentOutOfRangeException(nameof(interpolationMode), interpolationMode, null)
+        };
+    }
+
     public static SKPoint ToSKPoint(this Point p)
     {
         return new SKPoint(p.X, p.Y);

--- a/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
+++ b/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
@@ -128,16 +128,15 @@ public class FormattedText : IEquatable<FormattedText>
         buffer.AddUtf16(Text.AsSpan());
         buffer.GuessSegmentProperties();
 
-        using SKPaint paint = new() { TextSize = Size, Typeface = font.Typeface };
-        SKShaper.Result result = shaper.Shape(buffer, paint);
+        SKShaper.Result result = shaper.Shape(buffer, font);
 
         // create the text blob
         using var builder = new SKTextBlobBuilder();
         SKPositionedRunBuffer run = builder.AllocatePositionedRun(font, result.Codepoints.Length);
 
         // copy the glyphs
-        Span<ushort> glyphs = run.GetGlyphSpan();
-        Span<SKPoint> positions = run.GetPositionSpan();
+        Span<ushort> glyphs = run.Glyphs;
+        Span<SKPoint> positions = run.Positions;
         for (int i = 0; i < result.Codepoints.Length; i++)
         {
             glyphs[i] = (ushort)result.Codepoints[i];
@@ -147,7 +146,7 @@ public class FormattedText : IEquatable<FormattedText>
         }
 
         // build
-        using SKTextBlob textBlob = builder.Build();
+        using SKTextBlob? textBlob = builder.Build();
 
         for (int i = 0; i < glyphs.Length; i++)
         {
@@ -208,16 +207,15 @@ public class FormattedText : IEquatable<FormattedText>
         buffer.AddUtf16(Text.AsSpan());
         buffer.GuessSegmentProperties();
 
-        using SKPaint paint = new() { TextSize = Size, Typeface = font.Typeface, };
-        SKShaper.Result result = shaper.Shape(buffer, paint);
+        SKShaper.Result result = shaper.Shape(buffer, font);
 
         // create the text blob
         using var builder = new SKTextBlobBuilder();
         SKPositionedRunBuffer run = builder.AllocatePositionedRun(font, result.Codepoints.Length);
 
         var fillPath = new SKPath();
-        Span<ushort> glyphs = run.GetGlyphSpan();
-        Span<SKPoint> positions = run.GetPositionSpan();
+        Span<ushort> glyphs = run.Glyphs;
+        Span<SKPoint> positions = run.Positions;
         CollectionsMarshal.SetCount(_pathList, result.Codepoints.Length);
         Span<SKPathGeometry> pathList = CollectionsMarshal.AsSpan(_pathList);
         for (int i = 0; i < result.Codepoints.Length; i++)
@@ -250,7 +248,7 @@ public class FormattedText : IEquatable<FormattedText>
         // 空白で開始または、終了した場合
         var bounds = new Rect(0, 0, (glyphs.Length - 1) * Spacing + result.Width, fillPath.TightBounds.Height);
         Rect actualBounds = fillPath.TightBounds.ToGraphicsRect();
-        SKTextBlob textBlob = builder.Build();
+        SKTextBlob? textBlob = builder.Build();
 
         if (result.Codepoints.Length > 0)
         {


### PR DESCRIPTION
Upgrade HarfBuzzSharp and SkiaSharp to the latest versions. Introduce an extension method for converting BitmapInterpolationMode to SKSamplingOptions, ensuring proper usage in FilterEffectContext. Simplify text shaping by removing unnecessary SKPaint usage and updating glyph and position access.