### PR TITLE
Replace BitmapIcon with Image for better rendering in EditorHostFallback

### DIFF
--- a/src/Beutl/Views/EditorHostFallback.axaml
+++ b/src/Beutl/Views/EditorHostFallback.axaml
@@ -136,12 +136,12 @@
             <Button Click="SocialClick"
                     Tag="GitHub"
                     ToolTip.Tip="GitHub">
-                <ui:BitmapIcon x:Name="githubLogo" />
+                <Image x:Name="githubLogo" />
             </Button>
             <Button Click="SocialClick"
                     Tag="X"
                     ToolTip.Tip="X">
-                <ui:BitmapIcon x:Name="xLogo" Margin="2" />
+                <Image x:Name="xLogo" Margin="2" />
             </Button>
             <Button Click="SocialClick"
                     Tag="Url"

--- a/src/Beutl/Views/EditorHostFallback.axaml.cs
+++ b/src/Beutl/Views/EditorHostFallback.axaml.cs
@@ -4,6 +4,8 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
 using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -39,11 +41,12 @@ public partial class EditorHostFallback : UserControl
     {
         ThemeVariant theme = ActualThemeVariant;
 
-        void SetImage(string darkTheme, string lightTheme, BitmapIcon image)
+        void SetImage(string darkTheme, string lightTheme, Image image)
         {
-            image.UriSource = theme == ThemeVariant.Light || theme == FluentAvaloniaTheme.HighContrastTheme
+            using var stream = AssetLoader.Open(theme == ThemeVariant.Light || theme == FluentAvaloniaTheme.HighContrastTheme
                 ? new Uri(lightTheme)
-                : new Uri(darkTheme);
+                : new Uri(darkTheme));
+            image.Source = new Bitmap(stream);
         }
 
         SetImage(


### PR DESCRIPTION
Improve rendering by replacing BitmapIcon with Image in the EditorHostFallback component.