### PR TITLE
Fix button overlap issue in output window on Windows

### DIFF
--- a/src/Beutl/Pages/OutputDialog.axaml
+++ b/src/Beutl/Pages/OutputDialog.axaml
@@ -6,6 +6,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:viewModel="using:Beutl.ViewModels"
+             xmlns:wnd="using:FluentAvalonia.UI.Windowing"
              d:DesignHeight="450"
              d:DesignWidth="800"
              x:DataType="viewModel:OutputPageViewModel"
@@ -29,13 +30,15 @@
             </ui:CommandBar.Styles>
             <ui:CommandBar.PrimaryCommands>
                 <ui:CommandBarButton Click="OnAddClick"
-                                     IconSource="Add"
-                                     Label="{x:Static lang:Strings.Add}" />
+                                    wnd:AppWindow.AllowInteractionInTitleBar="True"
+                                    IconSource="Add"
+                                    Label="{x:Static lang:Strings.Add}" />
                 <ui:CommandBarSeparator />
                 <ui:CommandBarButton Click="OnRemoveClick"
-                                     IconSource="Dismiss"
-                                     IsEnabled="{Binding CanRemove.Value}"
-                                     Label="{x:Static lang:Strings.Close}" />
+                                    wnd:AppWindow.AllowInteractionInTitleBar="True"
+                                    IconSource="Dismiss"
+                                    IsEnabled="{Binding CanRemove.Value}"
+                                    Label="{x:Static lang:Strings.Close}" />
             </ui:CommandBar.PrimaryCommands>
         </ui:CommandBar>
 


### PR DESCRIPTION
The button on the output window overlaps with the drag area, making it unclickable in Windows environments. This update ensures that the button is fully clickable by allowing interaction in the title bar.

Fixes #1211