### PR TITLE
Fix RuntimeIdentifiers handling in build scripts

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <TargetFrameworks>net9.0;net9.0-windows</TargetFrameworks>
-    <!-- <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers> -->
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <TargetFrameworks>net9.0;net9.0-windows</TargetFrameworks>
-    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
+    <!-- <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers> -->
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -81,7 +81,10 @@ class Build : NukeBuild
 
             DotNetPublish(s => s
                 .EnableNoRestore()
-                .When(_ => Runtime != null, s => s.SetRuntime(Runtime).SetSelfContained(SelfContained))
+                .When(_ => Runtime != null, s => s
+                    .SetRuntime(Runtime)
+                    .SetSelfContained(SelfContained)
+                    .SetProperty("RuntimeIdentifiers", Runtime.ToString()))
                 .When(_ => Runtime == RuntimeIdentifier.win_x64, s => s.SetFramework($"{tfm}-windows"))
                 .When(_ => Runtime != RuntimeIdentifier.win_x64, s => s.SetFramework(tfm))
                 .SetConfiguration(Configuration)
@@ -100,7 +103,10 @@ class Build : NukeBuild
             {
                 AbsolutePath output = OutputDirectory / item;
                 DotNetPublish(s => s
-                    .When(_ => Runtime != null, s => s.SetRuntime(Runtime).SetSelfContained(SelfContained))
+                    .When(_ => Runtime != null, s => s
+                        .SetRuntime(Runtime)
+                        .SetSelfContained(SelfContained)
+                        .SetProperty("RuntimeIdentifiers", Runtime.ToString()))
                     .When(_ => Runtime == RuntimeIdentifier.win_x64, s => s.SetFramework($"{tfm}-windows"))
                     .When(_ => Runtime != RuntimeIdentifier.win_x64, s => s.SetFramework(tfm))
                     .EnableNoRestore()


### PR DESCRIPTION
Comment out and then uncomment RuntimeIdentifiers in Directory.Build.props, ensuring the build script correctly sets the RuntimeIdentifiers property during the publish process.