### PR TITLE
add: zh-Hans translate

### DIFF
--- a/src/Beutl.ExceptionHandler/Properties/Resources.zh-hans.resx
+++ b/src/Beutl.ExceptionHandler/Properties/Resources.zh-hans.resx
@@ -1,0 +1,14 @@
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/Beutl.ExceptionHandler/Properties/Resources.zh-hans.resx
+++ b/src/Beutl.ExceptionHandler/Properties/Resources.zh-hans.resx
@@ -11,4 +11,22 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Close" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="Content" xml:space="preserve">
+    <value>抱歉！发生了一个 Beutl 无法处理的错误。如果遥测数据采集已打开，那么日志是自动采集的。</value>
+  </data>
+  <data name="ErrorOccurred" xml:space="preserve">
+    <value>错误发生。</value>
+  </data>
+  <data name="LogFileNotFound" xml:space="preserve">
+    <value>日志文件未找到</value>
+  </data>
+  <data name="MoreDetails" xml:space="preserve">
+    <value>更多信息</value>
+  </data>
+  <data name="ShowLog" xml:space="preserve">
+    <value>显示日志</value>
+  </data>
 </root>

--- a/src/Beutl.Extensions.FFmpeg/Properties/Strings.zh-hans.resx
+++ b/src/Beutl.Extensions.FFmpeg/Properties/Strings.zh-hans.resx
@@ -1,0 +1,14 @@
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/Beutl.Extensions.FFmpeg/Properties/Strings.zh-hans.resx
+++ b/src/Beutl.Extensions.FFmpeg/Properties/Strings.zh-hans.resx
@@ -11,4 +11,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="FFmpegError" xml:space="preserve">
+    <value>FFmpeg 错误</value>
+  </data>
+  <data name="Make_sure_you_have_FFmpeg_installed" xml:space="preserve">
+    <value>请确保您已安装 FFmpeg。</value>
+  </data>
 </root>

--- a/src/Beutl.Extensions.MediaFoundation/Properties/Strings.zh-hans.resx
+++ b/src/Beutl.Extensions.MediaFoundation/Properties/Strings.zh-hans.resx
@@ -1,0 +1,14 @@
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/Beutl.Extensions.MediaFoundation/Properties/Strings.zh-hans.resx
+++ b/src/Beutl.Extensions.MediaFoundation/Properties/Strings.zh-hans.resx
@@ -11,4 +11,16 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Cache" xml:space="preserve">
+    <value>缓存</value>
+  </data>
+  <data name="DecodingName" xml:space="preserve">
+    <value>解码名称</value>
+  </data>
+  <data name="UseDXVA2" xml:space="preserve">
+    <value>使用 DXVA2</value>
+  </data>
+  <data name="UseDXVA2_Description" xml:space="preserve">
+    <value>使用 DirectX Video Accelerator 2.0 加速视频解码。</value>
+  </data>
 </root>

--- a/src/Beutl.Language/ExtensionsPage.zh-hans.resx
+++ b/src/Beutl.Language/ExtensionsPage.zh-hans.resx
@@ -1,0 +1,80 @@
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CheckUpdate" xml:space="preserve">
+    <value>检查更新</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>说明</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>更新</value>
+  </data>
+  <data name="Uninstall" xml:space="preserve">
+    <value>卸载</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>安装</value>
+  </data>
+  <data name="RemoveFromLibrary" xml:space="preserve">
+    <value>从库中移除</value>
+  </data>
+  <data name="Release_TargetVersion" xml:space="preserve">
+    <value>目标版本</value>
+  </data>
+  <data name="OpenUrl_Title" xml:space="preserve">
+    <value>确认要打开这个网址？</value>
+  </data>
+  <data name="OpenUrl_Content" xml:space="preserve">
+    <value>您正在试图打开网址 '{0}'。如果这个网址可疑，我们建议您不要打开它。</value>
+  </data>
+  <data name="OpenSettings" xml:space="preserve">
+    <value>打开设置</value>
+  </data>
+  <data name="AnAccountIsRequiredToGetExtension" xml:space="preserve">
+    <value>需要登录账号以下载扩展程序</value>
+  </data>
+  <data name="AuthorizationIsRequired" xml:space="preserve">
+    <value>需要进行认证。</value>
+  </data>
+  <data name="GotoSettings_Account" xml:space="preserve">
+    <value>前往 “设置 &gt; 账户 ”以登录。</value>
+  </data>
+  <data name="LocalPackage" xml:space="preserve">
+    <value>本地的包</value>
+  </data>
+  <data name="LocalPackages" xml:space="preserve">
+    <value>本地的包</value>
+  </data>
+  <data name="NoLogoImageAvailable" xml:space="preserve">
+    <value>没有 Logo 可用</value>
+  </data>
+  <data name="PackageInstaller" xml:space="preserve">
+    <value>包安装程序</value>
+  </data>
+  <data name="Package_LatestRelease" xml:space="preserve">
+    <value>最新发行版</value>
+  </data>
+  <data name="Package_LatestVersion" xml:space="preserve">
+    <value>最新版本号</value>
+  </data>
+  <data name="Package_Screenshots" xml:space="preserve">
+    <value>截图</value>
+  </data>
+  <data name="Package_SelectedRelease" xml:space="preserve">
+    <value>选中的发行版</value>
+  </data>
+  <data name="Package_Tags" xml:space="preserve">
+    <value>选中的 Tag</value>
+  </data>
+</root>

--- a/src/Beutl.Language/ExtensionsPage.zh-hans.resx
+++ b/src/Beutl.Language/ExtensionsPage.zh-hans.resx
@@ -77,4 +77,28 @@
   <data name="Package_Tags" xml:space="preserve">
     <value>选中的 Tag</value>
   </data>
+  <data name="Could_not_find_a_package_from_remote" xml:space="preserve">
+    <value>无法在服务器找到 '{0}' 这个包。</value>
+  </data>
+  <data name="PackageInstaller_ScheduledInstallation" xml:space="preserve">
+    <value>已经安排对 '{0}' 的安装。安装将在退出 Beutl 后开始。</value>
+  </data>
+  <data name="PackageInstaller_ScheduledUninstallation" xml:space="preserve">
+    <value>已经安排对 '{0}' 的卸载。卸载将在退出 Beutl 后开始。</value>
+  </data>
+  <data name="PackageInstaller_ScheduledUpdate" xml:space="preserve">
+    <value>已经安排对 '{0}' 的更新。更新装将在退出 Beutl 后开始。</value>
+  </data>
+  <data name="Package_InstalledVersion" xml:space="preserve">
+    <value>已安装版本</value>
+  </data>
+  <data name="Profile_PublishedPackages" xml:space="preserve">
+    <value>已发布的包</value>
+  </data>
+  <data name="Search_Packages" xml:space="preserve">
+    <value>包</value>
+  </data>
+  <data name="This_extension_does_not_support_your_Beutl_version" xml:space="preserve">
+    <value>该扩展程序不支持这个版本的 Beutl，如要强制安装，请使用 CLI 工具。</value>
+  </data>
 </root>

--- a/src/Beutl.Language/LocalizeService.cs
+++ b/src/Beutl.Language/LocalizeService.cs
@@ -9,6 +9,7 @@ public sealed class LocalizeService
     [
         "en-US",
         "ja-JP",
+        "zh-Hans"
     ];
 
     public bool IsSupportedCulture(CultureInfo ci)

--- a/src/Beutl.Language/Message.zh-hans.resx
+++ b/src/Beutl.Language/Message.zh-hans.resx
@@ -1,0 +1,143 @@
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DoYouWantToDeleteThisDirectory" xml:space="preserve">
+    <value>确认要删除这个目录吗？</value>
+  </data>
+  <data name="DoYouWantToDeleteThisFile" xml:space="preserve">
+    <value>确认要删除这个文件吗？</value>
+  </data>
+  <data name="DoYouWantToExcludeThisItemFromProject" xml:space="preserve">
+    <value>确认要将这个对象排除在项目之外吗？</value>
+  </data>
+  <data name="CouldNotOpenFollowingFileWithExtension" xml:space="preserve">
+    <value>无法打开带有 '{0}' 后缀名的文件。'{1}'</value>
+  </data>
+  <data name="Signin has become invalid" xml:space="preserve">
+    <value>登录已过期，请重新登录。</value>
+  </data>
+  <data name="RightClickToShowMenu" xml:space="preserve">
+    <value>右键以显示菜单</value>
+  </data>
+  <data name="Property_is_unset" xml:space="preserve">
+    <value>属性未设定</value>
+  </data>
+  <data name="ProjectVersionMismatch_Title" xml:space="preserve">
+    <value>版本不匹配</value>
+  </data>
+  <data name="ProjectVersionMismatch_Content" xml:space="preserve">
+    <value>这个项目是由更新版本 (&gt;= {0}) 的 Beutl 创建的。请更新 Beutl 以打开这个项目。</value>
+  </data>
+  <data name="PleaseWaitAMoment" xml:space="preserve">
+    <value>请稍等</value>
+  </data>
+  <data name="PleaseEnterString" xml:space="preserve">
+    <value>请输入文本</value>
+  </data>
+  <data name="OperationCouldNotBeExecuted" xml:space="preserve">
+    <value>无法执行这个操作</value>
+  </data>
+  <data name="OpeningProject" xml:space="preserve">
+    <value>正在打开项目</value>
+  </data>
+  <data name="OpeningBeutl" xml:space="preserve">
+    <value>正在启动 Beutl</value>
+  </data>
+  <data name="ItemsSaved" xml:space="preserve">
+    <value>已保存{0}个项目</value>
+  </data>
+  <data name="ItemSaved" xml:space="preserve">
+    <value>已保存{0}</value>
+  </data>
+  <data name="ItAlreadyExists" xml:space="preserve">
+    <value>已存在</value>
+  </data>
+  <data name="InvalidString" xml:space="preserve">
+    <value>无效的文本</value>
+  </data>
+  <data name="File_is_not_selected" xml:space="preserve">
+    <value>没有选择文件</value>
+  </data>
+  <data name="Files_are_saved_automatically" xml:space="preserve">
+    <value>文件是自动保存的。</value>
+  </data>
+  <data name="FileDoesNotExist" xml:space="preserve">
+    <value>文件不存在</value>
+  </data>
+  <data name="Failed_to_save_image" xml:space="preserve">
+    <value>图片保存失败</value>
+  </data>
+  <data name="AnimationIsEnabled" xml:space="preserve">
+    <value>动画已启用</value>
+  </data>
+  <data name="AnUnexpectedErrorHasOccurred" xml:space="preserve">
+    <value>发生了未预期的错误。</value>
+  </data>
+  <data name="ApiErrorOccurred" xml:space="preserve">
+    <value>API发生错误。</value>
+  </data>
+  <data name="Ask_if_you_want_to_run_in_restricted_mode" xml:space="preserve">
+    <value>似乎上一次程序没有正常退出。因为原因未知，您是否要启用限制模式？限制模式下将不会加载扩展程序。</value>
+  </data>
+  <data name="An_exception_occurred_while_saving_the_file" xml:space="preserve">
+    <value>保存文件时发生错误。</value>
+  </data>
+  <data name="An_exception_occurred_while_parsing_the_SVG_path" xml:space="preserve">
+    <value>解析 SVG 路径时发生错误。</value>
+  </data>
+  <data name="An_exception_occurred_while_drawing_frame" xml:space="preserve">
+    <value>渲染某一帧时发生错误。</value>
+  </data>
+  <data name="An_exception_occurred_during_audio_playback" xml:space="preserve">
+    <value>播放音频时发生错误。</value>
+  </data>
+  <data name="An_exception_occurred_during_output" xml:space="preserve">
+    <value>输出时发生错误。</value>
+  </data>
+  <data name="CannotDisplayThisContext" xml:space="preserve">
+    <value>无法显示这一上下文。</value>
+  </data>
+  <data name="CannotRenameBecauseConflicts" xml:space="preserve">
+    <value>无法将文件 "{0}" 重命名为 "{1}"，因为文件名已被使用。</value>
+  </data>
+  <data name="CheckDifferentVersion_Content" xml:space="preserve">
+    <value>您上次运行了不同版本的应用程序。</value>
+  </data>
+  <data name="CheckDifferentVersion_Title" xml:space="preserve">
+    <value>打开一个先前版本的文件可能会出现问题</value>
+  </data>
+  <data name="ContextNotCreated" xml:space="preserve">
+    <value>上下文未创建</value>
+  </data>
+  <data name="CouldNotOpenProject" xml:space="preserve">
+    <value>无法打开项目。</value>
+  </data>
+  <data name="Could_not_load_scene" xml:space="preserve">
+    <value>无法载入场景。。</value>
+  </data>
+  <data name="Double_click_to_hide_group" xml:space="preserve">
+    <value>双击以隐藏分组</value>
+  </data>
+  <data name="DoYouWantToLoadSideloadExtensions" xml:space="preserve">
+    <value>确认要加载这个侧载的扩展程序吗？</value>
+  </data>
+  <data name="EditorContextHasAlreadyBeenCreated" xml:space="preserve">
+    <value>编辑器上下文已创建。</value>
+  </data>
+  <data name="OpeningProjectMessage" xml:space="preserve">
+    <value>正在打开 '{0}'，请稍等。</value>
+  </data>
+  <data name="Unable_to_save_file" xml:space="preserve">
+    <value>无法保存文件</value>
+  </data>
+</root>

--- a/src/Beutl.Language/Message.zh-hans.resx
+++ b/src/Beutl.Language/Message.zh-hans.resx
@@ -140,4 +140,40 @@
   <data name="Unable_to_save_file" xml:space="preserve">
     <value>无法保存文件</value>
   </data>
+  <data name="Failed_to_load_package" xml:space="preserve">
+    <value>包加载失败。</value>
+  </data>
+  <data name="Failed_to_load_N_packages" xml:space="preserve">
+    <value>{0}个包加载失败。</value>
+  </data>
+  <data name="Changes_to_the_package_are_in_progress" xml:space="preserve">
+    <value>正在对包进行变更。</value>
+  </data>
+  <data name="To_open_Beutl_close_Beutl_PackageTools" xml:space="preserve">
+    <value>要打开 Beutl，请先关闭 Beutl.PackageTools。</value>
+  </data>
+  <data name="ValueLessThanZero" xml:space="preserve">
+    <value>不能填入小于0的数值。</value>
+  </data>
+  <data name="ValueLessThanOrEqualToZero" xml:space="preserve">
+    <value>不能填入小于或等于0的数值。</value>
+  </data>
+  <data name="A_new_version_is_available" xml:space="preserve">
+    <value>有新版本可用。</value>
+  </data>
+  <data name="This_version_has_been_discontinued_for_compatibility_reasonsversion" xml:space="preserve">
+    <value>这个版本已经因为兼容性原因而停止更新，请升级到更新的版本。</value>
+  </data>
+  <data name="No_supported_extensions_were_found" xml:space="preserve">
+    <value>找不到支持的扩展程序。</value>
+  </data>
+  <data name="Could_not_restore_because_type_could_not_be_found" xml:space="preserve">
+    <value>因为类型无法找到，无法进行还原。</value>
+  </data>
+  <data name="Looks_like_it_ended_with_an_error_last_time" xml:space="preserve">
+    <value>似乎上一次因错误而结束。</value>
+  </data>
+  <data name="NullWasSpecifiedForEditorContext" xml:space="preserve">
+    <value>编辑器上下文为空。</value>
+  </data>
 </root>

--- a/src/Beutl.Language/SettingsPage.zh-hans.resx
+++ b/src/Beutl.Language/SettingsPage.zh-hans.resx
@@ -1,0 +1,110 @@
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DeviceInformation" xml:space="preserve">
+    <value>设备信息</value>
+  </data>
+  <data name="DecoderPriority" xml:space="preserve">
+    <value>解码器优先级</value>
+  </data>
+  <data name="DecoderPriority_Description" xml:space="preserve">
+    <value>你可以修改解码器的优先级。越高的解码器将被优先使用。</value>
+  </data>
+  <data name="CustomColor" xml:space="preserve">
+    <value>自定义颜色</value>
+  </data>
+  <data name="CopyVersionInfo" xml:space="preserve">
+    <value>复制版本信息</value>
+  </data>
+  <data name="SignOut" xml:space="preserve">
+    <value>登出</value>
+  </data>
+  <data name="SignInWith" xml:space="preserve">
+    <value>使用你的社交账号登录</value>
+  </data>
+  <data name="SignInViaBrowser" xml:space="preserve">
+    <value>使用浏览器登录</value>
+  </data>
+  <data name="SignIn" xml:space="preserve">
+    <value>登录</value>
+  </data>
+  <data name="PropertyEditor" xml:space="preserve">
+    <value>属性编辑器</value>
+  </data>
+  <data name="Please_enter_a_file_extension" xml:space="preserve">
+    <value>请输入一个文件后缀名。</value>
+  </data>
+  <data name="OpenGLVersion" xml:space="preserve">
+    <value>OpenGL 版本</value>
+  </data>
+  <data name="GpuInformation" xml:space="preserve">
+    <value>GPU 信息</value>
+  </data>
+  <data name="FrameCacheScale_Half" xml:space="preserve">
+    <value>二分之一</value>
+  </data>
+  <data name="FrameCacheScale_Quarter" xml:space="preserve">
+    <value>四分之一</value>
+  </data>
+  <data name="FrameCacheScale" xml:space="preserve">
+    <value>缩放</value>
+  </data>
+  <data name="FrameCacheColorType" xml:space="preserve">
+    <value>颜色空间</value>
+  </data>
+  <data name="AccentColor" xml:space="preserve">
+    <value>强调色</value>
+  </data>
+  <data name="All_Editor_Extensions" xml:space="preserve">
+    <value>所有的编辑器扩展</value>
+  </data>
+  <data name="Add_file_extension" xml:space="preserve">
+    <value>添加文件后缀名</value>
+  </data>
+  <data name="ChangeAccountSettings" xml:space="preserve">
+    <value>更改账户设置</value>
+  </data>
+  <data name="NodeCacheMaxPixels" xml:space="preserve">
+    <value>最大像素数量</value>
+  </data>
+  <data name="NodeCacheMinPixels" xml:space="preserve">
+    <value>最小像素数量</value>
+  </data>
+  <data name="UseCustomAccentColor" xml:space="preserve">
+    <value>使用自定义的强调色</value>
+  </data>
+  <data name="Telemetry_Beutl_PackageManagement" xml:space="preserve">
+    <value>包管理器</value>
+  </data>
+  <data name="Telemetry_Beutl_Application" xml:space="preserve">
+    <value>应用程序</value>
+  </data>
+  <data name="EditorSettings" xml:space="preserve">
+    <value>编辑器设置</value>
+  </data>
+  <data name="Editor_Extension_Priority" xml:space="preserve">
+    <value>编辑器扩展程序权重</value>
+  </data>
+  <data name="EnableNodeCache" xml:space="preserve">
+    <value>启用节点缓存</value>
+  </data>
+  <data name="NodeCache" xml:space="preserve">
+    <value>节点缓存</value>
+  </data>
+  <data name="EnableFrameCache" xml:space="preserve">
+    <value>启用帧缓存</value>
+  </data>
+  <data name="FrameCacheMaxSize" xml:space="preserve">
+    <value>最大大小</value>
+  </data>
+</root>

--- a/src/Beutl.Language/SettingsPage.zh-hans.resx
+++ b/src/Beutl.Language/SettingsPage.zh-hans.resx
@@ -107,4 +107,58 @@
   <data name="FrameCacheMaxSize" xml:space="preserve">
     <value>最大大小</value>
   </data>
+  <data name="Telemetry_Beutl_Logging" xml:space="preserve">
+    <value>日志</value>
+  </data>
+  <data name="Telemetry_Description_Beutl_PackageManagement" xml:space="preserve">
+    <value>收集安装或卸载扩展程序的用时。</value>
+  </data>
+  <data name="Telemetry_Beutl_Api_Client" xml:space="preserve">
+    <value>API 客户端</value>
+  </data>
+  <data name="Telemetry_Description" xml:space="preserve">
+    <value>为了改进 Beutl，我们会收集匿名的数据。这项设定将在 Beutl 重新启动后生效。要了解更多信息，请访问我们网站的相关页面。</value>
+  </data>
+  <data name="Telemetry_Description_Beutl_Api_Client" xml:space="preserve">
+    <value>收集扩展程序商店和账户功能相关 API 的调用耗时等信息</value>
+  </data>
+  <data name="Telemetry_Description_Beutl_Logging" xml:space="preserve">
+    <value>要了解更多收集的信息，请查看同样保存在 “.beutl/log” 目录下的日志文件</value>
+  </data>
+  <data name="Telemetry_ShortDescription" xml:space="preserve">
+    <value>设置要收集的数据</value>
+  </data>
+  <data name="This_file_extension_already_exists" xml:space="preserve">
+    <value>这个文件后缀名已存在。</value>
+  </data>
+  <data name="Theme_Tip" xml:space="preserve">
+    <value>选择您喜欢的应用程序主题。</value>
+  </data>
+  <data name="Telemetry_Description_Beutl_Application" xml:space="preserve">
+    <value>收集以下信息以提高应用程序性能：应用程序启动时间、运行时间和应用程序接口的调用情况</value>
+  </data>
+  <data name="The_following_characters_are_not_allowed" xml:space="preserve">
+    <value>不允许使用下列字符 (" &gt; &lt; | : ? * \ /)</value>
+  </data>
+  <data name="Telemetry" xml:space="preserve">
+    <value>遥测数据采集</value>
+  </data>
+  <data name="SwapTimelineScrollDirection" xml:space="preserve">
+    <value>交换时间线的滚动方向</value>
+  </data>
+  <data name="ShowExactBoundaries" xml:space="preserve">
+    <value>更精确地显示边框</value>
+  </data>
+  <data name="ShowExactBoundaries_Description" xml:space="preserve">
+    <value>在预览窗口中更精确地显示边框。启用该选项可能会导致边框不可见。</value>
+  </data>
+  <data name="EnableAutoSave" xml:space="preserve">
+    <value>启用自动保存</value>
+  </data>
+  <data name="EnableAutoSave_Description" xml:space="preserve">
+    <value>在进行每一步操作后都会自动保存。</value>
+  </data>
+  <data name="FrameCacheMaxSize_Description" xml:space="preserve">
+    <value>调整缓存的大小，使其不超过这个字节数。</value>
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.zh-hans.resx
+++ b/src/Beutl.Language/Strings.zh-hans.resx
@@ -1,0 +1,842 @@
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Account" xml:space="preserve">
+    <value>账号</value>
+  </data>
+  <data name="Add" xml:space="preserve">
+    <value>添加</value>
+  </data>
+  <data name="AddElement" xml:space="preserve">
+    <value>添加元素</value>
+  </data>
+  <data name="AddNode" xml:space="preserve">
+    <value>添加节点</value>
+  </data>
+  <data name="All" xml:space="preserve">
+    <value>全部</value>
+  </data>
+  <data name="Agree" xml:space="preserve">
+    <value>同意</value>
+  </data>
+  <data name="Amount" xml:space="preserve">
+    <value>量</value>
+  </data>
+  <data name="Angle" xml:space="preserve">
+    <value>角度</value>
+  </data>
+  <data name="Animation" xml:space="preserve">
+    <value>动画</value>
+  </data>
+  <data name="Apply" xml:space="preserve">
+    <value>应用</value>
+  </data>
+  <data name="Audio" xml:space="preserve">
+    <value>音频</value>
+  </data>
+  <data name="Bitrate" xml:space="preserve">
+    <value>比特率</value>
+  </data>
+  <data name="Bitrate_Tip" xml:space="preserve">
+    <value>设置比特率</value>
+  </data>
+  <data name="Back" xml:space="preserve">
+    <value>返回</value>
+  </data>
+  <data name="BlendEffect" xml:space="preserve">
+    <value>混合效果</value>
+  </data>
+  <data name="BlendMode" xml:space="preserve">
+    <value>混合模式</value>
+  </data>
+  <data name="Blue" xml:space="preserve">
+    <value>蓝色</value>
+  </data>
+  <data name="Blur" xml:space="preserve">
+    <value>模糊</value>
+  </data>
+  <data name="Border" xml:space="preserve">
+    <value>轮廓</value>
+  </data>
+  <data name="BorderStyle" xml:space="preserve">
+    <value>轮廓风格</value>
+  </data>
+  <data name="Bottom" xml:space="preserve">
+    <value>底部</value>
+  </data>
+  <data name="Brightness" xml:space="preserve">
+    <value>亮度</value>
+  </data>
+  <data name="Brush" xml:space="preserve">
+    <value>笔刷</value>
+  </data>
+  <data name="Brush_LinearGradient" xml:space="preserve">
+    <value>线性渐变</value>
+  </data>
+  <data name="Center" xml:space="preserve">
+    <value>中心</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="Brush_Solid" xml:space="preserve">
+    <value>填充</value>
+  </data>
+  <data name="Change" xml:space="preserve">
+    <value>更改</value>
+  </data>
+  <data name="ChangeColor" xml:space="preserve">
+    <value>更改颜色</value>
+  </data>
+  <data name="Channels" xml:space="preserve">
+    <value>通道数</value>
+  </data>
+  <data name="Channels_Tip" xml:space="preserve">
+    <value>设置通道数</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>完成</value>
+  </data>
+  <data name="Copy" xml:space="preserve">
+    <value>复制</value>
+  </data>
+  <data name="CopyAll" xml:space="preserve">
+    <value>全部复制</value>
+  </data>
+  <data name="CopyAsImage" xml:space="preserve">
+    <value>复制为图像</value>
+  </data>
+  <data name="Copy_Description" xml:space="preserve">
+    <value>复制选中的对象</value>
+  </data>
+  <data name="CornerRadius" xml:space="preserve">
+    <value>圆角</value>
+  </data>
+  <data name="CreateNew" xml:space="preserve">
+    <value>新建</value>
+  </data>
+  <data name="CreateNewProject" xml:space="preserve">
+    <value>新建项目</value>
+  </data>
+  <data name="CreateNewProjectOrScene" xml:space="preserve">
+    <value>新建项目或场景</value>
+  </data>
+  <data name="CreateNewScene" xml:space="preserve">
+    <value>新建场景</value>
+  </data>
+  <data name="CubicBezierCurve" xml:space="preserve">
+    <value>贝塞尔曲线（三次）</value>
+  </data>
+  <data name="Cut" xml:space="preserve">
+    <value>剪切</value>
+  </data>
+  <data name="Cut_Description" xml:space="preserve">
+    <value>剪切选中的对象</value>
+  </data>
+  <data name="Dark" xml:space="preserve">
+    <value>暗色</value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="DeleteAll" xml:space="preserve">
+    <value>全部删除</value>
+  </data>
+  <data name="Delete_Description" xml:space="preserve">
+    <value>删除选中的对象</value>
+  </data>
+  <data name="DestinationRect" xml:space="preserve">
+    <value>目标</value>
+  </data>
+  <data name="DestinationToSaveTo" xml:space="preserve">
+    <value>保存路径</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>是</value>
+  </data>
+  <data name="Width" xml:space="preserve">
+    <value>宽度</value>
+  </data>
+  <data name="View" xml:space="preserve">
+    <value>显示</value>
+  </data>
+  <data name="Video" xml:space="preserve">
+    <value>视频</value>
+  </data>
+  <data name="UseNode" xml:space="preserve">
+    <value>使用节点</value>
+  </data>
+  <data name="Unsupported" xml:space="preserve">
+    <value>不支持</value>
+  </data>
+  <data name="Unlocked" xml:space="preserve">
+    <value>未锁定</value>
+  </data>
+  <data name="Unlock" xml:space="preserve">
+    <value>解锁</value>
+  </data>
+  <data name="Unknown" xml:space="preserve">
+    <value>未知</value>
+  </data>
+  <data name="Undo" xml:space="preserve">
+    <value>撤销</value>
+  </data>
+  <data name="Undo_Description" xml:space="preserve">
+    <value>撤销上一步操作</value>
+  </data>
+  <data name="TransformOrigin" xml:space="preserve">
+    <value>变换原点</value>
+  </data>
+  <data name="Transform" xml:space="preserve">
+    <value>变换</value>
+  </data>
+  <data name="Top" xml:space="preserve">
+    <value>顶部</value>
+  </data>
+  <data name="Tools" xml:space="preserve">
+    <value>工具</value>
+  </data>
+  <data name="Timeline" xml:space="preserve">
+    <value>时间线</value>
+  </data>
+  <data name="Text" xml:space="preserve">
+    <value>文本</value>
+  </data>
+  <data name="Theme" xml:space="preserve">
+    <value>主题</value>
+  </data>
+  <data name="Thickness" xml:space="preserve">
+    <value>厚度</value>
+  </data>
+  <data name="Split" xml:space="preserve">
+    <value>分割</value>
+  </data>
+  <data name="Speed" xml:space="preserve">
+    <value>速度</value>
+  </data>
+  <data name="Sound" xml:space="preserve">
+    <value>声音</value>
+  </data>
+  <data name="Size" xml:space="preserve">
+    <value>大小</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>设置</value>
+  </data>
+  <data name="Search" xml:space="preserve">
+    <value>搜索</value>
+  </data>
+  <data name="Scene" xml:space="preserve">
+    <value>场景</value>
+  </data>
+  <data name="SceneFile" xml:space="preserve">
+    <value>场景文件</value>
+  </data>
+  <data name="SceneSettings" xml:space="preserve">
+    <value>场景设置</value>
+  </data>
+  <data name="Scale" xml:space="preserve">
+    <value>缩放</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>保存</value>
+  </data>
+  <data name="SaveAll" xml:space="preserve">
+    <value>全部保存</value>
+  </data>
+  <data name="SaveAll_Description" xml:space="preserve">
+    <value>保存所有文件</value>
+  </data>
+  <data name="SaveAsImage" xml:space="preserve">
+    <value>保存为图片</value>
+  </data>
+  <data name="SaveFrameAsImage" xml:space="preserve">
+    <value>保存一帧作为图片</value>
+  </data>
+  <data name="SaveSelectedElementAsImage" xml:space="preserve">
+    <value>保存选中的元素为图片</value>
+  </data>
+  <data name="Save_Description" xml:space="preserve">
+    <value>保存当前文件</value>
+  </data>
+  <data name="TermsOfService" xml:space="preserve">
+    <value>使用条款</value>
+  </data>
+  <data name="Edit" xml:space="preserve">
+    <value>编辑</value>
+  </data>
+  <data name="DurationTime" xml:space="preserve">
+    <value>持续时间</value>
+  </data>
+  <data name="Disconnect" xml:space="preserve">
+    <value>断开连接</value>
+  </data>
+  <data name="DiscardChanges" xml:space="preserve">
+    <value>放弃更改</value>
+  </data>
+  <data name="Disagree" xml:space="preserve">
+    <value>拒绝</value>
+  </data>
+  <data name="Details" xml:space="preserve">
+    <value>详情</value>
+  </data>
+  <data name="DestinationToSaveTo_Tip" xml:space="preserve">
+    <value>设置保存路径</value>
+  </data>
+  <data name="Contrast" xml:space="preserve">
+    <value>对比度</value>
+  </data>
+  <data name="ClearBuffer" xml:space="preserve">
+    <value>清除缓冲区</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="CloseProject" xml:space="preserve">
+    <value>关闭项目</value>
+  </data>
+  <data name="CloseProject_Description" xml:space="preserve">
+    <value>关闭当前项目</value>
+  </data>
+  <data name="Color" xml:space="preserve">
+    <value>颜色</value>
+  </data>
+  <data name="Translate" xml:space="preserve">
+    <value>移动</value>
+  </data>
+  <data name="StrokeAlignment_Outside" xml:space="preserve">
+    <value>外侧</value>
+  </data>
+  <data name="StrokeAlignment_Inside" xml:space="preserve">
+    <value>内侧</value>
+  </data>
+  <data name="StrokeAlignment_Center" xml:space="preserve">
+    <value>中央</value>
+  </data>
+  <data name="StartTime" xml:space="preserve">
+    <value>开始时间</value>
+  </data>
+  <data name="StartPoint" xml:space="preserve">
+    <value>起始点</value>
+  </data>
+  <data name="StartEditing" xml:space="preserve">
+    <value>开始编辑</value>
+  </data>
+  <data name="SplitEquallyEffect" xml:space="preserve">
+    <value>均等分割</value>
+  </data>
+  <data name="SourceCode" xml:space="preserve">
+    <value>源代码</value>
+  </data>
+  <data name="ShowMore" xml:space="preserve">
+    <value>显示更多</value>
+  </data>
+  <data name="ShowDetails" xml:space="preserve">
+    <value>显示详情</value>
+  </data>
+  <data name="SampleRate" xml:space="preserve">
+    <value>采样率</value>
+  </data>
+  <data name="SampleRate_Tip" xml:space="preserve">
+    <value>设置采样率</value>
+  </data>
+  <data name="Rotation" xml:space="preserve">
+    <value>旋转</value>
+  </data>
+  <data name="RoundedRect" xml:space="preserve">
+    <value>圆角矩形</value>
+  </data>
+  <data name="Rotation3D" xml:space="preserve">
+    <value>3D旋转</value>
+  </data>
+  <data name="RightClickToOperateCache" xml:space="preserve">
+    <value>右键以对缓存进行操作</value>
+  </data>
+  <data name="Right" xml:space="preserve">
+    <value>右侧</value>
+  </data>
+  <data name="ResetZoom" xml:space="preserve">
+    <value>重置缩放</value>
+  </data>
+  <data name="Reset" xml:space="preserve">
+    <value>重置</value>
+  </data>
+  <data name="Rename" xml:space="preserve">
+    <value>重命名</value>
+  </data>
+  <data name="Rename_Description" xml:space="preserve">
+    <value>重命名选中的项目</value>
+  </data>
+  <data name="RemoveAnimation" xml:space="preserve">
+    <value>移除动画</value>
+  </data>
+  <data name="Remove" xml:space="preserve">
+    <value>移除</value>
+  </data>
+  <data name="Redo" xml:space="preserve">
+    <value>重做</value>
+  </data>
+  <data name="Redo_Description" xml:space="preserve">
+    <value>重做上一个操作</value>
+  </data>
+  <data name="Red" xml:space="preserve">
+    <value>红色</value>
+  </data>
+  <data name="Rectangle" xml:space="preserve">
+    <value>矩形</value>
+  </data>
+  <data name="Recently" xml:space="preserve">
+    <value>最近</value>
+  </data>
+  <data name="RecentProjects" xml:space="preserve">
+    <value>最近的项目</value>
+  </data>
+  <data name="Radius" xml:space="preserve">
+    <value>半径</value>
+  </data>
+  <data name="RadiusX" xml:space="preserve">
+    <value>半径X</value>
+  </data>
+  <data name="RadiusY" xml:space="preserve">
+    <value>半径Y</value>
+  </data>
+  <data name="RecentFiles" xml:space="preserve">
+    <value>最近的项目</value>
+  </data>
+  <data name="Properties" xml:space="preserve">
+    <value>属性</value>
+  </data>
+  <data name="QuadraticBezierCurve" xml:space="preserve">
+    <value>贝塞尔曲线（2次）</value>
+  </data>
+  <data name="Projects" xml:space="preserve">
+    <value>项目</value>
+  </data>
+  <data name="ProjectFile" xml:space="preserve">
+    <value>项目文件</value>
+  </data>
+  <data name="Project" xml:space="preserve">
+    <value>项目</value>
+  </data>
+  <data name="PrivacyPolicy" xml:space="preserve">
+    <value>隐私政策</value>
+  </data>
+  <data name="Position" xml:space="preserve">
+    <value>位置</value>
+  </data>
+  <data name="PlayPause_Description" xml:space="preserve">
+    <value>控制开始和暂停</value>
+  </data>
+  <data name="PlayPause" xml:space="preserve">
+    <value>开始/暂停</value>
+  </data>
+  <data name="Paste" xml:space="preserve">
+    <value>粘贴</value>
+  </data>
+  <data name="Paste_Description" xml:space="preserve">
+    <value>粘贴复制的数据</value>
+  </data>
+  <data name="PathEditor" xml:space="preserve">
+    <value>路径编辑器</value>
+  </data>
+  <data name="Output" xml:space="preserve">
+    <value>输出</value>
+  </data>
+  <data name="Others" xml:space="preserve">
+    <value>其他</value>
+  </data>
+  <data name="OpenProject" xml:space="preserve">
+    <value>打开项目</value>
+  </data>
+  <data name="OpenNodeTree" xml:space="preserve">
+    <value>打开节点树</value>
+  </data>
+  <data name="OpenFile" xml:space="preserve">
+    <value>打开文件</value>
+  </data>
+  <data name="OpenDocument" xml:space="preserve">
+    <value>打开文档</value>
+  </data>
+  <data name="OpenAFileYouHaveAlreadyCreated" xml:space="preserve">
+    <value>打开一个您已经创建的文件</value>
+  </data>
+  <data name="Open" xml:space="preserve">
+    <value>打开</value>
+  </data>
+  <data name="Opacity" xml:space="preserve">
+    <value>不透明度</value>
+  </data>
+  <data name="On" xml:space="preserve">
+    <value>开</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>确认</value>
+  </data>
+  <data name="Object" xml:space="preserve">
+    <value>对象</value>
+  </data>
+  <data name="Off" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="Offset" xml:space="preserve">
+    <value>便宜</value>
+  </data>
+  <data name="No" xml:space="preserve">
+    <value>否</value>
+  </data>
+  <data name="Next" xml:space="preserve">
+    <value>下一步</value>
+  </data>
+  <data name="NewFolder" xml:space="preserve">
+    <value>新建文件夹</value>
+  </data>
+  <data name="Name" xml:space="preserve">
+    <value>名称</value>
+  </data>
+  <data name="MainView" xml:space="preserve">
+    <value>主视图</value>
+  </data>
+  <data name="Lock" xml:space="preserve">
+    <value>锁定</value>
+  </data>
+  <data name="Locked" xml:space="preserve">
+    <value>已锁定</value>
+  </data>
+  <data name="Location" xml:space="preserve">
+    <value>位置</value>
+  </data>
+  <data name="Links" xml:space="preserve">
+    <value>链接</value>
+  </data>
+  <data name="Link" xml:space="preserve">
+    <value>链接</value>
+  </data>
+  <data name="Linear" xml:space="preserve">
+    <value>线性</value>
+  </data>
+  <data name="Line" xml:space="preserve">
+    <value>直线</value>
+  </data>
+  <data name="Light" xml:space="preserve">
+    <value>亮度</value>
+  </data>
+  <data name="License" xml:space="preserve">
+    <value>许可证</value>
+  </data>
+  <data name="Library" xml:space="preserve">
+    <value>库</value>
+  </data>
+  <data name="Length" xml:space="preserve">
+    <value>长度</value>
+  </data>
+  <data name="Left" xml:space="preserve">
+    <value>左侧</value>
+  </data>
+  <data name="Keymap" xml:space="preserve">
+    <value>键位</value>
+  </data>
+  <data name="Language" xml:space="preserve">
+    <value>语言</value>
+  </data>
+  <data name="KeyframeRate_Tip" xml:space="preserve">
+    <value>设置帧率</value>
+  </data>
+  <data name="KeyframeRate" xml:space="preserve">
+    <value>帧率</value>
+  </data>
+  <data name="IsNotValid" xml:space="preserve">
+    <value>{0}无效</value>
+  </data>
+  <data name="Invert" xml:space="preserve">
+    <value>反转</value>
+  </data>
+  <data name="Info" xml:space="preserve">
+    <value>信息</value>
+  </data>
+  <data name="Initialize" xml:space="preserve">
+    <value>初始化</value>
+  </data>
+  <data name="InnerShadow" xml:space="preserve">
+    <value>内侧阴影</value>
+  </data>
+  <data name="ImportSvgPath" xml:space="preserve">
+    <value>导入 SVG 路径</value>
+  </data>
+  <data name="ImportSvgPath_Description" xml:space="preserve">
+    <value>当前的形状将会被覆盖</value>
+  </data>
+  <data name="Import" xml:space="preserve">
+    <value>导入</value>
+  </data>
+  <data name="Image" xml:space="preserve">
+    <value>图片</value>
+  </data>
+  <data name="Hue" xml:space="preserve">
+    <value>色相</value>
+  </data>
+  <data name="Help" xml:space="preserve">
+    <value>帮助</value>
+  </data>
+  <data name="Height" xml:space="preserve">
+    <value>高度</value>
+  </data>
+  <data name="Group" xml:space="preserve">
+    <value>分组</value>
+  </data>
+  <data name="Green" xml:space="preserve">
+    <value>绿色</value>
+  </data>
+  <data name="GraphEditor" xml:space="preserve">
+    <value>图形编辑器</value>
+  </data>
+  <data name="GradientOrigin" xml:space="preserve">
+    <value>渐变原点</value>
+  </data>
+  <data name="Gamma" xml:space="preserve">
+    <value>伽马值</value>
+  </data>
+  <data name="FrameRate" xml:space="preserve">
+    <value>帧率</value>
+  </data>
+  <data name="FrameRate_Tip" xml:space="preserve">
+    <value>设置帧率</value>
+  </data>
+  <data name="FrameSize_Tip" xml:space="preserve">
+    <value>设置帧大小</value>
+  </data>
+  <data name="FrameSize" xml:space="preserve">
+    <value>帧大小</value>
+  </data>
+  <data name="Font" xml:space="preserve">
+    <value>字体</value>
+  </data>
+  <data name="FontFamily" xml:space="preserve">
+    <value>字体簇</value>
+  </data>
+  <data name="FontStyle" xml:space="preserve">
+    <value>字体风格</value>
+  </data>
+  <data name="FontWeight" xml:space="preserve">
+    <value>字重</value>
+  </data>
+  <data name="FinishEditing" xml:space="preserve">
+    <value>结束编辑</value>
+  </data>
+  <data name="Fill" xml:space="preserve">
+    <value>填充</value>
+  </data>
+  <data name="Files" xml:space="preserve">
+    <value>文件</value>
+  </data>
+  <data name="File" xml:space="preserve">
+    <value>文件</value>
+  </data>
+  <data name="Extensions" xml:space="preserve">
+    <value>扩展程序</value>
+  </data>
+  <data name="Exit" xml:space="preserve">
+    <value>退出</value>
+  </data>
+  <data name="Exit_Description" xml:space="preserve">
+    <value>退出应用程序</value>
+  </data>
+  <data name="AlwaysDisplay" xml:space="preserve">
+    <value>总是显示</value>
+  </data>
+  <data name="AlignmentX" xml:space="preserve">
+    <value>X对齐</value>
+  </data>
+  <data name="AlignmentY" xml:space="preserve">
+    <value>Y对齐</value>
+  </data>
+  <data name="Asymmetry" xml:space="preserve">
+    <value>非对称</value>
+  </data>
+  <data name="Backdrop" xml:space="preserve">
+    <value>背景</value>
+  </data>
+  <data name="BitmapInterpolationMode" xml:space="preserve">
+    <value>图像插值模式</value>
+  </data>
+  <data name="BlendMode_Clear" xml:space="preserve">
+    <value>清除</value>
+  </data>
+  <data name="BlendMode_Clear_Description" xml:space="preserve">
+    <value>清除为全透明</value>
+  </data>
+  <data name="BlendMode_Color" xml:space="preserve">
+    <value>颜色</value>
+  </data>
+  <data name="BrightnessRange" xml:space="preserve">
+    <value>亮度范围</value>
+  </data>
+  <data name="BringToTop" xml:space="preserve">
+    <value>移到顶部</value>
+  </data>
+  <data name="Brush_ConicalGradient" xml:space="preserve">
+    <value>锥形渐变</value>
+  </data>
+  <data name="Brush_PerlinNoise" xml:space="preserve">
+    <value>柏林噪声</value>
+  </data>
+  <data name="Brush_RadialGradient" xml:space="preserve">
+    <value>放射渐变</value>
+  </data>
+  <data name="ClipTransparentArea" xml:space="preserve">
+    <value>裁切透明区域</value>
+  </data>
+  <data name="Clipping" xml:space="preserve">
+    <value>裁切</value>
+  </data>
+  <data name="ChromaKey" xml:space="preserve">
+    <value>色度键</value>
+  </data>
+  <data name="CharactorSpacing" xml:space="preserve">
+    <value>文字间隔</value>
+  </data>
+  <data name="ColorKey" xml:space="preserve">
+    <value>颜色键</value>
+  </data>
+  <data name="ColorShift" xml:space="preserve">
+    <value>颜色偏移</value>
+  </data>
+  <data name="ColorPalette" xml:space="preserve">
+    <value>调色板</value>
+  </data>
+  <data name="Conic" xml:space="preserve">
+    <value>锥</value>
+  </data>
+  <data name="Conical" xml:space="preserve">
+    <value>锥形</value>
+  </data>
+  <data name="DockArea_BottomLeft" xml:space="preserve">
+    <value>底部左侧</value>
+  </data>
+  <data name="DockArea_BottomRight" xml:space="preserve">
+    <value>底部右侧</value>
+  </data>
+  <data name="DockArea_LeftBottom" xml:space="preserve">
+    <value>左下角</value>
+  </data>
+  <data name="DockArea_LeftTop" xml:space="preserve">
+    <value>左上角</value>
+  </data>
+  <data name="DockArea_RightBottom" xml:space="preserve">
+    <value>右下角</value>
+  </data>
+  <data name="DockArea_RightTop" xml:space="preserve">
+    <value>右上角</value>
+  </data>
+  <data name="DockArea_TopLeft" xml:space="preserve">
+    <value>上方左侧</value>
+  </data>
+  <data name="DockArea_TopRight" xml:space="preserve">
+    <value>上方右侧</value>
+  </data>
+  <data name="DropShadow" xml:space="preserve">
+    <value>阴影</value>
+  </data>
+  <data name="Easing" xml:space="preserve">
+    <value>曲线</value>
+  </data>
+  <data name="Easings" xml:space="preserve">
+    <value>曲线</value>
+  </data>
+  <data name="EditAnimation" xml:space="preserve">
+    <value>编辑动画</value>
+  </data>
+  <data name="EditAnimationInInlineView" xml:space="preserve">
+    <value>在原处编辑动画</value>
+  </data>
+  <data name="EditJson" xml:space="preserve">
+    <value>编辑 Json</value>
+  </data>
+  <data name="Editor" xml:space="preserve">
+    <value>编辑器</value>
+  </data>
+  <data name="Editors" xml:space="preserve">
+    <value>编辑器</value>
+  </data>
+  <data name="GeometryShape" xml:space="preserve">
+    <value>几何形状</value>
+  </data>
+  <data name="HighContrast" xml:space="preserve">
+    <value>高对比度</value>
+  </data>
+  <data name="HueRange" xml:space="preserve">
+    <value>色相范围</value>
+  </data>
+  <data name="HueRotate" xml:space="preserve">
+    <value>色相调整</value>
+  </data>
+  <data name="ImageFilter" xml:space="preserve">
+    <value>图片滤镜</value>
+  </data>
+  <data name="InvalidJson" xml:space="preserve">
+    <value>无效的 Json。</value>
+  </data>
+  <data name="InvertStyle" xml:space="preserve">
+    <value>反转风格</value>
+  </data>
+  <data name="LumaColor" xml:space="preserve">
+    <value>LumaColor</value>
+  </data>
+  <data name="LUT_Cube_File" xml:space="preserve">
+    <value>LUT (Cube 文件)</value>
+  </data>
+  <data name="Mosaic" xml:space="preserve">
+    <value>马赛克</value>
+  </data>
+  <data name="MemoryUsage" xml:space="preserve">
+    <value>内存使用量</value>
+  </data>
+  <data name="Move" xml:space="preserve">
+    <value>移动</value>
+  </data>
+  <data name="MoveTo" xml:space="preserve">
+    <value>移动至</value>
+  </data>
+  <data name="NodeTree" xml:space="preserve">
+    <value>节点数</value>
+  </data>
+  <data name="NoFilesUsedRecently" xml:space="preserve">
+    <value>没有最近使用的文件</value>
+  </data>
+  <data name="Number_of_Layers" xml:space="preserve">
+    <value>层数</value>
+  </data>
+  <data name="OpacityMask" xml:space="preserve">
+    <value>不透明度遮罩</value>
+  </data>
+  <data name="TimelineZoom" xml:space="preserve">
+    <value>缩放</value>
+  </data>
+  <data name="StrokeCap_Round" xml:space="preserve">
+    <value>圆角</value>
+  </data>
+  <data name="StrokeCap_Flat" xml:space="preserve">
+    <value>扁平</value>
+  </data>
+  <data name="StrokeCap_Square" xml:space="preserve">
+    <value>方形</value>
+  </data>
+  <data name="Smoothing" xml:space="preserve">
+    <value>平滑</value>
+  </data>
+  <data name="Ellipse" xml:space="preserve">
+    <value>椭圆</value>
+  </data>
+  <data name="FrameCache" xml:space="preserve">
+    <value>帧缓存</value>
+  </data>
+</root>

--- a/src/Beutl.Language/Strings.zh-hans.resx
+++ b/src/Beutl.Language/Strings.zh-hans.resx
@@ -30,7 +30,7 @@
     <value>同意</value>
   </data>
   <data name="Amount" xml:space="preserve">
-    <value>量</value>
+    <value>值</value>
   </data>
   <data name="Angle" xml:space="preserve">
     <value>角度</value>
@@ -261,7 +261,7 @@
     <value>保存为图片</value>
   </data>
   <data name="SaveFrameAsImage" xml:space="preserve">
-    <value>保存一帧作为图片</value>
+    <value>保存一帧为图片</value>
   </data>
   <data name="SaveSelectedElementAsImage" xml:space="preserve">
     <value>保存选中的元素为图片</value>
@@ -468,7 +468,7 @@
     <value>打开文档</value>
   </data>
   <data name="OpenAFileYouHaveAlreadyCreated" xml:space="preserve">
-    <value>打开一个您已经创建的文件</value>
+    <value>打开已有的文件</value>
   </data>
   <data name="Open" xml:space="preserve">
     <value>打开</value>
@@ -582,7 +582,7 @@
     <value>图片</value>
   </data>
   <data name="Hue" xml:space="preserve">
-    <value>色相</value>
+    <value>色调</value>
   </data>
   <data name="Help" xml:space="preserve">
     <value>帮助</value>
@@ -597,7 +597,7 @@
     <value>绿色</value>
   </data>
   <data name="GraphEditor" xml:space="preserve">
-    <value>图形编辑器</value>
+    <value>曲线编辑器</value>
   </data>
   <data name="GradientOrigin" xml:space="preserve">
     <value>渐变原点</value>
@@ -774,10 +774,10 @@
     <value>高对比度</value>
   </data>
   <data name="HueRange" xml:space="preserve">
-    <value>色相范围</value>
+    <value>色调范围</value>
   </data>
   <data name="HueRotate" xml:space="preserve">
-    <value>色相调整</value>
+    <value>色调调整</value>
   </data>
   <data name="ImageFilter" xml:space="preserve">
     <value>图片滤镜</value>
@@ -807,7 +807,7 @@
     <value>移动至</value>
   </data>
   <data name="NodeTree" xml:space="preserve">
-    <value>节点数</value>
+    <value>节点树</value>
   </data>
   <data name="NoFilesUsedRecently" xml:space="preserve">
     <value>没有最近使用的文件</value>
@@ -816,7 +816,7 @@
     <value>层数</value>
   </data>
   <data name="OpacityMask" xml:space="preserve">
-    <value>不透明度遮罩</value>
+    <value>不透明度蒙版</value>
   </data>
   <data name="TimelineZoom" xml:space="preserve">
     <value>缩放</value>
@@ -838,5 +838,245 @@
   </data>
   <data name="FrameCache" xml:space="preserve">
     <value>帧缓存</value>
+  </data>
+  <data name="Symmetry" xml:space="preserve">
+    <value>对称</value>
+  </data>
+  <data name="Exclude" xml:space="preserve">
+    <value>排除</value>
+  </data>
+  <data name="ExcludeAlphaChannel" xml:space="preserve">
+    <value>排除 Alpha 通道</value>
+  </data>
+  <data name="Exclude_Description" xml:space="preserve">
+    <value>排除选中的对象。</value>
+  </data>
+  <data name="UseGlobalClock" xml:space="preserve">
+    <value>使用全局时钟</value>
+  </data>
+  <data name="AddOutputProfile" xml:space="preserve">
+    <value>添加配置</value>
+  </data>
+  <data name="BlendMode_Difference" xml:space="preserve">
+    <value>相差值的绝对值</value>
+  </data>
+  <data name="BlendMode_Plus" xml:space="preserve">
+    <value>相加</value>
+  </data>
+  <data name="Element" xml:space="preserve">
+    <value>元素</value>
+  </data>
+  <data name="Encode" xml:space="preserve">
+    <value>编码</value>
+  </data>
+  <data name="Encoder" xml:space="preserve">
+    <value>编码器</value>
+  </data>
+  <data name="Encoder_Tip" xml:space="preserve">
+    <value>选择编码器</value>
+  </data>
+  <data name="Figure" xml:space="preserve">
+    <value>形状</value>
+  </data>
+  <data name="FilterEffect" xml:space="preserve">
+    <value>滤镜效果</value>
+  </data>
+  <data name="SplitByCurrentFrame" xml:space="preserve">
+    <value>切割于当前帧</value>
+  </data>
+  <data name="Hand" xml:space="preserve">
+    <value>移动</value>
+  </data>
+  <data name="AdjustDurationToCurrent" xml:space="preserve">
+    <value>对齐到当前帧</value>
+  </data>
+  <data name="Addition" xml:space="preserve">
+    <value>相加</value>
+  </data>
+  <data name="Stroke" xml:space="preserve">
+    <value>描边</value>
+  </data>
+  <data name="StrokeEffect" xml:space="preserve">
+    <value>描边</value>
+  </data>
+  <data name="ThirdPartyLicenses" xml:space="preserve">
+    <value>第三方许可证</value>
+  </data>
+  <data name="VerticalSpacing" xml:space="preserve">
+    <value>垂直方向间隔</value>
+  </data>
+  <data name="VerticalDivisions" xml:space="preserve">
+    <value>垂直分割数</value>
+  </data>
+  <data name="SpreadMethod" xml:space="preserve">
+    <value>蔓延模式</value>
+  </data>
+  <data name="SplitByCharacters" xml:space="preserve">
+    <value>按文字分割</value>
+  </data>
+  <data name="Radial" xml:space="preserve">
+    <value>放射状</value>
+  </data>
+  <data name="Skew" xml:space="preserve">
+    <value>倾斜</value>
+  </data>
+  <data name="AdjustDurationToPointer" xml:space="preserve">
+    <value>对齐到指针处</value>
+  </data>
+  <data name="Threshold" xml:space="preserve">
+    <value>二值化</value>
+  </data>
+  <data name="TileMode" xml:space="preserve">
+    <value>平铺模式</value>
+  </data>
+  <data name="BlendMode_ColorBurn_Description" xml:space="preserve">
+    <value>背景的暗色在前景中得到强调，使暗色更加突出。</value>
+  </data>
+  <data name="BlendMode_ColorBurn" xml:space="preserve">
+    <value>颜色加深</value>
+  </data>
+  <data name="Pen_StrokeJoin" xml:space="preserve">
+    <value>连接方法</value>
+  </data>
+  <data name="Pen_StrokeCap" xml:space="preserve">
+    <value>描边线帽</value>
+  </data>
+  <data name="Pen_StrokeAlignment" xml:space="preserve">
+    <value>位置</value>
+  </data>
+  <data name="ShakeEffect" xml:space="preserve">
+    <value>震动</value>
+  </data>
+  <data name="BlendMode_Plus_Description" xml:space="preserve">
+    <value>将前景与背景的颜色相加。</value>
+  </data>
+  <data name="BlendMode_ColorDodge" xml:space="preserve">
+    <value>颜色减淡</value>
+  </data>
+  <data name="BlendMode_ColorDodge_Description" xml:space="preserve">
+    <value>通过添加前景色来提亮背景。</value>
+  </data>
+  <data name="BlendMode_Color_Description" xml:space="preserve">
+    <value>将前景色调和饱和度应用于背景亮度。</value>
+  </data>
+  <data name="BlendMode_Darken" xml:space="preserve">
+    <value>调暗</value>
+  </data>
+  <data name="BlendMode_Darken_Description" xml:space="preserve">
+    <value>保持前景或背景的深色。</value>
+  </data>
+  <data name="BlendMode_Difference_Description" xml:space="preserve">
+    <value>强调颜色的相差值的绝对值</value>
+  </data>
+  <data name="BlendMode_Dst" xml:space="preserve">
+    <value>保持原样</value>
+  </data>
+  <data name="BlendMode_Xor" xml:space="preserve">
+    <value>位或</value>
+  </data>
+  <data name="BlendMode_Xor_Description" xml:space="preserve">
+    <value>使重叠区域透明，保留非重叠区域。</value>
+  </data>
+  <data name="BlendMode_Multiply" xml:space="preserve">
+    <value>相乘</value>
+  </data>
+  <data name="BlendMode_Multiply_Description" xml:space="preserve">
+    <value>将前景和背景的 RGB 颜色值相乘，产生更暗的效果。</value>
+  </data>
+  <data name="BlendMode_Modulate" xml:space="preserve">
+    <value>混合透明度</value>
+  </data>
+  <data name="BlendMode_Modulate_Description" xml:space="preserve">
+    <value>将前景色和背景色相乘，并考虑透明度。</value>
+  </data>
+  <data name="BlendMode_Luminosity" xml:space="preserve">
+    <value>亮度</value>
+  </data>
+  <data name="BlendMode_Luminosity_Description" xml:space="preserve">
+    <value>保持背景的色调和饱和度，并应用前景亮度。</value>
+  </data>
+  <data name="BlendMode_Hue" xml:space="preserve">
+    <value>色调</value>
+  </data>
+  <data name="BlendMode_Hue_Description" xml:space="preserve">
+    <value>保持背景的亮度和饱和度，并应用前景色调。</value>
+  </data>
+  <data name="BlendMode_Exclusion_Description" xml:space="preserve">
+    <value>产生更柔和的差异效果。</value>
+  </data>
+  <data name="BlendMode_Exclusion" xml:space="preserve">
+    <value>排除</value>
+  </data>
+  <data name="ChangeToOriginalLength" xml:space="preserve">
+    <value>更改回原长</value>
+  </data>
+  <data name="EllipticalArc" xml:space="preserve">
+    <value>圆弧</value>
+  </data>
+  <data name="EnableElement" xml:space="preserve">
+    <value>启用元素</value>
+  </data>
+  <data name="EnableLivePreview" xml:space="preserve">
+    <value>启用实时预览</value>
+  </data>
+  <data name="EndPoint" xml:space="preserve">
+    <value>终点</value>
+  </data>
+  <data name="Grayscale" xml:space="preserve">
+    <value>灰度</value>
+  </data>
+  <data name="HorizontalDivisions" xml:space="preserve">
+    <value>水平分割数</value>
+  </data>
+  <data name="HorizontalSpacing" xml:space="preserve">
+    <value>水平分割间隔</value>
+  </data>
+  <data name="Lighting" xml:space="preserve">
+    <value>亮度调节</value>
+  </data>
+  <data name="MaskType" xml:space="preserve">
+    <value>蒙版类型</value>
+  </data>
+  <data name="Negaposi" xml:space="preserve">
+    <value>正负</value>
+  </data>
+  <data name="Dilate" xml:space="preserve">
+    <value>膨胀</value>
+  </data>
+  <data name="EditInFrame" xml:space="preserve">
+    <value>在帧内编辑</value>
+  </data>
+  <data name="EditInTab" xml:space="preserve">
+    <value>在标签页内编辑</value>
+  </data>
+  <data name="Erode" xml:space="preserve">
+    <value>收缩</value>
+  </data>
+  <data name="StrokeJoin_Miter" xml:space="preserve">
+    <value>尖角连接</value>
+  </data>
+  <data name="StrokeJoin_Bevel" xml:space="preserve">
+    <value>倾斜连接</value>
+  </data>
+  <data name="StrokeJoin_Round" xml:space="preserve">
+    <value>圆弧连接</value>
+  </data>
+  <data name="Pen_MiterLimit" xml:space="preserve">
+    <value>尖角延伸限制</value>
+  </data>
+  <data name="Pen_DashArray" xml:space="preserve">
+    <value>虚线配置</value>
+  </data>
+  <data name="Pen_DashOffset" xml:space="preserve">
+    <value>虚线偏移</value>
+  </data>
+  <data name="Sigma" xml:space="preserve">
+    <value>强度</value>
+  </data>
+  <data name="ShadowOnly" xml:space="preserve">
+    <value>仅阴影</value>
+  </data>
+  <data name="FlatShadow" xml:space="preserve">
+    <value>扁平阴影</value>
   </data>
 </root>

--- a/src/Beutl.PackageTools.UI/Resources/Strings.zh-hans.resx
+++ b/src/Beutl.PackageTools.UI/Resources/Strings.zh-hans.resx
@@ -1,0 +1,14 @@
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/Beutl.PackageTools.UI/Resources/Strings.zh-hans.resx
+++ b/src/Beutl.PackageTools.UI/Resources/Strings.zh-hans.resx
@@ -11,4 +11,145 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AcceptAll" xml:space="preserve">
+    <value>同意全部</value>
+  </data>
+  <data name="Acceptance_of_License" xml:space="preserve">
+    <value>许可证同意详情</value>
+  </data>
+  <data name="Back" xml:space="preserve">
+    <value>返回</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="Canceled" xml:space="preserve">
+    <value>已取消</value>
+  </data>
+  <data name="Changes" xml:space="preserve">
+    <value>变更内容</value>
+  </data>
+  <data name="Clean" xml:space="preserve">
+    <value>清除</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="Close_this_window_because_other_Beutl_PackageTools_processes_are_running" xml:space="preserve">
+    <value>关闭这个窗口，因为有另一个 Beutl.PackageTools 在运行。</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>是</value>
+  </data>
+  <data name="Verify" xml:space="preserve">
+    <value>验证</value>
+  </data>
+  <data name="VerifyingHashCode" xml:space="preserve">
+    <value>正在进行验证...</value>
+  </data>
+  <data name="Verified" xml:space="preserve">
+    <value>已验证</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>更新</value>
+  </data>
+  <data name="Unknown" xml:space="preserve">
+    <value>未知</value>
+  </data>
+  <data name="Uninstalled_XXX" xml:space="preserve">
+    <value>卸载 '{0}'</value>
+  </data>
+  <data name="Uninstall" xml:space="preserve">
+    <value>卸载</value>
+  </data>
+  <data name="This_package_has_already_been_uninstalled" xml:space="preserve">
+    <value>这个包已被卸载。</value>
+  </data>
+  <data name="These_packages_were_not_deleted_successfully" xml:space="preserve">
+    <value>这些包没能成功删除。</value>
+  </data>
+  <data name="There_are_no_licenses_that_require_acceptance" xml:space="preserve">
+    <value>无需同意任何许可证。</value>
+  </data>
+  <data name="Succeeded" xml:space="preserve">
+    <value>成功</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+    <value>开始</value>
+  </data>
+  <data name="Skipped_verification_because_local_source_is_used" xml:space="preserve">
+    <value>因为使用的是本地来源，故跳过验证。</value>
+  </data>
+  <data name="Skipped_downloading_to_use_local_source" xml:space="preserve">
+    <value>因为使用的是本地来源，故跳过下载。</value>
+  </data>
+  <data name="ShowDetails" xml:space="preserve">
+    <value>显示更多</value>
+  </data>
+  <data name="Select_the_packages_to_be_deleted" xml:space="preserve">
+    <value>选择想要删除的包。</value>
+  </data>
+  <data name="Result" xml:space="preserve">
+    <value>结果</value>
+  </data>
+  <data name="ResolveDependencies" xml:space="preserve">
+    <value>解决依赖关系</value>
+  </data>
+  <data name="Deleted_unnecessary_packages" xml:space="preserve">
+    <value>不必要的包已删除。</value>
+  </data>
+  <data name="Delete_unnecessary_packages" xml:space="preserve">
+    <value>删除不必要的包</value>
+  </data>
+  <data name="Deleting_files" xml:space="preserve">
+    <value>文件删除中...</value>
+  </data>
+  <data name="Deleting_unnecessary_packages" xml:space="preserve">
+    <value>正在删除不必要的包...</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>下载</value>
+  </data>
+  <data name="Downloaded_XXX" xml:space="preserve">
+    <value>'{0}' 已下载。</value>
+  </data>
+  <data name="Downloading_XXX" xml:space="preserve">
+    <value>正在下载 '{0}' ...</value>
+  </data>
+  <data name="Do_you_really_want_to_continue_with_the_installation" xml:space="preserve">
+    <value>您真的要继续这个安装吗？</value>
+  </data>
+  <data name="Do_you_want_to_use_this_package" xml:space="preserve">
+    <value>您想要使用这个包吗？</value>
+  </data>
+  <data name="Failed" xml:space="preserve">
+    <value>失败</value>
+  </data>
+  <data name="Hash_code_verification_failed" xml:space="preserve">
+    <value>数据验证失败。这个包可能被修改。</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>安装</value>
+  </data>
+  <data name="No" xml:space="preserve">
+    <value>否</value>
+  </data>
+  <data name="Operation_canceled" xml:space="preserve">
+    <value>操作已取消。</value>
+  </data>
+  <data name="Package_with_same_ID_found_in_local_source" xml:space="preserve">
+    <value>在本地来源中找到了具有相同 ID 的包。</value>
+  </data>
+  <data name="Please_accept_the_following_license" xml:space="preserve">
+    <value>请先接受以下许可证。</value>
+  </data>
+  <data name="Waiting_for_all_Beutl_processes_to_terminate" xml:space="preserve">
+    <value>等待 Beutl 进程结束...</value>
+  </data>
+  <data name="XXX_has_been_released" xml:space="preserve">
+    <value>{0} 已发布。</value>
+  </data>
+  <data name="XXX_will_be_released" xml:space="preserve">
+    <value>{0} 将发布。</value>
+  </data>
 </root>


### PR DESCRIPTION
Add a zh-Hans (Simplified Chinese) translate for Beutl, most strings are translated, but some are still in progress.
This pr can be merged directly, and I will continue translating and fixing some problems in my spare time.

<img width="1013" alt="image" src="https://github.com/user-attachments/assets/fe24fe92-faf6-4c72-994f-0ea0bcf45808" />
