### PR TITLE
Fix type conversion error in property binding

### DIFF
--- a/src/Beutl/Converters/DockableDisplayModeConverter.cs
+++ b/src/Beutl/Converters/DockableDisplayModeConverter.cs
@@ -1,0 +1,39 @@
+﻿using Avalonia.Data.Converters;
+using ReDocking;
+
+namespace Beutl.Converters;
+
+public class DockableDisplayModeConverter : IValueConverter
+{
+    public static readonly DockableDisplayModeConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is ToolTabExtension.TabDisplayMode mode)
+        {
+            return mode switch
+            {
+                ToolTabExtension.TabDisplayMode.Docked => DockableDisplayMode.Docked,
+                ToolTabExtension.TabDisplayMode.Floating => DockableDisplayMode.Floating,
+                _ => DockableDisplayMode.Docked
+            };
+        }
+
+        return DockableDisplayMode.Docked;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is DockableDisplayMode mode)
+        {
+            return mode switch
+            {
+                DockableDisplayMode.Docked => ToolTabExtension.TabDisplayMode.Docked,
+                DockableDisplayMode.Floating => ToolTabExtension.TabDisplayMode.Floating,
+                _ => ToolTabExtension.TabDisplayMode.Docked
+            };
+        }
+
+        return ToolTabExtension.TabDisplayMode.Docked;
+    }
+}

--- a/src/Beutl/Views/EditView.axaml
+++ b/src/Beutl/Views/EditView.axaml
@@ -1,6 +1,7 @@
 <UserControl x:Class="Beutl.Views.EditView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:conv="using:Beutl.Converters"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:dock="using:ReDocking"
              xmlns:lang="clr-namespace:Beutl.Language;assembly=Beutl.Language"
@@ -16,7 +17,7 @@
              mc:Ignorable="d">
     <UserControl.Resources>
         <DataTemplate x:Key="LeftSideBarButtonDataTemplate" x:DataType="vm:ToolTabViewModel">
-            <dock:SideBarButton DisplayMode="{Binding Context.DisplayMode.Value}"
+            <dock:SideBarButton DisplayMode="{Binding Context.DisplayMode.Value, Converter={x:Static conv:DockableDisplayModeConverter.Instance}}"
                                 IsChecked="{Binding Context.IsSelected.Value}"
                                 ToolTip.Placement="Right"
                                 ToolTip.ShowDelay="200"
@@ -26,7 +27,7 @@
             </dock:SideBarButton>
         </DataTemplate>
         <DataTemplate x:Key="RightSideBarButtonDataTemplate" x:DataType="vm:ToolTabViewModel">
-            <dock:SideBarButton DisplayMode="{Binding Context.DisplayMode.Value}"
+            <dock:SideBarButton DisplayMode="{Binding Context.DisplayMode.Value, Converter={x:Static conv:DockableDisplayModeConverter.Instance}}"
                                 IsChecked="{Binding Context.IsSelected.Value}"
                                 ToolTip.Placement="Left"
                                 ToolTip.ShowDelay="200"

--- a/src/Beutl/Views/PathEditorView.axaml
+++ b/src/Beutl/Views/PathEditorView.axaml
@@ -11,7 +11,7 @@
              d:DesignHeight="450"
              d:DesignWidth="800"
              x:DataType="vm:PathEditorViewModel"
-             IsHitTestVisible="{Binding PathGeometry.Value}"
+             IsHitTestVisible="{Binding PathGeometry.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
              IsVisible="{Binding IsVisible.Value}"
              Matrix="{Binding AvaMatrix.Value}"
              SceneWidth="{Binding SceneWidth.Value}"


### PR DESCRIPTION
Resolve a type conversion error by introducing a new converter for DockableDisplayMode and updating bindings in the XAML files accordingly.