### PR TITLE
Make ElementViewModel creation single-threaded to resolve concurrency issues

### DIFF
--- a/src/Beutl/ViewModels/TimelineViewModel.cs
+++ b/src/Beutl/ViewModels/TimelineViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Specialized;
+using System.Collections.Specialized;
 using System.Numerics;
 using System.Reactive.Subjects;
 using System.Text.Json.Nodes;
@@ -74,11 +74,8 @@ public sealed class TimelineViewModel : IToolContext, IContextCommandHandler
         if (Scene.Children.Count > 0)
         {
             AddLayerHeaders(Scene.Children.Max(i => i.ZIndex) + 1);
-            var items = new ElementViewModel[Scene.Children.Count];
-            Parallel.ForEach(
-                Scene.Children,
-                (item, _, idx) => items[idx] = new ElementViewModel(item, this));
-            Elements.AddRange(items);
+            Elements.EnsureCapacity(Scene.Children.Count);
+            Elements.AddRange(Scene.Children.Select(item => new ElementViewModel(item, this)));
         }
 
         Scene.Children.TrackCollectionChanged(


### PR DESCRIPTION
Ensure that ElementViewModel instances are created in a single-threaded manner to prevent concurrency problems during initialization. This change replaces parallel processing with a sequential approach.