### PR TITLE
Fix child animations not applying with SourceOperator on Drawable groups

### DIFF
--- a/src/Beutl.ProjectSystem/Operation/SourceOperation.cs
+++ b/src/Beutl.ProjectSystem/Operation/SourceOperation.cs
@@ -1,7 +1,6 @@
 ﻿using System.Buffers;
 using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
-using System.Text.Json.Nodes;
 
 using Beutl.Animation;
 using Beutl.Collections;
@@ -83,15 +82,6 @@ public sealed class SourceOperation : Hierarchical, IAffectsRender
                         item.FlowRenderables = flow;
                         item.Operator.Evaluate(item);
                     }
-                }
-
-
-                foreach (Renderable item in flow.Span)
-                {
-                    item.ZIndex = element.ZIndex;
-                    item.TimeRange = new TimeRange(element.Start, element.Length);
-                    item.ApplyAnimations(element.Clock);
-                    item.IsVisible = element.IsEnabled;
                 }
             }
 


### PR DESCRIPTION
Fixed an issue where child animations were not applied when using `SourceOperator` with a group containing `Drawable` elements. Now, the child animations correctly affect all elements within the group.

Close #1253