### PR TITLE
Fix output processing issues and improve UI updates

### DIFF
--- a/src/Beutl/ViewModels/Tools/OutputViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/OutputViewModel.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Reactive.Subjects;
 using System.Text.Json.Nodes;
 using Avalonia.Platform.Storage;
@@ -189,8 +189,10 @@ public sealed class OutputViewModel : IOutputContext
                     var sampleProvider = new SampleProviderImpl(
                         scene, composer, audioSettings.SampleRate, sampleProgress);
 
-                    using (frameProgress.CombineLatest(sampleProgress).Subscribe(t =>
-                               ProgressValue.Value = t.Item1.TotalSeconds + t.Item2.TotalSeconds))
+                    using (frameProgress.CombineLatest(sampleProgress)
+                               .ObserveOnUIDispatcher()
+                               .Subscribe(t =>
+                                   ProgressValue.Value = t.Item1.TotalSeconds + t.Item2.TotalSeconds))
                     {
                         RenderNodeCacheContext cacheContext = renderer.GetCacheContext();
                         cacheContext.CacheOptions = RenderCacheOptions.Disabled;

--- a/src/Beutl/ViewModels/Tools/OutputViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/OutputViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 using System.Reactive.Subjects;
 using System.Text.Json.Nodes;
 using Avalonia.Platform.Storage;
@@ -151,6 +151,7 @@ public sealed class OutputViewModel : IOutputContext
         {
             _lastCts = new CancellationTokenSource();
             _isEncoding.Value = true;
+            ProgressText.Value = "";
             Started?.Invoke(this, EventArgs.Empty);
 
             await RenderThread.Dispatcher.InvokeAsync(async () =>

--- a/src/Beutl/ViewModels/Tools/OutputViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/OutputViewModel.cs
@@ -192,12 +192,8 @@ public sealed class OutputViewModel : IOutputContext
                     using (frameProgress.CombineLatest(sampleProgress).Subscribe(t =>
                                ProgressValue.Value = t.Item1.TotalSeconds + t.Item2.TotalSeconds))
                     {
-                        RenderNodeCacheContext? cacheContext = renderer.GetCacheContext();
-
-                        if (cacheContext != null)
-                        {
-                            cacheContext.CacheOptions = RenderCacheOptions.Disabled;
-                        }
+                        RenderNodeCacheContext cacheContext = renderer.GetCacheContext();
+                        cacheContext.CacheOptions = RenderCacheOptions.Disabled;
 
                         await controller.Encode(frameProvider, sampleProvider, _lastCts.Token);
                     }

--- a/src/Beutl/Views/Tools/OutputView.axaml
+++ b/src/Beutl/Views/Tools/OutputView.axaml
@@ -25,7 +25,6 @@
                     VerticalAlignment="Bottom"
                     Classes="accent"
                     Click="StartEncodeClick"
-                    Command="{Binding StartEncode}"
                     Content="{x:Static lang:Strings.Encode}"
                     IsEnabled="{Binding CanEncode.Value}"
                     IsVisible="{Binding !IsEncoding.Value}" />


### PR DESCRIPTION
- Prevented duplicate execution of output processing.  
- Reset `ProgressText` when starting output processing.  
- Simplified cache context handling in output processing.  
- Ensured UI updates for progress value during output processing.  
