### PR TITLE
fix: Use the same renderer for encoding and preview

### DIFF
--- a/src/Beutl.Extensibility/OutputExtension.cs
+++ b/src/Beutl.Extensibility/OutputExtension.cs
@@ -34,9 +34,9 @@ public abstract class OutputExtension : Extension
 
     public abstract IconSource? GetIcon();
 
-    public abstract bool TryCreateControl(string file, [NotNullWhen(true)] out Control? control);
+    public abstract bool TryCreateControl(IEditorContext editorContext, [NotNullWhen(true)] out Control? control);
 
-    public abstract bool TryCreateContext(string file, [NotNullWhen(true)] out IOutputContext? context);
+    public abstract bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IOutputContext? context);
 
     public virtual bool IsSupported(string file)
     {

--- a/src/Beutl/Services/PrimitiveImpls/SceneOutputExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneOutputExtension.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Platform.Storage;
 
 using Beutl.ProjectSystem;
+using Beutl.ViewModels;
 using Beutl.ViewModels.Tools;
 using Beutl.Views.Tools;
 using FluentAvalonia.UI.Controls;
@@ -43,11 +44,11 @@ public sealed class SceneOutputExtension : OutputExtension
         return ext is ".scene";
     }
 
-    public override bool TryCreateContext(string file, [NotNullWhen(true)] out IOutputContext? context)
+    public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IOutputContext? context)
     {
-        if (file.EndsWith(".scene") && File.Exists(file))
+        if (editorContext is EditViewModel editViewModel)
         {
-            context = new OutputViewModel(new SceneFile(file));
+            context = new OutputViewModel(editViewModel);
             return true;
         }
         else
@@ -57,9 +58,9 @@ public sealed class SceneOutputExtension : OutputExtension
         }
     }
 
-    public override bool TryCreateControl(string file, [NotNullWhen(true)] out Control? control)
+    public override bool TryCreateControl(IEditorContext editorContext, [NotNullWhen(true)] out Control? control)
     {
-        if (file.EndsWith(".scene"))
+        if (editorContext is EditViewModel)
         {
             control = new OutputView();
             return true;

--- a/src/Beutl/Views/Tools/OutputTab.axaml.cs
+++ b/src/Beutl/Views/Tools/OutputTab.axaml.cs
@@ -83,7 +83,7 @@ public partial class OutputTab : UserControl
                     control.DataContext = item.Context;
                     return control;
                 }
-                else if (item.Context.Extension.TryCreateControl(item.Context.TargetFile, out control))
+                else if (item.Context.Extension.TryCreateControl(item.EditorContext, out control))
                 {
                     _contextToViewType[item.Context.Extension] = control;
                     control.DataContext = item.Context;


### PR DESCRIPTION
Using different renderers caused issues where the preview tried to update during encoding.

## Description

## Breaking changes

## Fixed issues
