### PR TITLE
fix: use FileStream to avoid IO error when passing file path to FFmpeg

### DIFF
--- a/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingController.cs
+++ b/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingController.cs
@@ -191,7 +191,8 @@ public class FFmpegEncodingController(string outputFile, FFmpegEncodingSettings 
         CancellationToken cancellationToken)
     {
         bool encodeVideo = false, encodeAudio = false;
-        using (var muxer = MediaMuxer.Create(OutputFile))
+        using (var fs = File.OpenWrite(OutputFile))
+        using (var muxer = MediaMuxer.Create(fs, OutFormat.GuessFormat(null, OutputFile, null)))
         using (var videoFrame = new MediaFrame())
         using (var audioFrame = new MediaFrame())
         {

--- a/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingController.cs
+++ b/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingController.cs
@@ -307,7 +307,7 @@ public class FFmpegEncodingController(string outputFile, FFmpegEncodingSettings 
             // Console.WriteLine(
             //     $"pts:{pkt.Pts} pts_time:{0} dst:{pkt.Dts} dts_time:{0} duration:{pkt.Duration} duration_time:{0} stream_index:{streamIndex}");
             ffmpeg.av_packet_rescale_ts(pkt, encoder.TimeBase, stream.TimeBase);
-            muxer.WritePacket(pkt);
+            muxer.WritePacket(pkt).ThrowIfError();
         }
 
         return frame != null;


### PR DESCRIPTION
Passing file paths to FFmpeg was causing IO errors. This update changes the implementation to use `FileStream` instead.