### PR TITLE
Change encoder options to list format

### DIFF
--- a/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingController.cs
+++ b/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingController.cs
@@ -131,20 +131,9 @@ public class FFmpegEncodingController(string outputFile, FFmpegEncodingSettings 
         var fps = VideoSettings.FrameRate;
         var format = VideoSettings.Format;
         int bitRate = VideoSettings.Bitrate;
-        var options = new MediaDictionary
-        {
-            { "preset", VideoSettings.Preset },
-            { "crf", VideoSettings.Crf },
-            { "profile", VideoSettings.Profile },
-            { "level", VideoSettings.Level }
-        };
-        foreach (var item in options)
-        {
-            if (item.Value.Equals("(unset)", StringComparison.OrdinalIgnoreCase))
-            {
-                options.Remove(item.Key);
-            }
-        }
+        var options = new MediaDictionary(VideoSettings.Options
+            .Where(item => !string.IsNullOrWhiteSpace(item.Key))
+            .Select(item => new KeyValuePair<string, string>(item.Key, item.Value)));
 
         encoder = MediaEncoder.Create(codec, codecContext =>
         {


### PR DESCRIPTION
Refactor the encoder's additional options to use a list format, enhancing flexibility and maintainability. This change replaces individual properties with a collection of key-value pairs.