### PR TITLE
fix: Improve path resolving for linux

### DIFF
--- a/src/Beutl.Engine/Media/Font/FontManager.cs
+++ b/src/Beutl.Engine/Media/Font/FontManager.cs
@@ -25,7 +25,18 @@ public sealed class FontManager
             if (OperatingSystem.IsLinux())
             {
                 var output = new StringBuilder();
-                using Process process = Process.Start(new ProcessStartInfo("/usr/bin/fc-match", "--format %{file}")
+                string applicationPath = "/usr/bin/fc-match";
+                var paths = Environment.GetEnvironmentVariable("PATH")?.Split(Path.PathSeparator) ?? [];
+                foreach (var path in paths)
+                {
+                    var fullPath = Path.Combine(path, "fc-match");
+                    if (File.Exists(fullPath))
+                    {
+                        applicationPath = fullPath;
+                        break;
+                    }
+                }
+                using Process process = Process.Start(new ProcessStartInfo(applicationPath, "--format %{file}")
                 {
                     RedirectStandardOutput = true
                 })!;

--- a/src/Beutl.Extensions.FFmpeg/FFmpegPath.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegPath.cs
@@ -155,6 +155,8 @@ public static class FFmpegLoader
         else if (OperatingSystem.IsLinux())
         {
             paths.Add($"/usr/lib/{(Environment.Is64BitProcess ? "x86_64" : "x86")}-linux-gnu");
+            var libraryPath = Environment.GetEnvironmentVariable("LD_LIBRARY_PATH")?.Split(Path.PathSeparator) ?? [];
+            paths.AddRange(libraryPath);
         }
         else if (OperatingSystem.IsMacOS())
         {


### PR DESCRIPTION
## Description

Some distributions like NixOS manages path dynamically using some environments.

Linux環境においてライブラリおよびバイナリを含んでいるパスはディストリビューションによって変化するため、用意されている環境変数を使ってなるべく解決できるようにしました。

PATHの方はPOSIX仕様としてにて定義されているものの、LD_LIBRARY_PATHに関してはリンカとして利用されるldの仕様から派生したデファクトスタンダードになりますが、多くのディストリビューションでカバーされているものと認識しています。

## Breaking changes

## Fixed issues

related? #1134 