### PR TITLE
fix: prevent occasional playback of the initial part during audio playback

### DIFF
--- a/src/Beutl.ProjectSystem/Operation/PublishOperator.cs
+++ b/src/Beutl.ProjectSystem/Operation/PublishOperator.cs
@@ -42,7 +42,7 @@ public abstract class PublishOperator<T> : SourceOperator, IPublishOperator
 
     private readonly EvaluationTarget _evaluationTarget =
         typeof(T).IsAssignableTo(typeof(Drawable)) ? EvaluationTarget.Graphics
-        : typeof(T).IsAssignableTo(typeof(Audio.Audio)) ? EvaluationTarget.Audio : EvaluationTarget.Unknown;
+        : typeof(T).IsAssignableTo(typeof(Audio.Sound)) ? EvaluationTarget.Audio : EvaluationTarget.Unknown;
 
     static PublishOperator()
     {

--- a/src/Beutl/Models/BufferedPlayer.cs
+++ b/src/Beutl/Models/BufferedPlayer.cs
@@ -67,8 +67,9 @@ public sealed class BufferedPlayer : IPlayer
 
                     if (_queue.Count >= 120)
                     {
-                        _logger.LogInformation("Queue is full. Waiting for timer. Current queue count: {QueueCount}",
-                            _queue.Count);
+                        // _logger.LogInformation(
+                        //     "Queue is full. Waiting for timer. Current queue count: {QueueCount}",
+                        //     _queue.Count);
                         WaitTimer();
                     }
 


### PR DESCRIPTION
## Description
Sound objects were unintentionally passing through the graphics object pipeline, causing them to play at incorrect times.  
This PR fixes the issue by preventing sound objects from entering the graphics pipeline.

## Breaking changes

## Fixed issues
