### PR TITLE
Fix issue where keymap settings were not properly overridden

### DIFF
--- a/src/Beutl.Extensibility/ContextCommandAttribute.cs
+++ b/src/Beutl.Extensibility/ContextCommandAttribute.cs
@@ -38,7 +38,34 @@ public class ContextCommandDefinition(
 
     public string? Description { get; init; } = description;
 
-    public ContextCommandKeyGesture[]? KeyGestures { get; init; } = keyGestures;
+    public ContextCommandKeyGesture[]? KeyGestures { get; init; } = Normalize(keyGestures);
+
+    private static ContextCommandKeyGesture[]? Normalize(ContextCommandKeyGesture[]? keyGestures)
+    {
+        if (keyGestures == null) return keyGestures;
+
+        ContextCommandKeyGesture? fallbackGesture = null;
+        ContextCommandKeyGesture? windows = null;
+        ContextCommandKeyGesture? linux = null;
+        ContextCommandKeyGesture? osx = null;
+
+        foreach (ContextCommandKeyGesture gesture in keyGestures)
+        {
+            if (gesture.Platform == null) fallbackGesture = gesture;
+            else if (gesture.Platform == OSPlatform.Windows) windows = gesture;
+            else if (gesture.Platform == OSPlatform.Linux) linux = gesture;
+            else if (gesture.Platform == OSPlatform.OSX) osx = gesture;
+        }
+
+        if (windows == null && fallbackGesture != null)
+            windows = new ContextCommandKeyGesture(fallbackGesture.KeyGesture, OSPlatform.Windows);
+        if (linux == null && fallbackGesture != null)
+            linux = new ContextCommandKeyGesture(fallbackGesture.KeyGesture, OSPlatform.Linux);
+        if (osx == null && fallbackGesture != null)
+            osx = new ContextCommandKeyGesture(fallbackGesture.KeyGesture, OSPlatform.OSX);
+
+        return new[] { windows, linux, osx }.Where(i => i != null).ToArray()!;
+    }
 }
 
 public class ContextCommandKeyGesture(string? keyGesture, OSPlatform? platform = null)

--- a/src/Beutl/Helpers/GetCommandGestureExtension.cs
+++ b/src/Beutl/Helpers/GetCommandGestureExtension.cs
@@ -59,9 +59,9 @@ public class GetCommandGestureExtension : MarkupExtension
         OSPlatform pid = OperatingSystem.IsWindows() ? OSPlatform.Windows :
             OperatingSystem.IsMacOS() ? OSPlatform.OSX :
             OperatingSystem.IsLinux() ? OSPlatform.Linux :
-            OSPlatform.Create("Unknown");
+            throw new NotSupportedException();
 
         return e.KeyGestures
-            .FirstOrDefault(gesture => !gesture.Platform.HasValue || gesture.Platform == pid)?.KeyGesture!;
+            .FirstOrDefault(gesture => gesture.Platform == pid)?.KeyGesture!;
     }
 }

--- a/src/Beutl/ViewModels/SettingsPages/KeyMapSettingsPageViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsPages/KeyMapSettingsPageViewModel.cs
@@ -31,7 +31,7 @@ public class KeyMapSettingsItem
             OperatingSystem.IsLinux() ? OSPlatform.Linux :
             OSPlatform.OSX;
         var gesture = command.KeyGestures
-            .FirstOrDefault(i => !i.Platform.HasValue || i.Platform == os)
+            .FirstOrDefault(i => i.Platform == os)
             ?.KeyGesture;
         KeyGesture = new ReactiveProperty<KeyGesture?>(gesture);
     }
@@ -45,7 +45,8 @@ public class KeyMapSettingsItem
         KeyGesture.Value = gesture;
         OSPlatform os = OperatingSystem.IsWindows() ? OSPlatform.Windows :
             OperatingSystem.IsLinux() ? OSPlatform.Linux :
-            OSPlatform.OSX;
+            OperatingSystem.IsMacOS() ? OSPlatform.OSX :
+            throw new NotSupportedException();
         _commandManager.ChangeKeyGesture(Command, gesture, os);
     }
 }


### PR DESCRIPTION
Previously, when changing a default keymap (e.g., from Ctrl+K to S), both the new and old shortcuts could be used. This was caused by incorrect resolution logic, where the customized keymap did not properly override the default or shared (`null`) configuration. This fix ensures that customized keymaps fully replace the original ones as expected.

Closes #1335