### PR TITLE
feat(timeline): add a marker to tweak ending bar position

### DIFF
--- a/src/Beutl/Views/TimelineScale.cs
+++ b/src/Beutl/Views/TimelineScale.cs
@@ -285,6 +285,17 @@ public sealed class TimelineScale : Control
             context.DrawLine(_seekBarPen, seekbar, seekbar + bottom);
 
             context.DrawLine(_endingBarPen, endingbar, endingbar + bottom);
+
+            // EndingBarのドラッグ可能マーカーを描画
+            if (EndingBarBrush?.ToImmutable() is { } brush)
+            {
+                const int markerHeight = 16;
+                const int markerWidth = 4;
+                double left = _endingBarMargin.Left - markerWidth / 2.0;
+                double markerTop = height - markerHeight;
+                context.FillRectangle(brush, new Rect(left, markerTop, markerWidth, markerHeight));
+                context.DrawRectangle(brush, null, new Rect(left, markerTop, markerWidth, markerHeight));
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

EndingBarをドラッグで移動可能にしました。

https://github.com/user-attachments/assets/13e56ebc-d299-4034-abc5-c9931a3a0494


## Breaking changes

none

## Fixed issues

none