### PR TITLE
fix: clip for text block in ElementView.axaml

### DIFF
--- a/src/Beutl/Views/ElementView.axaml
+++ b/src/Beutl/Views/ElementView.axaml
@@ -137,6 +137,7 @@
         <Panel>
             <TextBlock x:Name="textBlock"
                        VerticalAlignment="Center"
+                       ClipToBounds="True"
                        Foreground="{Binding TextColor.Value, Converter={StaticResource ColorToBrushConverter}}"
                        Text="{Binding Name.Value}" />
             <TextBox x:Name="textBox"


### PR DESCRIPTION
Enable clipping for the text block to ensure content does not overflow its bounds.

Closes #1350