### PR TITLE
fix: adjust zoom functionality to maintain offset in Timeline view

### DIFF
--- a/src/Beutl/Views/Timeline.axaml.cs
+++ b/src/Beutl/Views/Timeline.axaml.cs
@@ -651,7 +651,12 @@ public sealed partial class Timeline : UserControl
                     return;
             }
 
-            ViewModel.Options.Value = ViewModel.Options.Value with { Scale = zoom, };
+            float oldScale = ViewModel.Options.Value.Scale;
+            var offset = ViewModel.Options.Value.Offset;
+            double pointerPos = _pointerFrame.ToPixel(ViewModel.Options.Value.Scale);
+            double deltaLeft = pointerPos - offset.X;
+            offset.X = (float)((pointerPos / oldScale * zoom) - deltaLeft);
+            ViewModel.Options.Value = ViewModel.Options.Value with { Scale = zoom, Offset = offset };
         }
     }
 


### PR DESCRIPTION
## Description
右クリックメニューでタイムラインの拡大率を変更した時、スクロール位置を調整するようにした。

## Breaking changes

## Fixed issues
- #1349