### PR TITLE
fix: add serialization and deserialization for Codec in FFmpegAudioEncoderSettings

### DIFF
--- a/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegAudioEncoderSettings.cs
+++ b/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegAudioEncoderSettings.cs
@@ -1,5 +1,5 @@
 ﻿using Beutl.Media.Encoding;
-
+using Beutl.Serialization;
 using FFmpeg.AutoGen;
 using FFmpegSharp;
 
@@ -37,6 +37,24 @@ public sealed class FFmpegAudioEncoderSettings : AudioEncoderSettings
     {
         get => GetValue(FormatProperty);
         set => SetValue(FormatProperty, value);
+    }
+
+    public override void Deserialize(ICoreSerializationContext context)
+    {
+        base.Deserialize(context);
+        string? codecName = context.GetValue<string>(nameof(Codec));
+        if (codecName != null)
+        {
+            Codec = AudioCodecChoicesProvider.GetChoices()
+                .Cast<CodecRecord>()
+                .FirstOrDefault(i => i.Name == codecName, CodecRecord.Default);
+        }
+    }
+
+    public override void Serialize(ICoreSerializationContext context)
+    {
+        base.Serialize(context);
+        context.SetValue(nameof(Codec), Codec.Name);
     }
 
     public enum AudioFormat


### PR DESCRIPTION
## Description
FFmpegエンコーダー設定の音声コーデック項目が保存されないのを修正

## Fixed issues
- Closes #1331
