### PR TITLE
Add configurable scene start time and timeline support

### DIFF
--- a/src/Beutl.Language/Strings.Designer.cs
+++ b/src/Beutl.Language/Strings.Designer.cs
@@ -1443,15 +1443,15 @@ namespace Beutl.Language {
             }
         }
         
-        public static string AdjustDurationToCurrent {
+        public static string SetStartTime {
             get {
-                return ResourceManager.GetString("AdjustDurationToCurrent", resourceCulture);
+                return ResourceManager.GetString("SetStartTime", resourceCulture);
             }
         }
         
-        public static string AdjustDurationToPointer {
+        public static string SetEndTime {
             get {
-                return ResourceManager.GetString("AdjustDurationToPointer", resourceCulture);
+                return ResourceManager.GetString("SetEndTime", resourceCulture);
             }
         }
         

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -821,11 +821,11 @@
   <data name="Hand" xml:space="preserve">
     <value>ハンド</value>
   </data>
-  <data name="AdjustDurationToCurrent" xml:space="preserve">
-    <value>現在の位置に時間を調整</value>
+  <data name="SetStartTime" xml:space="preserve">
+    <value>開始時間を設定</value>
   </data>
-  <data name="AdjustDurationToPointer" xml:space="preserve">
-    <value>ポインターの位置に時間を調整</value>
+  <data name="SetEndTime" xml:space="preserve">
+    <value>終了時間を設定</value>
   </data>
   <data name="Editor" xml:space="preserve">
     <value>エディター</value>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -816,11 +816,11 @@
   <data name="Hand" xml:space="preserve">
     <value>Hand</value>
   </data>
-  <data name="AdjustDurationToCurrent" xml:space="preserve">
-    <value>Adjust duration to current frame</value>
+  <data name="SetStartTime" xml:space="preserve">
+    <value>Set start time</value>
   </data>
-  <data name="AdjustDurationToPointer" xml:space="preserve">
-    <value>Adjust duration to pointer position</value>
+  <data name="SetEndTime" xml:space="preserve">
+    <value>Set end time</value>
   </data>
   <data name="Editor" xml:space="preserve">
     <value>Editor</value>

--- a/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
@@ -45,10 +45,12 @@ public class Scene : ProjectItem, IAffectsRender
 {
     public static readonly CoreProperty<PixelSize> FrameSizeProperty;
     public static readonly CoreProperty<Elements> ChildrenProperty;
+    public static readonly CoreProperty<TimeSpan> StartProperty;
     public static readonly CoreProperty<TimeSpan> DurationProperty;
     private readonly List<string> _includeElements = ["**/*.belm"];
     private readonly List<string> _excludeElements = [];
     private readonly Elements _children;
+    private TimeSpan _start = TimeSpan.FromMinutes(0);
     private TimeSpan _duration = TimeSpan.FromMinutes(5);
     private PixelSize _frameSize;
 
@@ -77,6 +79,10 @@ public class Scene : ProjectItem, IAffectsRender
             .Accessor(o => o.Children, (o, v) => o.Children = v)
             .Register();
 
+        StartProperty = ConfigureProperty<TimeSpan, Scene>(nameof(Start))
+            .Accessor(o => o.Start, (o, v) => o.Start = v)
+            .Register();
+
         DurationProperty = ConfigureProperty<TimeSpan, Scene>(nameof(Duration))
             .Accessor(o => o.Duration, (o, v) => o.Duration = v)
             .Register();
@@ -88,6 +94,19 @@ public class Scene : ProjectItem, IAffectsRender
     {
         get => _frameSize;
         set => SetAndRaise(FrameSizeProperty, ref _frameSize, value);
+    }
+
+    [Display(Name = nameof(Strings.StartTime), ResourceType = typeof(Strings))]
+    public TimeSpan Start
+    {
+        get => _start;
+        set
+        {
+            if (value < TimeSpan.Zero)
+                value = TimeSpan.Zero;
+
+            SetAndRaise(StartProperty, ref _start, value);
+        }
     }
 
     [Display(Name = nameof(Strings.DurationTime), ResourceType = typeof(Strings))]

--- a/src/Beutl/Models/BufferedPlayer.cs
+++ b/src/Beutl/Models/BufferedPlayer.cs
@@ -57,7 +57,8 @@ public sealed class BufferedPlayer : IPlayer
             {
                 _logger.LogInformation("Start rendering from frame {StartFrame} to {DurationFrame}", startFrame,
                     durationFrame);
-                for (int frame = startFrame; frame < durationFrame; frame++)
+                int endFrame = (int)_scene.Start.ToFrameNumber(_rate) + durationFrame;
+                for (int frame = startFrame; frame < endFrame; frame++)
                 {
                     if (!_isPlaying.Value)
                     {

--- a/src/Beutl/Models/FrameProviderImpl.cs
+++ b/src/Beutl/Models/FrameProviderImpl.cs
@@ -16,8 +16,8 @@ public class FrameProviderImpl(Scene scene, Rational rate, SceneRenderer rendere
     private Bitmap<Bgra8888> RenderCore(TimeSpan time)
     {
         int retry = 0;
-    Retry:
-        if (renderer.Render(time))
+        Retry:
+        if (renderer.Render(time + scene.Start))
         {
             return renderer.Snapshot();
         }

--- a/src/Beutl/Models/SampleProviderImpl.cs
+++ b/src/Beutl/Models/SampleProviderImpl.cs
@@ -19,7 +19,7 @@ public class SampleProviderImpl(Scene scene, SceneComposer composer, long sample
     {
         _lastPcm?.Dispose();
         _lastPcm = null;
-        var pcm = composer.Compose(TimeSpan.FromTicks(TimeSpan.TicksPerSecond * offset / sampleRate))
+        var pcm = composer.Compose(TimeSpan.FromTicks(TimeSpan.TicksPerSecond * offset / sampleRate) + scene.Start)
                   ?? throw new InvalidOperationException("composer.Composeがnullを返しました。");
         _lastPcm = pcm;
         _lastOffset = offset;

--- a/src/Beutl/Services/PrimitiveImpls/TimelineTabExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/TimelineTabExtension.cs
@@ -59,6 +59,14 @@ public sealed class TimelineTabExtension : ToolTabExtension
             new ContextCommandKeyGesture("Ctrl+K"),
             new ContextCommandKeyGesture("Cmd+K", OSPlatform.OSX),
         ]),
+        new ContextCommandDefinition("SetStartTime", Strings.SetStartTime, "",
+        [
+            new ContextCommandKeyGesture("OemOpenBrackets")
+        ]),
+        new ContextCommandDefinition("SetEndTime", Strings.SetEndTime, "",
+        [
+            new ContextCommandKeyGesture("OemCloseBrackets")
+        ]),
     ];
 
     public override IconSource GetIcon()

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -38,8 +38,13 @@ public sealed partial class EditViewModel : IEditorContext, ITimelineOptionsProv
 
         Scene = scene;
         SceneId = scene.Id.ToString();
+        Scene.Children.Attached += OnElementAttached;
+        Scene.Children.Detached += OnElementDetached;
         CurrentTime = new ReactivePropertySlim<TimeSpan>()
             .DisposeWith(_disposables);
+        MaximumTime = new ReactivePropertySlim<TimeSpan>()
+            .DisposeWith(_disposables);
+        CalculateMaximumTime();
         Renderer = scene.GetObservable(Scene.FrameSizeProperty).Select(_ => new SceneRenderer(Scene))
             .DisposePreviousValue()
             .ToReadOnlyReactivePropertySlim()
@@ -94,6 +99,67 @@ public sealed partial class EditViewModel : IEditorContext, ITimelineOptionsProv
         RestoreState();
 
         _logger.LogInformation("Initialized EditViewModel for Scene ({SceneId}).", SceneId);
+    }
+
+    private void OnElementDetached(Element obj)
+    {
+        obj.PropertyChanged -= OnElementPropertyChanged;
+
+        if (MaximumTime.Value < obj.Range.End)
+        {
+            MaximumTime.Value = obj.Range.End;
+        }
+        else
+        {
+            CalculateMaximumTime();
+        }
+    }
+
+    private void OnElementAttached(Element obj)
+    {
+        obj.PropertyChanged += OnElementPropertyChanged;
+
+        if (MaximumTime.Value < obj.Range.End)
+        {
+            MaximumTime.Value = obj.Range.End;
+        }
+        else
+        {
+            CalculateMaximumTime();
+        }
+    }
+
+    private void CalculateMaximumTime()
+    {
+        MaximumTime.Value = Scene.Children.Count > 0
+            ? Scene.Children.Max(i => i.Range.End)
+            : TimeSpan.Zero;
+    }
+
+    private void OnElementPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e is CorePropertyChangedEventArgs<TimeSpan> typedArgs)
+        {
+            bool startChanged = typedArgs.Property.Id == Element.StartProperty.Id;
+            bool lengthChanged = typedArgs.Property.Id == Element.LengthProperty.Id;
+
+            if (sender is Element element && (startChanged || lengthChanged))
+            {
+                // 変更前の値を取得
+                TimeRange oldRange = element.Range;
+                if (startChanged) oldRange = oldRange.WithStart(typedArgs.OldValue);
+                if (lengthChanged) oldRange = oldRange.WithDuration(typedArgs.OldValue);
+
+                if (MaximumTime.Value < element.Range.End)
+                {
+                    MaximumTime.Value = element.Range.End;
+                }
+                else if (MaximumTime.Value == oldRange.End)
+                {
+                    CalculateMaximumTime();
+                }
+            }
+        }
     }
 
     private static FrameCacheOptions CreateFrameCacheOptions()
@@ -197,6 +263,9 @@ public sealed partial class EditViewModel : IEditorContext, ITimelineOptionsProv
 
     public ReactivePropertySlim<TimeSpan> CurrentTime { get; }
 
+    // Timelineの横幅をmax(MaximumTime, start+duration)で決める
+    public ReactivePropertySlim<TimeSpan> MaximumTime { get; }
+
     public ReadOnlyReactivePropertySlim<SceneRenderer> Renderer { get; }
 
     public ReadOnlyReactivePropertySlim<SceneComposer> Composer { get; }
@@ -299,7 +368,10 @@ public sealed partial class EditViewModel : IEditorContext, ITimelineOptionsProv
             ["selected-object"] = SelectedObject.Value?.Id,
             ["max-layer-count"] = Options.Value.MaxLayerCount,
             ["scale"] = Options.Value.Scale,
-            ["offset"] = new JsonObject { ["x"] = Options.Value.Offset.X, ["y"] = Options.Value.Offset.Y, }
+            ["offset"] = new JsonObject
+            {
+                ["x"] = Options.Value.Offset.X, ["y"] = Options.Value.Offset.Y,
+            }
         };
 
         DockHost.WriteToJson(json);
@@ -393,13 +465,15 @@ public sealed partial class EditViewModel : IEditorContext, ITimelineOptionsProv
 
         return null;
     }
+
     public void AddElement(ElementDescription desc)
     {
         _logger.LogInformation("Adding new element with description: {Description}", desc);
 
         Element CreateElement()
         {
-            _logger.LogDebug("Creating new element with start: {Start}, length: {Length}, layer: {Layer}", desc.Start, desc.Length, desc.Layer);
+            _logger.LogDebug("Creating new element with start: {Start}, length: {Length}, layer: {Layer}", desc.Start,
+                desc.Length, desc.Layer);
             return new Element()
             {
                 Start = desc.Start,
@@ -420,7 +494,9 @@ public sealed partial class EditViewModel : IEditorContext, ITimelineOptionsProv
         {
             if (!desc.Position.IsDefault)
             {
-                _logger.LogDebug("Setting transform for operation: {Operation}, operator: {Operator}, position: {Position}", operation, op, desc.Position);
+                _logger.LogDebug(
+                    "Setting transform for operation: {Operation}, operator: {Operator}, position: {Position}",
+                    operation, op, desc.Position);
                 if (op.Properties.FirstOrDefault(v => v.PropertyType == typeof(ITransform)) is
                     IPropertyAdapter<ITransform?> transformp)
                 {
@@ -617,7 +693,8 @@ public sealed partial class EditViewModel : IEditorContext, ITimelineOptionsProv
                          .ToArray())
             {
                 timeline.DetachInline(item);
-                _logger.LogInformation("Detached inline animation ({AnimationId}) from timeline.", item.Property.Animation);
+                _logger.LogInformation("Detached inline animation ({AnimationId}) from timeline.",
+                    item.Property.Animation);
             }
         }
 

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -304,6 +304,12 @@ public sealed partial class EditViewModel : IEditorContext, ITimelineOptionsProv
     public async ValueTask DisposeAsync()
     {
         _logger.LogInformation("Disposing EditViewModel ({SceneId}).", SceneId);
+        foreach (Element element in Scene.Children)
+        {
+            element.PropertyChanged -= OnElementPropertyChanged;
+        }
+        Scene.Children.Attached -= OnElementAttached;
+        Scene.Children.Detached -= OnElementDetached;
         GlobalConfiguration.Instance.EditorConfig.PropertyChanged -= OnEditorConfigPropertyChanged;
         SaveState();
         await Player.DisposeAsync();

--- a/src/Beutl/ViewModels/GraphEditorViewModel.cs
+++ b/src/Beutl/ViewModels/GraphEditorViewModel.cs
@@ -138,8 +138,18 @@ public abstract class GraphEditorViewModel : IDisposable
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
 
-        PanelWidth = editViewModel.MaximumTime.CombineLatest(editViewModel.Scale)
-            .Select(i => i.First.ToPixel(i.Second))
+
+        PanelWidth = editViewModel.MaximumTime
+            .CombineLatest(
+                Scene.GetObservable(Scene.DurationProperty),
+                Scene.GetObservable(Scene.StartProperty),
+                editViewModel.CurrentTime)
+            .Select(i => TimeSpan.FromTicks(
+                Math.Max(
+                    Math.Max(i.First.Ticks, i.Second.Ticks + i.Third.Ticks),
+                    i.Fourth.Ticks)))
+            .CombineLatest(editViewModel.Scale)
+            .Select(i => i.First.ToPixel(i.Second) + 500)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
 

--- a/src/Beutl/ViewModels/GraphEditorViewModel.cs
+++ b/src/Beutl/ViewModels/GraphEditorViewModel.cs
@@ -32,7 +32,8 @@ public sealed class GraphEditorViewModel<T>(
 
         TimeSpan threshold = TimeSpan.FromSeconds(1d / rate) * 3;
 
-        IKeyFrame? keyFrame = Animation.KeyFrames.FirstOrDefault(v => Math.Abs(v.KeyTime.Ticks - keyTime.Ticks) <= threshold.Ticks);
+        IKeyFrame? keyFrame =
+            Animation.KeyFrames.FirstOrDefault(v => Math.Abs(v.KeyTime.Ticks - keyTime.Ticks) <= threshold.Ticks);
         if (keyFrame != null)
         {
             _logger.LogInformation("Editing existing key frame at {KeyTime}", keyTime);
@@ -55,7 +56,12 @@ public sealed class GraphEditorViewModel<T>(
         if (!kfAnimation.KeyFrames.Any(x => x.KeyTime == keyTime))
         {
             CommandRecorder recorder = EditorContext.CommandRecorder;
-            var keyframe = new KeyFrame<T> { Value = kfAnimation.Interpolate(keyTime), Easing = easing, KeyTime = keyTime };
+            var keyframe = new KeyFrame<T>
+            {
+                Value = kfAnimation.Interpolate(keyTime),
+                Easing = easing,
+                KeyTime = keyTime
+            };
 
             RecordableCommands.Create(GetStorables())
                 .OnDo(() => kfAnimation.KeyFrames.Add(keyframe, out _))
@@ -96,7 +102,8 @@ public abstract class GraphEditorViewModel : IDisposable
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
 
-        ElementColor = (Element?.GetObservable(Element.AccentColorProperty) ?? Observable.Return(Beutl.Media.Colors.Transparent))
+        ElementColor = (Element?.GetObservable(Element.AccentColorProperty) ??
+                        Observable.Return(Beutl.Media.Colors.Transparent))
             .Select(v => (IBrush)new ImmutableSolidColorBrush(v.ToAvalonia()))
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
@@ -120,6 +127,13 @@ public abstract class GraphEditorViewModel : IDisposable
         SeekBarMargin = editViewModel.CurrentTime
             .CombineLatest(editViewModel.Scale)
             .Select(item => new Thickness(item.First.ToPixel(item.Second), 0, 0, 0))
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        StartingBarMargin = Scene.GetObservable(Scene.StartProperty)
+            .CombineLatest(editViewModel.Scale)
+            .Select(item => item.First.ToPixel(item.Second))
+            .Select(p => new Thickness(p, 0, 0, 0))
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
 
@@ -167,6 +181,8 @@ public abstract class GraphEditorViewModel : IDisposable
     public ReadOnlyReactivePropertySlim<double> PanelWidth { get; }
 
     public ReadOnlyReactivePropertySlim<Thickness> SeekBarMargin { get; }
+
+    public ReadOnlyReactivePropertySlim<Thickness> StartingBarMargin { get; }
 
     public ReadOnlyReactivePropertySlim<Thickness> EndingBarMargin { get; }
 

--- a/src/Beutl/ViewModels/GraphEditorViewModel.cs
+++ b/src/Beutl/ViewModels/GraphEditorViewModel.cs
@@ -118,12 +118,6 @@ public abstract class GraphEditorViewModel : IDisposable
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
 
-        PanelWidth = Scene.GetObservable(Scene.DurationProperty)
-            .CombineLatest(editViewModel.Scale)
-            .Select(item => item.First.ToPixel(item.Second))
-            .ToReadOnlyReactivePropertySlim()
-            .DisposeWith(_disposables);
-
         SeekBarMargin = editViewModel.CurrentTime
             .CombineLatest(editViewModel.Scale)
             .Select(item => new Thickness(item.First.ToPixel(item.Second), 0, 0, 0))
@@ -137,7 +131,15 @@ public abstract class GraphEditorViewModel : IDisposable
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
 
-        EndingBarMargin = PanelWidth.Select(p => new Thickness(p, 0, 0, 0))
+        EndingBarMargin = Scene.GetObservable(Scene.DurationProperty)
+            .CombineLatest(editViewModel.Scale, StartingBarMargin)
+            .Select(item => item.First.ToPixel(item.Second) + item.Third.Left)
+            .Select(p => new Thickness(p, 0, 0, 0))
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        PanelWidth = editViewModel.MaximumTime.CombineLatest(editViewModel.Scale)
+            .Select(i => i.First.ToPixel(i.Second))
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
 

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -74,10 +74,12 @@ public sealed class PlayerViewModel : IAsyncDisposable
         Start = new ReactiveCommand(_isEnabled)
             .WithSubscribe(() =>
             {
+                int rate = GetFrameRate();
+                var endTime = Scene.Start + Scene.Duration - TimeSpan.FromSeconds(1d / rate);
                 // 現在の時間がスタートと同じ場合、0に移動
                 EditViewModel.CurrentTime.Value =
-                    EditViewModel.CurrentTime.Value > Scene.Start + Scene.Duration
-                        ? Scene.Start + Scene.Duration
+                    EditViewModel.CurrentTime.Value > endTime
+                        ? endTime
                         : EditViewModel.CurrentTime.Value > Scene.Start
                             ? Scene.Start
                             : TimeSpan.Zero;
@@ -87,19 +89,15 @@ public sealed class PlayerViewModel : IAsyncDisposable
         End = new ReactiveCommand(_isEnabled)
             .WithSubscribe(() =>
             {
-                // 現在の時間がスタートと同じ場合、0に移動
-                // EditViewModel.CurrentTime.Value = EditViewModel.CurrentTime.Value == Scene.Start + Scene.Duration
-                //     ? Scene.Children.Count > 0 ? Scene.Children.Max(i => i.Start + i.Length) : TimeSpan.Zero
-                //     : Scene.Start + Scene.Duration;
-                //
-
+                int rate = GetFrameRate();
+                var endTime = Scene.Start + Scene.Duration - TimeSpan.FromSeconds(1d / rate);
                 EditViewModel.CurrentTime.Value =
                     EditViewModel.CurrentTime.Value < Scene.Start
                         ? Scene.Start
-                        : EditViewModel.CurrentTime.Value < Scene.Start + Scene.Duration
-                            ? Scene.Start + Scene.Duration
+                        : EditViewModel.CurrentTime.Value < endTime
+                            ? endTime
                             : Scene.Children.Count > 0
-                                ? Scene.Children.Max(i => i.Start + i.Length)
+                                ? Scene.Children.Max(i => i.Start + i.Length) - TimeSpan.FromSeconds(1d / rate)
                                 : TimeSpan.Zero;
             })
             .DisposeWith(_disposables);

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -122,7 +122,13 @@ public sealed class PlayerViewModel : IAsyncDisposable
             .CombineLatest(Scene.GetObservable(Scene.DurationProperty), Scene.GetObservable(Scene.StartProperty),
                 CurrentFrame)
             .Select(i =>
-                TimeSpan.FromTicks(Math.Max(Math.Max(i.First.Ticks, i.Second.Ticks + i.Third.Ticks), i.Fourth.Ticks)))
+            {
+                // このDurationはSliderの最大値に使うので、一フレーム分を引く
+                var frame = TimeSpan.FromSeconds(1.0 / GetFrameRate());
+                return TimeSpan.FromTicks(Math.Max(
+                    Math.Max(i.First.Ticks - frame.Ticks, i.Second.Ticks + i.Third.Ticks - frame.Ticks),
+                    i.Fourth.Ticks));
+            })
             .ToReadOnlyReactiveProperty()
             .DisposeWith(_disposables);
 

--- a/src/Beutl/ViewModels/TimelineViewModel.cs
+++ b/src/Beutl/ViewModels/TimelineViewModel.cs
@@ -285,7 +285,7 @@ public sealed class TimelineViewModel : IToolContext, IContextCommandHandler
     private void OnSetEndTimeToPointerPosition()
     {
         int rate = Scene.FindHierarchicalParent<Project>().GetFrameRate();
-        TimeSpan time = ClickedFrame + TimeSpan.FromSeconds(1d / rate) - Scene.Start;
+        TimeSpan time = ClickedFrame + TimeSpan.FromSeconds(1d / rate);
         SetEndTimeCore(time);
     }
 

--- a/src/Beutl/ViewModels/TimelineViewModel.cs
+++ b/src/Beutl/ViewModels/TimelineViewModel.cs
@@ -59,6 +59,13 @@ public sealed class TimelineViewModel : IToolContext, IContextCommandHandler
             .ToReadOnlyReactivePropertySlim()
             .AddTo(_disposables);
 
+        StartingBarMargin = Scene.GetObservable(Scene.StartProperty)
+            .CombineLatest(editViewModel.Scale)
+            .Select(item => item.First.ToPixel(item.Second))
+            .Select(p => new Thickness(p, 0, 0, 0))
+            .ToReadOnlyReactivePropertySlim()
+            .AddTo(_disposables);
+
         EndingBarMargin = PanelWidth.Select(p => new Thickness(p, 0, 0, 0))
             .ToReadOnlyReactivePropertySlim()
             .AddTo(_disposables);
@@ -139,7 +146,8 @@ public sealed class TimelineViewModel : IToolContext, IContextCommandHandler
             {
                 if (HoveredCacheBlock.Value is not { } block) return;
 
-                _logger.LogInformation("Deleting frame cache for block starting at frame {StartFrame}.", block.StartFrame);
+                _logger.LogInformation("Deleting frame cache for block starting at frame {StartFrame}.",
+                    block.StartFrame);
                 FrameCacheManager manager = EditorContext.FrameCacheManager.Value;
                 if (block.IsLocked)
                 {
@@ -157,7 +165,8 @@ public sealed class TimelineViewModel : IToolContext, IContextCommandHandler
             {
                 if (HoveredCacheBlock.Value is not { } block) return;
 
-                _logger.LogInformation("Locking frame cache for block starting at frame {StartFrame}.", block.StartFrame);
+                _logger.LogInformation("Locking frame cache for block starting at frame {StartFrame}.",
+                    block.StartFrame);
                 FrameCacheManager manager = EditorContext.FrameCacheManager.Value;
                 manager.Lock(
                     block.StartFrame, block.StartFrame + block.LengthFrame);
@@ -171,7 +180,8 @@ public sealed class TimelineViewModel : IToolContext, IContextCommandHandler
             {
                 if (HoveredCacheBlock.Value is not { } block) return;
 
-                _logger.LogInformation("Unlocking frame cache for block starting at frame {StartFrame}.", block.StartFrame);
+                _logger.LogInformation("Unlocking frame cache for block starting at frame {StartFrame}.",
+                    block.StartFrame);
                 FrameCacheManager manager = EditorContext.FrameCacheManager.Value;
                 manager.Unlock(
                     block.StartFrame, block.StartFrame + block.LengthFrame);
@@ -181,6 +191,7 @@ public sealed class TimelineViewModel : IToolContext, IContextCommandHandler
 
         _logger.LogInformation("TimelineViewModel initialized successfully.");
     }
+
     private void OnAdjustDurationToPointer()
     {
         _logger.LogInformation("Adjusting scene duration to pointer position.");
@@ -214,6 +225,8 @@ public sealed class TimelineViewModel : IToolContext, IContextCommandHandler
     public ReadOnlyReactivePropertySlim<double> PanelWidth { get; }
 
     public ReadOnlyReactivePropertySlim<Thickness> SeekBarMargin { get; }
+
+    public ReadOnlyReactivePropertySlim<Thickness> StartingBarMargin { get; }
 
     public ReadOnlyReactivePropertySlim<Thickness> EndingBarMargin { get; }
 
@@ -465,7 +478,8 @@ public sealed class TimelineViewModel : IToolContext, IContextCommandHandler
                 if (anmProp != null)
                 {
                     AttachInline(anmProp, element);
-                    _logger.LogDebug("Inline animation attached for element {ElementId} and animation {AnimationId}.", element.Id, anmId);
+                    _logger.LogDebug("Inline animation attached for element {ElementId} and animation {AnimationId}.",
+                        element.Id, anmId);
                 }
                 else if (animatable != null)
                 {
@@ -475,11 +489,15 @@ public sealed class TimelineViewModel : IToolContext, IContextCommandHandler
                         var createdProp =
                             (IAnimatablePropertyAdapter)Activator.CreateInstance(type, anm.Property, animatable)!;
                         AttachInline(createdProp, element);
-                        _logger.LogDebug("Inline animation created and attached for element {ElementId} and animation {AnimationId}.", element.Id, anmId);
+                        _logger.LogDebug(
+                            "Inline animation created and attached for element {ElementId} and animation {AnimationId}.",
+                            element.Id, anmId);
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogError(ex, "An exception occurred while restoring the inline animation for element {ElementId} and animation {AnimationId}.", element.Id, anmId);
+                        _logger.LogError(ex,
+                            "An exception occurred while restoring the inline animation for element {ElementId} and animation {AnimationId}.",
+                            element.Id, anmId);
                     }
                 }
             }
@@ -512,7 +530,9 @@ public sealed class TimelineViewModel : IToolContext, IContextCommandHandler
                 Guid elementId = item.Element.Model.Id;
 
                 inlines.Add(new JsonObject { ["AnimationId"] = anmId, ["ElementId"] = elementId });
-                _logger.LogDebug("Inline animation state written to JSON for element {ElementId} and animation {AnimationId}.", elementId, anmId);
+                _logger.LogDebug(
+                    "Inline animation state written to JSON for element {ElementId} and animation {AnimationId}.",
+                    elementId, anmId);
             }
         }
 
@@ -523,7 +543,8 @@ public sealed class TimelineViewModel : IToolContext, IContextCommandHandler
 
     public void AttachInline(IAnimatablePropertyAdapter property, Element element)
     {
-        _logger.LogInformation("Attaching inline animation for element {ElementId} and property {Property}.", element.Id, property);
+        _logger.LogInformation("Attaching inline animation for element {ElementId} and property {Property}.",
+            element.Id, property);
         if (Inlines.Any(x => x.Element.Model == element && x.Property == property))
         {
             _logger.LogWarning("Inline animation already attached for element {ElementId}.", element.Id);
@@ -538,7 +559,8 @@ public sealed class TimelineViewModel : IToolContext, IContextCommandHandler
 
         // タイムラインのタブを開く
         Type type = typeof(InlineAnimationLayerViewModel<>).MakeGenericType(property.PropertyType);
-        if (Activator.CreateInstance(type, property, this, viewModel) is InlineAnimationLayerViewModel anmTimelineViewModel)
+        if (Activator.CreateInstance(type, property, this, viewModel) is InlineAnimationLayerViewModel
+            anmTimelineViewModel)
         {
             Inlines.Add(anmTimelineViewModel);
             _logger.LogInformation("Inline animation attached successfully for element {ElementId}.", element.Id);
@@ -559,7 +581,8 @@ public sealed class TimelineViewModel : IToolContext, IContextCommandHandler
 
         Inlines.Remove(item);
         item.Dispose();
-        _logger.LogInformation("Inline animation detached successfully for element {ElementId}.", item.Element.Model.Id);
+        _logger.LogInformation("Inline animation detached successfully for element {ElementId}.",
+            item.Element.Model.Id);
     }
 
     public IObservable<double> GetTrackedLayerTopObservable(IObservable<int> layer)

--- a/src/Beutl/ViewModels/TimelineViewModel.cs
+++ b/src/Beutl/ViewModels/TimelineViewModel.cs
@@ -68,8 +68,17 @@ public sealed class TimelineViewModel : IToolContext, IContextCommandHandler
             .ToReadOnlyReactivePropertySlim()
             .AddTo(_disposables);
 
-        PanelWidth = editViewModel.MaximumTime.CombineLatest(editViewModel.Scale)
-            .Select(i => i.First.ToPixel(i.Second))
+        PanelWidth = editViewModel.MaximumTime
+            .CombineLatest(
+                Scene.GetObservable(Scene.DurationProperty),
+                Scene.GetObservable(Scene.StartProperty),
+                editViewModel.CurrentTime)
+            .Select(i => TimeSpan.FromTicks(
+                Math.Max(
+                    Math.Max(i.First.Ticks, i.Second.Ticks + i.Third.Ticks),
+                    i.Fourth.Ticks)))
+            .CombineLatest(editViewModel.Scale)
+            .Select(i => i.First.ToPixel(i.Second) + 500)
             .ToReadOnlyReactivePropertySlim()
             .AddTo(_disposables);
 

--- a/src/Beutl/ViewModels/TimelineViewModel.cs
+++ b/src/Beutl/ViewModels/TimelineViewModel.cs
@@ -47,11 +47,6 @@ public sealed class TimelineViewModel : IToolContext, IContextCommandHandler
         Scene = editViewModel.Scene;
         Player = editViewModel.Player;
         FrameSelectionRange = new FrameSelectionRange(editViewModel.Scale).DisposeWith(_disposables);
-        PanelWidth = Scene.GetObservable(Scene.DurationProperty)
-            .CombineLatest(editViewModel.Scale)
-            .Select(item => item.First.ToPixel(item.Second))
-            .ToReadOnlyReactivePropertySlim()
-            .AddTo(_disposables);
 
         SeekBarMargin = editViewModel.CurrentTime
             .CombineLatest(editViewModel.Scale)
@@ -66,7 +61,15 @@ public sealed class TimelineViewModel : IToolContext, IContextCommandHandler
             .ToReadOnlyReactivePropertySlim()
             .AddTo(_disposables);
 
-        EndingBarMargin = PanelWidth.Select(p => new Thickness(p, 0, 0, 0))
+        EndingBarMargin = Scene.GetObservable(Scene.DurationProperty)
+            .CombineLatest(editViewModel.Scale, StartingBarMargin)
+            .Select(item => item.First.ToPixel(item.Second) + item.Third.Left)
+            .Select(p => new Thickness(p, 0, 0, 0))
+            .ToReadOnlyReactivePropertySlim()
+            .AddTo(_disposables);
+
+        PanelWidth = editViewModel.MaximumTime.CombineLatest(editViewModel.Scale)
+            .Select(i => i.First.ToPixel(i.Second))
             .ToReadOnlyReactivePropertySlim()
             .AddTo(_disposables);
 

--- a/src/Beutl/ViewModels/Tools/SceneSettingsTabViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/SceneSettingsTabViewModel.cs
@@ -40,8 +40,8 @@ public sealed class SceneSettingsTabViewModel : IToolContext
         Height.SetValidateNotifyError(ValidateSize);
         LayerCount.SetValidateNotifyError(ValidateSize);
 
-        StartInput.SetValidateNotifyError(TimeSpanValidator);
-        DurationInput.SetValidateNotifyError(TimeSpanValidator);
+        StartInput.SetValidateNotifyError(StartValidator);
+        DurationInput.SetValidateNotifyError(DurationValidator);
 
         CanApply = Width.CombineLatest(Height, StartInput, DurationInput, LayerCount).Select(t =>
             {
@@ -52,7 +52,7 @@ public sealed class SceneSettingsTabViewModel : IToolContext
                 string durationTime = t.Fourth;
                 return width > 0 &&
                     height > 0 &&
-                    TimeSpan.TryParse(startTime, out TimeSpan ts1) && ts1 > TimeSpan.Zero &&
+                    TimeSpan.TryParse(startTime, out TimeSpan ts1) && ts1 >= TimeSpan.Zero &&
                     TimeSpan.TryParse(durationTime, out TimeSpan ts2) && ts2 > TimeSpan.Zero &&
                     t.Fifth > 0;
             })
@@ -99,13 +99,32 @@ public sealed class SceneSettingsTabViewModel : IToolContext
         return;
     }
 
-    private static string? TimeSpanValidator(string str)
+    private static string? DurationValidator(string str)
     {
         if (TimeSpan.TryParse(str, out TimeSpan time))
         {
             if (time <= TimeSpan.Zero)
             {
                 return Message.ValueLessThanOrEqualToZero;
+            }
+            else
+            {
+                return null;
+            }
+        }
+        else
+        {
+            return Message.InvalidString;
+        }
+    }
+
+    private static string? StartValidator(string str)
+    {
+        if (TimeSpan.TryParse(str, out TimeSpan time))
+        {
+            if (time < TimeSpan.Zero)
+            {
+                return Message.ValueLessThanZero;
             }
             else
             {

--- a/src/Beutl/ViewModels/Tools/SceneSettingsTabViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/SceneSettingsTabViewModel.cs
@@ -24,6 +24,10 @@ public sealed class SceneSettingsTabViewModel : IToolContext
         Height = frameSize.Select(v => v.Height)
             .ToReactiveProperty()
             .DisposeWith(_disposable);
+        StartInput = _scene.GetObservable(Scene.StartProperty)
+            .Select(v => v.ToString())
+            .ToReactiveProperty()
+            .DisposeWith(_disposable)!;
         DurationInput = _scene.GetObservable(Scene.DurationProperty)
             .Select(v => v.ToString())
             .ToReactiveProperty()
@@ -35,35 +39,22 @@ public sealed class SceneSettingsTabViewModel : IToolContext
         Width.SetValidateNotifyError(ValidateSize);
         Height.SetValidateNotifyError(ValidateSize);
         LayerCount.SetValidateNotifyError(ValidateSize);
-        DurationInput.SetValidateNotifyError(str =>
-        {
-            if (TimeSpan.TryParse(str, out TimeSpan time))
-            {
-                if (time <= TimeSpan.Zero)
-                {
-                    return Message.ValueLessThanOrEqualToZero;
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            else
-            {
-                return Message.InvalidString;
-            }
-        });
 
-        CanApply = Width.CombineLatest(Height, DurationInput, LayerCount).Select(t =>
+        StartInput.SetValidateNotifyError(TimeSpanValidator);
+        DurationInput.SetValidateNotifyError(TimeSpanValidator);
+
+        CanApply = Width.CombineLatest(Height, StartInput, DurationInput, LayerCount).Select(t =>
             {
                 int width = t.First;
                 int height = t.Second;
 
-                string time = t.Third;
+                string startTime = t.Third;
+                string durationTime = t.Fourth;
                 return width > 0 &&
                     height > 0 &&
-                    TimeSpan.TryParse(time, out TimeSpan ts) && ts > TimeSpan.Zero &&
-                    t.Fourth > 0;
+                    TimeSpan.TryParse(startTime, out TimeSpan ts1) && ts1 > TimeSpan.Zero &&
+                    TimeSpan.TryParse(durationTime, out TimeSpan ts2) && ts2 > TimeSpan.Zero &&
+                    t.Fifth > 0;
             })
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposable);
@@ -71,15 +62,18 @@ public sealed class SceneSettingsTabViewModel : IToolContext
         Apply = new ReactiveCommand(CanApply)
             .WithSubscribe(() =>
             {
-                if (TimeSpan.TryParse(DurationInput.Value, out TimeSpan ts))
+                if (TimeSpan.TryParse(StartInput.Value, out TimeSpan start)
+                    &&TimeSpan.TryParse(DurationInput.Value, out TimeSpan duration))
                 {
                     if (Width.Value != _scene.FrameSize.Width
                         || Height.Value != _scene.FrameSize.Height
-                        || ts != _scene.Duration)
+                        || start != _scene.Start
+                        || duration != _scene.Duration)
                     {
                         CommandRecorder recorder = _editViewModel.CommandRecorder;
                         RecordableCommands.Edit(_scene, Scene.FrameSizeProperty, new(Width.Value, Height.Value))
-                            .Append(RecordableCommands.Edit(_scene, Scene.DurationProperty, ts))
+                            .Append(RecordableCommands.Edit(_scene, Scene.StartProperty, start))
+                            .Append(RecordableCommands.Edit(_scene, Scene.DurationProperty, duration))
                             .WithStoables([_scene])
                             .DoAndRecord(recorder);
                     }
@@ -97,10 +91,31 @@ public sealed class SceneSettingsTabViewModel : IToolContext
             {
                 Width.Value = _scene.FrameSize.Width;
                 Height.Value = _scene.FrameSize.Height;
+                StartInput.Value = _scene.Start.ToString();
                 DurationInput.Value = _scene.Duration.ToString();
                 LayerCount.Value = _editViewModel.Options.Value.MaxLayerCount;
             })
             .DisposeWith(_disposable);
+        return;
+    }
+
+    private static string? TimeSpanValidator(string str)
+    {
+        if (TimeSpan.TryParse(str, out TimeSpan time))
+        {
+            if (time <= TimeSpan.Zero)
+            {
+                return Message.ValueLessThanOrEqualToZero;
+            }
+            else
+            {
+                return null;
+            }
+        }
+        else
+        {
+            return Message.InvalidString;
+        }
     }
 
     public ReactiveCommand Apply { get; }
@@ -110,6 +125,8 @@ public sealed class SceneSettingsTabViewModel : IToolContext
     public ReactiveProperty<int> Width { get; }
 
     public ReactiveProperty<int> Height { get; }
+
+    public ReactiveProperty<string> StartInput { get; }
 
     public ReactiveProperty<string> DurationInput { get; }
 

--- a/src/Beutl/ViewModels/Tools/SceneSettingsTabViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/SceneSettingsTabViewModel.cs
@@ -96,7 +96,6 @@ public sealed class SceneSettingsTabViewModel : IToolContext
                 LayerCount.Value = _editViewModel.Options.Value.MaxLayerCount;
             })
             .DisposeWith(_disposable);
-        return;
     }
 
     private static string? DurationValidator(string str)

--- a/src/Beutl/Views/GraphEditorView.axaml
+++ b/src/Beutl/Views/GraphEditorView.axaml
@@ -42,11 +42,13 @@
                              ScaleBrush="{DynamicResource TextControlForeground}"
                              SeekBarBrush="{DynamicResource AccentFillColorDefaultBrush}"
                              SeekBarMargin="{Binding SeekBarMargin.Value}"
+                             StartingBarBrush="{DynamicResource SystemFillColorCriticalBrush}"
+                             StartingBarMargin="{Binding StartingBarMargin.Value}"
                              Offset="{Binding #scroll.Offset, Mode=OneWay}" />
 
-        <local:GraphEditorScale Grid.Row="1"
+        <local:GraphEditorScale x:Name="verticalScale"
+                                Grid.Row="1"
                                 Width="20"
-                                x:Name="verticalScale"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Stretch"
                                 Baseline="{Binding Baseline.Value}"
@@ -73,14 +75,12 @@
                                 <icons:SymbolIcon Symbol="Delete" />
                             </MenuItem.Icon>
                         </MenuItem>
-                        <MenuItem Header="{x:Static lang:Strings.CopyAll}"
-                                  Click="CopyAllClick">
+                        <MenuItem Click="CopyAllClick" Header="{x:Static lang:Strings.CopyAll}">
                             <MenuItem.Icon>
                                 <icons:SymbolIcon Symbol="DocumentCopy" />
                             </MenuItem.Icon>
                         </MenuItem>
-                        <MenuItem Header="{x:Static lang:Strings.Paste}"
-                                  Click="PasteClick">
+                        <MenuItem Click="PasteClick" Header="{x:Static lang:Strings.Paste}">
                             <MenuItem.Icon>
                                 <icons:SymbolIcon Symbol="ClipboardPaste" />
                             </MenuItem.Icon>
@@ -245,8 +245,7 @@
                                                               Fill="{DynamicResource SystemFillColorCaution}"
                                                               PointerPressed="OnKeyTimePointerPressed">
                                                             <Path.RenderTransform>
-                                                                <TranslateTransform X="{Binding RightTop.Value.X}"
-                                                                    Y="{Binding RightTop.Value.Y}" />
+                                                                <TranslateTransform X="{Binding RightTop.Value.X}" Y="{Binding RightTop.Value.Y}" />
                                                             </Path.RenderTransform>
                                                             <Path.Data>
                                                                 <PathGeometry>
@@ -271,8 +270,7 @@
                                                               StrokeThickness="3"
                                                               Tag="ControlPoint1">
                                                             <Path.RenderTransform>
-                                                                <TranslateTransform X="{Binding ControlPoint1.Value.X}"
-                                                                    Y="{Binding ControlPoint1.Value.Y}" />
+                                                                <TranslateTransform X="{Binding ControlPoint1.Value.X}" Y="{Binding ControlPoint1.Value.Y}" />
                                                             </Path.RenderTransform>
                                                         </Path>
 
@@ -288,8 +286,7 @@
                                                               StrokeThickness="3"
                                                               Tag="ControlPoint2">
                                                             <Path.RenderTransform>
-                                                                <TranslateTransform X="{Binding ControlPoint2.Value.X}"
-                                                                    Y="{Binding ControlPoint2.Value.Y}" />
+                                                                <TranslateTransform X="{Binding ControlPoint2.Value.X}" Y="{Binding ControlPoint2.Value.Y}" />
                                                             </Path.RenderTransform>
                                                         </Path>
                                                     </Panel>
@@ -309,6 +306,8 @@
                                        EndingBarMargin="{Binding EndingBarMargin.Value}"
                                        SeekBarBrush="{DynamicResource AccentFillColorDefaultBrush}"
                                        SeekBarMargin="{Binding SeekBarMargin.Value}"
+                                       StartingBarBrush="{DynamicResource SystemFillColorCriticalBrush}"
+                                       StartingBarMargin="{Binding StartingBarMargin.Value}"
                                        Viewport="{Binding #scroll.Viewport, Mode=OneWay}"
                                        ZIndex="6"
                                        Offset="{Binding #scroll.Offset, Mode=OneWay}" />

--- a/src/Beutl/Views/GraphEditorView.axaml.cs
+++ b/src/Beutl/Views/GraphEditorView.axaml.cs
@@ -10,6 +10,7 @@ using Beutl.Animation;
 using Beutl.Animation.Easings;
 using Beutl.Configuration;
 using Beutl.Helpers;
+using Beutl.ProjectSystem;
 using Beutl.Services;
 using Beutl.ViewModels;
 using Reactive.Bindings.Extensions;
@@ -22,7 +23,9 @@ namespace Beutl.Views;
 public partial class GraphEditorView : UserControl
 {
     private readonly CompositeDisposable _disposables = [];
-    private bool _pressed;
+    internal Timeline.MouseFlags _mouseFlag = Timeline.MouseFlags.Free;
+    private TimeSpan _initialStart;
+    private TimeSpan _initialDuration;
     private TimeSpan _lastRightClickPoint;
     private TimeSpan _pointerFrame;
 
@@ -44,7 +47,8 @@ public partial class GraphEditorView : UserControl
 
         scale.AddHandler(PointerWheelChangedEvent, OnContentPointerWheelChanged, RoutingStrategies.Tunnel);
         graphPanel.AddHandler(PointerWheelChangedEvent, OnContentPointerWheelChanged, RoutingStrategies.Tunnel);
-        verticalScale.AddHandler(PointerWheelChangedEvent, OnVerticalScalePointerWheelChanged, RoutingStrategies.Tunnel);
+        verticalScale.AddHandler(PointerWheelChangedEvent, OnVerticalScalePointerWheelChanged,
+            RoutingStrategies.Tunnel);
 
         this.SubscribeDataContextChange<GraphEditorViewModel>(
             OnDataContextAttached,
@@ -202,7 +206,10 @@ public partial class GraphEditorView : UserControl
             }
 
             Vector2 originalOffset = viewModel.Options.Value.Offset;
-            viewModel.Options.Value = viewModel.Options.Value with { Scale = scale, Offset = new Vector2(offset.X, originalOffset.Y) };
+            viewModel.Options.Value = viewModel.Options.Value with
+            {
+                Scale = scale, Offset = new Vector2(offset.X, originalOffset.Y)
+            };
 
             viewModel.ScrollOffset.Value = new(offset.X, offset.Y);
 
@@ -255,7 +262,10 @@ public partial class GraphEditorView : UserControl
             }
 
             Vector2 originalOffset = viewModel.Options.Value.Offset;
-            viewModel.Options.Value = viewModel.Options.Value with { Scale = scale, Offset = new Vector2(offset.X, originalOffset.Y) };
+            viewModel.Options.Value = viewModel.Options.Value with
+            {
+                Scale = scale, Offset = new Vector2(offset.X, originalOffset.Y)
+            };
 
             viewModel.ScrollOffset.Value = new(offset.X, offset.Y);
 
@@ -275,7 +285,7 @@ public partial class GraphEditorView : UserControl
 
     private void OnContentPointerExited(object? sender, PointerEventArgs e)
     {
-        _pressed = false;
+        _mouseFlag = Timeline.MouseFlags.Free;
     }
 
     private void OnContentPointerMoved(object? sender, PointerEventArgs e)
@@ -287,7 +297,8 @@ public partial class GraphEditorView : UserControl
             int rate = viewModel.Scene.FindHierarchicalParent<Project>().GetFrameRate();
             _pointerFrame = pointerPt.Position.X.ToTimeSpan(viewModel.Options.Value.Scale).RoundToRate(rate);
 
-            if (_pointerFrame >= viewModel.Scene.Duration)
+            if (_pointerFrame >= viewModel.Scene.Duration &&
+                _mouseFlag != Timeline.MouseFlags.EndingBarMarkerPressed)
             {
                 _pointerFrame = viewModel.Scene.Duration - TimeSpan.FromSeconds(1d / rate);
             }
@@ -297,21 +308,77 @@ public partial class GraphEditorView : UserControl
                 _pointerFrame = TimeSpan.Zero;
             }
 
-            if (_pressed)
+            if (_mouseFlag == Timeline.MouseFlags.SeekBarPressed)
             {
                 viewModel.EditorContext.CurrentTime.Value = _pointerFrame;
                 e.Handled = true;
+            }
+            else if (_mouseFlag == Timeline.MouseFlags.EndingBarMarkerPressed)
+            {
+                // ポインタ位置に基づいてシーンDurationを更新
+                TimeSpan newDuration = _pointerFrame;
+                if (newDuration < viewModel.Scene.Start)
+                {
+                    newDuration = viewModel.Scene.Start + TimeSpan.FromSeconds(1d / rate);
+                }
+
+                // 直接値を更新（コマンド記録なし）
+                viewModel.Scene.Duration = newDuration;
+                e.Handled = true;
+            }
+            else if (_mouseFlag == Timeline.MouseFlags.StartingBarMarkerPressed)
+            {
+                TimeSpan newStart = _pointerFrame;
+                if (newStart < TimeSpan.Zero)
+                {
+                    newStart = TimeSpan.Zero;
+                }
+                else if (newStart > viewModel.Scene.Duration)
+                {
+                    newStart = viewModel.Scene.Duration - TimeSpan.FromSeconds(1d / rate);
+                }
+
+                viewModel.Scene.Start = newStart;
+                e.Handled = true;
+            }
+            else
+            {
+                Point posScale = e.GetPosition(scale);
+                double startingBarX = viewModel.StartingBarMargin.Value.Left;
+                double endingBarX = viewModel.EndingBarMargin.Value.Left;
+
+                // EndingBarマーカーの当たり判定チェック
+                if (Timeline.IsPointInTimelineScaleMarker(posScale, startingBarX, endingBarX))
+                {
+                    scale.Cursor = new Cursor(StandardCursorType.SizeWestEast);
+                }
+                else
+                {
+                    scale.Cursor = Cursors.Arrow;
+                }
             }
         }
     }
 
     private void OnContentPointerReleased(object? sender, PointerReleasedEventArgs e)
     {
+        if (DataContext is not GraphEditorViewModel viewModel) return;
         PointerPoint pointerPt = e.GetCurrentPoint(graphPanel);
 
         if (pointerPt.Properties.PointerUpdateKind == PointerUpdateKind.LeftButtonReleased)
         {
-            _pressed = false;
+            if (_mouseFlag == Timeline.MouseFlags.EndingBarMarkerPressed)
+            {
+                RecordableCommands.Edit(viewModel.Scene, Scene.DurationProperty, viewModel.Scene.Duration, _initialDuration)
+                    .DoAndRecord(viewModel.EditorContext.CommandRecorder);
+            }
+            else if (_mouseFlag == Timeline.MouseFlags.StartingBarMarkerPressed)
+            {
+                RecordableCommands.Edit(viewModel.Scene, Scene.StartProperty, viewModel.Scene.Start, _initialStart)
+                    .DoAndRecord(viewModel.EditorContext.CommandRecorder);
+            }
+
+            _mouseFlag = Timeline.MouseFlags.Free;
         }
     }
 
@@ -323,10 +390,30 @@ public partial class GraphEditorView : UserControl
 
             if (pointerPt.Properties.IsLeftButtonPressed)
             {
-                _pressed = true;
+                double endingBarX = viewModel.EndingBarMargin.Value.Left;
+                double startingBarX = viewModel.StartingBarMargin.Value.Left;
+                Point scalePoint = e.GetPosition(scale);
 
-                viewModel.EditorContext.CurrentTime.Value = pointerPt.Position.X.ToTimeSpan(viewModel.Options.Value.Scale)
-                    .RoundToRate(viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30);
+                // マーカーの当たり判定チェック - TimelineScaleのマーカーのみ
+                if (Timeline.IsPointInTimelineScaleEndingMarker(scalePoint, endingBarX))
+                {
+                    _mouseFlag = Timeline.MouseFlags.EndingBarMarkerPressed;
+                    _initialDuration = viewModel.Scene.Duration; // 初期値を保存
+                }
+                else if (Timeline.IsPointInTimelineScaleStartingMarker(scalePoint, startingBarX))
+                {
+                    _mouseFlag = Timeline.MouseFlags.StartingBarMarkerPressed;
+                    _initialStart = viewModel.Scene.Start; // 初期値を保存
+                }
+                else
+                {
+                    _mouseFlag = Timeline.MouseFlags.SeekBarPressed;
+                    viewModel.EditorContext.CurrentTime.Value = pointerPt.Position.X
+                        .ToTimeSpan(viewModel.Options.Value.Scale)
+                        .RoundToRate(viewModel.Scene.FindHierarchicalParent<Project>() is { } proj
+                            ? proj.GetFrameRate()
+                            : 30);
+                }
 
                 e.Handled = true;
             }
@@ -549,7 +636,9 @@ public partial class GraphEditorView : UserControl
     private IKeyFrame? _keyframe;
     private TimeSpan _oldKeyTime;
     private GraphEditorKeyFrameViewModel? _keyframeViewModel;
+
     private bool _crossed;
+
     // 追従移動するキーフレーム
     private GraphEditorKeyFrameViewModel[]? _followingKeyFrames;
 
@@ -689,7 +778,9 @@ public partial class GraphEditorView : UserControl
             if (pointerPt.Properties.IsRightButtonPressed)
             {
                 _lastRightClickPoint = pointerPt.Position.X.ToTimeSpan(viewModel.Options.Value.Scale)
-                    .RoundToRate(viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30);
+                    .RoundToRate(viewModel.Scene.FindHierarchicalParent<Project>() is { } proj
+                        ? proj.GetFrameRate()
+                        : 30);
                 TimeSpan localTime = viewModel.ConvertKeyTime(_lastRightClickPoint);
 
                 deleteMenuItem.IsEnabled = viewModel.Animation.KeyFrames.Any(x => x.KeyTime == localTime);

--- a/src/Beutl/Views/GraphEditorView.axaml.cs
+++ b/src/Beutl/Views/GraphEditorView.axaml.cs
@@ -343,9 +343,9 @@ public partial class GraphEditorView : UserControl
                 double endingBarX = viewModel.EndingBarMargin.Value.Left;
 
                 // EndingBarマーカーの当たり判定チェック
-                if (Timeline.IsPointInTimelineScaleMarker(posScale, startingBarX, endingBarX))
+                if (Timeline.IsPointInTimelineScaleMarker(pointerPt.Position.X, posScale.Y, startingBarX, endingBarX))
                 {
-                    scale.Cursor = new Cursor(StandardCursorType.SizeWestEast);
+                    scale.Cursor = Cursors.SizeWestEast;
                 }
                 else
                 {
@@ -364,7 +364,8 @@ public partial class GraphEditorView : UserControl
         {
             if (_mouseFlag == Timeline.MouseFlags.EndingBarMarkerPressed)
             {
-                RecordableCommands.Edit(viewModel.Scene, Scene.DurationProperty, viewModel.Scene.Duration, _initialDuration)
+                RecordableCommands.Edit(viewModel.Scene, Scene.DurationProperty, viewModel.Scene.Duration,
+                        _initialDuration)
                     .DoAndRecord(viewModel.EditorContext.CommandRecorder);
             }
             else if (_mouseFlag == Timeline.MouseFlags.StartingBarMarkerPressed)
@@ -392,12 +393,12 @@ public partial class GraphEditorView : UserControl
                 Point scalePoint = e.GetPosition(scale);
 
                 // マーカーの当たり判定チェック - TimelineScaleのマーカーのみ
-                if (Timeline.IsPointInTimelineScaleEndingMarker(scalePoint, endingBarX))
+                if (Timeline.IsPointInTimelineScaleEndingMarker(pointerPt.Position.X, scalePoint.Y, endingBarX))
                 {
                     _mouseFlag = Timeline.MouseFlags.EndingBarMarkerPressed;
                     _initialDuration = viewModel.Scene.Duration; // 初期値を保存
                 }
-                else if (Timeline.IsPointInTimelineScaleStartingMarker(scalePoint, startingBarX))
+                else if (Timeline.IsPointInTimelineScaleStartingMarker(pointerPt.Position.X, scalePoint.Y, startingBarX))
                 {
                     _mouseFlag = Timeline.MouseFlags.StartingBarMarkerPressed;
                     _initialStart = viewModel.Scene.Start; // 初期値を保存

--- a/src/Beutl/Views/Timeline.axaml
+++ b/src/Beutl/Views/Timeline.axaml
@@ -122,8 +122,12 @@
                    PointerReleased="TimelinePanel_PointerReleased">
                 <Panel.ContextFlyout>
                     <ui:FAMenuFlyout>
-                        <ui:MenuFlyoutItem Command="{Binding AdjustDurationToPointer}" Text="{x:Static lang:Strings.AdjustDurationToPointer}" />
-                        <ui:MenuFlyoutItem Command="{Binding AdjustDurationToCurrent}" Text="{x:Static lang:Strings.AdjustDurationToCurrent}" />
+                        <ui:MenuFlyoutItem Command="{Binding SetStartTimeToPointerPosition}"
+                                           InputGesture="{h:GetCommandGestureExtension SetStartTime}"
+                                           Text="{x:Static lang:Strings.SetStartTime}" />
+                        <ui:MenuFlyoutItem Command="{Binding SetEndTimeToPointerPosition}"
+                                           InputGesture="{h:GetCommandGestureExtension SetEndTime}"
+                                           Text="{x:Static lang:Strings.SetEndTime}" />
                         <ui:ToggleMenuFlyoutItem IsChecked="{Binding AutoAdjustSceneDuration.Value, Mode=TwoWay}" Text="{x:Static lang:SettingsPage.AutoAdjustSceneDuration}" />
                         <ui:MenuFlyoutSeparator />
                         <ui:MenuFlyoutItem Click="AddElementClick" Text="{x:Static lang:Strings.AddElement}" />

--- a/src/Beutl/Views/Timeline.axaml
+++ b/src/Beutl/Views/Timeline.axaml
@@ -45,6 +45,8 @@
                              ScaleBrush="{DynamicResource TextControlForeground}"
                              SeekBarBrush="{DynamicResource AccentFillColorDefaultBrush}"
                              SeekBarMargin="{CompiledBinding SeekBarMargin.Value}"
+                             StartingBarBrush="{DynamicResource SystemFillColorCriticalBrush}"
+                             StartingBarMargin="{CompiledBinding StartingBarMargin.Value}"
                              Offset="{Binding #ContentScroll.Offset, Mode=OneWay}">
             <local:TimelineScale.ContextFlyout>
                 <ui:FAMenuFlyout>
@@ -177,6 +179,8 @@
                                        EndingBarMargin="{CompiledBinding EndingBarMargin.Value}"
                                        SeekBarBrush="{DynamicResource AccentFillColorDefaultBrush}"
                                        SeekBarMargin="{CompiledBinding SeekBarMargin.Value}"
+                                       StartingBarBrush="{DynamicResource SystemFillColorCriticalBrush}"
+                                       StartingBarMargin="{CompiledBinding StartingBarMargin.Value}"
                                        Viewport="{Binding #ContentScroll.Viewport, Mode=OneWay}"
                                        ZIndex="6"
                                        Offset="{Binding #ContentScroll.Offset, Mode=OneWay}" />

--- a/src/Beutl/Views/Timeline.axaml.cs
+++ b/src/Beutl/Views/Timeline.axaml.cs
@@ -505,12 +505,13 @@ public sealed partial class Timeline : UserControl
     }
 
     // TimelineScaleの長方形マーカーの当たり判定
-    private bool IsPointInTimelineScaleMarker(Point point, double startingBarX, double endingBarX)
+    // GraphEditorViewでも使用
+    internal static bool IsPointInTimelineScaleMarker(Point point, double startingBarX, double endingBarX)
     {
         return IsPointInTimelineScaleStartingMarker(point, startingBarX) || IsPointInTimelineScaleEndingMarker(point, endingBarX);
     }
 
-    private bool IsPointInTimelineScaleStartingMarker(Point point, double startingBarX)
+    internal static bool IsPointInTimelineScaleStartingMarker(Point point, double startingBarX)
     {
         // 長方形の範囲を計算
         var startRect = new Rect(startingBarX, 0, MarkerWidth, MarkerHeight);
@@ -519,7 +520,7 @@ public sealed partial class Timeline : UserControl
         return startRect.Contains(point);
     }
 
-    private bool IsPointInTimelineScaleEndingMarker(Point point, double endingBarX)
+    internal static bool IsPointInTimelineScaleEndingMarker(Point point, double endingBarX)
     {
         // 長方形の範囲を計算
         var endRect = new Rect(endingBarX - MarkerWidth, 0, MarkerWidth, MarkerHeight);

--- a/src/Beutl/Views/Timeline.axaml.cs
+++ b/src/Beutl/Views/Timeline.axaml.cs
@@ -383,18 +383,23 @@ public sealed partial class Timeline : UserControl
         }
         else if (_mouseFlag == MouseFlags.StartingBarMarkerPressed)
         {
-            TimeSpan newStart = _pointerFrame;
-            if (newStart < TimeSpan.Zero)
+            // Calculate the new starting point for the scene based on the pointer frame
+            TimeSpan clampedStart = _pointerFrame;
+            
+            // Ensure the new start time is not negative
+            if (clampedStart < TimeSpan.Zero)
             {
-                newStart = TimeSpan.Zero;
+                clampedStart = TimeSpan.Zero;
             }
-            else if (newStart > _initialDuration + _initialStart)
+            // Ensure the new start time does not exceed the total duration
+            else if (clampedStart > _initialDuration + _initialStart)
             {
-                newStart = _initialDuration + _initialStart - TimeSpan.FromSeconds(1d / rate);
+                clampedStart = _initialDuration + _initialStart - TimeSpan.FromSeconds(1d / rate);
             }
 
-            viewModel.Scene.Start = newStart;
-            viewModel.Scene.Duration = _initialDuration + _initialStart - newStart;
+            // Update the scene's start and duration based on the clamped start time
+            viewModel.Scene.Start = clampedStart;
+            viewModel.Scene.Duration = _initialDuration + _initialStart - clampedStart;
         }
         else
         {

--- a/src/Beutl/Views/Timeline.axaml.cs
+++ b/src/Beutl/Views/Timeline.axaml.cs
@@ -51,7 +51,7 @@ public sealed partial class Timeline : UserControl
     private CancellationTokenSource? _scrollCts;
 
     // 長方形マーカーのサイズを定義
-    private const int MarkerHeight = 16;
+    private const int MarkerHeight = 18;
     private const int MarkerWidth = 4;
 
     public Timeline()
@@ -403,9 +403,9 @@ public sealed partial class Timeline : UserControl
             double endingBarX = viewModel.EndingBarMargin.Value.Left;
 
             // EndingBarマーカーの当たり判定チェック
-            if (IsPointInTimelineScaleMarker(posScale, startingBarX, endingBarX))
+            if (IsPointInTimelineScaleMarker(pointerPt.Position.X, posScale.Y, startingBarX, endingBarX))
             {
-                Scale.Cursor = new Cursor(StandardCursorType.SizeWestEast);
+                Scale.Cursor = Cursors.SizeWestEast;
             }
             else
             {
@@ -506,28 +506,28 @@ public sealed partial class Timeline : UserControl
 
     // TimelineScaleの長方形マーカーの当たり判定
     // GraphEditorViewでも使用
-    internal static bool IsPointInTimelineScaleMarker(Point point, double startingBarX, double endingBarX)
+    internal static bool IsPointInTimelineScaleMarker(double x, double y, double startingBarX, double endingBarX)
     {
-        return IsPointInTimelineScaleStartingMarker(point, startingBarX) ||
-               IsPointInTimelineScaleEndingMarker(point, endingBarX);
+        return IsPointInTimelineScaleStartingMarker(x, y, startingBarX) ||
+               IsPointInTimelineScaleEndingMarker(x, y, endingBarX);
     }
 
-    internal static bool IsPointInTimelineScaleStartingMarker(Point point, double startingBarX)
+    internal static bool IsPointInTimelineScaleStartingMarker(double x, double y, double startingBarX)
     {
         // 長方形の範囲を計算
         var startRect = new Rect(startingBarX, 0, MarkerWidth, MarkerHeight);
 
         // 点が長方形内にあるか判定
-        return startRect.Contains(point);
+        return startRect.Contains(new Point(x, y));
     }
 
-    internal static bool IsPointInTimelineScaleEndingMarker(Point point, double endingBarX)
+    internal static bool IsPointInTimelineScaleEndingMarker(double x, double y, double endingBarX)
     {
         // 長方形の範囲を計算
         var endRect = new Rect(endingBarX - MarkerWidth, 0, MarkerWidth, MarkerHeight);
 
         // 点が長方形内にあるか判定
-        return endRect.Contains(point);
+        return endRect.Contains(new Point(x, y));
     }
 
     // ポインターが押された
@@ -557,13 +557,13 @@ public sealed partial class Timeline : UserControl
                 Point scalePoint = e.GetPosition(Scale);
 
                 // マーカーの当たり判定チェック - TimelineScaleのマーカーのみ
-                if (IsPointInTimelineScaleEndingMarker(scalePoint, endingBarX))
+                if (IsPointInTimelineScaleEndingMarker(pointerPt.Position.X, scalePoint.Y, endingBarX))
                 {
                     _mouseFlag = MouseFlags.EndingBarMarkerPressed;
                     // 初期値を保存
                     _initialDuration = viewModel.Scene.Duration;
                 }
-                else if (IsPointInTimelineScaleStartingMarker(scalePoint, startingBarX))
+                else if (IsPointInTimelineScaleStartingMarker(pointerPt.Position.X, scalePoint.Y, startingBarX))
                 {
                     _mouseFlag = MouseFlags.StartingBarMarkerPressed;
                     _initialStart = viewModel.Scene.Start; // 初期値を保存

--- a/src/Beutl/Views/TimelineOverlay.cs
+++ b/src/Beutl/Views/TimelineOverlay.cs
@@ -30,6 +30,10 @@ public sealed class TimelineOverlay : Control
         = AvaloniaProperty.RegisterDirect<TimelineOverlay, Rect>(
             nameof(SelectionRange), o => o.SelectionRange, (o, v) => o.SelectionRange = v);
 
+    public static readonly DirectProperty<TimelineOverlay, Thickness> StartingBarMarginProperty
+        = AvaloniaProperty.RegisterDirect<TimelineOverlay, Thickness>(
+            nameof(StartingBarMargin), o => o.StartingBarMargin, (o, v) => o.StartingBarMargin = v);
+
     public static readonly DirectProperty<TimelineOverlay, Thickness> EndingBarMarginProperty
         = AvaloniaProperty.RegisterDirect<TimelineOverlay, Thickness>(
             nameof(EndingBarMargin), o => o.EndingBarMargin, (o, v) => o.EndingBarMargin = v);
@@ -41,15 +45,20 @@ public sealed class TimelineOverlay : Control
     public static readonly StyledProperty<IBrush?> SeekBarBrushProperty
         = AvaloniaProperty.Register<TimelineOverlay, IBrush?>(nameof(SeekBarBrush));
 
+    public static readonly StyledProperty<IBrush?> StartingBarBrushProperty
+        = AvaloniaProperty.Register<TimelineOverlay, IBrush?>(nameof(StartingBarBrush));
+
     public static readonly StyledProperty<IBrush?> EndingBarBrushProperty
         = AvaloniaProperty.Register<TimelineOverlay, IBrush?>(nameof(EndingBarBrush));
 
     private Vector _offset;
+    private Thickness _startingBarMargin;
     private Thickness _endingBarMargin;
     private Thickness _seekBarMargin;
     private Size _viewport;
     private Rect _selectionRange;
     private ImmutablePen? _seekBarPen;
+    private ImmutablePen? _startingBarPen;
     private ImmutablePen? _endingBarPen;
 
     static TimelineOverlay()
@@ -58,9 +67,11 @@ public sealed class TimelineOverlay : Control
             OffsetProperty,
             ViewportProperty,
             SelectionRangeProperty,
+            StartingBarMarginProperty,
             EndingBarMarginProperty,
             SeekBarMarginProperty,
             SeekBarBrushProperty,
+            StartingBarBrushProperty,
             EndingBarBrushProperty);
     }
 
@@ -87,6 +98,12 @@ public sealed class TimelineOverlay : Control
         set => SetAndRaise(SelectionRangeProperty, ref _selectionRange, value);
     }
 
+    public Thickness StartingBarMargin
+    {
+        get => _startingBarMargin;
+        set => SetAndRaise(StartingBarMarginProperty, ref _startingBarMargin, value);
+    }
+
     public Thickness EndingBarMargin
     {
         get => _endingBarMargin;
@@ -105,6 +122,12 @@ public sealed class TimelineOverlay : Control
         set => SetValue(SeekBarBrushProperty, value);
     }
 
+    public IBrush? StartingBarBrush
+    {
+        get => GetValue(StartingBarBrushProperty);
+        set => SetValue(StartingBarBrushProperty, value);
+    }
+
     public IBrush? EndingBarBrush
     {
         get => GetValue(EndingBarBrushProperty);
@@ -118,6 +141,10 @@ public sealed class TimelineOverlay : Control
         {
             _seekBarPen = new ImmutablePen(SeekBarBrush?.ToImmutable(), 1.25);
         }
+        else if (change.Property == StartingBarBrushProperty)
+        {
+            _startingBarPen = new ImmutablePen(StartingBarBrush?.ToImmutable(), 1.25);
+        }
         else if (change.Property == EndingBarBrushProperty)
         {
             _endingBarPen = new ImmutablePen(EndingBarBrush?.ToImmutable(), 1.25);
@@ -128,6 +155,7 @@ public sealed class TimelineOverlay : Control
     {
         base.Render(context);
         _seekBarPen ??= new ImmutablePen(SeekBarBrush?.ToImmutable(), 1.25);
+        _startingBarPen ??= new ImmutablePen(StartingBarBrush?.ToImmutable(), 1.25);
         _endingBarPen ??= new ImmutablePen(EndingBarBrush?.ToImmutable(), 1.25);
 
         Rect rect = _selectionRange.Normalize();
@@ -139,10 +167,12 @@ public sealed class TimelineOverlay : Control
         {
             double height = _viewport.Height;
             var seekbar = new Point(_seekBarMargin.Left, 0);
+            var startingbar = new Point(_startingBarMargin.Left, 0);
             var endingbar = new Point(_endingBarMargin.Left, 0);
             var bottom = new Point(0, height);
 
             context.DrawLine(_seekBarPen, seekbar, seekbar + bottom);
+            context.DrawLine(_startingBarPen, startingbar, startingbar + bottom);
             context.DrawLine(_endingBarPen, endingbar, endingbar + bottom);
         }
     }

--- a/src/Beutl/Views/TimelineScale.cs
+++ b/src/Beutl/Views/TimelineScale.cs
@@ -3,7 +3,6 @@ using Avalonia.Controls;
 using Avalonia.Media;
 using Avalonia.Media.Immutable;
 using Avalonia.Media.TextFormatting;
-
 using static Beutl.ViewModels.BufferStatusViewModel;
 
 namespace Beutl.Views;
@@ -19,6 +18,10 @@ public sealed class TimelineScale : Control
     public static readonly DirectProperty<TimelineScale, Vector> OffsetProperty
         = AvaloniaProperty.RegisterDirect<TimelineScale, Vector>(
             nameof(Offset), o => o.Offset, (o, v) => o.Offset = v);
+
+    public static readonly DirectProperty<TimelineScale, Thickness> StartingBarMarginProperty
+        = AvaloniaProperty.RegisterDirect<TimelineScale, Thickness>(
+            nameof(StartingBarMargin), o => o.StartingBarMargin, (o, v) => o.StartingBarMargin = v);
 
     public static readonly DirectProperty<TimelineScale, Thickness> EndingBarMarginProperty
         = AvaloniaProperty.RegisterDirect<TimelineScale, Thickness>(
@@ -46,6 +49,9 @@ public sealed class TimelineScale : Control
     public static readonly StyledProperty<IBrush?> SeekBarBrushProperty
         = AvaloniaProperty.Register<TimelineScale, IBrush?>(nameof(SeekBarBrush));
 
+    public static readonly StyledProperty<IBrush?> StartingBarBrushProperty
+        = AvaloniaProperty.Register<TimelineScale, IBrush?>(nameof(StartingBarBrush));
+
     public static readonly StyledProperty<IBrush?> EndingBarBrushProperty
         = AvaloniaProperty.Register<TimelineScale, IBrush?>(nameof(EndingBarBrush));
 
@@ -61,17 +67,22 @@ public sealed class TimelineScale : Control
     private static readonly Typeface s_typeface = new(FontFamily.Default, FontStyle.Normal, FontWeight.Medium);
     private float _scale = 1;
     private Vector _offset;
+    private Thickness _startingBarMargin;
     private Thickness _endingBarMargin;
     private Thickness _seekBarMargin;
     private ImmutablePen? _pen;
     private ImmutablePen? _seekBarPen;
+    private ImmutablePen? _startingBarPen;
     private ImmutablePen? _endingBarPen;
+    private static readonly Geometry _rangeMarker;
 
     static TimelineScale()
     {
+        _rangeMarker = Geometry.Parse("M 0,0 L 4,0 L 4,8 L 0,16 Z");
         AffectsRender<TimelineScale>(
             ScaleProperty,
             OffsetProperty,
+            StartingBarMarginProperty,
             EndingBarMarginProperty,
             SeekBarMarginProperty,
             BufferStartProperty,
@@ -80,6 +91,7 @@ public sealed class TimelineScale : Control
             HoveredCacheBlockProperty,
             ScaleBrushProperty,
             SeekBarBrushProperty,
+            StartingBarBrushProperty,
             EndingBarBrushProperty,
             CacheBlockBrushProperty,
             LockedCacheBlockBrushProperty,
@@ -101,6 +113,12 @@ public sealed class TimelineScale : Control
     {
         get => _offset;
         set => SetAndRaise(OffsetProperty, ref _offset, value);
+    }
+
+    public Thickness StartingBarMargin
+    {
+        get => _startingBarMargin;
+        set => SetAndRaise(StartingBarMarginProperty, ref _startingBarMargin, value);
     }
 
     public Thickness EndingBarMargin
@@ -151,6 +169,12 @@ public sealed class TimelineScale : Control
         set => SetValue(SeekBarBrushProperty, value);
     }
 
+    public IBrush? StartingBarBrush
+    {
+        get => GetValue(StartingBarBrushProperty);
+        set => SetValue(StartingBarBrushProperty, value);
+    }
+
     public IBrush? EndingBarBrush
     {
         get => GetValue(EndingBarBrushProperty);
@@ -186,6 +210,10 @@ public sealed class TimelineScale : Control
         {
             _seekBarPen = new ImmutablePen(SeekBarBrush?.ToImmutable(), 1.25);
         }
+        else if (change.Property == StartingBarBrushProperty)
+        {
+            _startingBarPen = new ImmutablePen(StartingBarBrush?.ToImmutable(), 1.25);
+        }
         else if (change.Property == EndingBarBrushProperty)
         {
             _endingBarPen = new ImmutablePen(EndingBarBrush?.ToImmutable(), 1.25);
@@ -197,6 +225,7 @@ public sealed class TimelineScale : Control
         base.Render(context);
         _pen ??= new ImmutablePen(ScaleBrush?.ToImmutable(), 1);
         _seekBarPen ??= new ImmutablePen(SeekBarBrush?.ToImmutable(), 1.25);
+        _startingBarPen ??= new ImmutablePen(StartingBarBrush?.ToImmutable(), 1.25);
         _endingBarPen ??= new ImmutablePen(EndingBarBrush?.ToImmutable(), 1.25);
 
         const int top = 16;
@@ -266,7 +295,8 @@ public sealed class TimelineScale : Control
 
                     context.DrawRectangle(
                         item.IsLocked ? LockedCacheBlockBrush : CacheBlockBrush, null,
-                        new RoundedRect(new Rect(item.Start.ToPixel(Scale), Height - 4, item.Length.ToPixel(Scale), 4)));
+                        new RoundedRect(new Rect(item.Start.ToPixel(Scale), Height - 4, item.Length.ToPixel(Scale),
+                            4)));
                 }
             }
 
@@ -279,10 +309,13 @@ public sealed class TimelineScale : Control
 
             var size = new Size(1.25, height);
             var seekbar = new Point(_seekBarMargin.Left, 0);
+            var startingbar = new Point(_startingBarMargin.Left, 0);
             var endingbar = new Point(_endingBarMargin.Left, 0);
             var bottom = new Point(0, height);
 
             context.DrawLine(_seekBarPen, seekbar, seekbar + bottom);
+
+            context.DrawLine(_startingBarPen, startingbar, startingbar + bottom);
 
             context.DrawLine(_endingBarPen, endingbar, endingbar + bottom);
 
@@ -293,8 +326,27 @@ public sealed class TimelineScale : Control
                 const int markerWidth = 4;
                 double left = _endingBarMargin.Left - markerWidth / 2.0;
                 double markerTop = height - markerHeight;
-                context.FillRectangle(brush, new Rect(left, markerTop, markerWidth, markerHeight));
-                context.DrawRectangle(brush, null, new Rect(left, markerTop, markerWidth, markerHeight));
+                // context.FillRectangle(brush, new Rect(left, markerTop, markerWidth, markerHeight));
+                // context.DrawRectangle(brush, null, new Rect(left, markerTop, markerWidth, markerHeight));
+                using (context.PushTransform(Matrix.CreateTranslation(_endingBarMargin.Left, 0)))
+                using (context.PushTransform(Matrix.CreateScale(-1, 1)))
+                {
+                    context.DrawGeometry(brush, null, _rangeMarker);
+                }
+            }
+
+            if (StartingBarBrush?.ToImmutable() is { } brush2)
+            {
+                const int markerHeight = 16;
+                const int markerWidth = 4;
+                double left = _startingBarMargin.Left - markerWidth / 2.0;
+                double markerTop = height - markerHeight;
+                // context.FillRectangle(brush2, new Rect(left, markerTop, markerWidth, markerHeight));
+                // context.DrawRectangle(brush2, null, new Rect(left, markerTop, markerWidth, markerHeight));
+                using (context.PushTransform(Matrix.CreateTranslation(_startingBarMargin.Left, 0)))
+                {
+                    context.DrawGeometry(brush2, null, _rangeMarker);
+                }
             }
         }
     }

--- a/src/Beutl/Views/Tools/SceneSettingsTab.axaml
+++ b/src/Beutl/Views/Tools/SceneSettingsTab.axaml
@@ -18,6 +18,9 @@
                           Header="{x:Static lang:Strings.Size}"
                           SecondHeader="{x:Static lang:Strings.Height}" />
 
+        <TextBlock Margin="8,8,8,0" Text="{x:Static lang:Strings.StartTime}" />
+        <TextBox Margin="8,0" Text="{Binding StartInput.Value, Mode=TwoWay}" />
+
         <TextBlock Margin="8,8,8,0" Text="{x:Static lang:Strings.DurationTime}" />
         <TextBox Margin="8,0" Text="{Binding DurationInput.Value, Mode=TwoWay}" />
 


### PR DESCRIPTION
Introduce a Start property for Scene to allow configurable start times, along with UI bindings for user input. Enhance Timeline components to support rendering and handling of starting bars, adjusting calculations to incorporate the scene start offset.

- Closes #1340