### PR TITLE
fix: Match audio playback sample rate to project settings

### DIFF
--- a/src/Beutl.Engine/Audio/Platforms/XAudio2/XAudioContext.cs
+++ b/src/Beutl.Engine/Audio/Platforms/XAudio2/XAudioContext.cs
@@ -24,10 +24,10 @@ public sealed partial class XAudioContext : IDisposable
         }
     }
 
-    public XAudioContext()
+    public XAudioContext(int sampleRate = 44100)
     {
         Device = Vortice.XAudio2.XAudio2.XAudio2Create();
-        MasteringVoice = Device.CreateMasteringVoice(2, 44100, AudioStreamCategory.Other);
+        MasteringVoice = Device.CreateMasteringVoice(2, (uint)sampleRate, AudioStreamCategory.Other);
     }
 
     ~XAudioContext()

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -415,7 +415,8 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         {
             if (OperatingSystem.IsWindows())
             {
-                using var audioContext = new XAudioContext();
+                int sampleRate = EditViewModel.Composer.Value.SampleRate;
+                using var audioContext = new XAudioContext(sampleRate);
                 await PlayWithXA2(audioContext, scene).ConfigureAwait(false);
             }
             else


### PR DESCRIPTION
## Description

Fixed an issue where the mastering voice of `XAudioContext` was hardcoded to 44100Hz.

- Added a `sampleRate` parameter to the constructor (maintaining backward compatibility with a default value of 44100)
- Changed to pass the project's sample rate from `PlayerViewModel`
- Resolved audio skipping issues in 48KHz projects

## Breaking changes

None

## Fixed issues

None