### PR TITLE
fix(engine): recover render nodes after frame failures

### DIFF
--- a/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
@@ -193,41 +193,62 @@ public class Renderer : IRenderer
         }
         else
         {
-            shouldRender = entry.Node.Update(resource);
+            bool resourceChanged = entry.Node.Update(resource);
+            shouldRender = resourceChanged || entry.Node.HasChanges;
         }
 
-        if (shouldRender)
-        {
-            using var ctx = new GraphicsContext2D(entry.Node, FrameSize.ToSize(1), OutputScale);
-            drawable.Render(ctx, resource);
-        }
-
-        RevalidateAll(entry.Node);
-        var processor = new RenderNodeProcessor(entry.Node, CacheOptions.IsEnabled, OutputScale, MaxWorkingScale);
-        var ops = processor.PullToRoot();
-        Rect bounds = Rect.Empty;
-        int consumed = 0;
         try
         {
-            foreach (var op in ops)
+            if (shouldRender)
             {
-                op.Render(_immediateCanvas);
-                bounds = bounds.Union(op.Bounds);
-                // consumed++ trails op.Bounds (a throw site) so a throw before op.Dispose leaves
-                // this op in the cleanup sweep below.
-                consumed++;
-                op.Dispose();
+                using var ctx = new GraphicsContext2D(entry.Node, FrameSize.ToSize(1), OutputScale);
+                drawable.Render(ctx, resource);
             }
+
+            RevalidateAll(entry.Node);
+            var processor = new RenderNodeProcessor(entry.Node, CacheOptions.IsEnabled, OutputScale, MaxWorkingScale);
+            var ops = processor.PullToRoot();
+            Rect bounds = Rect.Empty;
+            int consumed = 0;
+            try
+            {
+                foreach (var op in ops)
+                {
+                    op.Render(_immediateCanvas);
+                    bounds = bounds.Union(op.Bounds);
+                    // consumed++ trails op.Bounds (a throw site) so a throw before op.Dispose leaves
+                    // this op in the cleanup sweep below.
+                    consumed++;
+                    op.Dispose();
+                }
+            }
+            catch
+            {
+                RenderNodeOperation.DisposeAll(ops.AsSpan(consumed));
+                throw;
+            }
+
+            entry.Bounds = bounds;
+            RenderNodeCacheHelper.MakeCache(entry.Node, CacheOptions, OutputScale, MaxWorkingScale);
+            return entry;
         }
         catch
         {
-            RenderNodeOperation.DisposeAll(ops.AsSpan(consumed));
+            // RevalidateAll clears HasChanges before the operations execute. If any later stage
+            // fails, mark the node dirty again so the next frame rebuilds the partially evaluated
+            // graph instead of replaying the same faulting operations indefinitely.
+            entry.Node.HasChanges = true;
+            try
+            {
+                RenderNodeCacheHelper.ClearCache(entry.Node);
+            }
+            catch (Exception cleanupEx)
+            {
+                s_logger.LogWarning(cleanupEx, "Failed to clear a render-node cache after rendering faulted.");
+            }
+
             throw;
         }
-
-        entry.Bounds = bounds;
-        RenderNodeCacheHelper.MakeCache(entry.Node, CacheOptions, OutputScale, MaxWorkingScale);
-        return entry;
     }
 
     private void AddDetachedHandler(Drawable drawable)

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RendererExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RendererExceptionSafetyTests.cs
@@ -58,9 +58,32 @@ public class RendererExceptionSafetyTests
         });
     }
 
+    [Test]
+    public void RenderDrawable_RebuildsCachedNode_AfterTransientRenderFailure()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var renderer = new Renderer(16, 16);
+            var drawable = new TransientFaultDrawable();
+            CompositionFrame frame = CreateFrame(drawable);
+
+            var first = Assert.Throws<InvalidOperationException>(() => renderer.Render(frame));
+
+            Assert.That(first!.Message, Is.EqualTo("transient"));
+            Assert.That(() => renderer.Render(frame), Throws.Nothing);
+            Assert.That(drawable.RenderCount, Is.EqualTo(2));
+        });
+    }
+
     private static CompositionFrame CreateFrame(params RenderNodeOperation[] operations)
     {
         var drawable = new FaultingDrawable(operations);
+        return CreateFrame(drawable);
+    }
+
+    private static CompositionFrame CreateFrame(Drawable drawable)
+    {
         var resource = (Drawable.Resource)drawable.ToResource(CompositionContext.Default);
         return new CompositionFrame(
             ImmutableArray.Create<EngineObject.Resource>(resource),
@@ -112,4 +135,41 @@ internal sealed partial class FaultingDrawable(RenderNodeOperation[] operations)
 internal sealed class FixedOpsNode(RenderNodeOperation[] operations) : RenderNode
 {
     public override RenderNodeOperation[] Process(RenderNodeContext context) => operations;
+}
+
+internal sealed partial class TransientFaultDrawable : Drawable
+{
+    public int RenderCount { get; private set; }
+
+    public override void Render(GraphicsContext2D context, Drawable.Resource resource)
+    {
+        RenderCount++;
+        bool shouldThrow = RenderCount == 1;
+        context.DrawNode(new TransientFaultNode(shouldThrow));
+    }
+
+    protected override Size MeasureCore(Size availableSize, Drawable.Resource resource) => new(4, 4);
+
+    protected override void OnDraw(GraphicsContext2D context, Drawable.Resource resource)
+    {
+    }
+}
+
+internal sealed class TransientFaultNode(bool shouldThrow) : RenderNode
+{
+    public override RenderNodeOperation[] Process(RenderNodeContext context)
+    {
+        return
+        [
+            RenderNodeOperation.CreateLambda(
+                new Rect(0, 0, 4, 4),
+                _ =>
+                {
+                    if (shouldThrow)
+                    {
+                        throw new InvalidOperationException("transient");
+                    }
+                })
+        ];
+    }
 }


### PR DESCRIPTION
## Description

- Mark a drawable render node dirty when any stage of its render pipeline fails.
- Clear partial render-node caches while preserving and rethrowing the original exception.
- Rebuild the drawable graph on the next frame instead of replaying the same faulting operations indefinitely.
- Add a regression test that reproduces the repeated failure against the previous implementation and verifies recovery on the next render.

The root cause was that `RevalidateAll` cleared `HasChanges` before render operations executed. If an operation then threw, the partially evaluated node remained cached as up to date, so subsequent frames reused the same broken operation graph and repeatedly raised `InvalidOperationException`.

## Affected areas

- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes

None.

## Test plan

- `dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --filter "FullyQualifiedName~RendererExceptionSafetyTests" --no-restore` (3 passed)
- Related render-node cache, filter crash-safety, and processor exception-safety tests (65 passed)
- `dotnet build src/Beutl.Engine/Beutl.Engine.csproj -f net10.0 --no-restore` (0 warnings, 0 errors)
- `git diff --check`

## Fixed issues / References

- Project board: [macOS frame rendering repeatedly throws InvalidOperationException](https://github.com/orgs/b-editor/projects/9/views/1?pane=issue&itemId=213326578)
