### PR TITLE
test(engine): GPU pass fusion stack 3/5 — pipeline coverage

### DIFF
--- a/tests/Beutl.Benchmarks/Program.cs
+++ b/tests/Beutl.Benchmarks/Program.cs
@@ -1,6 +1,8 @@
 ﻿using System.Reflection;
 
 using BenchmarkDotNet.Running;
+using Beutl.Benchmarks.Rendering;
 
 // Select a benchmark via `-- --filter <pattern>`; no args shows an interactive picker.
 BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args);
+return 0;

--- a/tests/Beutl.Benchmarks/Properties/AssemblyInfo.cs
+++ b/tests/Beutl.Benchmarks/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Beutl.UnitTests")]

--- a/tests/Beutl.Benchmarks/Rendering/RenderPipelineBenchmarkConfig.cs
+++ b/tests/Beutl.Benchmarks/Rendering/RenderPipelineBenchmarkConfig.cs
@@ -1,0 +1,95 @@
+﻿using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+
+namespace Beutl.Benchmarks.Rendering;
+
+/// <summary>
+/// Shared BenchmarkDotNet policy for paired persistent-lifetime render-pipeline measurements.
+/// Renderer warm-up and output/counter verification remain GlobalSetup responsibilities of the benchmark class.
+/// </summary>
+internal sealed class RenderPipelineBenchmarkConfig : ManualConfig
+{
+    public const string ArtifactsPathEnvironmentVariable = "BEUTL_RENDER_BENCHMARK_ARTIFACTS";
+
+    public const string CountersPathEnvironmentVariable = "BEUTL_RENDER_BENCHMARK_COUNTERS";
+
+    public const string OutputBlobsPathEnvironmentVariable = "BEUTL_RENDER_BENCHMARK_OUTPUT_BLOBS";
+
+    public const int SetupWarmupFrameCount = 5;
+
+    public const int BenchmarkWarmupCount = 3;
+
+    public const int BenchmarkIterationCount = 15;
+
+    public const int BenchmarkLaunchCount = 1;
+
+    public const int BenchmarkInvocationCount = 1;
+
+    public const int BenchmarkUnrollFactor = 1;
+
+    public const string BenchmarkJobId = "RenderPipeline";
+
+    public static string ExpectedJobDisplay =>
+        $"{BenchmarkJobId}(InvocationCount={BenchmarkInvocationCount}, "
+        + $"IterationCount={BenchmarkIterationCount}, LaunchCount={BenchmarkLaunchCount}, "
+        + $"RunStrategy={RunStrategy.Monitoring}, UnrollFactor={BenchmarkUnrollFactor}, "
+        + $"WarmupCount={BenchmarkWarmupCount})";
+
+    public const string LifetimeContract =
+        "persistent-root-pipeline-and-version-available-structural-program-render-cache-target-pool-state";
+
+    public const string RequestShapeContract = "complete-target-surface-request-with-rgba16f-readback";
+
+    public RenderPipelineBenchmarkConfig()
+    {
+        AddJob(Job.Default
+            .WithId(BenchmarkJobId)
+            .WithStrategy(RunStrategy.Monitoring)
+            .WithLaunchCount(BenchmarkLaunchCount)
+            .WithWarmupCount(BenchmarkWarmupCount)
+            .WithIterationCount(BenchmarkIterationCount)
+            .WithInvocationCount(BenchmarkInvocationCount)
+            .WithUnrollFactor(BenchmarkUnrollFactor));
+        AddDiagnoser(MemoryDiagnoser.Default);
+        AddColumnProvider(DefaultColumnProviders.Instance);
+        AddLogger(ConsoleLogger.Default);
+        AddExporter(JsonExporter.Full);
+
+        string? artifactsPath = Environment.GetEnvironmentVariable(ArtifactsPathEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(artifactsPath))
+        {
+            ArtifactsPath = Path.GetFullPath(artifactsPath);
+        }
+
+        string? countersPath = Environment.GetEnvironmentVariable(CountersPathEnvironmentVariable);
+        if (string.IsNullOrWhiteSpace(countersPath))
+        {
+            string root = !string.IsNullOrWhiteSpace(artifactsPath)
+                ? Path.GetFullPath(artifactsPath)
+                : Path.GetFullPath("BenchmarkDotNet.Artifacts");
+            Environment.SetEnvironmentVariable(
+                CountersPathEnvironmentVariable,
+                Path.Combine(root, "render-pipeline-counters"));
+        }
+    }
+
+    public static string GetCountersPath()
+    {
+        string? value = Environment.GetEnvironmentVariable(CountersPathEnvironmentVariable);
+        return !string.IsNullOrWhiteSpace(value)
+            ? Path.GetFullPath(value)
+            : throw new InvalidOperationException(
+                $"{CountersPathEnvironmentVariable} was not initialized by the benchmark configuration.");
+    }
+
+    public static string? GetOutputBlobsPath()
+    {
+        string? value = Environment.GetEnvironmentVariable(OutputBlobsPathEnvironmentVariable);
+        return string.IsNullOrWhiteSpace(value) ? null : Path.GetFullPath(value);
+    }
+}

--- a/tests/Beutl.Benchmarks/Rendering/RenderPipelineBenchmarkScenes.cs
+++ b/tests/Beutl.Benchmarks/Rendering/RenderPipelineBenchmarkScenes.cs
@@ -1,0 +1,301 @@
+﻿using System.Collections.ObjectModel;
+
+using Beutl.Graphics;
+using Beutl.Media;
+
+namespace Beutl.Benchmarks.Rendering;
+
+internal enum RenderPipelineBenchmarkAnimation
+{
+    None,
+    ParameterOnly,
+    StructuralToggle,
+}
+
+internal enum RenderPipelineBenchmarkBarrier
+{
+    None,
+    WholeSourceShader,
+    SpatialEffect,
+    TargetDependency,
+}
+
+internal enum RenderPipelineBenchmarkLayout
+{
+    TargetDomain,
+    CenteredContent,
+    DrawableGrid,
+}
+
+internal readonly record struct RenderPipelineBenchmarkFrameState(
+    float AnimatedAmount,
+    bool StructuralVariant);
+
+internal sealed record RenderPipelineBenchmarkSceneDefinition
+{
+    public RenderPipelineBenchmarkSceneDefinition(
+        string name,
+        int seed,
+        int semanticStageCount,
+        int topLevelDrawableCount = 1,
+        float contentScale = 0.8f,
+        RenderPipelineBenchmarkAnimation animation = RenderPipelineBenchmarkAnimation.None,
+        RenderPipelineBenchmarkBarrier barrier = RenderPipelineBenchmarkBarrier.None,
+        bool hasStaticPrefixCache = false,
+        bool hasTargetDependencies = false,
+        RenderPipelineBenchmarkLayout layout = RenderPipelineBenchmarkLayout.TargetDomain)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentOutOfRangeException.ThrowIfNegative(semanticStageCount);
+        ArgumentOutOfRangeException.ThrowIfLessThan(topLevelDrawableCount, 1);
+        if (!float.IsFinite(contentScale) || contentScale is <= 0 or > 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(contentScale), contentScale, "Content scale must be finite and in the range (0, 1].");
+        }
+
+        Name = name;
+        Seed = seed;
+        SemanticStageCount = semanticStageCount;
+        TopLevelDrawableCount = topLevelDrawableCount;
+        ContentScale = contentScale;
+        Animation = animation;
+        Barrier = barrier;
+        HasStaticPrefixCache = hasStaticPrefixCache;
+        HasTargetDependencies = hasTargetDependencies;
+        Layout = layout;
+    }
+
+    public string Name { get; }
+
+    public int Seed { get; }
+
+    public int SemanticStageCount { get; }
+
+    public int TopLevelDrawableCount { get; }
+
+    public float ContentScale { get; }
+
+    public RenderPipelineBenchmarkAnimation Animation { get; }
+
+    public RenderPipelineBenchmarkBarrier Barrier { get; }
+
+    public bool HasStaticPrefixCache { get; }
+
+    public bool HasTargetDependencies { get; }
+
+    public RenderPipelineBenchmarkLayout Layout { get; }
+
+    public RenderPipelineBenchmarkFrameState GetFrameState(int frameIndex)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(frameIndex);
+
+        return Animation switch
+        {
+            RenderPipelineBenchmarkAnimation.ParameterOnly => new(
+                AnimatedAmount: 0.75f + ((frameIndex % 60) / 59f * 0.5f),
+                StructuralVariant: false),
+            RenderPipelineBenchmarkAnimation.StructuralToggle => new(
+                AnimatedAmount: 1f,
+                StructuralVariant: ((frameIndex / 8) & 1) != 0),
+            _ => new(AnimatedAmount: 1f, StructuralVariant: false),
+        };
+    }
+}
+
+/// <summary>
+/// Stable workload metadata and source pixels shared by the baseline and feature render-pipeline benchmarks.
+/// Scene construction belongs in the benchmark harness so both worktrees consume these exact definitions.
+/// </summary>
+internal static class RenderPipelineBenchmarkScenes
+{
+    public const int SourceSeed = 20_040_719;
+
+    public const int DrawableGridMargin = 12;
+
+    public static readonly PixelSize ReferenceSize = new(384, 216);
+
+    public static readonly Rect TargetDomain = new(0, 0, ReferenceSize.Width, ReferenceSize.Height);
+
+    public static readonly PixelSize Hd1080 = new(1920, 1080);
+
+    private static readonly RenderPipelineBenchmarkSceneDefinition[] s_all =
+    [
+        new("NoEffectControl", SourceSeed + 0, semanticStageCount: 0),
+        new("SingleShader", SourceSeed + 1, semanticStageCount: 1),
+        new("ShaderOpacityShader", SourceSeed + 2, semanticStageCount: 3),
+        new(
+            "ShaderOpacityShaderBarrier",
+            SourceSeed + 3,
+            semanticStageCount: 4,
+            barrier: RenderPipelineBenchmarkBarrier.WholeSourceShader),
+        new("LongInvariantChain", SourceSeed + 4, semanticStageCount: 10),
+        new(
+            "ParameterOnlyAnimation",
+            SourceSeed + 5,
+            semanticStageCount: 3,
+            animation: RenderPipelineBenchmarkAnimation.ParameterOnly),
+        new(
+            "StructuralToggle",
+            SourceSeed + 6,
+            semanticStageCount: 3,
+            animation: RenderPipelineBenchmarkAnimation.StructuralToggle),
+        new(
+            "StaticPrefixAnimatedTail",
+            SourceSeed + 7,
+            semanticStageCount: 6,
+            animation: RenderPipelineBenchmarkAnimation.ParameterOnly,
+            hasStaticPrefixCache: true),
+        new(
+            "MixedSpatialColor",
+            SourceSeed + 8,
+            semanticStageCount: 5,
+            barrier: RenderPipelineBenchmarkBarrier.SpatialEffect),
+        new(
+            "SmallObjectFixedOverhead",
+            SourceSeed + 9,
+            semanticStageCount: 3,
+            contentScale: 0.1f,
+            layout: RenderPipelineBenchmarkLayout.CenteredContent),
+        new(
+            "MultipleDrawablesTargetDependencies",
+            SourceSeed + 10,
+            semanticStageCount: 4,
+            topLevelDrawableCount: 4,
+            barrier: RenderPipelineBenchmarkBarrier.TargetDependency,
+            hasTargetDependencies: true,
+            layout: RenderPipelineBenchmarkLayout.DrawableGrid),
+    ];
+
+    private static readonly IReadOnlyDictionary<string, RenderPipelineBenchmarkSceneDefinition> s_byName
+        = new ReadOnlyDictionary<string, RenderPipelineBenchmarkSceneDefinition>(
+            s_all.ToDictionary(static scene => scene.Name, StringComparer.Ordinal));
+
+    public static IReadOnlyList<RenderPipelineBenchmarkSceneDefinition> All { get; } = Array.AsReadOnly(s_all);
+
+    public static RenderPipelineBenchmarkSceneDefinition Get(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        return s_byName.TryGetValue(name, out RenderPipelineBenchmarkSceneDefinition? scene)
+            ? scene
+            : throw new ArgumentOutOfRangeException(nameof(name), name, "Unknown render-pipeline benchmark scene.");
+    }
+
+    /// <summary>
+    /// Bounds of one of a scene's top-level drawables, in the target domain.
+    /// </summary>
+    /// <remarks>
+    /// The benchmark harness draws from this and the frozen-workload gate checks recorded counters
+    /// against it, so the two cannot drift into disagreeing about a scene's rendered extent.
+    /// </remarks>
+    public static Rect GetDrawableBounds(RenderPipelineBenchmarkSceneDefinition scene, int index)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, scene.TopLevelDrawableCount);
+
+        switch (scene.Layout)
+        {
+            case RenderPipelineBenchmarkLayout.CenteredContent:
+                int contentWidth = Math.Max(1, (int)MathF.Round(TargetDomain.Width * scene.ContentScale));
+                int contentHeight = Math.Max(1, (int)MathF.Round(TargetDomain.Height * scene.ContentScale));
+                return new Rect(
+                    MathF.Floor((TargetDomain.Width - contentWidth) / 2),
+                    MathF.Floor((TargetDomain.Height - contentHeight) / 2),
+                    contentWidth,
+                    contentHeight);
+            case RenderPipelineBenchmarkLayout.DrawableGrid:
+                int cellWidth = (ReferenceSize.Width - (DrawableGridMargin * 3)) / 2;
+                int cellHeight = (ReferenceSize.Height - (DrawableGridMargin * 3)) / 2;
+                return new Rect(
+                    DrawableGridMargin + ((index & 1) * (cellWidth + DrawableGridMargin)),
+                    DrawableGridMargin + ((index >> 1) * (cellHeight + DrawableGridMargin)),
+                    cellWidth,
+                    cellHeight);
+            default:
+                return TargetDomain;
+        }
+    }
+
+    /// <summary>
+    /// Device extent a scene rasterizes to, which is the union of its top-level drawables.
+    /// </summary>
+    public static PixelSize GetOutputSize(RenderPipelineBenchmarkSceneDefinition scene)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+        Rect union = GetDrawableBounds(scene, 0);
+        for (int index = 1; index < scene.TopLevelDrawableCount; index++)
+            union = union.Union(GetDrawableBounds(scene, index));
+        return new PixelSize((int)union.Width, (int)union.Height);
+    }
+
+    public static Half[] CreateLinearPremultipliedRgba16F(
+        RenderPipelineBenchmarkSceneDefinition scene,
+        PixelSize size)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+        int length = GetRequiredComponentCount(size);
+        var result = new Half[length];
+        FillLinearPremultipliedRgba16F(result, scene, size);
+        return result;
+    }
+
+    public static void FillLinearPremultipliedRgba16F(
+        Span<Half> destination,
+        RenderPipelineBenchmarkSceneDefinition scene,
+        PixelSize size)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+        int requiredLength = GetRequiredComponentCount(size);
+        if (destination.Length != requiredLength)
+        {
+            throw new ArgumentException(
+                $"Destination must contain exactly {requiredLength} RGBA components.", nameof(destination));
+        }
+
+        int index = 0;
+        for (int y = 0; y < size.Height; y++)
+        {
+            for (int x = 0; x < size.Width; x++)
+            {
+                uint sample = MixPixel(scene.Seed, x, y);
+                float alpha = (96 + ((sample >> 24) & 0x8f)) / 255f;
+                float red = ((sample >> 16) & 0xff) / 255f * alpha;
+                float green = ((sample >> 8) & 0xff) / 255f * alpha;
+                float blue = (sample & 0xff) / 255f * alpha;
+
+                destination[index++] = (Half)red;
+                destination[index++] = (Half)green;
+                destination[index++] = (Half)blue;
+                destination[index++] = (Half)alpha;
+            }
+        }
+    }
+
+    private static int GetRequiredComponentCount(PixelSize size)
+    {
+        if (size.Width <= 0 || size.Height <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(size), size, "Benchmark dimensions must be positive.");
+        }
+
+        return checked(size.Width * size.Height * 4);
+    }
+
+    private static uint MixPixel(int seed, int x, int y)
+    {
+        unchecked
+        {
+            uint value = (uint)seed;
+            value ^= (uint)(x / 16) * 0x9e37_79b9u;
+            value ^= (uint)(y / 16) * 0x85eb_ca6bu;
+            value ^= (uint)x * 0xc2b2_ae35u;
+            value ^= (uint)y * 0x27d4_eb2fu;
+            value ^= value >> 16;
+            value *= 0x7feb_352du;
+            value ^= value >> 15;
+            value *= 0x846c_a68bu;
+            return value ^ (value >> 16);
+        }
+    }
+}

--- a/tests/Beutl.Benchmarks/Rendering/RenderPipelineBenchmarks.cs
+++ b/tests/Beutl.Benchmarks/Rendering/RenderPipelineBenchmarks.cs
@@ -1,0 +1,1318 @@
+﻿using System.Buffers.Binary;
+using System.Collections;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+using BenchmarkDotNet.Attributes;
+
+using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Backend;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+
+using Silk.NET.Vulkan;
+
+using SkiaSharp;
+
+using Bitmap = Beutl.Media.Bitmap;
+
+namespace Beutl.Benchmarks.Rendering;
+
+/// <summary>
+/// Complete-request render-pipeline workloads with renderer, node, program-cache, render-cache, and target-pool
+/// lifetimes that persist across setup, warm-up, and measured iterations.
+/// </summary>
+[Config(typeof(RenderPipelineBenchmarkConfig))]
+public class RenderPipelineBenchmarks
+{
+    private RenderPipelineBenchmarkSession? _session;
+
+    public static IEnumerable<string> SceneNames
+        => RenderPipelineBenchmarkScenes.All.Select(static scene => scene.Name);
+
+    [ParamsSource(nameof(SceneNames))]
+    public string CaseName { get; set; } = string.Empty;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _session = RenderThread.Dispatcher.Invoke(() => new RenderPipelineBenchmarkSession(CaseName));
+        RenderThread.Dispatcher.Invoke(_session.WarmAndVerify);
+    }
+
+    /// <summary>
+    /// Renders one complete requested surface. Output validation lives in <see cref="Setup"/>, and request-wide
+    /// counters and full-image hashing come from cleanup, so the measured body contains only production frame-state
+    /// update, render, readback, cheap token sampling, and steady-state disposal of the preceding result.
+    /// </summary>
+    [Benchmark]
+    public ulong RenderCompleteTargetRequest()
+    {
+        RenderPipelineBenchmarkSession session = _session
+            ?? throw new InvalidOperationException("Benchmark setup did not create a render session.");
+        return RenderThread.Dispatcher.Invoke(session.RenderMeasuredFrame);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        RenderPipelineBenchmarkSession? session = Interlocked.Exchange(ref _session, null);
+        if (session is null)
+            return;
+
+        RenderPipelineBenchmarkCounterRecord record = RenderThread.Dispatcher.Invoke(() =>
+        {
+            try
+            {
+                return session.CreateCounterRecord();
+            }
+            finally
+            {
+                session.Dispose();
+            }
+        });
+
+        string directory = RenderPipelineBenchmarkConfig.GetCountersPath();
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, CaseName + ".json");
+        using var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
+        JsonSerializer.Serialize(stream, record, RenderPipelineBenchmarkCounterRecord.JsonOptions);
+        stream.WriteByte((byte)'\n');
+    }
+}
+
+internal sealed class RenderPipelineBenchmarkSession : IDisposable
+{
+    private static readonly Rect s_targetDomain = RenderPipelineBenchmarkScenes.TargetDomain;
+
+    private readonly RenderPipelineBenchmarkSceneDefinition _scene;
+    private readonly RenderNode _root;
+    private readonly RenderNodeRenderer _renderer;
+    private readonly IReadOnlyList<IFrameStateConsumer> _animatedNodes;
+    private readonly IReadOnlyList<IDisposable> _sceneResources;
+    private readonly RenderPipelineEvidenceFingerprint _fingerprint;
+    private int _nextFrame;
+    private RenderPipelineObservedFrame? _lastSetupFrame;
+    private RenderNodeRasterization? _lastSetupRasterization;
+    private int _lastSetupFrameIndex = -1;
+    private RenderNodeRasterization? _lastMeasuredRasterization;
+    private int _lastMeasuredFrameIndex = -1;
+    private ulong _lastMeasuredToken;
+    private bool _disposed;
+
+    public RenderPipelineBenchmarkSession(string caseName)
+    {
+        RenderThread.Dispatcher.VerifyAccess();
+        _scene = RenderPipelineBenchmarkScenes.Get(caseName);
+        IGraphicsContext graphicsContext = GraphicsContextFactory.GetOrCreateShared()
+            ?? throw new InvalidOperationException(
+                "A real graphics context is required for render-pipeline benchmarks.");
+        _fingerprint = RenderPipelineEvidenceFingerprint.Capture(graphicsContext);
+
+        var animatedNodes = new List<IFrameStateConsumer>();
+        var sceneResources = new List<IDisposable>();
+        _root = CreateScene(_scene, animatedNodes, sceneResources);
+        _animatedNodes = animatedNodes.AsReadOnly();
+        _sceneResources = sceneResources.AsReadOnly();
+        RenderNodeRendererOptions options = CreateRendererOptions(_scene);
+        RenderPipelineInternalDiagnostics.SetPurpose(options, RenderRequestPurpose.Frame);
+        _renderer = new RenderNodeRenderer(_root, options);
+    }
+
+    public void WarmAndVerify()
+    {
+        ThrowIfDisposed();
+        RenderThread.Dispatcher.VerifyAccess();
+
+        (int Frame, bool RetainRasterization)[] plan = GetSetupRenderPlan(_scene);
+        var observed = new List<RenderPipelineObservedFrame>(plan.Length);
+        foreach ((int frame, bool retainRasterization) in plan)
+        {
+            observed.Add(RenderAndObserve(
+                frame,
+                retainRasterization));
+        }
+
+        RenderPipelineObservedFrame first = observed[0];
+        if (first.IsEmpty || first.Width <= 0 || first.Height <= 0
+            || !double.IsFinite(first.Energy) || first.Energy <= 1)
+        {
+            throw new InvalidOperationException(
+                $"Benchmark scene '{_scene.Name}' produced an empty, non-finite, or vacuous setup output.");
+        }
+
+        if (observed.Any(item => item.IsEmpty
+                                 || item.Bounds != first.Bounds
+                                 || item.Width != first.Width
+                                 || item.Height != first.Height))
+        {
+            throw new InvalidOperationException(
+                $"Benchmark scene '{_scene.Name}' did not preserve stable setup bounds and device dimensions.");
+        }
+
+        int distinctOutputs = observed.Select(static item => item.Sha256).Distinct(StringComparer.Ordinal).Count();
+        bool expectsAnimation = _scene.Animation != RenderPipelineBenchmarkAnimation.None;
+        if ((expectsAnimation && distinctOutputs < 2) || (!expectsAnimation && distinctOutputs != 1))
+        {
+            throw new InvalidOperationException(
+                $"Benchmark scene '{_scene.Name}' output stability did not match its declared animation mode.");
+        }
+
+        _lastSetupFrame = observed[^1];
+        _nextFrame = checked(plan[^1].Frame + 1);
+    }
+
+    public ulong RenderMeasuredFrame()
+    {
+        ThrowIfDisposed();
+        RenderThread.Dispatcher.VerifyAccess();
+        int frameIndex = _nextFrame++;
+        ApplyFrameState(frameIndex);
+        _lastMeasuredRasterization?.Dispose();
+        RenderNodeRasterization rasterization = _renderer.Rasterize();
+        _lastMeasuredRasterization = rasterization;
+        Bitmap? bitmap = rasterization.Bitmap;
+        _lastMeasuredFrameIndex = frameIndex;
+        _lastMeasuredToken = bitmap is null ? 0 : SampleToken(bitmap.GetPixelSpan<ushort>());
+        return _lastMeasuredToken;
+    }
+
+    public RenderPipelineBenchmarkCounterRecord CreateCounterRecord()
+    {
+        ThrowIfDisposed();
+        RenderThread.Dispatcher.VerifyAccess();
+        RenderPipelineObservedFrame setup = _lastSetupFrame
+            ?? throw new InvalidOperationException("Benchmark setup verification did not complete.");
+        if (_lastMeasuredFrameIndex < 0)
+            throw new InvalidOperationException("Benchmark completed without a measured request.");
+        RenderPipelineObservedFrame measured = Observe(
+            _lastMeasuredRasterization
+            ?? throw new InvalidOperationException("The final measured output was not retained for cleanup."));
+        using var diagnosticSession = new DiagnosticSession(_scene);
+        DiagnosticCapture diagnostics = diagnosticSession.Capture(_nextFrame);
+        AssertMatchingDiagnosticOutput(setup, diagnostics.SetupOutput);
+        AssertMatchingDiagnosticOutput(measured, diagnostics.MeasuredOutput);
+        using var expectationSession = new DiagnosticSession(_scene);
+        DiagnosticCapture expectation = expectationSession.Capture(_nextFrame);
+        AssertMatchingDiagnosticOutput(diagnostics.MeasuredOutput, expectation.MeasuredOutput);
+
+        string? outputBlobsPath = RenderPipelineBenchmarkConfig.GetOutputBlobsPath();
+        string setupBlobFile = string.Empty;
+        string measuredBlobFile = string.Empty;
+        if (outputBlobsPath is not null)
+        {
+            Bitmap setupBitmap = _lastSetupRasterization?.Bitmap
+                ?? throw new InvalidOperationException("The final setup output was not retained for evidence.");
+            Bitmap measuredBitmap = _lastMeasuredRasterization?.Bitmap
+                ?? throw new InvalidOperationException("The final measured output was not retained for evidence.");
+            setupBlobFile = _scene.Name + ".setup.rgba16f";
+            measuredBlobFile = _scene.Name + ".measured.rgba16f";
+            Directory.CreateDirectory(outputBlobsPath);
+            File.WriteAllBytes(
+                Path.Combine(outputBlobsPath, setupBlobFile),
+                EncodeRgba16f(setupBitmap));
+            File.WriteAllBytes(
+                Path.Combine(outputBlobsPath, measuredBlobFile),
+                EncodeRgba16f(measuredBitmap));
+        }
+
+        return new RenderPipelineBenchmarkCounterRecord
+        {
+            SchemaVersion = 3,
+            CaseName = _scene.Name,
+            Seed = _scene.Seed,
+            Width = setup.Width,
+            Height = setup.Height,
+            SetupWarmupFrames = RenderPipelineBenchmarkConfig.SetupWarmupFrameCount,
+            Lifetime = RenderPipelineBenchmarkConfig.LifetimeContract,
+            RequestShape = RenderPipelineBenchmarkConfig.RequestShapeContract,
+            SemanticStageCount = _scene.SemanticStageCount,
+            TopLevelDrawableCount = _scene.TopLevelDrawableCount,
+            Animation = _scene.Animation.ToString(),
+            Barrier = _scene.Barrier.ToString(),
+            HasStaticPrefixCache = _scene.HasStaticPrefixCache,
+            HasTargetDependencies = _scene.HasTargetDependencies,
+            OutputSha256 = setup.Sha256,
+            OutputChecksum = setup.Checksum.ToString("x16"),
+            OutputBounds = setup.Bounds,
+            SetupOutputBlobFile = setupBlobFile,
+            MeasuredOutputBlobFile = measuredBlobFile,
+            MeasuredOutputSha256 = measured.Sha256,
+            MeasuredOutputChecksum = measured.Checksum.ToString("x16"),
+            MeasuredOutputBounds = measured.Bounds,
+            MeasuredWidth = measured.Width,
+            MeasuredHeight = measured.Height,
+            ExpectedMeasuredOutputSha256 = expectation.MeasuredOutput.Sha256,
+            ExpectedMeasuredOutputChecksum = expectation.MeasuredOutput.Checksum.ToString("x16"),
+            ExpectedMeasuredOutputBounds = expectation.MeasuredOutput.Bounds,
+            ExpectedMeasuredWidth = expectation.MeasuredOutput.Width,
+            ExpectedMeasuredHeight = expectation.MeasuredOutput.Height,
+            Fingerprint = _fingerprint,
+            SetupLastRequestCounters = diagnostics.SetupCounters,
+            MeasuredLastRequestCounters = diagnostics.MeasuredCounters,
+            LastExecutionStatistics = diagnostics.LastExecutionStatistics,
+            StructuralPlanCacheStatistics = diagnostics.StructuralPlanCacheStatistics,
+            ProgramCacheStatistics = diagnostics.ProgramCacheStatistics,
+            TargetPoolStatistics = diagnostics.TargetPoolStatistics,
+        };
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        RenderThread.Dispatcher.VerifyAccess();
+        _lastMeasuredRasterization?.Dispose();
+        _lastMeasuredRasterization = null;
+        _lastSetupRasterization?.Dispose();
+        _lastSetupRasterization = null;
+        _renderer.Dispose();
+        _root.Dispose();
+        for (int index = _sceneResources.Count - 1; index >= 0; index--)
+            _sceneResources[index].Dispose();
+        _disposed = true;
+    }
+
+    private RenderPipelineObservedFrame RenderAndObserve(int frameIndex, bool retainRasterization)
+    {
+        ApplyFrameState(frameIndex);
+        RenderNodeRasterization? rasterization = _renderer.Rasterize();
+        try
+        {
+            RenderPipelineObservedFrame observed = Observe(rasterization);
+            if (retainRasterization)
+            {
+                _lastSetupRasterization?.Dispose();
+                _lastSetupRasterization = rasterization;
+                _lastSetupFrameIndex = frameIndex;
+                rasterization = null;
+            }
+            return observed;
+        }
+        finally
+        {
+            rasterization?.Dispose();
+        }
+    }
+
+    private static RenderPipelineObservedFrame Observe(RenderNodeRasterization rasterization)
+    {
+        Bitmap? bitmap = rasterization.Bitmap;
+        if (bitmap is null)
+        {
+            return new RenderPipelineObservedFrame(
+                true,
+                rasterization.Bounds,
+                0,
+                0,
+                0,
+                0,
+                string.Empty,
+                0);
+        }
+
+        Span<byte> bytes = bitmap.GetPixelSpan();
+        string sha256 = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+        Span<ushort> components = bitmap.GetPixelSpan<ushort>();
+        ulong token = SampleToken(components);
+        ulong checksum = CalculateChecksum(components);
+        double energy = 0;
+        for (int index = 0; index < components.Length; index += 17)
+            energy += Math.Abs((float)BitConverter.UInt16BitsToHalf(components[index]));
+
+        return new RenderPipelineObservedFrame(
+            false,
+            rasterization.Bounds,
+            bitmap.Width,
+            bitmap.Height,
+            token,
+            checksum,
+            sha256,
+            energy);
+    }
+
+    private void ApplyFrameState(int frameIndex)
+    {
+        RenderPipelineBenchmarkFrameState state = _scene.GetFrameState(frameIndex);
+        foreach (IFrameStateConsumer node in _animatedNodes)
+            node.Apply(state);
+    }
+
+    private static void ValidateSceneCounters(
+        RenderPipelineBenchmarkSceneDefinition scene,
+        IReadOnlyDictionary<string, long> counters)
+    {
+        if (scene.Name == "ShaderOpacityShader"
+            && counters.GetValueOrDefault("FusedStages") < 3)
+        {
+            throw new InvalidOperationException("The primary workload did not execute its fused three-stage chain.");
+        }
+
+        if (scene.Barrier is RenderPipelineBenchmarkBarrier.WholeSourceShader
+            or RenderPipelineBenchmarkBarrier.SpatialEffect
+            && counters.GetValueOrDefault("ExecutionIslands") < 2)
+        {
+            throw new InvalidOperationException($"Barrier workload '{scene.Name}' did not retain a hard island boundary.");
+        }
+
+        if (scene.HasStaticPrefixCache && counters.GetValueOrDefault("RenderCacheHits") < 1)
+        {
+            throw new InvalidOperationException("The static-prefix workload did not reach its persistent render cache.");
+        }
+
+        if (scene.HasTargetDependencies
+            && counters.GetValueOrDefault("RecordedTargetCommands") < scene.TopLevelDrawableCount)
+        {
+            throw new InvalidOperationException("The multi-root workload did not record every target dependency.");
+        }
+    }
+
+    private static void ValidateRequestCounters(IReadOnlyDictionary<string, long> counters)
+    {
+        if (counters.Count == 0 || counters.GetValueOrDefault("RecordedFragments") <= 0)
+            throw new InvalidOperationException("A benchmark request produced no request-wide diagnostics.");
+        if (counters.GetValueOrDefault("Failures") != 0
+            || counters.GetValueOrDefault("CleanupFailures") != 0
+            || counters.GetValueOrDefault("FailedOutcomes") != 0)
+        {
+            throw new InvalidOperationException("A benchmark request reported a render or cleanup failure.");
+        }
+        if (counters.GetValueOrDefault("IntermediateAcquires")
+            != counters.GetValueOrDefault("IntermediateDischarges"))
+        {
+            throw new InvalidOperationException("A benchmark request did not discharge every intermediate acquire.");
+        }
+
+        long outcomes = counters.GetValueOrDefault("ExecutedOutcomes")
+                        + counters.GetValueOrDefault("CachedOutcomes")
+                        + counters.GetValueOrDefault("MetadataOutcomes")
+                        + counters.GetValueOrDefault("SkippedOutcomes")
+                        + counters.GetValueOrDefault("FailedOutcomes");
+        if (outcomes != counters.GetValueOrDefault("RecordedFragments"))
+            throw new InvalidOperationException("A benchmark request did not reconcile every recorded fragment.");
+    }
+
+    private static ulong CalculateChecksum(ReadOnlySpan<ushort> components)
+    {
+        const ulong offset = 14695981039346656037;
+        const ulong prime = 1099511628211;
+        ulong result = offset;
+        for (int index = 0; index < components.Length; index += 13)
+        {
+            result ^= components[index];
+            result *= prime;
+        }
+        return result;
+    }
+
+    private static ulong SampleToken(ReadOnlySpan<ushort> components)
+        => components.Length == 0
+            ? 0
+            : ((ulong)components[0] << 48)
+              | ((ulong)components[components.Length / 3] << 32)
+              | ((ulong)components[components.Length * 2 / 3] << 16)
+              | components[^1];
+
+    private static int[] GetSetupFrames(RenderPipelineBenchmarkSceneDefinition scene)
+        => scene.Animation == RenderPipelineBenchmarkAnimation.StructuralToggle
+            ? [0, 1, 7, 8, 9]
+            : Enumerable.Range(0, RenderPipelineBenchmarkConfig.SetupWarmupFrameCount).ToArray();
+
+    private static (int Frame, bool RetainRasterization)[] GetSetupRenderPlan(
+        RenderPipelineBenchmarkSceneDefinition scene)
+    {
+        int[] frames = GetSetupFrames(scene);
+        return frames
+            .Select((frame, index) => (frame, index == frames.Length - 1))
+            .ToArray();
+    }
+
+    internal static IReadOnlyList<(int Frame, bool RetainRasterization)> GetSetupRenderPlanForTest(
+        string caseName)
+        => GetSetupRenderPlan(RenderPipelineBenchmarkScenes.Get(caseName));
+
+    private static RenderNodeRendererOptions CreateRendererOptions(RenderPipelineBenchmarkSceneDefinition scene)
+        => new()
+        {
+            DefaultRequest = new RenderNodeRenderRequest
+            {
+                Intent = RenderIntent.Preview,
+                TargetDomain = s_targetDomain,
+                OutputScale = 1,
+                MaxWorkingScale = 1,
+                CacheOptions = new Beutl.Graphics.Rendering.Cache.RenderCacheOptions(scene.HasStaticPrefixCache, Beutl.Graphics.Rendering.Cache.RenderCacheRules.Default),
+            },
+        };
+
+    private static void AssertMatchingDiagnosticOutput(
+        RenderPipelineObservedFrame production,
+        RenderPipelineObservedFrame diagnostic)
+    {
+        if (production.IsEmpty != diagnostic.IsEmpty
+            || production.Bounds != diagnostic.Bounds
+            || production.Width != diagnostic.Width
+            || production.Height != diagnostic.Height
+            || production.Token != diagnostic.Token
+            || production.Checksum != diagnostic.Checksum
+            || !string.Equals(production.Sha256, diagnostic.Sha256, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "Independent benchmark output captures did not reproduce the same output.");
+        }
+    }
+
+    private static RenderNode CreateScene(
+        RenderPipelineBenchmarkSceneDefinition scene,
+        List<IFrameStateConsumer> animatedNodes,
+        List<IDisposable> sceneResources)
+    {
+        return scene.Name switch
+        {
+            "NoEffectControl" => CreateSource(scene, s_targetDomain),
+            "SingleShader" => WrapShader(CreateSource(scene, s_targetDomain), BenchmarkShader.Gamma),
+            "ShaderOpacityShader" => CreatePrimary(scene, barrier: false),
+            "ShaderOpacityShaderBarrier" => CreatePrimary(scene, barrier: true),
+            "LongInvariantChain" => CreateLongChain(scene),
+            "ParameterOnlyAnimation" => CreateAnimatedChain(scene, animatedNodes),
+            "StructuralToggle" => CreateStructuralToggle(scene, animatedNodes),
+            "StaticPrefixAnimatedTail" => CreateStaticPrefix(scene, animatedNodes),
+            "MixedSpatialColor" => CreateMixedChain(scene, sceneResources),
+            "SmallObjectFixedOverhead" => CreateSmallObject(scene),
+            "MultipleDrawablesTargetDependencies" => CreateMultipleRoots(scene),
+            _ => throw new ArgumentOutOfRangeException(nameof(scene), scene.Name, "Unknown benchmark scene."),
+        };
+    }
+
+    private static RenderNode CreatePrimary(RenderPipelineBenchmarkSceneDefinition scene, bool barrier)
+    {
+        RenderNode current = CreateSource(scene, s_targetDomain);
+        current = WrapShader(current, BenchmarkShader.Gamma);
+        current = WrapOpacity(current, 0.625f);
+        if (barrier)
+            current = WrapShader(current, BenchmarkShader.WholeSourceIdentity);
+        return WrapShader(current, BenchmarkShader.Invert);
+    }
+
+    private static RenderNode CreateLongChain(RenderPipelineBenchmarkSceneDefinition scene)
+    {
+        RenderNode current = CreateSource(scene, s_targetDomain);
+        for (int index = 0; index < scene.SemanticStageCount; index++)
+            current = WrapShader(current, (index & 1) == 0 ? BenchmarkShader.Gamma : BenchmarkShader.Invert);
+        return current;
+    }
+
+    private static RenderNode CreateAnimatedChain(
+        RenderPipelineBenchmarkSceneDefinition scene,
+        List<IFrameStateConsumer> animatedNodes)
+    {
+        RenderNode current = WrapShader(CreateSource(scene, s_targetDomain), BenchmarkShader.Gamma);
+        var animated = new BenchmarkAnimatedShaderNode();
+        animated.AddChild(current);
+        animatedNodes.Add(animated);
+        return WrapShader(animated, BenchmarkShader.Invert);
+    }
+
+    private static RenderNode CreateStructuralToggle(
+        RenderPipelineBenchmarkSceneDefinition scene,
+        List<IFrameStateConsumer> animatedNodes)
+    {
+        RenderNode current = WrapShader(CreateSource(scene, s_targetDomain), BenchmarkShader.Gamma);
+        var toggle = new BenchmarkStructuralToggleNode();
+        toggle.AddChild(current);
+        animatedNodes.Add(toggle);
+        return WrapShader(toggle, BenchmarkShader.Invert);
+    }
+
+    private static RenderNode CreateStaticPrefix(
+        RenderPipelineBenchmarkSceneDefinition scene,
+        List<IFrameStateConsumer> animatedNodes)
+    {
+        RenderNode prefix = CreateSource(scene, s_targetDomain);
+        prefix = WrapShader(prefix, BenchmarkShader.Gamma);
+        prefix = WrapShader(prefix, BenchmarkShader.Invert);
+        prefix = WrapShader(prefix, BenchmarkShader.ChannelRotate);
+        var cacheBoundary = new BenchmarkCacheBoundaryNode();
+        cacheBoundary.AddChild(prefix);
+        cacheBoundary.Cache.ReportRenderCount(RenderNodeCache.Count);
+
+        var animated = new BenchmarkAnimatedShaderNode();
+        animated.AddChild(cacheBoundary);
+        animatedNodes.Add(animated);
+        RenderNode current = WrapOpacity(animated, 0.875f);
+        return WrapShader(current, BenchmarkShader.ChannelRotate);
+    }
+
+    private static RenderNode CreateMixedChain(
+        RenderPipelineBenchmarkSceneDefinition scene,
+        List<IDisposable> sceneResources)
+    {
+        RenderNode current = WrapShader(CreateSource(scene, s_targetDomain), BenchmarkShader.Gamma);
+        Blur blur = CreateMixedSpatialEffect();
+        FilterEffect.Resource blurResource = blur.ToResource(CompositionContext.Default);
+        sceneResources.Add(blurResource);
+        FilterEffectRenderNode blurNode = blurResource.CreateRenderNode();
+        blurNode.AddChild(current);
+        current = blurNode;
+        current = WrapShader(current, BenchmarkShader.Invert);
+        current = WrapOpacity(current, 0.8f);
+        return WrapShader(current, BenchmarkShader.ChannelRotate);
+    }
+
+    private static Blur CreateMixedSpatialEffect()
+    {
+        var blur = new Blur();
+        blur.Sigma.CurrentValue = new Size(3, 3);
+        return blur;
+    }
+
+    internal static FilterEffect CreateMixedSpatialEffectForTest()
+        => CreateMixedSpatialEffect();
+
+    private static RenderNode CreateSmallObject(RenderPipelineBenchmarkSceneDefinition scene)
+    {
+        Rect bounds = RenderPipelineBenchmarkScenes.GetDrawableBounds(scene, 0);
+        RenderNode current = WrapShader(CreateSource(scene, bounds), BenchmarkShader.Gamma);
+        current = WrapOpacity(current, 0.75f);
+        return WrapShader(current, BenchmarkShader.Invert);
+    }
+
+    private static RenderNode CreateMultipleRoots(RenderPipelineBenchmarkSceneDefinition scene)
+    {
+        var root = new ContainerRenderNode();
+        for (int index = 0; index < scene.TopLevelDrawableCount; index++)
+        {
+            Rect bounds = RenderPipelineBenchmarkScenes.GetDrawableBounds(scene, index);
+            RenderNode source = WrapShader(CreateSource(scene, bounds, index), BenchmarkShader.ChannelRotate);
+            var dependency = new BenchmarkTargetDependencyNode(bounds, index);
+            dependency.AddChild(source);
+            root.AddChild(dependency);
+        }
+        return root;
+    }
+
+    private static RenderNode CreateSource(
+        RenderPipelineBenchmarkSceneDefinition scene,
+        Rect bounds,
+        int variant = 0)
+    {
+        var size = new PixelSize((int)bounds.Width, (int)bounds.Height);
+        RenderTarget target = RenderTarget.Create(size.Width, size.Height)
+            ?? throw new InvalidOperationException(
+                $"Could not allocate the persistent {size.Width}x{size.Height} benchmark source.");
+        using (var bitmap = new Bitmap(
+                   size.Width,
+                   size.Height,
+                   BitmapColorType.RgbaF16,
+                   BitmapAlphaType.Premul,
+                   BitmapColorSpace.LinearSrgb))
+        {
+            RenderPipelineBenchmarkSceneDefinition sourceScene = variant == 0
+                ? scene
+                : new RenderPipelineBenchmarkSceneDefinition(
+                    scene.Name + "-source-" + variant,
+                    scene.Seed + variant * 101,
+                    scene.SemanticStageCount);
+            RenderPipelineBenchmarkScenes.CreateLinearPremultipliedRgba16F(sourceScene, size)
+                .CopyTo(bitmap.GetPixelSpan<Half>());
+            using var canvas = new ImmediateCanvas(target, 1, 1, new Size(size.Width, size.Height));
+            canvas.Clear();
+            canvas.DrawBitmap(bitmap, Brushes.Resource.White, null);
+        }
+        return new BenchmarkMaterializedSourceNode(target, bounds, scene.Name + "-source-" + variant);
+    }
+
+    private static RenderNode WrapShader(RenderNode child, ShaderDescription description)
+    {
+        var node = new BenchmarkShaderNode(description);
+        node.AddChild(child);
+        return node;
+    }
+
+    private static RenderNode WrapOpacity(RenderNode child, float opacity)
+    {
+        var node = new OpacityRenderNode(opacity);
+        node.AddChild(child);
+        return node;
+    }
+
+    private sealed class DiagnosticSession : IDisposable
+    {
+        private readonly RenderPipelineBenchmarkSceneDefinition _scene;
+        private readonly RenderNode _root;
+        private readonly RenderNodeRenderer _renderer;
+        private readonly object _diagnostics;
+        private readonly IReadOnlyList<IFrameStateConsumer> _animatedNodes;
+        private readonly IReadOnlyList<IDisposable> _sceneResources;
+        private bool _disposed;
+
+        public DiagnosticSession(RenderPipelineBenchmarkSceneDefinition scene)
+        {
+            _scene = scene;
+            var animatedNodes = new List<IFrameStateConsumer>();
+            var sceneResources = new List<IDisposable>();
+            _root = CreateScene(scene, animatedNodes, sceneResources);
+            _animatedNodes = animatedNodes.AsReadOnly();
+            _sceneResources = sceneResources.AsReadOnly();
+            _diagnostics = RenderPipelineInternalDiagnostics.CreateState();
+            RenderNodeRendererOptions options = CreateRendererOptions(scene);
+            RenderPipelineInternalDiagnostics.Attach(options, _diagnostics, RenderRequestPurpose.Frame);
+            _renderer = new RenderNodeRenderer(_root, options);
+        }
+
+        public DiagnosticCapture Capture(int productionNextFrame)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            int[] setupFrames = GetSetupFrames(_scene);
+            RenderPipelineObservedFrame? setupOutput = null;
+            SortedDictionary<string, long>? setupCounters = null;
+            for (int index = 0; index < setupFrames.Length; index++)
+            {
+                ApplyFrameState(setupFrames[index]);
+                using RenderNodeRasterization rasterization = _renderer.Rasterize();
+                SortedDictionary<string, long> counters = CaptureCounters(setupFrames[index], "setup");
+                ValidateRequestCounters(counters);
+                if (index == setupFrames.Length - 1)
+                {
+                    setupOutput = Observe(rasterization);
+                    setupCounters = counters;
+                }
+            }
+
+            SortedDictionary<string, long> verifiedSetupCounters = setupCounters
+                ?? throw new InvalidOperationException("The untimed diagnostic setup did not render a request.");
+            ValidateSceneCounters(_scene, verifiedSetupCounters);
+
+            int firstMeasuredFrame = checked(setupFrames[^1] + 1);
+            if (productionNextFrame <= firstMeasuredFrame)
+                throw new InvalidOperationException("The production benchmark completed without a measured request.");
+
+            SortedDictionary<string, long>? measuredCounters = null;
+            RenderPipelineObservedFrame? measuredOutput = null;
+            for (int frameIndex = firstMeasuredFrame; frameIndex < productionNextFrame; frameIndex++)
+            {
+                ApplyFrameState(frameIndex);
+                using RenderNodeRasterization rasterization = _renderer.Rasterize();
+                SortedDictionary<string, long> counters = CaptureCounters(frameIndex, "measured-shape");
+                ValidateRequestCounters(counters);
+                if (frameIndex == productionNextFrame - 1)
+                {
+                    measuredOutput = Observe(rasterization);
+                    measuredCounters = counters;
+                }
+            }
+            SortedDictionary<string, long> verifiedMeasuredCounters = measuredCounters
+                ?? throw new InvalidOperationException(
+                    "The untimed diagnostic session did not replay the final measured request.");
+            ValidateSceneCounters(_scene, verifiedMeasuredCounters);
+
+            return new DiagnosticCapture(
+                setupOutput
+                    ?? throw new InvalidOperationException("The untimed diagnostic setup produced no output."),
+                measuredOutput
+                    ?? throw new InvalidOperationException("The untimed diagnostic session produced no measured output."),
+                verifiedSetupCounters,
+                verifiedMeasuredCounters,
+                RenderPipelineInternalDiagnostics.CaptureNumericProperties(
+                    _renderer,
+                    "LastExecutionStatistics"),
+                RenderPipelineInternalDiagnostics.CaptureNumericProperties(
+                    _renderer,
+                    "StructuralPlanCacheStatistics"),
+                RenderPipelineInternalDiagnostics.CaptureNumericProperties(
+                    _renderer,
+                    "ProgramCacheStatistics"),
+                RenderPipelineInternalDiagnostics.CaptureNumericProperties(
+                    _renderer,
+                    "TargetPoolStatistics"));
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _renderer.Dispose();
+            _root.Dispose();
+            for (int index = _sceneResources.Count - 1; index >= 0; index--)
+                _sceneResources[index].Dispose();
+            _disposed = true;
+        }
+
+        private SortedDictionary<string, long> CaptureCounters(int frameIndex, string phase)
+        {
+            SortedDictionary<string, long> counters =
+                RenderPipelineInternalDiagnostics.CaptureLatestCounters(_diagnostics, out bool succeeded);
+            if (!succeeded)
+            {
+                throw new InvalidOperationException(
+                    $"Untimed {phase} diagnostic render {frameIndex} for '{_scene.Name}' failed.");
+            }
+            return counters;
+        }
+
+        private void ApplyFrameState(int frameIndex)
+        {
+            RenderPipelineBenchmarkFrameState state = _scene.GetFrameState(frameIndex);
+            foreach (IFrameStateConsumer node in _animatedNodes)
+                node.Apply(state);
+        }
+    }
+
+    private sealed record DiagnosticCapture(
+        RenderPipelineObservedFrame SetupOutput,
+        RenderPipelineObservedFrame MeasuredOutput,
+        SortedDictionary<string, long> SetupCounters,
+        SortedDictionary<string, long> MeasuredCounters,
+        SortedDictionary<string, long> LastExecutionStatistics,
+        SortedDictionary<string, long> StructuralPlanCacheStatistics,
+        SortedDictionary<string, long> ProgramCacheStatistics,
+        SortedDictionary<string, long> TargetPoolStatistics);
+
+    private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
+
+    private static byte[] EncodeRgba16f(Bitmap bitmap)
+    {
+        if (bitmap.ColorType != BitmapColorType.RgbaF16
+            || bitmap.AlphaType != BitmapAlphaType.Premul
+            || !bitmap.ColorSpace.Equals(BitmapColorSpace.LinearSrgb))
+        {
+            throw new InvalidOperationException("Benchmark bitmap must be RgbaF16/Premul/LinearSrgb.");
+        }
+
+        byte[] bytes = new byte[checked(bitmap.Width * bitmap.Height * 8)];
+        int destination = 0;
+        for (int y = 0; y < bitmap.Height; y++)
+        {
+            ReadOnlySpan<ushort> row = bitmap.GetRow<ushort>(y);
+            if (row.Length != bitmap.Width * 4)
+                throw new InvalidOperationException("Unexpected RGBA16F row length.");
+            foreach (ushort component in row)
+            {
+                BinaryPrimitives.WriteUInt16LittleEndian(bytes.AsSpan(destination, 2), component);
+                destination += 2;
+            }
+        }
+
+        return bytes;
+    }
+}
+
+internal interface IFrameStateConsumer
+{
+    void Apply(RenderPipelineBenchmarkFrameState state);
+}
+
+internal sealed class BenchmarkMaterializedSourceNode(
+    RenderTarget target,
+    Rect bounds,
+    string cacheIdentity) : RenderNode
+{
+    public override void Process(RenderNodeContext context)
+    {
+        RenderResource<RenderTarget> resource = context.Borrow(target, cacheIdentity, version: 1);
+        context.Publish(context.MaterializedInput(MaterializedInputDescription.FromRenderTarget(
+            resource,
+            bounds,
+            EffectiveScale.At(1),
+            PixelRect.FromRect(bounds, 1),
+            default,
+            RenderHitTestContract.OutputBounds)));
+    }
+
+    protected override void OnDispose(bool disposing)
+    {
+        if (disposing)
+            target.Dispose();
+    }
+}
+
+internal sealed class BenchmarkShaderNode(ShaderDescription description) : ContainerRenderNode
+{
+    public override void Process(RenderNodeContext context)
+    {
+        foreach (RenderFragmentHandle input in context.Inputs)
+            context.Publish(context.Shader(input, description));
+    }
+}
+
+internal sealed class BenchmarkAnimatedShaderNode : ContainerRenderNode, IFrameStateConsumer
+{
+    private float _amount = 1;
+
+    public void Apply(RenderPipelineBenchmarkFrameState state)
+    {
+        _amount = state.AnimatedAmount;
+    }
+
+    public override void Process(RenderNodeContext context)
+    {
+        float amount = _amount;
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            "uniform float amount; half4 apply(half4 color) { "
+            + "return half4(min(color.rgb * amount, color.aaa), color.a); }",
+            bindings => bindings.Uniform("amount", amount));
+        foreach (RenderFragmentHandle input in context.Inputs)
+            context.Publish(context.Shader(input, description));
+    }
+}
+
+internal sealed class BenchmarkStructuralToggleNode : ContainerRenderNode, IFrameStateConsumer
+{
+    private bool _variant;
+
+    public void Apply(RenderPipelineBenchmarkFrameState state)
+    {
+        _variant = state.StructuralVariant;
+    }
+
+    public override void Process(RenderNodeContext context)
+    {
+        ShaderDescription description = _variant ? BenchmarkShader.ChannelRotate : BenchmarkShader.Invert;
+        foreach (RenderFragmentHandle input in context.Inputs)
+            context.Publish(context.Shader(input, description));
+    }
+}
+
+internal sealed class BenchmarkCacheBoundaryNode : ContainerRenderNode
+{
+    public override void Process(RenderNodeContext context) => context.PassThrough();
+}
+
+internal sealed class BenchmarkTargetDependencyNode(Rect bounds, int index) : ContainerRenderNode
+{
+    public override void Process(RenderNodeContext context)
+    {
+        context.PublishRange(context.Inputs);
+        TargetCommandDescription command = TargetCommandDescription.Create(
+            index,
+            static (_, _) => { },
+            TargetRegion.Region(bounds),
+            bounds,
+            RenderHitTestContract.OutputBounds,
+            structuralKey: $"render-pipeline-target-dependency-{index}");
+        context.Publish(context.TargetCommand(context.Inputs, command));
+    }
+}
+
+internal static class BenchmarkShader
+{
+    public static ShaderDescription Gamma { get; } = ShaderDescription.CurrentPixel(
+        "half4 apply(half4 color) { return half4(sqrt(max(color.rgb, half3(0))), color.a); }");
+
+    public static ShaderDescription Invert { get; } = ShaderDescription.CurrentPixel(
+        "half4 apply(half4 color) { return half4(color.a - color.rgb, color.a); }");
+
+    public static ShaderDescription ChannelRotate { get; } = ShaderDescription.CurrentPixel(
+        "half4 apply(half4 color) { return half4(color.g, color.b, color.r, color.a); }");
+
+    public static ShaderDescription WholeSourceIdentity { get; } = ShaderDescription.WholeSource(
+        "uniform shader src; half4 main(float2 coord) { return src.eval(coord); }",
+        RenderBoundsContract.Identity);
+}
+
+internal sealed record RenderPipelineObservedFrame(
+    bool IsEmpty,
+    Rect Bounds,
+    int Width,
+    int Height,
+    ulong Token,
+    ulong Checksum,
+    string Sha256,
+    double Energy);
+
+internal static class RenderPipelineInternalDiagnostics
+{
+    private const BindingFlags InstanceFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+    public static object CreateState()
+    {
+        Type type = typeof(RenderNode).Assembly.GetType(
+            "Beutl.Graphics.Rendering.RenderPipelineDiagnosticsState",
+            throwOnError: true)!;
+        return Activator.CreateInstance(type, nonPublic: true)
+            ?? throw new InvalidOperationException("Could not create the internal render diagnostics state.");
+    }
+
+    public static void Attach(
+        RenderNodeRendererOptions options,
+        object state,
+        RenderRequestPurpose purpose)
+    {
+        // Diagnostics and Purpose live on the default request record; its init-only
+        // accessors remain reflection-settable before the renderer copies the request.
+        object request = GetProperty(options, "DefaultRequest");
+        SetProperty(request, "Diagnostics", state);
+        SetProperty(request, "Purpose", purpose);
+    }
+
+    public static void SetPurpose(RenderNodeRendererOptions options, RenderRequestPurpose purpose)
+        => SetProperty(GetProperty(options, "DefaultRequest"), "Purpose", purpose);
+
+    public static SortedDictionary<string, long> CaptureLatestCounters(object state, out bool succeeded)
+    {
+        object snapshot = GetProperty(state, "Latest");
+        succeeded = (bool)GetProperty(snapshot, "Succeeded");
+        object counters = GetProperty(snapshot, "Counters");
+        var result = new SortedDictionary<string, long>(StringComparer.Ordinal);
+        foreach (object item in (IEnumerable)counters)
+        {
+            object key = GetProperty(item, "Key");
+            object value = GetProperty(item, "Value");
+            result.Add(key.ToString()!, Convert.ToInt64(value, System.Globalization.CultureInfo.InvariantCulture));
+        }
+        return result;
+    }
+
+    public static SortedDictionary<string, long> CaptureNumericProperties(object owner, string propertyName)
+    {
+        object value = GetProperty(owner, propertyName);
+        var result = new SortedDictionary<string, long>(StringComparer.Ordinal);
+        foreach (PropertyInfo property in value.GetType().GetProperties(InstanceFlags).OrderBy(static x => x.Name))
+        {
+            object? propertyValue = property.GetValue(value);
+            if (TryConvertInt64(propertyValue, out long number))
+                result.Add(property.Name, number);
+        }
+        return result;
+    }
+
+    private static bool TryConvertInt64(object? value, out long result)
+    {
+        switch (value)
+        {
+            case byte item: result = item; return true;
+            case sbyte item: result = item; return true;
+            case short item: result = item; return true;
+            case ushort item: result = item; return true;
+            case int item: result = item; return true;
+            case uint item: result = item; return true;
+            case long item: result = item; return true;
+            case ulong item when item <= long.MaxValue: result = (long)item; return true;
+            default: result = 0; return false;
+        }
+    }
+
+    private static object GetProperty(object owner, string name)
+    {
+        PropertyInfo property = owner.GetType().GetProperty(name, InstanceFlags)
+            ?? throw new MissingMemberException(owner.GetType().FullName, name);
+        return property.GetValue(owner)
+            ?? throw new InvalidOperationException($"Property '{name}' unexpectedly returned null.");
+    }
+
+    private static void SetProperty(object owner, string name, object value)
+    {
+        PropertyInfo property = owner.GetType().GetProperty(name, InstanceFlags)
+            ?? throw new MissingMemberException(owner.GetType().FullName, name);
+        property.SetValue(owner, value);
+    }
+}
+
+internal sealed class RenderPipelineBenchmarkCounterRecord
+{
+    internal static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+
+    public int SchemaVersion { get; init; }
+    public string CaseName { get; init; } = string.Empty;
+    public int Seed { get; init; }
+    public int Width { get; init; }
+    public int Height { get; init; }
+    public int SetupWarmupFrames { get; init; }
+    public string Lifetime { get; init; } = string.Empty;
+    public string RequestShape { get; init; } = string.Empty;
+    public int SemanticStageCount { get; init; }
+    public int TopLevelDrawableCount { get; init; }
+    public string Animation { get; init; } = string.Empty;
+    public string Barrier { get; init; } = string.Empty;
+    public bool HasStaticPrefixCache { get; init; }
+    public bool HasTargetDependencies { get; init; }
+    public string OutputSha256 { get; init; } = string.Empty;
+    public string OutputChecksum { get; init; } = string.Empty;
+    public Rect OutputBounds { get; init; }
+    public string SetupOutputBlobFile { get; init; } = string.Empty;
+    public string MeasuredOutputBlobFile { get; init; } = string.Empty;
+    public string MeasuredOutputSha256 { get; init; } = string.Empty;
+    public string MeasuredOutputChecksum { get; init; } = string.Empty;
+    public Rect MeasuredOutputBounds { get; init; }
+    public int MeasuredWidth { get; init; }
+    public int MeasuredHeight { get; init; }
+    public string ExpectedMeasuredOutputSha256 { get; init; } = string.Empty;
+    public string ExpectedMeasuredOutputChecksum { get; init; } = string.Empty;
+    public Rect ExpectedMeasuredOutputBounds { get; init; }
+    public int ExpectedMeasuredWidth { get; init; }
+    public int ExpectedMeasuredHeight { get; init; }
+    public RenderPipelineEvidenceFingerprint Fingerprint { get; init; } = new();
+    public SortedDictionary<string, long> SetupLastRequestCounters { get; init; } = new(StringComparer.Ordinal);
+    public SortedDictionary<string, long> MeasuredLastRequestCounters { get; init; } = new(StringComparer.Ordinal);
+    public SortedDictionary<string, long> LastExecutionStatistics { get; init; } = new(StringComparer.Ordinal);
+    public SortedDictionary<string, long> StructuralPlanCacheStatistics { get; init; } = new(StringComparer.Ordinal);
+    public SortedDictionary<string, long> ProgramCacheStatistics { get; init; } = new(StringComparer.Ordinal);
+    public SortedDictionary<string, long> TargetPoolStatistics { get; init; } = new(StringComparer.Ordinal);
+}
+
+internal sealed class RenderPipelineEvidenceFingerprint
+{
+    public string OsDescription { get; init; } = string.Empty;
+    public string OsVersion { get; init; } = string.Empty;
+    public string OsBuild { get; init; } = string.Empty;
+    public string OsArchitecture { get; init; } = string.Empty;
+    public string ProcessArchitecture { get; init; } = string.Empty;
+    public string RuntimeIdentifier { get; init; } = string.Empty;
+    public string FrameworkDescription { get; init; } = string.Empty;
+    public string EnvironmentVersion { get; init; } = string.Empty;
+    public string RendererBackend { get; init; } = string.Empty;
+    public string SkiaBackend { get; init; } = string.Empty;
+    public string DeviceSelection { get; init; } = string.Empty;
+    public string VulkanApiVersion { get; init; } = string.Empty;
+    public string VulkanVendorId { get; init; } = string.Empty;
+    public string VulkanDeviceId { get; init; } = string.Empty;
+    public string VulkanDeviceType { get; init; } = string.Empty;
+    public string VulkanDeviceName { get; init; } = string.Empty;
+    public string VulkanDeviceUuid { get; init; } = string.Empty;
+    public string VulkanDriverUuid { get; init; } = string.Empty;
+    public string VulkanDriverId { get; init; } = string.Empty;
+    public string VulkanDriverName { get; init; } = string.Empty;
+    public string VulkanDriverInfo { get; init; } = string.Empty;
+    public string VulkanDriverVersionRaw { get; init; } = string.Empty;
+    public string VulkanDriverVersionDecoded { get; init; } = string.Empty;
+    public string[] VulkanEnabledExtensions { get; init; } = [];
+    public string MetalDeviceName { get; init; } = string.Empty;
+    public string MetalRegistryId { get; init; } = string.Empty;
+    public string MetalFeatureFamily { get; init; } = string.Empty;
+    public string MetalDriver { get; init; } = string.Empty;
+    public string SkiaSharpManagedVersion { get; init; } = string.Empty;
+    public string SkiaSharpNativeVersion { get; init; } = string.Empty;
+    public string SilkNetVulkanVersion { get; init; } = string.Empty;
+    public string BeutlEngineAssemblyVersion { get; init; } = string.Empty;
+
+    public static unsafe RenderPipelineEvidenceFingerprint Capture(IGraphicsContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        BindingFlags flags = BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        PropertyInfo instanceProperty = typeof(GraphicsContextFactory).GetProperty("VulkanInstance", flags)
+            ?? throw new MissingMemberException(typeof(GraphicsContextFactory).FullName, "VulkanInstance");
+        object instance = instanceProperty.GetValue(null)
+            ?? throw new InvalidOperationException("The Vulkan instance was not initialized.");
+        Vk vk = (Vk)(instance.GetType().GetProperty("Vk", flags)?.GetValue(instance)
+            ?? throw new InvalidOperationException("The Vulkan API handle was unavailable."));
+
+        MethodInfo selectedMethod = typeof(GraphicsContextFactory).GetMethod("GetSelectedGpuDetails", flags)
+            ?? throw new MissingMethodException(typeof(GraphicsContextFactory).FullName, "GetSelectedGpuDetails");
+        object selected = selectedMethod.Invoke(null, null)
+            ?? throw new InvalidOperationException("The selected Vulkan physical device was unavailable.");
+        PhysicalDevice physicalDevice = (PhysicalDevice)(selected.GetType().GetProperty("Device", flags)?.GetValue(selected)
+            ?? throw new InvalidOperationException("The selected Vulkan device handle was unavailable."));
+
+        var idProperties = new PhysicalDeviceIDProperties
+        {
+            SType = StructureType.PhysicalDeviceIDProperties,
+        };
+        var driverProperties = new PhysicalDeviceDriverProperties
+        {
+            SType = StructureType.PhysicalDeviceDriverProperties,
+            PNext = &idProperties,
+        };
+        var properties2 = new PhysicalDeviceProperties2
+        {
+            SType = StructureType.PhysicalDeviceProperties2,
+            PNext = &driverProperties,
+        };
+        vk.GetPhysicalDeviceProperties2(physicalDevice, &properties2);
+
+        PhysicalDeviceProperties properties = properties2.Properties;
+        string deviceName = FixedUtf8(properties.DeviceName, Vk.MaxPhysicalDeviceNameSize);
+        string driverName = FixedUtf8(driverProperties.DriverName, Vk.MaxDriverNameSize);
+        string driverInfo = FixedUtf8(driverProperties.DriverInfo, Vk.MaxDriverInfoSize);
+        string deviceUuid = Hex(idProperties.DeviceUuid, Vk.UuidSize);
+        string driverUuid = Hex(idProperties.DriverUuid, Vk.UuidSize);
+        MetalFingerprint metal = CaptureMetalFingerprint();
+        string backend = context.Backend.ToString();
+        string skiaBackend = context.GetType().FullName switch
+        {
+            "Beutl.Graphics.Backend.Composite.CompositeContext" => "Metal",
+            "Beutl.Graphics.Backend.Vulkan.VulkanContext" => "Vulkan",
+            _ => backend,
+        };
+        string osBuild = OperatingSystem.IsMacOS()
+            ? RunProcess("/usr/bin/sw_vers", ["-buildVersion"]).Trim()
+            : ReadOsBuild();
+
+        var result = new RenderPipelineEvidenceFingerprint
+        {
+            OsDescription = RuntimeInformation.OSDescription,
+            OsVersion = Environment.OSVersion.VersionString,
+            OsBuild = osBuild,
+            OsArchitecture = RuntimeInformation.OSArchitecture.ToString(),
+            ProcessArchitecture = RuntimeInformation.ProcessArchitecture.ToString(),
+            RuntimeIdentifier = RuntimeInformation.RuntimeIdentifier,
+            FrameworkDescription = RuntimeInformation.FrameworkDescription,
+            EnvironmentVersion = Environment.Version.ToString(),
+            RendererBackend = backend,
+            SkiaBackend = skiaBackend,
+            DeviceSelection = "automatic-no-preferred-device",
+            VulkanApiVersion = DecodeVulkanVersion(properties.ApiVersion),
+            VulkanVendorId = $"0x{properties.VendorID:x8}",
+            VulkanDeviceId = $"0x{properties.DeviceID:x8}",
+            VulkanDeviceType = properties.DeviceType.ToString(),
+            VulkanDeviceName = deviceName,
+            VulkanDeviceUuid = deviceUuid,
+            VulkanDriverUuid = driverUuid,
+            VulkanDriverId = driverProperties.DriverID.ToString(),
+            VulkanDriverName = driverName,
+            VulkanDriverInfo = driverInfo,
+            VulkanDriverVersionRaw = properties.DriverVersion.ToString(),
+            VulkanDriverVersionDecoded = DecodeVulkanVersion(properties.DriverVersion),
+            VulkanEnabledExtensions = GraphicsContextFactory.GetEnabledExtensions()
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal)
+                .ToArray(),
+            MetalDeviceName = metal.DeviceName,
+            MetalRegistryId = metal.RegistryId,
+            MetalFeatureFamily = metal.FeatureFamily,
+            MetalDriver = OperatingSystem.IsMacOS()
+                ? $"Apple Metal shipped with macOS build {osBuild}"
+                : "not-applicable",
+            SkiaSharpManagedVersion = AssemblyVersion(typeof(SKBitmap).Assembly),
+            SkiaSharpNativeVersion = SkiaSharpVersion.Native.ToString(),
+            SilkNetVulkanVersion = AssemblyVersion(typeof(Vk).Assembly),
+            BeutlEngineAssemblyVersion = AssemblyVersion(typeof(RenderNode).Assembly),
+        };
+        Validate(result);
+        return result;
+    }
+
+    private static MetalFingerprint CaptureMetalFingerprint()
+    {
+        if (!OperatingSystem.IsMacOS())
+            return new MetalFingerprint("not-applicable", "not-applicable", "not-applicable");
+
+        IntPtr device = MTLCreateSystemDefaultDevice();
+        if (device == IntPtr.Zero)
+            throw new InvalidOperationException("MTLCreateSystemDefaultDevice returned null.");
+        try
+        {
+            IntPtr nameObject = IntPtr_objc_msgSend(device, sel_registerName("name"));
+            IntPtr utf8 = IntPtr_objc_msgSend(nameObject, sel_registerName("UTF8String"));
+            string name = Marshal.PtrToStringUTF8(utf8)
+                ?? throw new InvalidOperationException("The Metal device name was null.");
+            ulong registryId = UInt64_objc_msgSend(device, sel_registerName("registryID"));
+            if (registryId == 0)
+                throw new InvalidOperationException("The Metal registry ID was zero.");
+
+            string profiler = RunProcess("/usr/sbin/system_profiler", ["SPDisplaysDataType", "-json"]);
+            using JsonDocument document = JsonDocument.Parse(profiler);
+            JsonElement gpu = document.RootElement.GetProperty("SPDisplaysDataType")[0];
+            string featureFamily = gpu.TryGetProperty("spdisplays_mtlgpufamilysupport", out JsonElement family)
+                ? family.GetString()
+                    ?? throw new InvalidOperationException("The Metal feature-family value was null.")
+                : throw new InvalidOperationException("system_profiler did not report a Metal feature family.");
+            return new MetalFingerprint(name, $"0x{registryId:x16}", featureFamily);
+        }
+        finally
+        {
+            objc_release(device);
+        }
+    }
+
+    private static unsafe string FixedUtf8(byte* value, uint maxLength)
+    {
+        int length = 0;
+        while (length < maxLength && value[length] != 0)
+            length++;
+        return Encoding.UTF8.GetString(new ReadOnlySpan<byte>(value, length));
+    }
+
+    private static unsafe string Hex(byte* value, uint length)
+        => Convert.ToHexString(new ReadOnlySpan<byte>(value, checked((int)length))).ToLowerInvariant();
+
+    private static string DecodeVulkanVersion(uint value)
+        => $"{value >> 22}.{(value >> 12) & 0x3ff}.{value & 0xfff}";
+
+    private static string ReadOsBuild()
+    {
+        if (OperatingSystem.IsLinux() && File.Exists("/etc/os-release"))
+            return Convert.ToHexString(SHA256.HashData(File.ReadAllBytes("/etc/os-release"))).ToLowerInvariant();
+        return Environment.OSVersion.VersionString;
+    }
+
+    private static string RunProcess(string fileName, IReadOnlyList<string> arguments)
+    {
+        var startInfo = new ProcessStartInfo(fileName)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (string argument in arguments)
+            startInfo.ArgumentList.Add(argument);
+        using Process process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"Could not start '{fileName}'.");
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"'{fileName}' exited with {process.ExitCode}: {stderr.Trim()}");
+        }
+        return stdout;
+    }
+
+    private static string AssemblyVersion(Assembly assembly)
+        => assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+           ?? assembly.GetName().Version?.ToString()
+           ?? throw new InvalidOperationException($"Assembly '{assembly.FullName}' has no version.");
+
+    internal static void Validate(RenderPipelineEvidenceFingerprint fingerprint)
+    {
+        ArgumentNullException.ThrowIfNull(fingerprint);
+        foreach (PropertyInfo property in typeof(RenderPipelineEvidenceFingerprint).GetProperties())
+        {
+            object? value = property.GetValue(fingerprint);
+            if (value is string text
+                && (text.Contains("unknown", StringComparison.OrdinalIgnoreCase)
+                    || (string.IsNullOrWhiteSpace(text)
+                        && !(string.Equals(fingerprint.VulkanDeviceType, "Cpu", StringComparison.OrdinalIgnoreCase)
+                             && string.Equals(property.Name, "VulkanDriverInfo", StringComparison.OrdinalIgnoreCase)))))
+            {
+                throw new InvalidOperationException(
+                    $"Fingerprint field '{property.Name}' is missing or unknown.");
+            }
+            if (value is string[] array
+                && (array.Length == 0 || array.Any(string.IsNullOrWhiteSpace)))
+            {
+                throw new InvalidOperationException($"Fingerprint field '{property.Name}' is empty.");
+            }
+        }
+    }
+
+    [DllImport("/System/Library/Frameworks/Metal.framework/Metal")]
+    private static extern IntPtr MTLCreateSystemDefaultDevice();
+
+    [DllImport("/usr/lib/libobjc.A.dylib")]
+    private static extern IntPtr sel_registerName(string name);
+
+    [DllImport("/usr/lib/libobjc.A.dylib", EntryPoint = "objc_msgSend")]
+    private static extern IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector);
+
+    [DllImport("/usr/lib/libobjc.A.dylib", EntryPoint = "objc_msgSend")]
+    private static extern ulong UInt64_objc_msgSend(IntPtr receiver, IntPtr selector);
+
+    [DllImport("/usr/lib/libobjc.A.dylib")]
+    private static extern void objc_release(IntPtr value);
+
+    private sealed record MetalFingerprint(string DeviceName, string RegistryId, string FeatureFamily);
+}

--- a/tests/Beutl.Graphics3DTests/GpuPassFusion3DBoundaryTests.cs
+++ b/tests/Beutl.Graphics3DTests/GpuPassFusion3DBoundaryTests.cs
@@ -1,0 +1,418 @@
+﻿using System.Numerics;
+
+using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Graphics.Shapes;
+using Beutl.Graphics3D;
+using Beutl.Graphics3D.Lighting;
+using Beutl.Graphics3D.Materials;
+using Beutl.Graphics3D.Primitives;
+using Beutl.Graphics3D.Textures;
+using Beutl.Media;
+
+namespace Beutl.Graphics3DTests;
+
+[TestFixture]
+[NonParallelizable]
+public sealed class GpuPassFusion3DBoundaryTests
+{
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void Scene3D_MaterializesOneBackendBoundary_ThenResumesTwoDimensionalWork()
+    {
+        GpuTestEnvironment.EnsureAvailable();
+        GpuTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var scene = new Scene3D();
+            scene.RenderWidth.CurrentValue = 32;
+            scene.RenderHeight.CurrentValue = 24;
+            scene.BackgroundColor.CurrentValue = new Color(255, 32, 64, 96);
+            using var resource = (Scene3D.Resource)scene.ToResource(CompositionContext.Default);
+            using var sceneNode = new Scene3DRenderNode(resource);
+            using var root = new DownstreamShaderNode(sceneNode);
+
+            using (CompiledRenderRequest compiled = Compile(root))
+            {
+                RenderFragmentReference sceneBoundary = compiled.Graph.Fragments
+                    .Select(static fragment => (RenderFragmentReference)fragment.Payload!)
+                    .Single(static fragment => fragment.Kind == RenderFragmentKind.OpaqueSource);
+                CompiledShaderRun[] shaderRuns = compiled.ExecutionPlan.ShaderRuns.ToArray();
+                Assert.Multiple(() =>
+                {
+                    Assert.That(
+                        sceneBoundary.ValueCardinality,
+                        Is.EqualTo(RenderValueCardinality.ZeroOrOne));
+                    Assert.That(compiled.ExecutionPlan.Boundaries.Count(static item =>
+                        item.Reason == ExecutionIslandBoundaryReason.ThreeD), Is.EqualTo(1));
+                    Assert.That(compiled.ExecutionPlan.Boundaries.Count(static item =>
+                        item.Reason == ExecutionIslandBoundaryReason.BackendTransition), Is.EqualTo(1));
+                    Assert.That(shaderRuns, Has.Length.EqualTo(1));
+                });
+                Assert.That(shaderRuns.Single().Stages, Has.Length.EqualTo(1));
+            }
+
+            using var renderer = new RenderNodeRenderer(
+                root,
+                new RenderNodeRendererOptions
+                {
+                    DefaultRequest = new RenderNodeRenderRequest
+                    {
+                        TargetDomain = new Rect(0, 0, 32, 24),
+                        OutputScale = 1,
+                        MaxWorkingScale = 1,
+                        CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    },
+                });
+            using RenderNodeRasterization rasterization = renderer.Rasterize();
+            Bitmap bitmap = rasterization.Bitmap
+                ?? throw new AssertionException("The 3D-to-2D hand-off must publish a bitmap.");
+            Vector4 expectedBackground = scene.BackgroundColor.CurrentValue.ToLinearPremultiplied();
+            Vector4 actualCenter = ReadLinearPixel(bitmap, 16, 12);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(rasterization.Bounds, Is.EqualTo(new Rect(0, 0, 32, 24)));
+                Assert.That(renderer.LastExecutionStatistics.Synchronizations, Is.EqualTo(1));
+                Assert.That(renderer.LastExecutionStatistics.ShaderRunExecutions, Is.EqualTo(1));
+                Assert.That(renderer.LastExecutionStatistics.ShaderStageExecutions, Is.EqualTo(1));
+                Assert.That(bitmap.GetPixelSpan<ushort>().ToArray(), Has.Some.Not.Zero,
+                    "The 3D-to-2D hand-off must publish a non-vacuous value.");
+                Assert.That(actualCenter.X, Is.EqualTo(expectedBackground.Z).Within(0.003f),
+                    "The downstream shader must swap blue into the red channel.");
+                Assert.That(actualCenter.Y, Is.EqualTo(expectedBackground.Y).Within(0.003f),
+                    "The downstream shader must preserve the green channel.");
+                Assert.That(actualCenter.Z, Is.EqualTo(expectedBackground.X).Within(0.003f),
+                    "The downstream shader must swap red into the blue channel.");
+                Assert.That(actualCenter.W, Is.EqualTo(expectedBackground.W).Within(0.003f),
+                    "The downstream shader must preserve alpha.");
+            });
+        });
+    }
+
+    private static Vector4 ReadLinearPixel(Bitmap bitmap, int x, int y)
+    {
+        int offset = ((y * bitmap.Width) + x) * 4;
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        return new Vector4(
+            (float)BitConverter.UInt16BitsToHalf(pixels[offset]),
+            (float)BitConverter.UInt16BitsToHalf(pixels[offset + 1]),
+            (float)BitConverter.UInt16BitsToHalf(pixels[offset + 2]),
+            (float)BitConverter.UInt16BitsToHalf(pixels[offset + 3]));
+    }
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void Scene3D_ReusesItsRendererAcrossRequests()
+    {
+        GpuTestEnvironment.EnsureAvailable();
+        GpuTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var scene = new Scene3D();
+            scene.RenderWidth.CurrentValue = 32;
+            scene.RenderHeight.CurrentValue = 24;
+            using var resource = (Scene3D.Resource)scene.ToResource(CompositionContext.Default);
+            using var sceneNode = new Scene3DRenderNode(resource);
+            Renderer3D? firstRenderer;
+
+            using (var renderer = new RenderNodeRenderer(
+                       sceneNode,
+                       new RenderNodeRendererOptions
+                       {
+                           DefaultRequest = new RenderNodeRenderRequest
+                           {
+                               TargetDomain = new Rect(0, 0, 32, 24),
+                               OutputScale = 1,
+                               MaxWorkingScale = 1,
+                               CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                           },
+                       }))
+            {
+                Assert.That(resource.Renderer, Is.Null);
+                using (renderer.Rasterize())
+                {
+                }
+
+                firstRenderer = resource.Renderer;
+                Assert.That(firstRenderer, Is.Not.Null);
+
+                using (renderer.Rasterize())
+                {
+                }
+
+                Assert.That(resource.Renderer, Is.SameAs(firstRenderer));
+            }
+
+            Assert.That(
+                resource.Renderer,
+                Is.SameAs(firstRenderer),
+                "Request and RenderNodeRenderer cleanup must not dispose the scene-owned renderer.");
+        });
+    }
+
+    [TestCase(MaterialTextureDependency.BasicDiffuseMap)]
+    [TestCase(MaterialTextureDependency.PbrAlbedoMap)]
+    [TestCase(MaterialTextureDependency.PbrNormalMap)]
+    [TestCase(MaterialTextureDependency.PbrMetallicRoughnessMap)]
+    [TestCase(MaterialTextureDependency.PbrEmissiveMap)]
+    [TestCase(MaterialTextureDependency.PbrAOMap)]
+    [TestCase(MaterialTextureDependency.TransparentColorMap)]
+    [Category("GpuPassFusionGpu")]
+    public void Scene3D_DrawableTextureConsumesItsPlannedNestedTarget(
+        MaterialTextureDependency dependency)
+    {
+        GpuTestEnvironment.EnsureAvailable();
+        GpuTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var drawable = new RectShape();
+            drawable.Width.CurrentValue = 12;
+            drawable.Height.CurrentValue = 8;
+            drawable.Fill.CurrentValue = new SolidColorBrush(new Color(255, 192, 0, 0));
+            var texture = new DrawableTextureSource();
+            texture.Drawable.CurrentValue = drawable;
+            texture.TextureWidth.CurrentValue = 12;
+            texture.TextureHeight.CurrentValue = 8;
+            Material3D material = CreateMaterial(dependency, texture);
+            using var resource = CreateSceneResource(material);
+            using var sceneNode = new Scene3DRenderNode(resource);
+
+            var targetDomain = new Rect(0, 0, 48, 36);
+            using CompiledRenderRequest compiled = Compile(
+                sceneNode,
+                targetDomain,
+                outputScale: 1.75f,
+                maxWorkingScale: 0.75f);
+            CompiledRenderRequest nested = compiled.NestedRequests.Single();
+            NestedRenderTargetBinding binding = nested.Request.Options.TargetBinding
+                ?? throw new AssertionException("The drawable texture has no planned target binding.");
+            Assert.Multiple(() =>
+            {
+                Assert.That(nested.Request.Options.TargetDomain, Is.EqualTo(new Rect(0, 0, 12, 8)));
+                Assert.That(nested.Request.Options.OutputScale, Is.EqualTo(0.75f));
+                Assert.That(nested.Request.Options.MaxWorkingScale, Is.EqualTo(0.75f));
+                Assert.That(binding.IsReady, Is.False);
+            });
+
+            ushort[] renderedPixels;
+            RenderExecutionStatistics statistics;
+            using var registry = new RenderTargetLeaseRegistry(factory: null);
+            using (RenderTargetLeaseSession targets = registry.BeginSession(
+                RenderIntent.Preview,
+                RenderAllocationBudget.Default))
+            using (RenderTargetLease root = targets.Acquire(
+                       PixelRect.FromRect(compiled.ExecutionTargetBounds, 1.75f).Size))
+            using (var canvas = new ImmediateCanvas(
+                       root.Target,
+                       density: 1.75f,
+                       maxWorkingScale: 0.75f,
+                       logicalSize: compiled.ExecutionTargetBounds.Size))
+            using (canvas.PushTransform(Matrix.CreateTranslation(
+                       -compiled.ExecutionTargetBounds.X,
+                       -compiled.ExecutionTargetBounds.Y)))
+            {
+                canvas.Clear();
+                var executor = new RenderRequestExecutor(targets);
+                executor.Execute(
+                    compiled,
+                    canvas,
+                    replayBounds: compiled.ExecutionTargetBounds);
+                statistics = executor.Statistics;
+                using Bitmap rendered = root.Target.Snapshot();
+                renderedPixels = rendered.GetPixelSpan<ushort>().ToArray();
+            }
+
+            ushort[] controlPixels = RenderScene(CreateMaterial(dependency, texture: null));
+            double maximumRgbDifference = MaximumRgbDifference(renderedPixels, controlPixels);
+            Assert.Multiple(() =>
+            {
+                Assert.That(statistics.IntermediateTargetAcquisitions, Is.GreaterThanOrEqualTo(1));
+                Assert.That(maximumRgbDifference, Is.GreaterThan(0.01),
+                    "The textured scene must differ from the no-texture control in RGB content.");
+                Assert.That(binding.Density, Is.EqualTo(0.75f),
+                    "The planned drawable target must match the 3D surface density passed to GetTexture.");
+                Assert.That(binding.DeviceBounds, Is.EqualTo(new PixelRect(0, 0, 9, 6)));
+                Assert.That(binding.IsDisposed, Is.True);
+                Assert.That(registry.Statistics.LeasedTargets, Is.Zero);
+            });
+        });
+    }
+
+    private static Scene3D.Resource CreateSceneResource(Material3D material)
+    {
+        var cube = new Cube3D();
+        cube.Material.CurrentValue = material;
+        var light = new DirectionalLight3D();
+        light.Direction.CurrentValue = new Vector3(0, 0, -1);
+        light.Intensity.CurrentValue = 1;
+        light.IsEnabled = true;
+
+        var scene = new Scene3D();
+        scene.RenderWidth.CurrentValue = 48;
+        scene.RenderHeight.CurrentValue = 36;
+        scene.BackgroundColor.CurrentValue = Colors.Black;
+        scene.AmbientColor.CurrentValue = Colors.White;
+        // Full white ambient saturates the clamped output, hiding every additive/specular
+        // contribution and zeroing the emissive/normal/metallic-roughness RGB differences.
+        scene.AmbientIntensity.CurrentValue = 0.2f;
+        var resource = (Scene3D.Resource)scene.ToResource(CompositionContext.Default);
+        resource.Objects.Add((Object3D.Resource)cube.ToResource(CompositionContext.Default));
+        resource.Lights.Add((Light3D.Resource)light.ToResource(CompositionContext.Default));
+        return resource;
+    }
+
+    private static ushort[] RenderScene(Material3D material)
+    {
+        using var resource = CreateSceneResource(material);
+        using var sceneNode = new Scene3DRenderNode(resource);
+        var targetDomain = new Rect(0, 0, 48, 36);
+        using CompiledRenderRequest compiled = Compile(
+            sceneNode,
+            targetDomain,
+            outputScale: 1.75f,
+            maxWorkingScale: 0.75f);
+        using var registry = new RenderTargetLeaseRegistry(factory: null);
+        using RenderTargetLeaseSession targets = registry.BeginSession(
+            RenderIntent.Preview,
+            RenderAllocationBudget.Default);
+        using RenderTargetLease root = targets.Acquire(
+            PixelRect.FromRect(compiled.ExecutionTargetBounds, 1.75f).Size);
+        using var canvas = new ImmediateCanvas(
+            root.Target,
+            density: 1.75f,
+            maxWorkingScale: 0.75f,
+            logicalSize: compiled.ExecutionTargetBounds.Size);
+        using (canvas.PushTransform(Matrix.CreateTranslation(
+                   -compiled.ExecutionTargetBounds.X,
+                   -compiled.ExecutionTargetBounds.Y)))
+        {
+            canvas.Clear();
+            var executor = new RenderRequestExecutor(targets);
+            executor.Execute(compiled, canvas, replayBounds: compiled.ExecutionTargetBounds);
+            using Bitmap rendered = root.Target.Snapshot();
+            return rendered.GetPixelSpan<ushort>().ToArray();
+        }
+    }
+
+    private static double MaximumRgbDifference(ushort[] textured, ushort[] control)
+    {
+        Assert.That(textured, Has.Length.EqualTo(control.Length));
+        double maximum = 0;
+        for (int offset = 0; offset < textured.Length; offset += 4)
+        {
+            for (int channel = 0; channel < 3; channel++)
+            {
+                float texturedValue = (float)BitConverter.UInt16BitsToHalf(textured[offset + channel]);
+                float controlValue = (float)BitConverter.UInt16BitsToHalf(control[offset + channel]);
+                Assert.That(float.IsFinite(texturedValue), Is.True,
+                    $"Textured output contains a non-finite value at component {offset + channel}.");
+                Assert.That(float.IsFinite(controlValue), Is.True,
+                    $"Control output contains a non-finite value at component {offset + channel}.");
+                maximum = Math.Max(maximum, Math.Abs(texturedValue - controlValue));
+            }
+        }
+
+        return maximum;
+    }
+
+    private static Material3D CreateMaterial(
+        MaterialTextureDependency dependency,
+        TextureSource? texture)
+    {
+        if (dependency == MaterialTextureDependency.BasicDiffuseMap)
+        {
+            var material = new BasicMaterial();
+            material.DiffuseMap.CurrentValue = texture;
+            return material;
+        }
+
+        if (dependency == MaterialTextureDependency.TransparentColorMap)
+        {
+            var material = new TransparentMaterial();
+            material.ColorMap.CurrentValue = texture;
+            return material;
+        }
+
+        var pbrMaterial = new PBRMaterial();
+        if (dependency == MaterialTextureDependency.PbrEmissiveMap)
+            pbrMaterial.Emissive.CurrentValue = Colors.White;
+        switch (dependency)
+        {
+            case MaterialTextureDependency.PbrAlbedoMap:
+                pbrMaterial.AlbedoMap.CurrentValue = texture;
+                break;
+            case MaterialTextureDependency.PbrNormalMap:
+                pbrMaterial.NormalMap.CurrentValue = texture;
+                break;
+            case MaterialTextureDependency.PbrMetallicRoughnessMap:
+                // The map multiplies the base factors, so zero bases would make it unobservable.
+                pbrMaterial.Metallic.CurrentValue = 1f;
+                pbrMaterial.Roughness.CurrentValue = 1f;
+                pbrMaterial.MetallicRoughnessMap.CurrentValue = texture;
+                break;
+            case MaterialTextureDependency.PbrEmissiveMap:
+                pbrMaterial.EmissiveMap.CurrentValue = texture;
+                break;
+            case MaterialTextureDependency.PbrAOMap:
+                pbrMaterial.AOMap.CurrentValue = texture;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(dependency), dependency, null);
+        }
+
+        return pbrMaterial;
+    }
+
+    private static CompiledRenderRequest Compile(RenderNode root)
+        => Compile(root, new Rect(0, 0, 32, 24));
+
+    private static CompiledRenderRequest Compile(
+        RenderNode root,
+        Rect targetDomain,
+        float outputScale = 1,
+        float maxWorkingScale = 1)
+    {
+        var request = new RenderRequest(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            targetDomain: targetDomain,
+            outputScale: outputScale,
+            maxWorkingScale: maxWorkingScale,
+            cachePolicy: RenderCacheOptions.Disabled,
+            fusionMode: FusionMode.Enabled));
+        try
+        {
+            RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(root);
+            return new RenderRequestCompiler().Compile(request, graph);
+        }
+        catch
+        {
+            request.Dispose();
+            throw;
+        }
+    }
+
+    private sealed class DownstreamShaderNode(RenderNode sceneNode) : RenderNode
+    {
+        private static readonly ShaderDescription s_shader = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return half4(color.bgr, color.a); }");
+
+        public override void Process(RenderNodeContext context)
+        {
+            foreach (RenderFragmentHandle input in context.RecordSubtree(sceneNode))
+                context.Publish(context.Shader(input, s_shader));
+        }
+    }
+
+    public enum MaterialTextureDependency
+    {
+        BasicDiffuseMap,
+        PbrAlbedoMap,
+        PbrNormalMap,
+        PbrMetallicRoughnessMap,
+        PbrEmissiveMap,
+        PbrAOMap,
+        TransparentColorMap,
+    }
+}

--- a/tests/Beutl.HeadlessUITests/DrawableBrushThumbnailTests.cs
+++ b/tests/Beutl.HeadlessUITests/DrawableBrushThumbnailTests.cs
@@ -1,0 +1,803 @@
+﻿using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Reactive.Subjects;
+using Avalonia.Headless.NUnit;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Shapes;
+using Beutl.Media;
+using Beutl.Threading;
+using AvaDispatcher = Avalonia.Threading.Dispatcher;
+using AvaImageBrush = Avalonia.Media.ImageBrush;
+using AvaPixelSize = Avalonia.PixelSize;
+using AvaPropertyChangedEventArgs = Avalonia.AvaloniaPropertyChangedEventArgs;
+using AvaStretch = Avalonia.Media.Stretch;
+
+namespace Beutl.HeadlessUITests;
+
+[NonParallelizable]
+[TestFixture]
+public class DrawableBrushThumbnailTests
+{
+    [AvaloniaTest]
+    public async Task Update_publishes_initial_thumbnail_and_propagates_resource_changes()
+    {
+        GpuTestGate.EnsureAvailable();
+        var drawableBrush = new DrawableBrush(CreateRectangle(40, 24, Colors.Red));
+        drawableBrush.Stretch.CurrentValue = Stretch.Uniform;
+        var resource = (DrawableBrush.Resource)drawableBrush.ToResource(new CompositionContext(TimeSpan.Zero));
+        var imageBrush = new AvaImageBrush();
+        var handler = new AvaloniaTypeConverter.DrawableImageBrushHandler(resource, imageBrush);
+
+        try
+        {
+            handler.Update();
+            await WaitUntilAsync(
+                () => imageBrush.Source is WriteableBitmap bitmap
+                      && bitmap.PixelSize == new AvaPixelSize(40, 24),
+                TimeSpan.FromSeconds(5));
+
+            var first = (WriteableBitmap)imageBrush.Source!;
+            uint initialPixel = SamplePixel(first, 20, 12);
+            Assert.That(imageBrush.Stretch, Is.EqualTo(AvaStretch.Uniform));
+
+            drawableBrush.Drawable.CurrentValue = CreateRectangle(72, 36, Colors.Blue);
+            drawableBrush.Stretch.CurrentValue = Stretch.None;
+            UpdateResource(resource, drawableBrush);
+            handler.Update();
+
+            await WaitUntilAsync(
+                () => imageBrush.Source is WriteableBitmap bitmap
+                      && !ReferenceEquals(bitmap, first)
+                      && bitmap.PixelSize == new AvaPixelSize(72, 36),
+                TimeSpan.FromSeconds(5));
+            var second = (WriteableBitmap)imageBrush.Source!;
+            uint updatedPixel = SamplePixel(second, 36, 18);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(imageBrush.Stretch, Is.EqualTo(AvaStretch.None));
+                Assert.That(imageBrush.Source, Is.Not.SameAs(first));
+                Assert.That(
+                    second.PixelSize,
+                    Is.EqualTo(new AvaPixelSize(72, 36)));
+                Assert.That((initialPixel & 0xFF), Is.GreaterThan(200), "The initial thumbnail must be red.");
+                Assert.That(((initialPixel >> 16) & 0xFF), Is.LessThan(30), "The initial thumbnail must not be blue.");
+                Assert.That(((updatedPixel >> 16) & 0xFF), Is.GreaterThan(200), "The updated thumbnail must be blue.");
+                Assert.That((updatedPixel & 0xFF), Is.LessThan(30), "The updated thumbnail must not be red.");
+                Assert.That((initialPixel >> 24), Is.GreaterThan(200));
+                Assert.That((updatedPixel >> 24), Is.GreaterThan(200));
+            });
+        }
+        finally
+        {
+            handler.Dispose();
+            await WaitUntilAsync(() => resource.IsDisposed, TimeSpan.FromSeconds(5));
+        }
+
+        Assert.That(imageBrush.Source, Is.Null);
+    }
+
+    private static uint SamplePixel(WriteableBitmap bitmap, int x, int y)
+    {
+        using ILockedFramebuffer buffer = bitmap.Lock();
+        Assert.That(
+            buffer.Format,
+            Is.EqualTo(Avalonia.Platform.PixelFormat.Rgba8888)
+                .Or.EqualTo(Avalonia.Platform.PixelFormat.Bgra8888),
+            $"SamplePixel assumes a 32bpp RGBA or BGRA bitmap but the format is {buffer.Format}.");
+        Assert.That(x, Is.InRange(0, buffer.Size.Width - 1));
+        Assert.That(y, Is.InRange(0, buffer.Size.Height - 1));
+
+        uint pixel;
+        unsafe
+        {
+            byte* row = (byte*)buffer.Address + (y * buffer.RowBytes);
+            pixel = ((uint*)row)[x];
+        }
+
+        return buffer.Format == Avalonia.Platform.PixelFormat.Bgra8888
+            ? (pixel & 0xFF00FF00) | ((pixel & 0x000000FF) << 16) | ((pixel & 0x00FF0000) >> 16)
+            : pixel;
+    }
+
+    [AvaloniaTest]
+    public async Task Superseded_update_never_publishes_its_stale_thumbnail()
+    {
+        GpuTestGate.EnsureAvailable();
+        var staleDrawable = new BlockingThumbnailDrawable(40, 24, Brushes.Resource.Red);
+        var drawableBrush = new DrawableBrush(staleDrawable);
+        var resource = (DrawableBrush.Resource)drawableBrush.ToResource(new CompositionContext(TimeSpan.Zero));
+        var imageBrush = new AvaImageBrush();
+        var publishedSizes = new ConcurrentQueue<AvaPixelSize>();
+        imageBrush.PropertyChanged += (_, args) =>
+        {
+            if (args.Property == AvaImageBrush.SourceProperty
+                && imageBrush.Source is WriteableBitmap bitmap)
+            {
+                publishedSizes.Enqueue(bitmap.PixelSize);
+            }
+        };
+        var handler = new AvaloniaTypeConverter.DrawableImageBrushHandler(resource, imageBrush);
+
+        try
+        {
+            handler.Update();
+            await staleDrawable.RenderEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            drawableBrush.Drawable.CurrentValue = CreateRectangle(72, 36, Colors.Blue);
+            UpdateResource(resource, drawableBrush);
+            handler.Update();
+            staleDrawable.ReleaseRender();
+
+            await WaitUntilAsync(
+                () => imageBrush.Source is WriteableBitmap bitmap
+                      && bitmap.PixelSize == new AvaPixelSize(72, 36),
+                TimeSpan.FromSeconds(5));
+
+            Assert.That(publishedSizes.ToArray(), Is.EqualTo(new[] { new AvaPixelSize(72, 36) }));
+        }
+        finally
+        {
+            staleDrawable.ReleaseRender();
+            handler.Dispose();
+            await WaitUntilAsync(() => resource.IsDisposed, TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Superseded_queued_publication_is_discarded_before_ui_delivery()
+    {
+        GpuTestGate.EnsureAvailable();
+        var drawableBrush = new DrawableBrush(CreateRectangle(40, 24, Colors.Red));
+        var resource = (DrawableBrush.Resource)drawableBrush.ToResource(new CompositionContext(TimeSpan.Zero));
+        var imageBrush = new AvaImageBrush();
+        var publishedSizes = new ConcurrentQueue<AvaPixelSize>();
+        imageBrush.PropertyChanged += (_, args) =>
+        {
+            if (args.Property == AvaImageBrush.SourceProperty
+                && imageBrush.Source is WriteableBitmap bitmap)
+            {
+                publishedSizes.Enqueue(bitmap.PixelSize);
+            }
+        };
+        var handler = new AvaloniaTypeConverter.DrawableImageBrushHandler(resource, imageBrush);
+
+        try
+        {
+            Assert.That(AvaDispatcher.UIThread.CheckAccess(), Is.True);
+            handler.Update();
+            RenderThread.Dispatcher.Invoke(
+                static () => { },
+                DispatchPriority.Low,
+                CancellationToken.None);
+
+            drawableBrush.Drawable.CurrentValue = CreateRectangle(72, 36, Colors.Blue);
+            UpdateResource(resource, drawableBrush);
+            handler.Update();
+
+            await WaitUntilAsync(
+                () => imageBrush.Source is WriteableBitmap bitmap
+                      && bitmap.PixelSize == new AvaPixelSize(72, 36),
+                TimeSpan.FromSeconds(5));
+
+            Assert.That(
+                publishedSizes.ToArray(),
+                Is.EqualTo(new[] { new AvaPixelSize(72, 36) }));
+        }
+        finally
+        {
+            handler.Dispose();
+            await WaitUntilAsync(() => resource.IsDisposed, TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Reentrant_source_callback_can_dispose_without_lock_inversion()
+    {
+        GpuTestGate.EnsureAvailable();
+        var drawableBrush = new DrawableBrush(CreateRectangle(40, 24, Colors.Red));
+        var resource = (DrawableBrush.Resource)drawableBrush.ToResource(new CompositionContext(TimeSpan.Zero));
+        var imageBrush = new AvaImageBrush();
+        var handler = new AvaloniaTypeConverter.DrawableImageBrushHandler(resource, imageBrush);
+        var callbackResult = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        Task? disposalTask = null;
+        imageBrush.PropertyChanged += (_, args) =>
+        {
+            if (args.Property != AvaImageBrush.SourceProperty
+                || imageBrush.Source is not WriteableBitmap)
+            {
+                return;
+            }
+
+            disposalTask = Task.Run(() =>
+            {
+                handler.Dispose();
+                handler.Dispose();
+            });
+            callbackResult.TrySetResult(disposalTask.Wait(TimeSpan.FromSeconds(1)));
+        };
+
+        try
+        {
+            handler.Update();
+
+            Assert.That(
+                await callbackResult.Task.WaitAsync(TimeSpan.FromSeconds(5)),
+                Is.True,
+                "A synchronous Source callback must not wait on the handler publication lock.");
+            await disposalTask!.WaitAsync(TimeSpan.FromSeconds(5));
+            await WaitUntilAsync(
+                () => resource.IsDisposed && imageBrush.Source is null,
+                TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            handler.Dispose();
+            await WaitUntilAsync(() => resource.IsDisposed, TimeSpan.FromSeconds(5));
+        }
+
+        Assert.That(imageBrush.Source, Is.Null);
+    }
+
+    [AvaloniaTest]
+    public async Task Superseding_update_during_stretch_notification_cancels_pending_source_publication()
+    {
+        GpuTestGate.EnsureAvailable();
+        var drawableBrush = new DrawableBrush(CreateRectangle(40, 24, Colors.Red));
+        drawableBrush.Stretch.CurrentValue = Stretch.Uniform;
+        var resource = (DrawableBrush.Resource)drawableBrush.ToResource(new CompositionContext(TimeSpan.Zero));
+        var imageBrush = new AvaImageBrush();
+        var handler = new AvaloniaTypeConverter.DrawableImageBrushHandler(resource, imageBrush);
+
+        try
+        {
+            handler.Update();
+            await WaitUntilAsync(
+                () => imageBrush.Source is WriteableBitmap bitmap
+                      && bitmap.PixelSize == new AvaPixelSize(40, 24),
+                TimeSpan.FromSeconds(5));
+
+            var first = (WriteableBitmap)imageBrush.Source!;
+            var replacementPublications = new ConcurrentQueue<WriteableBitmap>();
+            imageBrush.PropertyChanged += (_, args) =>
+            {
+                if (args.Property == AvaImageBrush.SourceProperty
+                    && imageBrush.Source is WriteableBitmap bitmap
+                    && !ReferenceEquals(bitmap, first))
+                {
+                    replacementPublications.Enqueue(bitmap);
+                }
+            };
+
+            int superseded = 0;
+            bool supersedingUpdateCompleted = false;
+            imageBrush.PropertyChanged += (_, args) =>
+            {
+                if (args.Property == AvaImageBrush.StretchProperty
+                    && imageBrush.Stretch == AvaStretch.None
+                    && Interlocked.Exchange(ref superseded, 1) == 0)
+                {
+                    supersedingUpdateCompleted = Task.Run(handler.Update)
+                        .Wait(TimeSpan.FromSeconds(1));
+                }
+            };
+
+            drawableBrush.Drawable.CurrentValue = CreateRectangle(72, 36, Colors.Blue);
+            drawableBrush.Stretch.CurrentValue = Stretch.None;
+            UpdateResource(resource, drawableBrush);
+            handler.Update();
+
+            await WaitUntilAsync(
+                () => imageBrush.Source is WriteableBitmap bitmap
+                      && !ReferenceEquals(bitmap, first)
+                      && bitmap.PixelSize == new AvaPixelSize(72, 36),
+                TimeSpan.FromSeconds(5));
+            RenderThread.Dispatcher.Invoke(
+                static () => { },
+                DispatchPriority.Low,
+                CancellationToken.None);
+            AvaDispatcher.UIThread.RunJobs();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    supersedingUpdateCompleted,
+                    Is.True,
+                    "A superseding update must be able to cancel the publishing update outside the gate.");
+                Assert.That(
+                    replacementPublications.Count,
+                    Is.EqualTo(1),
+                    "The canceled publication must not assign its stale bitmap before the replacement.");
+            });
+        }
+        finally
+        {
+            handler.Dispose();
+            await WaitUntilAsync(() => resource.IsDisposed, TimeSpan.FromSeconds(5));
+        }
+
+        Assert.That(imageBrush.Source, Is.Null);
+    }
+
+    [AvaloniaTest]
+    public async Task Reentrant_source_callback_that_restores_previous_bitmap_prevents_commit()
+    {
+        GpuTestGate.EnsureAvailable();
+        var drawableBrush = new DrawableBrush(CreateRectangle(40, 24, Colors.Red));
+        drawableBrush.Stretch.CurrentValue = Stretch.Uniform;
+        var resource = (DrawableBrush.Resource)drawableBrush.ToResource(new CompositionContext(TimeSpan.Zero));
+        var imageBrush = new AvaImageBrush();
+        var handler = new AvaloniaTypeConverter.DrawableImageBrushHandler(resource, imageBrush);
+
+        try
+        {
+            handler.Update();
+            await WaitUntilAsync(
+                () => imageBrush.Source is WriteableBitmap bitmap
+                      && bitmap.PixelSize == new AvaPixelSize(40, 24),
+                TimeSpan.FromSeconds(5));
+
+            var first = (WriteableBitmap)imageBrush.Source!;
+            WriteableBitmap? rejected = null;
+            EventHandler<AvaPropertyChangedEventArgs> restorePrevious = (_, args) =>
+            {
+                if (args.Property == AvaImageBrush.SourceProperty
+                    && imageBrush.Source is WriteableBitmap bitmap
+                    && !ReferenceEquals(bitmap, first)
+                    && rejected is null)
+                {
+                    rejected = bitmap;
+                    imageBrush.Source = first;
+                }
+            };
+            imageBrush.PropertyChanged += restorePrevious;
+
+            drawableBrush.Drawable.CurrentValue = CreateRectangle(72, 36, Colors.Blue);
+            drawableBrush.Stretch.CurrentValue = Stretch.None;
+            UpdateResource(resource, drawableBrush);
+            handler.Update();
+
+            await WaitUntilAsync(
+                () => rejected is not null && ReferenceEquals(imageBrush.Source, first),
+                TimeSpan.FromSeconds(5));
+            imageBrush.PropertyChanged -= restorePrevious;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(imageBrush.Source, Is.SameAs(first));
+                Assert.That(imageBrush.Stretch, Is.EqualTo(AvaStretch.Uniform));
+            });
+            using (first.Lock())
+            {
+            }
+
+            Assert.That(
+                CanLock(rejected!),
+                Is.False,
+                "The rejected bitmap must be disposed after the reentrant publication is rolled back.");
+        }
+        finally
+        {
+            handler.Dispose();
+            await WaitUntilAsync(() => resource.IsDisposed, TimeSpan.FromSeconds(5));
+        }
+
+        Assert.That(imageBrush.Source, Is.Null);
+    }
+
+    [AvaloniaTest]
+    public async Task Throwing_publication_callbacks_roll_back_bitmap_and_stretch_ownership()
+    {
+        GpuTestGate.EnsureAvailable();
+        var drawableBrush = new DrawableBrush(CreateRectangle(40, 24, Colors.Red));
+        drawableBrush.Stretch.CurrentValue = Stretch.Uniform;
+        var resource = (DrawableBrush.Resource)drawableBrush.ToResource(new CompositionContext(TimeSpan.Zero));
+        var imageBrush = new AvaImageBrush();
+        var handler = new AvaloniaTypeConverter.DrawableImageBrushHandler(resource, imageBrush);
+
+        try
+        {
+            handler.Update();
+            await WaitUntilAsync(
+                () => imageBrush.Source is WriteableBitmap bitmap
+                      && bitmap.PixelSize == new AvaPixelSize(40, 24),
+                TimeSpan.FromSeconds(5));
+
+            var first = (WriteableBitmap)imageBrush.Source!;
+            WriteableBitmap? rejected = null;
+            EventHandler<AvaPropertyChangedEventArgs> throwOnReplacement = (_, args) =>
+            {
+                if (args.Property == AvaImageBrush.SourceProperty
+                    && imageBrush.Source is WriteableBitmap bitmap
+                    && !ReferenceEquals(bitmap, first))
+                {
+                    rejected = bitmap;
+                    throw new InvalidOperationException("Injected publication failure.");
+                }
+            };
+            imageBrush.PropertyChanged += throwOnReplacement;
+            int stretchRollbackFailures = 0;
+            EventHandler<AvaPropertyChangedEventArgs> throwOnStretchRollback = (_, args) =>
+            {
+                if (args.Property == AvaImageBrush.StretchProperty
+                    && imageBrush.Stretch == AvaStretch.Uniform
+                    && rejected is not null)
+                {
+                    stretchRollbackFailures++;
+                    throw new InvalidOperationException("Injected stretch rollback failure.");
+                }
+            };
+            imageBrush.PropertyChanged += throwOnStretchRollback;
+
+            drawableBrush.Drawable.CurrentValue = CreateRectangle(72, 36, Colors.Blue);
+            drawableBrush.Stretch.CurrentValue = Stretch.None;
+            UpdateResource(resource, drawableBrush);
+            handler.Update();
+
+            await WaitUntilAsync(
+                () => rejected is not null && ReferenceEquals(imageBrush.Source, first),
+                TimeSpan.FromSeconds(5));
+            imageBrush.PropertyChanged -= throwOnReplacement;
+            imageBrush.PropertyChanged -= throwOnStretchRollback;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(imageBrush.Source, Is.SameAs(first));
+                Assert.That(imageBrush.Stretch, Is.EqualTo(AvaStretch.Uniform));
+                Assert.That(rejected, Is.Not.Null);
+                Assert.That(rejected, Is.Not.SameAs(first));
+                Assert.That(stretchRollbackFailures, Is.EqualTo(1));
+            });
+            using (first.Lock())
+            {
+            }
+
+            Assert.That(
+                () =>
+                {
+                    using var _ = rejected!.Lock();
+                },
+                Throws.Exception);
+
+            drawableBrush.Drawable.CurrentValue = CreateRectangle(96, 48, Colors.Green);
+            drawableBrush.Stretch.CurrentValue = Stretch.UniformToFill;
+            UpdateResource(resource, drawableBrush);
+            handler.Update();
+
+            await WaitUntilAsync(
+                () => imageBrush.Source is WriteableBitmap bitmap
+                      && bitmap.PixelSize == new AvaPixelSize(96, 48),
+                TimeSpan.FromSeconds(5));
+            Assert.Multiple(() =>
+            {
+                Assert.That(imageBrush.Source, Is.Not.SameAs(first));
+                Assert.That(imageBrush.Source, Is.Not.SameAs(rejected));
+                Assert.That(imageBrush.Stretch, Is.EqualTo(AvaStretch.UniformToFill));
+            });
+        }
+        finally
+        {
+            handler.Dispose();
+            await WaitUntilAsync(() => resource.IsDisposed, TimeSpan.FromSeconds(5));
+        }
+
+        Assert.That(imageBrush.Source, Is.Null);
+    }
+
+    [AvaloniaTest]
+    public async Task Dispose_during_empty_update_cancels_publication_and_releases_resource_once_idle()
+    {
+        var blockingDrawable = new BlockingThumbnailDrawable(0, 0, null);
+        var drawableBrush = new DrawableBrush(blockingDrawable);
+        var resource = (DrawableBrush.Resource)drawableBrush.ToResource(new CompositionContext(TimeSpan.Zero));
+        var imageBrush = new AvaImageBrush();
+        var handler = new AvaloniaTypeConverter.DrawableImageBrushHandler(resource, imageBrush);
+
+        try
+        {
+            handler.Update();
+            await blockingDrawable.RenderEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            handler.Dispose();
+            Assert.Multiple(() =>
+            {
+                Assert.That(resource.IsDisposed, Is.False,
+                    "The resource must remain alive until the render-thread update exits.");
+                Assert.That(imageBrush.Source, Is.Null);
+            });
+
+            blockingDrawable.ReleaseRender();
+            await WaitUntilAsync(() => resource.IsDisposed, TimeSpan.FromSeconds(5));
+
+            handler.Update();
+            await RenderThread.Dispatcher.InvokeAsync(
+                static () => { },
+                DispatchPriority.Low,
+                CancellationToken.None);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(resource.IsDisposed, Is.True);
+                Assert.That(imageBrush.Source, Is.Null);
+            });
+
+            handler.Dispose();
+        }
+        finally
+        {
+            blockingDrawable.ReleaseRender();
+            handler.Dispose();
+        }
+    }
+
+    [AvaloniaTest]
+    public void Immediate_subscription_disposal_cancels_resource_creation()
+    {
+        var blockerEntered = new ManualResetEventSlim();
+        var releaseBlocker = new ManualResetEventSlim();
+        IDisposable? subscription = null;
+
+        try
+        {
+            RenderThread.Dispatcher.Dispatch(
+                () =>
+                {
+                    blockerEntered.Set();
+                    releaseBlocker.Wait();
+                },
+                DispatchPriority.High);
+            Assert.That(blockerEntered.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+            var drawableBrush = new DisposalTrackingDrawableBrush();
+            using var clock = new BehaviorSubject<TimeSpan>(TimeSpan.Zero);
+            (_, subscription, _) = drawableBrush.ToAvaBrushSync(clock);
+            subscription.Dispose();
+
+            releaseBlocker.Set();
+            RenderThread.Dispatcher.Invoke(
+                static () => { },
+                DispatchPriority.Low,
+                CancellationToken.None);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(drawableBrush.ResourceUpdateCalls, Is.Zero);
+                Assert.That(drawableBrush.ResourceDisposeCalls, Is.Zero);
+            });
+        }
+        finally
+        {
+            subscription?.Dispose();
+            releaseBlocker.Set();
+            RenderThread.Dispatcher.Invoke(
+                static () => { },
+                DispatchPriority.Low,
+                CancellationToken.None);
+            blockerEntered.Dispose();
+            releaseBlocker.Dispose();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Resource_lifetime_and_updates_are_serialized_on_render_dispatcher()
+    {
+        var drawableBrush = new DisposalTrackingDrawableBrush();
+        using var clock = new BehaviorSubject<TimeSpan>(TimeSpan.Zero);
+        (_, IDisposable subscription, _) = drawableBrush.ToAvaBrushSync(clock);
+
+        await WaitUntilAsync(
+            () => drawableBrush.ResourceUpdateCalls == 1,
+            TimeSpan.FromSeconds(5));
+
+        clock.OnNext(TimeSpan.FromSeconds(1));
+        await WaitUntilAsync(
+            () => drawableBrush.ResourceUpdateCalls == 2,
+            TimeSpan.FromSeconds(5));
+
+        subscription.Dispose();
+
+        await WaitUntilAsync(
+            () => drawableBrush.ResourceDisposeCalls == 1,
+            TimeSpan.FromSeconds(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(drawableBrush.ResourceDisposeCalls, Is.EqualTo(1));
+            Assert.That(
+                drawableBrush.ResourceCreationThreadId,
+                Is.EqualTo(RenderThread.Dispatcher.Thread.ManagedThreadId));
+            Assert.That(
+                drawableBrush.LastResourceUpdateThreadId,
+                Is.EqualTo(RenderThread.Dispatcher.Thread.ManagedThreadId));
+            Assert.That(
+                drawableBrush.ResourceDisposalThreadId,
+                Is.EqualTo(RenderThread.Dispatcher.Thread.ManagedThreadId));
+        });
+    }
+
+    [AvaloniaTest]
+    public void Render_dispatcher_shutdown_abandons_queued_update_and_releases_resource()
+    {
+        var drawableBrush = new DrawableBrush();
+        var resource = (DrawableBrush.Resource)drawableBrush.ToResource(
+            new CompositionContext(TimeSpan.Zero));
+        var imageBrush = new AvaImageBrush();
+        var blockerEntered = new ManualResetEventSlim();
+        var releaseBlocker = new ManualResetEventSlim();
+        Dispatcher dispatcher = Dispatcher.Spawn();
+        var handler = new AvaloniaTypeConverter.DrawableImageBrushHandler(
+            resource,
+            imageBrush,
+            dispatcher);
+
+        try
+        {
+            dispatcher.Dispatch(
+                () =>
+                {
+                    blockerEntered.Set();
+                    releaseBlocker.Wait();
+                },
+                DispatchPriority.High);
+            Assert.That(blockerEntered.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+            handler.Update();
+            handler.Dispose();
+            Assert.That(resource.IsDisposed, Is.False);
+
+            dispatcher.Shutdown();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(resource.IsDisposed, Is.True);
+                Assert.That(imageBrush.Source, Is.Null);
+            });
+        }
+        finally
+        {
+            handler.Dispose();
+            if (!dispatcher.HasShutdownStarted)
+                dispatcher.Shutdown();
+            releaseBlocker.Set();
+            Assert.That(dispatcher.Thread.Join(TimeSpan.FromSeconds(5)), Is.True);
+            blockerEntered.Dispose();
+            releaseBlocker.Dispose();
+            resource.Dispose();
+        }
+    }
+
+    private static RectShape CreateRectangle(float width, float height, Color color)
+    {
+        return new RectShape
+        {
+            Width = { CurrentValue = width },
+            Height = { CurrentValue = height },
+            Fill = { CurrentValue = new SolidColorBrush(color) },
+        };
+    }
+
+    private static void UpdateResource(DrawableBrush.Resource resource, DrawableBrush drawableBrush)
+    {
+        bool updateOnly = false;
+        resource.Update(drawableBrush, new CompositionContext(TimeSpan.Zero), ref updateOnly);
+    }
+
+    private static bool CanLock(WriteableBitmap bitmap)
+    {
+        try
+        {
+            using var _ = bitmap.Lock();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (!condition())
+        {
+            AvaDispatcher.UIThread.RunJobs();
+            if (stopwatch.Elapsed >= timeout)
+                Assert.Fail($"Condition was not met within {timeout}.");
+
+            await Task.Delay(10);
+        }
+    }
+}
+
+internal sealed partial class BlockingThumbnailDrawable(
+    float width,
+    float height,
+    Brush.Resource? fill) : Drawable
+{
+    private readonly TaskCompletionSource<bool> _renderEntered =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<bool> _releaseRender =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public TaskCompletionSource<bool> RenderEntered => _renderEntered;
+
+    public void ReleaseRender() => _releaseRender.TrySetResult(true);
+
+    public override void Render(GraphicsContext2D context, Drawable.Resource resource)
+    {
+        if (width > 0 && height > 0 && fill is not null)
+        {
+            context.DrawRectangle(
+                new Rect(0, 0, width, height),
+                fill,
+                null);
+        }
+
+        _renderEntered.TrySetResult(true);
+        _releaseRender.Task.GetAwaiter().GetResult();
+    }
+
+    protected override Size MeasureCore(Size availableSize, Drawable.Resource resource) => new(width, height);
+
+    protected override void OnDraw(GraphicsContext2D context, Drawable.Resource resource)
+    {
+    }
+}
+
+internal sealed partial class DisposalTrackingDrawableBrush : DrawableBrush
+{
+    private int _resourceCreationThreadId;
+    private int _resourceDisposalThreadId;
+    private int _lastResourceUpdateThreadId;
+    private int _resourceDisposeCalls;
+    private int _resourceUpdateCalls;
+
+    public int ResourceCreationThreadId => Volatile.Read(ref _resourceCreationThreadId);
+
+    public int ResourceDisposalThreadId => Volatile.Read(ref _resourceDisposalThreadId);
+
+    public int LastResourceUpdateThreadId => Volatile.Read(ref _lastResourceUpdateThreadId);
+
+    public int ResourceDisposeCalls => Volatile.Read(ref _resourceDisposeCalls);
+
+    public int ResourceUpdateCalls => Volatile.Read(ref _resourceUpdateCalls);
+
+    public partial class Resource
+    {
+        private DisposalTrackingDrawableBrush? _owner;
+
+        partial void PostUpdate(DisposalTrackingDrawableBrush obj, CompositionContext context)
+        {
+            _owner = obj;
+            int updateCount = Interlocked.Increment(ref obj._resourceUpdateCalls);
+            if (updateCount == 1)
+            {
+                Volatile.Write(
+                    ref obj._resourceCreationThreadId,
+                    Environment.CurrentManagedThreadId);
+            }
+            else
+            {
+                Volatile.Write(
+                    ref obj._lastResourceUpdateThreadId,
+                    Environment.CurrentManagedThreadId);
+            }
+        }
+
+        partial void PostDispose(bool disposing)
+        {
+            if (disposing && _owner is not null)
+            {
+                Volatile.Write(
+                    ref _owner._resourceDisposalThreadId,
+                    Environment.CurrentManagedThreadId);
+                Interlocked.Increment(ref _owner._resourceDisposeCalls);
+            }
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/SelectedDrawableRenderTests.cs
+++ b/tests/Beutl.HeadlessUITests/SelectedDrawableRenderTests.cs
@@ -1,0 +1,316 @@
+﻿using Avalonia.Headless.NUnit;
+using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Shapes;
+using Beutl.Graphics.Transformation;
+using Beutl.Media;
+using Beutl.ProjectSystem;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+
+namespace Beutl.HeadlessUITests;
+
+[NonParallelizable]
+[TestFixture]
+public class SelectedDrawableRenderTests
+{
+    private static Task ResetProjectAsync() => TestReset.ResetShellAsync();
+
+    private static string NewWorkspace(string name)
+    {
+        string location = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(location);
+        return location;
+    }
+
+    private static async Task<EditViewModel> OpenEditor(string name)
+    {
+        Project project = (await TestShell.Project.CreateProject(
+            320, 240, 30, 44100, name, NewWorkspace(name)))!;
+        HeadlessTestHelpers.Settle();
+        Scene scene = project.Items.OfType<Scene>().First();
+
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+    }
+
+    [AvaloniaTest]
+    public async Task Shifted_selected_drawable_measure_matches_rasterization_and_caller_owns_result()
+    {
+        GpuTestGate.EnsureAvailable();
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditor("selected-drawable-shifted");
+        var drawable = new RectShape
+        {
+            Width = { CurrentValue = 48 },
+            Height = { CurrentValue = 32 },
+            AlignmentX = { CurrentValue = AlignmentX.Left },
+            AlignmentY = { CurrentValue = AlignmentY.Top },
+            Transform = { CurrentValue = new TranslateTransform(37, 29) },
+            Fill = { CurrentValue = new SolidColorBrush(Colors.Red) },
+        };
+
+        PixelSize measuredSize = await editor.Player.MeasureSelectedDrawable(drawable);
+        Bitmap playerBitmap = await editor.Player.DrawSelectedDrawable(drawable);
+        try
+        {
+            (RenderNodeMeasurement measurement, RenderNodeRasterization rasterization) =
+                RenderSelectedDrawable(drawable, editor.Renderer.Value.FrameSize);
+            try
+            {
+                Bitmap ownedBitmap = rasterization.Bitmap
+                    ?? throw new AssertionException("The shifted non-empty drawable produced no bitmap.");
+                bool contentMatches = playerBitmap.GetPixelSpan<ushort>()
+                    .SequenceEqual(ownedBitmap.GetPixelSpan<ushort>());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(measurement.OutputBounds, Is.EqualTo(new Rect(37, 29, 48, 32)));
+                    Assert.That(rasterization.Bounds, Is.EqualTo(measurement.OutputBounds));
+                    Assert.That(rasterization.IsEmpty, Is.False);
+                    Assert.That(rasterization.IsDisposed, Is.False);
+                    Assert.That(ownedBitmap.IsDisposed, Is.False,
+                        "Disposing the renderer must not dispose its returned rasterization.");
+                    Assert.That(measuredSize, Is.EqualTo(PixelRect.FromRect(measurement.OutputBounds).Size));
+                    Assert.That(playerBitmap.Width, Is.EqualTo(ownedBitmap.Width));
+                    Assert.That(playerBitmap.Height, Is.EqualTo(ownedBitmap.Height));
+                    Assert.That(contentMatches, Is.True,
+                        "PlayerViewModel must return the same rendered pixels as direct rasterization.");
+                    Assert.That(playerBitmap.IsDisposed, Is.False,
+                        "PlayerViewModel must return a clone that survives disposal of its rasterization.");
+                });
+                AssertOpaqueRedCenter(playerBitmap, "PlayerViewModel bitmap");
+                AssertOpaqueRedCenter(ownedBitmap, "direct rasterization bitmap");
+
+                rasterization.Dispose();
+                Assert.Multiple(() =>
+                {
+                    Assert.That(rasterization.IsDisposed, Is.True);
+                    Assert.That(ownedBitmap.IsDisposed, Is.True,
+                        "The caller-owned rasterization must dispose its bitmap.");
+                    Assert.That(
+                        () => _ = rasterization.Bitmap,
+                        Throws.TypeOf<ObjectDisposedException>());
+                });
+
+                rasterization.Dispose();
+            }
+            finally
+            {
+                rasterization.Dispose();
+            }
+        }
+        finally
+        {
+            playerBitmap.Dispose();
+        }
+
+        Assert.That(playerBitmap.IsDisposed, Is.True);
+    }
+
+    private static void AssertOpaqueRedCenter(Bitmap bitmap, string label)
+    {
+        Assert.That(bitmap.ColorType, Is.EqualTo(BitmapColorType.RgbaF16), label);
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        int offset = (((bitmap.Height / 2) * bitmap.Width) + (bitmap.Width / 2)) * 4;
+        float red = (float)BitConverter.UInt16BitsToHalf(pixels[offset]);
+        float green = (float)BitConverter.UInt16BitsToHalf(pixels[offset + 1]);
+        float blue = (float)BitConverter.UInt16BitsToHalf(pixels[offset + 2]);
+        float alpha = (float)BitConverter.UInt16BitsToHalf(pixels[offset + 3]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(red, Is.EqualTo(1).Within(0.001), $"{label} center red");
+            Assert.That(green, Is.EqualTo(0).Within(0.001), $"{label} center green");
+            Assert.That(blue, Is.EqualTo(0).Within(0.001), $"{label} center blue");
+            Assert.That(alpha, Is.EqualTo(1).Within(0.001), $"{label} center alpha");
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task Empty_selected_drawable_measure_matches_empty_rasterization()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditor("selected-drawable-empty");
+        var drawable = new RectShape
+        {
+            Width = { CurrentValue = 0 },
+            Height = { CurrentValue = 32 },
+            AlignmentX = { CurrentValue = AlignmentX.Left },
+            AlignmentY = { CurrentValue = AlignmentY.Top },
+            Transform = { CurrentValue = new TranslateTransform(37, 29) },
+        };
+
+        PixelSize measuredSize = await editor.Player.MeasureSelectedDrawable(drawable);
+        (RenderNodeMeasurement measurement, RenderNodeRasterization rasterization) =
+            RenderSelectedDrawable(drawable, editor.Renderer.Value.FrameSize);
+
+        try
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(measuredSize, Is.EqualTo(PixelSize.Empty));
+                Assert.That(measurement.OutputBounds, Is.EqualTo(Rect.Empty));
+                Assert.That(rasterization.Bounds, Is.EqualTo(measurement.OutputBounds));
+                Assert.That(rasterization.IsEmpty, Is.True);
+                Assert.That(rasterization.Bitmap, Is.Null);
+            });
+
+            // Assert.ThrowsAsync blocks the Avalonia UI thread and deadlocks the headless dispatcher,
+            // so await the empty-result failure inline with a bounded timeout.
+            InvalidOperationException? exception = null;
+            try
+            {
+                using Bitmap unexpected = await editor.Player.DrawSelectedDrawable(drawable)
+                    .WaitAsync(TimeSpan.FromSeconds(5));
+                Assert.Fail("An empty selected drawable must not produce a bitmap.");
+            }
+            catch (InvalidOperationException ex)
+            {
+                exception = ex;
+            }
+
+            Assert.That(exception!.Message, Does.Contain("produced no raster output"));
+
+            rasterization.Dispose();
+            Assert.Multiple(() =>
+            {
+                Assert.That(rasterization.IsDisposed, Is.True);
+                Assert.That(
+                    () => _ = rasterization.Bitmap,
+                    Throws.TypeOf<ObjectDisposedException>());
+            });
+        }
+        finally
+        {
+            rasterization.Dispose();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Full_target_group_uses_query_geometry_for_measurement_and_rasterization()
+    {
+        GpuTestGate.EnsureAvailable();
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditor("selected-drawable-full-target-group");
+        var group = new DrawableGroup();
+        group.Children.Add(new RectShape
+        {
+            Width = { CurrentValue = 48 },
+            Height = { CurrentValue = 32 },
+            AlignmentX = { CurrentValue = AlignmentX.Left },
+            AlignmentY = { CurrentValue = AlignmentY.Top },
+            Transform = { CurrentValue = new TranslateTransform(37, 29) },
+            Fill = { CurrentValue = new SolidColorBrush(Colors.Red) },
+        });
+
+        PixelSize measuredSize = await editor.Player.MeasureSelectedDrawable(group);
+        using Bitmap bitmap = await editor.Player.DrawSelectedDrawable(group);
+        (RenderNodeMeasurement measurement, RenderNodeRasterization rasterization) =
+            RenderSelectedDrawable(group, editor.Renderer.Value.FrameSize);
+        using (rasterization)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(measurement.OutputBounds, Is.EqualTo(new Rect(0, 0, 320, 240)));
+                Assert.That(measurement.QueryBounds, Is.EqualTo(new Rect(37, 29, 48, 32)));
+                Assert.That(rasterization.Bounds, Is.EqualTo(measurement.QueryBounds));
+                Assert.That(measuredSize, Is.EqualTo(new PixelSize(48, 32)));
+                Assert.That(bitmap.Width, Is.EqualTo(48));
+                Assert.That(bitmap.Height, Is.EqualTo(32));
+            });
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Nested_scene_selected_drawable_records_the_requested_output_scale()
+    {
+        GpuTestGate.EnsureAvailable();
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditor("selected-drawable-nested-scale");
+        string location = NewWorkspace("selected-drawable-nested-scale-source");
+        var innerScene = new Scene(64, 48, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(location, "inner.scene"))
+        };
+        var capture = new SelectedDrawableScaleCaptureDrawable();
+        var element = new Element
+        {
+            Start = TimeSpan.Zero,
+            Length = TimeSpan.FromSeconds(1),
+            IsEnabled = true,
+            Uri = new Uri(Path.Combine(location, "nested.layer"))
+        };
+        element.AddObject(capture);
+        element.AddObject(new RectShape
+        {
+            Width = { CurrentValue = 64 },
+            Height = { CurrentValue = 48 },
+        });
+        innerScene.Children.Add(element);
+        var drawable = new SceneDrawable();
+        drawable.ReferencedScene.CurrentValue = innerScene;
+
+        using Bitmap bitmap = await editor.Player.DrawSelectedDrawable(drawable, outputScale: 2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(capture.ObservedOutputScales, Is.EqualTo(new[] { 2f }));
+            Assert.That(bitmap.Width, Is.EqualTo(128));
+            Assert.That(bitmap.Height, Is.EqualTo(96));
+        });
+    }
+
+    private static (RenderNodeMeasurement, RenderNodeRasterization) RenderSelectedDrawable(
+        Drawable drawable,
+        PixelSize frameSize)
+    {
+        return RenderThread.Dispatcher.Invoke(() =>
+        {
+            using var resource = drawable.ToResource(new CompositionContext(TimeSpan.Zero));
+            using var root = new DrawableRenderNode(resource);
+            using (var context = new GraphicsContext2D(root, frameSize.ToSize(1)))
+            {
+                drawable.Render(context, resource);
+            }
+
+            var request = new RenderNodeRenderRequest
+            {
+                Intent = RenderIntent.Delivery,
+                TargetDomain = new Rect(default, frameSize.ToSize(1)),
+                OutputScale = 1,
+                CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+            };
+            using var renderer = new RenderNodeRenderer(
+                root,
+                new RenderNodeRendererOptions
+                {
+                    DefaultRequest = request,
+                });
+            RenderNodeMeasurement measurement = renderer.Measure();
+            RenderNodeRasterization rasterization = renderer.Rasterize(request with
+            {
+                RequestedRegion = measurement.QueryBounds,
+            });
+            return (measurement, rasterization);
+        });
+    }
+}
+
+internal sealed partial class SelectedDrawableScaleCaptureDrawable : Drawable
+{
+    public List<float> ObservedOutputScales { get; } = [];
+
+    public override void Render(GraphicsContext2D context, Drawable.Resource resource)
+    {
+        ObservedOutputScales.Add(context.OutputScale);
+    }
+
+    protected override Size MeasureCore(Size availableSize, Drawable.Resource resource)
+        => Size.Empty;
+
+    protected override void OnDraw(GraphicsContext2D context, Drawable.Resource resource)
+    {
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/ExportRendererFactoryTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ExportRendererFactoryTests.cs
@@ -1,0 +1,38 @@
+﻿using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Models;
+using Beutl.ProjectSystem;
+
+namespace Beutl.UnitTests.Editor;
+
+public sealed class ExportRendererFactoryTests
+{
+    [Test]
+    public void Create_ConfiguresTheRendererForDeliveryGradeOutput()
+    {
+        var scene = new Scene(240, 120, "Export");
+
+        using SceneRenderer renderer = ExportRendererFactory.Create(scene, renderScale: 2f);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(renderer.Intent, Is.EqualTo(RenderIntent.Delivery),
+                "An export must fail on an intermediate allocation failure, not silently drop content.");
+            Assert.That(renderer.MaxWorkingScale, Is.EqualTo(WorkingScaleCeiling.Export()));
+            Assert.That(renderer.OutputScale, Is.EqualTo(2f));
+            Assert.That(renderer.CacheOptions, Is.SameAs(RenderCacheOptions.Disabled));
+            Assert.That(renderer.Compositor.ForceOriginalSource, Is.True);
+            Assert.That(renderer.Compositor.DisableResourceShare, Is.True);
+        });
+    }
+
+    [Test]
+    public void PreviewSceneRenderer_StaysOnPreviewIntent()
+    {
+        var scene = new Scene(240, 120, "Preview");
+
+        using var renderer = new SceneRenderer(scene, maxWorkingScale: WorkingScaleCeiling.Preview(1f));
+
+        Assert.That(renderer.Intent, Is.EqualTo(RenderIntent.Preview));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/DrawableResourceRenderTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/DrawableResourceRenderTests.cs
@@ -1,0 +1,46 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Shapes;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics;
+
+/// <summary>
+/// Rendering a <c>Drawable.Resource</c> dispatches through
+/// <c>drawable.GetOriginal().Render(context, drawable)</c>, so a drawable — unlike a geometry — is still
+/// authored on its engine object rather than on its resource.
+/// </summary>
+[TestFixture]
+public sealed class DrawableResourceRenderTests
+{
+    [Test]
+    public void RenderingAnAttachedDrawableResource_RecordsItsFragment()
+    {
+        var shape = new RectShape
+        {
+            Width = { CurrentValue = 40 },
+            Height = { CurrentValue = 30 },
+            Fill = { CurrentValue = Brushes.White },
+        };
+        using Drawable.Resource attached = shape.ToResource(CompositionContext.Default);
+        using var node = new DrawableRenderNode(attached);
+        using (var context = new GraphicsContext2D(node, new Size(64, 64)))
+        {
+            attached.GetOriginal().Render(context, attached);
+        }
+
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+            });
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        Assert.That(rasterization.Bitmap, Is.Not.Null);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Baseline/BaselineDiagnosticsNeutralityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Baseline/BaselineDiagnosticsNeutralityTests.cs
@@ -1,0 +1,373 @@
+﻿using System.Collections.Immutable;
+
+using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Baseline;
+
+[TestFixture]
+public sealed class BaselineDiagnosticsNeutralityTests
+{
+    [Test]
+    public void RendererFrame_InstrumentationPreservesOutputAndRecordedSequence()
+    {
+        FrameRun disabled = RunFrame(instrumentationEnabled: false);
+        FrameRun enabled = RunFrame(instrumentationEnabled: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(enabled.Pixels, Is.EqualTo(disabled.Pixels));
+            Assert.That(enabled.Trace, Is.EqualTo(disabled.Trace));
+            Assert.That(disabled.Snapshot, Is.Null);
+            Assert.That(enabled.Snapshot, Is.Not.Null);
+            Assert.That(enabled.Snapshot!.Purpose, Is.EqualTo(RenderRequestPurpose.Frame));
+            Assert.That(enabled.Snapshot.Succeeded, Is.True);
+            Assert.That(enabled.Snapshot[RenderPipelineCounter.RecordedFragments], Is.GreaterThan(0));
+            Assert.That(enabled.Snapshot[RenderPipelineCounter.ExecutedOutcomes], Is.GreaterThan(0));
+        });
+    }
+
+    [Test]
+    public void Rasterize_InstrumentationPreservesOutputAllocationAndRecordedSequence()
+    {
+        RasterRun disabled = RunRasterize(instrumentationEnabled: false);
+        RasterRun enabled = RunRasterize(instrumentationEnabled: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(enabled.Pixels, Is.EqualTo(disabled.Pixels));
+            Assert.That(enabled.Allocations, Is.EqualTo(disabled.Allocations));
+            Assert.That(enabled.Trace, Is.EqualTo(disabled.Trace));
+            Assert.That(disabled.Snapshot, Is.Null);
+            Assert.That(enabled.Snapshot, Is.Not.Null);
+            Assert.That(enabled.Snapshot!.Purpose, Is.EqualTo(RenderRequestPurpose.Auxiliary));
+            Assert.That(enabled.Snapshot.Succeeded, Is.True);
+            Assert.That(enabled.Snapshot[RenderPipelineCounter.IntermediateAcquires], Is.GreaterThan(0));
+            Assert.That(
+                enabled.Snapshot[RenderPipelineCounter.IntermediateDischarges],
+                Is.EqualTo(enabled.Snapshot[RenderPipelineCounter.IntermediateAcquires]));
+            Assert.That(enabled.Snapshot[RenderPipelineCounter.IntermediateCreates], Is.GreaterThan(0));
+        });
+    }
+
+    [Test]
+    public void RenderFailure_InstrumentationPreservesExceptionAllocationAndCleanup()
+    {
+        FailureRun disabled = RunFailure(instrumentationEnabled: false, allocationFailure: false);
+        FailureRun enabled = RunFailure(instrumentationEnabled: true, allocationFailure: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(enabled.ExceptionType, Is.Not.Null);
+            Assert.That(enabled.ExceptionType, Is.EqualTo(disabled.ExceptionType));
+            Assert.That(enabled.ExceptionMessage, Is.EqualTo(disabled.ExceptionMessage));
+            Assert.That(enabled.Allocations, Is.EqualTo(disabled.Allocations));
+            Assert.That(enabled.Trace, Is.EqualTo(disabled.Trace));
+            Assert.That(disabled.Snapshot, Is.Null);
+            Assert.That(enabled.Snapshot, Is.Not.Null);
+            Assert.That(enabled.Snapshot!.Succeeded, Is.False);
+            Assert.That(enabled.Snapshot.FailurePhase, Is.EqualTo(RenderPipelineFailurePhase.Execution));
+            Assert.That(enabled.Snapshot[RenderPipelineCounter.FailedOutcomes], Is.EqualTo(1));
+            Assert.That(enabled.Snapshot[RenderPipelineCounter.Failures], Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void FrameDiagnostics_DisposeFailureIsRecordedAsCleanup()
+    {
+        var state = new RenderPipelineDiagnosticsState();
+        var trace = new List<string>();
+        using var node = new FixedOpsNode(
+            [new RecordedOperationSpec("dispose-fault", ThrowOnDispose: true)],
+            trace);
+        using var renderer = CreateRenderer(
+            node,
+            new TrackingTargetFactory(),
+            diagnostics: state,
+            purpose: RenderRequestPurpose.Frame);
+
+        Assert.Throws<AggregateException>(() => renderer.Rasterize());
+        RenderPipelineDiagnosticSnapshot snapshot = state.LatestFrame;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(trace, Is.EqualTo(new[] { "dispose-fault" }));
+            Assert.That(snapshot.Succeeded, Is.False);
+            Assert.That(snapshot.FailurePhase, Is.EqualTo(RenderPipelineFailurePhase.Cleanup));
+            Assert.That(snapshot[RenderPipelineCounter.CleanupFailures], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.Failures], Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void RendererConstructor_DisposesTransferredSurfaceOnFailure()
+    {
+        var target = new CpuRenderTarget(4, 4);
+
+        AggregateException exception = Assert.Throws<AggregateException>(() => new Renderer(
+            width: 8,
+            height: 8,
+            renderScale: 1,
+            maxWorkingScale: float.PositiveInfinity,
+            diagnostics: null,
+            surface: target))!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.InnerException, Is.TypeOf<ArgumentException>());
+            Assert.That(target.IsDisposed, Is.True);
+        });
+    }
+
+    [Test]
+    public void AllocationFailure_InstrumentationPreservesExceptionAttemptAndCleanup()
+    {
+        FailureRun disabled = RunFailure(instrumentationEnabled: false, allocationFailure: true);
+        FailureRun enabled = RunFailure(instrumentationEnabled: true, allocationFailure: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(enabled.ExceptionType, Is.Not.Null);
+            Assert.That(enabled.ExceptionType, Is.EqualTo(disabled.ExceptionType));
+            Assert.That(enabled.ExceptionMessage, Is.EqualTo(disabled.ExceptionMessage));
+            Assert.That(enabled.Allocations, Is.EqualTo(disabled.Allocations));
+            Assert.That(enabled.Trace, Is.EqualTo(disabled.Trace));
+            Assert.That(disabled.Snapshot, Is.Null);
+            Assert.That(enabled.Snapshot, Is.Not.Null);
+            Assert.That(enabled.Snapshot!.Succeeded, Is.False);
+            Assert.That(enabled.Snapshot.FailurePhase, Is.EqualTo(RenderPipelineFailurePhase.Allocation));
+            Assert.That(enabled.Snapshot[RenderPipelineCounter.Failures], Is.EqualTo(1));
+            Assert.That(enabled.Snapshot[RenderPipelineCounter.FailedOutcomes], Is.Zero,
+                "Root-target acquisition fails before any fragment becomes the active failure subject.");
+            Assert.That(
+                enabled.Snapshot[RenderPipelineCounter.SkippedOutcomes],
+                Is.EqualTo(enabled.Snapshot[RenderPipelineCounter.RecordedFragments]));
+        });
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void PersistentCache_InstrumentationPreservesDecisionAndOutput(bool cacheHit)
+    {
+        PullRun disabled = RunPull(instrumentationEnabled: false, cacheHit);
+        PullRun enabled = RunPull(instrumentationEnabled: true, cacheHit);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(enabled.ProcessCalls, Is.EqualTo(disabled.ProcessCalls));
+            Assert.That(enabled.OutputBounds, Is.EqualTo(disabled.OutputBounds));
+            Assert.That(enabled.CacheCount, Is.EqualTo(disabled.CacheCount));
+            Assert.That(enabled.Pixels, Is.EqualTo(disabled.Pixels));
+            Assert.That(disabled.Snapshot, Is.Null);
+            Assert.That(enabled.Snapshot, Is.Not.Null);
+            Assert.That(
+                enabled.Snapshot![cacheHit
+                    ? RenderPipelineCounter.RenderCacheHits
+                    : RenderPipelineCounter.RenderCacheMisses],
+                Is.EqualTo(1));
+            Assert.That(
+                enabled.Snapshot[cacheHit
+                    ? RenderPipelineCounter.CachedOutcomes
+                    : RenderPipelineCounter.ExecutedOutcomes],
+                Is.EqualTo(1));
+        });
+    }
+
+    private static FrameRun RunFrame(bool instrumentationEnabled)
+    {
+        return RenderThread.Dispatcher.Invoke(() =>
+        {
+            var trace = new List<string>();
+            var state = instrumentationEnabled ? new RenderPipelineDiagnosticsState() : null;
+            var target = new CpuRenderTarget(8, 8);
+            using var renderer = new Renderer(
+                width: 8,
+                height: 8,
+                renderScale: 1,
+                maxWorkingScale: float.PositiveInfinity,
+                diagnostics: state,
+                surface: target);
+            renderer.CacheOptions = RenderCacheOptions.Disabled;
+
+            var drawable = new global::Beutl.UnitTests.Engine.Graphics.Rendering.FaultingDrawable(
+                [new RecordedOperationSpec("frame")])
+            {
+                Discharged = trace,
+            };
+            var resource = (Drawable.Resource)drawable.ToResource(CompositionContext.Default);
+            var frame = new CompositionFrame(
+                ImmutableArray.Create<EngineObject.Resource>(resource),
+                new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)),
+                new PixelSize(8, 8));
+
+            renderer.Render(frame);
+            using Bitmap bitmap = renderer.Snapshot();
+            return new FrameRun(
+                bitmap.GetPixelSpan().ToArray(),
+                [.. trace],
+                state?.LatestFrame);
+        });
+    }
+
+    private static RasterRun RunRasterize(bool instrumentationEnabled)
+    {
+        var trace = new List<string>();
+        var state = instrumentationEnabled ? new RenderPipelineDiagnosticsState() : null;
+        using var node = new FixedOpsNode(
+            () => [new RecordedOperationSpec("raster")],
+            trace,
+            () => trace.Add("process"));
+        var factory = new TrackingTargetFactory();
+        using var renderer = CreateRenderer(node, factory, diagnostics: state);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        return new RasterRun(
+            rasterization.Bitmap!.GetPixelSpan().ToArray(),
+            [.. factory.Allocations],
+            [.. trace],
+            state?.Latest);
+    }
+
+    private static FailureRun RunFailure(bool instrumentationEnabled, bool allocationFailure)
+    {
+        var trace = new List<string>();
+        var state = instrumentationEnabled ? new RenderPipelineDiagnosticsState() : null;
+        using var node = new FixedOpsNode(
+            () => [new RecordedOperationSpec("render-fault", ThrowOnExecute: !allocationFailure)],
+            trace,
+            () => trace.Add("process"));
+        var factory = new TrackingTargetFactory(throwOnAllocation: allocationFailure);
+        using var renderer = CreateRenderer(node, factory, diagnostics: state);
+
+        Exception? failure = null;
+        try
+        {
+            using RenderNodeRasterization unexpected = renderer.Rasterize();
+        }
+        catch (Exception ex)
+        {
+            failure = ex;
+        }
+
+        return new FailureRun(
+            failure?.GetType(),
+            failure?.Message,
+            [.. factory.Allocations],
+            [.. trace],
+            state?.Latest);
+    }
+
+    private static PullRun RunPull(bool instrumentationEnabled, bool cacheHit)
+    {
+        var trace = new List<string>();
+        var state = instrumentationEnabled ? new RenderPipelineDiagnosticsState() : null;
+        using var node = new FixedOpsNode(
+            () => [new RecordedOperationSpec("pull")],
+            trace,
+            () => trace.Add("process"));
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        var factory = new TrackingTargetFactory();
+        using var renderer = CreateRenderer(
+            node,
+            factory,
+            useRenderCache: true,
+            diagnostics: state,
+            purpose: RenderRequestPurpose.Frame);
+        if (cacheHit)
+        {
+            using RenderNodeRasterization warmup = renderer.Rasterize();
+            state?.Reset();
+        }
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        return new PullRun(
+            node.ProcessCalls,
+            rasterization.Bounds,
+            node.Cache.CacheCount,
+            rasterization.Bitmap!.GetPixelSpan().ToArray(),
+            state?.LatestFrame);
+    }
+
+    private static RenderNodeRenderer CreateRenderer(
+        RenderNode root,
+        IRenderTargetFactory? targetFactory,
+        bool useRenderCache = false,
+        IRenderPipelineDiagnosticsState? diagnostics = null,
+        RenderRequestPurpose purpose = RenderRequestPurpose.Auxiliary)
+        => new(root, new RenderNodeRendererOptions
+        {
+            DefaultRequest = new RenderNodeRenderRequest
+            {
+                OutputScale = 1,
+                MaxWorkingScale = float.PositiveInfinity,
+                CacheOptions = new Beutl.Graphics.Rendering.Cache.RenderCacheOptions(useRenderCache, Beutl.Graphics.Rendering.Cache.RenderCacheRules.Default),
+                Purpose = purpose,
+                Diagnostics = diagnostics,
+            },
+            TargetFactory = targetFactory,
+        });
+
+    private sealed class TrackingTargetFactory(bool throwOnAllocation = false) : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public List<string> Allocations { get; } = [];
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+        {
+            PixelSize deviceSize = allocation.DeviceSize;
+            Allocations.Add($"{deviceSize.Width}x{deviceSize.Height}");
+            if (throwOnAllocation)
+                throw new InvalidOperationException("allocation-fault");
+
+            return new CpuRenderTarget(deviceSize.Width, deviceSize.Height);
+        }
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(CreateSurface(width, height), width, height)
+    {
+        private static SKSurface CreateSurface(int width, int height)
+        {
+            return SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear()))
+                ?? throw new InvalidOperationException("Could not create a CPU render target.");
+        }
+    }
+
+    private sealed record FrameRun(
+        byte[] Pixels,
+        string[] Trace,
+        RenderPipelineDiagnosticSnapshot? Snapshot);
+
+    private sealed record RasterRun(
+        byte[] Pixels,
+        string[] Allocations,
+        string[] Trace,
+        RenderPipelineDiagnosticSnapshot? Snapshot);
+
+    private sealed record FailureRun(
+        Type? ExceptionType,
+        string? ExceptionMessage,
+        string[] Allocations,
+        string[] Trace,
+        RenderPipelineDiagnosticSnapshot? Snapshot);
+
+    private sealed record PullRun(
+        int ProcessCalls,
+        Rect OutputBounds,
+        int CacheCount,
+        byte[] Pixels,
+        RenderPipelineDiagnosticSnapshot? Snapshot);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Baseline/GpuPassFusionBaselineTestSupport.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Baseline/GpuPassFusionBaselineTestSupport.cs
@@ -1,0 +1,1107 @@
+﻿using System.Globalization;
+using System.Security.Cryptography;
+using System.Text.Json;
+
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Rendering.Golden;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Baseline;
+
+internal static class GpuPassFusionBaselineEvidence
+{
+    public const int ExpectedSchemaVersion = 1;
+    public const int ExpectedGeneratorSeed = 20040719;
+    public const string ExpectedBaselineCodeSha = "43a38e665d9bf52548161a3917e748bd1457ff55";
+
+    // This is the trust anchor for the pinned manifest and its documented semantic refreshes.
+    // Update it only through an explicitly approved evidence regeneration and review.
+    public const string ExpectedManifestSha256 = "e83694b68eb6a6daf3286ac5ace4bf8bf8e7816705fc6f4930652f124da06b7e";
+
+    public const double NonVacuityParityTolerance = 0.02;
+    public const double MaximumWindowedRgbaMae = 0.05;
+
+    private static readonly string[] s_expectedManifestProperties =
+    [
+        "allocationFailures",
+        "artifactSha256",
+        "baselineCodeSha",
+        "baselineCommitTimestamp",
+        "benchmark",
+        "evidenceTools",
+        "fingerprint",
+        "generatorSeed",
+        "patchedDiffSha256",
+        "pixelFormat",
+        "prePatchRepositoryState",
+        "roiBaselineMode",
+        "scenes",
+        "schemaVersion",
+    ];
+
+    private static readonly string[] s_expectedEvidenceToolProperties =
+    [
+        "benchmarkRunnerSha256",
+        "generatorPatchSha256",
+        "generatorScriptSha256",
+        "generatorSourceBundleSha256",
+        "pairedRunnerSha256",
+        "refreshScriptSha256",
+    ];
+
+    private static readonly string[] s_expectedFingerprintProperties =
+    [
+        "beutlEngineAssemblyVersion",
+        "deviceSelection",
+        "environmentVersion",
+        "frameworkDescription",
+        "metalDeviceName",
+        "metalDriver",
+        "metalFeatureFamily",
+        "metalRegistryId",
+        "osArchitecture",
+        "osBuild",
+        "osDescription",
+        "osVersion",
+        "processArchitecture",
+        "rendererBackend",
+        "runtimeIdentifier",
+        "silkNetVulkanVersion",
+        "skiaBackend",
+        "skiaSharpManagedVersion",
+        "skiaSharpNativeVersion",
+        "vulkanApiVersion",
+        "vulkanDeviceId",
+        "vulkanDeviceName",
+        "vulkanDeviceType",
+        "vulkanDeviceUuid",
+        "vulkanDriverId",
+        "vulkanDriverInfo",
+        "vulkanDriverName",
+        "vulkanDriverUuid",
+        "vulkanDriverVersionDecoded",
+        "vulkanDriverVersionRaw",
+        "vulkanEnabledExtensions",
+        "vulkanVendorId",
+    ];
+
+    private static readonly string[] s_expectedPixelFormatProperties =
+    [
+        "alphaType",
+        "bytesPerPixel",
+        "colorSpace",
+        "colorType",
+        "endianness",
+        "packing",
+    ];
+
+    private static readonly string[] s_expectedSceneProperties =
+    [
+        "blob",
+        "blobHeight",
+        "blobWidth",
+        "category",
+        "controlSceneId",
+        "empty",
+        "id",
+        "legacyCounters",
+        "legacyEvents",
+        "logicalHeight",
+        "logicalWidth",
+        "maxWorkingScale",
+        "nonVacuity",
+        "nonVacuityMode",
+        "nonVacuityRegion",
+        "outputScale",
+        "parameters",
+        "query",
+        "requestedRegion",
+        "role",
+    ];
+
+    private static readonly string[] s_expectedNonVacuityProperties =
+    [
+        "alphaMae",
+        "linearRgbMae",
+        "marginAboveTolerance",
+        "maximumChannelError",
+        "metricMode",
+        "metricRegion",
+        "parityTolerance",
+        "sampleCount",
+    ];
+
+    private static readonly string[] s_expectedAllocationFailureProperties =
+    [
+        "exceptionMessage",
+        "exceptionType",
+        "injectionPoint",
+        "intent",
+        "legacyCounters",
+        "legacyEvents",
+        "maxWorkingScale",
+        "outcome",
+    ];
+
+    public static IReadOnlyList<string> RequiredFingerprintFields => s_expectedFingerprintProperties;
+
+    public static GpuPassFusionEvidenceManifest LoadAndVerify()
+    {
+        GpuPassFusionEvidencePaths paths = GpuPassFusionEvidencePaths.Discover();
+        VerifyFileHash(paths.ManifestPath, ExpectedManifestSha256, "target baseline manifest");
+
+        using FileStream stream = OpenExistingReadOnly(paths.ManifestPath, "target baseline manifest");
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(stream, new JsonDocumentOptions
+            {
+                AllowTrailingCommas = false,
+                CommentHandling = JsonCommentHandling.Disallow,
+                MaxDepth = 64,
+            });
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidDataException("The target baseline manifest is not valid JSON.", ex);
+        }
+
+        using (document)
+        {
+            JsonElement root = document.RootElement;
+            ValidateExactObjectShape(root, s_expectedManifestProperties, "manifest");
+
+            int schemaVersion = ReadInt32(root, "schemaVersion", "manifest");
+            if (schemaVersion != ExpectedSchemaVersion)
+            {
+                throw new InvalidDataException(
+                    $"Unexpected target baseline schema version {schemaVersion}; expected {ExpectedSchemaVersion}.");
+            }
+
+            string baselineCodeSha = ReadString(root, "baselineCodeSha", "manifest");
+            if (!string.Equals(baselineCodeSha, ExpectedBaselineCodeSha, StringComparison.Ordinal))
+            {
+                throw new InvalidDataException(
+                    $"Target baseline source SHA mismatch: expected {ExpectedBaselineCodeSha}, found {baselineCodeSha}.");
+            }
+
+            ValidateCommitTimestamp(ReadString(root, "baselineCommitTimestamp", "manifest"));
+            RequireExactString(root, "prePatchRepositoryState", "clean", "manifest");
+            string patchedDiffSha256 = ReadSha256(root, "patchedDiffSha256", "manifest");
+
+            int generatorSeed = ReadInt32(root, "generatorSeed", "manifest");
+            if (generatorSeed != ExpectedGeneratorSeed)
+            {
+                throw new InvalidDataException(
+                    $"Target baseline generator seed mismatch: expected {ExpectedGeneratorSeed}, found {generatorSeed}.");
+            }
+
+            RequireExactString(
+                root,
+                "roiBaselineMode",
+                "legacy-full-render-then-device-crop",
+                "manifest");
+
+            GpuPassFusionEvidenceTools tools = ReadEvidenceTools(root.GetProperty("evidenceTools"));
+            VerifyFileHash(paths.GeneratorPatchPath, tools.GeneratorPatchSha256, "target baseline generator patch");
+            VerifyFileHash(paths.GeneratorScriptPath, tools.GeneratorScriptSha256, "target baseline generator script");
+            VerifyFileHash(paths.PairedRunnerPath, tools.PairedRunnerSha256, "paired visual-evidence runner");
+            VerifyFileHash(paths.BenchmarkRunnerPath, tools.BenchmarkRunnerSha256, "paired benchmark runner");
+            VerifyFileHash(paths.RefreshScriptPath, tools.RefreshScriptSha256, "intentional visual-baseline refresh script");
+
+            IReadOnlyDictionary<string, IReadOnlyList<string>> fingerprint =
+                ReadFingerprint(root.GetProperty("fingerprint"));
+            ValidateFingerprint(fingerprint);
+            string engineVersion = fingerprint["beutlEngineAssemblyVersion"].Single();
+            if (!engineVersion.EndsWith('+' + ExpectedBaselineCodeSha, StringComparison.Ordinal))
+            {
+                throw new InvalidDataException(
+                    "The fingerprinted Beutl.Engine assembly does not identify the pinned baseline source SHA.");
+            }
+
+            ValidatePixelFormat(root.GetProperty("pixelFormat"));
+            IReadOnlyDictionary<string, string> artifactHashes = ReadArtifactHashes(root.GetProperty("artifactSha256"));
+            IReadOnlyList<GpuPassFusionEvidenceScene> scenes = ReadScenes(root.GetProperty("scenes"));
+            ValidateScenesAndArtifacts(paths, scenes, artifactHashes);
+            ValidateAllocationFailures(root.GetProperty("allocationFailures"));
+            ValidateBenchmark(root.GetProperty("benchmark"));
+
+            var manifest = new GpuPassFusionEvidenceManifest(
+                paths,
+                schemaVersion,
+                baselineCodeSha,
+                patchedDiffSha256,
+                generatorSeed,
+                tools,
+                fingerprint,
+                artifactHashes,
+                scenes);
+            VerifyRecordedNonVacuity(manifest);
+            return manifest;
+        }
+    }
+
+    public static void ValidateFingerprint(
+        IReadOnlyDictionary<string, IReadOnlyList<string>> fingerprint)
+    {
+        ArgumentNullException.ThrowIfNull(fingerprint);
+        string[] actualNames = [.. fingerprint.Keys.Order(StringComparer.Ordinal)];
+        if (!actualNames.SequenceEqual(s_expectedFingerprintProperties, StringComparer.Ordinal))
+        {
+            throw new InvalidDataException(
+                "Evidence fingerprint schema mismatch. "
+                + $"Expected [{string.Join(", ", s_expectedFingerprintProperties)}], "
+                + $"found [{string.Join(", ", actualNames)}].");
+        }
+
+        foreach ((string name, IReadOnlyList<string> values) in fingerprint)
+        {
+            if (values.Count == 0)
+                throw new InvalidDataException($"Evidence fingerprint field '{name}' is empty.");
+
+            foreach (string value in values)
+            {
+                if (string.IsNullOrWhiteSpace(value)
+                    || value.Contains("unknown", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidDataException(
+                        $"Evidence fingerprint field '{name}' is missing or unknown.");
+                }
+            }
+        }
+    }
+
+    public static void VerifyFileHash(string path, string expectedSha256, string description)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentException.ThrowIfNullOrWhiteSpace(description);
+        ValidateSha256(expectedSha256, $"expected {description} SHA-256");
+
+        using FileStream stream = OpenExistingReadOnly(path, description);
+        string actualSha256 = Convert.ToHexStringLower(SHA256.HashData(stream));
+        if (!string.Equals(actualSha256, expectedSha256, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException(
+                $"SHA-256 mismatch for {description}: expected {expectedSha256}, found {actualSha256}.");
+        }
+    }
+
+    public static GpuPassFusionNonVacuityDelta RecomputeNonVacuity(
+        GpuPassFusionEvidenceManifest manifest,
+        GpuPassFusionEvidenceScene scene)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentNullException.ThrowIfNull(scene);
+        if (!string.Equals(scene.Role, "parity", StringComparison.Ordinal)
+            || scene.ControlSceneId is null
+            || scene.Blob is null)
+        {
+            throw new InvalidDataException($"Scene '{scene.Id}' is not a complete parity workload.");
+        }
+
+        GpuPassFusionEvidenceScene control = manifest.GetScene(scene.ControlSceneId);
+        if (control.Blob is null)
+            throw new InvalidDataException($"Control scene '{control.Id}' has no immutable RGBA16F blob.");
+
+        string referencePath = Path.Combine(manifest.Paths.BaselineDirectory, scene.Blob);
+        string controlPath = Path.Combine(manifest.Paths.BaselineDirectory, control.Blob);
+        using Bitmap reference = Rgba16fGoldenStore.Read(referencePath, scene.BlobWidth, scene.BlobHeight);
+        using Bitmap disabled = Rgba16fGoldenStore.Read(controlPath, control.BlobWidth, control.BlobHeight);
+        return CalculateNonVacuityDelta(
+            reference,
+            disabled,
+            scene.NonVacuityMode,
+            scene.NonVacuityRegion);
+    }
+
+    public static GpuPassFusionNonVacuityDelta CalculateNonVacuityDelta(
+        Bitmap reference,
+        Bitmap control,
+        string metricMode,
+        GpuPassFusionPixelRegion? metricRegion)
+    {
+        ArgumentNullException.ThrowIfNull(reference);
+        ArgumentNullException.ThrowIfNull(control);
+        if (reference.Width != control.Width || reference.Height != control.Height)
+        {
+            throw new InvalidDataException(
+                $"Non-vacuity bitmap sizes differ: {reference.Width}x{reference.Height} versus "
+                + $"{control.Width}x{control.Height}.");
+        }
+
+        if (metricMode is not ("full-frame" or "alpha-edge-band"))
+            throw new InvalidDataException($"Unknown non-vacuity metric mode '{metricMode}'.");
+
+        GpuPassFusionPixelRegion region = metricRegion
+            ?? new GpuPassFusionPixelRegion(0, 0, reference.Width, reference.Height);
+        region.ValidateInside(reference.Width, reference.Height, "non-vacuity metric region");
+
+        double rgbError = 0;
+        double alphaError = 0;
+        double maximumChannelError = 0;
+        int sampleCount = 0;
+        for (int y = region.Y; y < region.Bottom; y++)
+        {
+            ReadOnlySpan<ushort> referenceRow = reference.GetRow<ushort>(y);
+            ReadOnlySpan<ushort> controlRow = control.GetRow<ushort>(y);
+            for (int x = region.X; x < region.Right; x++)
+            {
+                int offset = x * 4;
+                float referenceAlpha = HalfBitsToFiniteFloat(referenceRow[offset + 3], reference, x, y, 3);
+                float controlAlpha = HalfBitsToFiniteFloat(controlRow[offset + 3], control, x, y, 3);
+                if (metricMode == "alpha-edge-band"
+                    && !IsNonVacuityCoverageEdge(referenceAlpha)
+                    && !IsNonVacuityCoverageEdge(controlAlpha))
+                {
+                    continue;
+                }
+
+                sampleCount++;
+                for (int channel = 0; channel < 4; channel++)
+                {
+                    float referenceValue = HalfBitsToFiniteFloat(
+                        referenceRow[offset + channel],
+                        reference,
+                        x,
+                        y,
+                        channel);
+                    float controlValue = HalfBitsToFiniteFloat(
+                        controlRow[offset + channel],
+                        control,
+                        x,
+                        y,
+                        channel);
+                    double difference = Math.Abs(referenceValue - controlValue);
+                    maximumChannelError = Math.Max(maximumChannelError, difference);
+                    if (channel == 3)
+                        alphaError += difference;
+                    else
+                        rgbError += difference;
+                }
+            }
+        }
+
+        if (sampleCount == 0)
+            throw new InvalidDataException($"Non-vacuity metric mode '{metricMode}' selected no pixels.");
+
+        double linearRgbMae = rgbError / (sampleCount * 3d);
+        double alphaMae = alphaError / sampleCount;
+        double margin = Math.Max(linearRgbMae, alphaMae) - NonVacuityParityTolerance;
+        return new GpuPassFusionNonVacuityDelta(
+            linearRgbMae,
+            alphaMae,
+            maximumChannelError,
+            sampleCount,
+            margin);
+    }
+
+    private static void VerifyRecordedNonVacuity(GpuPassFusionEvidenceManifest manifest)
+    {
+        const double tolerance = 1e-12;
+        foreach (GpuPassFusionEvidenceScene scene in manifest.Scenes.Where(scene => scene.NonVacuity is not null))
+        {
+            GpuPassFusionNonVacuityRecord recorded = scene.NonVacuity!;
+            GpuPassFusionNonVacuityDelta actual = RecomputeNonVacuity(manifest, scene);
+            if (Math.Abs(actual.LinearRgbMae - recorded.LinearRgbMae) > tolerance
+                || Math.Abs(actual.AlphaMae - recorded.AlphaMae) > tolerance
+                || Math.Abs(actual.MaximumChannelError - recorded.MaximumChannelError) > tolerance
+                || actual.SampleCount != recorded.SampleCount
+                || Math.Abs(actual.MarginAboveTolerance - recorded.MarginAboveTolerance) > tolerance)
+            {
+                throw new InvalidDataException(
+                    $"Scene '{scene.Id}' has stale non-vacuity evidence that does not match its pinned blobs.");
+            }
+        }
+    }
+
+    private static GpuPassFusionEvidenceTools ReadEvidenceTools(JsonElement element)
+    {
+        ValidateExactObjectShape(element, s_expectedEvidenceToolProperties, "manifest.evidenceTools");
+        return new GpuPassFusionEvidenceTools(
+            ReadSha256(element, "benchmarkRunnerSha256", "manifest.evidenceTools"),
+            ReadSha256(element, "generatorPatchSha256", "manifest.evidenceTools"),
+            ReadSha256(element, "generatorScriptSha256", "manifest.evidenceTools"),
+            ReadSha256(element, "pairedRunnerSha256", "manifest.evidenceTools"),
+            ReadSha256(element, "refreshScriptSha256", "manifest.evidenceTools"),
+            ReadSha256(element, "generatorSourceBundleSha256", "manifest.evidenceTools"));
+    }
+
+    private static IReadOnlyDictionary<string, IReadOnlyList<string>> ReadFingerprint(JsonElement element)
+    {
+        ValidateExactObjectShape(element, s_expectedFingerprintProperties, "manifest.fingerprint");
+        var result = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
+        foreach (JsonProperty property in element.EnumerateObject())
+        {
+            IReadOnlyList<string> values;
+            if (property.NameEquals("vulkanEnabledExtensions"))
+            {
+                if (property.Value.ValueKind != JsonValueKind.Array)
+                {
+                    throw new InvalidDataException(
+                        "manifest.fingerprint.vulkanEnabledExtensions must be an array.");
+                }
+
+                values = [.. property.Value.EnumerateArray().Select(
+                    item => ReadStringValue(item, "manifest.fingerprint.vulkanEnabledExtensions[]"))];
+            }
+            else
+            {
+                values = [ReadStringValue(property.Value, $"manifest.fingerprint.{property.Name}")];
+            }
+
+            result.Add(property.Name, values);
+        }
+
+        return result;
+    }
+
+    private static void ValidatePixelFormat(JsonElement element)
+    {
+        ValidateExactObjectShape(element, s_expectedPixelFormatProperties, "manifest.pixelFormat");
+        RequireExactString(element, "colorType", "RGBA16F", "manifest.pixelFormat");
+        RequireExactString(element, "alphaType", "premultiplied", "manifest.pixelFormat");
+        RequireExactString(element, "colorSpace", "linear-sRGB", "manifest.pixelFormat");
+        RequireExactString(element, "endianness", "little", "manifest.pixelFormat");
+        RequireExactString(element, "packing", "row-packed-without-padding", "manifest.pixelFormat");
+        int bytesPerPixel = ReadInt32(element, "bytesPerPixel", "manifest.pixelFormat");
+        if (bytesPerPixel != 8)
+            throw new InvalidDataException("manifest.pixelFormat.bytesPerPixel must be 8.");
+    }
+
+    private static IReadOnlyDictionary<string, string> ReadArtifactHashes(JsonElement element)
+    {
+        RequireObject(element, "manifest.artifactSha256");
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (JsonProperty property in element.EnumerateObject())
+        {
+            ValidateSafeBlobName(property.Name);
+            string sha256 = ReadStringValue(property.Value, $"manifest.artifactSha256.{property.Name}");
+            ValidateSha256(sha256, $"manifest artifact SHA-256 for '{property.Name}'");
+            if (!result.TryAdd(property.Name, sha256))
+                throw new InvalidDataException($"Duplicate artifact hash entry '{property.Name}'.");
+        }
+
+        if (result.Count == 0)
+            throw new InvalidDataException("manifest.artifactSha256 must not be empty.");
+        return result;
+    }
+
+    private static IReadOnlyList<GpuPassFusionEvidenceScene> ReadScenes(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Array)
+            throw new InvalidDataException("manifest.scenes must be an array.");
+
+        var result = new List<GpuPassFusionEvidenceScene>();
+        var ids = new HashSet<string>(StringComparer.Ordinal);
+        foreach (JsonElement item in element.EnumerateArray())
+        {
+            string context = $"manifest.scenes[{result.Count}]";
+            ValidateExactObjectShape(item, s_expectedSceneProperties, context);
+            string id = ReadString(item, "id", context);
+            if (!ids.Add(id))
+                throw new InvalidDataException($"Duplicate scene id '{id}'.");
+
+            string category = ReadString(item, "category", context);
+            string role = ReadString(item, "role", context);
+            if (role is not ("parity" or "control" or "metadata"))
+                throw new InvalidDataException($"Scene '{id}' has unsupported role '{role}'.");
+
+            string? controlSceneId = ReadNullableString(item, "controlSceneId", context);
+            string? blob = ReadNullableString(item, "blob", context);
+            if (blob is not null)
+                ValidateSafeBlobName(blob);
+
+            int blobWidth = ReadInt32(item, "blobWidth", context);
+            int blobHeight = ReadInt32(item, "blobHeight", context);
+            int logicalWidth = ReadInt32(item, "logicalWidth", context);
+            int logicalHeight = ReadInt32(item, "logicalHeight", context);
+            double outputScale = ReadFiniteNumber(item, "outputScale", context);
+            if (logicalWidth <= 0 || logicalHeight <= 0 || outputScale <= 0)
+                throw new InvalidDataException($"Scene '{id}' has invalid logical dimensions or output scale.");
+
+            if (blob is null)
+            {
+                if (blobWidth != 0 || blobHeight != 0)
+                    throw new InvalidDataException($"Blob-less scene '{id}' must have zero blob dimensions.");
+            }
+            else if (blobWidth <= 0 || blobHeight <= 0)
+            {
+                throw new InvalidDataException($"Scene '{id}' has invalid blob dimensions.");
+            }
+
+            string nonVacuityMode = ReadString(item, "nonVacuityMode", context);
+            if (nonVacuityMode is not ("full-frame" or "alpha-edge-band"))
+                throw new InvalidDataException($"Scene '{id}' has unknown non-vacuity mode '{nonVacuityMode}'.");
+
+            GpuPassFusionPixelRegion? nonVacuityRegion =
+                ReadNullablePixelRegion(item.GetProperty("nonVacuityRegion"), $"{context}.nonVacuityRegion");
+            GpuPassFusionNonVacuityRecord? nonVacuity =
+                ReadNullableNonVacuity(item.GetProperty("nonVacuity"), $"{context}.nonVacuity");
+
+            JsonElement parameters = item.GetProperty("parameters");
+            ValidateObject(parameters, $"{context}.parameters");
+            GpuPassFusionPixelRegion? edgeCrop = ReadOptionalEdgeCrop(
+                parameters,
+                $"{context}.parameters");
+            ValidateCounterObject(item.GetProperty("legacyCounters"), $"{context}.legacyCounters");
+            ValidateStringArray(item.GetProperty("legacyEvents"), $"{context}.legacyEvents");
+            ValidateNullOrObject(item.GetProperty("query"), $"{context}.query");
+            JsonElement requestedRegionElement = item.GetProperty("requestedRegion");
+            ValidateNullOrObject(requestedRegionElement, $"{context}.requestedRegion");
+            GpuPassFusionPixelRegion? requestedRegion =
+                ReadNullablePixelRegion(requestedRegionElement, $"{context}.requestedRegion");
+            string maxWorkingScaleText = ReadString(item, "maxWorkingScale", context);
+            if (!float.TryParse(
+                    maxWorkingScaleText,
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out float maxWorkingScale)
+                || !float.IsFinite(maxWorkingScale)
+                || maxWorkingScale <= 0)
+            {
+                throw new InvalidDataException(
+                    $"Scene '{id}' has invalid maxWorkingScale '{maxWorkingScaleText}'.");
+            }
+            ReadBoolean(item, "empty", context);
+
+            result.Add(new GpuPassFusionEvidenceScene(
+                id,
+                category,
+                role,
+                controlSceneId,
+                blob,
+                blobWidth,
+                blobHeight,
+                logicalWidth,
+                logicalHeight,
+                (float)outputScale,
+                maxWorkingScale,
+                requestedRegion,
+                edgeCrop,
+                nonVacuityMode,
+                nonVacuityRegion,
+                nonVacuity));
+        }
+
+        if (result.Count == 0)
+            throw new InvalidDataException("manifest.scenes must not be empty.");
+        return result;
+    }
+
+    private static GpuPassFusionPixelRegion? ReadOptionalEdgeCrop(
+        JsonElement parameters,
+        string context)
+    {
+        if (!parameters.TryGetProperty("edgeCrop", out JsonElement value))
+            return null;
+
+        string text = ReadStringValue(value, $"{context}.edgeCrop");
+        string[] parts = text.Split(',');
+        if (parts.Length != 4
+            || !int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out int x)
+            || !int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out int y)
+            || !int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out int width)
+            || !int.TryParse(parts[3], NumberStyles.Integer, CultureInfo.InvariantCulture, out int height)
+            || width <= 0
+            || height <= 0)
+        {
+            throw new InvalidDataException(
+                $"{context}.edgeCrop must be 'x,y,width,height' with a positive extent.");
+        }
+
+        return new GpuPassFusionPixelRegion(x, y, width, height);
+    }
+
+    private static GpuPassFusionNonVacuityRecord? ReadNullableNonVacuity(
+        JsonElement element,
+        string context)
+    {
+        if (element.ValueKind == JsonValueKind.Null)
+            return null;
+
+        ValidateExactObjectShape(element, s_expectedNonVacuityProperties, context);
+        return new GpuPassFusionNonVacuityRecord(
+            ReadFiniteNumber(element, "linearRgbMae", context),
+            ReadFiniteNumber(element, "alphaMae", context),
+            ReadFiniteNumber(element, "maximumChannelError", context),
+            ReadInt32(element, "sampleCount", context),
+            ReadString(element, "metricMode", context),
+            ReadNullablePixelRegion(element.GetProperty("metricRegion"), $"{context}.metricRegion"),
+            ReadFiniteNumber(element, "parityTolerance", context),
+            ReadFiniteNumber(element, "marginAboveTolerance", context));
+    }
+
+    private static void ValidateScenesAndArtifacts(
+        GpuPassFusionEvidencePaths paths,
+        IReadOnlyList<GpuPassFusionEvidenceScene> scenes,
+        IReadOnlyDictionary<string, string> artifactHashes)
+    {
+        Dictionary<string, GpuPassFusionEvidenceScene> sceneById =
+            scenes.ToDictionary(scene => scene.Id, StringComparer.Ordinal);
+        var sceneByBlob = new Dictionary<string, GpuPassFusionEvidenceScene>(StringComparer.Ordinal);
+        foreach (GpuPassFusionEvidenceScene scene in scenes)
+        {
+            if (scene.Blob is not null)
+            {
+                if (sceneByBlob.TryGetValue(scene.Blob, out GpuPassFusionEvidenceScene? existing))
+                {
+                    if (existing.BlobWidth != scene.BlobWidth || existing.BlobHeight != scene.BlobHeight)
+                    {
+                        throw new InvalidDataException(
+                            $"Scenes sharing blob '{scene.Blob}' declare different dimensions.");
+                    }
+                }
+                else
+                {
+                    sceneByBlob.Add(scene.Blob, scene);
+                }
+            }
+
+            if (scene.Role == "parity")
+            {
+                if (scene.ControlSceneId is null || scene.NonVacuity is null)
+                    throw new InvalidDataException($"Parity scene '{scene.Id}' lacks control or non-vacuity evidence.");
+                if (!sceneById.TryGetValue(scene.ControlSceneId, out GpuPassFusionEvidenceScene? control))
+                    throw new InvalidDataException($"Parity scene '{scene.Id}' references a missing control.");
+                if (control.Role != "control" || control.Blob is null || scene.Blob is null)
+                    throw new InvalidDataException($"Parity scene '{scene.Id}' has an invalid control scene.");
+                if (control.BlobWidth != scene.BlobWidth || control.BlobHeight != scene.BlobHeight)
+                    throw new InvalidDataException($"Parity/control dimensions differ for scene '{scene.Id}'.");
+                if (scene.NonVacuity.MetricMode != scene.NonVacuityMode
+                    || scene.NonVacuity.MetricRegion != scene.NonVacuityRegion)
+                {
+                    throw new InvalidDataException($"Scene '{scene.Id}' has inconsistent non-vacuity declarations.");
+                }
+                if (scene.NonVacuity.ParityTolerance != NonVacuityParityTolerance
+                    || scene.NonVacuity.MarginAboveTolerance <= 0
+                    || scene.NonVacuity.SampleCount <= 0)
+                {
+                    throw new InvalidDataException($"Scene '{scene.Id}' has invalid non-vacuity thresholds.");
+                }
+            }
+            else if (scene.ControlSceneId is not null || scene.NonVacuity is not null)
+            {
+                throw new InvalidDataException($"Non-parity scene '{scene.Id}' carries parity-only evidence.");
+            }
+        }
+
+        string[] artifactNames = [.. artifactHashes.Keys.Order(StringComparer.Ordinal)];
+        string[] sceneBlobNames = [.. sceneByBlob.Keys.Order(StringComparer.Ordinal)];
+        if (!artifactNames.SequenceEqual(sceneBlobNames, StringComparer.Ordinal))
+        {
+            throw new InvalidDataException("Scene blob set does not match manifest.artifactSha256.");
+        }
+
+        string[] expectedFiles = ["manifest.json", .. artifactNames];
+        Array.Sort(expectedFiles, StringComparer.Ordinal);
+        string[] actualFiles =
+        [
+            .. Directory.EnumerateFiles(paths.BaselineDirectory, "*", SearchOption.TopDirectoryOnly)
+                .Select(path => Path.GetFileName(path)!)
+                .Order(StringComparer.Ordinal),
+        ];
+        if (!expectedFiles.SequenceEqual(actualFiles, StringComparer.Ordinal))
+        {
+            throw new InvalidDataException(
+                "Immutable target baseline file set differs from its manifest. "
+                + $"Expected [{string.Join(", ", expectedFiles)}], found [{string.Join(", ", actualFiles)}].");
+        }
+
+        foreach ((string blobName, string sha256) in artifactHashes)
+        {
+            string path = Path.Combine(paths.BaselineDirectory, blobName);
+            VerifyFileHash(path, sha256, $"target baseline blob '{blobName}'");
+            GpuPassFusionEvidenceScene scene = sceneByBlob[blobName];
+            long expectedLength = checked((long)scene.BlobWidth * scene.BlobHeight * 8);
+            long actualLength = new FileInfo(path).Length;
+            if (actualLength != expectedLength)
+            {
+                throw new InvalidDataException(
+                    $"RGBA16F blob '{blobName}' length mismatch: expected {expectedLength}, found {actualLength}.");
+            }
+        }
+    }
+
+    private static void ValidateAllocationFailures(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Array)
+            throw new InvalidDataException("manifest.allocationFailures must be an array.");
+
+        var intents = new HashSet<string>(StringComparer.Ordinal);
+        int index = 0;
+        foreach (JsonElement item in element.EnumerateArray())
+        {
+            string context = $"manifest.allocationFailures[{index++}]";
+            ValidateExactObjectShape(item, s_expectedAllocationFailureProperties, context);
+            string intent = ReadString(item, "intent", context);
+            if (!intents.Add(intent))
+                throw new InvalidDataException($"Duplicate allocation-failure intent '{intent}'.");
+
+            ReadString(item, "injectionPoint", context);
+            ReadString(item, "maxWorkingScale", context);
+            string outcome = ReadString(item, "outcome", context);
+            string? exceptionType = ReadNullableString(item, "exceptionType", context);
+            string? exceptionMessage = ReadNullableString(item, "exceptionMessage", context);
+            ValidateCounterObject(item.GetProperty("legacyCounters"), $"{context}.legacyCounters");
+            ValidateStringArray(item.GetProperty("legacyEvents"), $"{context}.legacyEvents", requireNonEmpty: true);
+
+            bool validOutcome = intent switch
+            {
+                "preview" => outcome == "dropped-output-without-throw"
+                    && exceptionType is null
+                    && exceptionMessage is null,
+                "delivery" => outcome == "threw"
+                    && exceptionType is not null
+                    && exceptionMessage is not null,
+                _ => false,
+            };
+            if (!validOutcome)
+                throw new InvalidDataException($"Allocation-failure outcome is incomplete for intent '{intent}'.");
+        }
+
+        if (!intents.SetEquals(["delivery", "preview"]))
+            throw new InvalidDataException("Allocation-failure evidence must contain preview and delivery exactly once.");
+    }
+
+    private static void ValidateBenchmark(JsonElement element)
+    {
+        ValidateExactObjectShape(
+            element,
+            ["command", "environment", "rawResultReference", "status"],
+            "manifest.benchmark");
+        foreach (string property in new[] { "command", "environment", "rawResultReference", "status" })
+            ReadString(element, property, "manifest.benchmark");
+    }
+
+    private static GpuPassFusionPixelRegion? ReadNullablePixelRegion(JsonElement element, string context)
+    {
+        if (element.ValueKind == JsonValueKind.Null)
+            return null;
+
+        ValidateExactObjectShape(element, ["height", "width", "x", "y"], context);
+        return new GpuPassFusionPixelRegion(
+            ReadInt32(element, "x", context),
+            ReadInt32(element, "y", context),
+            ReadInt32(element, "width", context),
+            ReadInt32(element, "height", context));
+    }
+
+    private static void ValidateExactObjectShape(
+        JsonElement element,
+        IReadOnlyCollection<string> expectedNames,
+        string context)
+    {
+        RequireObject(element, context);
+        string[] actualNames = [.. element.EnumerateObject().Select(item => item.Name).Order(StringComparer.Ordinal)];
+        if (!actualNames.SequenceEqual(expectedNames, StringComparer.Ordinal))
+        {
+            throw new InvalidDataException(
+                $"{context} schema mismatch. Expected [{string.Join(", ", expectedNames)}], "
+                + $"found [{string.Join(", ", actualNames)}].");
+        }
+    }
+
+    private static void ValidateObject(JsonElement element, string context) => RequireObject(element, context);
+
+    private static void ValidateNullOrObject(JsonElement element, string context)
+    {
+        if (element.ValueKind is not (JsonValueKind.Null or JsonValueKind.Object))
+            throw new InvalidDataException($"{context} must be null or an object.");
+    }
+
+    private static void ValidateCounterObject(JsonElement element, string context)
+    {
+        RequireObject(element, context);
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (JsonProperty property in element.EnumerateObject())
+        {
+            if (!names.Add(property.Name)
+                || !property.Value.TryGetInt64(out long value)
+                || value < 0)
+            {
+                throw new InvalidDataException($"{context}.{property.Name} is not a unique non-negative counter.");
+            }
+        }
+
+        if (names.Count == 0)
+            throw new InvalidDataException($"{context} must contain a request-wide counter snapshot.");
+    }
+
+    private static void ValidateStringArray(JsonElement element, string context, bool requireNonEmpty = false)
+    {
+        if (element.ValueKind != JsonValueKind.Array)
+            throw new InvalidDataException($"{context} must be an array.");
+        int count = 0;
+        foreach (JsonElement item in element.EnumerateArray())
+        {
+            ReadStringValue(item, $"{context}[]");
+            count++;
+        }
+        if (requireNonEmpty && count == 0)
+            throw new InvalidDataException($"{context} must not be empty.");
+    }
+
+    private static void RequireObject(JsonElement element, string context)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+            throw new InvalidDataException($"{context} must be an object.");
+    }
+
+    private static string ReadString(JsonElement parent, string name, string context)
+        => ReadStringValue(ReadRequiredProperty(parent, name, context), $"{context}.{name}");
+
+    private static string? ReadNullableString(JsonElement parent, string name, string context)
+    {
+        JsonElement element = ReadRequiredProperty(parent, name, context);
+        return element.ValueKind == JsonValueKind.Null
+            ? null
+            : ReadStringValue(element, $"{context}.{name}");
+    }
+
+    private static string ReadStringValue(JsonElement element, string context)
+    {
+        if (element.ValueKind != JsonValueKind.String)
+            throw new InvalidDataException($"{context} must be a string.");
+        string? value = element.GetString();
+        if (string.IsNullOrWhiteSpace(value))
+            throw new InvalidDataException($"{context} must not be empty.");
+        return value;
+    }
+
+    private static int ReadInt32(JsonElement parent, string name, string context)
+    {
+        JsonElement element = ReadRequiredProperty(parent, name, context);
+        if (!element.TryGetInt32(out int value))
+            throw new InvalidDataException($"{context}.{name} must be a 32-bit integer.");
+        return value;
+    }
+
+    private static bool ReadBoolean(JsonElement parent, string name, string context)
+    {
+        JsonElement element = ReadRequiredProperty(parent, name, context);
+        if (element.ValueKind is not (JsonValueKind.True or JsonValueKind.False))
+            throw new InvalidDataException($"{context}.{name} must be a Boolean.");
+        return element.GetBoolean();
+    }
+
+    private static double ReadFiniteNumber(JsonElement parent, string name, string context)
+    {
+        JsonElement element = ReadRequiredProperty(parent, name, context);
+        if (!element.TryGetDouble(out double value) || !double.IsFinite(value))
+            throw new InvalidDataException($"{context}.{name} must be a finite number.");
+        return value;
+    }
+
+    private static string ReadSha256(JsonElement parent, string name, string context)
+    {
+        string value = ReadString(parent, name, context);
+        ValidateSha256(value, $"{context}.{name}");
+        return value;
+    }
+
+    private static JsonElement ReadRequiredProperty(JsonElement parent, string name, string context)
+    {
+        RequireObject(parent, context);
+        if (!parent.TryGetProperty(name, out JsonElement result))
+            throw new InvalidDataException($"{context}.{name} is missing.");
+        return result;
+    }
+
+    private static void RequireExactString(
+        JsonElement parent,
+        string name,
+        string expected,
+        string context)
+    {
+        string value = ReadString(parent, name, context);
+        if (!string.Equals(value, expected, StringComparison.Ordinal))
+            throw new InvalidDataException($"{context}.{name} must be '{expected}', not '{value}'.");
+    }
+
+    private static void ValidateCommitTimestamp(string value)
+    {
+        if (!DateTimeOffset.TryParseExact(
+                value,
+                "yyyy-MM-dd'T'HH:mm:sszzz",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out _))
+        {
+            throw new InvalidDataException("manifest.baselineCommitTimestamp is not an exact offset timestamp.");
+        }
+    }
+
+    private static void ValidateSafeBlobName(string name)
+    {
+        if (!name.EndsWith(Rgba16fGoldenStore.Extension, StringComparison.Ordinal)
+            || !string.Equals(name, Path.GetFileName(name), StringComparison.Ordinal)
+            || name.Contains('/')
+            || name.Contains('\\'))
+        {
+            throw new InvalidDataException($"Unsafe or non-RGBA16F artifact name '{name}'.");
+        }
+    }
+
+    private static void ValidateSha256(string value, string context)
+    {
+        if (value.Length != 64 || value.Any(item => item is not (>= '0' and <= '9') and not (>= 'a' and <= 'f')))
+            throw new InvalidDataException($"{context} must be a lowercase SHA-256 digest.");
+    }
+
+    private static FileStream OpenExistingReadOnly(string path, string description)
+    {
+        try
+        {
+            return new FileStream(
+                path,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                bufferSize: 64 * 1024,
+                FileOptions.SequentialScan);
+        }
+        catch (FileNotFoundException ex)
+        {
+            throw new FileNotFoundException($"Required {description} is missing: {path}", path, ex);
+        }
+        catch (DirectoryNotFoundException ex)
+        {
+            throw new FileNotFoundException($"Required {description} is missing: {path}", path, ex);
+        }
+    }
+
+    private static float HalfBitsToFiniteFloat(ushort bits, Bitmap bitmap, int x, int y, int channel)
+    {
+        float value = (float)BitConverter.UInt16BitsToHalf(bits);
+        if (!float.IsFinite(value))
+        {
+            throw new InvalidDataException(
+                $"RGBA16F evidence contains a non-finite value at {bitmap.Width}x{bitmap.Height} "
+                + $"(x={x}, y={y}, channel={channel}).");
+        }
+
+        return value;
+    }
+
+    private static bool IsNonVacuityCoverageEdge(float alpha) => alpha > 0.01f && alpha < 0.75f;
+}
+
+internal sealed record GpuPassFusionEvidenceManifest(
+    GpuPassFusionEvidencePaths Paths,
+    int SchemaVersion,
+    string BaselineCodeSha,
+    string PatchedDiffSha256,
+    int GeneratorSeed,
+    GpuPassFusionEvidenceTools EvidenceTools,
+    IReadOnlyDictionary<string, IReadOnlyList<string>> Fingerprint,
+    IReadOnlyDictionary<string, string> ArtifactHashes,
+    IReadOnlyList<GpuPassFusionEvidenceScene> Scenes)
+{
+    public GpuPassFusionEvidenceScene GetScene(string id)
+    {
+        return Scenes.SingleOrDefault(scene => string.Equals(scene.Id, id, StringComparison.Ordinal))
+            ?? throw new InvalidDataException($"Manifest scene '{id}' is missing.");
+    }
+}
+
+internal static class GpuPassFusionEvidenceStackSliceGate
+{
+    private const string MissingCorpusReason =
+        "Stack 3/5 intentionally excludes immutable GPU evidence; corpus-backed checks run from stack 4/5 onward.";
+
+    public static bool HasStack4EvidenceSlice
+        => Directory.Exists(GpuPassFusionEvidencePaths.Discover().EvidenceDirectory);
+
+    public static void RequireStack4EvidenceSlice()
+    {
+        if (!HasStack4EvidenceSlice)
+            Assert.Ignore(MissingCorpusReason);
+    }
+}
+
+internal sealed record GpuPassFusionEvidencePaths(
+    string RepositoryRoot,
+    string EvidenceDirectory,
+    string BaselineDirectory,
+    string ManifestPath,
+    string GeneratorPatchPath,
+    string GeneratorScriptPath,
+    string PairedRunnerPath,
+    string BenchmarkRunnerPath,
+    string RefreshScriptPath)
+{
+    public static GpuPassFusionEvidencePaths Discover()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Beutl.slnx")))
+            directory = directory.Parent;
+
+        if (directory is null)
+        {
+            throw new DirectoryNotFoundException(
+                $"Could not locate the Beutl repository root above {AppContext.BaseDirectory}.");
+        }
+
+        string repositoryRoot = directory.FullName;
+        string evidenceDirectory = Path.Combine(
+            repositoryRoot,
+            "docs",
+            "specs",
+            "004-gpu-pass-fusion",
+            "evidence");
+        string baselineDirectory = Path.Combine(evidenceDirectory, "target-baseline");
+        return new GpuPassFusionEvidencePaths(
+            repositoryRoot,
+            evidenceDirectory,
+            baselineDirectory,
+            Path.Combine(baselineDirectory, "manifest.json"),
+            Path.Combine(evidenceDirectory, "target-baseline-generator.patch"),
+            Path.Combine(evidenceDirectory, "generate-target-baseline.sh"),
+            Path.Combine(evidenceDirectory, "run-paired-visual-evidence.sh"),
+            Path.Combine(evidenceDirectory, "run-paired-benchmarks.sh"),
+            Path.Combine(evidenceDirectory, "refresh-intentional-visual-baselines.sh"));
+    }
+}
+
+internal sealed record GpuPassFusionEvidenceTools(
+    string BenchmarkRunnerSha256,
+    string GeneratorPatchSha256,
+    string GeneratorScriptSha256,
+    string PairedRunnerSha256,
+    string RefreshScriptSha256,
+    string GeneratorSourceBundleSha256);
+
+internal sealed record GpuPassFusionEvidenceScene(
+    string Id,
+    string Category,
+    string Role,
+    string? ControlSceneId,
+    string? Blob,
+    int BlobWidth,
+    int BlobHeight,
+    int LogicalWidth,
+    int LogicalHeight,
+    float OutputScale,
+    float MaxWorkingScale,
+    GpuPassFusionPixelRegion? RequestedRegion,
+    GpuPassFusionPixelRegion? EdgeCrop,
+    string NonVacuityMode,
+    GpuPassFusionPixelRegion? NonVacuityRegion,
+    GpuPassFusionNonVacuityRecord? NonVacuity);
+
+internal sealed record GpuPassFusionNonVacuityRecord(
+    double LinearRgbMae,
+    double AlphaMae,
+    double MaximumChannelError,
+    int SampleCount,
+    string MetricMode,
+    GpuPassFusionPixelRegion? MetricRegion,
+    double ParityTolerance,
+    double MarginAboveTolerance);
+
+internal readonly record struct GpuPassFusionNonVacuityDelta(
+    double LinearRgbMae,
+    double AlphaMae,
+    double MaximumChannelError,
+    int SampleCount,
+    double MarginAboveTolerance);

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Baseline/GpuPassFusionBaselineTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Baseline/GpuPassFusionBaselineTests.cs
@@ -1,0 +1,518 @@
+﻿using System.Reflection;
+using System.Text.Json;
+
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Baseline;
+
+[TestFixture]
+public sealed class GpuPassFusionBaselineTests
+{
+    private const string ExpectedTargetBenchmarkManifestSha256 =
+        "39272c4eef6414cf4099f3f2ab0a388dded36473e86deb506f127c65b85e78c6";
+
+    private const string ExpectedPairedBenchmarkManifestSha256 =
+        "839eaf34e4fa5824a03333fa50418259ea3fca302a044eb767110afb6b676b1e";
+
+    private static readonly string[] ExpectedPairedBenchmarkCounterFiles =
+    [
+        "LongInvariantChain.json",
+        "MixedSpatialColor.json",
+        "MultipleDrawablesTargetDependencies.json",
+        "NoEffectControl.json",
+        "ParameterOnlyAnimation.json",
+        "ShaderOpacityShader.json",
+        "ShaderOpacityShaderBarrier.json",
+        "SingleShader.json",
+        "SmallObjectFixedOverhead.json",
+        "StaticPrefixAnimatedTail.json",
+        "StructuralToggle.json",
+    ];
+
+    private static readonly string[] ExpectedPairedBenchmarkArchiveFiles =
+    [
+        .. ExpectedPairedBenchmarkCounterFiles.Select(file => $"baseline-a/counters/{file}"),
+        .. ExpectedPairedBenchmarkCounterFiles.Select(file => $"baseline-b/counters/{file}"),
+        .. ExpectedPairedBenchmarkCounterFiles.Select(file => $"feature/counters/{file}"),
+        "baseline-a/code-sha.txt",
+        "baseline-a/command.txt",
+        "baseline-a/raw-benchmark-full.json",
+        "baseline-a/raw-benchmark-stdout.txt",
+        "baseline-b/code-sha.txt",
+        "baseline-b/command.txt",
+        "baseline-b/raw-benchmark-full.json",
+        "baseline-b/raw-benchmark-stdout.txt",
+        "feature/code-sha.txt",
+        "feature/command.txt",
+        "feature/raw-benchmark-full.json",
+        "feature/raw-benchmark-stdout.txt",
+        "manifest.json",
+    ];
+
+    [Test]
+    public void IntentionalRefreshScript_StagesAllLinkedTrustAnchorsBeforePublishing()
+    {
+        GpuPassFusionEvidenceStackSliceGate.RequireStack4EvidenceSlice();
+        GpuPassFusionEvidencePaths paths = GpuPassFusionEvidencePaths.Discover();
+        string script = File.ReadAllText(paths.RefreshScriptPath);
+        string benchmarkTest = File.ReadAllText(Path.Combine(
+            paths.RepositoryRoot,
+            "tests",
+            "Beutl.UnitTests",
+            "Engine",
+            "Graphics",
+            "Rendering",
+            "Baseline",
+            "GpuPassFusionBaselineTests.cs"));
+        string acceptanceReport = File.ReadAllText(Path.Combine(
+            paths.EvidenceDirectory,
+            "acceptance-report.md"));
+        int stagingStart = script.IndexOf("staged = []", StringComparison.Ordinal);
+        int benchmarkStage = script.IndexOf(
+            "staged.append((benchmark_test_stage, benchmark_test))",
+            StringComparison.Ordinal);
+        int acceptanceStage = script.IndexOf(
+            "staged.append((acceptance_stage, acceptance_report))",
+            StringComparison.Ordinal);
+        int publishStart = script.IndexOf("for source, destination in staged:", StringComparison.Ordinal);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                System.Text.RegularExpressions.Regex.Matches(
+                    benchmarkTest,
+                    "ExpectedTargetBenchmarkManifestSha256\\s*=\\s*\"[0-9a-f]{64}\";").Count,
+                Is.EqualTo(1));
+            Assert.That(
+                System.Text.RegularExpressions.Regex.Matches(
+                    acceptanceReport,
+                    "The current immutable trust-chain anchors are target visual manifest\\s+"
+                    + "`[0-9a-f]{64}` and\\s+target benchmark manifest\\s+`[0-9a-f]{64}`\\.").Count,
+                Is.EqualTo(1));
+            Assert.That(script, Does.Contain("benchmark manifest test trust anchor"));
+            Assert.That(script, Does.Contain("acceptance visual manifest trust anchor"));
+            Assert.That(script, Does.Contain("acceptance benchmark manifest trust anchor"));
+            Assert.That(stagingStart, Is.GreaterThanOrEqualTo(0));
+            Assert.That(benchmarkStage, Is.GreaterThan(stagingStart).And.LessThan(publishStart));
+            Assert.That(acceptanceStage, Is.GreaterThan(stagingStart).And.LessThan(publishStart));
+        });
+    }
+
+    [Test]
+    public void ImmutableEvidence_HasPinnedManifestToolAndBlobIntegrity()
+    {
+        GpuPassFusionEvidenceStackSliceGate.RequireStack4EvidenceSlice();
+        GpuPassFusionEvidenceManifest manifest = GpuPassFusionBaselineEvidence.LoadAndVerify();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(manifest.SchemaVersion, Is.EqualTo(GpuPassFusionBaselineEvidence.ExpectedSchemaVersion));
+            Assert.That(
+                manifest.BaselineCodeSha,
+                Is.EqualTo(GpuPassFusionBaselineEvidence.ExpectedBaselineCodeSha));
+            Assert.That(manifest.GeneratorSeed, Is.EqualTo(GpuPassFusionBaselineEvidence.ExpectedGeneratorSeed));
+            Assert.That(manifest.ArtifactHashes, Is.Not.Empty);
+            Assert.That(manifest.Scenes.Count(scene => scene.Role == "parity"), Is.GreaterThan(0));
+            Assert.That(
+                manifest.Fingerprint.Keys,
+                Is.EquivalentTo(GpuPassFusionBaselineEvidence.RequiredFingerprintFields));
+        }
+    }
+
+    [Test]
+    public void ImmutableTargetBenchmark_HasPinnedSchemaProvenanceFileSetAndArtifactHashes()
+    {
+        GpuPassFusionEvidenceStackSliceGate.RequireStack4EvidenceSlice();
+        GpuPassFusionEvidenceManifest baseline = GpuPassFusionBaselineEvidence.LoadAndVerify();
+        string directory = Path.Combine(baseline.Paths.EvidenceDirectory, "target-benchmark");
+        string manifestPath = Path.Combine(directory, "manifest.json");
+        GpuPassFusionBaselineEvidence.VerifyFileHash(
+            manifestPath,
+            ExpectedTargetBenchmarkManifestSha256,
+            "target benchmark manifest");
+
+        using JsonDocument document = JsonDocument.Parse(File.ReadAllBytes(manifestPath));
+        JsonElement root = document.RootElement;
+        Assert.That(
+            root.EnumerateObject().Select(static property => property.Name),
+            Is.EquivalentTo(new[]
+            {
+                "artifactSha256",
+                "baselineCodeSha",
+                "benchmarkDotNetVersion",
+                "cases",
+                "command",
+                "configuration",
+                "evidenceTools",
+                "fingerprint",
+                "patchedDiffSha256",
+                "prePatchRepositoryState",
+                "runCompletedUtc",
+                "runStartedUtc",
+                "schemaVersion",
+                "scope",
+                "visualManifestSha256",
+            }));
+        Assert.Multiple(() =>
+        {
+            Assert.That(root.GetProperty("schemaVersion").GetInt32(), Is.EqualTo(1));
+            Assert.That(root.GetProperty("baselineCodeSha").GetString(), Is.EqualTo(baseline.BaselineCodeSha));
+            Assert.That(root.GetProperty("patchedDiffSha256").GetString(), Is.EqualTo(baseline.PatchedDiffSha256));
+            Assert.That(root.GetProperty("prePatchRepositoryState").GetString(), Is.EqualTo("clean"));
+            Assert.That(
+                root.GetProperty("visualManifestSha256").GetString(),
+                Is.EqualTo(GpuPassFusionBaselineEvidence.ExpectedManifestSha256));
+        });
+
+        IReadOnlyDictionary<string, string> expectedTools = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["benchmarkRunnerSha256"] = baseline.EvidenceTools.BenchmarkRunnerSha256,
+            ["generatorPatchSha256"] = baseline.EvidenceTools.GeneratorPatchSha256,
+            ["generatorScriptSha256"] = baseline.EvidenceTools.GeneratorScriptSha256,
+            ["generatorSourceBundleSha256"] = baseline.EvidenceTools.GeneratorSourceBundleSha256,
+            ["pairedRunnerSha256"] = baseline.EvidenceTools.PairedRunnerSha256,
+            ["refreshScriptSha256"] = baseline.EvidenceTools.RefreshScriptSha256,
+        };
+        JsonElement tools = root.GetProperty("evidenceTools");
+        Assert.That(
+            tools.EnumerateObject().Select(static property => property.Name),
+            Is.EquivalentTo(expectedTools.Keys));
+        foreach ((string name, string expected) in expectedTools)
+            Assert.That(tools.GetProperty(name).GetString(), Is.EqualTo(expected), name);
+
+        JsonElement fingerprint = root.GetProperty("fingerprint");
+        Assert.That(
+            fingerprint.EnumerateObject().Select(static property => property.Name),
+            Is.EquivalentTo(baseline.Fingerprint.Keys));
+        foreach ((string name, IReadOnlyList<string> expected) in baseline.Fingerprint)
+        {
+            JsonElement actual = fingerprint.GetProperty(name);
+            IReadOnlyList<string?> values = actual.ValueKind == JsonValueKind.Array
+                ? actual.EnumerateArray().Select(static item => item.GetString()).ToArray()
+                : [actual.GetString()];
+            Assert.That(values, Is.EqualTo(expected), name);
+        }
+
+        string[] expectedArtifacts =
+        [
+            "counters.json",
+            "raw-benchmark-full.json",
+            "raw-benchmark-github.md",
+            "raw-benchmark-stdout.txt",
+        ];
+        JsonElement artifactHashes = root.GetProperty("artifactSha256");
+        Assert.That(
+            artifactHashes.EnumerateObject().Select(static property => property.Name),
+            Is.EquivalentTo(expectedArtifacts));
+        string[] actualFiles = Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories)
+            .Select(path => Path.GetRelativePath(directory, path).Replace(Path.DirectorySeparatorChar, '/'))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.That(actualFiles, Is.EqualTo(expectedArtifacts.Append("manifest.json").Order(StringComparer.Ordinal)));
+        foreach (string artifact in expectedArtifacts)
+        {
+            GpuPassFusionBaselineEvidence.VerifyFileHash(
+                Path.Combine(directory, artifact),
+                artifactHashes.GetProperty(artifact).GetString()
+                    ?? throw new InvalidDataException($"Target benchmark hash is null: {artifact}"),
+                $"target benchmark artifact '{artifact}'");
+        }
+    }
+
+    [Test]
+    public void PairedBenchmarkArchive_HasPinnedManifestFileSetAndArtifactHashes()
+    {
+        GpuPassFusionEvidenceStackSliceGate.RequireStack4EvidenceSlice();
+        GpuPassFusionEvidencePaths paths = GpuPassFusionEvidencePaths.Discover();
+        string directory = Path.Combine(paths.EvidenceDirectory, "paired-benchmark-run");
+        string manifestPath = Path.Combine(directory, "manifest.json");
+        GpuPassFusionBaselineEvidence.VerifyFileHash(
+            manifestPath,
+            ExpectedPairedBenchmarkManifestSha256,
+            "paired benchmark manifest");
+
+        using JsonDocument document = JsonDocument.Parse(File.ReadAllBytes(manifestPath));
+        JsonElement root = document.RootElement;
+        Assert.Multiple(() =>
+        {
+            Assert.That(root.GetProperty("schemaVersion").GetInt32(), Is.EqualTo(2));
+            Assert.That(
+                root.EnumerateObject().Select(static property => property.Name),
+                Does.Contain("overallAcceptancePassed"));
+        });
+
+        string[] actualFiles = Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories)
+            .Select(path => Path.GetRelativePath(directory, path).Replace(Path.DirectorySeparatorChar, '/'))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.That(actualFiles, Is.EqualTo(ExpectedPairedBenchmarkArchiveFiles.Order(StringComparer.Ordinal)));
+
+        foreach (string laneName in new[] { "baseline", "baselineRepeat", "feature" })
+        {
+            JsonElement lane = root.GetProperty(laneName);
+            string laneDirectory = laneName switch
+            {
+                "baseline" => "baseline-a",
+                "baselineRepeat" => "baseline-b",
+                _ => "feature",
+            };
+            string resultFile = lane.GetProperty("benchmarkDotNetResultFile").GetString()
+                ?? throw new InvalidDataException($"{laneName} result file is missing");
+            string resultPath = Path.Combine(directory, laneDirectory, resultFile);
+            GpuPassFusionBaselineEvidence.VerifyFileHash(
+                resultPath,
+                lane.GetProperty("benchmarkDotNetResultSha256").GetString()
+                    ?? throw new InvalidDataException($"{laneName} result hash is missing"),
+                $"{laneName} benchmark result");
+
+            string stdoutFile = lane.GetProperty("standardOutputFile").GetString()
+                ?? throw new InvalidDataException($"{laneName} stdout file is missing");
+            GpuPassFusionBaselineEvidence.VerifyFileHash(
+                Path.Combine(directory, laneDirectory, stdoutFile),
+                lane.GetProperty("standardOutputSha256").GetString()
+                    ?? throw new InvalidDataException($"{laneName} stdout hash is missing"),
+                $"{laneName} benchmark stdout");
+
+            JsonElement counterHashes = lane.GetProperty("counterFileSha256");
+            string counterDirectory = Path.Combine(directory, laneDirectory, "counters");
+            Assert.That(
+                counterHashes.EnumerateObject().Select(static property => property.Name),
+                Is.EquivalentTo(ExpectedPairedBenchmarkCounterFiles));
+            foreach (JsonProperty counter in counterHashes.EnumerateObject())
+            {
+                GpuPassFusionBaselineEvidence.VerifyFileHash(
+                    Path.Combine(counterDirectory, counter.Name),
+                    counter.Value.GetString() ?? throw new InvalidDataException($"{laneName} counter hash is null"),
+                    $"{laneName} counter '{counter.Name}'");
+            }
+        }
+    }
+
+    [Test]
+    public void FingerprintValidation_IsCompleteButEnvironmentIndependent()
+    {
+        Dictionary<string, IReadOnlyList<string>> foreignFingerprint =
+            GpuPassFusionBaselineEvidence.RequiredFingerprintFields.ToDictionary(
+                name => name,
+                name => (IReadOnlyList<string>)(name == "vulkanEnabledExtensions"
+                    ? ["VK_TEST_foreign_extension"]
+                    : [$"foreign-evidence-{name}"]),
+                StringComparer.Ordinal);
+
+        Assert.That(
+            () => GpuPassFusionBaselineEvidence.ValidateFingerprint(foreignFingerprint),
+            Throws.Nothing,
+            "Integrity validation must not select or reject blobs based on the current CI device.");
+    }
+    [Test]
+    public void FingerprintValidation_RejectsMissingAndUnknownFields()
+    {
+        Dictionary<string, IReadOnlyList<string>> missing =
+            GpuPassFusionBaselineEvidence.RequiredFingerprintFields
+                .Skip(1)
+                .ToDictionary(
+                    name => name,
+                    name => (IReadOnlyList<string>)[name],
+                    StringComparer.Ordinal);
+        Dictionary<string, IReadOnlyList<string>> unknown =
+            GpuPassFusionBaselineEvidence.RequiredFingerprintFields.ToDictionary(
+                name => name,
+                name => (IReadOnlyList<string>)(name == "deviceSelection" ? ["unknown"] : [name]),
+                StringComparer.Ordinal);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                () => GpuPassFusionBaselineEvidence.ValidateFingerprint(missing),
+                Throws.TypeOf<InvalidDataException>());
+            Assert.That(
+                () => GpuPassFusionBaselineEvidence.ValidateFingerprint(unknown),
+                Throws.TypeOf<InvalidDataException>());
+        }
+    }
+
+    [Test]
+    public void HashIntegrity_MissingFileFailsWithoutGeneratingIt()
+    {
+        string temporaryDirectory = CreateTemporaryDirectory();
+        string missingPath = Path.Combine(temporaryDirectory, "missing.rgba16f");
+        try
+        {
+            Assert.That(
+                () => GpuPassFusionBaselineEvidence.VerifyFileHash(
+                    missingPath,
+                    new string('0', 64),
+                    "synthetic missing evidence"),
+                Throws.TypeOf<FileNotFoundException>());
+            Assert.That(File.Exists(missingPath), Is.False, "Integrity checks must never generate missing evidence.");
+        }
+        finally
+        {
+            Directory.Delete(temporaryDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void HashIntegrity_MismatchFailsWithoutReplacingIt()
+    {
+        string temporaryDirectory = CreateTemporaryDirectory();
+        string artifactPath = Path.Combine(temporaryDirectory, "mismatched.rgba16f");
+        byte[] original = [0x42, 0x65, 0x75, 0x74, 0x6c];
+        try
+        {
+            File.WriteAllBytes(artifactPath, original);
+
+            Assert.That(
+                () => GpuPassFusionBaselineEvidence.VerifyFileHash(
+                    artifactPath,
+                    new string('0', 64),
+                    "synthetic mismatched evidence"),
+                Throws.TypeOf<InvalidDataException>());
+            Assert.That(
+                File.ReadAllBytes(artifactPath),
+                Is.EqualTo(original),
+                "Integrity checks must never replace mismatched evidence.");
+        }
+        finally
+        {
+            Directory.Delete(temporaryDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void SameProcessParityHarness_UsesOnlyBothInternalModesAndFixedBounds()
+    {
+        var modes = new List<FusionMode>();
+
+        GpuPassFusionParityResult result = GpuPassFusionSameProcessParityHarness.AssertParity(
+            mode =>
+            {
+                modes.Add(mode);
+                return CreateUniformBitmap(8, 8, red: 0.2f, green: 0.1f, blue: 0.3f, alpha: 0.5f);
+            },
+            new PixelRect(1, 1, 6, 6));
+
+        MethodInfo method = typeof(GpuPassFusionSameProcessParityHarness).GetMethod(
+            nameof(GpuPassFusionSameProcessParityHarness.AssertParity),
+            BindingFlags.Public | BindingFlags.Static)
+            ?? throw new InvalidOperationException("The same-process parity entry point is missing.");
+        Type[] parameterTypes = [.. method.GetParameters().Select(parameter => parameter.ParameterType)];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(modes, Is.EqualTo(new[] { FusionMode.Disabled, FusionMode.Enabled }));
+            Assert.That(
+                parameterTypes,
+                Is.EqualTo(new[] { typeof(Func<FusionMode, Bitmap>), typeof(PixelRect?) }),
+                "The normal-CI harness must not accept a manifest, historical blob, or configurable bound.");
+            Assert.That(GpuPassFusionSameProcessParityHarness.MinimumSsim, Is.EqualTo(0.99));
+            Assert.That(GpuPassFusionSameProcessParityHarness.MinimumWindowedSsim, Is.EqualTo(0.95));
+            Assert.That(GpuPassFusionSameProcessParityHarness.MaximumLinearRgbMae, Is.EqualTo(0.02));
+            Assert.That(GpuPassFusionSameProcessParityHarness.MaximumAlphaMae, Is.EqualTo(0.02));
+            Assert.That(GpuPassFusionSameProcessParityHarness.MaximumAaEdgeChannelError, Is.EqualTo(0.02));
+            Assert.That(result.FullImage.Ssim, Is.EqualTo(1));
+            Assert.That(result.FullImage.WindowedSsim, Is.EqualTo(1));
+            Assert.That(result.FullImage.LinearRgbMae, Is.Zero);
+            Assert.That(result.FullImage.AlphaMae, Is.Zero);
+            Assert.That(result.AaEdge, Is.Not.Null);
+            Assert.That(result.AaEdge!.Value.MaximumError.Maximum, Is.Zero);
+        }
+    }
+
+    [Test]
+    public void SameProcessParityHarness_RejectsAaChannelErrorAboveFixedBound()
+    {
+        Assert.That(
+            () => GpuPassFusionSameProcessParityHarness.AssertParity(
+                mode => CreateUniformBitmap(
+                    8,
+                    8,
+                    red: mode == FusionMode.Disabled ? 0.2f : 0.221f,
+                    green: 0.1f,
+                    blue: 0.3f,
+                    alpha: 0.5f),
+                new PixelRect(1, 1, 6, 6)),
+            Throws.TypeOf<MultipleAssertException>()
+                .With.Message.Contains("AA edge red-channel maximum error exceeded"),
+            "The fixed AA per-channel maximum must reject an error above 0.02 even when mean RGB error passes.");
+    }
+
+    [Test]
+    public void SameProcessParityHarness_RejectsLocalizedDefectThatPassesWholeFrameMetrics()
+    {
+        Assert.That(
+            () => GpuPassFusionSameProcessParityHarness.AssertParity(
+                mode => CreateCheckerboardBitmap(withLocalizedDefect: mode == FusionMode.Enabled)),
+            Throws.TypeOf<MultipleAssertException>()
+                .With.Message.Contains("minimum-window SSIM was too low"),
+            "A localized defect must not hide inside acceptable whole-frame SSIM and MAE values.");
+    }
+
+    private static Bitmap CreateCheckerboardBitmap(bool withLocalizedDefect)
+    {
+        const int size = 128;
+        var bitmap = new Bitmap(
+            size,
+            size,
+            BitmapColorType.RgbaF16,
+            BitmapAlphaType.Premul,
+            BitmapColorSpace.LinearSrgb);
+        Span<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        ushort one = BitConverter.HalfToUInt16Bits((Half)1f);
+        ushort zero = BitConverter.HalfToUInt16Bits((Half)0f);
+        ushort gray = BitConverter.HalfToUInt16Bits((Half)0.5f);
+        for (int y = 0; y < size; y++)
+        {
+            for (int x = 0; x < size; x++)
+            {
+                int offset = ((y * size) + x) * 4;
+                ushort value = withLocalizedDefect && x < 14 && y < 14
+                    ? gray
+                    : ((x + y) & 1) == 0 ? one : zero;
+                pixels[offset] = pixels[offset + 1] = pixels[offset + 2] = value;
+                pixels[offset + 3] = one;
+            }
+        }
+
+        return bitmap;
+    }
+
+    private static Bitmap CreateUniformBitmap(
+        int width,
+        int height,
+        float red,
+        float green,
+        float blue,
+        float alpha)
+    {
+        var bitmap = new Bitmap(
+            width,
+            height,
+            BitmapColorType.RgbaF16,
+            BitmapAlphaType.Premul,
+            BitmapColorSpace.LinearSrgb);
+        ushort[] pixel =
+        [
+            BitConverter.HalfToUInt16Bits((Half)red),
+            BitConverter.HalfToUInt16Bits((Half)green),
+            BitConverter.HalfToUInt16Bits((Half)blue),
+            BitConverter.HalfToUInt16Bits((Half)alpha),
+        ];
+        for (int y = 0; y < height; y++)
+        {
+            Span<ushort> row = bitmap.GetRow<ushort>(y);
+            for (int x = 0; x < width; x++)
+                pixel.CopyTo(row[(x * 4)..]);
+        }
+
+        return bitmap;
+    }
+
+    private static string CreateTemporaryDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"beutl-gpu-pass-baseline-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Baseline/GpuPassFusionNonVacuityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Baseline/GpuPassFusionNonVacuityTests.cs
@@ -1,0 +1,102 @@
+﻿using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Rendering.Golden;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Baseline;
+
+[TestFixture]
+public sealed class GpuPassFusionNonVacuityTests
+{
+    private static readonly Lazy<GpuPassFusionEvidenceManifest> s_manifest =
+        new(GpuPassFusionBaselineEvidence.LoadAndVerify);
+
+    private static IEnumerable<TestCaseData> ParityWorkloads
+    {
+        get
+        {
+            if (!GpuPassFusionEvidenceStackSliceGate.HasStack4EvidenceSlice)
+            {
+                yield return new TestCaseData(string.Empty)
+                    .SetName("RecordedNonVacuity_RequiresStack4Evidence");
+                yield break;
+            }
+
+            foreach (GpuPassFusionEvidenceScene scene in s_manifest.Value.Scenes.Where(
+                         item => item.Role == "parity"))
+            {
+                yield return new TestCaseData(scene.Id)
+                    .SetName($"RecordedNonVacuity_{scene.Id.Replace('-', '_')}");
+            }
+        }
+    }
+
+    [TestCaseSource(nameof(ParityWorkloads))]
+    public void RecordedNonVacuity_IsRecomputedFromReferenceAndControl(string sceneId)
+    {
+        GpuPassFusionEvidenceStackSliceGate.RequireStack4EvidenceSlice();
+        GpuPassFusionEvidenceScene scene = s_manifest.Value.GetScene(sceneId);
+        GpuPassFusionNonVacuityRecord recorded = scene.NonVacuity
+            ?? throw new InvalidDataException($"Parity scene '{scene.Id}' has no recorded non-vacuity evidence.");
+        GpuPassFusionNonVacuityDelta actual =
+            GpuPassFusionBaselineEvidence.RecomputeNonVacuity(s_manifest.Value, scene);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(actual.LinearRgbMae, Is.EqualTo(recorded.LinearRgbMae).Within(1e-12));
+            Assert.That(actual.AlphaMae, Is.EqualTo(recorded.AlphaMae).Within(1e-12));
+            Assert.That(
+                actual.MaximumChannelError,
+                Is.EqualTo(recorded.MaximumChannelError).Within(1e-12));
+            Assert.That(actual.SampleCount, Is.EqualTo(recorded.SampleCount));
+            Assert.That(
+                recorded.ParityTolerance,
+                Is.EqualTo(GpuPassFusionBaselineEvidence.NonVacuityParityTolerance));
+            Assert.That(
+                actual.MarginAboveTolerance,
+                Is.EqualTo(recorded.MarginAboveTolerance).Within(1e-12));
+            Assert.That(
+                actual.MarginAboveTolerance,
+                Is.GreaterThan(0),
+                $"Workload '{scene.Id}' does not distinguish its reference from control beyond parity tolerance.");
+        }
+    }
+
+    [TestCase("primary-control-gamma-disabled")]
+    [TestCase("primary-control-opacity-disabled")]
+    [TestCase("primary-control-invert-disabled")]
+    public void PrimaryChain_EachDisabledStageIsNonVacuous(string controlSceneId)
+    {
+        GpuPassFusionEvidenceStackSliceGate.RequireStack4EvidenceSlice();
+        GpuPassFusionEvidenceManifest manifest = s_manifest.Value;
+        GpuPassFusionEvidenceScene referenceScene = manifest.GetScene("primary-cross-node");
+        GpuPassFusionEvidenceScene controlScene = manifest.GetScene(controlSceneId);
+        using Bitmap reference = ReadScene(manifest, referenceScene);
+        using Bitmap control = ReadScene(manifest, controlScene);
+
+        GpuPassFusionNonVacuityDelta delta = GpuPassFusionBaselineEvidence.CalculateNonVacuityDelta(
+            reference,
+            control,
+            "full-frame",
+            metricRegion: null);
+        double discriminator = Math.Max(delta.LinearRgbMae, delta.AlphaMae);
+        double margin = discriminator - GpuPassFusionBaselineEvidence.NonVacuityParityTolerance;
+        TestContext.WriteLine(
+            $"[{controlSceneId}] discriminator={discriminator:F6}, marginAboveTolerance={margin:F6}");
+
+        Assert.That(
+            margin,
+            Is.GreaterThan(0.005),
+            $"Disabling stage control '{controlSceneId}' must exceed the parity tolerance by a meaningful margin.");
+    }
+
+    private static Bitmap ReadScene(
+        GpuPassFusionEvidenceManifest manifest,
+        GpuPassFusionEvidenceScene scene)
+    {
+        string blob = scene.Blob
+            ?? throw new InvalidDataException($"Scene '{scene.Id}' has no immutable RGBA16F blob.");
+        return Rgba16fGoldenStore.Read(
+            Path.Combine(manifest.Paths.BaselineDirectory, blob),
+            scene.BlobWidth,
+            scene.BlobHeight);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Baseline/GpuPassFusionSameProcessParityHarness.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Baseline/GpuPassFusionSameProcessParityHarness.cs
@@ -1,0 +1,171 @@
+﻿using Beutl.Graphics.Rendering;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Rendering.Golden;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Baseline;
+
+internal static class GpuPassFusionSameProcessParityHarness
+{
+    public const double MinimumSsim = 0.99;
+    public const double MinimumWindowedSsim = 0.95;
+    public const double MaximumLinearRgbMae = 0.02;
+    public const double MaximumAlphaMae = 0.02;
+    public const double MaximumAaEdgeChannelError = 0.02;
+    public const double MaximumAaEdgeMeanError = 0.02;
+
+    public static GpuPassFusionParityResult AssertParity(
+        Func<FusionMode, Bitmap> render,
+        PixelRect? aaEdgeRegion = null)
+    {
+        ArgumentNullException.ThrowIfNull(render);
+
+        using Bitmap disabled = render(FusionMode.Disabled)
+            ?? throw new InvalidOperationException("The fusion-disabled render returned null.");
+        using Bitmap enabled = render(FusionMode.Enabled)
+            ?? throw new InvalidOperationException("The fusion-enabled render returned null.");
+        if (ReferenceEquals(disabled, enabled))
+            throw new InvalidOperationException("Fusion-disabled and enabled runs must return independently owned images.");
+
+        string? nonFinite = ImageMetrics.FirstNonFinite(
+            ("fusion-disabled", disabled),
+            ("fusion-enabled", enabled));
+        Assert.That(nonFinite, Is.Null, "Same-process parity inputs must contain only finite RGBA16F values.");
+
+        GpuPassFusionParityMetrics fullImage = Measure(disabled, enabled);
+        GpuPassFusionAaParityMetrics? aaEdge = null;
+        if (aaEdgeRegion is { } region)
+        {
+            ValidateCrop(region, disabled.Width, disabled.Height);
+            using Bitmap disabledCrop = Crop(disabled, region);
+            using Bitmap enabledCrop = Crop(enabled, region);
+            GpuPassFusionParityMetrics cropMetrics = Measure(disabledCrop, enabledCrop);
+            double edgeMeanError = ImageMetrics.EdgeBandMeanAbsoluteError(disabledCrop, enabledCrop);
+            RgbaMaximumError edgeMaximum =
+                ImageMetrics.EdgeBandMaximumAbsoluteErrorPerChannel(disabledCrop, enabledCrop);
+            aaEdge = new GpuPassFusionAaParityMetrics(cropMetrics, edgeMeanError, edgeMaximum);
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            AssertMetrics(fullImage, "full image");
+            if (aaEdge is { } edge)
+            {
+                AssertMetrics(edge.Crop, "AA edge crop");
+                Assert.That(
+                    edge.EdgeBandMeanError,
+                    Is.LessThanOrEqualTo(MaximumAaEdgeMeanError),
+                    "AA edge-band mean error exceeded the fixed normal-CI bound.");
+                Assert.That(
+                    edge.MaximumError.Red,
+                    Is.LessThanOrEqualTo(MaximumAaEdgeChannelError),
+                    "AA edge red-channel maximum error exceeded the fixed normal-CI bound.");
+                Assert.That(
+                    edge.MaximumError.Green,
+                    Is.LessThanOrEqualTo(MaximumAaEdgeChannelError),
+                    "AA edge green-channel maximum error exceeded the fixed normal-CI bound.");
+                Assert.That(
+                    edge.MaximumError.Blue,
+                    Is.LessThanOrEqualTo(MaximumAaEdgeChannelError),
+                    "AA edge blue-channel maximum error exceeded the fixed normal-CI bound.");
+                Assert.That(
+                    edge.MaximumError.Alpha,
+                    Is.LessThanOrEqualTo(MaximumAaEdgeChannelError),
+                    "AA edge alpha-channel maximum error exceeded the fixed normal-CI bound.");
+            }
+        }
+
+        return new GpuPassFusionParityResult(fullImage, aaEdge);
+    }
+
+    private static GpuPassFusionParityMetrics Measure(Bitmap disabled, Bitmap enabled)
+    {
+        return new GpuPassFusionParityMetrics(
+            ImageMetrics.Ssim(disabled, enabled),
+            ImageMetrics.WindowedSsim(disabled, enabled, 16),
+            ImageMetrics.MeanAbsoluteError(disabled, enabled),
+            ImageMetrics.AlphaMeanAbsoluteError(disabled, enabled));
+    }
+
+    private static void AssertMetrics(GpuPassFusionParityMetrics metrics, string region)
+    {
+        Assert.That(metrics.Ssim, Is.GreaterThanOrEqualTo(MinimumSsim), $"{region} SSIM was too low.");
+        Assert.That(
+            metrics.WindowedSsim,
+            Is.GreaterThanOrEqualTo(MinimumWindowedSsim),
+            $"{region} minimum-window SSIM was too low.");
+        Assert.That(
+            metrics.LinearRgbMae,
+            Is.LessThanOrEqualTo(MaximumLinearRgbMae),
+            $"{region} linear RGB MAE was too high.");
+        Assert.That(
+            metrics.AlphaMae,
+            Is.LessThanOrEqualTo(MaximumAlphaMae),
+            $"{region} alpha MAE was too high.");
+    }
+
+    private static Bitmap Crop(Bitmap source, PixelRect region)
+    {
+        var result = new Bitmap(
+            region.Width,
+            region.Height,
+            BitmapColorType.RgbaF16,
+            BitmapAlphaType.Premul,
+            BitmapColorSpace.LinearSrgb);
+        for (int y = 0; y < region.Height; y++)
+        {
+            ReadOnlySpan<ushort> sourceRow = source.GetRow<ushort>(region.Y + y);
+            Span<ushort> destinationRow = result.GetRow<ushort>(y);
+            sourceRow.Slice(region.X * 4, region.Width * 4).CopyTo(destinationRow);
+        }
+
+        return result;
+    }
+
+    private static void ValidateCrop(PixelRect region, int width, int height)
+    {
+        if (region.X < 0
+            || region.Y < 0
+            || region.Width <= 0
+            || region.Height <= 0
+            || region.Right > width
+            || region.Bottom > height)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(region),
+                region,
+                $"AA edge region must be a non-empty subset of the {width}x{height} output.");
+        }
+    }
+}
+
+internal readonly record struct GpuPassFusionPixelRegion(int X, int Y, int Width, int Height)
+{
+    public int Right => checked(X + Width);
+
+    public int Bottom => checked(Y + Height);
+
+    public void ValidateInside(int imageWidth, int imageHeight, string description)
+    {
+        if (X < 0 || Y < 0 || Width <= 0 || Height <= 0 || Right > imageWidth || Bottom > imageHeight)
+        {
+            throw new InvalidDataException(
+                $"{description} ({X}, {Y}, {Width}, {Height}) is not a non-empty subset of "
+                + $"{imageWidth}x{imageHeight}.");
+        }
+    }
+}
+
+internal readonly record struct GpuPassFusionParityMetrics(
+    double Ssim,
+    double WindowedSsim,
+    double LinearRgbMae,
+    double AlphaMae);
+
+internal readonly record struct GpuPassFusionAaParityMetrics(
+    GpuPassFusionParityMetrics Crop,
+    double EdgeBandMeanError,
+    RgbaMaximumError MaximumError);
+
+internal readonly record struct GpuPassFusionParityResult(
+    GpuPassFusionParityMetrics FullImage,
+    GpuPassFusionAaParityMetrics? AaEdge);

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/BrushIntermediateAllocationIntentTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/BrushIntermediateAllocationIntentTests.cs
@@ -1,0 +1,304 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Shapes;
+using Beutl.Media;
+using Beutl.Media.Source;
+using Beutl.Serialization;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+/// <summary>
+/// Brush-owned intermediates must decide degrade-vs-fail from the explicit <see cref="RenderIntent"/>,
+/// not from the working-scale ceiling that happens to accompany it.
+/// </summary>
+[TestFixture]
+public sealed class BrushIntermediateAllocationIntentTests
+{
+    // Larger than any GPU or raster allocation can satisfy, so RenderTarget.Create returns null fast.
+    private const float UnallocatableScale = 2_000_000f;
+
+    private static readonly Rect s_bounds = new(0, 0, 8, 8);
+
+    [Test]
+    public void TileBrush_DeliveryFailsEvenWithAFiniteWorkingScaleCeiling()
+    {
+        using ImageBrush.Resource brush = CreateImageBrush();
+        var constructor = new BrushConstructor(
+            s_bounds, brush, BlendMode.SrcOver, UnallocatableScale,
+            maxWorkingScale: 4f, intent: RenderIntent.Delivery);
+
+        Assert.That(
+            () => constructor.CreateShader(),
+            Throws.TypeOf<InvalidOperationException>()
+                .With.Message.StartWith("Tile-brush intermediate allocation failed"));
+    }
+
+    [Test]
+    public void TileBrush_PreviewDegradesEvenWithoutAWorkingScaleCeiling()
+    {
+        using ImageBrush.Resource brush = CreateImageBrush();
+        var constructor = new BrushConstructor(
+            s_bounds, brush, BlendMode.SrcOver, UnallocatableScale,
+            maxWorkingScale: float.PositiveInfinity, intent: RenderIntent.Preview);
+
+        SKShader? shader = null;
+        Assert.That(() => shader = constructor.CreateShader(), Throws.Nothing);
+        Assert.That(shader, Is.Null);
+    }
+
+    [Test]
+    public void DrawableBrush_DeliveryFailsEvenWithAFiniteWorkingScaleCeiling()
+    {
+        using DrawableBrush.Resource brush = CreateDrawableBrush();
+        using SKShader tile = SKShader.CreateColor(SKColors.White);
+        var constructor = new BrushConstructor(
+            s_bounds,
+            new LoweredBrush(null, brush, new BrushTileContent(tile, s_bounds, EffectiveScale.At(1f))),
+            BlendMode.SrcOver,
+            UnallocatableScale,
+            maxWorkingScale: 4f,
+            intent: RenderIntent.Delivery);
+
+        Assert.That(
+            () => constructor.CreateShader(),
+            Throws.TypeOf<InvalidOperationException>()
+                .With.Message.StartWith("Drawable-brush intermediate allocation failed"));
+    }
+
+    [Test]
+    public void DrawableBrush_PreviewDegradesEvenWithoutAWorkingScaleCeiling()
+    {
+        using DrawableBrush.Resource brush = CreateDrawableBrush();
+        using SKShader tile = SKShader.CreateColor(SKColors.White);
+        var constructor = new BrushConstructor(
+            s_bounds,
+            new LoweredBrush(null, brush, new BrushTileContent(tile, s_bounds, EffectiveScale.At(1f))),
+            BlendMode.SrcOver,
+            UnallocatableScale,
+            maxWorkingScale: float.PositiveInfinity,
+            intent: RenderIntent.Preview);
+
+        SKShader? shader = null;
+        Assert.That(() => shader = constructor.CreateShader(), Throws.Nothing);
+        Assert.That(shader, Is.Null);
+    }
+
+    [Test]
+    public void UndefinedIntent_IsRejected()
+    {
+        Assert.That(
+            () => new BrushConstructor(s_bounds, brush: null, BlendMode.SrcOver, intent: (RenderIntent)12345),
+            Throws.TypeOf<ArgumentOutOfRangeException>().With.Property("ParamName").EqualTo("intent"));
+    }
+
+    [Test]
+    public void Canvas_HandsItsIntentToTheBrushesItPaintsWith()
+    {
+        using RenderTarget target = RenderTarget.CreateNull(8, 8);
+        using var canvas = new ImmediateCanvas(target, intent: RenderIntent.Delivery);
+        using ImageBrush.Resource brush = CreateImageBrush();
+
+        Assert.That(canvas.Intent, Is.EqualTo(RenderIntent.Delivery));
+        Assert.That(
+            () => canvas.DrawRectangle(new Rect(0, 0, UnallocatableScale, UnallocatableScale), brush, pen: null),
+            Throws.TypeOf<InvalidOperationException>()
+                .With.Message.StartWith("Tile-brush intermediate allocation failed"),
+            "A delivery canvas must propagate its intent into the brush intermediates it allocates.");
+    }
+
+    [Test]
+    public void PreviewCanvas_KeepsDrawingWhenABrushIntermediateCannotBeAllocated()
+    {
+        using RenderTarget target = RenderTarget.CreateNull(8, 8);
+        using var canvas = new ImmediateCanvas(target);
+        using ImageBrush.Resource brush = CreateImageBrush();
+
+        Assert.That(canvas.Intent, Is.EqualTo(RenderIntent.Preview));
+        Assert.That(
+            () => canvas.DrawRectangle(new Rect(0, 0, UnallocatableScale, UnallocatableScale), brush, pen: null),
+            Throws.Nothing);
+    }
+
+    [Test]
+    public void CanvasBrushConstructorHelper_CarriesDensityCeilingAndIntent()
+    {
+        using RenderTarget target = RenderTarget.CreateNull(8, 8);
+        using var canvas = new ImmediateCanvas(
+            target, density: 2f, maxWorkingScale: 4f, intent: RenderIntent.Delivery);
+
+        BrushConstructor constructor = canvas.CreateBrushConstructor(
+            s_bounds, Brushes.Resource.White, BlendMode.SrcOver);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(constructor.Scale, Is.EqualTo(canvas.Density));
+            Assert.That(constructor.MaxWorkingScale, Is.EqualTo(canvas.MaxWorkingScale));
+            Assert.That(constructor.Intent, Is.EqualTo(RenderIntent.Delivery));
+        });
+    }
+
+    // The executor-managed canvases are where most intermediate allocation happens; a delivery request
+    // that reached them as Preview degraded silently.
+    [TestCase(RenderIntent.Preview)]
+    [TestCase(RenderIntent.Delivery)]
+    public void TheOpaqueCallbackCanvasCarriesTheRequestIntent(RenderIntent intent)
+    {
+        RenderIntent? observed = null;
+        using var node = new IntentProbeOpaqueNode(s_bounds, canvas => observed = canvas.Intent);
+        using RenderNodeRenderer renderer = CreateRenderer(node, intent);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        Assert.That(observed, Is.EqualTo(intent));
+    }
+
+    [Test]
+    public void ADeliveryRequestFailsWhenAnOpaqueCallbackCannotAllocateItsBrushIntermediate()
+    {
+        using var node = new UnallocatableBrushOpaqueNode(s_bounds);
+        using RenderNodeRenderer renderer = CreateRenderer(node, RenderIntent.Delivery);
+
+        Assert.That(
+            () => renderer.Rasterize(),
+            Throws.TypeOf<InvalidOperationException>()
+                .With.Message.StartWith("Tile-brush intermediate allocation failed"));
+    }
+
+    [Test]
+    public void APreviewRequestAbsorbsTheSameOpaqueCallbackAllocationFailure()
+    {
+        using var node = new UnallocatableBrushOpaqueNode(s_bounds);
+        using RenderNodeRenderer renderer = CreateRenderer(node, RenderIntent.Preview);
+
+        Assert.That(() => renderer.Rasterize().Dispose(), Throws.Nothing);
+    }
+
+    [TestCase(RenderIntent.Preview)]
+    [TestCase(RenderIntent.Delivery)]
+    public void TheTargetCommandCanvasCarriesTheRequestIntent(RenderIntent intent)
+    {
+        RenderIntent? observed = null;
+        using var node = new TargetCommandProbeNode(s_bounds, canvas => observed = canvas.Intent);
+        using RenderNodeRenderer renderer = CreateRenderer(node, intent);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        Assert.That(observed, Is.EqualTo(intent));
+    }
+
+    private static RenderNodeRenderer CreateRenderer(RenderNode root, RenderIntent intent)
+        => new(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    Intent = intent,
+                    TargetDomain = s_bounds,
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+            });
+
+    private static ImageBrush.Resource CreateImageBrush()
+    {
+        using var bitmap = new Bitmap(4, 4);
+        using var stream = new MemoryStream();
+        bitmap.Save(stream, EncodedImageFormat.Png);
+
+        var source = new ImageSource();
+        source.ReadFrom(UriHelper.CreateBase64DataUri("image/png", stream.ToArray()));
+        var brush = new ImageBrush(source);
+        brush.Stretch.CurrentValue = Stretch.Fill;
+        brush.TileMode.CurrentValue = TileMode.None;
+        brush.DestinationRect.CurrentValue = RelativeRect.Fill;
+        return brush.ToResource(CompositionContext.Default);
+    }
+
+    private static DrawableBrush.Resource CreateDrawableBrush()
+    {
+        var content = new RectShape();
+        content.Width.CurrentValue = 8;
+        content.Height.CurrentValue = 8;
+        content.Fill.CurrentValue = Brushes.White;
+        var brush = new DrawableBrush(content);
+        brush.Stretch.CurrentValue = Stretch.Fill;
+        brush.TileMode.CurrentValue = TileMode.None;
+        brush.DestinationRect.CurrentValue = RelativeRect.Fill;
+        return brush.ToResource(CompositionContext.Default);
+    }
+
+    private sealed class IntentProbeOpaqueNode(Rect bounds, Action<ImmediateCanvas> probe) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            OpaqueRenderDescription description = OpaqueRenderDescription.CreateRequestLocal(
+                session =>
+                {
+                    using OpaqueRenderOutput output = session.CreateOutput(bounds);
+                    output.Canvas.Use(probe);
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.Source(bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: "brush-intent-probe-source");
+            context.Publish(context.OpaqueSource(description));
+        }
+    }
+
+    private sealed class UnallocatableBrushOpaqueNode(Rect bounds) : RenderNode
+    {
+        private readonly Brush.Resource _brush = CreateImageBrush();
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<Brush.Resource> brushToken = context.Borrow(
+                _brush,
+                _brush.GetOriginal().Id,
+                _brush.Version);
+            OpaqueRenderDescription description = OpaqueRenderDescription.Create(
+                bounds,
+                static (session, state) => session.UseDeclaredResource<Brush.Resource>("brush", currentBrush =>
+                {
+                    using OpaqueRenderOutput output = session.CreateOutput(state);
+                    output.Canvas.Use(canvas => canvas.DrawRectangle(
+                        new Rect(0, 0, UnallocatableScale, UnallocatableScale),
+                        currentBrush,
+                        pen: null));
+                    session.Publish(output);
+                }),
+                OpaqueRenderBoundsContract.Source(bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: "brush-intent-unallocatable-source",
+                resources: [brushToken.Bind("brush")]);
+            context.Publish(context.OpaqueSource(description));
+        }
+
+        protected override void OnDispose(bool disposing)
+        {
+            base.OnDispose(disposing);
+            if (disposing)
+                _brush.Dispose();
+        }
+    }
+
+    private sealed class TargetCommandProbeNode(Rect bounds, Action<ImmediateCanvas> probe) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            TargetCommandDescription command = TargetCommandDescription.CreateRequestLocal(
+                session => session.Canvas.Use(probe),
+                TargetRegion.Region(bounds),
+                bounds,
+                RenderHitTestContract.None);
+            context.Publish(context.TargetCommand([], command));
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/BrushSourceBoundsIdentityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/BrushSourceBoundsIdentityTests.cs
@@ -1,0 +1,107 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Graphics.Shapes;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+/// <summary>
+/// <c>BrushRecorder.CreateSourceBounds</c> builds its forward mapping as a <c>_ =&gt; bounds</c> closure declared
+/// inside the recorder, so the callback method the factory would otherwise default to is shared by every caller
+/// and says nothing about the rectangle the closure captured.
+/// </summary>
+[TestFixture]
+public sealed class BrushSourceBoundsIdentityTests
+{
+    private static readonly Rect s_domain = new(0, 0, 400, 300);
+
+    [Test]
+    public void ResizingABrushedSource_CompilesANewStructuralPlan()
+    {
+        var shape = new RectShape
+        {
+            Width = { CurrentValue = 60 },
+            Height = { CurrentValue = 40 },
+            Fill =
+            {
+                CurrentValue = new DrawableBrush(
+                    new RectShape
+                    {
+                        Width = { CurrentValue = 20 },
+                        Height = { CurrentValue = 20 },
+                        Fill = { CurrentValue = Brushes.Red },
+                    }),
+            },
+        };
+
+        using Drawable.Resource resource = shape.ToResource(CompositionContext.Default);
+        using var root = new DrawableRenderNode(resource);
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_domain,
+                    CacheOptions = RenderCacheOptions.Enabled,
+                    Purpose = RenderRequestPurpose.Frame,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        long afterFirst = RecordAndRasterize(shape, resource, root, renderer);
+        long afterReplay = RecordAndRasterize(shape, resource, root, renderer);
+        shape.Width.CurrentValue = 90;
+        long afterResize = RecordAndRasterize(shape, resource, root, renderer);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(afterFirst, Is.EqualTo(1));
+            Assert.That(afterReplay, Is.EqualTo(1), "an unchanged recording reuses its compiled plan");
+            Assert.That(
+                afterResize,
+                Is.EqualTo(2),
+                "the captured source rectangle has to reach the structural key, because the shared closure's "
+                + "method identity cannot carry it");
+        });
+    }
+
+    private static long RecordAndRasterize(
+        Drawable shape,
+        Drawable.Resource resource,
+        DrawableRenderNode root,
+        RenderNodeRenderer renderer)
+    {
+        bool updateOnly = false;
+        resource.Update(shape, CompositionContext.Default, ref updateOnly);
+        using (var context = new GraphicsContext2D(root, s_domain.Size))
+        {
+            shape.Render(context, resource);
+        }
+
+        renderer.Rasterize().Dispose();
+        return renderer.StructuralPlanCacheStatistics.Compilations;
+    }
+
+    private sealed class CpuTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+            => new CpuRenderTarget(allocation.DeviceSize.Width, allocation.DeviceSize.Height);
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/ComposedSceneRenderCacheTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/ComposedSceneRenderCacheTests.cs
@@ -1,0 +1,633 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Graphics.Shapes;
+using Beutl.Graphics.Transformation;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Cache;
+
+[NonParallelizable]
+[TestFixture]
+public sealed class ComposedSceneRenderCacheTests
+{
+    private static readonly PixelSize s_frameSize = new(240, 160);
+    private static readonly Rect s_frameBounds = new(default, s_frameSize.ToSize(1));
+
+    [Test]
+    public void ComposedScene_CacheHitAndDisabledRenderAreByteIdentical()
+    {
+        RenderThread.Dispatcher.Invoke(() =>
+        {
+            Drawable.Resource[] resources = CreateSceneResources();
+            try
+            {
+                using var root = new DrawableRenderNode(resources[0]);
+                using (var context = new GraphicsContext2D(root, s_frameSize.ToSize(1)))
+                {
+                    context.Clear();
+                    foreach (Drawable.Resource resource in resources)
+                    {
+                        context.DrawDrawable(resource);
+                    }
+                }
+
+                GeometryRenderNode? cacheableBackground = Descendants(root)
+                    .OfType<GeometryRenderNode>()
+                    .FirstOrDefault();
+                Assert.That(cacheableBackground, Is.Not.Null,
+                    "the composed fixture must include a cacheable shape subtree");
+                cacheableBackground!.Cache.ReportRenderCount(RenderNodeCache.Count);
+
+                var diagnostics = new RenderPipelineDiagnosticsState();
+                using var cachedRenderer = CreateRenderer(root, useRenderCache: true, diagnostics);
+                using RenderNodeRasterization first = cachedRenderer.Rasterize();
+                using RenderNodeRasterization second = cachedRenderer.Rasterize();
+
+                using var uncachedRenderer = CreateRenderer(root, useRenderCache: false);
+                using RenderNodeRasterization control = uncachedRenderer.Rasterize();
+
+                byte[] firstPixels = GetPixels(first);
+                byte[] secondPixels = GetPixels(second);
+                byte[] controlPixels = GetPixels(control);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(firstPixels, Has.Some.Not.Zero,
+                        "the composed fixture must produce visible pixels");
+                    Assert.That(second.Bounds, Is.EqualTo(first.Bounds));
+                    Assert.That(control.Bounds, Is.EqualTo(first.Bounds));
+                    Assert.That(secondPixels, Is.EqualTo(firstPixels),
+                        "the cache-hit render must be byte-identical to the cache-miss render. "
+                        + DescribeDifference(firstPixels, secondPixels));
+                    Assert.That(controlPixels, Is.EqualTo(firstPixels),
+                        "cache policy must not change the composed scene output. "
+                        + DescribeDifference(firstPixels, controlPixels));
+                    Assert.That(
+                        diagnostics.Latest[RenderPipelineCounter.RenderCacheHits],
+                        Is.GreaterThan(0),
+                        "the second enabled render must exercise a persistent render-cache hit");
+                });
+            }
+            finally
+            {
+                foreach (Drawable.Resource resource in resources)
+                {
+                    resource.Dispose();
+                }
+            }
+        });
+    }
+
+    [Test]
+    public void Text_DeviceGridDependentCacheCandidateIsBypassedAndMatchesDisabledRender()
+    {
+        RenderThread.Dispatcher.Invoke(() =>
+        {
+            var text = new TextBlock
+            {
+                FontFamily = { CurrentValue = FontFamily.Default },
+                Size = { CurrentValue = 72 },
+                Fill = { CurrentValue = Brushes.White },
+                Text = { CurrentValue = "ab" },
+                AlignmentX = { CurrentValue = AlignmentX.Left },
+                AlignmentY = { CurrentValue = AlignmentY.Top },
+            };
+            using Drawable.Resource resource = text.ToResource(CompositionContext.Default);
+
+            AssertCacheAdmissionParity<TextRenderNode>(resource, expectCacheHit: false);
+        });
+    }
+
+    [Test]
+    public void FractionalDrawableBrush_DeviceGridDependentCacheCandidateIsBypassed()
+    {
+        RenderThread.Dispatcher.Invoke(() =>
+        {
+            using Drawable.Resource resource = CreateDrawableBrushHost(0.5f);
+
+            AssertCacheAdmissionParity<GeometryRenderNode>(resource, expectCacheHit: false);
+        });
+    }
+
+    [Test]
+    public void IntegerPhaseText_CacheAdmissionAndReplayAreByteIdenticalToDisabledRender()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var text = new TextBlock
+            {
+                FontFamily = { CurrentValue = FontFamily.Default },
+                Size = { CurrentValue = 72 },
+                Fill = { CurrentValue = Brushes.White },
+                Text = { CurrentValue = "ab" },
+                Transform = { CurrentValue = new TranslateTransform(0, 0) },
+            };
+            using Drawable.Resource resource = text.ToResource(CompositionContext.Default);
+
+            AssertProductionCacheSequenceParity(
+                resource,
+                RenderCacheOptions.Enabled,
+                expectCacheHit: false);
+        });
+    }
+
+    [TestCase(BlendMode.DstIn)]
+    [TestCase(BlendMode.SrcIn)]
+    [TestCase(BlendMode.DstATop)]
+    public void PhaseUnsafeMaskScope_IsBypassedAndMatchesDisabledRender(BlendMode blendMode)
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var group = new DrawableGroup();
+            group.Children.Add(new RectShape
+            {
+                Width = { CurrentValue = 160 },
+                Height = { CurrentValue = 160 },
+                Fill = { CurrentValue = Brushes.White },
+            });
+            group.Children.Add(new EllipseShape
+            {
+                Width = { CurrentValue = 90 },
+                Height = { CurrentValue = 90 },
+                Fill = { CurrentValue = Brushes.White },
+                BlendMode = { CurrentValue = blendMode },
+            });
+            using Drawable.Resource resource = group.ToResource(CompositionContext.Default);
+
+            AssertProductionCacheSequenceParity(
+                resource,
+                RenderCacheOptions.Enabled,
+                expectCacheHit: false);
+        });
+    }
+
+    [Test]
+    public void PlainGroup_WithCenteredVectorContentIsConservativelyBypassed()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var group = new DrawableGroup();
+            group.Children.Add(new RectShape
+            {
+                Width = { CurrentValue = 160 },
+                Height = { CurrentValue = 160 },
+                Fill = { CurrentValue = Brushes.White },
+            });
+            using Drawable.Resource resource = group.ToResource(CompositionContext.Default);
+
+            AssertProductionCacheSequenceParity(
+                resource,
+                RenderCacheOptions.Enabled,
+                expectCacheHit: false);
+        });
+    }
+
+    [Test]
+    public void PlainGroup_DefaultRenderNodeRendererOptionsDoNotUsePersistentCache()
+    {
+        RenderThread.Dispatcher.Invoke(() =>
+        {
+            var group = new DrawableGroup();
+            group.Children.Add(new RectShape
+            {
+                Width = { CurrentValue = 160 },
+                Height = { CurrentValue = 160 },
+                Fill = { CurrentValue = Brushes.White },
+            });
+            using Drawable.Resource resource = group.ToResource(CompositionContext.Default);
+            using var root = new DrawableRenderNode(resource);
+            using (var context = new GraphicsContext2D(root, s_frameSize.ToSize(1)))
+            {
+                context.Clear();
+                context.DrawDrawable(resource);
+            }
+
+            GeometryRenderNode? cacheable = Descendants(root)
+                .OfType<GeometryRenderNode>()
+                .FirstOrDefault();
+            Assert.That(cacheable, Is.Not.Null, "the plain group must contain an eligible geometry node");
+            cacheable!.Cache.ReportRenderCount(RenderNodeCache.Count);
+
+            var diagnostics = new RenderPipelineDiagnosticsState();
+            var completedRequests = new List<RenderPipelineDiagnosticSnapshot>();
+            diagnostics.RequestCompleted += completedRequests.Add;
+            using var renderer = new RenderNodeRenderer(
+                root,
+                new RenderNodeRendererOptions
+                {
+                    DefaultRequest = new RenderNodeRenderRequest
+                    {
+                        TargetDomain = s_frameBounds,
+                        Purpose = RenderRequestPurpose.Frame,
+                        Diagnostics = diagnostics,
+                    },
+                    TargetFactory = new CpuTargetFactory(),
+                });
+            using RenderNodeRasterization first = renderer.Rasterize();
+            using RenderNodeRasterization second = renderer.Rasterize();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    completedRequests.Sum(
+                        static snapshot => snapshot[RenderPipelineCounter.RenderCacheCaptures]),
+                    Is.Zero,
+                    "default renderer options must not publish persistent cache entries");
+                Assert.That(
+                    completedRequests.Sum(
+                        static snapshot => snapshot[RenderPipelineCounter.RenderCacheHits]),
+                    Is.Zero,
+                    "default renderer options must not read persistent cache entries");
+            });
+        });
+    }
+
+    [Test]
+    public void DefaultPolicy_DoesNotAdmitPlainAntialiasedGeometryOnGpu()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var ellipse = new EllipseShape
+            {
+                Width = { CurrentValue = 91 },
+                Height = { CurrentValue = 73 },
+                Fill = { CurrentValue = Brushes.White },
+            };
+            using Drawable.Resource resource = ellipse.ToResource(CompositionContext.Default);
+
+            AssertProductionCacheSequenceParity(
+                resource,
+                RenderCacheOptions.Default,
+                expectCacheHit: false);
+        });
+    }
+
+    [Test]
+    public void FractionalDrawableBrush_UncachedRenderPreservesAnalyticRectangleCoverage()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Drawable.Resource resource = CreateDrawableBrushHost(
+                translation: 0.25f,
+                width: 120,
+                height: 120,
+                rectangularContent: true);
+            using Bitmap bitmap = RenderComposedFrame(resource, useRenderCache: false);
+
+            Rgba leftEdge = ReadPixel(bitmap, 60, 80);
+            Rgba topEdge = ReadPixel(bitmap, 120, 20);
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    leftEdge.Alpha,
+                    Is.EqualTo(0.75f).Within(0.01f),
+                    "The leading edge must retain 75% device-pixel coverage.");
+                Assert.That(
+                    topEdge.Alpha,
+                    Is.EqualTo(0.75f).Within(0.01f),
+                    "The top edge must retain 75% device-pixel coverage.");
+            });
+        });
+    }
+
+    [Test]
+    public void FractionalDrawableBrush_HasNoCacheAdmissionFrameFlicker()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Drawable.Resource resource = CreateDrawableBrushHost(
+                translation: 0.25f,
+                width: 120,
+                height: 120);
+
+            AssertProductionCacheSequenceParity(
+                resource,
+                RenderCacheOptions.Enabled,
+                expectCacheHit: false);
+        });
+    }
+
+    private static Drawable.Resource CreateDrawableBrushHost(
+        float translation,
+        float width = 40,
+        float height = 30,
+        bool rectangularContent = false)
+    {
+        Drawable content = rectangularContent
+            ? new RectShape
+            {
+                Width = { CurrentValue = width },
+                Height = { CurrentValue = height },
+                Fill = { CurrentValue = Brushes.White },
+            }
+            : new EllipseShape
+            {
+                Width = { CurrentValue = width },
+                Height = { CurrentValue = height },
+                Fill = { CurrentValue = Brushes.White },
+            };
+        var brush = new DrawableBrush(content)
+        {
+            Stretch = { CurrentValue = Stretch.Fill },
+            TileMode = { CurrentValue = TileMode.None },
+            DestinationRect = { CurrentValue = RelativeRect.Fill },
+        };
+        var host = new RectShape
+        {
+            Width = { CurrentValue = width },
+            Height = { CurrentValue = height },
+            Fill = { CurrentValue = brush },
+            Transform = { CurrentValue = new TranslateTransform(translation, translation) },
+        };
+        return host.ToResource(CompositionContext.Default);
+    }
+
+    private static void AssertCacheAdmissionParity<TNode>(
+        Drawable.Resource resource,
+        bool expectCacheHit)
+        where TNode : RenderNode
+    {
+        using var root = new DrawableRenderNode(resource);
+        using (var context = new GraphicsContext2D(root, s_frameSize.ToSize(1)))
+        {
+            context.Clear();
+            context.DrawDrawable(resource);
+        }
+
+        TNode? cacheable = Descendants(root).OfType<TNode>().FirstOrDefault();
+        Assert.That(cacheable, Is.Not.Null, $"the fixture must contain a {typeof(TNode).Name}");
+        cacheable!.Cache.ReportRenderCount(RenderNodeCache.Count);
+
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var cachedRenderer = CreateRenderer(root, useRenderCache: true, diagnostics);
+        using RenderNodeRasterization admission = cachedRenderer.Rasterize();
+        using RenderNodeRasterization hit = cachedRenderer.Rasterize();
+        using var uncachedRenderer = CreateRenderer(root, useRenderCache: false);
+        using RenderNodeRasterization control = uncachedRenderer.Rasterize();
+
+        byte[] admissionPixels = GetPixels(admission);
+        byte[] hitPixels = GetPixels(hit);
+        byte[] controlPixels = GetPixels(control);
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                admissionPixels,
+                Is.EqualTo(controlPixels),
+                "cache admission must not change output. "
+                + DescribeDifference(controlPixels, admissionPixels));
+            Assert.That(
+                hitPixels,
+                Is.EqualTo(controlPixels),
+                "cache replay must not change output. "
+                + DescribeDifference(controlPixels, hitPixels));
+            Assert.That(
+                diagnostics.Latest[RenderPipelineCounter.RenderCacheHits],
+                expectCacheHit ? Is.GreaterThan(0) : Is.EqualTo(0),
+                expectCacheHit
+                    ? "the second enabled render must exercise a persistent render-cache hit"
+                    : "a transformed device-grid-dependent source must bypass persistent caching");
+        });
+    }
+
+    private static RenderNodeRenderer CreateRenderer(
+        RenderNode root,
+        bool useRenderCache,
+        IRenderPipelineDiagnosticsState? diagnostics = null)
+    {
+        return new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_frameBounds,
+                    CacheOptions = new Beutl.Graphics.Rendering.Cache.RenderCacheOptions(useRenderCache, Beutl.Graphics.Rendering.Cache.RenderCacheRules.Default),
+                    Purpose = RenderRequestPurpose.Frame,
+                    Diagnostics = diagnostics,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+    }
+
+    private static void AssertProductionCacheSequenceParity(
+        Drawable.Resource resource,
+        RenderCacheOptions cacheOptions,
+        bool expectCacheHit)
+        => AssertProductionCacheSequence(
+            resource,
+            cacheOptions,
+            expectCacheHit,
+            assertPixelParity: true);
+
+    private static void AssertProductionCacheSequence(
+        Drawable.Resource resource,
+        RenderCacheOptions cacheOptions,
+        bool expectCacheHit,
+        bool assertPixelParity)
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        var completedRequests = new List<RenderPipelineDiagnosticSnapshot>();
+        diagnostics.RequestCompleted += completedRequests.Add;
+        using var cachedRenderer = new Renderer(
+            s_frameSize.Width,
+            s_frameSize.Height,
+            renderScale: 1,
+            maxWorkingScale: float.PositiveInfinity,
+            diagnostics: diagnostics,
+            surface: null)
+        {
+            CacheOptions = cacheOptions,
+        };
+        using var uncachedRenderer = new Renderer(s_frameSize.Width, s_frameSize.Height)
+        {
+            CacheOptions = RenderCacheOptions.Disabled,
+        };
+        var frameData = new CompositionFrame(
+            [resource],
+            new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)),
+            s_frameSize);
+        for (int frame = 0; frame < 6; frame++)
+        {
+            cachedRenderer.Render(frameData);
+            uncachedRenderer.Render(frameData);
+            using Bitmap actual = cachedRenderer.Snapshot();
+            using Bitmap control = uncachedRenderer.Snapshot();
+            byte[] expected = control.GetPixelSpan().ToArray();
+            byte[] actualPixels = actual.GetPixelSpan().ToArray();
+            if (assertPixelParity)
+            {
+                Assert.That(
+                    HasFiniteVisibleContent(control),
+                    Is.True,
+                    $"cache parity control frame {frame} must contain finite visible content (SC-013 non-vacuity).");
+                Assert.That(
+                    actualPixels,
+                    Is.EqualTo(expected),
+                    $"cache policy changed frame {frame}. {DescribeDifference(expected, actualPixels)}");
+            }
+        }
+
+        long hits = completedRequests.Sum(
+            static snapshot => snapshot[RenderPipelineCounter.RenderCacheHits]);
+        Assert.That(
+            hits,
+            expectCacheHit ? Is.GreaterThan(0) : Is.EqualTo(0),
+            expectCacheHit
+                ? "The explicitly enabled cached arm must execute a persistent cache hit."
+                : "The default-disabled or phase-unsafe arm must not execute a cache hit.");
+    }
+
+    private static bool HasFiniteVisibleContent(Bitmap bitmap)
+    {
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        for (int i = 3; i < pixels.Length; i += 4)
+        {
+            float a = (float)BitConverter.UInt16BitsToHalf(pixels[i]);
+            if (float.IsFinite(a) && a > 0f)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Bitmap RenderComposedFrame(Drawable.Resource resource, bool useRenderCache)
+    {
+        using var renderer = new Renderer(s_frameSize.Width, s_frameSize.Height)
+        {
+            CacheOptions = useRenderCache
+                ? RenderCacheOptions.Enabled
+                : RenderCacheOptions.Disabled,
+        };
+        renderer.Render(new CompositionFrame(
+            [resource],
+            new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)),
+            s_frameSize));
+        return renderer.Snapshot();
+    }
+
+    private static IEnumerable<RenderNode> Descendants(RenderNode node)
+    {
+        yield return node;
+        if (node is ContainerRenderNode container)
+        {
+            foreach (RenderNode child in container.Children)
+            {
+                foreach (RenderNode descendant in Descendants(child))
+                {
+                    yield return descendant;
+                }
+            }
+        }
+    }
+
+    private static byte[] GetPixels(RenderNodeRasterization rasterization)
+    {
+        Assert.That(rasterization.IsEmpty, Is.False);
+        return rasterization.Bitmap!.GetPixelSpan().ToArray();
+    }
+
+    private static Rgba ReadPixel(Bitmap bitmap, int x, int y)
+    {
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        int offset = ((y * bitmap.Width) + x) * 4;
+        return new Rgba(
+            (float)BitConverter.UInt16BitsToHalf(pixels[offset]),
+            (float)BitConverter.UInt16BitsToHalf(pixels[offset + 1]),
+            (float)BitConverter.UInt16BitsToHalf(pixels[offset + 2]),
+            (float)BitConverter.UInt16BitsToHalf(pixels[offset + 3]));
+    }
+
+    private static string DescribeDifference(ReadOnlySpan<byte> expected, ReadOnlySpan<byte> actual)
+    {
+        int differing = 0;
+        int first = -1;
+        int maximum = 0;
+        for (int i = 0; i < expected.Length; i++)
+        {
+            int delta = Math.Abs(expected[i] - actual[i]);
+            if (delta == 0)
+                continue;
+
+            first = first < 0 ? i : first;
+            differing++;
+            maximum = Math.Max(maximum, delta);
+        }
+
+        return $"{differing} bytes differ; first index {first}; maximum byte delta {maximum}.";
+    }
+
+    private static Drawable.Resource[] CreateSceneResources()
+    {
+        var background = new RectShape
+        {
+            Width = { CurrentValue = 240 },
+            Height = { CurrentValue = 160 },
+            Fill = { CurrentValue = Brushes.CornflowerBlue },
+        };
+
+        var accent = new EllipseShape
+        {
+            Width = { CurrentValue = 76 },
+            Height = { CurrentValue = 76 },
+            Fill = { CurrentValue = Brushes.OrangeRed },
+            FilterEffect =
+            {
+                CurrentValue = new Brightness
+                {
+                    Amount = { CurrentValue = 78 },
+                },
+            },
+            Transform = { CurrentValue = new TranslateTransform(44, -18) },
+        };
+
+        var label = new TextBlock
+        {
+            FontFamily = { CurrentValue = FontFamily.Default },
+            Size = { CurrentValue = 28 },
+            Fill = { CurrentValue = Brushes.White },
+            Text = { CurrentValue = "CACHE" },
+            Transform = { CurrentValue = new TranslateTransform(-28, 30) },
+        };
+
+        CompositionContext context = CompositionContext.Default;
+        return
+        [
+            background.ToResource(context),
+            accent.ToResource(context),
+            label.ToResource(context),
+        ];
+    }
+
+    private sealed class CpuTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+            => new CpuRenderTarget(allocation.DeviceSize.Width, allocation.DeviceSize.Height);
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height);
+
+    private readonly record struct Rgba(float Red, float Green, float Blue, float Alpha);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/ContributeValuesCacheHitExecutionTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/ContributeValuesCacheHitExecutionTests.cs
@@ -1,0 +1,284 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Cache;
+
+[TestFixture]
+public sealed class ContributeValuesCacheHitExecutionTests
+{
+    private static readonly Rect s_bounds = new(0, 0, 16, 12);
+
+    [Test]
+    public void ContributeValuesCacheHit_DoesNotCompleteThePrunedProducerInput()
+    {
+        var producer = new EmptyCombineContributionNode();
+        producer.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using var node = new ValueConsumerNode(producer);
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_bounds,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Enabled,
+                    Purpose = RenderRequestPurpose.Frame,
+                    FusionMode = FusionMode.Disabled,
+                    Diagnostics = diagnostics,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        using RenderNodeRasterization miss = renderer.Rasterize();
+        Assert.That(producer.Cache.IsCached, Is.True,
+            "the first render must publish the ContributeValues cache candidate");
+
+        using RenderNodeRasterization hit = renderer.Rasterize();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(miss.Bounds, Is.EqualTo(s_bounds));
+            Assert.That(hit.Bounds, Is.EqualTo(s_bounds));
+            Assert.That(producer.ExecuteCount, Is.EqualTo(1),
+                "the ContributeValues cache hit must prune the producer callback");
+            Assert.That(diagnostics.Latest[RenderPipelineCounter.RenderCacheHits], Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void OpaqueExpandCache_PreservesIndependentOutputDensities()
+    {
+        var producer = new IndependentDensityProducerNode();
+        producer.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using var node = new IndependentDensityObserverNode(producer);
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_bounds,
+                    MaxWorkingScale = 4,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Enabled,
+                    Purpose = RenderRequestPurpose.Frame,
+                    FusionMode = FusionMode.Disabled,
+                    Diagnostics = diagnostics,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        using RenderNodeRasterization miss = renderer.Rasterize();
+        using RenderNodeRasterization hit = renderer.Rasterize();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(miss.IsEmpty, Is.False);
+            Assert.That(hit.IsEmpty, Is.False);
+            Assert.That(producer.Cache.IsCached, Is.True);
+            Assert.That(producer.ExecuteCount, Is.EqualTo(1));
+            Assert.That(node.ObservedScales, Is.EqualTo(new[]
+            {
+                new[] { 1f, 2f },
+                new[] { 1f, 2f },
+            }), "the cold values and cached replay must retain each output's independent density");
+            Assert.That(diagnostics.Latest[RenderPipelineCounter.RenderCacheHits], Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void OpaqueExpandCache_RejectsActualOutputsOutsidePixelRule()
+    {
+        using var node = new IndependentDensityProducerNode();
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_bounds,
+                    MaxWorkingScale = 4,
+                    CacheOptions = new RenderCacheOptions(
+                        true,
+                        new RenderCacheRules(MaxPixels: 200, MinPixels: 1)),
+                    Purpose = RenderRequestPurpose.Frame,
+                    FusionMode = FusionMode.Disabled,
+                    Diagnostics = diagnostics,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        using RenderNodeRasterization first = renderer.Rasterize();
+        using RenderNodeRasterization second = renderer.Rasterize();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.IsEmpty, Is.False);
+            Assert.That(second.IsEmpty, Is.False);
+            Assert.That(node.Cache.IsCached, Is.False);
+            Assert.That(node.ExecuteCount, Is.EqualTo(2));
+            Assert.That(diagnostics.Latest[RenderPipelineCounter.RenderCacheHits], Is.Zero);
+            Assert.That(diagnostics.Latest[RenderPipelineCounter.RejectedRenderCacheCaptures], Is.EqualTo(1));
+        });
+    }
+
+    private sealed class ValueConsumerNode(RenderNode producer) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle input = context.RecordNode(producer, []).Single();
+            OpaqueRenderDescription description = OpaqueRenderDescription.Create(
+                nameof(ValueConsumerNode),
+                static (session, _) =>
+                {
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    output.Canvas.Use(session.Inputs[0].Draw);
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.Map(RenderBoundsContract.Identity),
+                RenderHitTestContract.AnyInput,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: nameof(ValueConsumerNode));
+            context.Publish(context.OpaqueMap(input, description));
+        }
+
+        protected override void OnDispose(bool disposing)
+        {
+            producer.Dispose();
+            base.OnDispose(disposing);
+        }
+    }
+
+    private sealed class EmptyCombineContributionNode : RenderNode
+    {
+        private readonly ExecutionProbe _probe = new();
+        private readonly object _probeKey = new();
+
+        public int ExecuteCount => _probe.Count;
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<ExecutionProbe> probeResource = context.Borrow(_probe, _probeKey, version: 1);
+            RenderFragmentHandle combined = context.OpaqueCombine([], OpaqueRenderDescription.Create(
+                typeof(EmptyCombineContributionNode),
+                static (session, _) => session.UseDeclaredResource<ExecutionProbe>("probe", probe =>
+                {
+                    probe.Record();
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    output.Canvas.Use(canvas => canvas.Clear(Colors.White));
+                    session.Publish(output);
+                }),
+                OpaqueRenderBoundsContract.FullInputs(
+                    static _ => s_bounds,
+                    "empty-combine-bounds"),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.ZeroOrOne,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: nameof(EmptyCombineContributionNode),
+                resources: [probeResource.Bind("probe")]));
+            context.Publish(context.ContributeValues(combined));
+        }
+    }
+
+    private sealed class IndependentDensityProducerNode : RenderNode
+    {
+        private readonly ExecutionProbe _probe = new();
+        private readonly object _probeKey = new();
+
+        public int ExecuteCount => _probe.Count;
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<ExecutionProbe> probeResource = context.Borrow(_probe, _probeKey, version: 1);
+            OpaqueRenderDescription description = OpaqueRenderDescription.Create(
+                typeof(IndependentDensityProducerNode),
+                static (session, _) => session.UseDeclaredResource<ExecutionProbe>("probe", probe =>
+                {
+                    probe.Record();
+                    using OpaqueRenderOutput left = session.CreateOutput(new Rect(0, 0, 8, 12), density: 1);
+                    using OpaqueRenderOutput right = session.CreateOutput(new Rect(8, 0, 8, 12), density: 2);
+                    left.Canvas.Use(canvas => canvas.Clear(Colors.Red));
+                    right.Canvas.Use(canvas => canvas.Clear(Colors.Blue));
+                    session.Publish(left);
+                    session.Publish(right);
+                }),
+                OpaqueRenderBoundsContract.FullInputs(static _ => s_bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Dynamic,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                resources: [probeResource.Bind("probe")]);
+            RenderFragmentHandle expanded = context.OpaqueExpand([], description);
+            context.Publish(context.ContributeValues(expanded));
+        }
+    }
+
+    private sealed class IndependentDensityObserverNode(IndependentDensityProducerNode producer) : RenderNode
+    {
+        private readonly RecordingProbe<float[]> _scaleProbe = new();
+        private readonly object _probeKey = new();
+
+        public IReadOnlyList<float[]> ObservedScales => _scaleProbe.Records;
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle input = context.RecordNode(producer, []).Single();
+            RenderResource<RecordingProbe<float[]>> probeResource = context.Borrow(
+                _scaleProbe,
+                _probeKey,
+                version: 1);
+            OpaqueRenderDescription description = OpaqueRenderDescription.Create(
+                typeof(IndependentDensityObserverNode),
+                static (session, _) => session.UseDeclaredResource<RecordingProbe<float[]>>("probe", probe =>
+                {
+                    probe.Record(session.Inputs
+                        .Select(static item => item.EffectiveScale.Value)
+                        .ToArray());
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    output.Canvas.Use(canvas =>
+                    {
+                        foreach (RenderExecutionInput item in session.Inputs)
+                            item.Draw(canvas);
+                    });
+                    session.Publish(output);
+                }),
+                OpaqueRenderBoundsContract.FullInputs(static _ => s_bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                resources: [probeResource.Bind("probe")]);
+            context.Publish(context.OpaqueCombine([input], description));
+        }
+
+        protected override void OnDispose(bool disposing)
+        {
+            producer.Dispose();
+            base.OnDispose(disposing);
+        }
+    }
+
+    private sealed class CpuTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+            => new CpuRenderTarget(allocation.DeviceSize.Width, allocation.DeviceSize.Height);
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/ProgramCacheTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/ProgramCacheTests.cs
@@ -1,0 +1,616 @@
+﻿using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Cache;
+
+[TestFixture]
+public sealed class ProgramCacheTests
+{
+    private const string SourceA = "half4 main(float2 p) { return half4(1); }";
+    private const string SourceB = "half4 main(float2 p) { return half4(0); }";
+
+    [Test]
+    public void GetOrCreate_MergedProgramFactory_ReceivesColdProgramOnly()
+    {
+        using var cache = CreateCache(maxRetainedBytes: 64);
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return color; }");
+        SkslMergedProgram first = SkslSnippetMerger.Merge([new SkslSnippetStage(description)]);
+        SkslMergedProgram equivalent = SkslSnippetMerger.Merge([new SkslSnippetStage(description)]);
+        ProgramCacheContextKey context = Context("device-a", "context-a");
+        SkslMergedProgram? factoryArgument = null;
+        int factoryCalls = 0;
+
+        FakeProgram created;
+        using (ProgramCacheLease<FakeProgram> lease = cache.GetOrCreate(first, context, Create))
+        {
+            created = lease.Program;
+        }
+
+        using (ProgramCacheLease<FakeProgram> warmed = cache.GetOrCreate(equivalent, context, Create))
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(warmed.Program, Is.SameAs(created));
+                Assert.That(warmed.IsCacheHit, Is.True);
+                Assert.That(factoryCalls, Is.EqualTo(1));
+                Assert.That(factoryArgument, Is.SameAs(first));
+            });
+        }
+
+        FakeProgram Create(SkslMergedProgram program)
+        {
+            factoryCalls++;
+            factoryArgument = program;
+            return new FakeProgram(factoryCalls, 16);
+        }
+    }
+
+    [Test]
+    public void GetOrCreate_WarmedEquivalentIdentity_IsAHitWithoutAnotherCreation()
+    {
+        using var cache = CreateCache(maxRetainedBytes: 64);
+        SkslMergedProgramIdentity firstIdentity = Identity(SourceA);
+        SkslMergedProgramIdentity equivalentIdentity = Identity(SourceA);
+        ProgramCacheContextKey context = Context("device-a", "context-a");
+        int nextId = 0;
+
+        FakeProgram firstProgram;
+        using (ProgramCacheLease<FakeProgram> first = cache.GetOrCreate(
+                   firstIdentity,
+                   context,
+                   () => new FakeProgram(++nextId, 16)))
+        {
+            firstProgram = first.Program;
+            first.Program.Bindings["gain"] = 7;
+            Assert.Multiple(() =>
+            {
+                Assert.That(first.IsCacheHit, Is.False);
+                Assert.That(first.IsTransient, Is.False);
+                Assert.That(first.Program.ResetCount, Is.EqualTo(1));
+            });
+        }
+
+        using (ProgramCacheLease<FakeProgram> warmed = cache.GetOrCreate(
+                   equivalentIdentity,
+                   context,
+                   () => new FakeProgram(++nextId, 16)))
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(warmed.IsCacheHit, Is.True);
+                Assert.That(warmed.IsTransient, Is.False);
+                Assert.That(warmed.Program, Is.SameAs(firstProgram));
+                Assert.That(warmed.Program.Bindings, Is.Empty,
+                    "runtime bindings from the preceding lease must never survive a warmed hit");
+                Assert.That(warmed.Program.ResetCount, Is.EqualTo(3),
+                    "a cached program is reset both when returned and immediately before it is leased again");
+            });
+        }
+
+        ProgramCacheStatistics statistics = cache.Statistics;
+        Assert.Multiple(() =>
+        {
+            Assert.That(statistics.Hits, Is.EqualTo(1));
+            Assert.That(statistics.Misses, Is.EqualTo(1));
+            Assert.That(statistics.Creations, Is.EqualTo(1));
+            Assert.That(statistics.RetainedPrograms, Is.EqualTo(1));
+            Assert.That(statistics.RetainedBytes, Is.EqualTo(16));
+        });
+    }
+
+    [Test]
+    public void GetOrCreate_HashBucketCollision_UsesFullSourceAndBindingSignature()
+    {
+        using var cache = CreateCache(maxRetainedBytes: 128);
+        const int forcedBucket = 12345;
+        SkslMergedProgramIdentity sourceA = Identity(SourceA, forcedBucket);
+        SkslMergedProgramIdentity sourceB = Identity(SourceB, forcedBucket);
+        SkslMergedProgramIdentity differentSignature = Identity(
+            SourceA,
+            forcedBucket,
+            [new SkslMergedBindingLayout(
+                0,
+                0,
+                SkslBindingKind.Uniform,
+                "gain",
+                "__beutl_s0_gain",
+                "float",
+                null,
+                null)]);
+        ProgramCacheContextKey context = Context("device-a", "context-a");
+        int nextId = 0;
+
+        FakeProgram first;
+        using (ProgramCacheLease<FakeProgram> lease = cache.GetOrCreate(
+                   sourceA,
+                   context,
+                   () => new FakeProgram(++nextId, 8)))
+        {
+            first = lease.Program;
+        }
+
+        using (ProgramCacheLease<FakeProgram> lease = cache.GetOrCreate(
+                   sourceB,
+                   context,
+                   () => new FakeProgram(++nextId, 8)))
+        {
+            Assert.That(lease.Program, Is.Not.SameAs(first));
+        }
+
+        using (ProgramCacheLease<FakeProgram> lease = cache.GetOrCreate(
+                   differentSignature,
+                   context,
+                   () => new FakeProgram(++nextId, 8)))
+        {
+            Assert.That(lease.Program, Is.Not.SameAs(first));
+        }
+
+        using (ProgramCacheLease<FakeProgram> lease = cache.GetOrCreate(
+                   Identity(SourceA, forcedBucket),
+                   context,
+                   () => new FakeProgram(++nextId, 8)))
+        {
+            Assert.That(lease.Program, Is.SameAs(first));
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.Statistics.Hits, Is.EqualTo(1));
+            Assert.That(cache.Statistics.Misses, Is.EqualTo(3));
+            Assert.That(cache.Statistics.Creations, Is.EqualTo(3));
+            Assert.That(cache.Statistics.RetainedPrograms, Is.EqualTo(3));
+        });
+    }
+
+    [Test]
+    public void GetOrCreate_ReentrantExactKey_UsesResetTransientWithoutCorruptingOuterBindings()
+    {
+        using var cache = CreateCache(maxRetainedBytes: 64);
+        SkslMergedProgramIdentity identity = Identity(SourceA);
+        ProgramCacheContextKey context = Context("device-a", "context-a");
+        var created = new List<FakeProgram>();
+
+        FakeProgram outerProgram;
+        using (ProgramCacheLease<FakeProgram> outer = cache.GetOrCreate(identity, context, Create))
+        {
+            outerProgram = outer.Program;
+            outer.Program.Bindings["outer"] = 41;
+            using (ProgramCacheLease<FakeProgram> inner = cache.GetOrCreate(identity, context, Create))
+            {
+                Assert.Multiple(() =>
+                {
+                    Assert.That(inner.IsCacheHit, Is.True,
+                        "the exact cached identity was found even though its mutable instance was already leased");
+                    Assert.That(inner.IsTransient, Is.True);
+                    Assert.That(inner.Program, Is.Not.SameAs(outer.Program));
+                    Assert.That(inner.Program.Bindings, Is.Empty);
+                });
+
+                inner.Program.Bindings["inner"] = 99;
+                Assert.That(outer.Program.Bindings["outer"], Is.EqualTo(41));
+            }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(created[1].Bindings, Is.Empty);
+                Assert.That(created[1].DisposeCount, Is.EqualTo(1));
+                Assert.That(outer.Program.Bindings["outer"], Is.EqualTo(41));
+            });
+        }
+
+        using (ProgramCacheLease<FakeProgram> warmed = cache.GetOrCreate(identity, context, Create))
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(warmed.IsCacheHit, Is.True);
+                Assert.That(warmed.IsTransient, Is.False);
+                Assert.That(warmed.Program, Is.SameAs(outerProgram));
+                Assert.That(warmed.Program.Bindings, Is.Empty);
+            });
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.Statistics.Hits, Is.EqualTo(2));
+            Assert.That(cache.Statistics.Misses, Is.EqualTo(1));
+            Assert.That(cache.Statistics.Creations, Is.EqualTo(2));
+        });
+
+        FakeProgram Create()
+        {
+            var program = new FakeProgram(created.Count + 1, 16);
+            created.Add(program);
+            return program;
+        }
+    }
+
+    [Test]
+    public void GetOrCreate_SharedImmutableMode_ReusesOneProgramUntilTheLastLeaseReturns()
+    {
+        using var cache = new ProgramCache<FakeProgram>(
+            resetRuntimeBindings: static _ => { },
+            retainedByteSize: static program => program.RetainedBytes,
+            maxRetainedBytes: 64,
+            shareLeasedPrograms: true);
+        SkslMergedProgramIdentity identity = Identity(SourceA);
+        ProgramCacheContextKey context = Context("device-a", "context-a");
+        int creations = 0;
+
+        ProgramCacheLease<FakeProgram> outer = cache.GetOrCreate(
+            identity,
+            context,
+            () => new FakeProgram(++creations, 16));
+        ProgramCacheLease<FakeProgram> inner = cache.GetOrCreate(
+            identity,
+            context,
+            () => new FakeProgram(++creations, 16));
+        FakeProgram program = outer.Program;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(inner.Program, Is.SameAs(program));
+            Assert.That(inner.IsCacheHit, Is.True);
+            Assert.That(inner.IsTransient, Is.False);
+            Assert.That(creations, Is.EqualTo(1));
+        });
+
+        Assert.That(cache.EvictContext("device-a", "context-a"), Is.EqualTo(1));
+        outer.Dispose();
+        Assert.That(program.DisposeCount, Is.Zero);
+        inner.Dispose();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(program.DisposeCount, Is.EqualTo(1));
+            Assert.That(cache.Statistics.Creations, Is.EqualTo(1));
+            Assert.That(cache.Statistics.RetainedPrograms, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void SynchronizeContext_EvictsProgramsFromThePreviousDestinationContext()
+    {
+        using var cache = CreateCache(maxRetainedBytes: 64);
+        SkslMergedProgramIdentity identity = Identity(SourceA);
+        ProgramCacheContextKey firstContext = Context("device-a", "context-a");
+        FakeProgram program;
+        using (ProgramCacheLease<FakeProgram> lease = cache.GetOrCreate(
+                   identity,
+                   firstContext,
+                   () => new FakeProgram(1, 16)))
+        {
+            program = lease.Program;
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.SynchronizeContext("device-a", "context-a"), Is.Zero);
+            Assert.That(cache.SynchronizeContext("device-a", "context-b"), Is.EqualTo(1));
+            Assert.That(program.DisposeCount, Is.EqualTo(1));
+            Assert.That(cache.Statistics.RetainedPrograms, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void GetOrCreate_ContextCompileContract_IsPartOfTheFullKey()
+    {
+        using var cache = CreateCache(maxRetainedBytes: 128);
+        SkslMergedProgramIdentity identity = Identity(SourceA);
+        ProgramCacheContextKey[] contexts =
+        [
+            Context("device-a", "context-a", capability: "skia-v1", format: "rgba16f", options: "default"),
+            Context("device-b", "context-a", capability: "skia-v1", format: "rgba16f", options: "default"),
+            Context("device-a", "context-b", capability: "skia-v1", format: "rgba16f", options: "default"),
+            Context("device-a", "context-a", capability: "skia-v2", format: "rgba16f", options: "default"),
+            Context("device-a", "context-a", capability: "skia-v1", format: "rgba8", options: "default"),
+            Context("device-a", "context-a", capability: "skia-v1", format: "rgba16f", options: "optimized"),
+        ];
+        int nextId = 0;
+
+        foreach (ProgramCacheContextKey context in contexts)
+        {
+            using ProgramCacheLease<FakeProgram> lease = cache.GetOrCreate(
+                identity,
+                context,
+                () => new FakeProgram(++nextId, 8));
+            Assert.That(lease.IsCacheHit, Is.False);
+        }
+
+        using ProgramCacheLease<FakeProgram> warmed = cache.GetOrCreate(
+            identity,
+            Context("device-a", "context-a", capability: "skia-v1", format: "rgba16f", options: "default"),
+            () => new FakeProgram(++nextId, 8));
+        Assert.Multiple(() =>
+        {
+            Assert.That(warmed.IsCacheHit, Is.True);
+            Assert.That(cache.Statistics.Misses, Is.EqualTo(contexts.Length));
+            Assert.That(cache.Statistics.Creations, Is.EqualTo(contexts.Length));
+        });
+    }
+
+    [Test]
+    public void ByteBudget_EvictsLeastRecentlyUsedAvailableProgram()
+    {
+        using var cache = CreateCache(maxRetainedBytes: 20);
+        ProgramCacheContextKey context = Context("device-a", "context-a");
+        SkslMergedProgramIdentity a = Identity(SourceA + "// a");
+        SkslMergedProgramIdentity b = Identity(SourceA + "// b");
+        SkslMergedProgramIdentity c = Identity(SourceA + "// c");
+        int nextId = 0;
+
+        FakeProgram programA = AcquireAndReturn(a);
+        FakeProgram programB = AcquireAndReturn(b);
+        Assert.That(AcquireAndReturn(a), Is.SameAs(programA), "A is now the most recently used entry");
+        _ = AcquireAndReturn(c);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(programA.DisposeCount, Is.Zero);
+            Assert.That(programB.DisposeCount, Is.EqualTo(1), "B is the least recently used available entry");
+            Assert.That(cache.Statistics.RetainedPrograms, Is.EqualTo(2));
+            Assert.That(cache.Statistics.RetainedBytes, Is.EqualTo(20));
+            Assert.That(cache.Statistics.Evictions, Is.EqualTo(1));
+        });
+
+        using ProgramCacheLease<FakeProgram> recreatedB = cache.GetOrCreate(
+            b,
+            context,
+            () => new FakeProgram(++nextId, 10));
+        Assert.Multiple(() =>
+        {
+            Assert.That(recreatedB.IsCacheHit, Is.False);
+            Assert.That(recreatedB.Program, Is.Not.SameAs(programB));
+        });
+
+        FakeProgram AcquireAndReturn(SkslMergedProgramIdentity identity)
+        {
+            using ProgramCacheLease<FakeProgram> lease = cache.GetOrCreate(
+                identity,
+                context,
+                () => new FakeProgram(++nextId, 10));
+            return lease.Program;
+        }
+    }
+
+    [Test]
+    public void OversizedProgram_IsTransientAndNeverBecomesAWarmedHit()
+    {
+        using var cache = CreateCache(maxRetainedBytes: 8);
+        SkslMergedProgramIdentity identity = Identity(SourceA);
+        ProgramCacheContextKey context = Context("device-a", "context-a");
+        var programs = new List<FakeProgram>();
+
+        for (int i = 0; i < 2; i++)
+        {
+            using ProgramCacheLease<FakeProgram> lease = cache.GetOrCreate(identity, context, Create);
+            Assert.Multiple(() =>
+            {
+                Assert.That(lease.IsCacheHit, Is.False);
+                Assert.That(lease.IsTransient, Is.True);
+            });
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(programs, Has.All.Matches<FakeProgram>(static program => program.DisposeCount == 1));
+            Assert.That(cache.Statistics.Misses, Is.EqualTo(2));
+            Assert.That(cache.Statistics.Creations, Is.EqualTo(2));
+            Assert.That(cache.Statistics.RetainedPrograms, Is.Zero);
+            Assert.That(cache.Statistics.RetainedBytes, Is.Zero);
+        });
+
+        FakeProgram Create()
+        {
+            var program = new FakeProgram(programs.Count + 1, 9);
+            programs.Add(program);
+            return program;
+        }
+    }
+
+    [Test]
+    public void EvictContextAndDevice_RemoveOnlyMatchingEntries()
+    {
+        using var cache = CreateCache(maxRetainedBytes: 128);
+        SkslMergedProgramIdentity identity = Identity(SourceA);
+        ProgramCacheContextKey a1 = Context("device-a", "context-1");
+        ProgramCacheContextKey a2 = Context("device-a", "context-2");
+        ProgramCacheContextKey b1 = Context("device-b", "context-1");
+        int nextId = 0;
+
+        FakeProgram programA1 = AcquireAndReturn(a1);
+        FakeProgram programA2 = AcquireAndReturn(a2);
+        FakeProgram programB1 = AcquireAndReturn(b1);
+
+        Assert.That(cache.EvictContext("device-a", "context-1"), Is.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(programA1.DisposeCount, Is.EqualTo(1));
+            Assert.That(programA2.DisposeCount, Is.Zero);
+            Assert.That(programB1.DisposeCount, Is.Zero);
+        });
+
+        Assert.That(cache.EvictDevice("device-a"), Is.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(programA2.DisposeCount, Is.EqualTo(1));
+            Assert.That(programB1.DisposeCount, Is.Zero);
+            Assert.That(cache.Statistics.RetainedPrograms, Is.EqualTo(1));
+        });
+
+        using ProgramCacheLease<FakeProgram> warmB = cache.GetOrCreate(
+            identity,
+            b1,
+            () => new FakeProgram(++nextId, 8));
+        Assert.That(warmB.Program, Is.SameAs(programB1));
+
+        FakeProgram AcquireAndReturn(ProgramCacheContextKey context)
+        {
+            using ProgramCacheLease<FakeProgram> lease = cache.GetOrCreate(
+                identity,
+                context,
+                () => new FakeProgram(++nextId, 8));
+            return lease.Program;
+        }
+    }
+
+    [Test]
+    public void EvictDevice_WhileLeased_DefersDisposalAndMakesLaterLookupMiss()
+    {
+        using var cache = CreateCache(maxRetainedBytes: 64);
+        SkslMergedProgramIdentity identity = Identity(SourceA);
+        ProgramCacheContextKey context = Context("device-a", "context-a");
+        int nextId = 0;
+        ProgramCacheLease<FakeProgram> outer = cache.GetOrCreate(
+            identity,
+            context,
+            () => new FakeProgram(++nextId, 16));
+        FakeProgram invalidated = outer.Program;
+
+        Assert.That(cache.EvictDevice("device-a"), Is.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(invalidated.DisposeCount, Is.Zero,
+                "device loss cannot invalidate a mutable program while its outer lease is still executing");
+            Assert.That(cache.Statistics.RetainedPrograms, Is.Zero);
+        });
+
+        using (ProgramCacheLease<FakeProgram> replacement = cache.GetOrCreate(
+                   identity,
+                   context,
+                   () => new FakeProgram(++nextId, 16)))
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(replacement.IsCacheHit, Is.False);
+                Assert.That(replacement.Program, Is.Not.SameAs(invalidated));
+            });
+        }
+
+        outer.Dispose();
+        Assert.Multiple(() =>
+        {
+            Assert.That(invalidated.DisposeCount, Is.EqualTo(1));
+            Assert.That(cache.Statistics.Misses, Is.EqualTo(2));
+            Assert.That(cache.Statistics.Creations, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void RuntimeResetFailure_EvictsAndDisposesPoisonedProgram()
+    {
+        using var cache = CreateCache(maxRetainedBytes: 64);
+        SkslMergedProgramIdentity identity = Identity(SourceA);
+        ProgramCacheContextKey context = Context("device-a", "context-a");
+        int nextId = 0;
+        ProgramCacheLease<FakeProgram> lease = cache.GetOrCreate(
+            identity,
+            context,
+            () => new FakeProgram(++nextId, 16));
+        FakeProgram poisoned = lease.Program;
+        poisoned.ThrowOnNextReset = true;
+
+        Assert.Throws<InvalidOperationException>(lease.Dispose);
+        Assert.Multiple(() =>
+        {
+            Assert.That(poisoned.DisposeCount, Is.EqualTo(1));
+            Assert.That(cache.Statistics.RetainedPrograms, Is.Zero);
+        });
+
+        using ProgramCacheLease<FakeProgram> replacement = cache.GetOrCreate(
+            identity,
+            context,
+            () => new FakeProgram(++nextId, 16));
+        Assert.That(replacement.IsCacheHit, Is.False);
+    }
+
+    [Test]
+    public void Dispose_WithActiveLease_DefersItsProgramAndRejectsLaterLookup()
+    {
+        var cache = CreateCache(maxRetainedBytes: 64);
+        SkslMergedProgramIdentity identity = Identity(SourceA);
+        ProgramCacheContextKey context = Context("device-a", "context-a");
+        ProgramCacheLease<FakeProgram> lease = cache.GetOrCreate(
+            identity,
+            context,
+            () => new FakeProgram(1, 16));
+        FakeProgram program = lease.Program;
+
+        cache.Dispose();
+        Assert.Multiple(() =>
+        {
+            Assert.That(program.DisposeCount, Is.Zero);
+            Assert.That(cache.Statistics.RetainedPrograms, Is.Zero);
+            Assert.Throws<ObjectDisposedException>(() => cache.GetOrCreate(
+                identity,
+                context,
+                () => new FakeProgram(2, 16)));
+        });
+
+        lease.Dispose();
+        cache.Dispose();
+        Assert.That(program.DisposeCount, Is.EqualTo(1));
+    }
+
+    private static ProgramCache<FakeProgram> CreateCache(long maxRetainedBytes)
+        => new(
+            static program => program.ResetRuntimeBindings(),
+            static program => program.RetainedBytes,
+            maxRetainedBytes);
+
+    private static ProgramCacheContextKey Context(
+        object device,
+        object context,
+        object? capability = null,
+        string format = "linear-premul-rgba16f",
+        object? options = null)
+        => new(
+            device,
+            context,
+            capability ?? "skia-default",
+            format,
+            options ?? "default");
+
+    private static SkslMergedProgramIdentity Identity(
+        string source,
+        int? bucketHashOverride = null,
+        IReadOnlyList<SkslMergedBindingLayout>? bindings = null)
+        => new(
+            source,
+            bindings ?? [],
+            SkslBackendBudget.Unlimited,
+            bucketHashOverride);
+
+    private sealed class FakeProgram(int id, long retainedBytes) : IDisposable
+    {
+        public int Id { get; } = id;
+
+        public long RetainedBytes { get; } = retainedBytes;
+
+        public Dictionary<string, int> Bindings { get; } = [];
+
+        public int ResetCount { get; private set; }
+
+        public int DisposeCount { get; private set; }
+
+        public bool ThrowOnNextReset { get; set; }
+
+        public void ResetRuntimeBindings()
+        {
+            ResetCount++;
+            Bindings.Clear();
+            if (ThrowOnNextReset)
+            {
+                ThrowOnNextReset = false;
+                throw new InvalidOperationException("Injected runtime reset failure.");
+            }
+        }
+
+        public void Dispose()
+        {
+            DisposeCount++;
+        }
+
+        public override string ToString() => $"FakeProgram {Id}";
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/RenderCacheCandidateTopologyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/RenderCacheCandidateTopologyTests.cs
@@ -1,0 +1,424 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Graphics.Shapes;
+using Beutl.Graphics.Transformation;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Cache;
+
+/// <summary>
+/// Pins <see cref="RenderCacheResolver.BuildCandidateTopology"/> to the pair-wise reachability
+/// semantics it replaced. The topology drives cache-candidate supersedence, so a divergence here
+/// silently changes which candidates are cached rather than failing loudly.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+public sealed class RenderCacheCandidateTopologyTests
+{
+    private static readonly PixelSize s_frameSize = new(240, 160);
+    private static readonly Rect s_syntheticBounds = new(0, 0, 64, 64);
+
+    private static readonly string[] s_graphs =
+    [
+        "RepresentativeScene",
+        "Shapes5",
+        "Shapes10",
+        "Shapes25",
+        "Shapes50",
+        "Shapes100",
+        "SharedFragmentId",
+        "DiamondInputs",
+        "DeepChain",
+        "DisconnectedRoots",
+    ];
+
+    private static GraphCase CreateGraph(string name) => name switch
+    {
+        "RepresentativeScene" => RepresentativeScene(),
+        "Shapes5" => ShapeScene(5),
+        "Shapes10" => ShapeScene(10),
+        "Shapes25" => ShapeScene(25),
+        "Shapes50" => ShapeScene(50),
+        "Shapes100" => ShapeScene(100),
+        "SharedFragmentId" => SharedFragmentIdCandidates(),
+        "DiamondInputs" => DiamondInputs(),
+        "DeepChain" => DeepChain(),
+        "DisconnectedRoots" => DisconnectedRoots(),
+        _ => throw new ArgumentOutOfRangeException(nameof(name), name, null),
+    };
+
+    [TestCaseSource(nameof(s_graphs))]
+    public void BuildCandidateTopology_MatchesThePairWiseReference(string name)
+    {
+        GraphCase graphCase = RenderThread.Dispatcher.Invoke(() => CreateGraph(name));
+        try
+        {
+            RenderCacheResolver.CandidateTopology actual = RenderCacheResolver.BuildCandidateTopology(
+                graphCase.Graph,
+                graphCase.References);
+            ReferenceTopology expected = BuildReferenceTopology(graphCase.Graph, graphCase.References);
+
+            TestContext.Out.WriteLine(
+                $"fragments={graphCase.Graph.Fragments.Length} candidates={graphCase.Graph.CacheCandidates.Length} " +
+                $"descendantPairs={expected.Descendants.Values.Sum(static set => set.Count)}");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    actual.Descendants.Keys,
+                    Is.EquivalentTo(expected.Descendants.Keys),
+                    "every candidate must get exactly one descendant set");
+                foreach ((RenderCacheCandidateId parent, HashSet<RenderCacheCandidateId> reference)
+                         in expected.Descendants)
+                {
+                    Assert.That(
+                        actual.Descendants[parent],
+                        Is.EquivalentTo(reference),
+                        $"descendants of {parent} must match the pair-wise reference");
+                }
+
+                Assert.That(actual.ParentFirst, Has.Length.EqualTo(expected.ParentFirst.Length));
+                for (int index = 0; index < Math.Min(actual.ParentFirst.Length, expected.ParentFirst.Length); index++)
+                {
+                    Assert.That(
+                        actual.ParentFirst[index],
+                        Is.SameAs(expected.ParentFirst[index]),
+                        $"parent-first entry {index} must match, so tie-breaking stays observable");
+                }
+            });
+        }
+        finally
+        {
+            graphCase.Dispose();
+        }
+    }
+
+    [Test]
+    public void BuildCandidateTopology_DoesNotGrowQuadraticallyWithCandidateCount()
+    {
+        using GraphCase small = RenderThread.Dispatcher.Invoke(() => ShapeScene(25));
+        using GraphCase large = RenderThread.Dispatcher.Invoke(() => ShapeScene(100));
+
+        long smallBytes = MeasureTopologyBytes(small);
+        long largeBytes = MeasureTopologyBytes(large);
+        double candidateRatio = (double)large.Graph.CacheCandidates.Length / small.Graph.CacheCandidates.Length;
+        double byteRatio = (double)largeBytes / smallBytes;
+
+        TestContext.Out.WriteLine(
+            $"candidates {small.Graph.CacheCandidates.Length} -> {large.Graph.CacheCandidates.Length} " +
+            $"({candidateRatio:F2}x), bytes {smallBytes} -> {largeBytes} ({byteRatio:F2}x)");
+
+        Assert.That(
+            byteRatio,
+            Is.LessThan(candidateRatio * candidateRatio / 2),
+            "one traversal per candidate must keep topology allocation well below the pair-wise quadratic");
+    }
+
+    private static long MeasureTopologyBytes(GraphCase graphCase)
+    {
+        for (int round = 0; round < 3; round++)
+            _ = RenderCacheResolver.BuildCandidateTopology(graphCase.Graph, graphCase.References);
+
+        long best = long.MaxValue;
+        for (int round = 0; round < 5; round++)
+        {
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            _ = RenderCacheResolver.BuildCandidateTopology(graphCase.Graph, graphCase.References);
+            best = Math.Min(best, GC.GetAllocatedBytesForCurrentThread() - before);
+        }
+
+        return best;
+    }
+
+    private sealed record ReferenceTopology(
+        Dictionary<RenderCacheCandidateId, HashSet<RenderCacheCandidateId>> Descendants,
+        RenderCacheCandidate[] ParentFirst);
+
+    /// <summary>
+    /// The implementation this fixture pins, transcribed from the revision that ran one full DFS per
+    /// ordered candidate pair. Kept verbatim so a divergence is attributable to the production change.
+    /// </summary>
+    private static ReferenceTopology BuildReferenceTopology(
+        RecordedRenderGraph graph,
+        IReadOnlyDictionary<RenderFragmentId, RenderFragmentReference> references)
+    {
+        var result = new Dictionary<RenderCacheCandidateId, HashSet<RenderCacheCandidateId>>();
+        foreach (RenderCacheCandidate parent in graph.CacheCandidates)
+        {
+            var descendants = new HashSet<RenderCacheCandidateId>();
+            foreach (RenderCacheCandidate child in graph.CacheCandidates)
+            {
+                if (parent.Id == child.Id)
+                    continue;
+                if (parent.FragmentId == child.FragmentId)
+                {
+                    if (parent.AuthoredOrder > child.AuthoredOrder)
+                        descendants.Add(child.Id);
+                    continue;
+                }
+
+                if (DependsOn(references[parent.FragmentId], references[child.FragmentId]))
+                    descendants.Add(child.Id);
+            }
+
+            result.Add(parent.Id, descendants);
+        }
+
+        RenderCacheCandidate[] parentFirst = [.. graph.CacheCandidates
+            .OrderByDescending(candidate => result[candidate.Id].Count)
+            .ThenByDescending(static candidate => candidate.AuthoredOrder)];
+        return new ReferenceTopology(result, parentFirst);
+    }
+
+    private static bool DependsOn(
+        RenderFragmentReference parent,
+        RenderFragmentReference possibleDescendant)
+    {
+        var visited = new HashSet<RenderFragmentReference>(ReferenceEqualityComparer.Instance);
+        var pending = new Stack<RenderFragmentReference>(parent.Inputs);
+        while (pending.TryPop(out RenderFragmentReference? current))
+        {
+            if (ReferenceEquals(current, possibleDescendant))
+                return true;
+            if (!visited.Add(current))
+                continue;
+            foreach (RenderFragmentReference input in current.Inputs)
+                pending.Push(input);
+        }
+
+        return false;
+    }
+
+    private sealed class GraphCase(
+        RecordedRenderGraph graph,
+        Dictionary<RenderFragmentId, RenderFragmentReference> references,
+        IDisposable[] owned) : IDisposable
+    {
+        public RecordedRenderGraph Graph { get; } = graph;
+
+        public Dictionary<RenderFragmentId, RenderFragmentReference> References { get; } = references;
+
+        public void Dispose()
+        {
+            foreach (IDisposable disposable in owned)
+                disposable.Dispose();
+        }
+    }
+
+    private static GraphCase RepresentativeScene()
+        => RecordDrawables(RenderCacheCandidateTopologyScenes.CreateRepresentativeScene());
+
+    private static GraphCase ShapeScene(int shapes)
+        => RecordDrawables(RenderCacheCandidateTopologyScenes.CreateShapeScene(shapes, s_frameSize));
+
+    private static GraphCase RecordDrawables(Drawable.Resource[] resources)
+    {
+        var root = new DrawableRenderNode(resources[0]);
+        using (var context = new GraphicsContext2D(root, s_frameSize.ToSize(1)))
+        {
+            context.Clear();
+            foreach (Drawable.Resource resource in resources)
+                context.DrawDrawable(resource);
+        }
+
+        WarmCaches(root, []);
+        var request = new RenderRequest(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            cachePolicy: RenderCacheOptions.Enabled,
+            targetDomain: new Rect(default, s_frameSize.ToSize(1))));
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(root);
+        Assert.That(graph.CacheCandidates, Is.Not.Empty, "the recorded scene must produce cache candidates");
+        return new GraphCase(graph, IndexReferences(graph), [request, root, .. resources]);
+    }
+
+    private static void WarmCaches(RenderNode current, HashSet<RenderNode> seen)
+    {
+        if (current.IsDisposed || !seen.Add(current))
+            return;
+
+        ReadOnlySpan<RenderNode> children = current.ChildNodes;
+        for (int i = 0; i < children.Length; i++)
+            WarmCaches(children[i], seen);
+
+        current.Cache.ReportRenderCount(RenderNodeCache.Count);
+        current.HasChanges = false;
+    }
+
+    private static Dictionary<RenderFragmentId, RenderFragmentReference> IndexReferences(
+        RecordedRenderGraph graph)
+    {
+        var references = new Dictionary<RenderFragmentId, RenderFragmentReference>(graph.Fragments.Length);
+        foreach (RecordedRenderFragment fragment in graph.Fragments)
+        {
+            if (fragment.Payload is RenderFragmentReference reference)
+                references.Add(fragment.Id, reference);
+        }
+
+        return references;
+    }
+
+    private static GraphCase SharedFragmentIdCandidates()
+    {
+        RenderFragmentReference leaf = Pure();
+        RenderFragmentReference middle = Pure([leaf]);
+        RenderFragmentReference root = Pure([middle]);
+        return BuildSynthetic(
+            [leaf, middle, root],
+            [root],
+            [(leaf, new object()), (middle, new object()), (middle, new object()), (root, new object())]);
+    }
+
+    private static GraphCase DiamondInputs()
+    {
+        RenderFragmentReference shared = Pure();
+        RenderFragmentReference left = Pure([shared]);
+        RenderFragmentReference right = Pure([shared]);
+        RenderFragmentReference root = Pure([left, right]);
+        return BuildSynthetic(
+            [shared, left, right, root],
+            [root],
+            [(shared, new object()), (left, new object()), (right, new object()), (root, new object())]);
+    }
+
+    private static GraphCase DeepChain()
+    {
+        var chain = new List<RenderFragmentReference>();
+        RenderFragmentReference current = Pure();
+        chain.Add(current);
+        for (int index = 0; index < 39; index++)
+        {
+            current = Pure([current]);
+            chain.Add(current);
+        }
+
+        return BuildSynthetic(
+            chain,
+            [current],
+            [.. chain.Select(static reference => (reference, (object)new object()))]);
+    }
+
+    private static GraphCase DisconnectedRoots()
+    {
+        RenderFragmentReference leftLeaf = Pure();
+        RenderFragmentReference leftRoot = Pure([leftLeaf]);
+        RenderFragmentReference rightLeaf = Pure();
+        RenderFragmentReference rightRoot = Pure([rightLeaf]);
+        return BuildSynthetic(
+            [leftLeaf, leftRoot, rightLeaf, rightRoot],
+            [leftRoot, rightRoot],
+            [
+                (leftLeaf, new object()),
+                (leftRoot, new object()),
+                (rightLeaf, new object()),
+                (rightRoot, new object()),
+            ]);
+    }
+
+    private static GraphCase BuildSynthetic(
+        IReadOnlyList<RenderFragmentReference> references,
+        IReadOnlyList<RenderFragmentReference> roots,
+        IReadOnlyList<(RenderFragmentReference Reference, object Key)> candidates)
+    {
+        var request = new RenderRequest(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            cachePolicy: RenderCacheOptions.Enabled,
+            targetDomain: s_syntheticBounds));
+        var builder = new RecordedRenderGraphBuilder(request.Id);
+        foreach (RenderFragmentReference reference in references)
+        {
+            RenderProvenanceId provenanceId = builder.AddProvenance(reference, "topology-test");
+            RenderValueId[] valueInputs = reference.Inputs.SelectMany(static item => item.ValueIds).ToArray();
+            reference.ValueIds = [builder.AddValue(valueInputs, provenanceId, reference)];
+            reference.Id = builder.AddFragment(reference.ValueIds, provenanceId, reference);
+        }
+
+        foreach ((RenderFragmentReference reference, object key) in candidates)
+            builder.AddCacheCandidate(reference.Id!.Value, key);
+        foreach (RenderFragmentReference root in roots)
+            builder.PublishRoot(root.Id!.Value);
+
+        RecordedRenderGraph graph = builder.Build();
+        return new GraphCase(graph, IndexReferences(graph), [request]);
+    }
+
+    private static RenderFragmentReference Pure(IReadOnlyList<RenderFragmentReference>? inputs = null)
+        => new(
+            RenderFragmentKind.ContributeValues,
+            s_syntheticBounds,
+            EffectiveScale.Unbounded,
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: false,
+            hasOpaqueExternalWork: false,
+            inputs ?? [],
+            payload: null,
+            static _ => true);
+}
+
+internal static class RenderCacheCandidateTopologyScenes
+{
+    public static Drawable.Resource[] CreateRepresentativeScene()
+    {
+        var background = new RectShape
+        {
+            Width = { CurrentValue = 240 },
+            Height = { CurrentValue = 160 },
+            Fill = { CurrentValue = Brushes.CornflowerBlue },
+        };
+
+        var accent = new EllipseShape
+        {
+            Width = { CurrentValue = 76 },
+            Height = { CurrentValue = 76 },
+            Fill = { CurrentValue = Brushes.OrangeRed },
+            FilterEffect = { CurrentValue = new Brightness { Amount = { CurrentValue = 78 } } },
+            Transform = { CurrentValue = new TranslateTransform(44, -18) },
+        };
+
+        var label = new TextBlock
+        {
+            FontFamily = { CurrentValue = FontFamily.Default },
+            Size = { CurrentValue = 28 },
+            Fill = { CurrentValue = Brushes.White },
+            Text = { CurrentValue = "CACHE" },
+            Transform = { CurrentValue = new TranslateTransform(-28, 30) },
+        };
+
+        CompositionContext context = CompositionContext.Default;
+        return [background.ToResource(context), accent.ToResource(context), label.ToResource(context)];
+    }
+
+    public static Drawable.Resource[] CreateShapeScene(int shapes, PixelSize frameSize)
+    {
+        CompositionContext context = CompositionContext.Default;
+        var result = new List<Drawable.Resource>(shapes + 1);
+        var background = new RectShape
+        {
+            Width = { CurrentValue = frameSize.Width },
+            Height = { CurrentValue = frameSize.Height },
+            Fill = { CurrentValue = Brushes.CornflowerBlue },
+        };
+        result.Add(background.ToResource(context));
+
+        for (int index = 0; index < shapes; index++)
+        {
+            var shape = new EllipseShape
+            {
+                Width = { CurrentValue = 20 + index % 7 },
+                Height = { CurrentValue = 20 + index % 5 },
+                Fill = { CurrentValue = Brushes.OrangeRed },
+                FilterEffect = { CurrentValue = new Brightness { Amount = { CurrentValue = 50 + index % 40 } } },
+                Transform = { CurrentValue = new TranslateTransform(index % 17 * 7, index % 11 * 9) },
+            };
+            result.Add(shape.ToResource(context));
+        }
+
+        return [.. result];
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/RenderCacheIdentityChannelTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/RenderCacheIdentityChannelTests.cs
@@ -1,0 +1,353 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Cache;
+
+/// <summary>
+/// Characterizes which pixel-affecting channels are rejected as mutable callback state and which channels
+/// remain explicit author-owned resource identities whose versions must be maintained correctly.
+/// </summary>
+/// <remarks>
+/// State passing rejects a mutable reference or delegate anywhere in its complete field graph. Static reads
+/// and resources registered behind an explicitly pinned key and version remain author-declared identity
+/// channels, so the stale-output tests and verification backstop still characterize those cases.
+/// </remarks>
+[TestFixture]
+public sealed class RenderCacheIdentityChannelTests
+{
+    private static readonly Rect s_bounds = new(0, 0, 16, 12);
+
+    [Test]
+    public void MutableObjectReferencedByState_IsRejectedBeforeRecording()
+    {
+        using var node = new MutableStateHolderNode();
+        AssertMutableStateRejected(node);
+    }
+
+    [Test]
+    public void StaticFieldReadByTheStaticCallback_IsServedStale()
+    {
+        using var node = new StaticFieldNode();
+        StaticFieldNode.Color = Colors.Red;
+        AssertServedStale(node, static () => StaticFieldNode.Color = Colors.Blue);
+    }
+
+    [Test]
+    public void CapturingDelegateInsideAStateHolderObject_IsRejectedBeforeRecording()
+    {
+        using var node = new DelegateInHolderNode();
+        AssertMutableStateRejected(node);
+    }
+
+    [Test]
+    public void BorrowedResourceBehindAPinnedCacheKeyAndVersion_IsServedStale()
+    {
+        using var node = new PinnedResourceNode();
+        AssertServedStale(node, () => node.Payload.Color = Colors.Blue);
+    }
+
+    [Test]
+    public void CapturingDelegateBorrowedAsAResource_IsServedStale()
+    {
+        using var node = new BorrowedDelegateNode();
+        AssertServedStale(node, () => node.Color = Colors.Blue);
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void AnOpenChannelIsCaughtByRenderCacheVerification()
+    {
+        using var node = new StaticFieldNode();
+        StaticFieldNode.Color = Colors.Red;
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using RenderNodeRenderer renderer = CreateRenderer(node, null);
+
+        using (RenderNodeRasterization _ = renderer.Rasterize())
+        {
+        }
+
+        StaticFieldNode.Color = Colors.Blue;
+        RenderCacheOutputMismatchException? mismatch;
+        using (RenderCacheVerification.EnableForAllRequests())
+        {
+            mismatch = Assert.Throws<RenderCacheOutputMismatchException>(() => renderer.Rasterize());
+        }
+
+        TestContext.Out.WriteLine(mismatch!.Message);
+        Assert.That(mismatch.Message, Does.Contain(nameof(StaticFieldNode)),
+            "verification is the backstop for a static channel the recording-time rules cannot close");
+    }
+
+    private static void AssertMutableStateRejected(ProbedRenderNode node)
+    {
+        using RenderNodeRenderer renderer = CreateRenderer(node, null);
+
+        ArgumentException? rejection = Assert.Throws<ArgumentException>(() => renderer.Rasterize());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rejection!.ParamName, Is.EqualTo("state"));
+            Assert.That(rejection.Message, Does.Contain("deeply immutable"));
+        });
+    }
+
+    /// <summary>
+    /// Drives two frames around <paramref name="changeTheDrawnValue"/> and asserts the second frame reused the
+    /// first frame's pixels without re-executing the producer.
+    /// </summary>
+    private static void AssertServedStale(ProbedRenderNode node, Action changeTheDrawnValue)
+    {
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using RenderNodeRenderer renderer = CreateRenderer(node, diagnostics);
+
+        using (RenderNodeRasterization _ = renderer.Rasterize())
+        {
+        }
+
+        changeTheDrawnValue();
+        using RenderNodeRasterization second = renderer.Rasterize();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(diagnostics.Latest[RenderPipelineCounter.RenderCacheHits], Is.EqualTo(1),
+                "the changed value never reached the cache identity, so the lookup still matches");
+            Assert.That(node.ExecuteCount, Is.EqualTo(1),
+                "a cache hit serves the stored pixels without re-executing the producer");
+            Assert.That(TopLeft(second), Is.EqualTo(ToPremultipliedHalfBits(Colors.Red)),
+                "the second frame shows the first frame's colour");
+        });
+    }
+
+    private static RenderNodeRenderer CreateRenderer(
+        RenderNode node,
+        RenderPipelineDiagnosticsState? diagnostics)
+        => new(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_bounds,
+                    CacheOptions = RenderCacheOptions.Enabled,
+                    Purpose = RenderRequestPurpose.Frame,
+                    Diagnostics = diagnostics,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+    private static ulong TopLeft(RenderNodeRasterization rasterization)
+    {
+        Assert.That(rasterization.IsEmpty, Is.False);
+        return ReadFirstPixel(rasterization.Bitmap!);
+    }
+
+    private static ulong ToPremultipliedHalfBits(Color color)
+    {
+        using var target = new CpuRenderTarget(1, 1);
+        target.Value.Canvas.Clear(color.ToSKColor());
+        using Bitmap snapshot = target.Snapshot();
+        return ReadFirstPixel(snapshot);
+    }
+
+    private static ulong ReadFirstPixel(Bitmap bitmap)
+    {
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        return ((ulong)pixels[0] << 48)
+               | ((ulong)pixels[1] << 32)
+               | ((ulong)pixels[2] << 16)
+               | pixels[3];
+    }
+
+    private static OpaqueRenderDescription Describe<TState>(
+        TState state,
+        Action<OpaqueRenderSession, TState> execute,
+        IEnumerable<RenderResourceBinding>? resources = null)
+        where TState : notnull
+        => OpaqueRenderDescription.Create(
+            state,
+            execute,
+            OpaqueRenderBoundsContract.FullInputs(static _ => s_bounds),
+            RenderHitTestContract.OutputBounds,
+            RenderValueCardinality.Single,
+            RenderScaleContract.MaterializeAtWorkingScale,
+            resources: resources);
+
+    internal sealed class ColorBox
+    {
+        public Color Color { get; set; }
+    }
+
+    private abstract class ProbedRenderNode : RenderNode
+    {
+        protected readonly ExecutionProbe Probe = new();
+        private readonly object _probeKey = new();
+
+        public int ExecuteCount => Probe.Count;
+
+        protected RenderResourceBinding BindProbe(RenderNodeContext context)
+            => context.Borrow(Probe, _probeKey, version: 1).Bind("probe");
+    }
+
+    /// <summary>Channel 1: state holds a reference whose contents change between frames.</summary>
+    private sealed class MutableStateHolderNode : ProbedRenderNode
+    {
+        public ColorBox Box { get; } = new() { Color = Colors.Red };
+
+        public override void Process(RenderNodeContext context)
+        {
+            OpaqueRenderDescription description = Describe(
+                Box,
+                static (session, box) => session.UseDeclaredResource<ExecutionProbe>("probe", probe =>
+                {
+                    probe.Record();
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    output.Canvas.Use(canvas => canvas.Clear(box.Color));
+                    session.Publish(output);
+                }),
+                resources: [BindProbe(context)]);
+            context.Publish(context.ContributeValues(context.OpaqueCombine([], description)));
+        }
+    }
+
+    /// <summary>Channel 2: the static callback reads a static field the state never mentions.</summary>
+    private sealed class StaticFieldNode : ProbedRenderNode
+    {
+        public static Color Color { get; set; } = Colors.Red;
+
+        public override void Process(RenderNodeContext context)
+        {
+            OpaqueRenderDescription description = Describe(
+                typeof(StaticFieldNode),
+                static (session, _) => session.UseDeclaredResource<ExecutionProbe>("probe", probe =>
+                {
+                    probe.Record();
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    output.Canvas.Use(canvas => canvas.Clear(Color));
+                    session.Publish(output);
+                }),
+                resources: [BindProbe(context)]);
+            context.Publish(context.ContributeValues(context.OpaqueCombine([], description)));
+        }
+    }
+
+    /// <summary>
+    /// Channel 3: a capturing delegate one level down. The state walk descends through tuple elements, so the
+    /// same delegate placed directly in the state tuple is now rejected; a holder object is where it survives.
+    /// </summary>
+    private sealed class DelegateInHolderNode : ProbedRenderNode
+    {
+        private readonly ColorSource _source;
+
+        public DelegateInHolderNode() => _source = new ColorSource(() => Color);
+
+        public Color Color { get; set; } = Colors.Red;
+
+        public override void Process(RenderNodeContext context)
+        {
+            OpaqueRenderDescription description = Describe(
+                _source,
+                static (session, source) => session.UseDeclaredResource<ExecutionProbe>("probe", probe =>
+                {
+                    probe.Record();
+                    Color color = source.Read();
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    output.Canvas.Use(canvas => canvas.Clear(color));
+                    session.Publish(output);
+                }),
+                resources: [BindProbe(context)]);
+            context.Publish(context.ContributeValues(context.OpaqueCombine([], description)));
+        }
+
+        private sealed class ColorSource(Func<Color> read)
+        {
+            public Color Read() => read();
+        }
+    }
+
+    /// <summary>Channel 4: a borrowed resource whose content changes behind a pinned cache key and version.</summary>
+    private sealed class PinnedResourceNode : ProbedRenderNode
+    {
+        private static readonly object s_pinnedCacheKey = new();
+
+        public ColorBox Payload { get; } = new() { Color = Colors.Red };
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<ColorBox> resource =
+                context.Borrow(Payload, cacheKey: s_pinnedCacheKey, version: 1);
+            OpaqueRenderDescription description = Describe(
+                typeof(PinnedResourceNode),
+                static (session, _) => session.UseDeclaredResource<ExecutionProbe>("probe", probe =>
+                {
+                    probe.Record();
+                    session.UseDeclaredResource<ColorBox>("payload", payload =>
+                    {
+                        using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                        output.Canvas.Use(canvas => canvas.Clear(payload.Color));
+                        session.Publish(output);
+                    });
+                }),
+                resources: [resource.Bind("payload"), BindProbe(context)]);
+            context.Publish(context.ContributeValues(context.OpaqueCombine([], description)));
+        }
+    }
+
+    /// <summary>
+    /// Channel 5: the route the contract itself recommends and
+    /// <c>FilterEffectInputBinding.PublishDeferredPreviews</c> took. The capturing delegate did not stop
+    /// capturing; it moved out of the callback closure into a declared resource under an author-declared identity.
+    /// </summary>
+    private sealed class BorrowedDelegateNode : ProbedRenderNode
+    {
+        private static readonly object s_declaredIdentity = new();
+
+        private readonly Func<Color> _readColor;
+
+        public BorrowedDelegateNode() => _readColor = () => Color;
+
+        public Color Color { get; set; } = Colors.Red;
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<Func<Color>> sink = context.Borrow(_readColor, cacheKey: s_declaredIdentity);
+            OpaqueRenderDescription description = Describe(
+                typeof(BorrowedDelegateNode),
+                static (session, _) => session.UseDeclaredResource<ExecutionProbe>("probe", probe =>
+                {
+                    probe.Record();
+                    session.UseDeclaredResource<Func<Color>>("readColor", readColor =>
+                    {
+                        Color color = readColor();
+                        using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                        output.Canvas.Use(canvas => canvas.Clear(color));
+                        session.Publish(output);
+                    });
+                }),
+                resources: [sink.Bind("readColor"), BindProbe(context)]);
+            context.Publish(context.ContributeValues(context.OpaqueCombine([], description)));
+        }
+    }
+
+    private sealed class CpuTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+            => new CpuRenderTarget(allocation.DeviceSize.Width, allocation.DeviceSize.Height);
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/RenderCacheResolutionTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/RenderCacheResolutionTests.cs
@@ -1,0 +1,2193 @@
+﻿using System.Collections.Immutable;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Cache;
+
+[TestFixture]
+public sealed class RenderCacheResolutionTests
+{
+    private static readonly Rect s_bounds = new(0, 0, 64, 64);
+    private static readonly RenderCacheResolutionContext s_context = new(
+        RenderCacheFormatIdentity.LinearPremultipliedRgba16Float,
+        new RenderCacheDeviceContextIdentity("device-a", "context-a"));
+
+    [Test]
+    public void Recorder_DeclaresOnlyWarmEnabledNodeCandidatesWithoutReadingCachePixels()
+    {
+        using var coldNode = new CacheableNode(disableCache: false);
+        using var warmNode = new CacheableNode(disableCache: false);
+        using var disabledNode = new CacheableNode(disableCache: true);
+        warmNode.Cache.ReportRenderCount(RenderNodeCache.Count);
+        disabledNode.Cache.ReportRenderCount(RenderNodeCache.Count);
+
+        using var coldRequest = NewRequest();
+        using var firstWarmRequest = NewRequest();
+        using var secondWarmRequest = NewRequest();
+        using var disabledRequest = NewRequest();
+        RecordedRenderGraph cold = new RenderRequestRecorder(coldRequest).Record(coldNode);
+        RecordedRenderGraph firstWarm = new RenderRequestRecorder(firstWarmRequest).Record(warmNode);
+        RecordedRenderGraph secondWarm = new RenderRequestRecorder(secondWarmRequest).Record(warmNode);
+        RecordedRenderGraph disabled = new RenderRequestRecorder(disabledRequest).Record(disabledNode);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cold.CacheCandidates, Is.Empty);
+            Assert.That(disabled.CacheCandidates, Is.Empty);
+            Assert.That(firstWarm.CacheCandidates.Length, Is.EqualTo(1));
+            Assert.That(firstWarm.CacheCandidates.Single().Cache, Is.SameAs(warmNode.Cache));
+            Assert.That(
+                secondWarm.CacheCandidates.Single().CacheKey,
+                Is.SameAs(firstWarm.CacheCandidates.Single().CacheKey));
+            Assert.That(warmNode.ExecuteCount, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void FrameCache_ColdMissPublishesAndWarmHitSkipsProducerWithPixelParity()
+    {
+        using var node = new SolidCacheNode();
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using var renderer = CreateFrameRenderer(node);
+
+        using RenderNodeRasterization cold = renderer.Rasterize();
+        using RenderNodeRasterization warm = renderer.Rasterize();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cold.Bitmap, Is.Not.Null);
+            Assert.That(warm.Bitmap, Is.Not.Null);
+            Assert.That(node.ExecuteCount, Is.EqualTo(1));
+            Assert.That(node.Cache.IsCached, Is.True);
+            Assert.That(
+                warm.Bitmap!.GetPixelSpan<ushort>().SequenceEqual(cold.Bitmap!.GetPixelSpan<ushort>()),
+                Is.True);
+        });
+    }
+
+    [Test]
+    public void StaticPrefixCache_AcceptsHundredAnimatedFramesWithZeroPrefixExecution()
+    {
+        using var node = new SolidCacheNode();
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var renderer = CreateFrameRenderer(node, diagnostics: diagnostics);
+
+        using RenderNodeRasterization first = renderer.Rasterize();
+        Assert.That(node.ExecuteCount, Is.EqualTo(1),
+            "the static prefix must execute exactly once on the cold frame");
+        ushort[] firstPixels = first.Bitmap!.GetPixelSpan<ushort>().ToArray();
+
+        for (int frame = 1; frame < 100; frame++)
+        {
+            using RenderNodeRasterization rasterization = renderer.Rasterize();
+            Assert.That(
+                rasterization.Bitmap!.GetPixelSpan<ushort>().SequenceEqual(firstPixels),
+                Is.True,
+                $"warm frame {frame} must match the cold prefix output (SC-012)");
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.ExecuteCount, Is.EqualTo(1),
+                "the static prefix must not re-execute across 100 animated frames (SC-012)");
+            Assert.That(node.Cache.IsCached, Is.True);
+        });
+    }
+
+    [Test]
+    public void ExecutionFailure_RejectsEveryStagedCaptureWithoutPartialPublication()
+    {
+        using var root = new ContainerRenderNode();
+        var completed = new SolidCacheNode();
+        var failing = new SolidCacheNode(throwOnExecute: true);
+        completed.Cache.ReportRenderCount(RenderNodeCache.Count);
+        failing.Cache.ReportRenderCount(RenderNodeCache.Count);
+        root.AddChild(completed);
+        root.AddChild(failing);
+        using var renderer = CreateFrameRenderer(root);
+
+        Assert.That(() => renderer.Rasterize(), Throws.InvalidOperationException);
+        Assert.Multiple(() =>
+        {
+            Assert.That(completed.ExecuteCount, Is.EqualTo(1));
+            Assert.That(failing.ExecuteCount, Is.EqualTo(1));
+            Assert.That(completed.Cache.IsCached, Is.False);
+            Assert.That(failing.Cache.IsCached, Is.False);
+        });
+    }
+
+    [Test]
+    public void PublicationFailure_RejectsTheWholeBatch()
+    {
+        using var root = new ContainerRenderNode();
+        var first = new SolidCacheNode();
+        var invalidatedOwner = new SolidCacheNode();
+        invalidatedOwner.OnExecute = invalidatedOwner.Cache.Dispose;
+        first.Cache.ReportRenderCount(RenderNodeCache.Count);
+        invalidatedOwner.Cache.ReportRenderCount(RenderNodeCache.Count);
+        root.AddChild(first);
+        root.AddChild(invalidatedOwner);
+        using var renderer = CreateFrameRenderer(root);
+
+        Assert.That(() => renderer.Rasterize(), Throws.InstanceOf<ObjectDisposedException>());
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Cache.IsCached, Is.False);
+            Assert.That(invalidatedOwner.Cache.IsCached, Is.False);
+        });
+    }
+
+    [Test]
+    public void SuccessfulPublication_TransfersOneTargetAndDisposesItExactlyOnceOnInvalidation()
+    {
+        using var node = new SolidCacheNode();
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        var factory = new TrackingTargetFactory();
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        var renderer = CreateFrameRenderer(node, factory, diagnostics);
+
+        using (renderer.Rasterize())
+        {
+        }
+        RenderPipelineDiagnosticSnapshot publication = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            Assert.That(
+                publication[RenderPipelineCounter.RenderCacheResolutionPasses],
+                Is.InRange(1, 2));
+            Assert.That(publication[RenderPipelineCounter.RenderCacheCaptures], Is.EqualTo(1));
+            Assert.That(publication[RenderPipelineCounter.RejectedRenderCacheCaptures], Is.Zero);
+            Assert.That(publication[RenderPipelineCounter.IntermediateAcquires], Is.EqualTo(2));
+            Assert.That(publication[RenderPipelineCounter.IntermediateDischarges], Is.EqualTo(2));
+        });
+
+        renderer.Dispose();
+        TrackingRenderTarget[] transferred = factory.Targets
+            .Where(static target => !target.IsDisposed)
+            .ToArray();
+
+        Assert.That(transferred, Has.Length.EqualTo(1));
+        node.Cache.Invalidate();
+        Assert.Multiple(() =>
+        {
+            Assert.That(transferred[0].IsDisposed, Is.True);
+            Assert.That(transferred[0].DisposeCalls, Is.EqualTo(1));
+            Assert.That(factory.Targets, Has.All.Matches<TrackingRenderTarget>(target => target.DisposeCalls == 1));
+        });
+    }
+
+    [Test]
+    public void AuxiliaryRequests_MayNotPublishPersistentMisses()
+    {
+        using var node = new SolidCacheNode();
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_bounds,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Enabled,
+                },
+            });
+
+        using (renderer.Rasterize())
+        using (renderer.Rasterize())
+        {
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.ExecuteCount, Is.EqualTo(2));
+            Assert.That(node.Cache.IsCached, Is.False);
+        });
+    }
+
+    [Test]
+    public void ParentHit_SupersedesChildWithoutLookingUpOrRewritingIt()
+    {
+        RenderFragmentReference child = Pure();
+        RenderFragmentReference parent = Pure([child]);
+        using Scenario scenario = Build(
+            [child, parent],
+            [parent],
+            [(child, "child"), (parent, "parent")]);
+        RenderCacheResolution cold = Resolve(scenario);
+        var lookup = new RecordingLookup();
+        lookup.AddRange(cold.MissCaptures);
+
+        RenderCacheResolution warmed = Resolve(scenario, lookup);
+        RenderCacheDecision childDecision = warmed.GetDecision(scenario.Candidate(child));
+        RenderCacheDecision parentDecision = warmed.GetDecision(scenario.Candidate(parent));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(parentDecision.Kind, Is.EqualTo(RenderCacheResolutionKind.Hit));
+            Assert.That(childDecision.Kind, Is.EqualTo(RenderCacheResolutionKind.Superseded));
+            Assert.That(childDecision.SupersededBy, Is.EqualTo(parentDecision.Candidate.Id));
+            Assert.That(lookup.RequestedKeys, Is.EqualTo(new object[] { "parent" }));
+            Assert.That(parent.Inputs.Single(), Is.SameAs(child));
+            Assert.That(scenario.Graph.Fragments.Count, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void ParentMiss_LeavesValidChildHitSelectableAndStagesTheParent()
+    {
+        RenderFragmentReference child = Pure();
+        RenderFragmentReference parent = Pure([child], payload: new RuntimeValue(1));
+        using Scenario scenario = Build(
+            [child, parent],
+            [parent],
+            [(child, "child"), (parent, "parent")]);
+        RenderCacheResolution cold = Resolve(scenario);
+        var lookup = new RecordingLookup();
+        lookup.Add(cold.GetDecision(scenario.Candidate(child)).MissCapture!);
+
+        RenderCacheResolution warmed = Resolve(scenario, lookup);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                warmed.GetDecision(scenario.Candidate(parent)).Kind,
+                Is.EqualTo(RenderCacheResolutionKind.MissCapture));
+            Assert.That(
+                warmed.GetDecision(scenario.Candidate(child)).Kind,
+                Is.EqualTo(RenderCacheResolutionKind.Hit));
+            Assert.That(warmed.Hits.Single().OriginalProducerId, Is.EqualTo(child.Id));
+            Assert.That(warmed.MissCaptures.Single().ProducerId, Is.EqualTo(parent.Id));
+            Assert.That(lookup.RequestedKeys, Is.EqualTo(new object[] { "parent", "child" }));
+        });
+    }
+
+    [TestCase("TargetCommand", "TargetTokenDependency")]
+    [TestCase("RawTargetScope", "RawTargetWork")]
+    [TestCase("TargetCapture", "TargetTokenDependency")]
+    public void TargetAndRawCandidates_BypassWhilePureChildrenRemainSelectable(
+        string boundaryKindName,
+        string expectedReasonName)
+    {
+        RenderFragmentKind boundaryKind = Enum.Parse<RenderFragmentKind>(boundaryKindName);
+        RenderCacheBypassReason expectedReason = Enum.Parse<RenderCacheBypassReason>(expectedReasonName);
+        RenderFragmentReference child = Pure();
+        RenderFragmentReference boundary = Boundary(boundaryKind, child);
+        RenderFragmentReference[] roots = boundaryKind == RenderFragmentKind.TargetCapture
+            ? [child, boundary]
+            : [boundary];
+        using Scenario scenario = Build(
+            [child, boundary],
+            roots,
+            [(child, "child"), (boundary, "boundary")]);
+        RenderCacheResolution cold = Resolve(scenario);
+        var lookup = new RecordingLookup();
+        RenderCacheMissCapture? childCapture = cold
+            .GetDecision(scenario.Candidate(child))
+            .MissCapture;
+        if (childCapture is not null)
+            lookup.Add(childCapture);
+
+        RenderCacheResolution warmed = Resolve(scenario, lookup);
+        RenderCacheDecision boundaryDecision = warmed.GetDecision(scenario.Candidate(boundary));
+        RenderCacheDecision childDecision = warmed.GetDecision(scenario.Candidate(child));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(boundaryDecision.Kind, Is.EqualTo(RenderCacheResolutionKind.Bypass));
+            Assert.That(boundaryDecision.BypassReason, Is.EqualTo(expectedReason));
+            if (childCapture is not null)
+                Assert.That(childDecision.Kind, Is.EqualTo(RenderCacheResolutionKind.Hit));
+        });
+    }
+
+    [Test]
+    public void CompleteIdentity_InvalidatesCoverageDensityFormatPurposeDeviceContextAndBounds()
+    {
+        using Scenario baseline = SingleCandidate();
+        RenderCacheResolution cold = Resolve(baseline);
+        var lookup = new RecordingLookup();
+        lookup.Add(cold.MissCaptures.Single());
+
+        AssertMiss(SingleCandidate(requestedRegion: new Rect(0, 0, 32, 64)), s_context, lookup);
+        AssertMiss(SingleCandidate(outputScale: 2), s_context, lookup);
+        AssertMiss(
+            SingleCandidate(),
+            new RenderCacheResolutionContext(
+                new RenderCacheFormatIdentity("RGBA8", "Premultiplied", "LinearSrgb"),
+                s_context.DeviceContext),
+            lookup);
+        AssertMiss(SingleCandidate(purpose: RenderRequestPurpose.Auxiliary), s_context, lookup);
+        AssertMiss(
+            SingleCandidate(),
+            new RenderCacheResolutionContext(
+                s_context.Format,
+                new RenderCacheDeviceContextIdentity("device-b", "context-a")),
+            lookup);
+        AssertMiss(
+            SingleCandidate(),
+            new RenderCacheResolutionContext(
+                s_context.Format,
+                new RenderCacheDeviceContextIdentity("device-a", "context-b")),
+            lookup);
+        AssertMiss(SingleCandidate(bounds: new Rect(0, 0, 63, 64)), s_context, lookup);
+    }
+
+    [Test]
+    public void ReusableShaderBinderIdentity_InvalidatesRequestScalesWhenResolvedDensityIsUnchanged()
+    {
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            "uniform float amount; half4 apply(half4 color) { return color * amount; }",
+            bindings => bindings.Uniform(
+                "amount",
+                1f,
+                static (writer, value, context) =>
+                    writer.Set(value + context.OutputScale + context.MaxWorkingScale),
+                structuralKey: "request-scale-sensitive-binder",
+                cachePolicy: ShaderBindingCachePolicy.ReuseFromSnapshot));
+        EffectiveScale fixedSupply = EffectiveScale.At(2);
+        using Scenario baseline = ShaderCandidate(
+            description,
+            outputScale: 1,
+            maxWorkingScale: 4,
+            scale: fixedSupply);
+        RenderCacheResolution cold = Resolve(baseline);
+        var lookup = new RecordingLookup();
+        lookup.Add(cold.MissCaptures.Single());
+
+        AssertMiss(
+            ShaderCandidate(description, outputScale: 1.5f, maxWorkingScale: 4, scale: fixedSupply),
+            s_context,
+            lookup);
+        AssertMiss(
+            ShaderCandidate(description, outputScale: 1, maxWorkingScale: 8, scale: fixedSupply),
+            s_context,
+            lookup);
+    }
+
+    [Test]
+    public void ReusableShaderBinderIdentity_InvalidatesSharedStageRequirementAcrossFanOut()
+    {
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            "uniform float amount; half4 apply(half4 color) { return color * amount; }",
+            bindings => bindings.Uniform(
+                "amount",
+                1f,
+                static (writer, value, context) => writer.Set(value + context.RequiredRegion.Width),
+                structuralKey: "required-region-sensitive-binder",
+                cachePolicy: ShaderBindingCachePolicy.ReuseFromSnapshot));
+        using Scenario baseline = ShaderFanOut(description, widenSiblingRequirement: false);
+        RenderCachePlanningResult cold = ResolvePlanning(baseline);
+        var lookup = new RecordingLookup();
+        lookup.Add(cold.Resolution.MissCaptures.Single());
+
+        using Scenario expanded = ShaderFanOut(description, widenSiblingRequirement: true);
+        RenderCachePlanningResult expandedResult = ResolvePlanning(expanded, lookup);
+        RenderCacheResolution resolution = expandedResult.Resolution;
+        Rect baselineCandidateRequirement = baseline.Regions
+            .GetFragmentRequirement(baseline.Named("candidate"))
+            .Resolve(baseline.Named("candidate").Bounds);
+        Rect expandedCandidateRequirement = expanded.Regions
+            .GetFragmentRequirement(expanded.Named("candidate"))
+            .Resolve(expanded.Named("candidate").Bounds);
+        Rect baselineSharedRequirement = baseline.Regions
+            .GetFragmentRequirement(baseline.Named("shared"))
+            .Resolve(baseline.Named("shared").Bounds);
+        Rect expandedSharedRequirement = expanded.Regions
+            .GetFragmentRequirement(expanded.Named("shared"))
+            .Resolve(expanded.Named("shared").Bounds);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(baselineCandidateRequirement, Is.EqualTo(new Rect(16, 16, 16, 16)));
+            Assert.That(expandedCandidateRequirement, Is.EqualTo(baselineCandidateRequirement));
+            Assert.That(baselineSharedRequirement, Is.EqualTo(new Rect(16, 16, 16, 16)));
+            Assert.That(expandedSharedRequirement, Is.EqualTo(new Rect(8, 8, 32, 32)));
+            Assert.That(
+                expandedResult.MaterializationDemands[expanded.Named("shared")],
+                Is.EqualTo(cold.MaterializationDemands[baseline.Named("shared")]));
+            Assert.That(
+                resolution.MissCaptures.Single().Identity.Bounds,
+                Is.EqualTo(cold.Resolution.MissCaptures.Single().Identity.Bounds));
+            Assert.That(
+                resolution.MissCaptures.Single().Identity.Coverage,
+                Is.EqualTo(cold.Resolution.MissCaptures.Single().Identity.Coverage));
+            Assert.That(
+                resolution.MissCaptures.Single().Identity.Density,
+                Is.EqualTo(cold.Resolution.MissCaptures.Single().Identity.Density));
+            Assert.That(resolution.Hits, Is.Empty);
+            Assert.That(resolution.MissCaptures, Has.Length.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void BinderFreeShaderIdentity_ReusesAcrossUnobservedSharedStageRequirement()
+    {
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return color; }");
+        using Scenario baseline = ShaderFanOut(description, widenSiblingRequirement: false);
+        RenderCacheResolution cold = Resolve(baseline);
+        var lookup = new RecordingLookup();
+        lookup.Add(cold.MissCaptures.Single());
+
+        using Scenario expanded = ShaderFanOut(description, widenSiblingRequirement: true);
+        RenderCacheResolution resolution = Resolve(expanded, lookup);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                expanded.Regions.GetFragmentRequirement(expanded.Named("shared")),
+                Is.Not.EqualTo(baseline.Regions.GetFragmentRequirement(baseline.Named("shared"))));
+            Assert.That(resolution.Hits, Has.Length.EqualTo(1));
+            Assert.That(resolution.MissCaptures, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void ReusableShaderBinderIdentity_InvalidatesTransparentMaterializedInputRequirement()
+    {
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            "uniform float amount; half4 apply(half4 color) { return color * amount; }",
+            bindings => bindings.Uniform(
+                "amount",
+                1f,
+                static (writer, value, context) => writer.Set(value + context.InputBounds.Width),
+                structuralKey: "input-bounds-sensitive-binder",
+                cachePolicy: ShaderBindingCachePolicy.ReuseFromSnapshot));
+        using Scenario baseline = TransparentShaderFanOut(description, widenSiblingRequirement: false);
+        RenderCachePlanningResult cold = ResolvePlanning(baseline);
+        var lookup = new RecordingLookup();
+        lookup.Add(cold.Resolution.MissCaptures.Single());
+
+        using Scenario expanded = TransparentShaderFanOut(description, widenSiblingRequirement: true);
+        RenderCachePlanningResult expandedResult = ResolvePlanning(expanded, lookup);
+        RenderCacheResolution resolution = expandedResult.Resolution;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                expanded.Regions.GetFragmentRequirement(expanded.Named("candidate")),
+                Is.EqualTo(baseline.Regions.GetFragmentRequirement(baseline.Named("candidate"))));
+            Assert.That(
+                expanded.Regions.GetFragmentRequirement(expanded.Named("wrapper")),
+                Is.EqualTo(baseline.Regions.GetFragmentRequirement(baseline.Named("wrapper"))));
+            Assert.That(
+                baseline.Regions.GetFragmentRequirement(baseline.Named("producer")),
+                Is.EqualTo(RequiredRegion.Region(new Rect(16, 16, 16, 16))));
+            Assert.That(
+                expanded.Regions.GetFragmentRequirement(expanded.Named("producer")),
+                Is.EqualTo(RequiredRegion.Region(new Rect(8, 8, 32, 32))));
+            Assert.That(
+                expandedResult.MaterializationDemands[expanded.Named("producer")],
+                Is.EqualTo(cold.MaterializationDemands[baseline.Named("producer")]));
+            Assert.That(resolution.Hits, Is.Empty);
+            Assert.That(resolution.MissCaptures, Has.Length.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void BinderFreeCandidateIdentity_ReusesWhenExternalReusableSiblingChangesSharedRequirement()
+    {
+        using Scenario baseline = ExternalReusableShaderFanOut(widenSiblingRequirement: false);
+        RenderCacheResolution cold = Resolve(baseline);
+        var lookup = new RecordingLookup();
+        lookup.Add(cold.MissCaptures.Single());
+
+        using Scenario expanded = ExternalReusableShaderFanOut(widenSiblingRequirement: true);
+        RenderCacheResolution resolution = Resolve(expanded, lookup);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                expanded.Regions.GetFragmentRequirement(expanded.Named("candidate")),
+                Is.EqualTo(baseline.Regions.GetFragmentRequirement(baseline.Named("candidate"))));
+            Assert.That(
+                baseline.Regions.GetFragmentRequirement(baseline.Named("producer")),
+                Is.EqualTo(RequiredRegion.Region(new Rect(16, 16, 16, 16))));
+            Assert.That(
+                expanded.Regions.GetFragmentRequirement(expanded.Named("producer")),
+                Is.EqualTo(RequiredRegion.Region(new Rect(8, 8, 32, 32))));
+            Assert.That(resolution.Hits, Has.Length.EqualTo(1));
+            Assert.That(resolution.MissCaptures, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void GridSensitiveIdentity_DistinguishesIntegralDestinationTranslations()
+    {
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return color; }");
+        var firstContext = new RenderCacheResolutionContext(
+            s_context.Format,
+            s_context.DeviceContext,
+            deviceGridOffset: new Vector(1, 1));
+        var secondContext = new RenderCacheResolutionContext(
+            s_context.Format,
+            s_context.DeviceContext,
+            deviceGridOffset: new Vector(2, 2));
+        var lookup = new RecordingLookup();
+        using (Scenario first = ShaderCandidate(description))
+        {
+            RenderCacheResolution cold = Resolve(first, context: firstContext);
+            lookup.AddRange(cold.MissCaptures);
+            Assert.That(
+                cold.MissCaptures.Single().Identity.DeviceGridOffset,
+                Is.EqualTo(new Vector(1, 1)));
+        }
+
+        using Scenario second = ShaderCandidate(description);
+        RenderCacheResolution moved = Resolve(second, lookup, secondContext);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(moved.Hits, Is.Empty);
+            Assert.That(moved.MissCaptures, Has.Length.EqualTo(1));
+            Assert.That(
+                moved.MissCaptures.Single().Identity.DeviceGridOffset,
+                Is.EqualTo(new Vector(2, 2)));
+        });
+    }
+
+    [TestCase(2f, 2f)]
+    [TestCase(1.5f, 1.5f)]
+    public void DivergentFanOut_ColdAndWarmCacheUseHighestCappedDensity(
+        float maxWorkingScale,
+        float expectedDensity)
+    {
+        RenderFragmentReference source = Pure();
+        RenderFragmentReference unitScale = FixedScaleMap(source, 1, 1);
+        RenderFragmentReference doubleScale = FixedScaleMap(source, 2, expectedDensity);
+        using Scenario scenario = Build(
+            [source, unitScale, doubleScale],
+            [unitScale, doubleScale],
+            [(source, "source")],
+            maxWorkingScale: maxWorkingScale);
+
+        RenderCacheResolution cold = Resolve(scenario);
+        RenderCacheMissCapture capture = cold.MissCaptures.Single();
+        var lookup = new RecordingLookup();
+        lookup.Add(capture);
+
+        RenderCacheResolution warm = Resolve(scenario, lookup);
+        RenderCacheDecision decision = warm.GetDecision(scenario.Candidate(source));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(capture.Identity.Density, Is.EqualTo(expectedDensity));
+            Assert.That(decision.Kind, Is.EqualTo(RenderCacheResolutionKind.Hit));
+            Assert.That(decision.Hit!.Entry.Identity.Density, Is.EqualTo(expectedDensity));
+        });
+    }
+
+    [Test]
+    public void MaterializationDemands_OpacityMaskDependencyUsesActiveTargetDensity()
+    {
+        RenderFragmentReference primary = Pure(scale: EffectiveScale.At(0.5f));
+        RenderFragmentReference maskDependency = Pure();
+        var opacityMask = new RenderFragmentReference(
+            RenderFragmentKind.OpacityMask,
+            s_bounds,
+            EffectiveScale.At(0.5f),
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: false,
+            hasOpaqueExternalWork: false,
+            [primary, maskDependency],
+            payload: null,
+            static _ => true);
+
+        IReadOnlyDictionary<RenderFragmentReference, EffectiveScale> demands =
+            RenderMaterializationDemandResolver.Resolve(
+                [opacityMask],
+                outputScale: 1,
+                maxWorkingScale: float.PositiveInfinity).Demands;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(demands[opacityMask], Is.EqualTo(EffectiveScale.At(0.5f)));
+            Assert.That(demands[primary], Is.EqualTo(EffectiveScale.At(0.5f)));
+            Assert.That(demands[maskDependency], Is.EqualTo(EffectiveScale.At(1)));
+        });
+    }
+
+    [Test]
+    public void MaterializationDemands_CachedOpacityMaskDependencyUsesValueDensity()
+    {
+        RenderFragmentReference primary = Pure(scale: EffectiveScale.At(0.5f));
+        RenderFragmentReference maskDependency = Pure();
+        var opacityMask = new RenderFragmentReference(
+            RenderFragmentKind.OpacityMask,
+            s_bounds,
+            EffectiveScale.At(0.5f),
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: false,
+            hasOpaqueExternalWork: false,
+            [primary, maskDependency],
+            payload: null,
+            static _ => true);
+        var boundaries = new HashSet<RenderFragmentReference>(
+            ReferenceEqualityComparer.Instance)
+        {
+            opacityMask,
+        };
+
+        IReadOnlyDictionary<RenderFragmentReference, EffectiveScale> demands =
+            RenderMaterializationDemandResolver.Resolve(
+                [opacityMask],
+                outputScale: 1,
+                maxWorkingScale: float.PositiveInfinity,
+                boundaries).Demands;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(demands[opacityMask], Is.EqualTo(EffectiveScale.At(0.5f)));
+            Assert.That(demands[primary], Is.EqualTo(EffectiveScale.At(0.5f)));
+            Assert.That(demands[maskDependency], Is.EqualTo(EffectiveScale.At(0.5f)));
+        });
+    }
+
+    [TestCase("LegacyFilterEffect")]
+    [TestCase("Shader")]
+    [TestCase("Geometry")]
+    public void PreviewDropEligibility_EffectClassConsumerMakesExclusiveInputEligible(
+        string consumerClass)
+    {
+        RenderFragmentKind consumerKind = consumerClass switch
+        {
+            "LegacyFilterEffect" => RenderFragmentKind.LegacyFilterEffect,
+            "Shader" => RenderFragmentKind.Shader,
+            "Geometry" => RenderFragmentKind.Geometry,
+            _ => throw new ArgumentOutOfRangeException(nameof(consumerClass)),
+        };
+        RenderFragmentReference source = Pure();
+        RenderFragmentReference consumer = EffectClassConsumer(consumerKind, source);
+
+        RenderMaterializationDemandResolution resolution =
+            RenderMaterializationDemandResolver.Resolve(
+                [consumer],
+                outputScale: 1,
+                maxWorkingScale: float.PositiveInfinity);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(resolution.PreviewDropEligibleMaterializations, Does.Contain(source));
+            Assert.That(resolution.PreviewDropEligibleMaterializations, Does.Not.Contain(consumer));
+        });
+    }
+
+    [Test]
+    public void PreviewDropEligibility_AnyGenericConsumerExcludesInput()
+    {
+        RenderFragmentReference source = Pure();
+        RenderFragmentReference effectConsumer = EffectClassConsumer(RenderFragmentKind.Shader, source);
+        RenderFragmentReference genericConsumer = Pure([source]);
+
+        RenderMaterializationDemandResolution resolution =
+            RenderMaterializationDemandResolver.Resolve(
+                [effectConsumer, genericConsumer],
+                outputScale: 1,
+                maxWorkingScale: float.PositiveInfinity);
+
+        Assert.That(resolution.PreviewDropEligibleMaterializations, Does.Not.Contain(source));
+    }
+
+    [Test]
+    public void PreviewDropEligibility_CacheBoundaryExcludesInput()
+    {
+        RenderFragmentReference source = Pure();
+        RenderFragmentReference effectConsumer = EffectClassConsumer(RenderFragmentKind.Shader, source);
+        var boundaries = new HashSet<RenderFragmentReference>(ReferenceEqualityComparer.Instance)
+        {
+            source,
+        };
+
+        RenderMaterializationDemandResolution resolution =
+            RenderMaterializationDemandResolver.Resolve(
+                [effectConsumer, source],
+                outputScale: 1,
+                maxWorkingScale: float.PositiveInfinity,
+                boundaries);
+
+        Assert.That(resolution.PreviewDropEligibleMaterializations, Does.Not.Contain(source));
+    }
+
+    [Test]
+    public void OpacityMaskIdentity_IncludesUnboundedDependencyMaterializationDemand()
+    {
+        using Scenario unitScale = OpacityMaskCandidate(outputScale: 1);
+        using Scenario doubleScale = OpacityMaskCandidate(outputScale: 2);
+        ImmutableArray<RenderFragmentReference> unitRoots =
+            RenderRequestCompiler.ResolveRoots(unitScale.Graph);
+        ImmutableArray<RenderFragmentReference> doubleRoots =
+            RenderRequestCompiler.ResolveRoots(doubleScale.Graph);
+        IReadOnlyDictionary<RenderFragmentReference, EffectiveScale> unitDemands =
+            RenderMaterializationDemandResolver.Resolve(
+                unitRoots,
+                outputScale: 1,
+                maxWorkingScale: float.PositiveInfinity).Demands;
+        IReadOnlyDictionary<RenderFragmentReference, EffectiveScale> doubleDemands =
+            RenderMaterializationDemandResolver.Resolve(
+                doubleRoots,
+                outputScale: 2,
+                maxWorkingScale: float.PositiveInfinity).Demands;
+
+        RenderFragmentOutputIdentity unitIdentity = RenderFragmentOutputIdentity.Create(
+            unitRoots.Single(),
+            unitScale.Graph.RequestId,
+            unitDemands);
+        RenderFragmentOutputIdentity doubleIdentity = RenderFragmentOutputIdentity.Create(
+            doubleRoots.Single(),
+            doubleScale.Graph.RequestId,
+            doubleDemands);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                unitDemands[unitScale.Named("dependency")],
+                Is.EqualTo(EffectiveScale.At(1)));
+            Assert.That(
+                doubleDemands[doubleScale.Named("dependency")],
+                Is.EqualTo(EffectiveScale.At(2)));
+            Assert.That(doubleIdentity, Is.Not.EqualTo(unitIdentity));
+        });
+    }
+
+    [Test]
+    public void SingleCandidate_ColdAndWarmConvergeWithinTwoPassesAndProbeLookupOnce()
+    {
+        using Scenario scenario = SingleCandidate();
+        var lookup = new RecordingLookup();
+
+        RenderCachePlanningResult cold = ResolvePlanning(scenario, lookup);
+        Assert.Multiple(() =>
+        {
+            Assert.That(cold.ResolutionPasses, Is.InRange(1, 2));
+            Assert.That(cold.Resolution.MissCaptures, Has.Length.EqualTo(1));
+            Assert.That(lookup.RequestedKeys, Is.EqualTo(new object[] { "source" }));
+        });
+
+        lookup.Add(cold.Resolution.MissCaptures.Single());
+        lookup.RequestedKeys.Clear();
+        RenderCachePlanningResult warm = ResolvePlanning(scenario, lookup);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(warm.ResolutionPasses, Is.InRange(1, 2));
+            Assert.That(warm.Resolution.Hits, Has.Length.EqualTo(1));
+            Assert.That(lookup.RequestedKeys, Is.EqualTo(new object[] { "source" }));
+        });
+    }
+
+    [Test]
+    public void LookupOnlyStableHit_ConvergesInTwoPassesWithOneUnderlyingProbe()
+    {
+        using Scenario scenario = SingleCandidate();
+        RenderCachePlanningResult cold = ResolvePlanning(scenario);
+        var lookup = new RecordingLookup();
+        lookup.Add(cold.Resolution.MissCaptures.Single());
+        var lookupOnlyContext = new RenderCacheResolutionContext(
+            s_context.Format,
+            s_context.DeviceContext,
+            allowPersistentLookup: true,
+            allowCapturePublication: false);
+
+        RenderCachePlanningResult result = ResolvePlanning(
+            scenario,
+            lookup,
+            lookupOnlyContext);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ResolutionPasses, Is.EqualTo(2));
+            Assert.That(result.Resolution.Hits, Has.Length.EqualTo(1));
+            Assert.That(result.Resolution.MissCaptures, Is.Empty);
+            Assert.That(lookup.RequestedKeys, Is.EqualTo(new object[] { "source" }));
+        });
+    }
+
+    [Test]
+    public void FourPassBoundaryCascade_FallsBackWithUncachedDemandsAndReportsTheCap()
+    {
+        RenderFragmentReference source = Pure();
+        RenderFragmentReference fourth = ValueReplayMap(
+            source,
+            EffectiveScale.At(0.0625f),
+            "fourth-runtime");
+        RenderFragmentReference third = ValueReplayMap(
+            fourth,
+            EffectiveScale.At(0.125f),
+            "third-runtime");
+        RenderFragmentReference second = ValueReplayMap(
+            third,
+            EffectiveScale.At(0.25f),
+            "second-runtime");
+        RenderFragmentReference first = ValueReplayMap(
+            second,
+            EffectiveScale.At(0.5f),
+            "first-runtime");
+        using Scenario scenario = Build(
+            [source, fourth, third, second, first],
+            [first],
+            [
+                (fourth, "fourth"),
+                (third, "third"),
+                (second, "second"),
+                (first, "first"),
+            ],
+            names: new Dictionary<string, RenderFragmentReference>
+            {
+                ["source"] = source,
+            });
+        var lookup = new DelayedIdentityHitLookup(
+            new Dictionary<object, int>
+            {
+                ["first"] = 1,
+                ["second"] = 2,
+                ["third"] = 3,
+                ["fourth"] = 4,
+            });
+        var lookupOnlyContext = new RenderCacheResolutionContext(
+            s_context.Format,
+            s_context.DeviceContext,
+            allowPersistentLookup: true,
+            allowCapturePublication: false);
+
+        RenderCachePlanningResult result = ResolvePlanning(
+            scenario,
+            lookup,
+            lookupOnlyContext);
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        RenderPipelineDiagnosticRecorder recorder = RenderPipelineDiagnosticRecorder.Start(
+            diagnostics,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            "FourPassBoundaryCascade")!;
+        recorder.RecordRenderCacheResolutionPasses(result.ResolutionPasses);
+        recorder.Complete();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ResolutionPasses, Is.EqualTo(4));
+            Assert.That(
+                result.Resolution.Decisions,
+                Has.All.Property(nameof(RenderCacheDecision.BypassReason))
+                    .EqualTo(RenderCacheBypassReason.UnstableBoundaryPlan));
+            Assert.That(
+                result.MaterializationDemands[scenario.Named("source")],
+                Is.EqualTo(EffectiveScale.At(1)));
+            Assert.That(
+                diagnostics.Latest[RenderPipelineCounter.RenderCacheResolutionPasses],
+                Is.EqualTo(4));
+        });
+    }
+
+    [Test]
+    public void OpacityMaskCacheBoundary_ColdAndWarmCrossDensityUseStableValueDemand()
+    {
+        using Scenario coldScenario = OpacityMaskCandidate(outputScale: 1);
+        RenderCachePlanningResult cold = ResolvePlanning(coldScenario);
+        var lookup = new RecordingLookup();
+        lookup.Add(cold.Resolution.MissCaptures.Single());
+
+        using Scenario warmScenario = OpacityMaskCandidate(outputScale: 2);
+        RenderCachePlanningResult warm = ResolvePlanning(warmScenario, lookup);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                cold.MaterializationDemands[coldScenario.Named("dependency")],
+                Is.EqualTo(EffectiveScale.At(0.5f)));
+            Assert.That(
+                warm.MaterializationDemands[warmScenario.Named("dependency")],
+                Is.EqualTo(EffectiveScale.At(0.5f)));
+            Assert.That(warm.Resolution.Hits.Length, Is.EqualTo(1));
+            Assert.That(
+                warm.Resolution.Hits.Single().Identity,
+                Is.EqualTo(cold.Resolution.MissCaptures.Single().Identity));
+        });
+    }
+
+    [Test]
+    public void LookupOnlyBoundaryCycle_FallsBackToUncachedReplayDemands()
+    {
+        using Scenario scenario = OpacityMaskCandidate(outputScale: 1);
+        var lookup = new FirstIdentityOnlyLookup();
+        var lookupOnlyContext = new RenderCacheResolutionContext(
+            s_context.Format,
+            s_context.DeviceContext,
+            allowPersistentLookup: true,
+            allowCapturePublication: false);
+
+        RenderCachePlanningResult result = ResolvePlanning(
+            scenario,
+            lookup,
+            lookupOnlyContext);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Resolution.Hits, Is.Empty);
+            Assert.That(result.Resolution.MissCaptures, Is.Empty);
+            Assert.That(result.ResolutionPasses, Is.EqualTo(2));
+            Assert.That(
+                result.Resolution.Decisions.Single().BypassReason,
+                Is.EqualTo(RenderCacheBypassReason.UnstableBoundaryPlan));
+            Assert.That(
+                result.MaterializationDemands[scenario.Named("dependency")],
+                Is.EqualTo(EffectiveScale.At(1)));
+        });
+    }
+
+    [Test]
+    public void NestedValueReplayCaches_WarmParentHitUsesRawPlanningBoundaries()
+    {
+        RenderFragmentReference dependency = Pure();
+        RenderFragmentReference child = ValueReplayMap(dependency, EffectiveScale.At(1), "child");
+        RenderFragmentReference parent = ValueReplayMap(child, EffectiveScale.At(0.5f), "parent");
+        using Scenario scenario = Build(
+            [dependency, child, parent],
+            [parent],
+            [(child, "child"), (parent, "parent")],
+            names: new Dictionary<string, RenderFragmentReference>
+            {
+                ["dependency"] = dependency,
+                ["child"] = child,
+                ["parent"] = parent,
+            });
+        RenderCachePlanningResult cold = ResolvePlanning(scenario);
+        var lookup = new RecordingLookup();
+        lookup.AddRange(cold.Resolution.MissCaptures);
+
+        RenderCachePlanningResult warm = ResolvePlanning(scenario, lookup);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                warm.Resolution.GetDecision(scenario.Candidate("parent")).Kind,
+                Is.EqualTo(RenderCacheResolutionKind.Hit));
+            Assert.That(
+                warm.Resolution.GetDecision(scenario.Candidate("child")).Kind,
+                Is.EqualTo(RenderCacheResolutionKind.Superseded));
+            Assert.That(
+                warm.MaterializationDemands[scenario.Named("dependency")],
+                Is.EqualTo(EffectiveScale.At(1)));
+        });
+    }
+
+    [Test]
+    public void PlanningBoundaryThatBecomesIneligible_IsRemovedFromFinalDemands()
+    {
+        var expandedBounds = new Rect(0, 0, 12_000, 1);
+        var parentBounds = new Rect(0, 0, 32, 32);
+        RenderFragmentReference dependency = Pure();
+        RenderBoundsContract expandChild = RenderBoundsContract.Create(
+            static _ => new Rect(0, 0, 12_000, 1),
+            static _ => s_bounds,
+            "expand-child");
+        RenderFragmentReference child = ValueReplayMap(
+            dependency,
+            EffectiveScale.Unbounded,
+            "expanding-child",
+            expandedBounds,
+            expandChild);
+        RenderBoundsContract shrinkToParent = RenderBoundsContract.CreateFullInput(
+            static _ => new Rect(0, 0, 32, 32),
+            "shrink-parent");
+        RenderFragmentReference parent = ValueReplayMap(
+            child,
+            EffectiveScale.At(2),
+            "shrink-parent",
+            parentBounds,
+            shrinkToParent);
+        using Scenario scenario = Build(
+            [dependency, child, parent],
+            [parent],
+            [(child, "child"), (parent, "parent")],
+            names: new Dictionary<string, RenderFragmentReference>
+            {
+                ["dependency"] = dependency,
+                ["child"] = child,
+                ["parent"] = parent,
+            },
+            cacheRules: new RenderCacheRules(MaxPixels: 20_000, MinPixels: 1));
+
+        RenderCachePlanningResult result = ResolvePlanning(scenario);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                result.Resolution.GetDecision(scenario.Candidate("parent")).Kind,
+                Is.EqualTo(RenderCacheResolutionKind.MissCapture));
+            Assert.That(
+                result.Resolution.GetDecision(scenario.Candidate("child")).BypassReason,
+                Is.EqualTo(RenderCacheBypassReason.OutsideCacheRules));
+            Assert.That(
+                result.MaterializationDemands[scenario.Named("dependency")],
+                Is.EqualTo(EffectiveScale.At(2)));
+        });
+    }
+
+    [Test]
+    public void MaterializationDemands_TargetCommandLayerUsesConcreteInputSupply()
+    {
+        RenderFragmentReference denseInput = Pure(scale: EffectiveScale.At(2));
+        var layer = new RenderFragmentReference(
+            RenderFragmentKind.Layer,
+            s_bounds,
+            EffectiveScale.Unbounded,
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: true,
+            hasOpaqueExternalWork: false,
+            [denseInput],
+            payload: null,
+            static _ => true);
+        var command = new RenderFragmentReference(
+            RenderFragmentKind.TargetCommand,
+            s_bounds,
+            EffectiveScale.Unbounded,
+            RenderValueCardinality.None,
+            contributesValuesToTarget: false,
+            canBeUsedAsValueInput: false,
+            hasTargetEffects: true,
+            hasOpaqueExternalWork: false,
+            [layer],
+            payload: null,
+            static _ => false);
+
+        IReadOnlyDictionary<RenderFragmentReference, EffectiveScale> demands =
+            RenderMaterializationDemandResolver.Resolve(
+                [command],
+                outputScale: 1,
+                maxWorkingScale: float.PositiveInfinity).Demands;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(demands[layer], Is.EqualTo(EffectiveScale.At(2)));
+            Assert.That(demands[denseInput], Is.EqualTo(EffectiveScale.At(2)));
+        });
+    }
+
+    [Test]
+    public void ContributeValuesCache_DelegatesDensityAndFootprintToLargeLayerInput()
+    {
+        var inputBounds = new Rect(0, 0, 64, 1);
+        var layerDomain = new Rect(0, 0, 10_000, 1);
+        var requestedRegion = new Rect(0, 0, 1, 1);
+        const float outputScale = 2;
+        float expectedDensity = RenderScaleUtilities.ClampWorkingScaleToBufferBudget(
+            layerDomain,
+            outputScale);
+        RenderFragmentReference leaf = Pure(bounds: inputBounds);
+        var layer = new RenderFragmentReference(
+            RenderFragmentKind.Layer,
+            inputBounds,
+            EffectiveScale.Unbounded,
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: false,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: true,
+            hasOpaqueExternalWork: false,
+            [leaf],
+            new LayerRenderFragmentPayload(layerDomain),
+            static _ => false);
+        var contributing = new RenderFragmentReference(
+            RenderFragmentKind.ContributeValues,
+            inputBounds,
+            EffectiveScale.Unbounded,
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: true,
+            hasOpaqueExternalWork: false,
+            [layer],
+            payload: null,
+            static _ => true);
+        using Scenario scenario = Build(
+            [leaf, layer, contributing],
+            [contributing],
+            [(contributing, "contributing")],
+            requestedRegion,
+            outputScale,
+            cacheRules: new RenderCacheRules(MaxPixels: 1_000, MinPixels: 1));
+
+        RenderCachePlanningResult planning = ResolvePlanning(scenario);
+        IReadOnlyDictionary<RenderFragmentReference, EffectiveScale> demands =
+            planning.MaterializationDemands;
+        RenderCacheDecision decision = planning.Resolution
+            .GetDecision(scenario.Candidate(contributing));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(demands[contributing], Is.EqualTo(EffectiveScale.At(expectedDensity)));
+            Assert.That(demands[layer], Is.EqualTo(EffectiveScale.At(expectedDensity)));
+            Assert.That(
+                (long)PixelRect.FromRect(layerDomain, expectedDensity).Width,
+                Is.GreaterThan(1_000));
+            Assert.That(decision.Kind, Is.EqualTo(RenderCacheResolutionKind.Bypass));
+            Assert.That(decision.BypassReason, Is.EqualTo(RenderCacheBypassReason.OutsideCacheRules));
+        });
+    }
+
+    [Test]
+    public void FullHashCollision_NeverSubstitutesAnUnequalEntry()
+    {
+        using Scenario first = SingleCandidate(candidateKey: new CollidingKey("first"));
+        RenderCacheResolution cold = Resolve(first);
+        RenderCacheEntry wrong = new(cold.MissCaptures.Single().Identity, new object());
+        using Scenario second = SingleCandidate(candidateKey: new CollidingKey("second"));
+
+        RenderCacheResolution resolution = Resolve(second, new CollisionLookup(wrong));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(wrong.Identity.GetHashCode(),
+                Is.EqualTo(resolution.MissCaptures.Single().Identity.GetHashCode()));
+            Assert.That(resolution.Hits, Is.Empty);
+            Assert.That(resolution.MissCaptures.Length, Is.EqualTo(1));
+            Assert.That(resolution.MissCaptures.Single().Identity, Is.Not.EqualTo(wrong.Identity));
+        });
+    }
+
+    [Test]
+    public void StaticPrefix_StaysWarmAcrossAnimatedTailIdentityChanges()
+    {
+        var lookup = new RecordingLookup();
+        using (Scenario first = PrefixAndTail(frame: 0))
+        {
+            RenderCacheResolution cold = Resolve(first, lookup);
+            lookup.AddRange(cold.MissCaptures);
+        }
+
+        for (int frame = 1; frame <= 5; frame++)
+        {
+            using Scenario scenario = PrefixAndTail(frame);
+            RenderCacheResolution resolution = Resolve(scenario, lookup);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    resolution.GetDecision(scenario.Candidate("prefix")).Kind,
+                    Is.EqualTo(RenderCacheResolutionKind.Hit),
+                    $"static prefix at frame {frame}");
+                Assert.That(
+                    resolution.GetDecision(scenario.Candidate("tail")).Kind,
+                    Is.EqualTo(RenderCacheResolutionKind.MissCapture),
+                    $"animated tail at frame {frame}");
+            });
+            lookup.AddRange(resolution.MissCaptures);
+        }
+    }
+
+    [Test]
+    public void FusionMode_IsPartOfRenderOutputCacheIdentity()
+    {
+        var lookup = new RecordingLookup();
+        RenderOutputCacheIdentity enabledIdentity;
+        using (Scenario enabled = SingleCandidate(fusionMode: FusionMode.Enabled))
+        {
+            RenderCacheResolution cold = Resolve(enabled, lookup);
+            RenderCacheMissCapture capture = cold.MissCaptures.Single();
+            enabledIdentity = capture.Identity;
+            lookup.Add(capture);
+        }
+
+        using Scenario disabled = SingleCandidate(fusionMode: FusionMode.Disabled);
+        RenderCacheResolution resolution = Resolve(disabled, lookup);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(resolution.Hits, Is.Empty);
+            Assert.That(resolution.MissCaptures, Has.Length.EqualTo(1));
+            Assert.That(resolution.MissCaptures.Single().Identity, Is.Not.EqualTo(enabledIdentity));
+            Assert.That(enabledIdentity.FusionMode, Is.EqualTo(FusionMode.Enabled));
+            Assert.That(resolution.MissCaptures.Single().Identity.FusionMode, Is.EqualTo(FusionMode.Disabled));
+        });
+    }
+
+    [Test]
+    public void ShaderIdentity_DifferentStructureWithSameRuntimeIdentityDoesNotHit()
+    {
+        ShaderDescription firstDescription = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return color; }");
+        ShaderDescription secondDescription = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return half4(color.bgr, color.a); }");
+        Assert.That(
+            secondDescription.CreateRuntimeIdentity(),
+            Is.EqualTo(firstDescription.CreateRuntimeIdentity()),
+            "The regression requires equal runtime bindings so only shader structure distinguishes the outputs.");
+
+        var lookup = new RecordingLookup();
+        RenderOutputCacheIdentity firstIdentity;
+        using (Scenario first = ShaderCandidate(firstDescription))
+        {
+            RenderCacheResolution cold = Resolve(first, lookup);
+            RenderCacheMissCapture capture = cold.MissCaptures.Single();
+            firstIdentity = capture.Identity;
+            lookup.Add(capture);
+        }
+
+        using Scenario second = ShaderCandidate(secondDescription);
+        RenderCacheResolution resolution = Resolve(second, lookup);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(resolution.Hits, Is.Empty);
+            Assert.That(resolution.MissCaptures, Has.Length.EqualTo(1));
+            Assert.That(resolution.MissCaptures.Single().Identity, Is.Not.EqualTo(firstIdentity));
+        });
+    }
+
+    [Test]
+    public void GeometryIdentity_DifferentStructureWithSameRuntimeIdentityDoesNotHit()
+    {
+        GeometryDescription firstDescription = GeometryDescription.Create(
+            "stable-geometry",
+            RenderStableGeometry,
+            RenderBoundsContract.Identity,
+            RenderHitTestContract.OutputBounds,
+            structuralKey: "geometry-a");
+        GeometryDescription secondDescription = GeometryDescription.Create(
+            "stable-geometry",
+            RenderStableGeometry,
+            RenderBoundsContract.Identity,
+            RenderHitTestContract.OutputBounds,
+            structuralKey: "geometry-b");
+        Assert.That(
+            secondDescription.RuntimeIdentity,
+            Is.EqualTo(firstDescription.RuntimeIdentity),
+            "The regression requires equal runtime state so only geometry structure distinguishes the outputs.");
+
+        var lookup = new RecordingLookup();
+        RenderOutputCacheIdentity firstIdentity;
+        using (Scenario first = GeometryCandidate(firstDescription))
+        {
+            RenderCacheResolution cold = Resolve(first, lookup);
+            RenderCacheMissCapture capture = cold.MissCaptures.Single();
+            firstIdentity = capture.Identity;
+            lookup.Add(capture);
+        }
+
+        using Scenario second = GeometryCandidate(secondDescription);
+        RenderCacheResolution resolution = Resolve(second, lookup);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(resolution.Hits, Is.Empty);
+            Assert.That(resolution.MissCaptures, Has.Length.EqualTo(1));
+            Assert.That(resolution.MissCaptures.Single().Identity, Is.Not.EqualTo(firstIdentity));
+        });
+    }
+
+    [Test]
+    public void MissCapture_RetainsProducerValuesAndProvenanceWithoutChangingTokenTopology()
+    {
+        RenderFragmentReference source = Pure();
+        RenderFragmentReference command = Boundary(RenderFragmentKind.TargetCommand, source);
+        using Scenario scenario = Build(
+            [source, command],
+            [command],
+            [(source, "source")]);
+        TargetDependencyPlan before = TargetDependencyLowerer.Lower([command]);
+
+        RenderCacheResolution resolution = Resolve(scenario);
+        TargetDependencyPlan after = TargetDependencyLowerer.Lower([command]);
+        RecordedRenderFragment producer = scenario.Graph.Fragments.Single(item => item.Id == source.Id);
+        RenderCacheMissCapture capture = resolution.MissCaptures.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(capture.ProducerId, Is.EqualTo(producer.Id));
+            Assert.That(capture.ValueIds, Is.EqualTo(producer.Values));
+            Assert.That(capture.ProvenanceId, Is.EqualTo(producer.ProvenanceId));
+            Assert.That(command.Inputs.Single(), Is.SameAs(source));
+            Assert.That(after.Steps, Is.EqualTo(before.Steps));
+            Assert.That(after.Scopes, Is.EqualTo(before.Scopes));
+        });
+    }
+
+    [Test]
+    public void Resolve_BeforeRegionDiscovery_IsRejected()
+    {
+        RenderFragmentReference source = Pure();
+        using Scenario scenario = Build(
+            [source],
+            [source],
+            [(source, "source")],
+            stopAtMetadata: true);
+
+        Assert.That(
+            () => new RenderCacheResolver().Resolve(
+                scenario.Request,
+                scenario.Graph,
+                scenario.Regions,
+                RenderRequestCompiler.ResolveRoots(scenario.Graph),
+                s_context),
+            Throws.InvalidOperationException);
+    }
+
+    [Test]
+    public void Resolve_DefaultContextWithoutCandidates_IsRejected()
+    {
+        RenderFragmentReference source = Pure();
+        using Scenario scenario = Build(
+            [source],
+            [source],
+            []);
+
+        Assert.That(
+            () => new RenderCacheResolver().Resolve(
+                scenario.Request,
+                scenario.Graph,
+                scenario.Regions,
+                RenderRequestCompiler.ResolveRoots(scenario.Graph),
+                default),
+            Throws.ArgumentException);
+    }
+
+    private static Scenario PrefixAndTail(int frame)
+    {
+        RenderFragmentReference prefix = Pure(payload: new RuntimeValue(100));
+        RenderFragmentReference tail = Pure([prefix], payload: new RuntimeValue(frame));
+        return Build(
+            [prefix, tail],
+            [tail],
+            [(prefix, "prefix"), (tail, "tail")],
+            names: new Dictionary<string, RenderFragmentReference>
+            {
+                ["prefix"] = prefix,
+                ["tail"] = tail,
+            });
+    }
+
+    private static Scenario ShaderCandidate(
+        ShaderDescription description,
+        float outputScale = 1,
+        float maxWorkingScale = float.PositiveInfinity,
+        EffectiveScale? scale = null)
+    {
+        RenderFragmentReference source = Pure(scale: scale);
+        var shader = new RenderFragmentReference(
+            RenderFragmentKind.Shader,
+            s_bounds,
+            scale ?? EffectiveScale.Unbounded,
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: false,
+            hasOpaqueExternalWork: false,
+            [source],
+            new ShaderRenderFragmentPayload(description, description.CreateRuntimeIdentity()),
+            static _ => true);
+        return Build(
+            [source, shader],
+            [shader],
+            [(shader, "shader")],
+            outputScale: outputScale,
+            maxWorkingScale: maxWorkingScale);
+    }
+
+    private static Scenario ShaderFanOut(
+        ShaderDescription sharedDescription,
+        bool widenSiblingRequirement)
+    {
+        RenderFragmentReference source = Pure();
+        RenderFragmentReference shared = Shader(source, sharedDescription);
+        RenderFragmentReference candidate = Shader(
+            shared,
+            ShaderDescription.CurrentPixel("half4 apply(half4 color) { return color; }"));
+        RenderBoundsContract siblingBounds = widenSiblingRequirement
+            ? RenderBoundsContract.Create(
+                static input => input,
+                static requested => requested.Inflate(new Thickness(8)),
+                "fanout-expanded-requirement")
+            : RenderBoundsContract.Create(
+                static input => input,
+                static requested => requested,
+                "fanout-identity-requirement");
+        RenderFragmentReference sibling = Shader(
+            shared,
+            ShaderDescription.WholeSource(
+                "uniform shader src; half4 main(float2 coord) { return src.eval(coord); }",
+                siblingBounds));
+
+        return Build(
+            [source, shared, candidate, sibling],
+            [candidate, sibling],
+            [(candidate, "fanout-candidate")],
+            requestedRegion: new Rect(16, 16, 16, 16),
+            names: new Dictionary<string, RenderFragmentReference>
+            {
+                ["candidate"] = candidate,
+                ["shared"] = shared,
+            });
+    }
+
+    private static Scenario TransparentShaderFanOut(
+        ShaderDescription reusableDescription,
+        bool widenSiblingRequirement)
+    {
+        RenderFragmentReference source = Pure();
+        RenderFragmentReference producer = Shader(
+            source,
+            ShaderDescription.CurrentPixel("half4 apply(half4 color) { return color; }"));
+        RenderFragmentReference wrapper = Pure([producer]);
+        RenderFragmentReference candidate = Shader(wrapper, reusableDescription);
+        RenderBoundsContract siblingBounds = widenSiblingRequirement
+            ? RenderBoundsContract.Create(
+                static input => input,
+                static requested => requested.Inflate(new Thickness(8)),
+                "transparent-fanout-expanded-requirement")
+            : RenderBoundsContract.Create(
+                static input => input,
+                static requested => requested,
+                "transparent-fanout-identity-requirement");
+        RenderFragmentReference sibling = Shader(
+            producer,
+            ShaderDescription.WholeSource(
+                "uniform shader src; half4 main(float2 coord) { return src.eval(coord); }",
+                siblingBounds));
+
+        return Build(
+            [source, producer, wrapper, candidate, sibling],
+            [candidate, sibling],
+            [(candidate, "transparent-fanout-candidate")],
+            requestedRegion: new Rect(16, 16, 16, 16),
+            names: new Dictionary<string, RenderFragmentReference>
+            {
+                ["candidate"] = candidate,
+                ["producer"] = producer,
+                ["wrapper"] = wrapper,
+            });
+    }
+
+    private static Scenario ExternalReusableShaderFanOut(bool widenSiblingRequirement)
+    {
+        RenderFragmentReference source = Pure();
+        RenderFragmentReference producer = Shader(
+            source,
+            ShaderDescription.CurrentPixel("half4 apply(half4 color) { return color; }"));
+        RenderFragmentReference candidate = Shader(
+            producer,
+            ShaderDescription.CurrentPixel("half4 apply(half4 color) { return color; }"));
+        RenderBoundsContract siblingBounds = widenSiblingRequirement
+            ? RenderBoundsContract.Create(
+                static input => input,
+                static requested => requested.Inflate(new Thickness(8)),
+                "external-reusable-expanded-requirement")
+            : RenderBoundsContract.Create(
+                static input => input,
+                static requested => requested,
+                "external-reusable-identity-requirement");
+        ShaderDescription siblingDescription = ShaderDescription.WholeSource(
+            "uniform shader src; uniform float amount; "
+            + "half4 main(float2 coord) { return src.eval(coord) * amount; }",
+            siblingBounds,
+            bindings => bindings.Uniform(
+                "amount",
+                1f,
+                static (writer, value, context) => writer.Set(value + context.InputBounds.Width),
+                structuralKey: "external-input-bounds-sensitive-binder",
+                cachePolicy: ShaderBindingCachePolicy.ReuseFromSnapshot));
+        RenderFragmentReference sibling = Shader(producer, siblingDescription);
+
+        return Build(
+            [source, producer, candidate, sibling],
+            [candidate, sibling],
+            [(candidate, "binder-free-candidate")],
+            requestedRegion: new Rect(16, 16, 16, 16),
+            names: new Dictionary<string, RenderFragmentReference>
+            {
+                ["candidate"] = candidate,
+                ["producer"] = producer,
+            });
+    }
+
+    private static RenderFragmentReference Shader(
+        RenderFragmentReference input,
+        ShaderDescription description)
+        => new(
+            RenderFragmentKind.Shader,
+            description.Bounds.TransformBounds(input.Bounds),
+            input.EffectiveScale,
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: false,
+            hasOpaqueExternalWork: false,
+            [input],
+            new ShaderRenderFragmentPayload(description, description.CreateRuntimeIdentity()),
+            static _ => true);
+
+    private static Scenario GeometryCandidate(GeometryDescription description)
+    {
+        RenderFragmentReference source = Pure();
+        var geometry = new RenderFragmentReference(
+            RenderFragmentKind.Geometry,
+            s_bounds,
+            EffectiveScale.Unbounded,
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: false,
+            hasOpaqueExternalWork: false,
+            [source],
+            new GeometryRenderFragmentPayload(description, description.RuntimeIdentity!.Value.Key),
+            static _ => true);
+        return Build(
+            [source, geometry],
+            [geometry],
+            [(geometry, "geometry")]);
+    }
+
+    private static Scenario OpacityMaskCandidate(float outputScale)
+    {
+        RenderFragmentReference primary = Pure(scale: EffectiveScale.At(0.5f));
+        RenderFragmentReference dependency = Pure();
+        var opacityMask = new RenderFragmentReference(
+            RenderFragmentKind.OpacityMask,
+            s_bounds,
+            EffectiveScale.At(0.5f),
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: false,
+            hasOpaqueExternalWork: false,
+            [primary, dependency],
+            payload: null,
+            static _ => true);
+        return Build(
+            [primary, dependency, opacityMask],
+            [opacityMask],
+            [(opacityMask, "mask")],
+            outputScale: outputScale,
+            names: new Dictionary<string, RenderFragmentReference>
+            {
+                ["dependency"] = dependency,
+            });
+    }
+
+    private static RenderFragmentReference ValueReplayMap(
+        RenderFragmentReference input,
+        EffectiveScale scale,
+        string key,
+        Rect? bounds = null,
+        RenderBoundsContract? boundsContract = null)
+    {
+        TargetScopeDescription description = TargetScopeDescription.CreateValueReplayMap(
+            static session => session.Canvas.Use(_ => session.ReplayInput()),
+            boundsContract ?? RenderBoundsContract.Identity,
+            RenderHitTestContract.AnyInput,
+            RenderScaleContract.PreserveInputSupply,
+            deviceGridSensitivity: RenderDeviceGridSensitivity.Insensitive,
+            deviceGridMapping: RenderDeviceGridMapping.Preserved,
+            structuralKey: key);
+        return new RenderFragmentReference(
+            RenderFragmentKind.TargetScope,
+            bounds ?? input.Bounds,
+            scale,
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: true,
+            hasOpaqueExternalWork: false,
+            [input],
+            new TargetScopeRenderFragmentPayload(description),
+            static _ => true);
+    }
+
+    private static RenderRequest NewRequest()
+        => new(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            cachePolicy: RenderCacheOptions.Enabled,
+            targetDomain: s_bounds));
+
+    private static RenderNodeRenderer CreateFrameRenderer(
+        RenderNode node,
+        IRenderTargetFactory? targetFactory = null,
+        IRenderPipelineDiagnosticsState? diagnostics = null)
+        => new(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_bounds,
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Enabled,
+                    Purpose = RenderRequestPurpose.Frame,
+                    Diagnostics = diagnostics,
+                },
+                TargetFactory = targetFactory,
+            });
+
+    private static Scenario SingleCandidate(
+        Rect? requestedRegion = null,
+        float outputScale = 1,
+        RenderRequestPurpose purpose = RenderRequestPurpose.Frame,
+        Rect? bounds = null,
+        object? candidateKey = null,
+        FusionMode fusionMode = FusionMode.Enabled)
+    {
+        RenderFragmentReference source = Pure(bounds: bounds);
+        return Build(
+            [source],
+            [source],
+            [(source, candidateKey ?? "source")],
+            requestedRegion,
+            outputScale,
+            purpose,
+            fusionMode: fusionMode);
+    }
+
+    private static void AssertMiss(
+        Scenario scenario,
+        RenderCacheResolutionContext context,
+        IRenderCacheLookup lookup)
+    {
+        using (scenario)
+        {
+            RenderCacheResolution resolution = Resolve(scenario, lookup, context);
+            Assert.That(resolution.Hits, Is.Empty);
+            Assert.That(resolution.MissCaptures.Length, Is.EqualTo(1));
+        }
+    }
+
+    private static RenderCacheResolution Resolve(
+        Scenario scenario,
+        IRenderCacheLookup? lookup = null,
+        RenderCacheResolutionContext? context = null)
+        => ResolvePlanning(scenario, lookup, context).Resolution;
+
+    private static RenderCachePlanningResult ResolvePlanning(
+        Scenario scenario,
+        IRenderCacheLookup? lookup = null,
+        RenderCacheResolutionContext? context = null)
+        => new RenderCacheResolver().Resolve(
+            scenario.Request,
+            scenario.Graph,
+            scenario.Regions,
+            RenderRequestCompiler.ResolveRoots(scenario.Graph),
+            context ?? s_context,
+            lookup);
+
+    private static Scenario Build(
+        IReadOnlyList<RenderFragmentReference> references,
+        IReadOnlyList<RenderFragmentReference> roots,
+        IReadOnlyList<(RenderFragmentReference Reference, object Key)> candidates,
+        Rect? requestedRegion = null,
+        float outputScale = 1,
+        RenderRequestPurpose purpose = RenderRequestPurpose.Frame,
+        IReadOnlyDictionary<string, RenderFragmentReference>? names = null,
+        bool stopAtMetadata = false,
+        float maxWorkingScale = float.PositiveInfinity,
+        RenderCacheRules? cacheRules = null,
+        FusionMode fusionMode = FusionMode.Enabled)
+    {
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            purpose,
+            targetDomain: s_bounds,
+            requestedRegion: requestedRegion,
+            outputScale: outputScale,
+            maxWorkingScale: maxWorkingScale,
+            cachePolicy: new RenderCacheOptions(
+                IsEnabled: true,
+                cacheRules ?? RenderCacheRules.Default),
+            fusionMode: fusionMode);
+        var request = new RenderRequest(options);
+        var builder = new RecordedRenderGraphBuilder(request.Id);
+        var provenance = new Dictionary<RenderFragmentReference, RenderProvenanceId>(
+            ReferenceEqualityComparer.Instance);
+        foreach (RenderFragmentReference reference in references)
+        {
+            RenderProvenanceId provenanceId = builder.AddProvenance(reference, "test-node");
+            provenance.Add(reference, provenanceId);
+            RenderValueId[] inputs = reference.Inputs.SelectMany(static item => item.ValueIds).ToArray();
+            reference.ValueIds = reference.ValueCardinality.Maximum == 0
+                ? []
+                : [builder.AddValue(inputs, provenanceId, reference)];
+            reference.Id = builder.AddFragment(reference.ValueIds, provenanceId, reference);
+        }
+
+        var candidateIds = new Dictionary<RenderFragmentReference, RenderCacheCandidateId>(
+            ReferenceEqualityComparer.Instance);
+        foreach ((RenderFragmentReference reference, object key) in candidates)
+        {
+            candidateIds.Add(
+                reference,
+                builder.AddCacheCandidate(reference.Id!.Value, key));
+        }
+        foreach (RenderFragmentReference root in roots)
+            builder.PublishRoot(root.Id!.Value);
+
+        RecordedRenderGraph graph = builder.Build();
+        request.TransitionTo(RenderRequestState.Recording);
+        request.TransitionTo(RenderRequestState.Recorded);
+        _ = TargetDependencyLowerer.Lower([.. roots], options.TargetDomain);
+        request.TransitionTo(RenderRequestState.TargetDependenciesLowered);
+        request.TransitionTo(RenderRequestState.MetadataResolved);
+        RegionAnalysis regions = new RegionAnalyzer().Analyze(options, roots);
+        if (!stopAtMetadata)
+            request.TransitionTo(RenderRequestState.RegionsResolved);
+
+        return new Scenario(request, graph, regions, candidateIds, names);
+    }
+
+    private static RenderFragmentReference Pure(
+        IReadOnlyList<RenderFragmentReference>? inputs = null,
+        object? payload = null,
+        Rect? bounds = null,
+        EffectiveScale? scale = null)
+    {
+        inputs ??= [];
+        return new RenderFragmentReference(
+            RenderFragmentKind.ContributeValues,
+            bounds ?? s_bounds,
+            scale ?? EffectiveScale.Unbounded,
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: inputs.Any(static item => item.HasTargetEffects),
+            hasOpaqueExternalWork: inputs.Any(static item => item.HasOpaqueExternalWork),
+            inputs,
+            payload,
+            static _ => true);
+    }
+
+    private static RenderFragmentReference EffectClassConsumer(
+        RenderFragmentKind kind,
+        RenderFragmentReference input)
+    {
+        object payload = kind switch
+        {
+            RenderFragmentKind.LegacyFilterEffect => new LegacyFilterEffectRenderFragmentPayload(
+                null!,
+                [],
+                null,
+                1,
+                [],
+                []),
+            RenderFragmentKind.Shader => CreateShaderPayload(),
+            RenderFragmentKind.Geometry => CreateGeometryPayload(),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+        return new RenderFragmentReference(
+            kind,
+            s_bounds,
+            EffectiveScale.Unbounded,
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: false,
+            hasOpaqueExternalWork: kind == RenderFragmentKind.LegacyFilterEffect,
+            [input],
+            payload,
+            static _ => true);
+    }
+
+    private static ShaderRenderFragmentPayload CreateShaderPayload()
+    {
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return color; }");
+        return new ShaderRenderFragmentPayload(description, description.CreateRuntimeIdentity());
+    }
+
+    private static GeometryRenderFragmentPayload CreateGeometryPayload()
+    {
+        GeometryDescription description = GeometryDescription.CreateRequestLocal(
+            static _ => { },
+            RenderBoundsContract.Identity,
+            RenderHitTestContract.OutputBounds);
+        return new GeometryRenderFragmentPayload(description, new object());
+    }
+
+    private static RenderFragmentReference FixedScaleMap(
+        RenderFragmentReference input,
+        float authoredScale,
+        float resolvedScale)
+    {
+        var identity = new FixedScaleIdentity(authoredScale);
+        OpaqueRenderDescription description = OpaqueRenderDescription.CreateRequestLocal(
+            static _ => { },
+            OpaqueRenderBoundsContract.Map(RenderBoundsContract.Identity),
+            RenderHitTestContract.AnyInput,
+            RenderValueCardinality.Single,
+            RenderScaleContract.Custom(
+                new FixedScaleResolver(authoredScale).Resolve,
+                identity),
+            structuralKey: identity);
+        return new RenderFragmentReference(
+            RenderFragmentKind.OpaqueMap,
+            s_bounds,
+            EffectiveScale.At(resolvedScale),
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: false,
+            hasOpaqueExternalWork: true,
+            [input],
+            new OpaqueRenderFragmentPayload(
+                OpaqueRenderTopology.Map,
+                description,
+                [RenderInputReadback.None]),
+            static _ => true);
+    }
+
+    private static RenderFragmentReference Boundary(
+        RenderFragmentKind kind,
+        RenderFragmentReference child)
+    {
+        object payload;
+        RenderValueCardinality cardinality;
+        bool contributes;
+        bool canBeUsed;
+        IReadOnlyList<RenderFragmentReference> inputs;
+        switch (kind)
+        {
+            case RenderFragmentKind.TargetCommand:
+                payload = new TargetCommandRenderFragmentPayload(
+                    TargetCommandDescription.Create(
+                        "command",
+                        static (_, _) => { },
+                        TargetRegion.Region(s_bounds),
+                        Rect.Empty,
+                        RenderHitTestContract.None),
+                    []);
+                cardinality = RenderValueCardinality.None;
+                contributes = false;
+                canBeUsed = false;
+                inputs = [child];
+                break;
+            case RenderFragmentKind.RawTargetScope:
+                payload = new RawTargetScopeRenderFragmentPayload(
+                    RawTargetScopeDescription.CreateRequestLocal(
+                        static _ => { },
+                        RenderBoundsContract.Identity,
+                        RenderHitTestContract.AnyInput,
+                        RenderScaleContract.PreserveInputSupply));
+                cardinality = RenderValueCardinality.Single;
+                contributes = true;
+                canBeUsed = false;
+                inputs = [child];
+                break;
+            case RenderFragmentKind.TargetCapture:
+                payload = new TargetCaptureRenderFragmentPayload(
+                    TargetCaptureDescription.Create(
+                        TargetRegion.Region(s_bounds),
+                        s_bounds,
+                        RenderHitTestContract.None,
+                        TargetCaptureScaleContract.MaterializeAtWorkingScale));
+                cardinality = RenderValueCardinality.Single;
+                contributes = false;
+                canBeUsed = true;
+                inputs = [];
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(kind));
+        }
+
+        return new RenderFragmentReference(
+            kind,
+            kind == RenderFragmentKind.TargetCommand ? Rect.Empty : s_bounds,
+            kind == RenderFragmentKind.TargetCommand ? EffectiveScale.Unbounded : EffectiveScale.At(1),
+            cardinality,
+            contributes,
+            canBeUsed,
+            hasTargetEffects: true,
+            hasOpaqueExternalWork: kind == RenderFragmentKind.RawTargetScope,
+            inputs,
+            payload,
+            static _ => false);
+    }
+
+    private sealed class Scenario : IDisposable
+    {
+        private readonly IReadOnlyDictionary<RenderFragmentReference, RenderCacheCandidateId> _candidateIds;
+        private readonly IReadOnlyDictionary<string, RenderFragmentReference>? _names;
+
+        public Scenario(
+            RenderRequest request,
+            RecordedRenderGraph graph,
+            RegionAnalysis regions,
+            IReadOnlyDictionary<RenderFragmentReference, RenderCacheCandidateId> candidateIds,
+            IReadOnlyDictionary<string, RenderFragmentReference>? names)
+        {
+            Request = request;
+            Graph = graph;
+            Regions = regions;
+            _candidateIds = candidateIds;
+            _names = names;
+        }
+
+        public RenderRequest Request { get; }
+
+        public RecordedRenderGraph Graph { get; }
+
+        public RegionAnalysis Regions { get; }
+
+        public RenderCacheCandidateId Candidate(RenderFragmentReference reference)
+            => _candidateIds[reference];
+
+        public RenderCacheCandidateId Candidate(string name)
+            => Candidate(_names![name]);
+
+        public RenderFragmentReference Named(string name)
+            => _names![name];
+
+        public void Dispose() => Request.Dispose();
+    }
+
+    private sealed class RecordingLookup : IRenderCacheLookup
+    {
+        private readonly List<RenderCacheEntry> _entries = [];
+
+        public List<object> RequestedKeys { get; } = [];
+
+        public void Add(RenderCacheMissCapture capture)
+            => _entries.Add(new RenderCacheEntry(capture.Identity, new object()));
+
+        public void AddRange(IEnumerable<RenderCacheMissCapture> captures)
+        {
+            foreach (RenderCacheMissCapture capture in captures)
+                Add(capture);
+        }
+
+        public bool TryGet(
+            RenderCacheCandidate candidate,
+            RenderOutputCacheIdentity identity,
+            out RenderCacheEntry? entry)
+        {
+            RequestedKeys.Add(candidate.CacheKey);
+            entry = _entries.FirstOrDefault(item => item.Identity.Equals(identity));
+            return entry is not null;
+        }
+    }
+
+    private sealed class CollisionLookup(RenderCacheEntry entry) : IRenderCacheLookup
+    {
+        public bool TryGet(
+            RenderCacheCandidate candidate,
+            RenderOutputCacheIdentity identity,
+            out RenderCacheEntry? result)
+        {
+            result = entry;
+            return true;
+        }
+    }
+
+    private sealed class FirstIdentityOnlyLookup : IRenderCacheLookup
+    {
+        private RenderOutputCacheIdentity? _firstIdentity;
+
+        public bool TryGet(
+            RenderCacheCandidate candidate,
+            RenderOutputCacheIdentity identity,
+            out RenderCacheEntry? result)
+        {
+            if (_firstIdentity is null)
+            {
+                _firstIdentity = identity;
+                result = new RenderCacheEntry(identity, new object());
+                return true;
+            }
+
+            if (_firstIdentity.Equals(identity))
+            {
+                result = new RenderCacheEntry(identity, new object());
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+    }
+
+    private sealed class DelayedIdentityHitLookup(IReadOnlyDictionary<object, int> hitThresholds)
+        : IRenderCacheLookup
+    {
+        private readonly Dictionary<object, List<RenderOutputCacheIdentity>> _identities = [];
+
+        public bool TryGet(
+            RenderCacheCandidate candidate,
+            RenderOutputCacheIdentity identity,
+            out RenderCacheEntry? result)
+        {
+            if (!_identities.TryGetValue(candidate.CacheKey, out var identities))
+            {
+                identities = [];
+                _identities.Add(candidate.CacheKey, identities);
+            }
+
+            int identityIndex = identities.FindIndex(item => item.Equals(identity));
+            if (identityIndex < 0)
+            {
+                identities.Add(identity);
+                identityIndex = identities.Count - 1;
+            }
+
+            bool hit = identityIndex + 1 >= hitThresholds[candidate.CacheKey];
+            result = hit
+                ? new RenderCacheEntry(identity, new object())
+                : null;
+            return hit;
+        }
+    }
+
+    private sealed record RuntimeValue(int Value);
+
+    private sealed record FixedScaleResolver(float Scale)
+    {
+        public float Resolve(RenderScaleContext _) => Scale;
+    }
+
+    private readonly record struct FixedScaleIdentity(float Scale);
+
+    private static void RenderStableGeometry(GeometrySession session, string state)
+    {
+    }
+
+    private sealed record CollidingKey(string Value)
+    {
+        public override int GetHashCode() => 7;
+    }
+
+    private sealed class CacheableNode(bool disableCache) : RenderNode
+    {
+        private readonly ExecutionProbe _probe = new();
+        private readonly object _probeKey = new();
+
+        public int ExecuteCount => _probe.Count;
+
+        public override void Process(RenderNodeContext context)
+        {
+            if (disableCache)
+                context.DisableRenderCache();
+
+            RenderResource<ExecutionProbe> probe = context.Borrow(_probe, _probeKey, version: 1);
+            OpaqueRenderDescription description = OpaqueRenderDescription.Create(
+                "stable",
+                static (session, _) => session.UseDeclaredResource<ExecutionProbe>(
+                    "probe",
+                    static probe => probe.Record()),
+                OpaqueRenderBoundsContract.Source(s_bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                resources: [probe.Bind("probe")]);
+            context.Publish(context.OpaqueSource(description));
+        }
+    }
+
+    private sealed class SolidCacheNode(bool throwOnExecute = false) : RenderNode
+    {
+        private readonly SolidCacheProbe _probe = new();
+        private readonly object _probeKey = new();
+
+        public int ExecuteCount => _probe.Count;
+
+        public Action? OnExecute
+        {
+            get => _probe.OnExecute;
+            set => _probe.OnExecute = value;
+        }
+
+        public override void Process(RenderNodeContext context)
+        {
+            Brush.Resource fill = Brushes.Resource.Red;
+            RenderResource<Brush.Resource> fillResource = context.Borrow(
+                fill,
+                fill.GetOriginal().Id,
+                fill.Version);
+            RenderResource<SolidCacheProbe> probeResource = context.Borrow(_probe, _probeKey, version: 1);
+            OpaqueRenderDescription description = OpaqueRenderDescription.Create(
+                throwOnExecute,
+                static (session, shouldThrow) =>
+                    session.UseDeclaredResource<SolidCacheProbe>("probe", probe =>
+                    {
+                        probe.Record();
+                        if (shouldThrow)
+                            throw new InvalidOperationException("injected execution failure");
+
+                        session.UseDeclaredResource<Brush.Resource>("fill", currentFill =>
+                        {
+                            using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                            output.Canvas.Use(canvas => canvas.DrawRectangle(s_bounds, currentFill, pen: null));
+                            session.Publish(output);
+                        });
+                    }),
+                OpaqueRenderBoundsContract.Source(s_bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                resources: [fillResource.Bind("fill"), probeResource.Bind("probe")]);
+            context.Publish(context.OpaqueSource(description));
+        }
+    }
+
+    private sealed class SolidCacheProbe
+    {
+        public int Count { get; private set; }
+
+        public Action? OnExecute { get; set; }
+
+        public void Record()
+        {
+            Count++;
+            OnExecute?.Invoke();
+        }
+    }
+
+    private sealed class TrackingTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public List<TrackingRenderTarget> Targets { get; } = [];
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+        {
+            PixelSize deviceSize = allocation.DeviceSize;
+            var result = new TrackingRenderTarget(deviceSize);
+            Targets.Add(result);
+            return result;
+        }
+    }
+
+    private sealed class TrackingRenderTarget : RenderTarget
+    {
+        private static readonly SKColorSpace s_colorSpace = SKColorSpace.CreateSrgbLinear();
+
+        public TrackingRenderTarget(PixelSize size)
+            : base(CreateSurface(size), size.Width, size.Height)
+        {
+        }
+
+        public int DisposeCalls { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!IsDisposed)
+                DisposeCalls++;
+            base.Dispose(disposing);
+        }
+
+        private static SKSurface CreateSurface(PixelSize size)
+            => SKSurface.Create(new SKImageInfo(
+                   size.Width,
+                   size.Height,
+                   SKColorType.RgbaF16,
+                   SKAlphaType.Premul,
+                   s_colorSpace))
+               ?? throw new InvalidOperationException("Could not create a cache-test render target.");
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/RenderCacheVerificationTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/RenderCacheVerificationTests.cs
@@ -1,0 +1,839 @@
+﻿using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Graphics.Shapes;
+using Beutl.Graphics.Transformation;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Cache;
+
+[TestFixture]
+public sealed class RenderCacheVerificationTests
+{
+    private static readonly Rect s_bounds = new(0, 0, 16, 12);
+    private static readonly PixelSize s_frameSize = new(240, 160);
+
+    [Test]
+    public void AnUnderSpecifiedIdentity_IsRejectedBeforeItCanReachTheCache()
+    {
+        var color = Colors.Red;
+        ArgumentException? rejection = Assert.Throws<ArgumentException>(
+            () => OpaqueRenderDescription.Create(
+                typeof(RenderCacheVerificationTests),
+                (session, _) =>
+                {
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    output.Canvas.Use(canvas => canvas.Clear(color));
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.FullInputs(static _ => s_bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale));
+
+        TestContext.Out.WriteLine(rejection!.Message);
+        Assert.Multiple(() =>
+        {
+            Assert.That(rejection.ParamName, Is.EqualTo("execute"));
+            Assert.That(rejection.Message, Does.Contain("state"),
+                "the message must name the channel the captured value has to move into");
+            Assert.That(rejection.Message, Does.Contain("CreateRequestLocal"),
+                "the message must name the opt-out for a value that cannot be an identity");
+        });
+    }
+
+    [Test]
+    public void RequestLocalOutput_IsNeverServedFromAnEarlierRequest()
+    {
+        using var node = new RequestLocalColorFillNode();
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using RenderNodeRenderer renderer = CreateRenderer(node, diagnostics);
+
+        using (RenderNodeRasterization _ = renderer.Rasterize())
+        {
+        }
+
+        node.Color = Colors.Blue;
+        using RenderNodeRasterization repainted = renderer.Rasterize(VerifyingRequest(diagnostics));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(diagnostics.Latest[RenderPipelineCounter.RenderCacheHits], Is.Zero,
+                "a request-local identity can never satisfy a later request's cache lookup");
+            Assert.That(node.ExecuteCount, Is.EqualTo(2));
+            Assert.That(TopLeft(repainted), Is.EqualTo(ToPremultipliedHalfBits(Colors.Blue)));
+        });
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void DefaultStructuralKey_NamesTheDeclaringNodeNotOnlyTheCallbackSignature()
+    {
+        using var node = new CornerDefectNode();
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using RenderNodeRenderer renderer = CreateRenderer(node);
+
+        using (RenderNodeRasterization _ = renderer.Rasterize())
+        {
+        }
+
+        RenderCacheOutputMismatchException? exception;
+        using (RenderCacheVerification.EnableForAllRequests())
+        {
+            exception = Assert.Throws<RenderCacheOutputMismatchException>(() => renderer.Rasterize());
+        }
+
+        TestContext.Out.WriteLine(exception!.Message);
+        Assert.That(
+            exception.Message,
+            Does.Contain($"structural key '{typeof(CornerDefectNode).FullName}."),
+            "an unlabelled description defaults to its callback method, which only names the node through "
+            + "its declaring type");
+    }
+
+    [Test]
+    public void CompleteRuntimeIdentity_MissesTheCacheWhenTheDrawnValueChanges()
+    {
+        using var node = new ColorFillNode();
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using RenderNodeRenderer renderer = CreateRenderer(node, diagnostics);
+
+        using (RenderNodeRasterization _ = renderer.Rasterize())
+        {
+        }
+
+        node.Color = Colors.Blue;
+        using RenderNodeRasterization repainted = renderer.Rasterize(VerifyingRequest(diagnostics));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(diagnostics.Latest[RenderPipelineCounter.RenderCacheHits], Is.Zero,
+                "a complete identity misses when the drawn value changes");
+            Assert.That(TopLeft(repainted), Is.EqualTo(ToPremultipliedHalfBits(Colors.Blue)));
+        });
+    }
+
+    [Test]
+    public void UnchangedProducer_PassesVerificationAndStillHitsTheCache()
+    {
+        using var node = new ColorFillNode();
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using RenderNodeRenderer renderer = CreateRenderer(node, diagnostics);
+
+        using (RenderNodeRasterization _ = renderer.Rasterize())
+        {
+        }
+
+        using RenderNodeRasterization verified = renderer.Rasterize(VerifyingRequest(diagnostics));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(diagnostics.Latest[RenderPipelineCounter.RenderCacheHits], Is.EqualTo(1),
+                "verification must keep serving the cache hit, not demote it to a miss");
+            Assert.That(node.ExecuteCount, Is.EqualTo(2),
+                "verification re-executes the producer of every cache hit");
+            Assert.That(TopLeft(verified), Is.EqualTo(ToPremultipliedHalfBits(Colors.Red)));
+        });
+    }
+
+    [Test]
+    public void ComposedGraph_PassesVerificationAcrossNestedCacheCandidates()
+    {
+        using var producer = new ColorFillNode();
+        producer.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using var consumer = new TintingConsumerNode(producer);
+        consumer.Cache.ReportRenderCount(RenderNodeCache.Count);
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using RenderNodeRenderer renderer = CreateRenderer(consumer, diagnostics);
+
+        using (RenderNodeRasterization _ = renderer.Rasterize())
+        {
+        }
+
+        using RenderNodeRasterization verified = renderer.Rasterize(VerifyingRequest(diagnostics));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(verified.IsEmpty, Is.False);
+            Assert.That(diagnostics.Latest[RenderPipelineCounter.RenderCacheHits], Is.GreaterThan(0));
+        });
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void ComposedProductionScene_PassesVerificationOnEveryCacheHit()
+    {
+        RenderThread.Dispatcher.Invoke(() =>
+        {
+            Drawable.Resource[] resources = CreateSceneResources();
+            try
+            {
+                using var root = new DrawableRenderNode(resources[0]);
+                using (var context = new GraphicsContext2D(root, s_frameSize.ToSize(1)))
+                {
+                    context.Clear();
+                    foreach (Drawable.Resource resource in resources)
+                        context.DrawDrawable(resource);
+                }
+
+                foreach (RenderNode node in Descendants(root))
+                    node.Cache.ReportRenderCount(RenderNodeCache.Count);
+
+                var diagnostics = new RenderPipelineDiagnosticsState();
+                using var renderer = new RenderNodeRenderer(
+                    root,
+                    new RenderNodeRendererOptions
+                    {
+                        DefaultRequest = new RenderNodeRenderRequest
+                        {
+                            TargetDomain = new Rect(default, s_frameSize.ToSize(1)),
+                            CacheOptions = RenderCacheOptions.Enabled,
+                            Purpose = RenderRequestPurpose.Frame,
+                            Diagnostics = diagnostics,
+                            VerifyCacheOutputs = true,
+                        },
+                    });
+
+                long hits = 0;
+                for (int frame = 0; frame < 4; frame++)
+                {
+                    using RenderNodeRasterization rasterization = renderer.Rasterize();
+                    Assert.That(rasterization.IsEmpty, Is.False);
+                    hits += diagnostics.Latest[RenderPipelineCounter.RenderCacheHits];
+                }
+
+                Assert.That(hits, Is.GreaterThan(0),
+                    "the composed production scene must exercise verified render-cache hits");
+            }
+            finally
+            {
+                foreach (Drawable.Resource resource in resources)
+                    resource.Dispose();
+            }
+        });
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void EnableForAllRequests_TurnsVerificationOnWithoutTouchingTheRequest()
+    {
+        using var node = new CornerDefectNode();
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using RenderNodeRenderer renderer = CreateRenderer(node);
+
+        using (RenderNodeRasterization _ = renderer.Rasterize())
+        {
+        }
+
+        using (RenderCacheVerification.EnableForAllRequests())
+        {
+            Assert.That(RenderCacheVerification.IsEnabled, Is.True);
+            Assert.Throws<RenderCacheOutputMismatchException>(() => renderer.Rasterize());
+        }
+
+        Assert.That(RenderCacheVerification.IsEnabled, Is.False);
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void LoweredDrawableBrushSource_PassesVerificationAcrossANestedContentChange()
+    {
+        var contentFill = new SolidColorBrush { Color = { CurrentValue = Colors.White } };
+        var content = new RectShape
+        {
+            Width = { CurrentValue = (float)s_bounds.Width },
+            Height = { CurrentValue = (float)s_bounds.Height },
+            Fill = { CurrentValue = contentFill },
+        };
+        var brush = new DrawableBrush(content) { Stretch = { CurrentValue = Stretch.Fill } };
+        using DrawableBrush.Resource brushResource = brush.ToResource(CompositionContext.Default);
+        using var node = new LoweredDrawableBrushNode(brushResource);
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using RenderNodeRenderer renderer = CreateRenderer(node, diagnostics);
+
+        long hits = 0;
+        using (RenderCacheVerification.EnableForAllRequests())
+        {
+            for (int frame = 0; frame < 2; frame++)
+            {
+                using RenderNodeRasterization rasterization = renderer.Rasterize();
+                Assert.That(rasterization.IsEmpty, Is.False);
+                hits += diagnostics.Latest[RenderPipelineCounter.RenderCacheHits];
+            }
+
+            contentFill.Color.CurrentValue = Colors.Blue;
+            bool updateOnly = false;
+            brushResource.Update(brush, CompositionContext.Default, ref updateOnly);
+
+            using RenderNodeRasterization changed = renderer.Rasterize();
+            Assert.That(TopLeft(changed), Is.EqualTo(ToPremultipliedHalfBits(Colors.Blue)));
+        }
+
+        Assert.That(hits, Is.GreaterThan(0),
+            "the identical frame must record a verified cache hit for the change to prove anything");
+    }
+
+    [Test]
+    public void NonIdempotentCallback_FailsVerificationWithFusionEnabled()
+    {
+        using var node = new CornerDefectNode();
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using RenderNodeRenderer renderer = CreateRenderer(node, fusionMode: FusionMode.Enabled);
+
+        using (RenderNodeRasterization _ = renderer.Rasterize())
+        {
+        }
+
+        var exception = Assert.Throws<RenderCacheOutputMismatchException>(
+            () => renderer.Rasterize(VerifyingRequest(fusionMode: FusionMode.Enabled)));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception!.Message, Does.Contain(nameof(CornerDefectNode)));
+            Assert.That(exception.Message, Does.Contain("runtime identity"));
+            Assert.That(exception.Message, Does.Contain("device pixel"));
+        });
+    }
+
+    [Test]
+    public void OffOriginDefect_IsReportedAtItsDevicePixel()
+    {
+        using var node = new CornerDefectNode();
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using RenderNodeRenderer renderer = CreateRenderer(node);
+
+        using (RenderNodeRasterization _ = renderer.Rasterize())
+        {
+        }
+
+        var exception = Assert.Throws<RenderCacheOutputMismatchException>(
+            () => renderer.Rasterize(VerifyingRequest()));
+
+        TestContext.Out.WriteLine(exception!.Message);
+        Assert.That(
+            exception.Message,
+            Does.Contain($"device pixel ({CornerDefectNode.DefectX}, {CornerDefectNode.DefectY})"));
+    }
+
+    [Test]
+    public void DefectInConsumerNode_NamesTheConsumer()
+    {
+        using var producer = new ColorFillNode();
+        producer.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using var consumer = new DefectiveConsumerNode(producer);
+        consumer.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using RenderNodeRenderer renderer = CreateRenderer(consumer);
+
+        using (RenderNodeRasterization _ = renderer.Rasterize())
+        {
+        }
+
+        var exception = Assert.Throws<RenderCacheOutputMismatchException>(
+            () => renderer.Rasterize(VerifyingRequest()));
+
+        TestContext.Out.WriteLine(exception!.Message);
+        Assert.That(exception.Message, Does.Contain(nameof(DefectiveConsumerNode)));
+    }
+
+    [Test]
+    public void NonIdempotentCallback_MessageOffersBothExplanations()
+    {
+        using var node = new AlternatingColorNode();
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using RenderNodeRenderer renderer = CreateRenderer(node);
+
+        using (RenderNodeRasterization _ = renderer.Rasterize())
+        {
+        }
+
+        var exception = Assert.Throws<RenderCacheOutputMismatchException>(
+            () => renderer.Rasterize(VerifyingRequest()));
+
+        TestContext.Out.WriteLine(exception!.Message);
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Message, Does.Contain("runtime identity omits"));
+            Assert.That(exception.Message, Does.Contain("not idempotent"));
+        });
+    }
+
+    [Test]
+    public void TargetScopeProducer_ReportsItsOwnStructuralKey()
+    {
+        using var node = new MarkedTargetScopeNode();
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using RenderNodeRenderer renderer = CreateRenderer(node, diagnostics);
+
+        using (RenderNodeRasterization _ = renderer.Rasterize())
+        {
+        }
+
+        var exception = Assert.Throws<RenderCacheOutputMismatchException>(
+            () => renderer.Rasterize(VerifyingRequest(diagnostics)));
+
+        TestContext.Out.WriteLine(exception!.Message);
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Message, Does.Contain("produced by TargetScope"));
+            Assert.That(
+                exception.Message,
+                Does.Contain($"structural key '{MarkedTargetScopeNode.ScopeStructuralKey}'"),
+                "the target-scope payload carries a structural key and the message must report it");
+        });
+    }
+
+    [Test]
+    public void FailedVerificationReexecution_StillServesTheCachedOutput()
+    {
+        using var node = new ThrowOnReexecutionNode();
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using RenderNodeRenderer renderer = CreateRenderer(node, diagnostics);
+
+        using (RenderNodeRasterization _ = renderer.Rasterize())
+        {
+        }
+
+        using RenderNodeRasterization served = renderer.Rasterize(VerifyingRequest(diagnostics));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.ExecuteAttempts, Is.EqualTo(2),
+                "verification must have attempted the re-execution that throws");
+            Assert.That(diagnostics.Latest[RenderPipelineCounter.RenderCacheHits], Is.EqualTo(1));
+            Assert.That(served.IsEmpty, Is.False,
+                "a failed verification re-execution must not drop the content the cache could serve");
+            Assert.That(TopLeft(served), Is.EqualTo(ToPremultipliedHalfBits(Colors.Red)));
+        });
+    }
+
+    private static RenderNodeRenderRequest VerifyingRequest(
+        RenderPipelineDiagnosticsState? diagnostics = null,
+        FusionMode fusionMode = FusionMode.Disabled)
+        => new()
+        {
+            TargetDomain = s_bounds,
+            CacheOptions = RenderCacheOptions.Enabled,
+            Purpose = RenderRequestPurpose.Frame,
+            FusionMode = fusionMode,
+            Diagnostics = diagnostics,
+            VerifyCacheOutputs = true,
+        };
+
+    private static RenderNodeRenderer CreateRenderer(
+        RenderNode node,
+        RenderPipelineDiagnosticsState? diagnostics = null,
+        FusionMode fusionMode = FusionMode.Disabled)
+        => new(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_bounds,
+                    CacheOptions = RenderCacheOptions.Enabled,
+                    Purpose = RenderRequestPurpose.Frame,
+                    FusionMode = fusionMode,
+                    Diagnostics = diagnostics,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+    private static ulong TopLeft(RenderNodeRasterization rasterization)
+    {
+        Assert.That(rasterization.IsEmpty, Is.False);
+        return ReadFirstPixel(rasterization.Bitmap!);
+    }
+
+    private static ulong ToPremultipliedHalfBits(Color color)
+    {
+        using var target = new CpuRenderTarget(1, 1);
+        target.Value.Canvas.Clear(color.ToSKColor());
+        using Bitmap snapshot = target.Snapshot();
+        return ReadFirstPixel(snapshot);
+    }
+
+    // Raw Skia: a Brush.Resource has to be declared on the description to pass callback resource authorization,
+    // and these fixtures paint from state the description deliberately does not describe.
+    private static void FillRect(ImmediateCanvas canvas, Rect rect, Color color)
+    {
+        using var paint = new SKPaint { Color = color.ToSKColor(), IsAntialias = false };
+        canvas.Canvas.DrawRect(rect.ToSKRect(), paint);
+    }
+
+    private static ulong ReadFirstPixel(Bitmap bitmap)
+    {
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        return ((ulong)pixels[0] << 48)
+               | ((ulong)pixels[1] << 32)
+               | ((ulong)pixels[2] << 16)
+               | pixels[3];
+    }
+
+    private static Drawable.Resource[] CreateSceneResources()
+    {
+        var background = new RectShape
+        {
+            Width = { CurrentValue = s_frameSize.Width },
+            Height = { CurrentValue = s_frameSize.Height },
+            Fill = { CurrentValue = Brushes.CornflowerBlue },
+        };
+
+        var accent = new EllipseShape
+        {
+            Width = { CurrentValue = 76 },
+            Height = { CurrentValue = 76 },
+            Fill = { CurrentValue = Brushes.OrangeRed },
+            FilterEffect = { CurrentValue = new Brightness { Amount = { CurrentValue = 78 } } },
+            Transform = { CurrentValue = new TranslateTransform(44, -18) },
+        };
+
+        var label = new TextBlock
+        {
+            FontFamily = { CurrentValue = FontFamily.Default },
+            Size = { CurrentValue = 28 },
+            Fill = { CurrentValue = Brushes.White },
+            Text = { CurrentValue = "CACHE" },
+            Transform = { CurrentValue = new TranslateTransform(-28, 30) },
+        };
+
+        CompositionContext context = CompositionContext.Default;
+        return
+        [
+            background.ToResource(context),
+            accent.ToResource(context),
+            label.ToResource(context),
+        ];
+    }
+
+    private static IEnumerable<RenderNode> Descendants(RenderNode node)
+    {
+        yield return node;
+        if (node is ContainerRenderNode container)
+        {
+            foreach (RenderNode child in container.Children)
+            {
+                foreach (RenderNode descendant in Descendants(child))
+                    yield return descendant;
+            }
+        }
+    }
+
+    private sealed class ColorFillNode : RenderNode
+    {
+        private readonly ExecutionProbe _probe = new();
+        private readonly object _probeKey = new();
+
+        public Color Color { get; set; } = Colors.Red;
+
+        public int ExecuteCount => _probe.Count;
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<ExecutionProbe> probe = context.Borrow(_probe, _probeKey, version: 1);
+            OpaqueRenderDescription description = OpaqueRenderDescription.Create(
+                Color,
+                static (session, color) => session.UseDeclaredResource<ExecutionProbe>("probe", probe =>
+                {
+                    probe.Record();
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    output.Canvas.Use(canvas => canvas.Clear(color));
+                    session.Publish(output);
+                }),
+                OpaqueRenderBoundsContract.FullInputs(static _ => s_bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                resources: [probe.Bind("probe")]);
+            context.Publish(context.ContributeValues(context.OpaqueCombine([], description)));
+        }
+    }
+
+    private sealed class CornerDefectNode : RenderNode
+    {
+        public const int DefectX = 12;
+        public const int DefectY = 9;
+
+        private readonly ExecutionProbe _probe = new();
+        private readonly object _probeKey = new();
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<ExecutionProbe> probeResource = context.Borrow(_probe, _probeKey, version: 1);
+            OpaqueRenderDescription description = OpaqueRenderDescription.Create(
+                typeof(CornerDefectNode),
+                static (session, _) => session.UseDeclaredResource<ExecutionProbe>("probe", probe =>
+                {
+                    probe.Record();
+                    bool defective = probe.Count > 1;
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    output.Canvas.Use(canvas =>
+                    {
+                        canvas.Clear(Colors.Red);
+                        if (defective)
+                        {
+                            FillRect(
+                                canvas,
+                                new Rect(
+                                    DefectX,
+                                    DefectY,
+                                    s_bounds.Width - DefectX,
+                                    s_bounds.Height - DefectY),
+                                Colors.Blue);
+                        }
+                    });
+                    session.Publish(output);
+                }),
+                OpaqueRenderBoundsContract.FullInputs(static _ => s_bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                resources: [probeResource.Bind("probe")]);
+            context.Publish(context.ContributeValues(context.OpaqueCombine([], description)));
+        }
+    }
+
+    private sealed class AlternatingColorNode : RenderNode
+    {
+        private readonly ExecutionProbe _probe = new();
+        private readonly object _probeKey = new();
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<ExecutionProbe> probeResource = context.Borrow(_probe, _probeKey, version: 1);
+            OpaqueRenderDescription description = OpaqueRenderDescription.Create(
+                typeof(AlternatingColorNode),
+                static (session, _) => session.UseDeclaredResource<ExecutionProbe>("probe", probe =>
+                {
+                    probe.Record();
+                    Color color = probe.Count % 2 == 1 ? Colors.Red : Colors.Blue;
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    output.Canvas.Use(canvas => canvas.Clear(color));
+                    session.Publish(output);
+                }),
+                OpaqueRenderBoundsContract.FullInputs(static _ => s_bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                resources: [probeResource.Bind("probe")]);
+            context.Publish(context.ContributeValues(context.OpaqueCombine([], description)));
+        }
+    }
+
+    private sealed class ThrowOnReexecutionNode : RenderNode
+    {
+        private readonly ExecutionProbe _probe = new();
+        private readonly object _probeKey = new();
+
+        public int ExecuteAttempts => _probe.Count;
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<ExecutionProbe> probeResource = context.Borrow(_probe, _probeKey, version: 1);
+            OpaqueRenderDescription description = OpaqueRenderDescription.Create(
+                typeof(ThrowOnReexecutionNode),
+                static (session, _) => session.UseDeclaredResource<ExecutionProbe>("probe", probe =>
+                {
+                    probe.Record();
+                    if (probe.Count > 1)
+                        throw new InvalidOperationException("The verification re-execution fails.");
+
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    output.Canvas.Use(canvas => canvas.Clear(Colors.Red));
+                    session.Publish(output);
+                }),
+                OpaqueRenderBoundsContract.FullInputs(static _ => s_bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                resources: [probeResource.Bind("probe")]);
+            context.Publish(context.ContributeValues(context.OpaqueCombine([], description)));
+        }
+    }
+
+    // The scope's state and structural key are both complete, but its callback paints a different marker on
+    // each execution. State passing cannot fix non-idempotence, so verification must still report it against
+    // the scope's own structural key.
+    private sealed class MarkedTargetScopeNode : RenderNode
+    {
+        public const string ScopeStructuralKey = "marked-target-scope";
+
+        private readonly ExecutionProbe _probe = new();
+        private readonly object _probeKey = new();
+
+        public override void Process(RenderNodeContext context)
+        {
+            OpaqueRenderDescription sourceDescription = OpaqueRenderDescription.Create(
+                typeof(MarkedTargetScopeNode),
+                static (session, _) =>
+                {
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    output.Canvas.Use(canvas => canvas.Clear(Colors.White));
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.FullInputs(static _ => s_bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale);
+            RenderFragmentHandle source =
+                context.ContributeValues(context.OpaqueCombine([], sourceDescription));
+
+            RenderResource<ExecutionProbe> probeResource = context.Borrow(_probe, _probeKey, version: 1);
+            TargetScopeDescription scopeDescription = TargetScopeDescription.Create(
+                typeof(MarkedTargetScopeNode),
+                static (session, _) => session.UseDeclaredResource<ExecutionProbe>("probe", probe =>
+                    session.Canvas.Use(canvas =>
+                    {
+                        probe.Record();
+                        session.ReplayInput();
+                        FillRect(canvas, s_bounds, probe.Count > 1 ? Colors.Lime : Colors.Red);
+                    })),
+                RenderBoundsContract.Identity,
+                RenderHitTestContract.AnyInput,
+                RenderScaleContract.PreserveInputSupply,
+                deviceGridSensitivity: RenderDeviceGridSensitivity.PhaseDependent,
+                deviceGridMapping: RenderDeviceGridMapping.Preserved,
+                structuralKey: ScopeStructuralKey,
+                resources: [probeResource.Bind("probe")]);
+            context.Publish(context.Layer([context.TargetScope(source, scopeDescription)], s_bounds));
+        }
+    }
+
+    private sealed class DefectiveConsumerNode(RenderNode producer) : RenderNode
+    {
+        private readonly ExecutionProbe _probe = new();
+        private readonly object _probeKey = new();
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle input = context.RecordNode(producer, []).Single();
+            RenderResource<ExecutionProbe> probeResource = context.Borrow(_probe, _probeKey, version: 1);
+            OpaqueRenderDescription description = OpaqueRenderDescription.Create(
+                typeof(DefectiveConsumerNode),
+                static (session, _) => session.UseDeclaredResource<ExecutionProbe>("probe", probe =>
+                {
+                    probe.Record();
+                    bool defective = probe.Count > 1;
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    output.Canvas.Use(canvas =>
+                    {
+                        session.Inputs[0].Draw(canvas);
+                        if (defective)
+                            FillRect(canvas, s_bounds, Colors.Lime);
+                    });
+                    session.Publish(output);
+                }),
+                OpaqueRenderBoundsContract.Map(RenderBoundsContract.Identity),
+                RenderHitTestContract.AnyInput,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                resources: [probeResource.Bind("probe")]);
+            context.Publish(context.OpaqueMap(input, description));
+        }
+
+        protected override void OnDispose(bool disposing)
+        {
+            producer.Dispose();
+            base.OnDispose(disposing);
+        }
+    }
+
+    private sealed class TintingConsumerNode(RenderNode producer) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle input = context.RecordNode(producer, []).Single();
+            OpaqueRenderDescription description = OpaqueRenderDescription.Create(
+                typeof(TintingConsumerNode),
+                static (session, _) =>
+                {
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    output.Canvas.Use(session.Inputs[0].Draw);
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.Map(RenderBoundsContract.Identity),
+                RenderHitTestContract.AnyInput,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale);
+            context.Publish(context.OpaqueMap(input, description));
+        }
+
+        protected override void OnDispose(bool disposing)
+        {
+            producer.Dispose();
+            base.OnDispose(disposing);
+        }
+    }
+
+    private sealed class RequestLocalColorFillNode : RenderNode
+    {
+        public Color Color { get; set; } = Colors.Red;
+
+        public int ExecuteCount { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            Color color = Color;
+            OpaqueRenderDescription description = OpaqueRenderDescription.CreateRequestLocal(
+                session =>
+                {
+                    ExecuteCount++;
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    output.Canvas.Use(canvas => canvas.Clear(color));
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.FullInputs(static _ => s_bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale);
+            context.Publish(context.ContributeValues(context.OpaqueCombine([], description)));
+        }
+    }
+
+    private sealed class LoweredDrawableBrushNode(Brush.Resource fill) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            context.Publish(context.PaintedSource(
+                state: s_bounds,
+                draw: static (session, state) =>
+                    session.Canvas.DrawRectangle(state, session.Fill, session.Pen),
+                fill: fill.Capture(),
+                pen: null,
+                brushBounds: s_bounds,
+                outputBounds: s_bounds,
+                hitTest: RenderHitTestContract.OutputBounds,
+                scale: RenderScaleContract.Vector,
+                structuralKey: nameof(LoweredDrawableBrushNode)));
+        }
+    }
+
+    private sealed class CpuTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+            => new CpuRenderTarget(allocation.DeviceSize.Width, allocation.DeviceSize.Height);
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/StructuralAndProgramCacheTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/StructuralAndProgramCacheTests.cs
@@ -1,0 +1,694 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Cache;
+
+[TestFixture]
+public sealed class StructuralAndProgramCacheTests
+{
+    private const string FirstSource =
+        "uniform float gain; half4 apply(half4 color) { return color * gain; }";
+    private const string SecondSource =
+        "uniform float gain; half4 apply(half4 color) { return half4(color.rgb * gain, color.a); }";
+
+    [Test]
+    public void ParameterOnlyAnimation_ReusesOneStructuralPlanForOneHundredFrames()
+    {
+        using var source = new CpuRenderTarget(8, 8);
+        source.Value.Canvas.Clear(new SKColor(160, 96, 32, 224));
+        using Bitmap sourceBitmap = source.Snapshot();
+        using var node = new ExecutableParameterShaderNode(source);
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = new Rect(0, 0, 8, 8),
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+        ushort[]? firstPixels = null;
+        ushort[]? finalPixels = null;
+
+        for (int frame = 0; frame < 100; frame++)
+        {
+            node.Value = frame / 100f;
+            using RenderNodeRasterization raster = renderer.Rasterize();
+            Assert.That(raster.Bitmap, Is.Not.Null);
+            if (frame == 0)
+                firstPixels = raster.Bitmap!.GetPixelSpan<ushort>().ToArray();
+            if (frame == 99)
+                finalPixels = raster.Bitmap!.GetPixelSpan<ushort>().ToArray();
+        }
+
+        StructuralPlanCacheStatistics statistics = renderer.StructuralPlanCacheStatistics;
+        double maximumFinalDifference = MaximumScaledDifference(sourceBitmap, finalPixels!, 0.99f);
+        Assert.Multiple(() =>
+        {
+            Assert.That(statistics.Compilations, Is.EqualTo(1));
+            Assert.That(statistics.Misses, Is.EqualTo(1));
+            Assert.That(statistics.Hits, Is.EqualTo(99));
+            Assert.That(statistics.Replacements, Is.Zero);
+            Assert.That(renderer.ProgramCacheStatistics.Creations, Is.EqualTo(1));
+            Assert.That(renderer.ProgramCacheStatistics.Misses, Is.EqualTo(1));
+            Assert.That(renderer.ProgramCacheStatistics.Hits, Is.EqualTo(99));
+            Assert.That(renderer.LastExecutionStatistics.ProgramCacheHits, Is.EqualTo(1));
+            Assert.That(finalPixels, Is.Not.EqualTo(firstPixels),
+                "a warmed plan and program must bind the current frame's direct uniform value");
+            Assert.That(finalPixels, Has.Some.Not.Zero,
+                "the final animated frame must produce a non-vacuous result");
+            Assert.That(maximumFinalDifference, Is.LessThan(0.002),
+                "the final warmed frame must bind the authored 0.99 direct-uniform value");
+        });
+    }
+
+    private static double MaximumScaledDifference(Bitmap source, ushort[] actual, float scale)
+    {
+        ReadOnlySpan<ushort> expected = source.GetPixelSpan<ushort>();
+        Assert.That(actual, Has.Length.EqualTo(expected.Length));
+        double maximum = 0;
+        for (int index = 0; index < actual.Length; index++)
+        {
+            float sourceValue = (float)BitConverter.UInt16BitsToHalf(expected[index]);
+            float actualValue = (float)BitConverter.UInt16BitsToHalf(actual[index]);
+            maximum = Math.Max(maximum, Math.Abs(actualValue - (sourceValue * scale)));
+        }
+
+        return maximum;
+    }
+
+    [Test]
+    public void BoundsOnlyRuntimeChange_RebindsCurrentBoundsWithoutRecompiling()
+    {
+        using var cache = new StructuralPlanCache();
+        using var node = new ParameterShaderNode
+        {
+            Bounds = new Rect(1, 2, 8, 6),
+        };
+
+        using (CompiledRenderRequest first = Compile(cache, node))
+        {
+            Assert.That(first.ExecutionPlan.ShaderRuns.Single().Output.Bounds, Is.EqualTo(node.Bounds));
+        }
+
+        node.Bounds = new Rect(4, 3, 17, 11);
+        using CompiledRenderRequest second = Compile(cache, node);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(second.ExecutionPlan.ShaderRuns.Single().Output.Bounds, Is.EqualTo(node.Bounds));
+            Assert.That(second.SelectedOutputBounds, Is.EqualTo(node.Bounds));
+            Assert.That(cache.Statistics.Compilations, Is.EqualTo(1));
+            Assert.That(cache.Statistics.Hits, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void DeclaredStructuralToggle_CompilesExactlyOneReplacement()
+    {
+        using var cache = new StructuralPlanCache();
+        using var node = new ParameterShaderNode();
+
+        using (Compile(cache, node))
+        {
+        }
+
+        node.StructuralVariant = 1;
+        using (Compile(cache, node))
+        {
+        }
+        using (Compile(cache, node))
+        {
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.Statistics.Compilations, Is.EqualTo(2));
+            Assert.That(cache.Statistics.Misses, Is.EqualTo(2));
+            Assert.That(cache.Statistics.Replacements, Is.EqualTo(1));
+            Assert.That(cache.Statistics.Hits, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void CustomBinder_SnapshotValueIsRuntimeOnly_BinderKeyIsStructural()
+    {
+        using var cache = new StructuralPlanCache();
+        using var node = new ParameterShaderNode
+        {
+            UseCustomBinder = true,
+            BinderStructuralKey = "binder-v1",
+        };
+
+        using (Compile(cache, node))
+        {
+        }
+
+        node.Value = 0.75f;
+        using (Compile(cache, node))
+        {
+        }
+
+        Assert.That(cache.Statistics.Hits, Is.EqualTo(1),
+            "custom binder snapshot values must not enter structural identity");
+
+        node.BinderStructuralKey = "binder-v2";
+        using (Compile(cache, node))
+        {
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.Statistics.Compilations, Is.EqualTo(2));
+            Assert.That(cache.Statistics.Replacements, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void FusionMode_IsPartOfStructuralIdentity()
+    {
+        using var cache = new StructuralPlanCache();
+        using var node = new ParameterShaderNode();
+
+        using (Compile(cache, node, FusionMode.Enabled))
+        {
+        }
+        using (Compile(cache, node, FusionMode.Disabled))
+        {
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.Statistics.Compilations, Is.EqualTo(2));
+            Assert.That(cache.Statistics.Misses, Is.EqualTo(2));
+            Assert.That(cache.Statistics.Replacements, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void OpacityBoundsEligibilityChange_ReplacesStructuralPlan()
+    {
+        var inputBounds = new Rect(2, 3, 12, 8);
+        AssertOpacityEligibilityChangeReplacesStructuralPlan(
+            inputBounds,
+            new Rect(2, 3, 11, 8),
+            EffectiveScale.Unbounded,
+            EffectiveScale.Unbounded);
+    }
+
+    [Test]
+    public void OpacityScaleEligibilityChange_ReplacesStructuralPlan()
+    {
+        var bounds = new Rect(2, 3, 12, 8);
+        AssertOpacityEligibilityChangeReplacesStructuralPlan(
+            bounds,
+            bounds,
+            EffectiveScale.Unbounded,
+            EffectiveScale.At(1));
+    }
+
+    [Test]
+    public void ForcedHashCollision_UsesFullIdentityAndThenWarmsReplacement()
+    {
+        using var cache = new StructuralPlanCache();
+        using var firstNode = new ParameterShaderNode { StructuralVariant = 0 };
+        using var secondNode = new ParameterShaderNode { StructuralVariant = 1 };
+        using var equivalentNode = new ParameterShaderNode { StructuralVariant = 1, Value = 0.8f };
+        using RenderRequest firstRequest = CreateRequest(FusionMode.Enabled);
+        using RenderRequest secondRequest = CreateRequest(FusionMode.Enabled);
+        using RenderRequest equivalentRequest = CreateRequest(FusionMode.Enabled);
+        RecordedRenderGraph firstGraph = new RenderRequestRecorder(firstRequest).Record(firstNode);
+        RecordedRenderGraph secondGraph = new RenderRequestRecorder(secondRequest).Record(secondNode);
+        RecordedRenderGraph equivalentGraph = new RenderRequestRecorder(equivalentRequest).Record(equivalentNode);
+        StructuralPlanIdentity firstIdentity = StructuralPlanIdentity.Create(
+            firstRequest.Options.PlanIdentity,
+            firstGraph,
+            SkslBackendBudget.Unlimited);
+        StructuralPlanIdentity secondIdentity = StructuralPlanIdentity.Create(
+            secondRequest.Options.PlanIdentity,
+            secondGraph,
+            SkslBackendBudget.Unlimited);
+        StructuralPlanIdentity equivalentIdentity = StructuralPlanIdentity.Create(
+            equivalentRequest.Options.PlanIdentity,
+            equivalentGraph,
+            SkslBackendBudget.Unlimited);
+        const int forcedBucket = 0x1234;
+
+        _ = GetOrCompile(cache, firstIdentity, firstGraph, forcedBucket);
+        _ = GetOrCompile(cache, secondIdentity, secondGraph, forcedBucket);
+        ExecutionIslandPlan warmed = GetOrCompile(
+            cache,
+            equivalentIdentity,
+            equivalentGraph,
+            forcedBucket);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstIdentity, Is.Not.EqualTo(secondIdentity));
+            Assert.That(secondIdentity, Is.EqualTo(equivalentIdentity));
+            Assert.That(cache.Statistics.Compilations, Is.EqualTo(2));
+            Assert.That(cache.Statistics.Misses, Is.EqualTo(2));
+            Assert.That(cache.Statistics.Replacements, Is.EqualTo(1));
+            Assert.That(cache.Statistics.Hits, Is.EqualTo(1));
+            Assert.That(
+                warmed.ShaderRuns.Single().Stages.Single().Description.CreateRuntimeIdentity(),
+                Is.EqualTo(equivalentNode.LastDescription!.CreateRuntimeIdentity()),
+                "the warmed collision-safe template must bind the current request's runtime description");
+        });
+    }
+
+    [Test]
+    public void Renderer_PersistsStructuralCacheAcrossRequests()
+    {
+        using var node = new EmptyNode();
+        using var renderer = new RenderNodeRenderer(node);
+
+        using (renderer.Rasterize())
+        {
+        }
+        using (renderer.Rasterize())
+        {
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(renderer.StructuralPlanCacheStatistics.Compilations, Is.EqualTo(1));
+            Assert.That(renderer.StructuralPlanCacheStatistics.Hits, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void RenderInputReadbackSelection_ReplacesStructuralPlanAndRebindsSnapshots()
+    {
+        using var node = new MutableTargetCommandReadbackNode();
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = new Rect(0, 0, 8, 8),
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        using (renderer.Rasterize())
+        {
+        }
+
+        node.ReadFirstInput = false;
+        using (renderer.Rasterize())
+        {
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.SnapshotCounts, Is.EqualTo(new[] { 1, 1 }));
+            Assert.That(renderer.StructuralPlanCacheStatistics.Compilations, Is.EqualTo(2));
+            Assert.That(renderer.StructuralPlanCacheStatistics.Misses, Is.EqualTo(2));
+            Assert.That(renderer.StructuralPlanCacheStatistics.Replacements, Is.EqualTo(1));
+            Assert.That(renderer.StructuralPlanCacheStatistics.Hits, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void NestedRequestFamily_ReusesEveryCurrentPlanAndTrimsRemovedMembers()
+    {
+        using var cache = new StructuralPlanCache();
+        using var child = new EmptyNode();
+        using var nested = new NestedParentNode(child);
+        using var flat = new EmptyNode();
+
+        using (Compile(cache, nested))
+        {
+        }
+        using (Compile(cache, nested))
+        {
+        }
+
+        StructuralPlanCacheStatistics warmed = cache.Statistics;
+        Assert.Multiple(() =>
+        {
+            Assert.That(warmed.Compilations, Is.EqualTo(2));
+            Assert.That(warmed.Misses, Is.EqualTo(2));
+            Assert.That(warmed.Hits, Is.EqualTo(2));
+            Assert.That(warmed.Replacements, Is.Zero);
+            Assert.That(warmed.RetainedPlans, Is.EqualTo(2));
+        });
+
+        using (Compile(cache, flat))
+        {
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.Statistics.Hits, Is.EqualTo(3));
+            Assert.That(cache.Statistics.RetainedPlans, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void TargetLayerScope_EmptyRegionClass_CompilesOneReplacement()
+    {
+        using var cache = new StructuralPlanCache();
+        using var node = new MutableTargetLayerScopeNode();
+
+        using (Compile(cache, node))
+        {
+        }
+
+        node.Region = TargetRegion.Region(new Rect(0, 0, 8, 8));
+        using (Compile(cache, node))
+        {
+        }
+        using (Compile(cache, node))
+        {
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.Statistics.Compilations, Is.EqualTo(2));
+            Assert.That(cache.Statistics.Misses, Is.EqualTo(2));
+            Assert.That(cache.Statistics.Replacements, Is.EqualTo(1));
+            Assert.That(cache.Statistics.Hits, Is.EqualTo(1));
+        });
+    }
+
+    private static ExecutionIslandPlan GetOrCompile(
+        StructuralPlanCache cache,
+        StructuralPlanIdentity identity,
+        RecordedRenderGraph graph,
+        int forcedBucket)
+    {
+        var planner = new ExecutionIslandPlanner();
+        return cache.GetOrCompile(
+            identity,
+            graph,
+            () => planner.Plan(
+                graph,
+                RenderRequestCompiler.ResolveRoots(graph),
+                FusionMode.Enabled,
+                SkslBackendBudget.Unlimited),
+            forcedBucket);
+    }
+
+    private static void AssertOpacityEligibilityChangeReplacesStructuralPlan(
+        Rect changedInputBounds,
+        Rect changedOpacityBounds,
+        EffectiveScale changedInputScale,
+        EffectiveScale changedOpacityScale)
+    {
+        var eligibleBounds = new Rect(2, 3, 12, 8);
+        using var cache = new StructuralPlanCache();
+        using RenderRequest eligibleRequest = CreateRequest(FusionMode.Enabled);
+        using RenderRequest changedRequest = CreateRequest(FusionMode.Enabled);
+        RecordedRenderGraph eligibleGraph = CreateOpacityGraph(
+            eligibleRequest.Id,
+            eligibleBounds,
+            eligibleBounds,
+            EffectiveScale.Unbounded,
+            EffectiveScale.Unbounded);
+        RecordedRenderGraph changedGraph = CreateOpacityGraph(
+            changedRequest.Id,
+            changedInputBounds,
+            changedOpacityBounds,
+            changedInputScale,
+            changedOpacityScale);
+        StructuralPlanIdentity eligibleIdentity = StructuralPlanIdentity.Create(
+            eligibleRequest.Options.PlanIdentity,
+            eligibleGraph,
+            SkslBackendBudget.Unlimited);
+        StructuralPlanIdentity changedIdentity = StructuralPlanIdentity.Create(
+            changedRequest.Options.PlanIdentity,
+            changedGraph,
+            SkslBackendBudget.Unlimited);
+        const int forcedBucket = 0x4f50;
+
+        _ = GetOrCompile(
+            cache,
+            eligibleIdentity,
+            eligibleGraph,
+            forcedBucket);
+        _ = GetOrCompile(
+            cache,
+            changedIdentity,
+            changedGraph,
+            forcedBucket);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(eligibleIdentity, Is.Not.EqualTo(changedIdentity));
+            Assert.That(cache.Statistics.Compilations, Is.EqualTo(2));
+            Assert.That(cache.Statistics.Misses, Is.EqualTo(2));
+            Assert.That(cache.Statistics.Replacements, Is.EqualTo(1));
+            Assert.That(cache.Statistics.Hits, Is.Zero);
+        });
+    }
+
+    private static RecordedRenderGraph CreateOpacityGraph(
+        RenderRequestId requestId,
+        Rect inputBounds,
+        Rect opacityBounds,
+        EffectiveScale inputScale,
+        EffectiveScale opacityScale)
+    {
+        var input = new RenderFragmentReference(
+            RenderFragmentKind.ContributeValues,
+            inputBounds,
+            inputScale,
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: false,
+            hasOpaqueExternalWork: false,
+            [],
+            payload: null,
+            static _ => true);
+        var opacity = new RenderFragmentReference(
+            RenderFragmentKind.Opacity,
+            opacityBounds,
+            opacityScale,
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: false,
+            hasOpaqueExternalWork: false,
+            [input],
+            new OpacityRenderFragmentPayload(
+                0.625f,
+                OpacityRenderNode.CreateFusionDescription(0.625f)),
+            static _ => true);
+        var builder = new RecordedRenderGraphBuilder(requestId);
+        RenderProvenanceId provenance = builder.AddProvenance(
+            typeof(StructuralAndProgramCacheTests),
+            "opacity-structural-cache-test");
+        foreach (RenderFragmentReference reference in new[] { input, opacity })
+        {
+            RenderValueId[] inputs = reference.Inputs
+                .SelectMany(static item => item.ValueIds)
+                .ToArray();
+            reference.ValueIds = [builder.AddValue(inputs, provenance, reference)];
+            reference.Id = builder.AddFragment(reference.ValueIds, provenance, reference);
+        }
+
+        builder.PublishRoot(opacity.Id!.Value);
+        return builder.Build();
+    }
+
+    private static CompiledRenderRequest Compile(
+        StructuralPlanCache cache,
+        RenderNode node,
+        FusionMode fusionMode = FusionMode.Enabled)
+    {
+        RenderRequest request = CreateRequest(fusionMode);
+        try
+        {
+            RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+            return new RenderRequestCompiler(cache).Compile(request, graph);
+        }
+        catch
+        {
+            request.Dispose();
+            throw;
+        }
+    }
+
+    private static RenderRequest CreateRequest(FusionMode fusionMode)
+        => new(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            outputScale: 1,
+            maxWorkingScale: 1,
+            cachePolicy: RenderCacheOptions.Disabled,
+            fusionMode: fusionMode));
+
+    private sealed class ParameterShaderNode : RenderNode
+    {
+        public Rect Bounds { get; set; } = new(2, 3, 12, 8);
+
+        public float Value { get; set; } = 0.25f;
+
+        public int StructuralVariant { get; set; }
+
+        public bool UseCustomBinder { get; set; }
+
+        public object BinderStructuralKey { get; set; } = "binder-v1";
+
+        public ShaderDescription? LastDescription { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            OpaqueRenderDescription source = OpaqueRenderDescription.Create(
+                ("source-frame", Value),
+                static (_, _) => { },
+                OpaqueRenderBoundsContract.Source(Bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: "structural-cache-source");
+            RenderFragmentHandle input = context.OpaqueSource(source);
+            string shaderSource = StructuralVariant == 0 ? FirstSource : SecondSource;
+            LastDescription = ShaderDescription.CurrentPixel(
+                shaderSource,
+                bindings =>
+                {
+                    if (UseCustomBinder)
+                    {
+                        bindings.Uniform(
+                            "gain",
+                            Value,
+                            BindFloat,
+                            BinderStructuralKey,
+                            ShaderBindingCachePolicy.ReuseFromSnapshot);
+                    }
+                    else
+                    {
+                        bindings.Uniform("gain", Value);
+                    }
+                });
+            context.Publish(context.Shader(input, LastDescription));
+        }
+
+        private static void BindFloat(
+            ShaderUniformWriter writer,
+            float value,
+            ShaderExecutionContext context)
+            => writer.Set(value);
+    }
+
+    private sealed class EmptyNode : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+        }
+    }
+
+    private sealed class NestedParentNode(RenderNode child) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+            => _ = context.RecordNestedTarget(child, new Rect(0, 0, 8, 8));
+    }
+
+    private sealed class MutableTargetLayerScopeNode : RenderNode
+    {
+        public TargetRegion Region { get; set; } = TargetRegion.Empty;
+
+        public override void Process(RenderNodeContext context)
+            => context.Publish(context.TargetLayerScope([], Region));
+    }
+
+    private sealed class MutableTargetCommandReadbackNode : RenderNode
+    {
+        private static readonly Rect s_bounds = new(0, 0, 8, 8);
+
+        public bool ReadFirstInput { get; set; } = true;
+
+        public int[] SnapshotCounts { get; } = new int[2];
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle first = context.OpaqueSource(CreateSource("first"));
+            RenderFragmentHandle second = context.OpaqueSource(CreateSource("second"));
+            int selectedInput = ReadFirstInput ? 0 : 1;
+            RenderFragmentHandle command = context.TargetCommand(
+                [first, second],
+                TargetCommandDescription.CreateRequestLocal(
+                    session => session.Inputs[selectedInput].UseSnapshot(
+                        _ => SnapshotCounts[selectedInput]++),
+                    TargetRegion.Empty,
+                    Rect.Empty,
+                    RenderHitTestContract.None,
+                    inputReadbacks: ReadFirstInput
+                        ? [RenderInputReadback.All, RenderInputReadback.None]
+                        : [RenderInputReadback.None, RenderInputReadback.All],
+                    structuralKey: "mutable-target-input-readback"));
+            context.PublishRange([first, second, command]);
+        }
+
+        private static OpaqueRenderDescription CreateSource(string key)
+            => OpaqueRenderDescription.CreateRequestLocal(
+                session =>
+                {
+                    using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.Source(s_bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: ("mutable-target-input-readback-source", key));
+    }
+
+    private sealed class ExecutableParameterShaderNode(RenderTarget source) : RenderNode
+    {
+        public float Value { get; set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<RenderTarget> target = context.Borrow(
+                source,
+                "structural-program-cache-source",
+                version: 1);
+            RenderFragmentHandle input = context.MaterializedInput(
+                MaterializedInputDescription.FromRenderTarget(
+                    target,
+                    new Rect(0, 0, 8, 8),
+                    EffectiveScale.At(1),
+                    new PixelRect(0, 0, 8, 8),
+                    default,
+                    RenderHitTestContract.OutputBounds));
+            ShaderDescription shader = ShaderDescription.CurrentPixel(
+                FirstSource,
+                bindings => bindings.Uniform("gain", Value));
+            context.Publish(context.Shader(input, shader));
+        }
+    }
+
+    private sealed class CpuTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+            => new CpuRenderTarget(allocation.DeviceSize.Width, allocation.DeviceSize.Height);
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/ColorShiftSnapshotIntentTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/ColorShiftSnapshotIntentTests.cs
@@ -1,0 +1,50 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+/// <summary>
+/// <see cref="ColorShift"/>'s readback failure must decide degrade-vs-fail from the explicit
+/// <see cref="RenderIntent"/>, not from the working-scale ceiling that happens to accompany it.
+/// </summary>
+[TestFixture]
+public sealed class ColorShiftSnapshotIntentTests
+{
+    [TestCase(float.PositiveInfinity)]
+    [TestCase(2f)]
+    public void DeliveryFailsRegardlessOfTheWorkingScaleCeiling(float maxWorkingScale)
+    {
+        using var targets = new EffectTargets();
+        var context = new CustomFilterEffectContext(
+            targets,
+            RenderIntent.Delivery,
+            RenderRequestPurpose.Auxiliary,
+            outputScale: 1f,
+            workingScale: 1f,
+            maxWorkingScale: maxWorkingScale);
+
+        Assert.That(
+            () => ColorShift.ThrowIfDeliverySnapshotFailure(context.Intent, 0),
+            Throws.TypeOf<InvalidOperationException>()
+                .With.Message.StartWith("ColorShift snapshot failed for target 0"));
+    }
+
+    [TestCase(float.PositiveInfinity)]
+    [TestCase(2f)]
+    public void PreviewDegradesRegardlessOfTheWorkingScaleCeiling(float maxWorkingScale)
+    {
+        using var targets = new EffectTargets();
+        var context = new CustomFilterEffectContext(
+            targets,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            outputScale: 1f,
+            workingScale: 1f,
+            maxWorkingScale: maxWorkingScale);
+
+        Assert.That(
+            () => ColorShift.ThrowIfDeliverySnapshotFailure(context.Intent, 0),
+            Throws.Nothing);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/DrawBackdropRenderNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/DrawBackdropRenderNodeTests.cs
@@ -1,0 +1,88 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+[TestFixture]
+public sealed class DrawBackdropRenderNodeTests
+{
+    private static readonly Rect s_domain = new(0, 0, 120, 90);
+
+    [Test]
+    public void BuiltInBackdrop_RecordsOverAZeroAreaCanvasWithoutReportingAPhantomHit()
+    {
+        using var root = new ContainerRenderNode();
+        using (var context = new GraphicsContext2D(root))
+        {
+            context.DrawBackdrop(context.Snapshot());
+        }
+
+        using RenderNodeRenderer renderer = CreateRenderer(root);
+        RenderNodeMeasurement measurement = renderer.Measure();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(measurement.QueryBounds, Is.EqualTo(Rect.Empty));
+            Assert.That(renderer.HitTest(default), Is.False);
+        });
+    }
+
+    [Test]
+    public void RawBackdrop_RecordsOverAZeroAreaCanvasWithoutReportingAPhantomHit()
+    {
+        using var root = new ContainerRenderNode();
+        using (var context = new GraphicsContext2D(root))
+        {
+            context.DrawBackdrop(new StubBackdrop());
+        }
+
+        using RenderNodeRenderer renderer = CreateRenderer(root);
+        RenderNodeMeasurement measurement = renderer.Measure();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(measurement.QueryBounds, Is.EqualTo(Rect.Empty));
+            Assert.That(renderer.HitTest(default), Is.False);
+        });
+    }
+
+    [Test]
+    public void Backdrop_KeepsOutputBoundsHitTestingOverAPositiveAreaCanvas()
+    {
+        using var root = new ContainerRenderNode();
+        using (var context = new GraphicsContext2D(root, s_domain.Size))
+        {
+            context.DrawBackdrop(new StubBackdrop());
+        }
+
+        using RenderNodeRenderer renderer = CreateRenderer(root);
+        RenderNodeMeasurement measurement = renderer.Measure();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(measurement.QueryBounds, Is.EqualTo(s_domain));
+            Assert.That(renderer.HitTest(new Point(60, 45)), Is.True);
+            Assert.That(renderer.HitTest(new Point(200, 45)), Is.False);
+        });
+    }
+
+    private static RenderNodeRenderer CreateRenderer(RenderNode root)
+        => new(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_domain,
+                    CacheOptions = RenderCacheOptions.Disabled,
+                },
+            });
+
+    private sealed class StubBackdrop : IBackdrop
+    {
+        public void Draw(ImmediateCanvas canvas)
+        {
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/EngineResourceIdentityRoutingTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/EngineResourceIdentityRoutingTests.cs
@@ -1,0 +1,381 @@
+﻿using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Particles;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Graphics3D;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+/// <summary>
+/// Covers the six render-node sites that read <c>GetOriginal().Id</c> directly and now route through
+/// <see cref="EngineResourceIdentity.Of"/>.
+/// </summary>
+/// <remarks>
+/// Each site keeps a <see cref="Guid"/>-typed identity element, so the routing has to stay allocation-free to be
+/// worth taking. The recorded end-to-end outcomes below are what each node actually does with a detached
+/// resource, measured rather than reasoned about. Which site a detached resource reaches first depends on which
+/// of a node's resources is detached, so the outcome is recorded per input shape rather than per node.
+/// <c>Geometry.Resource</c> now builds its path from itself, so a detached geometry no longer fails ahead of the
+/// routed identity read; <see cref="DetachedGeometryResourceTests"/> covers that path.
+/// </remarks>
+[TestFixture]
+public sealed class EngineResourceIdentityRoutingTests
+{
+    private const int Iterations = 20000;
+    private const int Rounds = 5;
+
+    private static GeometryHitTestIdentityShape s_geometrySink;
+    private static Guid s_geometryClipSink;
+    private static (Guid Id, int Version, ClipOperation Operation) s_geometryClipStateSink;
+    private static ParticleSnapshotIdentityShape s_particleSink;
+    private static (Type Owner, Guid Id, int Segment) s_filterEffectSink;
+    private static SceneSnapshotIdentityShape s_sceneSnapshotSink;
+    private static SceneRuntimeIdentityShape s_sceneRuntimeSink;
+
+    [Test]
+    public void ADetachedResourceOfEveryRoutedSiteType_DerivesAnIdentityInsteadOfThrowing()
+    {
+        using var geometry = new EllipseGeometry.Resource();
+        using var brush = new SolidColorBrush.Resource();
+        using var pen = new Pen.Resource();
+        using var emitter = new ParticleEmitter.Resource();
+        using var effect = new ShakeEffect.Resource();
+        using var scene = new Scene3D.Resource();
+        EngineObject.Resource[] resources = [geometry, brush, pen, emitter, effect, scene];
+
+        using (Assert.EnterMultipleScope())
+        {
+            foreach (EngineObject.Resource resource in resources)
+            {
+                Assert.That(resource.GetOriginal(), Is.Null,
+                    $"{resource.GetType()} is detached, so it has no backing id");
+                Guid first = Guid.Empty;
+                Assert.DoesNotThrow(() => first = EngineResourceIdentity.Of(resource));
+                Assert.That(EngineResourceIdentity.Of(resource), Is.EqualTo(first),
+                    "the synthesized identity is held weakly against the resource and survives between reads");
+                Assert.That(first, Is.Not.EqualTo(Guid.Empty));
+            }
+        }
+    }
+
+    /// <summary>
+    /// The one site this change rescues end to end. A detached <see cref="Brush.Resource"/> reaches
+    /// <see cref="GeometryRenderNode"/>'s identity read before anything else dereferences it, so the routing
+    /// turns a <see cref="NullReferenceException"/> into a complete render. Both the node's constructor and
+    /// <c>GraphicsContext2D.DrawGeometry</c> take a publicly constructible <c>Brush.Resource?</c>, so this is
+    /// an ordinary plugin shape rather than a contrived one.
+    /// </summary>
+    [Test]
+    public void GeometryRenderNode_WithADetachedFill_RendersInsteadOfThrowing()
+    {
+        var geometry = new EllipseGeometry { Width = { CurrentValue = 40 }, Height = { CurrentValue = 30 } };
+        using Beutl.Media.Geometry.Resource geometryResource = geometry.ToResource(CompositionContext.Default);
+        using var fill = new SolidColorBrush.Resource();
+        using var node = new GeometryRenderNode(geometryResource, fill, null);
+
+        Exception? failure = RecordAndCaptureFailure(node);
+
+        Assert.That(failure, Is.Null,
+            "with the geometry attached, the detached fill's identity read is the first dereference, "
+            + "so the routing has to rescue it");
+    }
+
+    [Test]
+    public void GeometryRenderNode_WithADetachedGeometry_ReachesItsRoutedIdentityRead()
+    {
+        using var geometry = new EllipseGeometry.Resource { Width = 40, Height = 30 };
+        using var node = new GeometryRenderNode(geometry, null, null);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(RecordAndCaptureFailure(node), Is.Null,
+                "GetRenderBounds no longer dereferences the backing object, so recording reaches the routed read");
+            Assert.That(RecordedFragmentCount(node), Is.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public void GeometryClipRenderNode_WithADetachedGeometry_RecordsItsScope()
+    {
+        using var geometry = new EllipseGeometry.Resource { Width = 40, Height = 30 };
+        using var node = new GeometryClipRenderNode(geometry, ClipOperation.Intersect);
+        node.AddChild(new RectangleRenderNode(new Rect(0, 0, 8, 8), null, null));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(RecordAndCaptureFailure(node), Is.Null,
+                "the routed identity read and the Bounds read one statement later both survive detachment now");
+            Assert.That(RecordedFragmentCount(node), Is.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public void ParticleRenderNode_NeverReachesItsIdentityRead_BecauseADetachedEmitterHasNoAliveParticles()
+    {
+        using var emitter = new ParticleEmitter.Resource();
+        using var node = new ParticleRenderNode(emitter);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(emitter.GetAliveParticles().Length, Is.Zero,
+                "the simulator field is initialized inline but only Update ever simulates");
+            Assert.That(RecordAndCaptureFailure(node), Is.Null);
+            Assert.That(RecordedFragmentCount(node), Is.Zero);
+        }
+    }
+
+    [Test]
+    public void Scene3DRenderNode_NeverReachesItsIdentityReads_BecauseADetachedSceneHasNoCamera()
+    {
+        using var scene = new Scene3D.Resource();
+        using var node = new Scene3DRenderNode(scene);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(scene.Camera, Is.Null);
+            Assert.That(RecordAndCaptureFailure(node), Is.Null);
+            Assert.That(RecordedFragmentCount(node), Is.Zero);
+        }
+    }
+
+    [Test]
+    public void ADetachedResourceBorrowedTwiceInOneRequest_CoalescesOntoOneSlot()
+    {
+        using var detached = new EngineObject.Resource();
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+        using var node = new TwiceBorrowingNode(detached);
+
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        var payload = (OpaqueRenderFragmentPayload)SingleRoot(graph).Payload!;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(payload.Description.Resources, Has.Count.EqualTo(2));
+            Assert.That(payload.Description.Resources[0].Resource.SlotIdentity,
+                Is.SameAs(payload.Description.Resources[1].Resource.SlotIdentity),
+                "registry coalescing compares keys with Equals, and two boxed equal Guids satisfy that");
+            Assert.That(payload.Description.Resources[0].Resource.CacheIdentity.Key,
+                Is.EqualTo(EngineResourceIdentity.Of(detached)));
+        }
+    }
+
+    [Test]
+    public void EveryRoutedSite_BuildsItsIdentityWithoutAllocating()
+    {
+        var geometry = new EllipseGeometry { Width = { CurrentValue = 40 }, Height = { CurrentValue = 30 } };
+        var fill = new SolidColorBrush(Colors.Red);
+        var pen = new Pen { Brush = { CurrentValue = Brushes.Black }, Thickness = { CurrentValue = 2 } };
+        using Beutl.Media.Geometry.Resource geometryResource = geometry.ToResource(CompositionContext.Default);
+        using SolidColorBrush.Resource fillResource = fill.ToResource(CompositionContext.Default);
+        using Pen.Resource penResource = pen.ToResource(CompositionContext.Default);
+        var emitter = new ParticleEmitter();
+        using var emitterResource =
+            (ParticleEmitter.Resource)emitter.ToResource(new CompositionContext(TimeSpan.FromSeconds(1)));
+        var effect = new ShakeEffect();
+        using FilterEffect.Resource effectResource = effect.ToResource(CompositionContext.Default);
+        var scene = new Scene3D();
+        using var sceneResource = (Scene3D.Resource)scene.ToResource(CompositionContext.Default);
+        var bounds = new Rect(0, 0, 32, 24);
+
+        (string Site, long Before, long After)[] measurements =
+        [
+            Compare(
+                "GeometryRenderNode.cs:48,50,52",
+                () => s_geometrySink = new GeometryHitTestIdentityShape(
+                    geometryResource.GetOriginal().Id,
+                    geometryResource.Version,
+                    fillResource.GetOriginal().Id,
+                    fillResource.Version,
+                    penResource.GetOriginal().Id,
+                    penResource.Version),
+                () => s_geometrySink = new GeometryHitTestIdentityShape(
+                    EngineResourceIdentity.Of(geometryResource),
+                    geometryResource.Version,
+                    EngineResourceIdentity.Of(fillResource),
+                    fillResource.Version,
+                    EngineResourceIdentity.Of(penResource),
+                    penResource.Version)),
+            Compare(
+                "GeometryClipRenderNode.cs:46",
+                () =>
+                {
+                    s_geometryClipSink = geometryResource.GetOriginal().Id;
+                    s_geometryClipStateSink =
+                        (s_geometryClipSink, geometryResource.Version, ClipOperation.Intersect);
+                },
+                () =>
+                {
+                    s_geometryClipSink = EngineResourceIdentity.Of(geometryResource);
+                    s_geometryClipStateSink =
+                        (s_geometryClipSink, geometryResource.Version, ClipOperation.Intersect);
+                }),
+            Compare(
+                "ParticleRenderNode.cs:55",
+                () => s_particleSink = new ParticleSnapshotIdentityShape(
+                    emitterResource.GetOriginal().Id,
+                    emitterResource.Version),
+                () => s_particleSink = new ParticleSnapshotIdentityShape(
+                    EngineResourceIdentity.Of(emitterResource),
+                    emitterResource.Version)),
+            Compare(
+                "FilterEffectRenderNode.cs:201",
+                () => s_filterEffectSink =
+                    (typeof(FilterEffectRenderNode), effectResource.GetOriginal().Id, 0),
+                () => s_filterEffectSink =
+                    (typeof(FilterEffectRenderNode), EngineResourceIdentity.Of(effectResource), 0)),
+            Compare(
+                "Scene3DRenderNode.cs:97",
+                () => s_sceneSnapshotSink = new SceneSnapshotIdentityShape(
+                    sceneResource.GetOriginal().Id,
+                    sceneResource.Version),
+                () => s_sceneSnapshotSink = new SceneSnapshotIdentityShape(
+                    EngineResourceIdentity.Of(sceneResource),
+                    sceneResource.Version)),
+            Compare(
+                "Scene3DRenderNode.cs:117",
+                () => s_sceneRuntimeSink = new SceneRuntimeIdentityShape(
+                    sceneResource.GetOriginal().Id,
+                    sceneResource.Version,
+                    bounds),
+                () => s_sceneRuntimeSink = new SceneRuntimeIdentityShape(
+                    EngineResourceIdentity.Of(sceneResource),
+                    sceneResource.Version,
+                    bounds)),
+        ];
+
+        using (Assert.EnterMultipleScope())
+        {
+            foreach ((string site, long before, long after) in measurements)
+            {
+                TestContext.Out.WriteLine(
+                    $"{site}: {before} -> {after} bytes per {Iterations} builds");
+                Assert.That(after, Is.LessThanOrEqualTo(before), $"{site} got more expensive");
+                Assert.That(after, Is.Zero, $"{site} must build its identity without allocating");
+            }
+
+            // The sinks give each measured identity somewhere to be stored. Two of them are written but never
+            // otherwise read, which is CS0414 and so a build break under this repository's 0-warning bar; these
+            // reads exist to answer that compiler warning and assert nothing a reader should rely on.
+            _ = s_geometryClipStateSink;
+            _ = s_filterEffectSink;
+        }
+    }
+
+    private static (string Site, long Before, long After) Compare(string site, Action before, Action after)
+        => (site, Measure(before), Measure(after));
+
+    private static long Measure(Action build)
+    {
+        for (int index = 0; index < 200; index++)
+            build();
+
+        long best = long.MaxValue;
+        for (int round = 0; round < Rounds; round++)
+        {
+            long start = GC.GetAllocatedBytesForCurrentThread();
+            for (int index = 0; index < Iterations; index++)
+                build();
+            best = Math.Min(best, GC.GetAllocatedBytesForCurrentThread() - start);
+        }
+
+        return best;
+    }
+
+    private static Exception? RecordAndCaptureFailure(RenderNode node)
+    {
+        try
+        {
+            _ = RecordedFragmentCount(node);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return Unwrap(ex);
+        }
+    }
+
+    private static int RecordedFragmentCount(RenderNode node)
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+        return new RenderRequestRecorder(request).Record(node).PublicationRoots.Count();
+    }
+
+    private static Exception Unwrap(Exception exception)
+    {
+        Exception current = exception;
+        while (current.InnerException is { } inner)
+            current = inner;
+        return current;
+    }
+
+    private static Type? DeepestFrameType(Exception exception)
+        => new System.Diagnostics.StackTrace(exception).GetFrame(0)?.GetMethod()?.DeclaringType;
+
+    private static RenderRequest CreateRequest(RenderRequestOwner owner)
+        => new(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            outputScale: 1,
+            maxWorkingScale: 1,
+            targetDomain: new Rect(0, 0, 32, 32),
+            cachePolicy: RenderCacheOptions.Disabled,
+            owner: owner));
+
+    private static RenderFragmentReference SingleRoot(RecordedRenderGraph graph)
+    {
+        RenderFragmentId rootId = graph.PublicationRoots.Single();
+        return (RenderFragmentReference)graph.Fragments
+            .Single(fragment => fragment.Id == rootId)
+            .Payload!;
+    }
+
+    private readonly record struct GeometryHitTestIdentityShape(
+        Guid GeometryId,
+        int GeometryVersion,
+        Guid? FillId,
+        int? FillVersion,
+        Guid? PenId,
+        int? PenVersion);
+
+    private readonly record struct ParticleSnapshotIdentityShape(Guid ResourceId, int Version);
+
+    private readonly record struct SceneSnapshotIdentityShape(Guid SceneId, int Version);
+
+    private readonly record struct SceneRuntimeIdentityShape(Guid SceneId, int Version, Rect Bounds);
+
+    private sealed class TwiceBorrowingNode(EngineObject.Resource resource) : RenderNode
+    {
+        private static readonly Rect s_bounds = new(0, 0, 8, 8);
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<EngineObject.Resource> first = context.Borrow(
+                resource,
+                EngineResourceIdentity.Of(resource),
+                resource.Version);
+            RenderResource<EngineObject.Resource> second = context.Borrow(
+                resource,
+                EngineResourceIdentity.Of(resource),
+                resource.Version);
+            OpaqueRenderDescription description = OpaqueRenderDescription.Create(
+                s_bounds,
+                static (session, bounds) =>
+                {
+                    using OpaqueRenderOutput output = session.CreateOutput(bounds);
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.Source(s_bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                resources: [first.Bind("first"), second.Bind("second")]);
+            context.Publish(context.OpaqueSource(description));
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/EngineResourceIdentityStabilityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/EngineResourceIdentityStabilityTests.cs
@@ -1,0 +1,433 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Particles;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Graphics.Shapes;
+using Beutl.Graphics3D;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+/// <summary>
+/// Proves that routing the six <c>GetOriginal().Id</c> sites through <see cref="EngineResourceIdentity.Of"/>
+/// moves no attached resource's recorded identity.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The two short nodes are compared against a verbatim reconstruction of their pre-change <c>Process</c>,
+/// recorded in the same process, so the whole declared list and the runtime identity are compared element by
+/// element rather than read off a diff. The reconstruction's own identity types are re-declared here, so the
+/// comparison flattens every composite key into its leaf elements and their declared types.
+/// </para>
+/// <para>
+/// The remaining three nodes have <c>Process</c> bodies whose bulk is private helpers and backend setup, so
+/// their recorded identity elements are compared against the pre-change expression evaluated verbatim here
+/// instead of against a reconstructed node.
+/// </para>
+/// </remarks>
+[TestFixture]
+public sealed class EngineResourceIdentityStabilityTests
+{
+    [Test]
+    public void GeometryRenderNode_RecordsWhatThePreChangeProcessRecorded()
+    {
+        var geometry = new EllipseGeometry { Width = { CurrentValue = 40 }, Height = { CurrentValue = 30 } };
+        var fill = new SolidColorBrush(Colors.Red);
+        var pen = new Pen { Brush = { CurrentValue = Brushes.Black }, Thickness = { CurrentValue = 2 } };
+        using Beutl.Media.Geometry.Resource geometryResource = geometry.ToResource(CompositionContext.Default);
+        using SolidColorBrush.Resource fillResource = fill.ToResource(CompositionContext.Default);
+        using Pen.Resource penResource = pen.ToResource(CompositionContext.Default);
+        using var shipped = new GeometryRenderNode(geometryResource, fillResource, penResource);
+        using var preChange = new PreChangeGeometryRenderNode(geometryResource, fillResource, penResource);
+
+        IReadOnlyList<string> shippedIdentity = OpaqueIdentity(shipped);
+        IReadOnlyList<string> preChangeIdentity = OpaqueIdentity(preChange);
+
+        TestContext.Out.WriteLine(string.Join(Environment.NewLine, shippedIdentity));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(shippedIdentity, Is.Not.Empty);
+            Assert.That(shippedIdentity, Is.EqualTo(preChangeIdentity).AsCollection);
+            Assert.That(shippedIdentity, Has.Some.EqualTo($"System.Guid={geometry.Id}"));
+        }
+    }
+
+    [Test]
+    public void GeometryClipRenderNode_RecordsWhatThePreChangeProcessRecorded()
+    {
+        var geometry = new EllipseGeometry { Width = { CurrentValue = 40 }, Height = { CurrentValue = 30 } };
+        using Beutl.Media.Geometry.Resource geometryResource = geometry.ToResource(CompositionContext.Default);
+        using var shipped = new GeometryClipRenderNode(geometryResource, ClipOperation.Intersect);
+        shipped.AddChild(new RectangleRenderNode(new Rect(0, 0, 16, 16), null, null));
+        using var preChange = new PreChangeGeometryClipRenderNode(geometryResource, ClipOperation.Intersect);
+        preChange.AddChild(new RectangleRenderNode(new Rect(0, 0, 16, 16), null, null));
+
+        IReadOnlyList<string> shippedIdentity = TargetScopeIdentity(shipped);
+        IReadOnlyList<string> preChangeIdentity = TargetScopeIdentity(preChange);
+
+        TestContext.Out.WriteLine(string.Join(Environment.NewLine, shippedIdentity));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(shippedIdentity, Is.Not.Empty);
+            Assert.That(shippedIdentity, Is.EqualTo(preChangeIdentity).AsCollection);
+            Assert.That(shippedIdentity, Has.Some.EqualTo($"System.Guid={geometry.Id}"));
+        }
+    }
+
+    [Test]
+    public void ParticleRenderNode_KeepsTheSnapshotIdentityElementsThePreChangeExpressionProduces()
+    {
+        var particle = new RectShape();
+        particle.Width.CurrentValue = 8;
+        particle.Height.CurrentValue = 8;
+        particle.Fill.CurrentValue = Brushes.White;
+        var emitter = new ParticleEmitter();
+        emitter.ParticleDrawable.CurrentValue = particle;
+        using var resource =
+            (ParticleEmitter.Resource)emitter.ToResource(new CompositionContext(TimeSpan.FromSeconds(1)));
+        Assert.That(resource.GetAliveParticles().Length, Is.GreaterThanOrEqualTo(1),
+            "precondition: the identity site is only reached when the emitter has alive particles");
+        using var node = new ParticleRenderNode(resource);
+
+        IReadOnlyList<string> recorded = DeclaredKeys(node, RenderFragmentKind.TargetCommand);
+
+        Assert.That(recorded, Is.EqualTo(Describe(
+            (resource.GetOriginal().Id, resource.Version))).AsCollection);
+    }
+
+    [Test]
+    public void FilterEffectRenderNode_KeepsTheSegmentOwnKeyElementsThePreChangeExpressionProduces()
+    {
+        var effect = new ShakeEffect();
+        effect.StrengthX.CurrentValue = 4;
+        using FilterEffect.Resource resource = effect.ToResource(CompositionContext.Default);
+        using var node = new FilterEffectRenderNode(resource);
+        node.AddChild(new RectangleRenderNode(new Rect(0, 0, 16, 16), null, null));
+
+        IReadOnlyList<string> recorded = DeclaredKeys(node, RenderFragmentKind.LegacyFilterEffect);
+
+        Assert.That(recorded, Is.EqualTo(Describe(
+            (typeof(FilterEffectRenderNode), resource.GetOriginal().Id, 0))).AsCollection);
+    }
+
+    [Test]
+    public void Scene3DRenderNode_KeepsTheSnapshotAndRuntimeIdentityElementsThePreChangeExpressionProduces()
+    {
+        var scene = new Scene3D();
+        scene.RenderWidth.CurrentValue = 32;
+        scene.RenderHeight.CurrentValue = 24;
+        using var resource = (Scene3D.Resource)scene.ToResource(CompositionContext.Default);
+        using var node = new Scene3DRenderNode(resource);
+        var bounds = new Rect(0, 0, 32, 24);
+
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        var payload = (OpaqueRenderFragmentPayload)SingleRoot(graph).Payload!;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                Describe(payload.Description.Resources[0].Resource.CacheIdentity.Key),
+                Is.EqualTo(Describe((resource.GetOriginal().Id, resource.Version))).AsCollection);
+            Assert.That(
+                Describe(payload.Description.RuntimeIdentity!.Value.Key),
+                Is.EqualTo(Describe((resource.GetOriginal().Id, resource.Version, bounds))).AsCollection);
+        }
+    }
+
+    private static IReadOnlyList<string> OpaqueIdentity(RenderNode node)
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        var payload = (OpaqueRenderFragmentPayload)SingleRoot(graph).Payload!;
+        var result = new List<string>();
+        AppendResources(result, payload.Description.Resources);
+        result.Add("runtime:");
+        Append(result, null, payload.Description.RuntimeIdentity?.Key);
+        return result;
+    }
+
+    private static IReadOnlyList<string> TargetScopeIdentity(RenderNode node)
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        var payload = (TargetScopeRenderFragmentPayload)SingleRoot(graph).Payload!;
+        var result = new List<string>();
+        AppendResources(result, payload.Description.Resources);
+        result.Add("runtime:");
+        Append(result, null, payload.Description.RuntimeIdentity?.Key);
+        return result;
+    }
+
+    private static IReadOnlyList<string> DeclaredKeys(RenderNode node, RenderFragmentKind kind)
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        RenderFragmentReference fragment = graph.Fragments
+            .Select(static item => (RenderFragmentReference)item.Payload!)
+            .Single(item => item.Kind == kind);
+        RenderResource resource = fragment.Payload switch
+        {
+            TargetCommandRenderFragmentPayload command => command.Description.Resources.Single().Resource,
+            LegacyFilterEffectRenderFragmentPayload legacy => legacy.Context,
+            _ => throw new InvalidOperationException($"Unexpected payload {fragment.Payload}."),
+        };
+        var result = new List<string>();
+        Append(result, null, resource.CacheIdentity.Key);
+        return result;
+    }
+
+    private static void AppendResources(List<string> result, IReadOnlyList<RenderResourceBinding> resources)
+    {
+        result.Add($"count={resources.Count}");
+        foreach (RenderResourceBinding binding in resources)
+        {
+            result.Add($"name={binding.Name}");
+            RenderResource resource = binding.Resource;
+            Append(result, null, resource.CacheIdentity.Key);
+            result.Add($"version={resource.CacheIdentity.Version}");
+        }
+    }
+
+    private static IReadOnlyList<string> Describe(object? key)
+    {
+        var result = new List<string>();
+        Append(result, null, key);
+        return result;
+    }
+
+    private static void Append(List<string> result, Type? declared, object? value)
+    {
+        if (value is null)
+        {
+            result.Add($"{Name(declared)}=null");
+            return;
+        }
+
+        Type runtime = value.GetType();
+        if (IsComposite(runtime))
+        {
+            foreach (FieldInfo field in runtime
+                         .GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                         .OrderBy(static field => field.MetadataToken))
+            {
+                Append(result, field.FieldType, field.GetValue(value));
+            }
+
+            return;
+        }
+
+        result.Add($"{Name(declared ?? runtime)}={Format(value)}");
+    }
+
+    private static bool IsComposite(Type type)
+        => type is { IsValueType: true, IsPrimitive: false, IsEnum: false }
+           && (typeof(ITuple).IsAssignableFrom(type)
+               || type.GetMethod(
+                   "PrintMembers",
+                   BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic) is not null);
+
+    private static string Name(Type? type)
+        => type is null ? "<unknown>"
+            : Nullable.GetUnderlyingType(type) is { } underlying ? $"{underlying.FullName}?"
+            : type.FullName!;
+
+    private static string Format(object value)
+        => value is Type type ? type.FullName! : value.ToString()!;
+
+    private static RenderRequest CreateRequest(RenderRequestOwner owner)
+        => new(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            outputScale: 1,
+            maxWorkingScale: 1,
+            targetDomain: new Rect(0, 0, 64, 64),
+            cachePolicy: RenderCacheOptions.Disabled,
+            owner: owner));
+
+    private static RenderFragmentReference SingleRoot(RecordedRenderGraph graph)
+    {
+        RenderFragmentId rootId = graph.PublicationRoots.Single();
+        return (RenderFragmentReference)graph.Fragments
+            .Single(fragment => fragment.Id == rootId)
+            .Payload!;
+    }
+
+    // Verbatim copy of GeometryRenderNode.Process at 74deae450, before the identity reads were routed.
+    private sealed class PreChangeGeometryRenderNode(
+        Beutl.Media.Geometry.Resource geometry,
+        Brush.Resource? fill,
+        Pen.Resource? pen)
+        : BrushRenderNode(fill, pen)
+    {
+        public (Beutl.Media.Geometry.Resource Resource, int Version)? Geometry { get; private set; } = geometry.Capture();
+
+        public override void Process(RenderNodeContext context)
+        {
+            if (Geometry is not { } geometrySnapshot)
+                return;
+
+            (Brush.Resource Resource, int Version)? fillSnapshot = Fill;
+            (Pen.Resource Resource, int Version)? penSnapshot = Pen;
+            Beutl.Media.Geometry.Resource geometry = geometrySnapshot.Resource;
+            Brush.Resource? fill = fillSnapshot?.Resource;
+            Pen.Resource? pen = penSnapshot?.Resource;
+            Rect bounds = PenHelper.CalculateBoundsWithStrokeCap(
+                geometry.GetRenderBounds(pen),
+                pen);
+            if (bounds.Width == 0 || bounds.Height == 0)
+                return;
+
+            RenderResource<Beutl.Media.Geometry.Resource> geometryResource = context.Borrow(geometrySnapshot);
+            var hitTestState = new GeometryHitTestState(geometry, fill, pen);
+            var hitTestIdentity = new GeometryHitTestIdentity(
+                geometry.GetOriginal().Id,
+                geometrySnapshot.Version,
+                fill?.GetOriginal().Id,
+                fillSnapshot?.Version,
+                pen?.GetOriginal().Id,
+                penSnapshot?.Version);
+            RenderResource<GeometryHitTestState> hitTestResource = context.Borrow(
+                hitTestState,
+                hitTestIdentity);
+
+            context.Publish(context.PaintedSource(
+                primary: geometryResource,
+                state: bounds,
+                draw: static (session, geometry, _) =>
+                    session.Canvas.DrawGeometry(geometry, session.Fill, session.Pen),
+                fill: fillSnapshot,
+                pen: penSnapshot,
+                brushBounds: bounds,
+                outputBounds: bounds,
+                hitTest: RenderHitTestContract.FromResource(
+                    hitTestResource,
+                    static (state, point) => state.HitTest(point),
+                    typeof(GeometryHitTestState)),
+                scale: RenderScaleContract.Vector,
+                structuralKey: typeof(GeometryRenderNode),
+                resources: [hitTestResource.Bind("hitTest")]));
+        }
+
+        protected override void OnDispose(bool disposing)
+        {
+            base.OnDispose(disposing);
+            Geometry = null!;
+        }
+
+        private sealed class GeometryHitTestState(
+            Beutl.Media.Geometry.Resource geometry,
+            Brush.Resource? fill,
+            Pen.Resource? pen)
+        {
+            public bool HitTest(Point point)
+            {
+                return (fill is not null && geometry.FillContains(point))
+                       || (pen is not null && geometry.StrokeContains(pen, point));
+            }
+        }
+
+        private readonly record struct GeometryHitTestIdentity(
+            Guid GeometryId,
+            int GeometryVersion,
+            Guid? FillId,
+            int? FillVersion,
+            Guid? PenId,
+            int? PenVersion);
+    }
+
+    // Verbatim copy of GeometryClipRenderNode.Process at 74deae450, before the identity read was routed.
+    private sealed class PreChangeGeometryClipRenderNode(Beutl.Media.Geometry.Resource clip, ClipOperation operation)
+        : ContainerRenderNode
+    {
+        public (Beutl.Media.Geometry.Resource Resource, int Version)? Clip { get; private set; } = clip.Capture();
+
+        public ClipOperation Operation { get; private set; } = operation;
+
+        public override void Process(RenderNodeContext context)
+        {
+            if (Clip is not { } clip)
+            {
+                context.PassThrough();
+                return;
+            }
+            if (context.Inputs.Count == 0)
+                return;
+
+            ClipOperation operation = Operation;
+            Guid geometryId = clip.Resource.GetOriginal().Id;
+            var boundsMetadata = new GeometryClipBoundsMetadata(clip.Resource.Bounds, operation);
+            RenderResource<Beutl.Media.Geometry.Resource> resource = context.Borrow(clip);
+            var hitTestState = new GeometryClipHitTestState(clip.Resource, operation);
+            RenderResource<GeometryClipHitTestState> hitTestResource = context.Borrow(
+                hitTestState,
+                cacheKey: (geometryId, clip.Version, operation));
+            TargetScopeDescription description = TargetScopeDescription.Create(
+                (geometryId, clip.Version, operation),
+                static (session, state) => session.UseDeclaredResource<Beutl.Media.Geometry.Resource>(
+                    "geometry",
+                    geometry =>
+                    session.Canvas.Use(canvas =>
+                    {
+                        using (canvas.PushClip(geometry, state.operation))
+                        {
+                            session.ReplayInput();
+                        }
+                    })),
+                RenderBoundsContract.Create(
+                    boundsMetadata.TransformBounds,
+                    boundsMetadata.GetRequiredInputBounds,
+                    structuralKey: (typeof(GeometryClipRenderNode), "clip-bounds")),
+                RenderHitTestContract.FromResource(
+                    hitTestResource,
+                    static (state, hitTest, point) => state.HitTest(hitTest, point),
+                    structuralKey: typeof(GeometryClipRenderNode)),
+                RenderScaleContract.PreserveInputSupply,
+                deviceGridSensitivity: RenderDeviceGridSensitivity.PhaseDependent,
+                deviceGridMapping: RenderDeviceGridMapping.Preserved,
+                resources: [resource.Bind("geometry"), hitTestResource.Bind("hitTest")]);
+
+            foreach (RenderFragmentHandle input in context.Inputs)
+            {
+                context.Publish(context.TargetScope(input, description));
+            }
+        }
+
+        protected override void OnDispose(bool disposing)
+        {
+            base.OnDispose(disposing);
+            Clip = null!;
+        }
+
+        private readonly record struct GeometryClipBoundsMetadata(Rect Bounds, ClipOperation Operation)
+        {
+            public Rect TransformBounds(Rect value)
+                => Operation == ClipOperation.Intersect ? value.Intersect(Bounds) : value;
+
+            public Rect GetRequiredInputBounds(Rect value)
+                => Operation == ClipOperation.Intersect ? value.Intersect(Bounds) : value;
+        }
+
+        private sealed class GeometryClipHitTestState(
+            Beutl.Media.Geometry.Resource geometry,
+            ClipOperation operation)
+        {
+            public bool HitTest(RenderHitTestContext context, Point point)
+            {
+                bool insideClip = geometry.FillContains(point);
+                bool clipAcceptsPoint = operation == ClipOperation.Intersect ? insideClip : !insideClip;
+                return clipAcceptsPoint && context.Inputs.Any(input => input.HitTest(point));
+            }
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/EngineResourceIdentityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/EngineResourceIdentityTests.cs
@@ -1,0 +1,96 @@
+﻿using Beutl.Engine;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+/// <summary>
+/// Covers the derivation every CWT-synthesized cache-key helper in the renderer routes through.
+/// </summary>
+/// <remarks>
+/// <see cref="EngineObject.Resource.GetOriginal"/> returns null for a resource that never went through
+/// <see cref="EngineObject.ToResource"/> — a shape the public
+/// <c>FilterEffectContext.RegisterBrush</c>/<c>RegisterPen</c> entry points accept.
+/// </remarks>
+[TestFixture]
+public sealed class EngineResourceIdentityTests
+{
+    private const int Iterations = 20000;
+
+    [Test]
+    public void ADetachedResource_HasNoBackingObjectId()
+    {
+        using var detached = new EngineObject.Resource();
+
+        Assert.That(detached.GetOriginal(), Is.Null);
+    }
+
+    [Test]
+    public void GetCacheKey_OnADetachedResource_ReturnsASynthesizedIdentityInsteadOfThrowing()
+    {
+        using var detached = new EngineObject.Resource();
+
+        object first = DeferredOpaqueSource.GetCacheKey(detached);
+        object second = DeferredOpaqueSource.GetCacheKey(detached);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first, Is.EqualTo(second),
+                "the synthesized identity is held weakly against the resource, so it survives between reads");
+            Assert.That(first, Is.Not.EqualTo(Guid.Empty),
+                "a detached resource must not collapse onto the default backing id");
+        });
+    }
+
+    [Test]
+    public void GetCacheKey_OnTwoDetachedResources_KeepsThemApart()
+    {
+        using var first = new EngineObject.Resource();
+        using var second = new EngineObject.Resource();
+
+        Assert.That(
+            DeferredOpaqueSource.GetCacheKey(first),
+            Is.Not.EqualTo(DeferredOpaqueSource.GetCacheKey(second)));
+    }
+
+    [Test]
+    public void GetCacheKey_OnAnAttachedResource_EqualsTheBackingObjectId()
+    {
+        Brush.Resource attached = Brushes.Resource.White;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DeferredOpaqueSource.GetCacheKey(attached), Is.EqualTo(attached.GetOriginal().Id),
+                "an attached resource keeps the cache identity it had before the helper was routed");
+            Assert.That(
+                DeferredOpaqueSource.GetCacheKey(attached).GetHashCode(),
+                Is.EqualTo(attached.GetOriginal().Id.GetHashCode()),
+                "every consumer of this key buckets by hash before comparing");
+        });
+    }
+
+    [Test]
+    public void GetCacheKey_OnAnAttachedResource_AllocatesNoMoreThanReadingTheIdDirectly()
+    {
+        Brush.Resource attached = Brushes.Resource.White;
+
+        long routed = MeasureBytesPerCall(() => DeferredOpaqueSource.GetCacheKey(attached));
+        long direct = MeasureBytesPerCall(() => attached.GetOriginal().Id);
+
+        TestContext.Out.WriteLine($"routed: {routed} bytes/call, direct: {direct} bytes/call");
+        Assert.That(routed, Is.EqualTo(direct),
+            "both forms box exactly one Guid, so routing the helper moves no allocation into Process");
+    }
+
+    private static long MeasureBytesPerCall(Func<object> read)
+    {
+        for (int index = 0; index < 200; index++)
+            _ = read();
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int index = 0; index < Iterations; index++)
+            _ = read();
+        long after = GC.GetAllocatedBytesForCurrentThread();
+        return (after - before) / Iterations;
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/DeclaredResourceAddressingTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/DeclaredResourceAddressingTests.cs
@@ -1,0 +1,235 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Failure;
+
+/// <summary>
+/// Covers stable named addressing for every session that exposes declared resources.
+/// </summary>
+[TestFixture]
+public sealed class DeclaredResourceAddressingTests
+{
+    private static readonly Rect s_bounds = new(0, 0, 8, 8);
+
+    [TestCase(DeclaredResourceSession.Opaque)]
+    [TestCase(DeclaredResourceSession.Geometry)]
+    [TestCase(DeclaredResourceSession.TargetScope)]
+    [TestCase(DeclaredResourceSession.TargetCommand)]
+    public void ANameOutsideTheDeclaredListThrowsKeyNotFound(DeclaredResourceSession session)
+    {
+        using var node = new DeclaredResourceNode(session, DeclaredResourceUse.MissingName);
+        using RenderNodeRenderer renderer = FailureTestSupport.CreateRenderer(node);
+
+        KeyNotFoundException? failure =
+            Assert.Throws<KeyNotFoundException>(() => renderer.Rasterize());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Does.Contain("missing"));
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+        });
+    }
+
+    [TestCase(DeclaredResourceSession.Opaque)]
+    [TestCase(DeclaredResourceSession.Geometry)]
+    [TestCase(DeclaredResourceSession.TargetScope)]
+    [TestCase(DeclaredResourceSession.TargetCommand)]
+    public void AMismatchedTypeArgumentThrowsInvalidOperation(DeclaredResourceSession session)
+    {
+        using var node = new DeclaredResourceNode(session, DeclaredResourceUse.TypeMismatch);
+        using RenderNodeRenderer renderer = FailureTestSupport.CreateRenderer(node);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(() => renderer.Rasterize());
+
+        TestContext.Out.WriteLine(failure!.Message);
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure.Message, Does.Contain("Declared resource 'first'"));
+            Assert.That(failure.Message, Does.Contain("RenderResource<Geometry.Resource>"),
+                "the message must name the type the callback asked for");
+            Assert.That(failure.Message, Does.Contain("RenderResource<SolidColorBrush.Resource>"),
+                "and the type actually declared under that name");
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void ReorderingResourcesOfTheSameTypePreservesTheirNamedMeaning()
+    {
+        using var declared = new DeclaredResourceNode(
+            DeclaredResourceSession.Opaque,
+            DeclaredResourceUse.FirstBrush);
+        using var reordered = new DeclaredResourceNode(
+            DeclaredResourceSession.Opaque,
+            DeclaredResourceUse.FirstBrush)
+        { SwapDeclaredBrushes = true };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Render(declared), Is.EqualTo(ToPremultipliedHalfBits(Colors.Red)));
+            Assert.That(Render(reordered), Is.EqualTo(ToPremultipliedHalfBits(Colors.Red)),
+                "the stable name must keep addressing the first brush after declaration order changes");
+        });
+    }
+
+    private static ulong Render(RenderNode node)
+    {
+        using RenderNodeRenderer renderer = FailureTestSupport.CreateRenderer(node);
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        Assert.That(rasterization.IsEmpty, Is.False);
+        return ReadFirstPixel(rasterization.Bitmap!);
+    }
+
+    private static ulong ToPremultipliedHalfBits(Color color)
+    {
+        using var target = new FailureTestRenderTarget(new PixelSize(1, 1));
+        target.Value.Canvas.Clear(color.ToSKColor());
+        using Bitmap snapshot = target.Snapshot();
+        return ReadFirstPixel(snapshot);
+    }
+
+    private static ulong ReadFirstPixel(Bitmap bitmap)
+    {
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        return ((ulong)pixels[0] << 48)
+               | ((ulong)pixels[1] << 32)
+               | ((ulong)pixels[2] << 16)
+               | pixels[3];
+    }
+
+    public enum DeclaredResourceSession
+    {
+        Opaque,
+        Geometry,
+        TargetScope,
+        TargetCommand,
+    }
+
+    public enum DeclaredResourceUse
+    {
+        MissingName,
+        TypeMismatch,
+        FirstBrush,
+    }
+
+    private sealed class DeclaredResourceNode(
+        DeclaredResourceSession session,
+        DeclaredResourceUse use) : RenderNode
+    {
+        public bool SwapDeclaredBrushes { get; init; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<SolidColorBrush.Resource> first = Borrow(context, Brushes.Resource.Red);
+            RenderResource<SolidColorBrush.Resource> second = Borrow(context, Brushes.Resource.Lime);
+            RenderResourceBinding[] declared = SwapDeclaredBrushes
+                ? [second.Bind("second"), first.Bind("first")]
+                : [first.Bind("first"), second.Bind("second")];
+
+            bool failInSource = session == DeclaredResourceSession.Opaque
+                                && use != DeclaredResourceUse.FirstBrush;
+            RenderFragmentHandle source = context.OpaqueSource(
+                OpaqueRenderDescription.Create(
+                    failInSource ? use : DeclaredResourceUse.FirstBrush,
+                    static (opaque, state) =>
+                    {
+                        if (state == DeclaredResourceUse.MissingName)
+                        {
+                            opaque.UseDeclaredResource<SolidColorBrush.Resource>("missing", static _ => { });
+                            return;
+                        }
+
+                        if (state == DeclaredResourceUse.TypeMismatch)
+                        {
+                            opaque.UseDeclaredResource<Geometry.Resource>("first", static _ => { });
+                            return;
+                        }
+
+                        opaque.UseDeclaredResource<SolidColorBrush.Resource>("first", brush =>
+                        {
+                            using OpaqueRenderOutput output = opaque.CreateOutput(s_bounds);
+                            output.Canvas.Use(canvas => canvas.DrawRectangle(s_bounds, brush, null));
+                            opaque.Publish(output);
+                        });
+                    },
+                    OpaqueRenderBoundsContract.Source(s_bounds),
+                    RenderHitTestContract.OutputBounds,
+                    RenderValueCardinality.Single,
+                    RenderScaleContract.MaterializeAtWorkingScale,
+                    resources: declared));
+
+            switch (session)
+            {
+                case DeclaredResourceSession.Geometry:
+                    context.Publish(context.ContributeValues(context.Geometry(
+                        source,
+                        GeometryDescription.Create(
+                            use,
+                            static (geometry, state) =>
+                            {
+                                if (state == DeclaredResourceUse.MissingName)
+                                    geometry.UseDeclaredResource<SolidColorBrush.Resource>("missing", static _ => { });
+                                else
+                                    geometry.UseDeclaredResource<Geometry.Resource>("first", static _ => { });
+                            },
+                            RenderBoundsContract.Identity,
+                            RenderHitTestContract.AnyInput,
+                            resources: declared))));
+                    break;
+
+                case DeclaredResourceSession.TargetScope:
+                    context.Publish(context.Layer(
+                        [
+                            context.TargetScope(
+                                source,
+                                TargetScopeDescription.Create(
+                                    use,
+                                    static (scope, state) =>
+                                    {
+                                        if (state == DeclaredResourceUse.MissingName)
+                                            scope.UseDeclaredResource<SolidColorBrush.Resource>("missing", static _ => { });
+                                        else
+                                            scope.UseDeclaredResource<Geometry.Resource>("first", static _ => { });
+                                    },
+                                    RenderBoundsContract.Identity,
+                                    RenderHitTestContract.AnyInput,
+                                    RenderScaleContract.PreserveInputSupply,
+                                    deviceGridSensitivity: RenderDeviceGridSensitivity.PhaseDependent,
+                                    resources: declared)),
+                        ],
+                        s_bounds));
+                    break;
+
+                case DeclaredResourceSession.TargetCommand:
+                    context.Publish(context.ContributeValues(source));
+                    context.Publish(context.TargetCommand(
+                        [],
+                        TargetCommandDescription.Create(
+                            use,
+                            static (command, state) =>
+                            {
+                                if (state == DeclaredResourceUse.MissingName)
+                                    command.UseDeclaredResource<SolidColorBrush.Resource>("missing", static _ => { });
+                                else
+                                    command.UseDeclaredResource<Geometry.Resource>("first", static _ => { });
+                            },
+                            TargetRegion.Empty,
+                            Rect.Empty,
+                            RenderHitTestContract.None,
+                            resources: declared)));
+                    break;
+
+                default:
+                    context.Publish(context.ContributeValues(source));
+                    break;
+            }
+        }
+
+        private static RenderResource<SolidColorBrush.Resource> Borrow(
+            RenderNodeContext context,
+            SolidColorBrush.Resource brush)
+            => context.Borrow(brush, brush.GetOriginal().Id, brush.Version);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/DeferredCallbackFailureTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/DeferredCallbackFailureTests.cs
@@ -1,0 +1,706 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Failure;
+
+[TestFixture]
+public sealed class DeferredCallbackFailureTests
+{
+    private static readonly Rect s_bounds = new(0, 0, 8, 8);
+
+    [TestCase(GuardedCanvasViolation.AuthorDispose)]
+    [TestCase(GuardedCanvasViolation.Snapshot)]
+    [TestCase(GuardedCanvasViolation.NestedDraw)]
+    [TestCase(GuardedCanvasViolation.SaveLayer)]
+    [TestCase(GuardedCanvasViolation.OpacityLayer)]
+    [TestCase(GuardedCanvasViolation.BlendLayer)]
+    [TestCase(GuardedCanvasViolation.MaskLayer)]
+    [TestCase(GuardedCanvasViolation.PaintLayer)]
+    [TestCase(GuardedCanvasViolation.NativeTarget)]
+    [TestCase(GuardedCanvasViolation.HiddenAllocation)]
+    [TestCase(GuardedCanvasViolation.HiddenFlush)]
+    public void GuardedCallbackCanvas_RejectsAuthorEscapeHatchesWithoutLeakingTargets(
+        GuardedCanvasViolation violation)
+    {
+        using var node = new GuardedCanvasViolationNode(violation);
+        var factory = new FailureTestTargetFactory();
+        using var renderer = FailureTestSupport.CreateRenderer(node, factory, useRenderCache: false);
+
+        Assert.That(() => renderer.Rasterize(), Throws.TypeOf<InvalidOperationException>());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.CallbackEntries, Is.EqualTo(1));
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            Assert.That(node.Cache.IsCached, Is.False);
+            Assert.That(factory.Targets, Has.All.Matches<FailureTestRenderTarget>(target => !target.IsDisposed));
+        });
+    }
+
+    [TestCase(GeometryFailure.UndeclaredInputReadback)]
+    [TestCase(GeometryFailure.DuplicateInputReadback)]
+    [TestCase(GeometryFailure.Callback)]
+    [TestCase(GeometryFailure.InvalidShrink)]
+    [TestCase(GeometryFailure.SecondCanvasOpen)]
+    [TestCase(GeometryFailure.UseAfterCanvasClose)]
+    public void GeometryDeferredPhases_PreserveTheFirstFailureAndInvalidateTheSession(
+        GeometryFailure failurePoint)
+    {
+        using var node = new GeometryFailureNode(failurePoint);
+        using var renderer = FailureTestSupport.CreateRenderer(node, useRenderCache: false);
+
+        Type expectedType = failurePoint switch
+        {
+            GeometryFailure.InvalidShrink => typeof(ArgumentException),
+            GeometryFailure.UseAfterCanvasClose => typeof(ObjectDisposedException),
+            _ => typeof(InvalidOperationException),
+        };
+        Assert.That(
+            () => renderer.Rasterize(),
+            failurePoint == GeometryFailure.Callback
+                ? Throws.TypeOf(expectedType).And.Message.EqualTo("geometry-callback-primary")
+                : Throws.TypeOf(expectedType));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.CallbackEntries, Is.EqualTo(1));
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            Assert.That(node.Cache.IsCached, Is.False);
+            Assert.That(node.RetainedSession, Is.Not.Null);
+            Assert.That(() => _ = node.RetainedSession!.OutputBounds, Throws.TypeOf<InvalidOperationException>());
+        });
+    }
+
+    [Test]
+    public void GeometryOutputAcquisitionFailure_HappensBeforeCallbackAndReturnsPriorTargets()
+    {
+        using var node = new GeometryFailureNode(GeometryFailure.Callback);
+        var factory = new FailureTestTargetFactory(failAt: 2);
+        using var renderer = FailureTestSupport.CreateRenderer(
+            node, factory, useRenderCache: false, intent: RenderIntent.Delivery);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(() => renderer.Rasterize());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Does.Contain("could not allocate"));
+            Assert.That(node.CallbackEntries, Is.Zero);
+            Assert.That(factory.CreateCalls, Is.EqualTo(3));
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            Assert.That(node.Cache.IsCached, Is.False);
+        });
+    }
+
+    [Test]
+    public void GeometryOutputAcquisitionFailure_DropsInPreviewWithoutEnteringTheCallback()
+    {
+        using var node = new GeometryFailureNode(GeometryFailure.Callback);
+        var factory = new FailureTestTargetFactory(failAt: 2);
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var renderer = FailureTestSupport.CreateRenderer(
+            node, factory, useRenderCache: false, diagnostics: diagnostics);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.CallbackEntries, Is.Zero);
+            Assert.That(factory.CreateCalls, Is.EqualTo(3));
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            Assert.That(node.Cache.IsCached, Is.False);
+            Assert.That(diagnostics.Latest.Succeeded, Is.True);
+            Assert.That(diagnostics.Latest[RenderPipelineCounter.PreviewAllocationDrops], Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void CallbackCanvasOpenFailure_PreservesProviderExceptionAndKeepsTheFacadeOneShot()
+    {
+        var primary = new InvalidOperationException("callback-canvas-open-primary");
+        var token = new RenderExecutionSessionToken();
+        var canvas = new RenderCallbackCanvas(
+            token,
+            density: 1,
+            s_bounds,
+            () => throw primary,
+            CallbackCanvasCapability.Draw);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => canvas.Use(static _ => { }));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.SameAs(primary));
+            Assert.That(() => canvas.Use(static _ => { }), Throws.TypeOf<InvalidOperationException>());
+        });
+        token.Complete();
+        Assert.That(() => _ = canvas.LogicalBounds, Throws.TypeOf<InvalidOperationException>());
+    }
+
+    [Test]
+    public void SessionCompletion_PreservesBodyFailureWhenAnActiveCanvasAlsoFailsCompletion()
+    {
+        var primary = new InvalidOperationException("session-body-primary");
+        var token = new RenderExecutionSessionToken();
+        using RenderTarget target = RenderTarget.CreateNull(8, 8);
+        using var canvas = new ImmediateCanvas(target, logicalSize: s_bounds.Size);
+        token.EnterCanvas(canvas, facade: null);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => token.RunAndComplete(() => throw primary));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.SameAs(primary));
+            Assert.That(token.ThrowIfInactive, Throws.TypeOf<InvalidOperationException>());
+        });
+    }
+
+    [Test]
+    public void SessionCompletion_SurfacesActiveCanvasFailureWithoutAPrimaryFailure()
+    {
+        var token = new RenderExecutionSessionToken();
+        using RenderTarget target = RenderTarget.CreateNull(8, 8);
+        using var canvas = new ImmediateCanvas(target, logicalSize: s_bounds.Size);
+        token.EnterCanvas(canvas, facade: null);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => token.RunAndComplete(static () => { }));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Does.Contain("canvas is still active"));
+            Assert.That(token.ThrowIfInactive, Throws.TypeOf<InvalidOperationException>());
+        });
+    }
+
+    [TestCase(OpaqueTopology.Source)]
+    [TestCase(OpaqueTopology.Map)]
+    [TestCase(OpaqueTopology.Combine)]
+    [TestCase(OpaqueTopology.Expand)]
+    public void EveryOpaqueTopology_PropagatesItsDeferredCallbackFailure(OpaqueTopology topology)
+    {
+        var primary = new InvalidOperationException($"opaque-{topology}");
+        using var node = new OpaqueTopologyFailureNode(topology, primary);
+        using var renderer = FailureTestSupport.CreateRenderer(node, useRenderCache: false);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(() => renderer.Rasterize());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.SameAs(primary));
+            Assert.That(node.FaultingCallbackEntries, Is.EqualTo(1));
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            Assert.That(node.Cache.IsCached, Is.False);
+        });
+    }
+
+    [TestCase(DynamicOutputFailure.MissingRequiredOutput)]
+    [TestCase(DynamicOutputFailure.ExceedsMaximum)]
+    [TestCase(DynamicOutputFailure.OutOfDeclaredBounds)]
+    public void OpaqueDynamicOutputValidation_RejectsInvalidPublicationAtomically(
+        DynamicOutputFailure failurePoint)
+    {
+        using var node = new DynamicOutputFailureNode(failurePoint);
+        using var renderer = FailureTestSupport.CreateRenderer(node, useRenderCache: false);
+
+        Exception? failure = Assert.Catch(() => renderer.Rasterize());
+
+        Type expectedType = failurePoint == DynamicOutputFailure.OutOfDeclaredBounds
+            ? typeof(ArgumentException)
+            : typeof(InvalidOperationException);
+        string expectedMessage = failurePoint switch
+        {
+            DynamicOutputFailure.MissingRequiredOutput => "published 0 values outside its declared cardinality [1, 1]",
+            DynamicOutputFailure.ExceedsMaximum => "published 2 values outside its declared cardinality [0, 1]",
+            DynamicOutputFailure.OutOfDeclaredBounds => "contained by the declared output bounds",
+            _ => throw new ArgumentOutOfRangeException(nameof(failurePoint), failurePoint, null),
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.GetType(), Is.EqualTo(expectedType));
+            Assert.That(failure!.Message, Does.Contain(expectedMessage));
+            Assert.That(node.CallbackEntries, Is.EqualTo(1));
+            Assert.That(node.ReachedFailurePoint, Is.EqualTo(failurePoint));
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            Assert.That(node.Cache.IsCached, Is.False);
+        });
+    }
+
+    [Test]
+    public void UndeclaredResourceUse_IsRejectedInsideTheRealOpaqueSession()
+    {
+        using var node = new UndeclaredResourceNode();
+        using var renderer = FailureTestSupport.CreateRenderer(node, useRenderCache: false);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(() => renderer.Rasterize());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Does.Contain("was not declared"));
+            Assert.That(node.Borrowed.DisposeCalls, Is.Zero);
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            Assert.That(node.Cache.IsCached, Is.False);
+        });
+    }
+
+    [Test]
+    public void SuccessfulDeferredCallback_SealsSessionInputOutputAndCanvasFacadesAfterReturn()
+    {
+        using var node = new RetainedFacadeNode();
+        using var renderer = FailureTestSupport.CreateRenderer(node, useRenderCache: false);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rasterization.IsEmpty, Is.False);
+            Assert.That(() => _ = node.Session!.OutputBounds, Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => _ = node.Input!.Bounds, Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => _ = node.Output!.Bounds, Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => _ = node.CanvasFacade!.LogicalBounds, Throws.TypeOf<InvalidOperationException>());
+            Assert.That(node.ImmediateCanvas, Is.Not.Null);
+            Assert.That(
+                () => node.ImmediateCanvas!.Clear(),
+                Throws.TypeOf<ObjectDisposedException>());
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+        });
+    }
+
+    [TestCase(HiddenRendererCall.Render, false)]
+    [TestCase(HiddenRendererCall.Rasterize, false)]
+    [TestCase(HiddenRendererCall.Measure, false)]
+    [TestCase(HiddenRendererCall.HitTest, false)]
+    [TestCase(HiddenRendererCall.Render, true)]
+    [TestCase(HiddenRendererCall.Rasterize, true)]
+    [TestCase(HiddenRendererCall.Measure, true)]
+    [TestCase(HiddenRendererCall.HitTest, true)]
+    public void DeferredCallback_RejectsHiddenRendererLaunchAndClearsTheGuard(
+        HiddenRendererCall call,
+        bool constructBeforeCallback)
+    {
+        using var hiddenRoot = new RectangleRenderNode(s_bounds, Brushes.Resource.White, null);
+        using var preconstructed = constructBeforeCallback ? CreateHiddenRenderer(hiddenRoot) : null;
+        using var node = new HiddenRendererLaunchNode(hiddenRoot, preconstructed, call);
+        using var renderer = FailureTestSupport.CreateRenderer(node, useRenderCache: false);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => renderer.Rasterize());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Does.Contain("cannot be launched"));
+            Assert.That(node.CallbackEntries, Is.EqualTo(1));
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+        });
+
+        using RenderNodeRenderer outside = preconstructed ?? CreateHiddenRenderer(hiddenRoot);
+        Assert.That(() => outside.Measure(), Throws.Nothing,
+            "The execution-callback guard must be cleared even when the callback fails.");
+    }
+
+    private static RenderNodeRenderer CreateHiddenRenderer(RenderNode root)
+        => new(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_bounds,
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+            });
+
+    public enum GuardedCanvasViolation
+    {
+        AuthorDispose,
+        Snapshot,
+        NestedDraw,
+        SaveLayer,
+        OpacityLayer,
+        BlendLayer,
+        MaskLayer,
+        PaintLayer,
+        NativeTarget,
+        HiddenAllocation,
+        HiddenFlush,
+    }
+
+    public enum GeometryFailure
+    {
+        UndeclaredInputReadback,
+        DuplicateInputReadback,
+        Callback,
+        InvalidShrink,
+        SecondCanvasOpen,
+        UseAfterCanvasClose,
+    }
+
+    public enum OpaqueTopology
+    {
+        Source,
+        Map,
+        Combine,
+        Expand,
+    }
+
+    public enum DynamicOutputFailure
+    {
+        MissingRequiredOutput,
+        ExceedsMaximum,
+        OutOfDeclaredBounds,
+    }
+
+    public enum HiddenRendererCall
+    {
+        Render,
+        Rasterize,
+        Measure,
+        HitTest,
+    }
+
+    private sealed class HiddenRendererLaunchNode(
+        RenderNode hiddenRoot,
+        RenderNodeRenderer? preconstructed,
+        HiddenRendererCall call) : RenderNode
+    {
+        public int CallbackEntries { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            context.Publish(context.OpaqueSource(FailureTestSupport.SourceDescription(
+                ExecuteDeferred,
+                structuralKey: $"hidden-renderer-{call}-{preconstructed is not null}")));
+        }
+
+        private void ExecuteDeferred(OpaqueRenderSession session)
+        {
+            CallbackEntries++;
+            using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+            output.Canvas.Use(canvas =>
+            {
+                RenderNodeRenderer renderer = preconstructed ?? CreateHiddenRenderer(hiddenRoot);
+                try
+                {
+                    switch (call)
+                    {
+                        case HiddenRendererCall.Render:
+                            renderer.Render(canvas);
+                            break;
+                        case HiddenRendererCall.Rasterize:
+                            using (renderer.Rasterize())
+                            {
+                            }
+                            break;
+                        case HiddenRendererCall.Measure:
+                            _ = renderer.Measure();
+                            break;
+                        case HiddenRendererCall.HitTest:
+                            _ = renderer.HitTest(new Point(1, 1));
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                }
+                finally
+                {
+                    if (preconstructed is null)
+                        renderer.Dispose();
+                }
+            });
+            session.Publish(output);
+        }
+    }
+
+    private sealed class GuardedCanvasViolationNode(GuardedCanvasViolation violation) : RenderNode
+    {
+        public int CallbackEntries { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            OpaqueRenderDescription description = FailureTestSupport.SourceDescription(
+                session =>
+                {
+                    CallbackEntries++;
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    using SKSurface hiddenSurface = SKSurface.Create(new SKImageInfo(1, 1));
+                    output.Canvas.Use(canvas => InvokeViolation(canvas, hiddenSurface));
+                    session.Publish(output);
+                },
+                structuralKey: $"guarded-canvas-{violation}");
+            context.Publish(context.OpaqueSource(description));
+        }
+
+        private void InvokeViolation(ImmediateCanvas canvas, SKSurface hiddenSurface)
+        {
+            switch (violation)
+            {
+                case GuardedCanvasViolation.AuthorDispose:
+                    canvas.Dispose();
+                    break;
+                case GuardedCanvasViolation.Snapshot:
+                    _ = canvas.Snapshot();
+                    break;
+                case GuardedCanvasViolation.NestedDraw:
+                    canvas.DrawNode(this);
+                    break;
+                case GuardedCanvasViolation.SaveLayer:
+                    canvas.PushLayer().Dispose();
+                    break;
+                case GuardedCanvasViolation.OpacityLayer:
+                    canvas.PushOpacity(0.5f).Dispose();
+                    break;
+                case GuardedCanvasViolation.BlendLayer:
+                    canvas.PushBlendMode(BlendMode.Multiply).Dispose();
+                    break;
+                case GuardedCanvasViolation.MaskLayer:
+                    canvas.PushOpacityMask(Brushes.Resource.White, s_bounds).Dispose();
+                    break;
+                case GuardedCanvasViolation.PaintLayer:
+                    using (var paint = new SKPaint())
+                        canvas.PushPaint(paint).Dispose();
+                    break;
+                case GuardedCanvasViolation.NativeTarget:
+                    using (RenderTarget.GetRenderTarget(canvas))
+                    {
+                    }
+                    break;
+                case GuardedCanvasViolation.HiddenAllocation:
+                    using (canvas.CreateExecutionView())
+                    {
+                    }
+                    break;
+                case GuardedCanvasViolation.HiddenFlush:
+                    canvas.DrawSurface(hiddenSurface, default);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+    }
+
+    private sealed class GeometryFailureNode(GeometryFailure failurePoint) : RenderNode
+    {
+        public int CallbackEntries { get; private set; }
+
+        public GeometrySession? RetainedSession { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle source = context.OpaqueSource(FailureTestSupport.SourceDescription(
+                structuralKey: $"geometry-source-{failurePoint}"));
+            bool readback = failurePoint == GeometryFailure.DuplicateInputReadback;
+            GeometryDescription description = GeometryDescription.CreateRequestLocal(
+                session =>
+                {
+                    CallbackEntries++;
+                    RetainedSession = session;
+                    switch (failurePoint)
+                    {
+                        case GeometryFailure.UndeclaredInputReadback:
+                            session.Input.UseSnapshot(static _ => { });
+                            break;
+                        case GeometryFailure.DuplicateInputReadback:
+                            session.Input.UseSnapshot(static _ => { });
+                            session.Input.UseSnapshot(static _ => { });
+                            break;
+                        case GeometryFailure.Callback:
+                            throw new InvalidOperationException("geometry-callback-primary");
+                        case GeometryFailure.InvalidShrink:
+                            session.SetOutputBounds(new Rect(-1, -1, 12, 12));
+                            break;
+                        case GeometryFailure.SecondCanvasOpen:
+                            session.Canvas.Use(static canvas => canvas.Clear(Colors.Red));
+                            session.Canvas.Use(static canvas => canvas.Clear(Colors.Blue));
+                            break;
+                        case GeometryFailure.UseAfterCanvasClose:
+                            {
+                                ImmediateCanvas? retained = null;
+                                session.Canvas.Use(canvas => retained = canvas);
+                                retained!.Clear();
+                                break;
+                            }
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                },
+                RenderBoundsContract.Identity,
+                RenderHitTestContract.AnyInput,
+                structuralKey: $"geometry-failure-{failurePoint}",
+                requiresReadback: readback);
+            context.Publish(context.Geometry(source, description));
+        }
+    }
+
+    private sealed class OpaqueTopologyFailureNode(
+        OpaqueTopology topology,
+        InvalidOperationException failure) : RenderNode
+    {
+        public int FaultingCallbackEntries { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            void Fail(OpaqueRenderSession _)
+            {
+                FaultingCallbackEntries++;
+                throw failure;
+            }
+
+            if (topology == OpaqueTopology.Source)
+            {
+                context.Publish(context.OpaqueSource(OpaqueRenderDescription.CreateRequestLocal(
+                    Fail,
+                    OpaqueRenderBoundsContract.Source(s_bounds),
+                    RenderHitTestContract.OutputBounds,
+                    RenderValueCardinality.Single,
+                    RenderScaleContract.MaterializeAtWorkingScale,
+                    structuralKey: "faulting-opaque-source")));
+                return;
+            }
+
+            RenderFragmentHandle first = context.OpaqueSource(FailureTestSupport.SourceDescription(
+                structuralKey: $"opaque-{topology}-input-a"));
+            if (topology == OpaqueTopology.Map)
+            {
+                OpaqueRenderDescription map = OpaqueRenderDescription.CreateRequestLocal(
+                    Fail,
+                    OpaqueRenderBoundsContract.Map(RenderBoundsContract.Identity),
+                    RenderHitTestContract.AnyInput,
+                    RenderValueCardinality.Single,
+                    RenderScaleContract.PreserveInputSupply,
+                    structuralKey: "faulting-opaque-map");
+                context.Publish(context.OpaqueMap(first, map));
+                return;
+            }
+
+            RenderFragmentHandle second = context.OpaqueSource(FailureTestSupport.SourceDescription(
+                structuralKey: $"opaque-{topology}-input-b"));
+            OpaqueRenderDescription many = OpaqueRenderDescription.CreateRequestLocal(
+                Fail,
+                OpaqueRenderBoundsContract.FullInputs(
+                    static bounds => bounds.Aggregate(default(Rect), static (result, value) => result.Union(value)),
+                    $"opaque-{topology}-bounds"),
+                RenderHitTestContract.AnyInput,
+                topology == OpaqueTopology.Combine ? RenderValueCardinality.Single : RenderValueCardinality.Dynamic,
+                RenderScaleContract.Vector,
+                structuralKey: $"faulting-opaque-{topology}");
+            RenderFragmentHandle output = topology == OpaqueTopology.Combine
+                ? context.OpaqueCombine([first, second], many)
+                : context.OpaqueExpand([first, second], many);
+            context.Publish(output);
+        }
+    }
+
+    private sealed class DynamicOutputFailureNode(DynamicOutputFailure failurePoint) : RenderNode
+    {
+        public int CallbackEntries { get; private set; }
+
+        public DynamicOutputFailure? ReachedFailurePoint { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            OpaqueRenderDescription description = OpaqueRenderDescription.CreateRequestLocal(
+                session =>
+                {
+                    CallbackEntries++;
+                    ReachedFailurePoint = failurePoint;
+                    switch (failurePoint)
+                    {
+                        case DynamicOutputFailure.MissingRequiredOutput:
+                            return;
+                        case DynamicOutputFailure.ExceedsMaximum:
+                            {
+                                using OpaqueRenderOutput first = session.CreateOutput(new Rect(0, 0, 4, 8));
+                                using OpaqueRenderOutput second = session.CreateOutput(new Rect(4, 0, 4, 8));
+                                session.Publish(first);
+                                session.Publish(second);
+                                return;
+                            }
+                        case DynamicOutputFailure.OutOfDeclaredBounds:
+                            using (session.CreateOutput(new Rect(-1, 0, 9, 8)))
+                            {
+                            }
+                            return;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                },
+                OpaqueRenderBoundsContract.Source(s_bounds),
+                RenderHitTestContract.OutputBounds,
+                failurePoint == DynamicOutputFailure.ExceedsMaximum
+                    ? RenderValueCardinality.Range(0, 1)
+                    : RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: $"dynamic-output-{failurePoint}");
+            context.Publish(context.OpaqueSource(description));
+        }
+    }
+
+    private sealed class UndeclaredResourceNode : RenderNode
+    {
+        public FailureTestDisposable Borrowed { get; } = new();
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<FailureTestDisposable> borrowed = context.Borrow(
+                Borrowed,
+                "undeclared-callback-resource",
+                0);
+            OpaqueRenderDescription description = OpaqueRenderDescription.CreateRequestLocal(
+                session => session.UseResource(borrowed, static _ => { }),
+                OpaqueRenderBoundsContract.Source(s_bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: "undeclared-resource-source");
+            context.Publish(context.OpaqueSource(description));
+        }
+    }
+
+    private sealed class RetainedFacadeNode : RenderNode
+    {
+        public OpaqueRenderSession? Session { get; private set; }
+
+        public RenderExecutionInput? Input { get; private set; }
+
+        public OpaqueRenderOutput? Output { get; private set; }
+
+        public RenderCallbackCanvas? CanvasFacade { get; private set; }
+
+        public ImmediateCanvas? ImmediateCanvas { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle source = context.OpaqueSource(FailureTestSupport.SourceDescription(
+                structuralKey: "retained-facade-source"));
+            OpaqueRenderDescription map = OpaqueRenderDescription.CreateRequestLocal(
+                session =>
+                {
+                    Session = session;
+                    Input = session.Inputs.Single();
+                    OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    Output = output;
+                    CanvasFacade = output.Canvas;
+                    output.Canvas.Use(canvas =>
+                    {
+                        ImmediateCanvas = canvas;
+                        session.Inputs.Single().Draw(canvas);
+                    });
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.Map(RenderBoundsContract.Identity),
+                RenderHitTestContract.AnyInput,
+                RenderValueCardinality.Single,
+                RenderScaleContract.PreserveInputSupply,
+                structuralKey: "retained-facade-map");
+            context.Publish(context.OpaqueMap(source, map));
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/GeometrySessionTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/GeometrySessionTests.cs
@@ -1,0 +1,316 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Failure;
+
+[TestFixture]
+public sealed class GeometrySessionTests
+{
+    [Test]
+    public void Description_RequiresBoundsHitTestAndStableIdentities()
+    {
+        using var registry = new RenderRequestResourceRegistry();
+        var raw = new object();
+        RenderResource<object> resource = registry.RegisterBorrowed(raw, "geometry-resource", 3);
+        Action<GeometrySession> render = static _ => { };
+        GeometryDescription description = GeometryDescription.Create(
+            ("pixels", 4),
+            static (_, _) => { },
+            RenderBoundsContract.Identity,
+            RenderHitTestContract.AnyInput,
+            structuralKey: "geometry",
+            requiresReadback: true,
+            resources: [resource.Bind("geometry")]);
+        GeometryDescription requestLocal = GeometryDescription.CreateRequestLocal(
+            render,
+            RenderBoundsContract.Identity,
+            RenderHitTestContract.AnyInput);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(description.Bounds, Is.EqualTo(RenderBoundsContract.Identity));
+            Assert.That(description.HitTest, Is.EqualTo(RenderHitTestContract.AnyInput));
+            Assert.That(description.StructuralKey, Is.EqualTo("geometry"));
+            Assert.That(description.RuntimeIdentity, Is.Not.Null);
+            Assert.That(description.RequiresReadback, Is.True);
+            Assert.That(description.Resources, Has.Count.EqualTo(1));
+            Assert.That(description.Resources[0].Name, Is.EqualTo("geometry"));
+            Assert.That(description.Resources[0].Resource, Is.SameAs(resource));
+            Assert.That(requestLocal.RuntimeIdentity, Is.Null,
+                "A request-local description publishes no identity a later request could match.");
+            Assert.That(
+                () => GeometryDescription.CreateRequestLocal(null!, RenderBoundsContract.Identity, RenderHitTestContract.None),
+                Throws.TypeOf<ArgumentNullException>());
+            Assert.That(
+                () => GeometryDescription.CreateRequestLocal(render, default, RenderHitTestContract.None),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => GeometryDescription.CreateRequestLocal(render, RenderBoundsContract.Identity, default),
+                Throws.TypeOf<ArgumentException>());
+        });
+    }
+
+    [Test]
+    public void Description_DerivesEqualIdentitiesFromEqualStateAndDistinctOnesFromDistinctState()
+    {
+        GeometryDescription first = GeometryDescription.Create(
+            ("pixels", 4),
+            RenderNothing,
+            RenderBoundsContract.Identity,
+            RenderHitTestContract.AnyInput);
+        GeometryDescription second = GeometryDescription.Create(
+            ("pixels", 4),
+            RenderNothing,
+            RenderBoundsContract.Identity,
+            RenderHitTestContract.AnyInput);
+        GeometryDescription different = GeometryDescription.Create(
+            ("pixels", 5),
+            RenderNothing,
+            RenderBoundsContract.Identity,
+            RenderHitTestContract.AnyInput);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(second.RuntimeIdentity, Is.EqualTo(first.RuntimeIdentity),
+                "Equal state must produce an identity a later request's cache lookup can match.");
+            Assert.That(different.RuntimeIdentity, Is.Not.EqualTo(first.RuntimeIdentity),
+                "A changed state value must change the identity, which is what makes a stale hit impossible.");
+        });
+    }
+
+    [Test]
+    public void Create_RejectsACapturingCallbackAndNamesTheStateParameter()
+    {
+        var color = Colors.Red;
+        ArgumentException? rejection = Assert.Throws<ArgumentException>(
+            () => GeometryDescription.Create(
+                "under-specified",
+                (session, _) => session.Canvas.Use(canvas => canvas.Clear(color)),
+                RenderBoundsContract.Identity,
+                RenderHitTestContract.AnyInput));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rejection!.ParamName, Is.EqualTo("render"));
+            Assert.That(rejection.Message, Does.Contain("state"));
+        });
+    }
+
+    private static void RenderNothing(GeometrySession session, (string Kind, int Value) state)
+    {
+    }
+
+    [Test]
+    public void Description_StructuralIdentityUsesFullValueEquality()
+    {
+        using var registry = new RenderRequestResourceRegistry();
+        RenderResource<object> firstObject = registry.RegisterBorrowed(new object(), "first-object", 1);
+        RenderResource<string> firstString = registry.RegisterBorrowed(new string('a', 1), "first-string", 1);
+        RenderResource<object> secondObject = registry.RegisterBorrowed(new object(), "second-object", 1);
+        RenderResource<string> secondString = registry.RegisterBorrowed(new string('b', 1), "second-string", 1);
+
+        GeometryDescription first = CreateDescription(
+            RenderBoundsContract.Identity,
+            RenderHitTestContract.AnyInput,
+            requiresReadback: true,
+            resources: [firstObject.Bind("object"), firstString.Bind("text")]);
+        GeometryDescription equal = CreateDescription(
+            RenderBoundsContract.Identity,
+            RenderHitTestContract.AnyInput,
+            requiresReadback: true,
+            resources: [secondObject.Bind("object"), secondString.Bind("text")]);
+        GeometryDescription differentBounds = CreateDescription(
+            RenderBoundsContract.FullInput,
+            RenderHitTestContract.AnyInput,
+            requiresReadback: true,
+            resources: [secondObject.Bind("object"), secondString.Bind("text")]);
+        GeometryDescription differentHitTest = CreateDescription(
+            RenderBoundsContract.Identity,
+            RenderHitTestContract.None,
+            requiresReadback: true,
+            resources: [secondObject.Bind("object"), secondString.Bind("text")]);
+        GeometryDescription differentReadback = CreateDescription(
+            RenderBoundsContract.Identity,
+            RenderHitTestContract.AnyInput,
+            requiresReadback: false,
+            resources: [secondObject.Bind("object"), secondString.Bind("text")]);
+        GeometryDescription differentResourceOrder = CreateDescription(
+            RenderBoundsContract.Identity,
+            RenderHitTestContract.AnyInput,
+            requiresReadback: true,
+            resources: [secondString.Bind("text"), secondObject.Bind("object")]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.StructuralIdentity, Is.EqualTo(equal.StructuralIdentity));
+            Assert.That(
+                first.StructuralIdentity.GetHashCode(),
+                Is.EqualTo(equal.StructuralIdentity.GetHashCode()));
+            Assert.That(first.StructuralIdentity, Is.Not.EqualTo(differentBounds.StructuralIdentity));
+            Assert.That(first.StructuralIdentity, Is.Not.EqualTo(differentHitTest.StructuralIdentity));
+            Assert.That(first.StructuralIdentity, Is.Not.EqualTo(differentReadback.StructuralIdentity));
+            Assert.That(first.StructuralIdentity, Is.Not.EqualTo(differentResourceOrder.StructuralIdentity));
+        });
+
+        static GeometryDescription CreateDescription(
+            RenderBoundsContract bounds,
+            RenderHitTestContract hitTest,
+            bool requiresReadback,
+            IEnumerable<RenderResourceBinding> resources)
+        {
+            return GeometryDescription.CreateRequestLocal(
+                static _ => { },
+                bounds,
+                hitTest,
+                structuralKey: "geometry-shape",
+                requiresReadback: requiresReadback,
+                resources: resources);
+        }
+    }
+
+    [Test]
+    public void Session_UsesCompositionGlobalCanvasAndScopesEveryFacade()
+    {
+        var inputBounds = new Rect(8.5f, 17.25f, 10, 8);
+        var outputBounds = new Rect(10.25f, 20.5f, 5, 4);
+        const float density = 2;
+        PixelRect deviceBounds = PixelRect.FromRect(outputBounds, density);
+        var sessionToken = new RenderExecutionSessionToken();
+        using var registry = new RenderRequestResourceRegistry();
+        var raw = new object();
+        RenderResource<object> resource = registry.RegisterBorrowed(raw, "geometry-resource", 2);
+        registry.Commit(resource);
+        var input = new RenderExecutionInput(
+            sessionToken,
+            inputBounds,
+            EffectiveScale.At(1.5f),
+            static (_, _) => { },
+            static (_, _) => { },
+            createShader: null,
+            createSnapshot: null,
+            readbackDeclared: false);
+        using RenderTarget target = RenderTarget.CreateNull(deviceBounds.Width, deviceBounds.Height);
+        var canvas = new RenderCallbackCanvas(
+            sessionToken,
+            density,
+            outputBounds,
+            () => new ImmediateCanvas(target, density, maxWorkingScale: 4, outputBounds.Size),
+            CallbackCanvasCapability.Draw);
+        var session = new GeometrySession(
+            sessionToken,
+            input,
+            outputBounds,
+            outputBounds,
+            deviceBounds,
+            outputScale: 1,
+            workingScale: density,
+            maxWorkingScale: 4,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            canvas,
+            [resource.Bind("geometry")]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(session.Input, Is.SameAs(input));
+            Assert.That(session.OutputBounds, Is.EqualTo(outputBounds));
+            Assert.That(session.RequiredRegion, Is.EqualTo(outputBounds));
+            Assert.That(session.DeviceBounds, Is.EqualTo(deviceBounds));
+            Assert.That(session.DeviceSize, Is.EqualTo(deviceBounds.Size));
+            Assert.That(session.OutputScale, Is.EqualTo(1));
+            Assert.That(session.WorkingScale, Is.EqualTo(density));
+            Assert.That(session.MaxWorkingScale, Is.EqualTo(4));
+            Assert.That(session.Intent, Is.EqualTo(RenderIntent.Preview));
+            Assert.That(session.Purpose, Is.EqualTo(RenderRequestPurpose.Frame));
+        });
+
+        bool resourceUsed = false;
+        session.UseResource(resource, value => resourceUsed = ReferenceEquals(value, raw));
+        session.Canvas.Use(immediate => session.Input.Draw(immediate));
+        Assert.Multiple(() =>
+        {
+            Assert.That(resourceUsed, Is.True);
+            Assert.That(() => session.Canvas.Use(static _ => { }), Throws.TypeOf<InvalidOperationException>());
+        });
+
+        sessionToken.Complete();
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => _ = session.Input, Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => _ = session.OutputBounds, Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => session.UseResource(resource, static _ => { }), Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => session.SetOutputBounds(outputBounds), Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => session.DiscardOutput(), Throws.TypeOf<InvalidOperationException>());
+        });
+    }
+
+    [Test]
+    public void Session_AllowsOnlyContainedShrinkAndDiscardWins()
+    {
+        Rect allocated = new(10, 20, 30, 40);
+        GeometrySession session = CreateSession(allocated, out RenderExecutionSessionToken token, out RenderTarget target);
+        try
+        {
+            var shrink = new Rect(12, 23, 8, 9);
+            session.SetOutputBounds(shrink);
+            Assert.That(session.OutputBounds, Is.EqualTo(shrink));
+            Assert.That(
+                () => session.SetOutputBounds(new Rect(0, 0, 100, 100)),
+                Throws.TypeOf<ArgumentException>());
+
+            session.DiscardOutput();
+            session.SetOutputBounds(new Rect(13, 24, 1, 1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(session.IsOutputDiscarded, Is.True);
+                Assert.That(session.OutputBounds, Is.EqualTo(new Rect(13, 24, 1, 1)));
+            });
+        }
+        finally
+        {
+            token.Complete();
+            target.Dispose();
+        }
+    }
+
+    private static GeometrySession CreateSession(
+        Rect bounds,
+        out RenderExecutionSessionToken token,
+        out RenderTarget target)
+    {
+        token = new RenderExecutionSessionToken();
+        var input = new RenderExecutionInput(
+            token,
+            bounds,
+            EffectiveScale.At(1),
+            static (_, _) => { },
+            static (_, _) => { },
+            createShader: null,
+            createSnapshot: null,
+            readbackDeclared: false);
+        PixelRect deviceBounds = PixelRect.FromRect(bounds, 1);
+        RenderTarget outputTarget = RenderTarget.CreateNull(deviceBounds.Width, deviceBounds.Height);
+        target = outputTarget;
+        var canvas = new RenderCallbackCanvas(
+            token,
+            density: 1,
+            bounds,
+            () => new ImmediateCanvas(outputTarget, 1, float.PositiveInfinity, bounds.Size),
+            CallbackCanvasCapability.Draw);
+        return new GeometrySession(
+            token,
+            input,
+            bounds,
+            bounds,
+            deviceBounds,
+            outputScale: 1,
+            workingScale: 1,
+            maxWorkingScale: float.PositiveInfinity,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            canvas,
+            []);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/NestedTargetAndCleanupFailureTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/NestedTargetAndCleanupFailureTests.cs
@@ -1,0 +1,1439 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Failure;
+
+[TestFixture]
+public sealed class NestedTargetAndCleanupFailureTests
+{
+    private static readonly Rect s_bounds = new(0, 0, 8, 8);
+
+    [TestCase(TargetCallbackFailure.CommandCallback)]
+    [TestCase(TargetCallbackFailure.UndeclaredTargetReadback)]
+    [TestCase(TargetCallbackFailure.MissingTargetReadback)]
+    [TestCase(TargetCallbackFailure.UndeclaredInputReadback)]
+    [TestCase(TargetCallbackFailure.DuplicateInputReadback)]
+    [TestCase(TargetCallbackFailure.ScopeCallback)]
+    [TestCase(TargetCallbackFailure.ScopeMissingReplay)]
+    [TestCase(TargetCallbackFailure.ScopeDoubleReplay)]
+    [TestCase(TargetCallbackFailure.RawCommandCallback)]
+    [TestCase(TargetCallbackFailure.RawScopeCallback)]
+    [TestCase(TargetCallbackFailure.RawScopeMissingReplay)]
+    [TestCase(TargetCallbackFailure.RawScopeDoubleReplay)]
+    public void TargetCommandScopeAndRawFailures_DischargeAllStateAndSealTheSession(
+        TargetCallbackFailure failurePoint)
+    {
+        using var node = new TargetCallbackFailureNode(failurePoint);
+        using var renderer = FailureTestSupport.CreateRenderer(node, useRenderCache: false);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => renderer.Rasterize());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Does.Contain(ExpectedTargetCallbackFailureMessage(failurePoint)));
+            Assert.That(node.CallbackEntries, Is.EqualTo(1));
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            Assert.That(node.Cache.IsCached, Is.False);
+            Assert.That(node.VerifyRetainedSession is not null, Is.True);
+        });
+        Action verifyRetainedSession = node.VerifyRetainedSession
+            ?? throw new AssertionException("The deferred callback did not expose its retained-session probe.");
+        Assert.That(verifyRetainedSession, Throws.TypeOf<InvalidOperationException>());
+    }
+
+    private static string ExpectedTargetCallbackFailureMessage(TargetCallbackFailure failurePoint)
+        => failurePoint switch
+        {
+            TargetCallbackFailure.CommandCallback => "target-command-primary",
+            TargetCallbackFailure.UndeclaredTargetReadback => "did not declare target readback",
+            TargetCallbackFailure.MissingTargetReadback => "consume its snapshot exactly once",
+            TargetCallbackFailure.UndeclaredInputReadback => "CPU readback was not declared",
+            TargetCallbackFailure.DuplicateInputReadback => "snapshot is a one-shot lease",
+            TargetCallbackFailure.ScopeCallback => "target-scope-primary",
+            TargetCallbackFailure.ScopeMissingReplay or TargetCallbackFailure.ScopeDoubleReplay
+                => "A target scope input must be replayed exactly once",
+            TargetCallbackFailure.RawCommandCallback => "raw-command-primary",
+            TargetCallbackFailure.RawScopeCallback => "raw-scope-primary",
+            TargetCallbackFailure.RawScopeMissingReplay or TargetCallbackFailure.RawScopeDoubleReplay
+                => "A raw target scope input must be replayed exactly once",
+            _ => throw new ArgumentOutOfRangeException(nameof(failurePoint), failurePoint, null),
+        };
+
+    [Test]
+    public void TargetCaptureAllocationFailure_DischargesTheRootAndPublishesNoCapture()
+    {
+        using var node = new TargetCaptureNode();
+        var factory = new FailureTestTargetFactory(failAt: 1);
+        using var renderer = FailureTestSupport.CreateRenderer(node, factory, useRenderCache: false);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(() => renderer.Rasterize());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Does.Contain("could not allocate"));
+            Assert.That(factory.CreateCalls, Is.EqualTo(2));
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            Assert.That(node.Cache.IsCached, Is.False);
+        });
+    }
+
+    [TestCase(TransientMaterializationKind.Layer)]
+    [TestCase(TransientMaterializationKind.TargetLayerScope)]
+    public void TransientMaterializationFailure_ReleasesItsValueBeforePropagating(
+        TransientMaterializationKind kind)
+    {
+        using RenderTarget destination = FailureTestSupport.CreateCpuTarget();
+        using var registry = new RenderTargetLeaseRegistry(factory: null);
+        using var node = new TransientMaterializationFailureNode(
+            kind,
+            () => registry.Statistics.LeasedTargets);
+        using RenderRequest request = FailureTestSupport.CreateFrameRequest(useRenderCache: false);
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        using CompiledRenderRequest compiled = new RenderRequestCompiler().Compile(request, graph);
+        using var canvas = new ImmediateCanvas(destination);
+        using RenderTargetLeaseSession targets = registry.BeginSession(
+            RenderIntent.Preview,
+            RenderAllocationBudget.Default,
+            destination);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => new RenderRequestExecutor(targets).Execute(compiled, canvas));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.SameAs(node.PrimaryFailure));
+            Assert.That(node.LeasedTargetsObservedBySource, Is.EqualTo(1),
+                "The failure must occur after the transient target has been acquired.");
+            Assert.That(node.LeasedTargetsObservedByCaller, Is.Zero,
+                "The transient target must be released before control returns to the replaying caller.");
+            Assert.That(registry.Statistics.LeasedTargets, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void TargetCapturePostAllocationFailure_ReleasesItsValueBeforePropagating()
+    {
+        var primary = new InvalidOperationException("target-capture-post-allocation");
+        using RenderTarget destination = FailureTestSupport.CreateCpuTarget();
+        using var registry = new RenderTargetLeaseRegistry(factory: null);
+        using var node = new TargetCapturePostAllocationFailureNode(
+            primary,
+            () => registry.Statistics.LeasedTargets);
+        using RenderRequest request = FailureTestSupport.CreateFrameRequest(useRenderCache: false);
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        using CompiledRenderRequest compiled = new RenderRequestCompiler().Compile(request, graph);
+        using var canvas = new ImmediateCanvas(destination);
+        using RenderTargetLeaseSession targets = registry.BeginSession(
+            RenderIntent.Preview,
+            RenderAllocationBudget.Default,
+            destination);
+        int? leasedTargetsObservedByHook = null;
+        var executor = new RenderRequestExecutor(
+            targets,
+            afterCaptureAllocation: kind =>
+            {
+                if (kind == RenderFragmentKind.TargetCapture)
+                {
+                    leasedTargetsObservedByHook = registry.Statistics.LeasedTargets;
+                    throw primary;
+                }
+            });
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => executor.Execute(compiled, canvas));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.SameAs(primary));
+            Assert.That(leasedTargetsObservedByHook, Is.EqualTo(1));
+            Assert.That(node.LeasedTargetsObservedByCaller, Is.Zero,
+                "The capture target must be released before control returns to the replaying caller.");
+            Assert.That(registry.Statistics.Creates, Is.EqualTo(1));
+            Assert.That(registry.Statistics.PeakLiveTargets, Is.EqualTo(1));
+            Assert.That(registry.Statistics.LeasedTargets, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void Graphics3DBackendBoundaryFailure_RemainsPrimaryAndPublishesNoOutput()
+    {
+        var primary = new InvalidOperationException("graphics3d-backend-primary");
+        using var node = new BackendBoundaryFailureNode(primary);
+        using var renderer = FailureTestSupport.CreateRenderer(node, useRenderCache: false);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(() => renderer.Rasterize());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.SameAs(primary));
+            Assert.That(node.ExecuteCalls, Is.EqualTo(1));
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            Assert.That(node.Cache.IsCached, Is.False);
+        });
+    }
+
+    [Test]
+    public void NestedChildRegionAnalysisFailure_FailsTheFamilyBeforeAllocationAndPreservesThePrimary()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        var snapshots = new List<RenderPipelineDiagnosticSnapshot>();
+        diagnostics.RequestCompleted += snapshots.Add;
+        using var owner = new RenderRequestOwner();
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            targetDomain: s_bounds,
+            requestedRegion: s_bounds,
+            outputScale: 1,
+            maxWorkingScale: 1,
+            cachePolicy: RenderCacheOptions.Enabled,
+            owner: owner,
+            diagnostics: diagnostics);
+        using var child = new NestedRegionAnalysisFailureNode();
+        using var parent = new NestedPlanningFailureParentNode(child);
+        child.Cache.ReportRenderCount(RenderNodeCache.Count);
+        parent.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using var request = new RenderRequest(options);
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(parent);
+        RecordedNestedRenderRequest nested = graph.NestedRequests.Single();
+        var factory = new FailureTestTargetFactory();
+        using RenderTarget destination = FailureTestSupport.CreateCpuTarget();
+        using var canvas = new ImmediateCanvas(destination);
+        using var registry = new RenderTargetLeaseRegistry(factory);
+        using RenderTargetLeaseSession targets = registry.BeginSession(
+            RenderIntent.Preview,
+            RenderAllocationBudget.Default,
+            destination);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(() =>
+        {
+            using CompiledRenderRequest compiled = new RenderRequestCompiler().Compile(request, graph);
+            new RenderRequestExecutor(targets).Execute(compiled, canvas);
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.SameAs(NestedRegionAnalysisFailureNode.PrimaryFailure));
+            Assert.That(owner.PrimaryFailure?.SourceException, Is.SameAs(failure));
+            Assert.That(owner.SecondaryFailures, Is.Empty);
+            Assert.That(owner.CleanupFailures, Is.Empty);
+            Assert.That(owner.IsCleanedUp, Is.True);
+            Assert.That(nested.Request.State, Is.EqualTo(RenderRequestState.Failed));
+            Assert.That(request.State, Is.EqualTo(RenderRequestState.Failed));
+            Assert.That(child.ExecuteCalls, Is.Zero);
+            Assert.That(parent.ExecuteCalls, Is.Zero);
+            Assert.That(factory.CreateCalls, Is.Zero);
+            Assert.That(registry.Statistics.OwnedTargets, Is.Zero);
+            Assert.That(registry.Statistics.LeasedTargets, Is.Zero);
+            Assert.That(child.Cache.IsCached, Is.False);
+            Assert.That(parent.Cache.IsCached, Is.False);
+        });
+
+        Assert.That(
+            snapshots.Select(static snapshot => snapshot.RequestId),
+            Is.EqualTo(new[] { nested.Request.Id.Value, request.Id.Value }));
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshots[0].ParentRequestId, Is.EqualTo(request.Id.Value));
+            Assert.That(snapshots[1].ParentRequestId, Is.Null);
+            Assert.That(snapshots[1].Events, Has.Some.Matches<RenderPipelineDiagnosticEvent>(item =>
+                item.Kind == RenderPipelineDiagnosticEventKind.NestedRequest
+                && item.RelatedRequestId == nested.Request.Id.Value));
+            Assert.That(snapshots, Has.All.Matches<RenderPipelineDiagnosticSnapshot>(snapshot =>
+                !snapshot.Succeeded
+                && snapshot.FailurePhase == RenderPipelineFailurePhase.RegionAnalysis
+                && snapshot[RenderPipelineCounter.Failures] == 1
+                && snapshot[RenderPipelineCounter.ExecutedOutcomes] == 0
+                && snapshot[RenderPipelineCounter.ExecutedGpuPasses] == 0
+                && snapshot[RenderPipelineCounter.RenderCacheCaptures] == 0
+                && snapshot[RenderPipelineCounter.RejectedRenderCacheCaptures] == 0
+                && snapshot[RenderPipelineCounter.ExternalRootResources] == 0
+                && snapshot[RenderPipelineCounter.IntermediateAcquires]
+                == snapshot[RenderPipelineCounter.IntermediateDischarges]));
+            Assert.That(snapshots, Has.All.Matches<RenderPipelineDiagnosticSnapshot>(snapshot =>
+                snapshot[RenderPipelineCounter.RecordedFragments]
+                == snapshot[RenderPipelineCounter.ExecutedOutcomes]
+                + snapshot[RenderPipelineCounter.CachedOutcomes]
+                + snapshot[RenderPipelineCounter.MetadataOutcomes]
+                + snapshot[RenderPipelineCounter.SkippedOutcomes]
+                + snapshot[RenderPipelineCounter.FailedOutcomes]));
+        });
+    }
+
+    [Test]
+    public void NestedRequest_ExecutesAndCompletesWithinTheParentRequestFamily()
+    {
+        using var owner = new RenderRequestOwner();
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            targetDomain: s_bounds,
+            requestedRegion: s_bounds,
+            outputScale: 1,
+            maxWorkingScale: 1,
+            cachePolicy: RenderCacheOptions.Disabled,
+            owner: owner);
+        using var child = new NestedChildNode();
+        using var parent = new NestedParentNode(child);
+        using var request = new RenderRequest(options);
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(parent);
+        RecordedNestedRenderRequest nested = graph.NestedRequests.Single();
+        using CompiledRenderRequest compiled = new RenderRequestCompiler().Compile(request, graph);
+        using RenderTarget destination = FailureTestSupport.CreateCpuTarget();
+        using var canvas = new ImmediateCanvas(destination);
+        using var registry = new RenderTargetLeaseRegistry(factory: null);
+        using RenderTargetLeaseSession targets = registry.BeginSession(
+            RenderIntent.Preview,
+            RenderAllocationBudget.Default,
+            destination);
+
+        new RenderRequestExecutor(targets).Execute(compiled, canvas);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(child.ExecuteCalls, Is.EqualTo(1),
+                "A declared separate-target nested request must execute as part of the parent plan.");
+            Assert.That(nested.Request.State, Is.EqualTo(RenderRequestState.Completed));
+            Assert.That(registry.Statistics.LeasedTargets, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void NestedTarget_ParentReadsThePreparedFullDomainWithShiftedChildPixels()
+    {
+        var fullDomain = new Rect(0, 0, 10, 7);
+        var childBounds = new Rect(2, 1, 5, 4);
+        using var child = new ShiftedNestedChildNode(childBounds);
+        using var parent = new NestedOutputConsumerNode(child, fullDomain);
+        using var renderer = new RenderNodeRenderer(
+            parent,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = fullDomain,
+                    RequestedRegion = fullDomain,
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+            });
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        Bitmap bitmap = rasterization.Bitmap
+            ?? throw new AssertionException("The parent did not publish its nested target output.");
+        var inside = bitmap.SKBitmap.GetPixel(4, 3);
+        var outside = bitmap.SKBitmap.GetPixel(0, 0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(inside.Red, Is.GreaterThan(240));
+            Assert.That(inside.Alpha, Is.GreaterThan(240));
+            Assert.That(outside.Alpha, Is.Zero,
+                "The child must preserve its shifted origin inside the full transparent target domain.");
+            Assert.That(parent.NestedTarget, Is.Not.Null);
+            Assert.That(parent.NestedTarget!.Target.LogicalBounds, Is.EqualTo(fullDomain));
+            Assert.That(parent.NestedTarget.Target.DeviceBounds, Is.EqualTo(new PixelRect(0, 0, 10, 7)));
+            Assert.That(parent.NestedTarget.Target.IsDisposed, Is.True,
+                "The prepared child lease must remain live through the parent callback and discharge afterward.");
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void NestedTarget_MetadataQueriesRecurseWithoutExecutingOrAllocating()
+    {
+        using var child = new NestedChildNode();
+        using var parent = new NestedParentNode(child);
+        var factory = new FailureTestTargetFactory();
+        using var renderer = new RenderNodeRenderer(
+            parent,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_bounds,
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = factory,
+            });
+
+        RenderNodeMeasurement measurement = renderer.Measure();
+        bool hit = renderer.HitTest(new Point(1, 1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(measurement.HasFragments, Is.True);
+            Assert.That(hit, Is.True);
+            Assert.That(child.ExecuteCalls, Is.Zero);
+            Assert.That(factory.CreateCalls, Is.Zero);
+            Assert.That(renderer.TargetPoolStatistics.OwnedTargets, Is.Zero);
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void NestedChildExecutionFailure_FailsTheWholeFamilyWithOnePrimaryAndSkipsParentGpuWork()
+    {
+        using var owner = new RenderRequestOwner();
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        var snapshots = new List<RenderPipelineDiagnosticSnapshot>();
+        diagnostics.RequestCompleted += snapshots.Add;
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            targetDomain: s_bounds,
+            requestedRegion: s_bounds,
+            outputScale: 1,
+            maxWorkingScale: 1,
+            cachePolicy: RenderCacheOptions.Disabled,
+            owner: owner,
+            diagnostics: diagnostics);
+        var primary = new InvalidOperationException("nested-child-primary");
+        var executionOrder = new List<string>();
+        using var child = new NestedExecutionNode("child", executionOrder, failure: primary);
+        using var parent = new NestedExecutionNode(
+            "parent",
+            executionOrder,
+            nestedRoot: child,
+            parentOptions: options);
+        using var request = new RenderRequest(options);
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(parent);
+        RecordedNestedRenderTarget nested = parent.NestedRequest
+            ?? throw new AssertionException("The parent did not record its nested request.");
+        using RenderRequest nestedRequest = nested.Request;
+        using CompiledRenderRequest compiled = new RenderRequestCompiler().Compile(request, graph);
+        using RenderTarget destination = FailureTestSupport.CreateCpuTarget();
+        using var canvas = new ImmediateCanvas(destination);
+        var factory = new FailureTestTargetFactory();
+        using var registry = new RenderTargetLeaseRegistry(factory);
+        using RenderTargetLeaseSession targets = registry.BeginSession(
+            RenderIntent.Preview,
+            RenderAllocationBudget.Default,
+            destination);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => new RenderRequestExecutor(targets).Execute(compiled, canvas));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.SameAs(primary));
+            Assert.That(owner.PrimaryFailure?.SourceException, Is.SameAs(primary));
+            Assert.That(owner.SecondaryFailures, Is.Empty,
+                "Propagating one child failure to the parent must not record it twice.");
+            Assert.That(executionOrder, Is.EqualTo(new[] { "child" }));
+            Assert.That(child.ExecuteCalls, Is.EqualTo(1));
+            Assert.That(parent.ExecuteCalls, Is.Zero,
+                "Parent GPU work must not start after a nested child has failed.");
+            Assert.That(factory.CreateCalls, Is.GreaterThan(0),
+                "The child must fail after acquiring execution storage so lease cleanup is exercised.");
+            Assert.That(nestedRequest.State, Is.EqualTo(RenderRequestState.Failed));
+            Assert.That(request.State, Is.EqualTo(RenderRequestState.Failed));
+            Assert.That(owner.IsCleanedUp, Is.True);
+            Assert.That(registry.Statistics.LeasedTargets, Is.Zero);
+            Assert.That(parent.NestedRequest!.Target.IsDisposed, Is.True,
+                "Family failure must reject and discharge the staged child target.");
+        });
+
+        Assert.That(
+            snapshots.Select(static snapshot => snapshot.RequestId),
+            Is.EqualTo(new[] { nestedRequest.Id.Value, request.Id.Value }),
+            "Nested completion must be reconciled before its parent completion.");
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshots[0].ParentRequestId, Is.EqualTo(request.Id.Value));
+            Assert.That(snapshots[0].Succeeded, Is.False);
+            Assert.That(snapshots[0].FailurePhase, Is.EqualTo(RenderPipelineFailurePhase.Execution));
+            Assert.That(snapshots[0][RenderPipelineCounter.Failures], Is.EqualTo(1));
+            Assert.That(snapshots[0][RenderPipelineCounter.FailedOutcomes], Is.EqualTo(1));
+            Assert.That(snapshots[1].ParentRequestId, Is.Null);
+            Assert.That(snapshots[1].Succeeded, Is.False);
+            Assert.That(snapshots[1].FailurePhase, Is.EqualTo(RenderPipelineFailurePhase.Execution));
+            Assert.That(snapshots[1][RenderPipelineCounter.Failures], Is.EqualTo(1));
+            Assert.That(snapshots[1][RenderPipelineCounter.SkippedOutcomes], Is.EqualTo(1));
+            Assert.That(
+                snapshots,
+                Has.All.Matches<RenderPipelineDiagnosticSnapshot>(snapshot =>
+                    snapshot[RenderPipelineCounter.IntermediateAcquires]
+                    == snapshot[RenderPipelineCounter.IntermediateDischarges]));
+        });
+    }
+
+    [Test]
+    public void ParentFailureAfterNestedCacheStaging_RejectsEveryFamilyCaptureAndFailsBothRequests()
+    {
+        using var owner = new RenderRequestOwner();
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        var snapshots = new List<RenderPipelineDiagnosticSnapshot>();
+        diagnostics.RequestCompleted += snapshots.Add;
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            targetDomain: s_bounds,
+            requestedRegion: s_bounds,
+            outputScale: 1,
+            maxWorkingScale: 1,
+            cachePolicy: RenderCacheOptions.Enabled,
+            owner: owner,
+            diagnostics: diagnostics);
+        var primary = new InvalidOperationException("nested-parent-primary");
+        var executionOrder = new List<string>();
+        using var child = new NestedExecutionNode("child-cache", executionOrder);
+        child.Cache.ReportRenderCount(RenderNodeCache.Count);
+        var parentCache = new NestedExecutionNode("parent-cache", executionOrder);
+        parentCache.Cache.ReportRenderCount(RenderNodeCache.Count);
+        var parentFailure = new NestedExecutionNode("parent-failure", executionOrder, failure: primary);
+        using var parent = new NestedContainerNode(child, options, parentCache, parentFailure);
+        using var request = new RenderRequest(options);
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(parent);
+        RecordedNestedRenderTarget nested = parent.NestedRequest
+            ?? throw new AssertionException("The parent did not record its nested request.");
+        using RenderRequest nestedRequest = nested.Request;
+        using CompiledRenderRequest compiled = new RenderRequestCompiler(
+            renderCacheContext: FailureTestSupport.CacheResolutionContext).Compile(request, graph);
+        using RenderTarget destination = FailureTestSupport.CreateCpuTarget();
+        using var canvas = new ImmediateCanvas(destination);
+        using var registry = new RenderTargetLeaseRegistry(factory: null);
+        using RenderTargetLeaseSession targets = registry.BeginSession(
+            RenderIntent.Preview,
+            RenderAllocationBudget.Default,
+            destination);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => new RenderRequestExecutor(targets).Execute(compiled, canvas));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.SameAs(primary));
+            Assert.That(owner.PrimaryFailure?.SourceException, Is.SameAs(primary));
+            Assert.That(owner.SecondaryFailures, Is.Empty,
+                "A successful child body is not a secondary failure when its family later aborts.");
+            Assert.That(
+                executionOrder,
+                Is.EqualTo(new[] { "child-cache", "parent-cache", "parent-failure" }));
+            Assert.That(child.ExecuteCalls, Is.EqualTo(1));
+            Assert.That(parentCache.ExecuteCalls, Is.EqualTo(1));
+            Assert.That(parentFailure.ExecuteCalls, Is.EqualTo(1));
+            Assert.That(nestedRequest.State, Is.EqualTo(RenderRequestState.Failed));
+            Assert.That(request.State, Is.EqualTo(RenderRequestState.Failed));
+            Assert.That(child.Cache.IsCached, Is.False,
+                "A nested capture must remain staged until the whole family commits.");
+            Assert.That(parentCache.Cache.IsCached, Is.False,
+                "A parent capture must not publish when later parent execution fails.");
+            Assert.That(owner.IsCleanedUp, Is.True);
+            Assert.That(registry.Statistics.LeasedTargets, Is.Zero);
+        });
+
+        Assert.That(
+            snapshots.Select(static snapshot => snapshot.RequestId),
+            Is.EqualTo(new[] { nestedRequest.Id.Value, request.Id.Value }));
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshots, Has.All.Matches<RenderPipelineDiagnosticSnapshot>(snapshot =>
+                !snapshot.Succeeded
+                && snapshot.FailurePhase == RenderPipelineFailurePhase.Execution
+                && snapshot[RenderPipelineCounter.Failures] == 1
+                && snapshot[RenderPipelineCounter.RenderCacheCaptures] == 0
+                && snapshot[RenderPipelineCounter.RejectedRenderCacheCaptures] == 1
+                && snapshot[RenderPipelineCounter.IntermediateAcquires]
+                == snapshot[RenderPipelineCounter.IntermediateDischarges]));
+            Assert.That(snapshots[0].ParentRequestId, Is.EqualTo(request.Id.Value));
+            Assert.That(snapshots[0][RenderPipelineCounter.ExecutedOutcomes], Is.EqualTo(1));
+            Assert.That(snapshots[0][RenderPipelineCounter.FailedOutcomes], Is.Zero,
+                "The successfully executed child body becomes a dependent request failure, not a failed fragment.");
+            Assert.That(snapshots[1].ParentRequestId, Is.Null);
+            Assert.That(snapshots[1][RenderPipelineCounter.ExecutedOutcomes], Is.EqualTo(1));
+            Assert.That(snapshots[1][RenderPipelineCounter.FailedOutcomes], Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void TwoLevelNestedRequests_ExecuteDepthFirstAndCompleteEveryRequest()
+    {
+        using var owner = new RenderRequestOwner();
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        var snapshots = new List<RenderPipelineDiagnosticSnapshot>();
+        diagnostics.RequestCompleted += snapshots.Add;
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            targetDomain: s_bounds,
+            requestedRegion: s_bounds,
+            outputScale: 1,
+            maxWorkingScale: 1,
+            cachePolicy: RenderCacheOptions.Disabled,
+            owner: owner,
+            diagnostics: diagnostics);
+        var executionOrder = new List<string>();
+        using var grandchild = new NestedExecutionNode("grandchild", executionOrder);
+        using var child = new NestedExecutionNode(
+            "child",
+            executionOrder,
+            nestedRoot: grandchild,
+            parentOptions: options);
+        using var parent = new NestedExecutionNode(
+            "parent",
+            executionOrder,
+            nestedRoot: child,
+            parentOptions: options);
+        using var request = new RenderRequest(options);
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(parent);
+        RecordedNestedRenderTarget childRecording = parent.NestedRequest
+            ?? throw new AssertionException("The parent did not record its nested child request.");
+        RecordedNestedRenderTarget grandchildRecording = child.NestedRequest
+            ?? throw new AssertionException("The child did not record its nested grandchild request.");
+        using RenderRequest childRequest = childRecording.Request;
+        using RenderRequest grandchildRequest = grandchildRecording.Request;
+        using CompiledRenderRequest compiled = new RenderRequestCompiler().Compile(request, graph);
+        using RenderTarget destination = FailureTestSupport.CreateCpuTarget();
+        using var canvas = new ImmediateCanvas(destination);
+        using var registry = new RenderTargetLeaseRegistry(factory: null);
+        using RenderTargetLeaseSession targets = registry.BeginSession(
+            RenderIntent.Preview,
+            RenderAllocationBudget.Default,
+            destination);
+
+        new RenderRequestExecutor(targets).Execute(compiled, canvas);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(executionOrder, Is.EqualTo(new[] { "grandchild", "child", "parent" }));
+            Assert.That(grandchild.ExecuteCalls, Is.EqualTo(1));
+            Assert.That(child.ExecuteCalls, Is.EqualTo(1));
+            Assert.That(parent.ExecuteCalls, Is.EqualTo(1));
+            Assert.That(grandchildRequest.State, Is.EqualTo(RenderRequestState.Completed));
+            Assert.That(childRequest.State, Is.EqualTo(RenderRequestState.Completed));
+            Assert.That(request.State, Is.EqualTo(RenderRequestState.Completed));
+            Assert.That(owner.PrimaryFailure, Is.Null);
+            Assert.That(owner.IsCleanedUp, Is.True);
+            Assert.That(registry.Statistics.LeasedTargets, Is.Zero);
+        });
+
+        Assert.That(
+            snapshots.Select(static snapshot => snapshot.RequestId),
+            Is.EqualTo(new[]
+            {
+                grandchildRequest.Id.Value,
+                childRequest.Id.Value,
+                request.Id.Value,
+            }));
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshots, Has.All.Matches<RenderPipelineDiagnosticSnapshot>(snapshot =>
+                snapshot.Succeeded
+                && snapshot[RenderPipelineCounter.IntermediateAcquires]
+                == snapshot[RenderPipelineCounter.IntermediateDischarges]));
+            Assert.That(snapshots[0].ParentRequestId, Is.EqualTo(childRequest.Id.Value));
+            Assert.That(snapshots[1].ParentRequestId, Is.EqualTo(request.Id.Value));
+            Assert.That(snapshots[2].ParentRequestId, Is.Null);
+            Assert.That(snapshots[1].Events, Has.Some.Matches<RenderPipelineDiagnosticEvent>(item =>
+                item.Kind == RenderPipelineDiagnosticEventKind.NestedRequest
+                && item.RelatedRequestId == grandchildRequest.Id.Value));
+            Assert.That(snapshots[2].Events, Has.Some.Matches<RenderPipelineDiagnosticEvent>(item =>
+                item.Kind == RenderPipelineDiagnosticEventKind.NestedRequest
+                && item.RelatedRequestId == childRequest.Id.Value));
+        });
+    }
+
+    [Test]
+    public void ExecutionPrimary_SurvivesCleanupFaultAndCleanupContinuesInStrictLifoOrder()
+    {
+        var order = new List<string>();
+        var primary = new InvalidOperationException("execution-primary");
+        var cleanup = new InvalidOperationException("cleanup-secondary");
+        using var node = new PrimaryAndCleanupFailureNode(order, primary, cleanup);
+        using var renderer = FailureTestSupport.CreateRenderer(
+            node,
+            useRenderCache: true,
+            purpose: RenderRequestPurpose.Frame);
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(() => renderer.Rasterize());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.SameAs(primary));
+            Assert.That(order, Is.EqualTo(new[] { "last", "throwing", "first" }));
+            Assert.That(node.Resources, Has.All.Matches<OrderedDisposable>(resource => resource.DisposeCalls == 1));
+            Assert.That(node.Cache.IsCached, Is.False);
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void LaterExecutionFailure_RejectsAnEarlierStagedCacheCaptureWithoutPartialPublication()
+    {
+        using var successful = new CacheableChildNode(throwOnExecute: false);
+        using var faulting = new CacheableChildNode(throwOnExecute: true);
+        successful.Cache.ReportRenderCount(RenderNodeCache.Count);
+        faulting.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using var root = new ContainerRenderNode();
+        root.AddChild(successful);
+        root.AddChild(faulting);
+        using var renderer = FailureTestSupport.CreateRenderer(
+            root,
+            useRenderCache: true,
+            purpose: RenderRequestPurpose.Frame);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(() => renderer.Rasterize());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Is.EqualTo("later-cache-candidate-failure"));
+            Assert.That(successful.ExecuteCalls, Is.EqualTo(1));
+            Assert.That(faulting.ExecuteCalls, Is.EqualTo(1));
+            Assert.That(successful.Cache.IsCached, Is.False);
+            Assert.That(faulting.Cache.IsCached, Is.False);
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+        });
+
+        root.RemoveChild(successful);
+        root.RemoveChild(faulting);
+    }
+
+    [Test]
+    public void CleanupFaultBeforeCachePublication_RejectsCaptureAndDischargesEveryResource()
+    {
+        var order = new List<string>();
+        var cleanup = new InvalidOperationException("pre-publication-cleanup");
+        using var node = new CleanupFailureCacheableNode(order, cleanup);
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using var renderer = FailureTestSupport.CreateRenderer(
+            node,
+            useRenderCache: true,
+            purpose: RenderRequestPurpose.Frame);
+
+        AggregateException? failure = Assert.Throws<AggregateException>(() => renderer.Rasterize());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Flatten().InnerExceptions, Does.Contain(cleanup));
+            Assert.That(order, Is.EqualTo(new[] { "last", "throwing", "first" }));
+            Assert.That(node.Resources, Has.All.Matches<OrderedDisposable>(resource => resource.DisposeCalls == 1));
+            Assert.That(node.Cache.IsCached, Is.False);
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void AtomicCacheTransfer_CommitsTheWholeReplacementBeforeOldStorageCleanupFailure()
+    {
+        var oldDisposalFailure = new InvalidOperationException("old-cache-dispose-primary");
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var node = new CacheableChildNode(throwOnExecute: false);
+        using (var seedRequest = FailureTestSupport.CreateFrameRequest(useRenderCache: false))
+        {
+            RecordedRenderGraph seedGraph = new RenderRequestRecorder(seedRequest).Record(node);
+            RenderFragmentReference seedRoot = RenderRequestCompiler.ResolveRoots(seedGraph).Single();
+            var seedIdentity = new RenderOutputCacheIdentity(
+                "deliberately-stale-cache-identity",
+                RenderFragmentOutputIdentity.Create(seedRoot, seedGraph.RequestId),
+                s_bounds,
+                RequiredRegion.Region(s_bounds),
+                density: 1,
+                RenderCacheFormatIdentity.LinearPremultipliedRgba16Float,
+                RenderIntent.Preview,
+                RenderRequestPurpose.Frame,
+                FusionMode.Enabled,
+                new RenderCacheDeviceContextIdentity("stale-device", "stale-context"));
+            RenderNodeCache.PublishAtomically(
+            [
+                new RenderNodeCachePublication(
+                    node.Cache,
+                    seedIdentity,
+                    [new RenderNodeCachedValue(
+                        new FailureTestRenderTarget(new PixelSize(8, 8), oldDisposalFailure),
+                        s_bounds,
+                        EffectiveScale.At(1))]),
+            ]);
+        }
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using var renderer = FailureTestSupport.CreateRenderer(
+            node,
+            useRenderCache: true,
+            purpose: RenderRequestPurpose.Frame,
+            diagnostics: diagnostics);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(() => renderer.Rasterize());
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        int cleanupIndex = snapshot.Events.ToList().FindIndex(
+            static item => item.Kind == RenderPipelineDiagnosticEventKind.CleanupFailure);
+        int publicationIndex = snapshot.Events.ToList().FindIndex(
+            static item => item.Kind == RenderPipelineDiagnosticEventKind.CacheCapturePublished);
+        int completionIndex = snapshot.Events.ToList().FindIndex(
+            static item => item.Kind == RenderPipelineDiagnosticEventKind.RequestCompleted);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.SameAs(oldDisposalFailure));
+            Assert.That(node.ExecuteCalls, Is.EqualTo(1));
+            Assert.That(node.Cache.IsCached, Is.True);
+            Assert.That(node.Cache.CacheCount, Is.EqualTo(1));
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            Assert.That(snapshot.FailurePhase, Is.EqualTo(RenderPipelineFailurePhase.Cleanup));
+            Assert.That(snapshot[RenderPipelineCounter.Failures], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.CleanupFailures], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.RenderCacheCaptures], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.RejectedRenderCacheCaptures], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.IntermediateAcquires],
+                Is.EqualTo(snapshot[RenderPipelineCounter.IntermediateDischarges]));
+            Assert.That(cleanupIndex, Is.GreaterThanOrEqualTo(0));
+            Assert.That(publicationIndex, Is.GreaterThan(cleanupIndex));
+            Assert.That(completionIndex, Is.GreaterThan(publicationIndex));
+        });
+    }
+
+    [Test]
+    public void NestedPostCommitCleanupFailure_ReconcilesEveryFamilyDiagnosticScope()
+    {
+        using var owner = new RenderRequestOwner();
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        var snapshots = new List<RenderPipelineDiagnosticSnapshot>();
+        diagnostics.RequestCompleted += snapshots.Add;
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            targetDomain: s_bounds,
+            requestedRegion: s_bounds,
+            outputScale: 1,
+            maxWorkingScale: 1,
+            cachePolicy: RenderCacheOptions.Enabled,
+            owner: owner,
+            diagnostics: diagnostics);
+        var oldDisposalFailure = new InvalidOperationException("nested-old-cache-dispose-primary");
+        var executionOrder = new List<string>();
+        using var child = new NestedExecutionNode("child-cache-cleanup", executionOrder);
+        SeedThrowingStaleCache(child, oldDisposalFailure);
+        child.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using var parent = new NestedExecutionNode(
+            "parent-cache-cleanup",
+            executionOrder,
+            nestedRoot: child,
+            parentOptions: options);
+        using var request = new RenderRequest(options);
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(parent);
+        RecordedNestedRenderTarget nested = parent.NestedRequest
+            ?? throw new AssertionException("The parent did not record its nested request.");
+        using RenderRequest nestedRequest = nested.Request;
+        using CompiledRenderRequest compiled = new RenderRequestCompiler(
+            renderCacheContext: FailureTestSupport.CacheResolutionContext).Compile(request, graph);
+        using RenderTarget destination = FailureTestSupport.CreateCpuTarget();
+        using var canvas = new ImmediateCanvas(destination);
+        using var registry = new RenderTargetLeaseRegistry(factory: null);
+        using RenderTargetLeaseSession targets = registry.BeginSession(
+            RenderIntent.Preview,
+            RenderAllocationBudget.Default,
+            destination);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => new RenderRequestExecutor(targets).Execute(compiled, canvas));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.SameAs(oldDisposalFailure));
+            Assert.That(child.Cache.IsCached, Is.True);
+            Assert.That(snapshots.Select(static snapshot => snapshot.RequestId),
+                Is.EqualTo(new[] { nestedRequest.Id.Value, request.Id.Value }));
+            Assert.That(snapshots,
+                Has.All.Matches<RenderPipelineDiagnosticSnapshot>(snapshot =>
+                    !snapshot.Succeeded
+                    && snapshot.FailurePhase == RenderPipelineFailurePhase.Cleanup
+                    && snapshot[RenderPipelineCounter.Failures] == 1
+                    && snapshot[RenderPipelineCounter.CleanupFailures] == 1
+                    && snapshot[RenderPipelineCounter.IntermediateAcquires]
+                    == snapshot[RenderPipelineCounter.IntermediateDischarges]));
+            Assert.That(snapshots[0][RenderPipelineCounter.RenderCacheCaptures], Is.EqualTo(1));
+            Assert.That(snapshots[0][RenderPipelineCounter.RejectedRenderCacheCaptures], Is.Zero);
+            Assert.That(snapshots[1][RenderPipelineCounter.RenderCacheCaptures], Is.Zero);
+        });
+    }
+
+    private static void SeedThrowingStaleCache(RenderNode node, Exception disposalFailure)
+    {
+        using var seedRequest = FailureTestSupport.CreateFrameRequest(useRenderCache: false);
+        RecordedRenderGraph seedGraph = new RenderRequestRecorder(seedRequest).Record(node);
+        RenderFragmentReference seedRoot = RenderRequestCompiler.ResolveRoots(seedGraph).Single();
+        var seedIdentity = new RenderOutputCacheIdentity(
+            "nested-deliberately-stale-cache-identity",
+            RenderFragmentOutputIdentity.Create(seedRoot, seedGraph.RequestId),
+            s_bounds,
+            RequiredRegion.Region(s_bounds),
+            density: 1,
+            RenderCacheFormatIdentity.LinearPremultipliedRgba16Float,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            FusionMode.Enabled,
+            new RenderCacheDeviceContextIdentity("nested-stale-device", "nested-stale-context"));
+        RenderNodeCache.PublishAtomically(
+        [
+            new RenderNodeCachePublication(
+                node.Cache,
+                seedIdentity,
+                [new RenderNodeCachedValue(
+                    new FailureTestRenderTarget(new PixelSize(8, 8), disposalFailure),
+                    s_bounds,
+                    EffectiveScale.At(1))]),
+        ]);
+    }
+
+    public enum TargetCallbackFailure
+    {
+        CommandCallback,
+        UndeclaredTargetReadback,
+        MissingTargetReadback,
+        UndeclaredInputReadback,
+        DuplicateInputReadback,
+        ScopeCallback,
+        ScopeMissingReplay,
+        ScopeDoubleReplay,
+        RawCommandCallback,
+        RawScopeCallback,
+        RawScopeMissingReplay,
+        RawScopeDoubleReplay,
+    }
+
+    public enum TransientMaterializationKind
+    {
+        Layer,
+        TargetLayerScope,
+    }
+
+    private sealed class TransientMaterializationFailureNode(
+        TransientMaterializationKind kind,
+        Func<int> getLeasedTargetCount) : RenderNode
+    {
+        public InvalidOperationException PrimaryFailure { get; } =
+            new($"transient-{kind}-failure");
+
+        public int? LeasedTargetsObservedBySource { get; private set; }
+
+        public int? LeasedTargetsObservedByCaller { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle source = context.OpaqueSource(FailureTestSupport.SourceDescription(
+                execute: _ =>
+                {
+                    LeasedTargetsObservedBySource = getLeasedTargetCount();
+                    throw PrimaryFailure;
+                },
+                structuralKey: $"transient-{kind}-source"));
+            RenderFragmentHandle transient = kind switch
+            {
+                TransientMaterializationKind.Layer => context.Layer([source], s_bounds),
+                TransientMaterializationKind.TargetLayerScope => context.TargetLayerScope(
+                    [source],
+                    TargetRegion.Region(s_bounds)),
+                _ => throw new ArgumentOutOfRangeException(),
+            };
+            TargetScopeDescription caller = TargetScopeDescription.CreateRequestLocal(
+                session =>
+                {
+                    try
+                    {
+                        session.Canvas.Use(_ => session.ReplayInput());
+                    }
+                    catch (InvalidOperationException ex) when (ReferenceEquals(ex, PrimaryFailure))
+                    {
+                        LeasedTargetsObservedByCaller = getLeasedTargetCount();
+                        throw;
+                    }
+                },
+                RenderBoundsContract.Identity,
+                RenderHitTestContract.AnyInput,
+                RenderScaleContract.PreserveInputSupply,
+                deviceGridSensitivity: RenderDeviceGridSensitivity.PhaseDependent,
+                structuralKey: $"transient-{kind}-caller");
+            context.Publish(context.TargetScope(transient, caller));
+        }
+    }
+
+    private sealed class TargetCapturePostAllocationFailureNode(
+        InvalidOperationException primaryFailure,
+        Func<int> getLeasedTargetCount) : RenderNode
+    {
+        public int? LeasedTargetsObservedByCaller { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle capture = context.ContributeValues(context.TargetCapture(
+                TargetCaptureDescription.Create(
+                    TargetRegion.Region(s_bounds),
+                    s_bounds,
+                    RenderHitTestContract.OutputBounds,
+                    TargetCaptureScaleContract.MaterializeAtWorkingScale)));
+            TargetScopeDescription caller = TargetScopeDescription.CreateRequestLocal(
+                session => session.Canvas.Use(_ =>
+                {
+                    try
+                    {
+                        session.ReplayInput();
+                    }
+                    catch (InvalidOperationException ex) when (ReferenceEquals(ex, primaryFailure))
+                    {
+                        LeasedTargetsObservedByCaller = getLeasedTargetCount();
+                        throw;
+                    }
+                }),
+                RenderBoundsContract.Identity,
+                RenderHitTestContract.AnyInput,
+                RenderScaleContract.PreserveInputSupply,
+                deviceGridSensitivity: RenderDeviceGridSensitivity.PhaseDependent,
+                structuralKey: nameof(TargetCapturePostAllocationFailureNode));
+            context.Publish(context.TargetScope(capture, caller));
+        }
+    }
+
+    private sealed class TargetCallbackFailureNode(TargetCallbackFailure failurePoint) : RenderNode
+    {
+        public int CallbackEntries { get; private set; }
+
+        public Action? VerifyRetainedSession { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            if (failurePoint is TargetCallbackFailure.RawCommandCallback)
+            {
+                RawTargetCommandDescription rawCommand = RawTargetCommandDescription.CreateRequestLocal(
+                    session =>
+                    {
+                        CallbackEntries++;
+                        VerifyRetainedSession = () => _ = session.Intent;
+                        throw new InvalidOperationException("raw-command-primary");
+                    },
+                    s_bounds,
+                    RenderHitTestContract.OutputBounds,
+                    structuralKey: "raw-command-failure");
+                context.Publish(context.RawTargetCommand(rawCommand));
+                return;
+            }
+
+            RenderFragmentHandle source = context.OpaqueSource(FailureTestSupport.SourceDescription(
+                structuralKey: $"target-callback-source-{failurePoint}"));
+            if (failurePoint is TargetCallbackFailure.CommandCallback
+                or TargetCallbackFailure.UndeclaredTargetReadback
+                or TargetCallbackFailure.MissingTargetReadback
+                or TargetCallbackFailure.UndeclaredInputReadback
+                or TargetCallbackFailure.DuplicateInputReadback)
+            {
+                bool targetReadback = failurePoint == TargetCallbackFailure.MissingTargetReadback;
+                bool inputReadback = failurePoint == TargetCallbackFailure.DuplicateInputReadback;
+                TargetCommandDescription command = TargetCommandDescription.CreateRequestLocal(
+                    session =>
+                    {
+                        CallbackEntries++;
+                        VerifyRetainedSession = () => _ = session.Intent;
+                        switch (failurePoint)
+                        {
+                            case TargetCallbackFailure.CommandCallback:
+                                throw new InvalidOperationException("target-command-primary");
+                            case TargetCallbackFailure.UndeclaredTargetReadback:
+                                session.UseSnapshot(static _ => { });
+                                break;
+                            case TargetCallbackFailure.MissingTargetReadback:
+                                break;
+                            case TargetCallbackFailure.UndeclaredInputReadback:
+                                session.Inputs.Single().UseSnapshot(static _ => { });
+                                break;
+                            case TargetCallbackFailure.DuplicateInputReadback:
+                                session.Inputs.Single().UseSnapshot(static _ => { });
+                                session.Inputs.Single().UseSnapshot(static _ => { });
+                                break;
+                        }
+                    },
+                    TargetRegion.Region(s_bounds),
+                    s_bounds,
+                    RenderHitTestContract.OutputBounds,
+                    targetReadback ? TargetAccess.Readback : TargetAccess.ReadWrite,
+                    inputReadbacks: inputReadback ? [RenderInputReadback.All] : null,
+                    structuralKey: $"target-command-{failurePoint}");
+                context.Publish(source);
+                context.Publish(context.TargetCommand([source], command));
+                return;
+            }
+
+            if (failurePoint is TargetCallbackFailure.ScopeCallback
+                or TargetCallbackFailure.ScopeMissingReplay
+                or TargetCallbackFailure.ScopeDoubleReplay)
+            {
+                TargetScopeDescription scope = TargetScopeDescription.CreateRequestLocal(
+                    session =>
+                    {
+                        CallbackEntries++;
+                        VerifyRetainedSession = () => _ = session.Intent;
+                        switch (failurePoint)
+                        {
+                            case TargetCallbackFailure.ScopeCallback:
+                                throw new InvalidOperationException("target-scope-primary");
+                            case TargetCallbackFailure.ScopeMissingReplay:
+                                break;
+                            case TargetCallbackFailure.ScopeDoubleReplay:
+                                session.Canvas.Use(_ =>
+                                {
+                                    session.ReplayInput();
+                                    session.ReplayInput();
+                                });
+                                break;
+                        }
+                    },
+                    RenderBoundsContract.Identity,
+                    RenderHitTestContract.AnyInput,
+                    RenderScaleContract.PreserveInputSupply,
+                    deviceGridSensitivity: RenderDeviceGridSensitivity.PhaseDependent,
+                    structuralKey: $"target-scope-{failurePoint}");
+                context.Publish(context.TargetScope(source, scope));
+                return;
+            }
+
+            RawTargetScopeDescription rawScope = RawTargetScopeDescription.CreateRequestLocal(
+                session =>
+                {
+                    CallbackEntries++;
+                    VerifyRetainedSession = () => _ = session.Intent;
+                    switch (failurePoint)
+                    {
+                        case TargetCallbackFailure.RawScopeCallback:
+                            throw new InvalidOperationException("raw-scope-primary");
+                        case TargetCallbackFailure.RawScopeMissingReplay:
+                            break;
+                        case TargetCallbackFailure.RawScopeDoubleReplay:
+                            session.ReplayInput();
+                            session.ReplayInput();
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                },
+                RenderBoundsContract.Identity,
+                RenderHitTestContract.AnyInput,
+                RenderScaleContract.PreserveInputSupply,
+                structuralKey: $"raw-target-scope-{failurePoint}");
+            context.Publish(context.RawTargetScope(source, rawScope));
+        }
+    }
+
+    private sealed class TargetCaptureNode : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle capture = context.TargetCapture(TargetCaptureDescription.Create(
+                TargetRegion.Region(s_bounds),
+                s_bounds,
+                RenderHitTestContract.OutputBounds,
+                TargetCaptureScaleContract.MaterializeAtWorkingScale));
+            context.Publish(context.ContributeValues(capture));
+        }
+    }
+
+    private sealed class BackendBoundaryFailureNode(InvalidOperationException failure) : RenderNode
+    {
+        public int ExecuteCalls { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            context.Publish(context.OpaqueSource(FailureTestSupport.SourceDescription(
+                _ =>
+                {
+                    ExecuteCalls++;
+                    throw failure;
+                },
+                structuralKey: "graphics3d-backend-failure",
+                backendBoundary: RenderBackendBoundary.Graphics3D)));
+        }
+    }
+
+    private sealed class NestedPlanningFailureParentNode(RenderNode child) : RenderNode
+    {
+        public int ExecuteCalls { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            _ = context.RecordNestedTarget(child, s_bounds);
+            context.Publish(context.OpaqueSource(FailureTestSupport.SourceDescription(
+                session =>
+                {
+                    ExecuteCalls++;
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    output.Canvas.Use(canvas => canvas.Clear(Colors.CornflowerBlue));
+                    session.Publish(output);
+                },
+                structuralKey: "nested-planning-parent")));
+        }
+    }
+
+    private sealed class NestedRegionAnalysisFailureNode : RenderNode
+    {
+        public static InvalidOperationException PrimaryFailure { get; } =
+            new("nested-region-analysis-primary");
+
+        public int ExecuteCalls { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle source = context.OpaqueSource(FailureTestSupport.SourceDescription(
+                session =>
+                {
+                    ExecuteCalls++;
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    output.Canvas.Use(canvas => canvas.Clear(Colors.CornflowerBlue));
+                    session.Publish(output);
+                },
+                structuralKey: "nested-planning-child"));
+            RenderBoundsContract bounds = RenderBoundsContract.Create(
+                static value => value,
+                ThrowDuringRequiredInputBounds,
+                structuralKey: "nested-region-analysis-failure");
+            GeometryDescription geometry = GeometryDescription.CreateRequestLocal(
+                static _ => { },
+                bounds,
+                RenderHitTestContract.AnyInput,
+                structuralKey: "nested-region-analysis-geometry");
+            context.Publish(context.Geometry(source, geometry));
+        }
+
+        private static Rect ThrowDuringRequiredInputBounds(Rect _)
+            => throw PrimaryFailure;
+    }
+
+    private sealed class NestedParentNode(RenderNode child) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            _ = context.RecordNestedTarget(child, s_bounds);
+            context.Publish(context.OpaqueSource(FailureTestSupport.SourceDescription(
+                structuralKey: "nested-parent-source")));
+        }
+    }
+
+    private sealed class NestedChildNode : RenderNode
+    {
+        public int ExecuteCalls { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            context.Publish(context.OpaqueSource(FailureTestSupport.SourceDescription(
+                session =>
+                {
+                    ExecuteCalls++;
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    output.Canvas.Use(canvas => canvas.Clear(Colors.Green));
+                    session.Publish(output);
+                },
+                structuralKey: "nested-child-source")));
+        }
+    }
+
+    private sealed class ShiftedNestedChildNode(Rect bounds) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            OpaqueRenderDescription description = OpaqueRenderDescription.CreateRequestLocal(
+                session =>
+                {
+                    using OpaqueRenderOutput output = session.CreateOutput(bounds);
+                    output.Canvas.Use(canvas => canvas.Clear(Colors.Red));
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.Source(bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: "shifted-nested-child");
+            context.Publish(context.OpaqueSource(description));
+        }
+    }
+
+    private sealed class NestedOutputConsumerNode(
+        RenderNode child,
+        Rect targetDomain) : RenderNode
+    {
+        public RecordedNestedRenderTarget? NestedTarget { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            NestedTarget = context.RecordNestedTarget(child, targetDomain);
+            RecordedNestedRenderTarget nested = NestedTarget;
+            OpaqueRenderDescription description = OpaqueRenderDescription.CreateRequestLocal(
+                session => session.UseNestedTarget(
+                    nested.Binding,
+                    image =>
+                    {
+                        using OpaqueRenderOutput output = session.CreateOutput(targetDomain);
+                        output.Canvas.Use(canvas =>
+                        {
+                            canvas.Clear(Colors.Transparent);
+                            image.Draw(canvas);
+                        });
+                        session.Publish(output);
+                    }),
+                OpaqueRenderBoundsContract.Source(targetDomain),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: "nested-output-consumer",
+                resources: [nested.Binding.Bind("nested")]);
+            context.Publish(context.OpaqueSource(description));
+        }
+    }
+
+    private sealed class NestedExecutionNode(
+        string name,
+        ICollection<string> executionOrder,
+        RenderNode? nestedRoot = null,
+        RenderRequestOptions? parentOptions = null,
+        Exception? failure = null) : RenderNode
+    {
+        public int ExecuteCalls { get; private set; }
+
+        public RecordedNestedRenderTarget? NestedRequest { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            if ((nestedRoot is null) != (parentOptions is null))
+            {
+                throw new InvalidOperationException(
+                    "A nested root and its inherited parent options must be supplied together.");
+            }
+
+            if (nestedRoot is not null)
+            {
+                NestedRequest = context.RecordNestedTarget(nestedRoot, s_bounds);
+            }
+
+            context.Publish(context.OpaqueSource(FailureTestSupport.SourceDescription(
+                session =>
+                {
+                    ExecuteCalls++;
+                    executionOrder.Add(name);
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    output.Canvas.Use(canvas => canvas.Clear(Colors.Cyan));
+                    if (failure is not null)
+                        throw failure;
+                    session.Publish(output);
+                },
+                structuralKey: $"nested-family-{name}")));
+        }
+    }
+
+    private sealed class NestedContainerNode : ContainerRenderNode
+    {
+        private readonly RenderNode _nestedRoot;
+        private readonly RenderRequestOptions _parentOptions;
+
+        public NestedContainerNode(
+            RenderNode nestedRoot,
+            RenderRequestOptions parentOptions,
+            params RenderNode[] parentChildren)
+        {
+            _nestedRoot = nestedRoot;
+            _parentOptions = parentOptions;
+            foreach (RenderNode child in parentChildren)
+                AddChild(child);
+        }
+
+        public RecordedNestedRenderTarget? NestedRequest { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            NestedRequest = context.RecordNestedTarget(_nestedRoot, s_bounds);
+            context.PassThrough();
+        }
+    }
+
+    private sealed class PrimaryAndCleanupFailureNode : RenderNode
+    {
+        private readonly List<string> _order;
+        private readonly InvalidOperationException _primary;
+
+        public PrimaryAndCleanupFailureNode(
+            List<string> order,
+            InvalidOperationException primary,
+            InvalidOperationException cleanup)
+        {
+            _order = order;
+            _primary = primary;
+            Resources =
+            [
+                new OrderedDisposable("first", order),
+                new OrderedDisposable("throwing", order, cleanup),
+                new OrderedDisposable("last", order),
+            ];
+        }
+
+        public OrderedDisposable[] Resources { get; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            for (int index = 0; index < Resources.Length; index++)
+                _ = context.Own(Resources[index], $"primary-cleanup-{index}", 0);
+            context.Publish(context.OpaqueSource(FailureTestSupport.SourceDescription(
+                _ => throw _primary,
+                structuralKey: "primary-and-cleanup-source")));
+        }
+    }
+
+    private sealed class CacheableChildNode(bool throwOnExecute) : RenderNode
+    {
+        public int ExecuteCalls { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            context.Publish(context.OpaqueSource(FailureTestSupport.SourceDescription(
+                session =>
+                {
+                    ExecuteCalls++;
+                    if (throwOnExecute)
+                        throw new InvalidOperationException("later-cache-candidate-failure");
+                    using OpaqueRenderOutput output = session.CreateOutput(s_bounds);
+                    output.Canvas.Use(canvas => canvas.Clear(Colors.Purple));
+                    session.Publish(output);
+                },
+                structuralKey: throwOnExecute ? "faulting-cache-child" : "successful-cache-child")));
+        }
+    }
+
+    private sealed class CleanupFailureCacheableNode : RenderNode
+    {
+        public CleanupFailureCacheableNode(List<string> order, InvalidOperationException cleanup)
+        {
+            Resources =
+            [
+                new OrderedDisposable("first", order),
+                new OrderedDisposable("throwing", order, cleanup),
+                new OrderedDisposable("last", order),
+            ];
+        }
+
+        public OrderedDisposable[] Resources { get; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            for (int index = 0; index < Resources.Length; index++)
+                _ = context.Own(Resources[index], $"cleanup-cacheable-{index}", 0);
+            context.Publish(context.OpaqueSource(FailureTestSupport.SourceDescription(
+                structuralKey: "cleanup-cacheable-source")));
+        }
+    }
+
+    private sealed class OrderedDisposable(
+        string name,
+        ICollection<string> order,
+        Exception? failure = null) : IDisposable
+    {
+        public int DisposeCalls { get; private set; }
+
+        public void Dispose()
+        {
+            DisposeCalls++;
+            order.Add(name);
+            if (failure is not null)
+                throw failure;
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/RenderNodeRendererLifetimeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/RenderNodeRendererLifetimeTests.cs
@@ -1,0 +1,320 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Failure;
+
+[TestFixture]
+public sealed class RenderNodeRendererLifetimeTests
+{
+    [Test]
+    public void Rasterize_EmptySelection_ReturnsEmptyResultWithoutAllocating()
+    {
+        var bounds = new Rect(0, 0, 8, 8);
+        var emptySelection = new Rect(3, 4, 0, 2);
+        using var source = new TrackingRenderTarget(new PixelSize(8, 8));
+        using var node = new ShaderNode(source, bounds);
+        using var factory = new TrackingTargetFactory();
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = bounds,
+                    RequestedRegion = emptySelection,
+                    OutputScale = 2,
+                    MaxWorkingScale = 2,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    Purpose = RenderRequestPurpose.Frame,
+                    Diagnostics = diagnostics,
+                },
+                TargetFactory = factory,
+            });
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rasterization.Bounds, Is.EqualTo(emptySelection));
+            Assert.That(rasterization.OutputScale, Is.EqualTo(2));
+            Assert.That(rasterization.IsEmpty, Is.True);
+            Assert.That(rasterization.Bitmap, Is.Null);
+            Assert.That(factory.Targets, Is.Empty);
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            Assert.That(snapshot.Succeeded, Is.True);
+            Assert.That(snapshot.Purpose, Is.EqualTo(RenderRequestPurpose.Frame));
+            Assert.That(snapshot[RenderPipelineCounter.RecordedFragments], Is.GreaterThan(0));
+            Assert.That(
+                snapshot[RenderPipelineCounter.SkippedOutcomes],
+                Is.EqualTo(snapshot[RenderPipelineCounter.RecordedFragments]));
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedOutcomes], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.FailedOutcomes], Is.Zero);
+            Assert.That(snapshot.Events[^1].Kind, Is.EqualTo(RenderPipelineDiagnosticEventKind.RequestCompleted));
+            Assert.That(diagnostics.LatestFrame, Is.SameAs(snapshot));
+        });
+    }
+
+    [TestCase(3, 4, 0, 2)]
+    [TestCase(20, 20, 2, 2)]
+    public void Render_EmptySelection_PublishesSuccessfulSkippedDiagnostics(
+        int x,
+        int y,
+        int width,
+        int height)
+    {
+        var bounds = new Rect(0, 0, 8, 8);
+        using var source = new TrackingRenderTarget(new PixelSize(8, 8));
+        using var node = new ShaderNode(source, bounds);
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = bounds,
+                    RequestedRegion = new Rect(x, y, width, height),
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    Purpose = RenderRequestPurpose.Frame,
+                    Diagnostics = diagnostics,
+                },
+            });
+        using RenderTarget target = RenderTarget.CreateNull(8, 8);
+        using var canvas = new ImmediateCanvas(target);
+
+        renderer.Render(canvas);
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot.Succeeded, Is.True);
+            Assert.That(snapshot.Purpose, Is.EqualTo(RenderRequestPurpose.Frame));
+            Assert.That(snapshot[RenderPipelineCounter.RecordedFragments], Is.GreaterThan(0));
+            Assert.That(
+                snapshot[RenderPipelineCounter.SkippedOutcomes],
+                Is.EqualTo(snapshot[RenderPipelineCounter.RecordedFragments]));
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedOutcomes], Is.Zero);
+            Assert.That(
+                snapshot[RenderPipelineCounter.ExternalRootResources],
+                Is.EqualTo(width == 0 || height == 0 ? 0 : 1));
+            Assert.That(snapshot[RenderPipelineCounter.FailedOutcomes], Is.Zero);
+            Assert.That(snapshot.Events[^1].Kind, Is.EqualTo(RenderPipelineDiagnosticEventKind.RequestCompleted));
+            Assert.That(diagnostics.LatestFrame, Is.SameAs(snapshot));
+        });
+    }
+
+    [Test]
+    public void Rasterize_EmptySelection_SurfacesLeaseSessionCleanupFailure()
+    {
+        var bounds = new Rect(0, 0, 8, 8);
+        var cleanup = new InvalidOperationException("empty-selection-target-cleanup");
+        using var source = new TrackingRenderTarget(new PixelSize(8, 8));
+        using var node = new ShaderNode(source, bounds);
+        using var factory = new TrackingTargetFactory(
+            index => index == 0 ? cleanup : null);
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = bounds,
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = factory,
+            });
+
+        using (RenderNodeRasterization seeded = renderer.Rasterize())
+        {
+            Assert.That(seeded.Bitmap, Is.Not.Null);
+        }
+
+        TrackingRenderTarget faultingTarget = factory.Targets[0];
+        node.PublishOutput = false;
+        Exception? observed = null;
+        int emptyResults = 0;
+        const int safetyLimit = 512;
+        while (!faultingTarget.IsDisposed && emptyResults < safetyLimit)
+        {
+            try
+            {
+                using RenderNodeRasterization empty = renderer.Rasterize();
+                Assert.That(empty.Bitmap, Is.Null);
+                emptyResults++;
+            }
+            catch (Exception ex)
+            {
+                observed = ex;
+                break;
+            }
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(observed, Is.SameAs(cleanup));
+            Assert.That(emptyResults, Is.GreaterThan(0));
+            Assert.That(faultingTarget.IsDisposed, Is.True);
+            Assert.That(faultingTarget.DisposeCalls, Is.EqualTo(1));
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void Dispose_ReleasesRendererOwnedState_AndPreservesBorrowedState()
+    {
+        var bounds = new Rect(0, 0, 8, 8);
+        using var source = new TrackingRenderTarget(new PixelSize(8, 8));
+        source.Value.Canvas.Clear(new SKColor(80, 120, 160, 192));
+        using var node = new ShaderNode(source, bounds);
+        using var cacheSeed = new TrackingRenderTarget(new PixelSize(8, 8));
+        RenderNodeCache.PublishAtomically(
+            [RenderCacheTestSupport.CreatePublication(node.Cache, cacheSeed, bounds)]);
+        using var factory = new TrackingTargetFactory();
+        var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = bounds,
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = factory,
+            });
+
+        RenderNodeRasterization rasterization = renderer.Rasterize();
+        Bitmap bitmap = rasterization.Bitmap
+            ?? throw new AssertionException("The lifetime test requires a non-empty rasterization.");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(renderer.StructuralPlanCacheStatistics.RetainedPlans, Is.EqualTo(1));
+            Assert.That(renderer.ProgramCacheStatistics.RetainedPrograms, Is.EqualTo(1));
+            Assert.That(renderer.TargetPoolStatistics.OwnedTargets, Is.GreaterThanOrEqualTo(1));
+            Assert.That(factory.Targets, Is.Not.Empty);
+            Assert.That(factory.Targets, Has.All.Matches<TrackingRenderTarget>(target => !target.IsDisposed));
+        });
+
+        renderer.Dispose();
+        using RenderTarget cached = node.Cache.UseCache(out Rect cachedBounds);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(renderer.StructuralPlanCacheStatistics.RetainedPlans, Is.Zero);
+            Assert.That(renderer.ProgramCacheStatistics.RetainedPrograms, Is.Zero);
+            Assert.That(renderer.ProgramCacheStatistics.RetainedBytes, Is.Zero);
+            Assert.That(renderer.TargetPoolStatistics.OwnedTargets, Is.Zero);
+            Assert.That(renderer.TargetPoolStatistics.OwnedBytes, Is.Zero);
+            Assert.That(factory.Targets, Has.All.Matches<TrackingRenderTarget>(target => target.IsDisposed));
+            Assert.That(factory.Targets, Has.All.Matches<TrackingRenderTarget>(target => target.DisposeCalls == 1));
+            Assert.That(factory.IsDisposed, Is.False, "The caller owns the target factory.");
+            Assert.That(node.IsDisposed, Is.False, "The caller owns the root node.");
+            Assert.That(node.Cache.IsDisposed, Is.False, "The root owns its render cache.");
+            Assert.That(cachedBounds, Is.EqualTo(bounds));
+            Assert.That(cached.IsDisposed, Is.False);
+            Assert.That(source.IsDisposed, Is.False, "Borrowed materialized inputs remain caller-owned.");
+            Assert.That(bitmap.IsDisposed, Is.False, "A returned rasterization owns its bitmap independently.");
+        });
+
+        rasterization.Dispose();
+        Assert.That(bitmap.IsDisposed, Is.True);
+    }
+
+    private sealed class ShaderNode(RenderTarget source, Rect bounds) : RenderNode
+    {
+        public bool PublishOutput { get; set; } = true;
+
+        public override void Process(RenderNodeContext context)
+        {
+            if (!PublishOutput)
+                return;
+
+            RenderResource<RenderTarget> target = context.Borrow(
+                source,
+                "renderer-lifetime-source",
+                version: 1);
+            RenderFragmentHandle input = context.MaterializedInput(
+                MaterializedInputDescription.FromRenderTarget(
+                    target,
+                    bounds,
+                    EffectiveScale.At(1),
+                    PixelRect.FromRect(bounds, 1),
+                    default,
+                    RenderHitTestContract.OutputBounds));
+            ShaderDescription shader = ShaderDescription.CurrentPixel(
+                "uniform float gain; half4 apply(half4 color) { return color * gain; }",
+                static bindings => bindings.Uniform("gain", 0.75f));
+            context.Publish(context.Shader(input, shader));
+        }
+    }
+
+    private sealed class TrackingTargetFactory(
+        Func<int, Exception?>? disposeFailureAt = null) : IRenderTargetFactory, IDisposable
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public List<TrackingRenderTarget> Targets { get; } = [];
+
+        public bool IsDisposed { get; private set; }
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+        {
+            PixelSize deviceSize = allocation.DeviceSize;
+            var target = new TrackingRenderTarget(
+                deviceSize,
+                disposeFailureAt?.Invoke(Targets.Count));
+            Targets.Add(target);
+            return target;
+        }
+
+        public void Dispose()
+        {
+            IsDisposed = true;
+        }
+    }
+
+    private sealed class TrackingRenderTarget : RenderTarget
+    {
+        private static readonly SKColorSpace s_colorSpace = SKColorSpace.CreateSrgbLinear();
+        private readonly Exception? _disposeFailure;
+
+        public TrackingRenderTarget(PixelSize size, Exception? disposeFailure = null)
+            : base(CreateSurface(size), size.Width, size.Height)
+        {
+            _disposeFailure = disposeFailure;
+        }
+
+        public int DisposeCalls { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            bool shouldThrow = disposing && !IsDisposed && _disposeFailure is not null;
+            if (disposing && !IsDisposed)
+                DisposeCalls++;
+
+            base.Dispose(disposing);
+            if (shouldThrow)
+                throw _disposeFailure!;
+        }
+
+        private static SKSurface CreateSurface(PixelSize size)
+            => SKSurface.Create(new SKImageInfo(
+                   size.Width,
+                   size.Height,
+                   SKColorType.RgbaF16,
+                   SKAlphaType.Premul,
+                   s_colorSpace))
+               ?? throw new InvalidOperationException("Could not create the lifetime-test render target.");
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/RenderRequestOwnerTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/RenderRequestOwnerTests.cs
@@ -1,0 +1,115 @@
+﻿using Beutl.Graphics.Rendering;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Failure;
+
+[TestFixture]
+public sealed class RenderRequestOwnerTests
+{
+    [Test]
+    public void PrimaryFailure_IsPreservedAndLaterFailuresAreSecondary()
+    {
+        var primary = new ApplicationException("render-primary");
+        var later = new InvalidOperationException("render-secondary");
+        var cleanup = new IOException("cleanup-secondary");
+        using var owner = new RenderRequestOwner();
+        owner.Register(() => throw cleanup);
+
+        owner.RecordPrimaryFailure(primary);
+        owner.RecordPrimaryFailure(primary);
+        owner.RecordPrimaryFailure(later);
+        owner.Cleanup();
+
+        Exception thrown = Assert.Throws<ApplicationException>(() => owner.ThrowIfFailed())!;
+        Assert.Multiple(() =>
+        {
+            Assert.That(thrown, Is.SameAs(primary));
+            Assert.That(owner.PrimaryFailure?.SourceException, Is.SameAs(primary));
+            Assert.That(owner.SecondaryFailures, Is.EqualTo(new Exception[] { later, cleanup }));
+            Assert.That(owner.CleanupFailures, Is.EqualTo(new Exception[] { cleanup }));
+        });
+    }
+
+    [Test]
+    public void DischargeAndAcceptedCacheTransfer_PreventCleanupExactlyOnce()
+    {
+        int cleanupCount = 0;
+        using var owner = new RenderRequestOwner();
+        RenderOwnershipToken discharged = owner.Register(() => cleanupCount++);
+        RenderOwnershipToken transferred = owner.Register(() => cleanupCount++);
+        RenderOwnershipToken pending = owner.Register(() => cleanupCount++);
+
+        owner.Discharge(discharged);
+        owner.DischargeAfterAcceptedCacheTransfer(transferred);
+        owner.Cleanup();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cleanupCount, Is.EqualTo(1));
+            Assert.That(discharged.State, Is.EqualTo(RenderOwnershipState.Discharged));
+            Assert.That(transferred.State, Is.EqualTo(RenderOwnershipState.CacheTransferred));
+            Assert.That(pending.State, Is.EqualTo(RenderOwnershipState.Discharged));
+            Assert.That(() => owner.Discharge(discharged), Throws.TypeOf<InvalidOperationException>());
+            Assert.That(
+                () => owner.DischargeAfterAcceptedCacheTransfer(transferred),
+                Throws.TypeOf<InvalidOperationException>());
+        });
+    }
+
+    [Test]
+    public void ResourceCleanupAndCacheTransfer_HaveDistinctOwnershipOutcomes()
+    {
+        var releasedValue = new TrackedDisposable();
+        var transferredValue = new TrackedDisposable();
+        using var registry = new RenderRequestResourceRegistry();
+        using var owner = new RenderRequestOwner();
+        RenderResource<TrackedDisposable> released = registry.RegisterOwned(releasedValue);
+        RenderResource<TrackedDisposable> transferred = registry.RegisterOwned(transferredValue);
+        registry.Commit(released);
+        registry.Commit(transferred);
+        owner.Register(() => registry.Release(released));
+        RenderOwnershipToken transferToken = owner.Register(() => registry.Release(transferred));
+
+        TrackedDisposable cachePayload = registry.TransferOwned(transferred);
+        owner.DischargeAfterAcceptedCacheTransfer(transferToken);
+        owner.Cleanup();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(releasedValue.DisposeCount, Is.EqualTo(1));
+            Assert.That(transferredValue.DisposeCount, Is.Zero);
+            Assert.That(cachePayload, Is.SameAs(transferredValue));
+        });
+
+        cachePayload.Dispose();
+        Assert.That(transferredValue.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void TokenFromAnotherOwner_IsRejected()
+    {
+        using var first = new RenderRequestOwner();
+        using var second = new RenderRequestOwner();
+        RenderOwnershipToken token = first.Register(static () => { });
+
+        Assert.That(() => second.Discharge(token), Throws.TypeOf<InvalidOperationException>());
+    }
+
+    [Test]
+    public void RegisterAfterCleanup_IsRejected()
+    {
+        using var owner = new RenderRequestOwner();
+        owner.Cleanup();
+
+        Assert.That(() => owner.Register(static () => { }), Throws.TypeOf<InvalidOperationException>());
+    }
+
+    private sealed class TrackedDisposable : IDisposable
+    {
+        public int DisposeCount { get; private set; }
+
+        public void Dispose()
+        {
+            DisposeCount++;
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/RenderResourceOwnershipTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/RenderResourceOwnershipTests.cs
@@ -1,0 +1,255 @@
+﻿using Beutl.Graphics.Rendering;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Failure;
+
+[TestFixture]
+public sealed class RenderResourceOwnershipTests
+{
+    [Test]
+    public void OwnedRegistration_TransfersToRequestAndDischargesExactlyOnce()
+    {
+        var value = new TrackedDisposable();
+        using var registry = new RenderRequestResourceRegistry();
+
+        RenderResource<TrackedDisposable> resource = registry.RegisterOwned(value, "owned", version: 4);
+        registry.Commit(resource);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(resource.CacheIdentity, Is.EqualTo(new RenderResourceIdentity("owned", 4)));
+            Assert.That(resource.OwnershipState, Is.EqualTo(RenderResourceOwnershipState.RequestOwned));
+            Assert.That(registry.Use(resource, static item => item), Is.SameAs(value));
+            Assert.That(value.DisposeCount, Is.Zero);
+        });
+
+        registry.Release(resource);
+        registry.Release(resource);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(value.DisposeCount, Is.EqualTo(1));
+            Assert.That(resource.OwnershipState, Is.EqualTo(RenderResourceOwnershipState.Discharged));
+            Assert.That(() => _ = resource.CacheIdentity, Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => _ = resource.SlotIdentity, Throws.TypeOf<InvalidOperationException>(),
+                "A released public token must not retain the request slot or raw resource.");
+            Assert.That(() => registry.Use(resource, static item => item), Throws.TypeOf<InvalidOperationException>());
+        });
+    }
+
+    [Test]
+    public void DuplicateOwnedAndOwnedBorrowedConflicts_AreRejectedBeforeAnotherTransfer()
+    {
+        var ownedValue = new TrackedDisposable();
+        using var ownedRegistry = new RenderRequestResourceRegistry();
+        RenderResource<TrackedDisposable> owned = ownedRegistry.RegisterOwned(ownedValue);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => ownedRegistry.RegisterOwned(ownedValue),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(
+                () => ownedRegistry.RegisterBorrowed(ownedValue, "borrow", 0),
+                Throws.TypeOf<InvalidOperationException>());
+        });
+
+        ownedRegistry.Rollback(owned);
+        Assert.That(ownedValue.DisposeCount, Is.EqualTo(1));
+
+        var borrowedValue = new TrackedDisposable();
+        using var borrowedRegistry = new RenderRequestResourceRegistry();
+        RenderResource<TrackedDisposable> borrowed = borrowedRegistry.RegisterBorrowed(borrowedValue, "borrow", 0);
+
+        Assert.That(
+            () => borrowedRegistry.RegisterOwned(borrowedValue),
+            Throws.TypeOf<InvalidOperationException>());
+
+        borrowedRegistry.Rollback(borrowed);
+        Assert.That(borrowedValue.DisposeCount, Is.Zero);
+    }
+
+    [Test]
+    public void RolledBackOwnership_RemainsATombstoneForTheRequestFamily()
+    {
+        var value = new TrackedDisposable();
+        using var registry = new RenderRequestResourceRegistry();
+        RenderResource<TrackedDisposable> resource = registry.RegisterOwned(value);
+        registry.Rollback(resource);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(value.DisposeCount, Is.EqualTo(1));
+            Assert.That(() => registry.RegisterOwned(value), Throws.TypeOf<InvalidOperationException>());
+            Assert.That(
+                () => registry.RegisterBorrowed(value, "disposed", 0),
+                Throws.TypeOf<InvalidOperationException>());
+        });
+    }
+
+    [Test]
+    public void RolledBackBorrow_RemainsATombstoneForTheRequestFamily()
+    {
+        var value = new TrackedDisposable();
+        using var registry = new RenderRequestResourceRegistry();
+        RenderResource<TrackedDisposable> resource = registry.RegisterBorrowed(value);
+        registry.Rollback(resource);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(value.DisposeCount, Is.Zero);
+            Assert.That(() => registry.RegisterOwned(value), Throws.TypeOf<InvalidOperationException>());
+        });
+    }
+
+    [Test]
+    public void FinalRelease_DuringUseIsRejectedBeforeOwnershipMutation()
+    {
+        var value = new TrackedDisposable();
+        using var registry = new RenderRequestResourceRegistry();
+        RenderResource<TrackedDisposable> resource = registry.RegisterOwned(value);
+        registry.Commit(resource);
+
+        Assert.That(
+            () => registry.Use(resource, _ =>
+            {
+                registry.Release(resource);
+                return 0;
+            }),
+            Throws.TypeOf<InvalidOperationException>());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(resource.RegistrationState, Is.EqualTo(RenderResourceRegistrationState.Committed));
+            Assert.That(resource.OwnershipState, Is.EqualTo(RenderResourceOwnershipState.RequestOwned));
+            Assert.That(registry.Slots, Has.Count.EqualTo(1));
+            Assert.That(value.DisposeCount, Is.Zero);
+        });
+
+        registry.Release(resource);
+        Assert.That(value.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void ExplicitBorrowIdentity_CoalescesOnlyForMatchingKeyAndVersion()
+    {
+        var value = new object();
+        using var registry = new RenderRequestResourceRegistry();
+
+        RenderResource<object> first = registry.RegisterBorrowed(value, "stable", version: 7);
+        RenderResource<object> second = registry.RegisterBorrowed(value, "stable", version: 7);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(second, Is.Not.SameAs(first));
+            Assert.That(second.SlotIdentity, Is.SameAs(first.SlotIdentity));
+            Assert.That(second.CacheIdentity, Is.EqualTo(first.CacheIdentity));
+            Assert.That(
+                () => registry.RegisterBorrowed(value, "different", version: 7),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(
+                () => registry.RegisterBorrowed(value, "stable", version: 8),
+                Throws.TypeOf<InvalidOperationException>());
+        });
+
+        registry.Commit(first);
+        registry.Commit(second);
+        registry.Release(first);
+
+        Assert.That(registry.Use(second, static item => item), Is.SameAs(value));
+
+        registry.Release(second);
+        Assert.That(second.OwnershipState, Is.EqualTo(RenderResourceOwnershipState.ReleasedToken));
+    }
+
+    [Test]
+    public void NullBorrowKeys_CreateDistinctRequestLocalIdentities()
+    {
+        var value = new object();
+        using var firstRegistry = new RenderRequestResourceRegistry();
+        using var secondRegistry = new RenderRequestResourceRegistry();
+
+        RenderResource<object> first = firstRegistry.RegisterBorrowed(value);
+        RenderResource<object> second = firstRegistry.RegisterBorrowed(value);
+        RenderResource<object> otherRequest = secondRegistry.RegisterBorrowed(value);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.SlotIdentity, Is.Not.SameAs(second.SlotIdentity));
+            Assert.That(first.CacheIdentity.Key, Is.Not.Null);
+            Assert.That(first.CacheIdentity, Is.Not.EqualTo(second.CacheIdentity));
+            Assert.That(first.CacheIdentity, Is.Not.EqualTo(otherRequest.CacheIdentity));
+        });
+    }
+
+    [Test]
+    public void OwnedResource_CanTransferToPersistentCacheWithoutRequestDisposal()
+    {
+        var value = new TrackedDisposable();
+        using var registry = new RenderRequestResourceRegistry();
+        RenderResource<TrackedDisposable> resource = registry.RegisterOwned(value, "cache", 1);
+        registry.Commit(resource);
+
+        TrackedDisposable transferred = registry.TransferOwned(resource);
+        registry.Release(resource);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(transferred, Is.SameAs(value));
+            Assert.That(value.DisposeCount, Is.Zero);
+            Assert.That(resource.OwnershipState, Is.EqualTo(RenderResourceOwnershipState.Discharged));
+            Assert.That(() => _ = resource.SlotIdentity, Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => registry.TransferOwned(resource), Throws.TypeOf<InvalidOperationException>());
+        });
+
+        transferred.Dispose();
+        Assert.That(value.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void RuntimeIdentity_RejectsDefaultWhenValidated()
+    {
+        var identity = new RenderRuntimeIdentity(("frame", 3));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(identity.Key, Is.EqualTo(("frame", 3)));
+            Assert.That(() => identity.ThrowIfUninitialized("identity"), Throws.Nothing);
+            Assert.That(
+                () => default(RenderRuntimeIdentity).ThrowIfUninitialized("identity"),
+                Throws.TypeOf<ArgumentException>().With.Property("ParamName").EqualTo("identity"));
+        });
+    }
+
+    [Test]
+    public void Registration_RejectsKeysThatCannotBeRetainedSafely()
+    {
+        int captured = 1;
+        Func<int> closure = () => captured;
+        var ownedValue = new TrackedDisposable();
+        using var registry = new RenderRequestResourceRegistry();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => registry.RegisterOwned(ownedValue, ownedValue),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => registry.RegisterBorrowed(new object(), new byte[4]),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => registry.RegisterBorrowed(new object(), closure),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(ownedValue.DisposeCount, Is.Zero);
+        });
+    }
+
+    private sealed class TrackedDisposable : IDisposable
+    {
+        public int DisposeCount { get; private set; }
+
+        public void Dispose()
+        {
+            DisposeCount++;
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/ShaderAndAllocationFailureTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/ShaderAndAllocationFailureTests.cs
@@ -1,0 +1,562 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Failure;
+
+[TestFixture]
+public sealed class ShaderAndAllocationFailureTests
+{
+    [Test]
+    public void DescriptionValidationFailure_HappensDuringRecordingBeforeAnyTargetAllocation()
+    {
+        using var node = new InvalidDescriptionNode();
+        var factory = new TrackingTargetFactory();
+        using var renderer = CreateRenderer(node, factory);
+
+        ArgumentException? failure = Assert.Throws<ArgumentException>(() => renderer.Rasterize());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Does.Contain("CurrentPixel"));
+            Assert.That(factory.CreateCalls, Is.Zero);
+            Assert.That(factory.Targets, Is.Empty);
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            Assert.That(renderer.ProgramCacheStatistics.RetainedPrograms, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void SnippetMergeFailure_DoesNotPoisonAValidDeterministicRetry()
+    {
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return color; }");
+        var stage = new SkslSnippetStage(description);
+        SkslMergedProgram before = SkslSnippetMerger.Merge([stage]);
+
+        ArgumentException? failure = Assert.Throws<ArgumentException>(
+            () => SkslSnippetMerger.Merge([]));
+        SkslMergedProgram after = SkslSnippetMerger.Merge([stage]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Does.Contain("At least one CurrentPixel stage"));
+            Assert.That(after.Source, Is.EqualTo(before.Source));
+            Assert.That(after.Bindings, Is.EqualTo(before.Bindings));
+            Assert.That(after.Identity, Is.EqualTo(before.Identity));
+        });
+    }
+
+    [Test]
+    public void InvalidProgram_PreservesValidationFailureAndReturnsEveryTargetToThePool()
+    {
+        using var node = new ShaderNode(ShaderDescription.WholeSource(
+            "uniform shader src; half4 main(float2 p) { this is not valid SkSL; }",
+            RenderBoundsContract.Identity));
+        var factory = new TrackingTargetFactory();
+        var renderer = CreateRenderer(node, factory);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => renderer.Rasterize());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Does.StartWith("SkSL program validation failed:"));
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            Assert.That(renderer.TargetPoolStatistics.OwnedTargets, Is.GreaterThan(0));
+            Assert.That(renderer.ProgramCacheStatistics.RetainedPrograms, Is.Zero,
+                "A failed backend compile must not install a program-cache entry.");
+            Assert.That(factory.Targets, Has.All.Matches<TrackingRenderTarget>(target => !target.IsDisposed));
+        });
+
+        renderer.Dispose();
+        Assert.That(factory.Targets, Has.All.Matches<TrackingRenderTarget>(target => target.DisposeCalls == 1));
+    }
+
+    [TestCase(RuntimeBindingFailure.MissingUniform)]
+    [TestCase(RuntimeBindingFailure.DuplicateUniform)]
+    [TestCase(RuntimeBindingFailure.MissingResource)]
+    [TestCase(RuntimeBindingFailure.DuplicateResource)]
+    public void RuntimeBindingFailure_SealsTheWriterAndDischargesEveryTarget(
+        RuntimeBindingFailure failurePoint)
+    {
+        using var node = new RuntimeBindingFailureNode(failurePoint);
+        var factory = new TrackingTargetFactory();
+        var renderer = CreateRenderer(node, factory);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => renderer.Rasterize());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Does.Contain("must set its writer exactly once"));
+            Assert.That(node.VerifyRetainedWriter is not null, Is.True);
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            Assert.That(renderer.ProgramCacheStatistics.RetainedPrograms, Is.EqualTo(1),
+                "A runtime binding failure must not corrupt the immutable compiled program.");
+        });
+        Action verifyRetainedWriter = node.VerifyRetainedWriter
+            ?? throw new AssertionException("The runtime binder did not expose its retained-writer probe.");
+        Assert.That(verifyRetainedWriter, Throws.TypeOf<InvalidOperationException>());
+
+        renderer.Dispose();
+        Assert.That(factory.Targets, Has.All.Matches<TrackingRenderTarget>(target => target.DisposeCalls == 1));
+    }
+
+    [Test]
+    public void MaterializationCallbackFailure_DischargesTheCreatedOutputWithoutPartialPublication()
+    {
+        var primary = new InvalidOperationException("materialization-callback-primary");
+        using var node = new MaterializationFailureNode(primary);
+        var factory = new TrackingTargetFactory();
+        var renderer = CreateRenderer(node, factory);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => renderer.Rasterize());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.SameAs(primary));
+            Assert.That(node.CallbackEntries, Is.EqualTo(1));
+            Assert.That(factory.CreateCalls, Is.EqualTo(2),
+                "The root and callback output were both acquired before the injected callback fault.");
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            Assert.That(node.Cache.IsCached, Is.False);
+            Assert.That(factory.Targets, Has.All.Matches<TrackingRenderTarget>(target => !target.IsDisposed));
+        });
+
+        renderer.Dispose();
+        Assert.That(factory.Targets, Has.All.Matches<TrackingRenderTarget>(target => target.DisposeCalls == 1));
+    }
+
+    [Test]
+    public void UniformProviderFailure_RemainsPrimaryAndDoesNotPublishARasterization()
+    {
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            "uniform float gain; half4 apply(half4 color) { return color * gain; }",
+            bindings => bindings.Uniform(
+                "gain",
+                0.5f,
+                static (_, _, _) => throw new InvalidOperationException("uniform-provider-failure"),
+                structuralKey: "throwing-uniform-provider",
+                cachePolicy: ShaderBindingCachePolicy.ReuseFromSnapshot));
+        using var node = new ShaderNode(description);
+        var factory = new TrackingTargetFactory();
+        var renderer = CreateRenderer(node, factory);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => renderer.Rasterize());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Is.EqualTo("uniform-provider-failure"));
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            Assert.That(renderer.ProgramCacheStatistics.RetainedPrograms, Is.EqualTo(1),
+                "A provider failure must not corrupt the immutable compiled program.");
+        });
+
+        renderer.Dispose();
+        Assert.That(factory.Targets, Has.All.Matches<TrackingRenderTarget>(target => target.DisposeCalls == 1));
+    }
+
+    [Test]
+    public void DeliveryTargetAcquisitionFailure_DischargesTheAlreadyAcceptedRootWithoutPartialOutput()
+    {
+        using var node = new ShaderNode(ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return color; }"));
+        var factory = new TrackingTargetFactory(failAt: 1);
+        var renderer = CreateRenderer(node, factory, RenderIntent.Delivery);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => renderer.Rasterize());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Does.Contain("could not allocate"));
+            Assert.That(factory.CreateCalls, Is.EqualTo(2));
+            Assert.That(factory.Targets, Has.Count.EqualTo(1));
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            Assert.That(factory.Targets.Single().IsDisposed, Is.False,
+                "An accepted target remains renderer-owned until renderer disposal.");
+        });
+
+        renderer.Dispose();
+        Assert.That(factory.Targets.Single().DisposeCalls, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void PreviewTargetAcquisitionFailure_SilentlyChangesThePixelsDeliveryRefusesToProduce()
+    {
+        static byte[] RasterizePreview(TrackingTargetFactory factory)
+        {
+            using var node = new ShaderNode(ShaderDescription.CurrentPixel(
+                "half4 apply(half4 color) { return color; }"));
+            using RenderNodeRenderer renderer = CreateRenderer(node, factory, RenderIntent.Preview);
+            using RenderNodeRasterization rasterization = renderer.Rasterize();
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            return rasterization.Bitmap!.GetPixelSpan().ToArray();
+        }
+
+        byte[] intact = RasterizePreview(new TrackingTargetFactory());
+        byte[] degraded = RasterizePreview(new TrackingTargetFactory(failAt: 1));
+
+        Assert.That(degraded, Is.Not.EqualTo(intact),
+            "Preview absorbs the allocation failure and returns different pixels, which is why a "
+            + "delivery-grade render must use RenderIntent.Delivery and fail instead.");
+    }
+
+    [Test]
+    public void ProgramCacheDisposal_ContinuesAfterEachProgramFaultAndSurfacesTheFirstFailure()
+    {
+        var cache = new ProgramCache<ThrowingProgram>(
+            static _ => { },
+            static _ => 1,
+            maxRetainedBytes: 16);
+        var programs = new List<ThrowingProgram>();
+        ProgramCacheContextKey context = new(
+            "device",
+            "context",
+            "capability",
+            "linear-premul-rgba16f",
+            "options");
+        Acquire("half4 main(float2 p) { return half4(1); }");
+        Acquire("half4 main(float2 p) { return half4(0); }");
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(cache.Dispose);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Is.EqualTo("program-dispose-1"),
+                "The most-recently-used program is the first disposal attempt.");
+            Assert.That(programs.Select(static program => program.DisposeCalls), Is.All.EqualTo(1));
+            Assert.That(cache.Statistics.RetainedPrograms, Is.Zero);
+            Assert.DoesNotThrow(cache.Dispose);
+        });
+
+        void Acquire(string source)
+        {
+            var identity = new SkslMergedProgramIdentity(
+                source,
+                [],
+                SkslBackendBudget.Unlimited);
+            using ProgramCacheLease<ThrowingProgram> lease = cache.GetOrCreate(
+                identity,
+                context,
+                () =>
+                {
+                    var program = new ThrowingProgram(programs.Count);
+                    programs.Add(program);
+                    return program;
+                });
+        }
+    }
+
+    [Test]
+    public void ProgramCreationFailure_LeavesNoEntryAndAValidRetryCanBeRetained()
+    {
+        using var cache = new ProgramCache<TrackingProgram>(
+            static _ => { },
+            static _ => 1,
+            maxRetainedBytes: 16);
+        var identity = new SkslMergedProgramIdentity(
+            "half4 main(float2 p) { return half4(1); }",
+            [],
+            SkslBackendBudget.Unlimited);
+        var context = new ProgramCacheContextKey(
+            "device",
+            "context",
+            "capability",
+            "linear-premul-rgba16f",
+            "options");
+        var primary = new InvalidOperationException("program-creation-primary");
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => cache.GetOrCreate(identity, context, () => throw primary));
+        var recovered = new TrackingProgram();
+        using (ProgramCacheLease<TrackingProgram> lease = cache.GetOrCreate(
+                   identity,
+                   context,
+                   () => recovered))
+        {
+            Assert.That(lease.IsCacheHit, Is.False);
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.SameAs(primary));
+            Assert.That(cache.Statistics.Misses, Is.EqualTo(2));
+            Assert.That(cache.Statistics.Creations, Is.EqualTo(1));
+            Assert.That(cache.Statistics.RetainedPrograms, Is.EqualTo(1));
+        });
+
+        cache.Dispose();
+        Assert.That(recovered.DisposeCalls, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void RendererDisposal_ContinuesAfterPoolFaultAndStillReleasesProgramsAndPlans()
+    {
+        var poolFailure = new InvalidOperationException("renderer-pool-dispose-primary");
+        using var node = new ShaderNode(ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return color; }"));
+        var factory = new TrackingTargetFactory(
+            disposeFailureAt: index => index == 0 ? poolFailure : null);
+        var renderer = CreateRenderer(node, factory);
+        using (RenderNodeRasterization rasterization = renderer.Rasterize())
+        {
+            Assert.That(rasterization.IsEmpty, Is.False);
+        }
+        Assert.Multiple(() =>
+        {
+            Assert.That(renderer.ProgramCacheStatistics.RetainedPrograms, Is.EqualTo(1));
+            Assert.That(renderer.StructuralPlanCacheStatistics.RetainedPlans, Is.EqualTo(1));
+            Assert.That(factory.Targets, Has.Count.GreaterThanOrEqualTo(2));
+        });
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(renderer.Dispose);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.SameAs(poolFailure));
+            Assert.That(renderer.TargetPoolStatistics.OwnedTargets, Is.Zero);
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+            Assert.That(renderer.ProgramCacheStatistics.RetainedPrograms, Is.Zero);
+            Assert.That(renderer.StructuralPlanCacheStatistics.RetainedPlans, Is.Zero);
+            Assert.That(factory.Targets, Has.All.Matches<TrackingRenderTarget>(target => target.DisposeCalls == 1));
+            Assert.DoesNotThrow(renderer.Dispose);
+        });
+    }
+
+    public enum RuntimeBindingFailure
+    {
+        MissingUniform,
+        DuplicateUniform,
+        MissingResource,
+        DuplicateResource,
+    }
+
+    private static RenderNodeRenderer CreateRenderer(
+        RenderNode root,
+        IRenderTargetFactory factory,
+        RenderIntent intent = RenderIntent.Preview)
+        => new(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    Intent = intent,
+                    TargetDomain = new Rect(0, 0, 8, 8),
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = factory,
+            });
+
+    private sealed class ShaderNode(ShaderDescription description) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            OpaqueRenderDescription source = OpaqueRenderDescription.CreateRequestLocal(
+                session =>
+                {
+                    using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                    output.Canvas.Use(canvas => canvas.Clear(Colors.CornflowerBlue));
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.Source(new Rect(0, 0, 8, 8)),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: "shader-allocation-failure-source");
+            context.Publish(context.Shader(context.OpaqueSource(source), description));
+        }
+    }
+
+    private sealed class InvalidDescriptionNode : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            _ = ShaderDescription.CurrentPixel(
+                "half4 main(float2 position) { return half4(position, 0, 1); }");
+        }
+    }
+
+    private sealed class RuntimeBindingFailureNode(RuntimeBindingFailure failurePoint) : RenderNode
+    {
+        private readonly object _resource = new();
+
+        public Action? VerifyRetainedWriter { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            ShaderDescription description = failurePoint is RuntimeBindingFailure.MissingUniform
+                or RuntimeBindingFailure.DuplicateUniform
+                ? CreateUniformDescription()
+                : CreateResourceDescription(context);
+            RenderFragmentHandle source = context.OpaqueSource(OpaqueRenderDescription.CreateRequestLocal(
+                session =>
+                {
+                    using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                    output.Canvas.Use(canvas => canvas.Clear(Colors.CornflowerBlue));
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.Source(new Rect(0, 0, 8, 8)),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: $"runtime-binding-source-{failurePoint}"));
+            context.Publish(context.Shader(source, description));
+        }
+
+        private ShaderDescription CreateUniformDescription()
+        {
+            return ShaderDescription.CurrentPixel(
+                "uniform float gain; half4 apply(half4 color) { return color * gain; }",
+                bindings => bindings.Uniform(
+                    "gain",
+                    0.5f,
+                    (writer, value, _) =>
+                    {
+                        VerifyRetainedWriter = () => writer.Set(value);
+                        if (failurePoint == RuntimeBindingFailure.MissingUniform)
+                            return;
+
+                        writer.Set(value);
+                        writer.Set(value);
+                    },
+                    structuralKey: $"runtime-uniform-{failurePoint}"));
+        }
+
+        private ShaderDescription CreateResourceDescription(RenderNodeContext context)
+        {
+            RenderResource<object> resource = context.Borrow(
+                _resource,
+                cacheKey: "runtime-binding-resource",
+                version: 1);
+            return ShaderDescription.CurrentPixel(
+                "uniform shader lookup; half4 apply(half4 color) { return lookup.eval(color.rg); }",
+                bindings => bindings.Resource(
+                    "lookup",
+                    resource,
+                    ShaderResourceCoordinateSpace.Value,
+                    (writer, _, _) =>
+                    {
+                        VerifyRetainedWriter = () =>
+                        {
+                            using SKShader retained = SKShader.CreateColor(SKColors.White);
+                            writer.Set(retained);
+                        };
+                        if (failurePoint == RuntimeBindingFailure.MissingResource)
+                            return;
+
+                        writer.Set(SKShader.CreateColor(SKColors.White));
+                        using SKShader duplicate = SKShader.CreateColor(SKColors.Black);
+                        writer.Set(duplicate);
+                    },
+                    structuralKey: $"runtime-resource-{failurePoint}"));
+        }
+    }
+
+    private sealed class MaterializationFailureNode(InvalidOperationException failure) : RenderNode
+    {
+        public int CallbackEntries { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            context.Publish(context.OpaqueSource(OpaqueRenderDescription.CreateRequestLocal(
+                session =>
+                {
+                    CallbackEntries++;
+                    using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                    output.Canvas.Use(canvas => canvas.Clear(Colors.CornflowerBlue));
+                    throw failure;
+                },
+                OpaqueRenderBoundsContract.Source(new Rect(0, 0, 8, 8)),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: "materialization-callback-failure")));
+        }
+    }
+
+    private sealed class TrackingTargetFactory(
+        int? failAt = null,
+        Func<int, Exception?>? disposeFailureAt = null) : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public List<TrackingRenderTarget> Targets { get; } = [];
+
+        public int CreateCalls { get; private set; }
+
+        public RenderTarget? Create(RenderTargetAllocationDescriptor allocation)
+        {
+            PixelSize deviceSize = allocation.DeviceSize;
+            int index = CreateCalls++;
+            if (index == failAt)
+                return null;
+
+            var target = new TrackingRenderTarget(deviceSize, disposeFailureAt?.Invoke(index));
+            Targets.Add(target);
+            return target;
+        }
+    }
+
+    private sealed class TrackingRenderTarget : RenderTarget
+    {
+        private readonly Exception? _disposeFailure;
+
+        public TrackingRenderTarget(PixelSize size, Exception? disposeFailure = null)
+            : base(
+                SKSurface.Create(new SKImageInfo(
+                    size.Width,
+                    size.Height,
+                    SKColorType.RgbaF16,
+                    SKAlphaType.Premul,
+                    SKColorSpace.CreateSrgbLinear())),
+                size.Width,
+                size.Height)
+        {
+            _disposeFailure = disposeFailure;
+        }
+
+        public int DisposeCalls { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            bool fail = disposing && !IsDisposed && _disposeFailure is not null;
+            if (disposing && !IsDisposed)
+                DisposeCalls++;
+            base.Dispose(disposing);
+            if (fail)
+                throw _disposeFailure!;
+        }
+    }
+
+    private sealed class TrackingProgram : IDisposable
+    {
+        public int DisposeCalls { get; private set; }
+
+        public void Dispose()
+        {
+            DisposeCalls++;
+        }
+    }
+
+    private sealed class ThrowingProgram(int id) : IDisposable
+    {
+        public int DisposeCalls { get; private set; }
+
+        public void Dispose()
+        {
+            DisposeCalls++;
+            throw new InvalidOperationException($"program-dispose-{id}");
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Fusion/CrossNodeShaderFusionTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Fusion/CrossNodeShaderFusionTests.cs
@@ -1,0 +1,938 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Backend;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+using Beutl.UnitTests.Engine.Graphics.Rendering.Golden;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Fusion;
+
+[TestFixture]
+[NonParallelizable]
+public sealed class CrossNodeShaderFusionTests
+{
+    private static readonly Rect s_bounds = new(3, 5, 12, 8);
+
+    [Test]
+    public void Enabled_CompilesDistinctShaderOpacityShaderNodesAsOneRun()
+    {
+        using CompiledRenderRequest compiled = CompilePrimaryChain(FusionMode.Enabled);
+
+        CompiledShaderRun run = compiled.ExecutionPlan.ShaderRuns.Single();
+        Assert.Multiple(() =>
+        {
+            Assert.That(compiled.ExecutionPlan.Islands, Has.Length.EqualTo(1));
+            Assert.That(run.Stages.Select(static stage => stage.Kind), Is.EqualTo(new[]
+            {
+                RenderFragmentKind.Shader,
+                RenderFragmentKind.Opacity,
+                RenderFragmentKind.Shader,
+            }));
+            Assert.That(run.Stages.Select(static stage => stage.CoverageBehavior), Is.EqualTo(new[]
+            {
+                SkslCoverageBehavior.RequiresResolvedCoverage,
+                SkslCoverageBehavior.PremultipliedCoverageHomogeneous,
+                SkslCoverageBehavior.RequiresResolvedCoverage,
+            }));
+            Assert.That(run.Program.StageCount, Is.EqualTo(3));
+            Assert.That(run.IsFused, Is.True);
+            Assert.That(run.CoverageSource, Is.EqualTo(ShaderRunCoverageSource.MaterializedInput));
+            Assert.That(run.Output.CanBeUsedAsValueInput, Is.True,
+                "The typed opacity descriptor must preserve value-input eligibility.");
+            Assert.That(compiled.ExecutionPlan.Boundaries, Has.Some.Matches<ExecutionIslandBoundary>(
+                static boundary => boundary.Reason == ExecutionIslandBoundaryReason.MaterializedInput));
+        });
+
+        string source = run.Program.Source;
+        int gamma = source.IndexOf("__beutl_s0_apply", StringComparison.Ordinal);
+        int opacity = source.IndexOf("__beutl_s1_apply", StringComparison.Ordinal);
+        int invert = source.IndexOf("__beutl_s2_apply", StringComparison.Ordinal);
+        Assert.That(gamma, Is.GreaterThanOrEqualTo(0));
+        Assert.That(opacity, Is.GreaterThan(gamma));
+        Assert.That(invert, Is.GreaterThan(opacity));
+    }
+
+    [Test]
+    public void Disabled_KeepsIdenticalSemanticStagesButPreventsComposition()
+    {
+        using CompiledRenderRequest enabled = CompilePrimaryChain(FusionMode.Enabled);
+        using CompiledRenderRequest disabled = CompilePrimaryChain(FusionMode.Disabled);
+
+        CompiledShaderStage[] enabledStages = enabled.ExecutionPlan.ShaderRuns
+            .SelectMany(static run => run.Stages)
+            .ToArray();
+        CompiledShaderStage[] disabledStages = disabled.ExecutionPlan.ShaderRuns
+            .SelectMany(static run => run.Stages)
+            .ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(enabled.Request.Options.PlanIdentity,
+                Is.Not.EqualTo(disabled.Request.Options.PlanIdentity));
+            Assert.That(enabled.ExecutionPlan.ShaderRuns.Count(), Is.EqualTo(1));
+            Assert.That(disabled.ExecutionPlan.ShaderRuns.Count(), Is.EqualTo(3));
+            Assert.That(disabled.ExecutionPlan.ShaderRuns.Select(static run => run.Stages.Length),
+                Is.EqualTo(new[] { 1, 1, 1 }));
+            Assert.That(disabledStages.Select(static stage => stage.Kind),
+                Is.EqualTo(enabledStages.Select(static stage => stage.Kind)));
+            Assert.That(disabledStages.Select(static stage => stage.Description.Source.Text),
+                Is.EqualTo(enabledStages.Select(static stage => stage.Description.Source.Text)));
+            Assert.That(disabled.ExecutionPlan.Boundaries.Count(static boundary =>
+                    boundary.Reason == ExecutionIslandBoundaryReason.FusionDisabled),
+                Is.EqualTo(2));
+        });
+    }
+
+    [TestCase(-1f, 0f)]
+    [TestCase(2f, 1f)]
+    public void FiniteOutOfRangeOpacity_NormalizesBeforePlanningAndMatchesUnfusedExecution(
+        float authoredOpacity,
+        float expectedOpacity)
+    {
+        var targetFactory = new CpuTargetFactory();
+        using RenderTarget source = targetFactory.CreateCpuTarget(
+            new PixelSize((int)s_bounds.Width, (int)s_bounds.Height));
+        source.Value.Canvas.Clear(new SKColor(48, 112, 216, 176));
+        using var enabledNode = new PrimaryChainNode(source, s_bounds, authoredOpacity);
+        using var disabledNode = new PrimaryChainNode(source, s_bounds, authoredOpacity);
+        using var expectedNode = new PrimaryChainNode(source, s_bounds, expectedOpacity);
+        using var enabled = CreateCpuRenderer(enabledNode, FusionMode.Enabled, targetFactory);
+        using var disabled = CreateCpuRenderer(disabledNode, FusionMode.Disabled, targetFactory);
+        using var expected = CreateCpuRenderer(expectedNode, FusionMode.Enabled, targetFactory);
+
+        using RenderNodeRasterization enabledRaster = enabled.Rasterize();
+        using RenderNodeRasterization disabledRaster = disabled.Rasterize();
+        using RenderNodeRasterization expectedRaster = expected.Rasterize();
+
+        Assert.That(enabledRaster.Bitmap, Is.Not.Null);
+        Assert.That(disabledRaster.Bitmap, Is.Not.Null);
+        Assert.That(expectedRaster.Bitmap, Is.Not.Null);
+        RgbaMaximumError fusionParity = ImageMetrics.MaximumAbsoluteErrorPerChannel(
+            disabledRaster.Bitmap!,
+            enabledRaster.Bitmap!);
+        RgbaMaximumError normalizedParity = ImageMetrics.MaximumAbsoluteErrorPerChannel(
+            expectedRaster.Bitmap!,
+            enabledRaster.Bitmap!);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(enabled.LastExecutionStatistics.ShaderStageExecutions, Is.EqualTo(3));
+            Assert.That(enabled.LastExecutionStatistics.FusedShaderRunExecutions, Is.EqualTo(1),
+                "The normalized opacity must remain eligible for its adjacent shader run.");
+            Assert.That(disabled.LastExecutionStatistics.ShaderStageExecutions, Is.EqualTo(3));
+            Assert.That(disabled.LastExecutionStatistics.FusedShaderRunExecutions, Is.Zero);
+            Assert.That(normalizedParity.Maximum, Is.Zero,
+                "Recording must make an out-of-range opacity identical to its clamped value.");
+            Assert.That(fusionParity.Maximum, Is.LessThanOrEqualTo(0.003),
+                "FusionMode must not change finite out-of-range opacity semantics.");
+        });
+    }
+
+    [Test]
+    public void CpuDestination_UsesPortableBudgetAndSplitsLongShaderChain()
+    {
+        int stageCount = SkslBackendBudgetResolver.Portable.MaxStages + 1;
+        var targetFactory = new CpuTargetFactory();
+        using var node = new LongShaderChainNode(stageCount);
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    Intent = RenderIntent.Preview,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    FusionMode = FusionMode.Enabled,
+                    Purpose = RenderRequestPurpose.Frame,
+                },
+                TargetFactory = targetFactory,
+            });
+        using RenderTarget destination = targetFactory.CreateCpuTarget(new PixelSize(24, 16));
+        using var canvas = new ImmediateCanvas(destination, logicalSize: new Size(24, 16));
+
+        Assert.That(destination.Value.Context, Is.Null);
+        renderer.Render(canvas);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(renderer.LastExecutionStatistics.ShaderRunExecutions, Is.EqualTo(2));
+            Assert.That(renderer.LastExecutionStatistics.ShaderStageExecutions, Is.EqualTo(stageCount));
+            Assert.That(renderer.LastExecutionStatistics.FusedShaderRunExecutions, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void ChangingFromCpuToGpuDestination_SelectsTheActualSurfaceCapabilityClass()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            int stageCount = SkslBackendBudgetResolver.Portable.MaxStages + 1;
+            var cpuFactory = new CpuTargetFactory();
+            using var node = new LongShaderChainNode(stageCount);
+            using var renderer = new RenderNodeRenderer(
+                node,
+                new RenderNodeRendererOptions
+                {
+                    DefaultRequest = new RenderNodeRenderRequest
+                    {
+                        Intent = RenderIntent.Preview,
+                        CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                        FusionMode = FusionMode.Enabled,
+                        Purpose = RenderRequestPurpose.Frame,
+                    },
+                });
+            using RenderTarget cpuDestination = cpuFactory.CreateCpuTarget(new PixelSize(24, 16));
+            using var cpuCanvas = new ImmediateCanvas(cpuDestination, logicalSize: new Size(24, 16));
+            using RenderTarget gpuDestination = RenderTarget.Create(24, 16)
+                ?? throw new InvalidOperationException("Could not create the GPU fusion-test surface.");
+            using var gpuCanvas = new ImmediateCanvas(gpuDestination, logicalSize: new Size(24, 16));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(cpuDestination.Value.Context, Is.Null);
+                Assert.That(
+                    gpuDestination.Value.Context?.Backend,
+                    Is.AnyOf(GRBackend.Vulkan, GRBackend.Metal));
+            });
+
+            renderer.Render(cpuCanvas);
+            StructuralPlanCacheStatistics cpuStatistics = renderer.StructuralPlanCacheStatistics;
+            renderer.Render(gpuCanvas);
+            StructuralPlanCacheStatistics firstGpuStatistics = renderer.StructuralPlanCacheStatistics;
+            renderer.Render(gpuCanvas);
+            StructuralPlanCacheStatistics warmedGpuStatistics = renderer.StructuralPlanCacheStatistics;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(cpuStatistics.Compilations, Is.EqualTo(1));
+                Assert.That(firstGpuStatistics.Compilations, Is.EqualTo(2));
+                Assert.That(firstGpuStatistics.Replacements, Is.EqualTo(1));
+                Assert.That(warmedGpuStatistics.Compilations, Is.EqualTo(2));
+                Assert.That(warmedGpuStatistics.Hits, Is.EqualTo(1));
+                Assert.That(renderer.LastExecutionStatistics.ShaderRunExecutions, Is.EqualTo(2));
+                Assert.That(renderer.LastExecutionStatistics.ShaderStageExecutions, Is.EqualTo(stageCount));
+            });
+        });
+    }
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void ProgramCache_ContextChangeMissesAndThenWarmsTheNewContext()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using IGraphicsContext firstContext = GraphicsContextFactory.CreateContext();
+            using IGraphicsContext secondContext = GraphicsContextFactory.CreateContext();
+            using RenderTarget firstDestination = CreateContextTarget(firstContext, 24, 16);
+            using RenderTarget secondDestination = CreateContextTarget(secondContext, 24, 16);
+            using var firstCanvas = new ImmediateCanvas(
+                firstDestination,
+                logicalSize: new Size(24, 16));
+            using var secondCanvas = new ImmediateCanvas(
+                secondDestination,
+                logicalSize: new Size(24, 16));
+            using RenderTarget source = new CpuTargetFactory().CreateCpuTarget(
+                new PixelSize((int)s_bounds.Width, (int)s_bounds.Height));
+            source.Value.Canvas.Clear(new SKColor(48, 112, 216, 176));
+            using var node = new PrimaryChainNode(source, s_bounds);
+            using var renderer = CreateRenderer(node, FusionMode.Enabled);
+
+            renderer.Render(firstCanvas);
+            ProgramCacheStatistics firstCold = renderer.ProgramCacheStatistics;
+            renderer.Render(firstCanvas);
+            ProgramCacheStatistics firstWarm = renderer.ProgramCacheStatistics;
+            renderer.Render(secondCanvas);
+            ProgramCacheStatistics secondCold = renderer.ProgramCacheStatistics;
+            renderer.Render(secondCanvas);
+            ProgramCacheStatistics secondWarm = renderer.ProgramCacheStatistics;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(firstDestination.Value.Context?.Backend,
+                    Is.EqualTo(secondDestination.Value.Context?.Backend));
+                Assert.That(firstDestination.Value.Context?.Handle,
+                    Is.Not.EqualTo(secondDestination.Value.Context?.Handle));
+                Assert.That(firstCold.Creations, Is.EqualTo(1));
+                Assert.That(firstCold.Hits, Is.Zero);
+                Assert.That(firstCold.RetainedPrograms, Is.EqualTo(1));
+                Assert.That(firstWarm.Creations, Is.EqualTo(1));
+                Assert.That(firstWarm.Hits, Is.EqualTo(1));
+                Assert.That(firstWarm.RetainedPrograms, Is.EqualTo(1));
+                Assert.That(secondCold.Creations, Is.EqualTo(2));
+                Assert.That(secondCold.Hits, Is.EqualTo(1));
+                Assert.That(secondCold.Evictions, Is.EqualTo(1));
+                Assert.That(secondCold.RetainedPrograms, Is.EqualTo(1),
+                    "switching contexts must eagerly discharge the old context's program");
+                Assert.That(secondWarm.Creations, Is.EqualTo(2));
+                Assert.That(secondWarm.Hits, Is.EqualTo(2));
+                Assert.That(secondWarm.Evictions, Is.EqualTo(1));
+                Assert.That(secondWarm.RetainedPrograms, Is.EqualTo(1));
+            });
+        });
+    }
+
+    [Test]
+    public void PublishedIntermediateFanOut_IsAnExplicitDeterministicBoundary()
+    {
+        using CompiledRenderRequest compiled = CompilePrimaryChain(
+            FusionMode.Enabled,
+            publishFirstShader: true);
+
+        CompiledShaderRun[] runs = compiled.ExecutionPlan.ShaderRuns.ToArray();
+        Assert.Multiple(() =>
+        {
+            Assert.That(runs, Has.Length.EqualTo(2));
+            Assert.That(runs[0].Stages.Select(static stage => stage.Kind),
+                Is.EqualTo(new[] { RenderFragmentKind.Shader }));
+            Assert.That(runs[1].Stages.Select(static stage => stage.Kind),
+                Is.EqualTo(new[] { RenderFragmentKind.Opacity, RenderFragmentKind.Shader }));
+            Assert.That(compiled.ExecutionPlan.Boundaries, Has.Some.Matches<ExecutionIslandBoundary>(
+                static boundary => boundary.Reason == ExecutionIslandBoundaryReason.Branching));
+        });
+    }
+
+    [Test]
+    public void Planner_OmitsCommittedFragmentsThatAreNotReachableFromAPublication()
+    {
+        var requestId = new RenderRequestId(1);
+        RenderFragmentReference source = Fragment(
+            RenderFragmentKind.MaterializedInput,
+            EffectiveScale.At(1),
+            payload: null);
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return color; }");
+        RenderFragmentReference unpublished = Fragment(
+            RenderFragmentKind.Shader,
+            EffectiveScale.At(1),
+            new ShaderRenderFragmentPayload(description, description.CreateRuntimeIdentity()),
+            source);
+        RecordedRenderGraph graph = BuildGraph(requestId, [source, unpublished], [source]);
+
+        ExecutionIslandPlan plan = new ExecutionIslandPlanner().Plan(
+            graph,
+            RenderRequestCompiler.ResolveRoots(graph),
+            FusionMode.Enabled,
+            SkslBackendBudget.Unlimited);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(graph.Fragments, Has.Length.EqualTo(2));
+            Assert.That(plan.Islands, Is.Empty);
+            Assert.That(plan.Boundaries, Is.Empty);
+        });
+    }
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void Enabled_ExecutesDistinctNodePrimaryChainOnce_WithParityAndAWarmedProgram()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using RenderTarget source = CreateSourceTarget();
+            using var node = new PrimaryChainNode(source, s_bounds);
+            var diagnostics = new RenderPipelineDiagnosticsState();
+            using var enabled = CreateRenderer(node, FusionMode.Enabled, diagnostics: diagnostics);
+            using var disabled = CreateRenderer(node, FusionMode.Disabled);
+
+            using RenderNodeRasterization disabledRaster = disabled.Rasterize();
+            using RenderNodeRasterization enabledRaster = enabled.Rasterize();
+            using RenderNodeRasterization warmedRaster = enabled.Rasterize();
+
+            Assert.That(disabledRaster.Bitmap, Is.Not.Null);
+            Assert.That(enabledRaster.Bitmap, Is.Not.Null);
+            Assert.That(warmedRaster.Bitmap, Is.Not.Null);
+            RgbaMaximumError parity = ImageMetrics.MaximumAbsoluteErrorPerChannel(
+                disabledRaster.Bitmap!,
+                enabledRaster.Bitmap!);
+            RgbaMaximumError warmedParity = ImageMetrics.MaximumAbsoluteErrorPerChannel(
+                enabledRaster.Bitmap!,
+                warmedRaster.Bitmap!);
+            double ssim = ImageMetrics.Ssim(disabledRaster.Bitmap!, enabledRaster.Bitmap!);
+            double energy = SumAbsoluteChannels(enabledRaster.Bitmap!);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(energy, Is.GreaterThan(1), "the execution oracle must not be transparent or vacuous");
+                Assert.That(ssim, Is.GreaterThanOrEqualTo(0.99));
+                Assert.That(parity.Maximum, Is.LessThanOrEqualTo(0.0025));
+                Assert.That(warmedParity.Maximum, Is.Zero);
+                Assert.That(enabled.LastExecutionStatistics.ShaderRunExecutions, Is.EqualTo(1));
+                Assert.That(enabled.LastExecutionStatistics.ShaderStageExecutions, Is.EqualTo(3));
+                Assert.That(enabled.LastExecutionStatistics.FusedShaderRunExecutions, Is.EqualTo(1));
+                Assert.That(enabled.LastExecutionStatistics.IntermediateTargetAcquisitions, Is.Zero);
+                Assert.That(enabled.LastExecutionStatistics.Synchronizations, Is.Zero);
+                Assert.That(diagnostics.Latest[RenderPipelineCounter.PlannedGpuPasses], Is.EqualTo(1));
+                Assert.That(diagnostics.Latest[RenderPipelineCounter.ExecutedGpuPasses], Is.EqualTo(1));
+                Assert.That(enabled.LastExecutionStatistics.ProgramCacheHits, Is.EqualTo(1));
+                Assert.That(enabled.ProgramCacheStatistics.Creations, Is.EqualTo(1));
+                Assert.That(enabled.ProgramCacheStatistics.Hits, Is.EqualTo(1));
+                Assert.That(enabled.TargetPoolStatistics.Creates, Is.EqualTo(1));
+                Assert.That(enabled.TargetPoolStatistics.Misses, Is.EqualTo(1));
+                Assert.That(enabled.TargetPoolStatistics.Reuses, Is.EqualTo(1));
+                Assert.That(enabled.TargetPoolStatistics.LeasedTargets, Is.Zero);
+                Assert.That(disabled.LastExecutionStatistics.ShaderRunExecutions, Is.EqualTo(3));
+                Assert.That(disabled.LastExecutionStatistics.FusedShaderRunExecutions, Is.Zero);
+                Assert.That(enabled.Options.DefaultRequest.FusionMode, Is.EqualTo(FusionMode.Enabled));
+                Assert.That(disabled.Options.DefaultRequest.FusionMode, Is.EqualTo(FusionMode.Disabled));
+                Assert.That(enabled.StructuralPlanCacheStatistics.Compilations, Is.EqualTo(1));
+                Assert.That(enabled.StructuralPlanCacheStatistics.Misses, Is.EqualTo(1));
+                Assert.That(enabled.StructuralPlanCacheStatistics.Hits, Is.EqualTo(1));
+                Assert.That(disabled.StructuralPlanCacheStatistics.Compilations, Is.EqualTo(1));
+                Assert.That(disabled.StructuralPlanCacheStatistics.Misses, Is.EqualTo(1));
+                Assert.That(disabled.StructuralPlanCacheStatistics.Hits, Is.Zero);
+                Assert.That(node.ProcessCounts, Is.EqualTo(new[] { 3, 3, 3 }),
+                    "Each render must traverse the countable source, Gamma, and Invert node transactions.");
+            });
+        });
+    }
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void UnboundedVectorShaderRoot_DrawsTerminalRunDirectlyAndCacheForcesMaterialization()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var directDiagnostics = new RenderPipelineDiagnosticsState();
+            using var directNode = new VectorTerminalShaderNode(publishTwice: false);
+            using var direct = CreateRenderer(
+                directNode,
+                FusionMode.Enabled,
+                diagnostics: directDiagnostics);
+            using RenderNodeRasterization directRaster = direct.Rasterize();
+
+            var cacheDiagnostics = new RenderPipelineDiagnosticsState();
+            using var cachedNode = new VectorTerminalShaderNode(publishTwice: false);
+            cachedNode.Cache.ReportRenderCount(RenderNodeCache.Count);
+            using var cached = CreateRenderer(
+                cachedNode,
+                FusionMode.Enabled,
+                useRenderCache: true,
+                diagnostics: cacheDiagnostics);
+            using RenderNodeRasterization missRaster = cached.Rasterize();
+            RenderExecutionStatistics missStatistics = cached.LastExecutionStatistics;
+            using RenderNodeRasterization hitRaster = cached.Rasterize();
+
+            Assert.That(directRaster.Bitmap, Is.Not.Null);
+            Assert.That(missRaster.Bitmap, Is.Not.Null);
+            Assert.That(hitRaster.Bitmap, Is.Not.Null);
+            RgbaMaximumError missParity = ImageMetrics.MaximumAbsoluteErrorPerChannel(
+                directRaster.Bitmap!,
+                missRaster.Bitmap!);
+            RgbaMaximumError hitParity = ImageMetrics.MaximumAbsoluteErrorPerChannel(
+                directRaster.Bitmap!,
+                hitRaster.Bitmap!);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(directNode.OutputScale.IsUnbounded, Is.True);
+                Assert.That(direct.LastExecutionStatistics.ShaderRunExecutions, Is.EqualTo(1));
+                Assert.That(direct.LastExecutionStatistics.IntermediateTargetAcquisitions, Is.EqualTo(1),
+                    "Only the vector coverage input should materialize; the terminal Shader writes the root target.");
+                Assert.That(directDiagnostics.Latest[RenderPipelineCounter.ExecutedGpuPasses], Is.EqualTo(2));
+                Assert.That(cachedNode.Cache.IsCached, Is.True);
+                Assert.That(missStatistics.IntermediateTargetAcquisitions, Is.GreaterThan(1),
+                    "A selected cache capture must force a materialized terminal Shader value.");
+                Assert.That(cacheDiagnostics.Latest[RenderPipelineCounter.RenderCacheHits], Is.EqualTo(1));
+                Assert.That(missParity.Maximum, Is.LessThanOrEqualTo(0.02));
+                Assert.That(hitParity.Maximum, Is.LessThanOrEqualTo(0.02));
+            });
+        });
+    }
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void PublishedShaderFanOut_DisablesTerminalDirectDraw()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var node = new VectorTerminalShaderNode(publishTwice: true);
+            using var renderer = CreateRenderer(node, FusionMode.Enabled);
+
+            using RenderNodeRasterization result = renderer.Rasterize();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Bitmap, Is.Not.Null);
+                Assert.That(node.OutputScale.IsUnbounded, Is.True);
+                Assert.That(renderer.LastExecutionStatistics.ShaderRunExecutions, Is.EqualTo(1));
+                Assert.That(renderer.LastExecutionStatistics.IntermediateTargetAcquisitions, Is.EqualTo(2),
+                    "Fan-out must materialize both the vector input and terminal Shader output exactly once.");
+            });
+        });
+    }
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void TerminalDirectDraw_PreservesActiveDestinationState_WithCacheMissAsReference()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using RenderTarget source = CreateSourceTarget();
+            using var directNode = new PrimaryChainNode(source, s_bounds);
+            using var cachedNode = new PrimaryChainNode(source, s_bounds);
+            cachedNode.Cache.ReportRenderCount(RenderNodeCache.Count);
+            using var direct = CreateRenderer(directNode, FusionMode.Enabled);
+            using var cached = CreateRenderer(cachedNode, FusionMode.Enabled, useRenderCache: true);
+
+            using Bitmap directBitmap = RenderWithActiveDestinationState(direct);
+            using Bitmap cachedBitmap = RenderWithActiveDestinationState(cached);
+            using Bitmap background = CreateActiveDestinationBackground();
+            RgbaMaximumError parity = ImageMetrics.MaximumAbsoluteErrorPerChannel(
+                directBitmap,
+                cachedBitmap);
+            RgbaMaximumError directChange = ImageMetrics.MaximumAbsoluteErrorPerChannel(
+                directBitmap,
+                background);
+            RgbaMaximumError cachedChange = ImageMetrics.MaximumAbsoluteErrorPerChannel(
+                cachedBitmap,
+                background);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(direct.LastExecutionStatistics.IntermediateTargetAcquisitions, Is.Zero);
+                Assert.That(cached.LastExecutionStatistics.IntermediateTargetAcquisitions, Is.GreaterThan(0));
+                Assert.That(cachedNode.Cache.IsCached, Is.True);
+                Assert.That(directChange.Maximum, Is.GreaterThan(0.02),
+                    "The terminal direct draw must modify the cleared destination.");
+                Assert.That(cachedChange.Maximum, Is.GreaterThan(0.02),
+                    "The cache-materialized terminal draw must modify the cleared destination.");
+                Assert.That(parity.Maximum, Is.LessThanOrEqualTo(0.02));
+            });
+        });
+    }
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void TerminalDirectDraw_FractionalDestinationFallsBackToMaterializedComposite()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using RenderTarget source = CreateSourceTarget();
+            using var directNode = new PrimaryChainNode(source, s_bounds);
+            using var cachedNode = new PrimaryChainNode(source, s_bounds);
+            cachedNode.Cache.ReportRenderCount(RenderNodeCache.Count);
+            using var direct = CreateRenderer(directNode, FusionMode.Enabled);
+            using var cached = CreateRenderer(cachedNode, FusionMode.Enabled, useRenderCache: true);
+
+            using Bitmap directBitmap = RenderWithDestinationTranslation(direct, 2.25f, 1.5f);
+            using Bitmap cachedBitmap = RenderWithDestinationTranslation(cached, 2.25f, 1.5f);
+            RgbaMaximumError parity = ImageMetrics.MaximumAbsoluteErrorPerChannel(
+                directBitmap,
+                cachedBitmap);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(direct.LastExecutionStatistics.IntermediateTargetAcquisitions, Is.GreaterThan(0),
+                    "A fractional device origin must disable the terminal direct draw.");
+                Assert.That(cached.LastExecutionStatistics.IntermediateTargetAcquisitions, Is.GreaterThan(0));
+                Assert.That(parity.Maximum, Is.LessThanOrEqualTo(0.02));
+            });
+        });
+    }
+
+    private static RenderNodeRenderer CreateRenderer(
+        RenderNode node,
+        FusionMode fusionMode,
+        bool useRenderCache = false,
+        IRenderPipelineDiagnosticsState? diagnostics = null)
+        => new(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    Intent = RenderIntent.Preview,
+                    TargetDomain = s_bounds,
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                    CacheOptions = new Beutl.Graphics.Rendering.Cache.RenderCacheOptions(useRenderCache, Beutl.Graphics.Rendering.Cache.RenderCacheRules.Default),
+                    FusionMode = fusionMode,
+                    Purpose = RenderRequestPurpose.Frame,
+                    Diagnostics = diagnostics,
+                },
+            });
+
+    private static RenderNodeRenderer CreateCpuRenderer(
+        RenderNode node,
+        FusionMode fusionMode,
+        IRenderTargetFactory targetFactory)
+        => new(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    Intent = RenderIntent.Preview,
+                    TargetDomain = s_bounds,
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    FusionMode = fusionMode,
+                    Purpose = RenderRequestPurpose.Frame,
+                },
+                TargetFactory = targetFactory,
+            });
+
+    private static Bitmap RenderWithActiveDestinationState(RenderNodeRenderer renderer)
+        => RenderWithDestinationTranslation(renderer, 2, 1);
+
+    private static Bitmap CreateActiveDestinationBackground()
+    {
+        using RenderTarget target = RenderTarget.Create(32, 24)
+            ?? throw new InvalidOperationException("Could not allocate the active-state background control.");
+        target.Value.Canvas.Clear(new SKColor(26, 48, 72, 255));
+        return target.Snapshot();
+    }
+
+    private static Bitmap RenderWithDestinationTranslation(
+        RenderNodeRenderer renderer,
+        float x,
+        float y)
+    {
+        using RenderTarget target = RenderTarget.Create(32, 24)
+            ?? throw new InvalidOperationException("Could not allocate the active-state destination.");
+        using var canvas = new ImmediateCanvas(target, logicalSize: new Size(32, 24));
+        canvas.Clear(new Color(255, 26, 48, 72));
+        using (canvas.PushTransform(Matrix.CreateTranslation(x, y)))
+        using (canvas.PushClip(new Rect(4, 5, 10, 7)))
+        using (canvas.PushOpacity(0.625f))
+        using (canvas.PushBlendMode(BlendMode.Screen))
+        {
+            renderer.Render(canvas);
+        }
+
+        return target.Snapshot();
+    }
+
+    private static RenderTarget CreateSourceTarget()
+    {
+        RenderTarget target = RenderTarget.Create((int)s_bounds.Width, (int)s_bounds.Height)
+            ?? throw new InvalidOperationException("Could not allocate the deterministic fusion source.");
+        using var paint = new SKPaint
+        {
+            Color = new SKColor(48, 112, 216, 176),
+            IsAntialias = false,
+        };
+        target.Value.Canvas.Clear(new SKColor(12, 24, 40, 96));
+        target.Value.Canvas.DrawRect(SKRect.Create(2, 1, 8, 6), paint);
+        return target;
+    }
+
+    private static RenderTarget CreateContextTarget(
+        IGraphicsContext context,
+        int width,
+        int height)
+    {
+        ITexture2D texture = context.CreateTexture2D(
+            width,
+            height,
+            TextureFormat.RGBA16Float);
+        try
+        {
+            return new TextureRenderTarget(texture);
+        }
+        catch
+        {
+            texture.Dispose();
+            throw;
+        }
+    }
+
+    private static double SumAbsoluteChannels(Bitmap bitmap)
+    {
+        double result = 0;
+        foreach (ushort bits in bitmap.GetPixelSpan<ushort>())
+            result += Math.Abs((float)BitConverter.UInt16BitsToHalf(bits));
+        return result;
+    }
+
+    private sealed class PrimaryChainNode : RenderNode
+    {
+        private static readonly ShaderDescription s_gamma = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return half4(sqrt(max(color.rgb, half3(0))), color.a); }");
+
+        private static readonly ShaderDescription s_invert = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return half4(color.a - color.rgb, color.a); }");
+
+        private readonly MaterializedSourceNode _source;
+        private readonly ShaderStageNode _gamma = new(s_gamma);
+        private readonly OpacityRenderNode _opacity;
+        private readonly ShaderStageNode _invert = new(s_invert);
+
+        public PrimaryChainNode(RenderTarget source, Rect bounds, float opacity = 0.625f)
+        {
+            _source = new MaterializedSourceNode(source, bounds);
+            _opacity = new OpacityRenderNode(opacity);
+        }
+
+        public int[] ProcessCounts =>
+        [
+            _source.ProcessCalls,
+            _gamma.ProcessCalls,
+            _invert.ProcessCalls,
+        ];
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle current = context.RecordNode(_source, []).Single();
+            current = context.RecordNode(_gamma, [current]).Single();
+            current = context.RecordNode(_opacity, [current]).Single();
+            current = context.RecordNode(_invert, [current]).Single();
+            context.Publish(current);
+        }
+
+        protected override void OnDispose(bool disposing)
+        {
+            _invert.Dispose();
+            _opacity.Dispose();
+            _gamma.Dispose();
+            _source.Dispose();
+            base.OnDispose(disposing);
+        }
+    }
+
+    private sealed class MaterializedSourceNode(RenderTarget source, Rect bounds) : RenderNode
+    {
+        public int ProcessCalls { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            ProcessCalls++;
+            RenderResource<RenderTarget> target = context.Borrow(source, "primary-fusion-source", 1);
+            context.Publish(context.MaterializedInput(
+                MaterializedInputDescription.FromRenderTarget(
+                    target,
+                    bounds,
+                    EffectiveScale.At(1),
+                    PixelRect.FromRect(bounds, 1),
+                    default,
+                    RenderHitTestContract.OutputBounds)));
+        }
+    }
+
+    private sealed class ShaderStageNode(ShaderDescription description) : RenderNode
+    {
+        public int ProcessCalls { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            ProcessCalls++;
+            Assert.That(context.Inputs, Has.Exactly(1).Items);
+            context.Publish(context.Shader(context.Inputs[0], description));
+        }
+    }
+
+    private sealed class LongShaderChainNode : RenderNode
+    {
+        private static readonly ShaderDescription s_shader = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return color; }");
+
+        private readonly RectangleRenderNode _source = new(
+            new Rect(3, 5, 12, 8),
+            Brushes.Resource.White,
+            pen: null);
+        private readonly ShaderStageNode[] _stages;
+
+        public LongShaderChainNode(int stageCount)
+        {
+            _stages = Enumerable.Range(0, stageCount)
+                .Select(static _ => new ShaderStageNode(s_shader))
+                .ToArray();
+        }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle current = context.RecordNode(_source, []).Single();
+            foreach (ShaderStageNode stage in _stages)
+                current = context.RecordNode(stage, [current]).Single();
+            context.Publish(current);
+        }
+
+        protected override void OnDispose(bool disposing)
+        {
+            foreach (ShaderStageNode stage in _stages)
+                stage.Dispose();
+            _source.Dispose();
+            base.OnDispose(disposing);
+        }
+    }
+
+    private sealed class CpuTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public RenderTarget CreateCpuTarget(PixelSize deviceSize)
+            => CreateCore(deviceSize);
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+            => CreateCore(allocation.DeviceSize);
+
+        private static RenderTarget CreateCore(PixelSize deviceSize)
+        {
+            SKSurface surface = SKSurface.Create(new SKImageInfo(
+                    deviceSize.Width,
+                    deviceSize.Height,
+                    SKColorType.RgbaF16,
+                    SKAlphaType.Premul,
+                    SKColorSpace.CreateSrgbLinear()))
+                ?? throw new InvalidOperationException("Could not create the CPU fusion-test surface.");
+            return new CpuRenderTarget(surface, deviceSize);
+        }
+    }
+
+    private sealed class CpuRenderTarget(SKSurface surface, PixelSize size)
+        : RenderTarget(surface, size.Width, size.Height)
+    {
+    }
+
+    private sealed class TextureRenderTarget : RenderTarget
+    {
+        private ITexture2D? _texture;
+
+        public TextureRenderTarget(ITexture2D texture)
+            : base(texture.CreateSkiaSurface(), texture.Width, texture.Height)
+        {
+            _texture = texture;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            try
+            {
+                base.Dispose(disposing);
+            }
+            finally
+            {
+                if (disposing)
+                    Interlocked.Exchange(ref _texture, null)?.Dispose();
+            }
+        }
+    }
+
+    private sealed class VectorTerminalShaderNode(bool publishTwice) : RenderNode
+    {
+        private static readonly ShaderDescription s_shader = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return half4(color.bgr, color.a); }");
+
+        private readonly EllipseRenderNode _source = new(
+            new Rect(4.25f, 6.5f, 9.5f, 5.75f),
+            Brushes.Resource.White,
+            pen: null);
+        private readonly ShaderStageNode _shader = new(s_shader);
+
+        public EffectiveScale OutputScale { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle current = context.RecordNode(_source, []).Single();
+            current = context.RecordNode(_shader, [current]).Single();
+            if (!current.TryGetMetadata(out RenderFragmentMetadata metadata))
+                throw new InvalidOperationException("The finite shader output must expose concrete metadata.");
+            OutputScale = metadata.EffectiveScale;
+            context.Publish(current);
+            if (publishTwice)
+                context.Publish(current);
+        }
+
+        protected override void OnDispose(bool disposing)
+        {
+            _shader.Dispose();
+            _source.Dispose();
+            base.OnDispose(disposing);
+        }
+    }
+
+    private static CompiledRenderRequest CompilePrimaryChain(
+        FusionMode fusionMode,
+        bool publishFirstShader = false)
+    {
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            fusionMode: fusionMode);
+        var request = new RenderRequest(options);
+
+        RenderFragmentReference source = Fragment(
+            RenderFragmentKind.MaterializedInput,
+            EffectiveScale.At(1),
+            payload: null);
+        ShaderDescription gamma = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return half4(sqrt(color.rgb), color.a); }");
+        RenderFragmentReference firstShader = Fragment(
+            RenderFragmentKind.Shader,
+            EffectiveScale.At(1),
+            new ShaderRenderFragmentPayload(gamma, gamma.CreateRuntimeIdentity()),
+            source);
+        RenderFragmentReference opacity = Fragment(
+            RenderFragmentKind.Opacity,
+            EffectiveScale.At(1),
+            new OpacityRenderFragmentPayload(
+                0.625f,
+                OpacityRenderNode.CreateFusionDescription(0.625f)),
+            firstShader);
+        ShaderDescription invert = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return half4(color.a - color.rgb, color.a); }");
+        RenderFragmentReference secondShader = Fragment(
+            RenderFragmentKind.Shader,
+            EffectiveScale.At(1),
+            new ShaderRenderFragmentPayload(invert, invert.CreateRuntimeIdentity()),
+            opacity);
+
+        RecordedRenderGraph graph = BuildGraph(
+            request.Id,
+            [source, firstShader, opacity, secondShader],
+            publishFirstShader ? [firstShader, secondShader] : [secondShader]);
+        request.TransitionTo(RenderRequestState.Recording);
+        request.TransitionTo(RenderRequestState.Recorded);
+        return new RenderRequestCompiler().Compile(request, graph);
+    }
+
+    private static RenderFragmentReference Fragment(
+        RenderFragmentKind kind,
+        EffectiveScale scale,
+        object? payload,
+        params RenderFragmentReference[] inputs)
+    {
+        return new RenderFragmentReference(
+            kind,
+            s_bounds,
+            scale,
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: false,
+            hasOpaqueExternalWork: false,
+            inputs,
+            payload,
+            static _ => true);
+    }
+
+    private static RecordedRenderGraph BuildGraph(
+        RenderRequestId requestId,
+        IReadOnlyList<RenderFragmentReference> references,
+        IReadOnlyList<RenderFragmentReference> roots)
+    {
+        var builder = new RecordedRenderGraphBuilder(requestId);
+        RenderProvenanceId provenance = builder.AddProvenance(typeof(CrossNodeShaderFusionTests), "test");
+        foreach (RenderFragmentReference reference in references)
+        {
+            RenderValueId[] inputs = reference.Inputs.SelectMany(static input => input.ValueIds).ToArray();
+            reference.ValueIds = [builder.AddValue(inputs, provenance, reference)];
+            reference.Id = builder.AddFragment(reference.ValueIds, provenance, reference);
+        }
+        foreach (RenderFragmentReference root in roots)
+            builder.PublishRoot(root.Id!.Value);
+        return builder.Build();
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Fusion/ExecutionIslandAuthorityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Fusion/ExecutionIslandAuthorityTests.cs
@@ -1,0 +1,624 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Fusion;
+
+[TestFixture]
+[NonParallelizable]
+public sealed class ExecutionIslandAuthorityTests
+{
+    private static readonly Rect s_bounds = new(0, 0, 24, 16);
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void TerminalOpacity_DispatchesTheCompiledRunBeforeSemanticReplay()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using RenderTarget source = FusionBoundaryExecutionTestSupport.CreatePatternSource(s_bounds);
+            using var node = new TerminalOpacityNode(source);
+            using var renderer = CreateRenderer(node);
+
+            using RenderNodeRasterization result = renderer.Rasterize();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Bitmap, Is.Not.Null);
+                Assert.That(FusionBoundaryExecutionTestSupport.SumAbsoluteChannels(result.Bitmap!),
+                    Is.GreaterThan(1));
+                Assert.That(renderer.LastExecutionStatistics.ShaderRunExecutions, Is.EqualTo(1));
+                Assert.That(renderer.LastExecutionStatistics.ShaderStageExecutions, Is.EqualTo(2));
+                Assert.That(renderer.LastExecutionStatistics.FusedShaderRunExecutions, Is.EqualTo(1));
+            });
+        });
+    }
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void SameBackendCompiledRun_HasNoExecutorManagedFlush()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using RenderTarget source = FusionBoundaryExecutionTestSupport.CreatePatternSource(s_bounds);
+            using RenderTarget destination = RenderTarget.Create((int)s_bounds.Width, (int)s_bounds.Height)
+                ?? throw new InvalidOperationException("Could not allocate the flush-test destination.");
+            using var canvas = new ImmediateCanvas(destination, logicalSize: s_bounds.Size);
+            using var node = new TerminalOpacityNode(source);
+            using var renderer = CreateRenderer(node);
+            var observed = new ConcurrentQueue<ImmediateCanvasFlushKind>();
+
+            using (ImmediateCanvas.ObserveFlushes(observed.Enqueue))
+                renderer.Render(canvas);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.LastExecutionStatistics.Synchronizations, Is.Zero);
+                Assert.That(observed, Is.Empty,
+                    "A same-backend compiled run must not hide synchronization behind canvas disposal or blits.");
+            });
+        });
+    }
+
+    [Test]
+    public void OpacityOnly_IsPlannedAsASemanticGpuPassIsland()
+    {
+        using CompiledRenderRequest compiled = CompileOpacityOnly();
+        RenderFragmentReference opacity = compiled.Roots.Single();
+        Assert.Multiple(() =>
+        {
+            Assert.That(compiled.ExecutionPlan.ShaderRuns, Is.Empty);
+            Assert.That(compiled.ExecutionPlan.Islands, Has.Exactly(1).Items);
+            Assert.That(compiled.ExecutionPlan.TryGetMembership(opacity, out ExecutionIslandMembership membership),
+                Is.True);
+            Assert.That(membership.Island.Kind, Is.EqualTo(ExecutionIslandKind.Compatibility));
+            Assert.That(membership.Island.PlansGpuPass, Is.True);
+            Assert.That(compiled.ExecutionPlan.Boundaries,
+                Has.Some.Matches<ExecutionIslandBoundary>(static boundary =>
+                    boundary.Reason == ExecutionIslandBoundaryReason.SemanticComposite));
+        });
+    }
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void OpacityOnly_RuntimeUsesSemanticReplayWithOneGpuPass()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using RenderTarget source = FusionBoundaryExecutionTestSupport.CreatePatternSource(s_bounds);
+            using Bitmap sourceBitmap = source.Snapshot();
+            using var node = new OpacityOnlyNode(source);
+            var diagnostics = new RenderPipelineDiagnosticsState();
+            using var renderer = CreateRenderer(node, diagnostics);
+
+            using RenderNodeRasterization result = renderer.Rasterize();
+            double maximumDifference = MaximumOpacityDifference(sourceBitmap, result.Bitmap!, 0.625f);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(FusionBoundaryExecutionTestSupport.SumAbsoluteChannels(result.Bitmap!),
+                    Is.GreaterThan(1));
+                Assert.That(renderer.LastExecutionStatistics.ShaderRunExecutions, Is.Zero);
+                Assert.That(renderer.LastExecutionStatistics.ShaderStageExecutions, Is.Zero);
+                Assert.That(diagnostics.Latest[RenderPipelineCounter.PlannedGpuPasses], Is.EqualTo(1));
+                Assert.That(diagnostics.Latest[RenderPipelineCounter.ExecutedGpuPasses], Is.EqualTo(1));
+                Assert.That(maximumDifference, Is.LessThan(0.002),
+                    "Semantic opacity replay must scale every premultiplied channel and alpha by 0.625.");
+            });
+        });
+    }
+
+    private static double MaximumOpacityDifference(Bitmap source, Bitmap actual, float opacity)
+    {
+        ReadOnlySpan<ushort> sourcePixels = source.GetPixelSpan<ushort>();
+        ReadOnlySpan<ushort> actualPixels = actual.GetPixelSpan<ushort>();
+        Assert.That(actualPixels.Length, Is.EqualTo(sourcePixels.Length));
+        double maximum = 0;
+        for (int index = 0; index < sourcePixels.Length; index++)
+        {
+            float sourceValue = (float)BitConverter.UInt16BitsToHalf(sourcePixels[index]);
+            float actualValue = (float)BitConverter.UInt16BitsToHalf(actualPixels[index]);
+            maximum = Math.Max(maximum, Math.Abs(actualValue - (sourceValue * opacity)));
+        }
+
+        return maximum;
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    [Category("GpuPassFusionGpu")]
+    public void DeclaredInputReadback_IsPlannedAndCountedOnlyAtActualUse(bool opaque)
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using RenderTarget source = FusionBoundaryExecutionTestSupport.CreatePatternSource(s_bounds);
+            using var node = new DeclaredInputReadbackNode(source, opaque);
+            using FusionBoundaryExecutionResult result = FusionBoundaryExecutionTestSupport.Execute(
+                node,
+                s_bounds,
+                FusionMode.Enabled);
+
+            ExecutionIslandBoundaryReason semanticReason = opaque
+                ? ExecutionIslandBoundaryReason.Opaque
+                : ExecutionIslandBoundaryReason.Geometry;
+            Assert.Multiple(() =>
+            {
+                Assert.That(FusionBoundaryExecutionTestSupport.SumAbsoluteChannels(result.Bitmap),
+                    Is.GreaterThan(1));
+                Assert.That(result.Statistics.Synchronizations, Is.EqualTo(1));
+                Assert.That(result.Diagnostics[RenderPipelineCounter.Synchronizations], Is.EqualTo(1));
+                Assert.That(result.Diagnostics[RenderPipelineCounter.PlannedGpuPasses], Is.EqualTo(1));
+                Assert.That(result.Diagnostics[RenderPipelineCounter.ExecutedGpuPasses], Is.EqualTo(1));
+                Assert.That(result.Diagnostics.Events,
+                    Has.Some.Matches<RenderPipelineDiagnosticEvent>(item =>
+                        item.Kind == RenderPipelineDiagnosticEventKind.BoundaryPlanned
+                        && item.BoundaryReason == RenderPipelineBoundaryReason.Readback));
+                Assert.That(result.Diagnostics.Events,
+                    Has.Some.Matches<RenderPipelineDiagnosticEvent>(item =>
+                        item.Kind == RenderPipelineDiagnosticEventKind.BoundaryPlanned
+                        && item.BoundaryReason == (semanticReason == ExecutionIslandBoundaryReason.Geometry
+                            ? RenderPipelineBoundaryReason.Geometry
+                            : RenderPipelineBoundaryReason.Opaque)));
+            });
+        });
+    }
+
+    [Test]
+    public void PlanLedger_RejectsDirectExecutionOfANonTerminalShaderStage()
+    {
+        using CompiledRenderRequest compiled = CompileTerminalOpacity();
+        CompiledShaderRun run = compiled.ExecutionPlan.ShaderRuns.Single();
+        RenderFragmentReference interior = Find(compiled.Graph, run.Stages[0].FragmentId);
+        ExecutionIslandExecutionLedger ledger = compiled.ExecutionPlan.CreateExecutionLedger(
+            compiled.Graph,
+            compiled.Roots,
+            compiled.CacheResolution);
+
+        Assert.That(
+            () => ledger.Begin(interior),
+            Throws.InvalidOperationException.With.Message.Contains("non-terminal"));
+    }
+
+    [Test]
+    public void PlanLedger_RejectsDuplicateIslandExecution()
+    {
+        using CompiledRenderRequest compiled = CompileTerminalOpacity();
+        CompiledShaderRun run = compiled.ExecutionPlan.ShaderRuns.Single();
+        ExecutionIslandExecutionLedger ledger = compiled.ExecutionPlan.CreateExecutionLedger(
+            compiled.Graph,
+            compiled.Roots,
+            compiled.CacheResolution);
+
+        ExecutionIsland island = ledger.Begin(run.Output);
+        ledger.Complete(island);
+
+        Assert.That(
+            () => ledger.Begin(run.Output),
+            Throws.InvalidOperationException.With.Message.Contains("more than once"));
+    }
+
+    [Test]
+    public void PlanLedger_RejectsAReachableExecutableFragmentMissingFromThePlan()
+    {
+        using CompiledRenderRequest compiled = CompileTerminalOpacity();
+        var invalid = new ExecutionIslandPlan([], compiled.ExecutionPlan.Boundaries);
+
+        Assert.That(
+            () => invalid.CreateExecutionLedger(
+                compiled.Graph,
+                compiled.Roots,
+                compiled.CacheResolution),
+            Throws.InvalidOperationException.With.Message.Contains("not assigned"));
+    }
+
+    [Test]
+    public void Plan_RejectsOneFragmentAssignedToMultipleIslands()
+    {
+        var requestId = new RenderRequestId(1);
+        var fragmentId = new RenderFragmentId(requestId, 1);
+
+        Assert.That(
+            () => new ExecutionIslandPlan(
+            [
+                new ExecutionIsland(
+                    new ExecutionIslandId(1),
+                    ExecutionIslandKind.Compatibility,
+                    [fragmentId],
+                    plansGpuPass: false),
+                new ExecutionIsland(
+                    new ExecutionIslandId(2),
+                    ExecutionIslandKind.Compatibility,
+                    [fragmentId],
+                    plansGpuPass: false),
+            ],
+            []),
+            Throws.ArgumentException.With.Message.Contains("more than one execution island"));
+    }
+
+    [Test]
+    public void PlanLedger_UsesPublicationOrderInsteadOfAuthoredIslandOrder()
+    {
+        var fixture = CreateReversePublicationFixture();
+        ExecutionIslandExecutionLedger ledger = fixture.Plan.CreateExecutionLedger(
+            fixture.Graph,
+            fixture.Roots,
+            new RenderCacheResolution([]));
+
+        ExecutionIsland second = ledger.Begin(fixture.Second);
+        ledger.Complete(second);
+        ExecutionIsland first = ledger.Begin(fixture.First);
+        ledger.Complete(first);
+
+        Assert.That(() => ledger.ValidateCompleted(), Throws.Nothing);
+
+        ExecutionIslandExecutionLedger reversed = fixture.Plan.CreateExecutionLedger(
+            fixture.Graph,
+            fixture.Roots,
+            new RenderCacheResolution([]));
+        ExecutionIsland authoredFirst = reversed.Begin(fixture.First);
+        reversed.Complete(authoredFirst);
+        ExecutionIsland authoredSecond = reversed.Begin(fixture.Second);
+        Assert.That(
+            () => reversed.Complete(authoredSecond),
+            Throws.InvalidOperationException.With.Message.Contains("painter order"));
+    }
+
+    [Test]
+    public void PlanLedger_VisitsOpacityMaskDependenciesBeforePrimaryReplay()
+    {
+        var requestId = new RenderRequestId(1);
+        RenderFragmentReference primarySource = Fragment(
+            RenderFragmentKind.MaterializedInput,
+            EffectiveScale.At(1),
+            payload: null);
+        RenderFragmentReference primary = Fragment(
+            RenderFragmentKind.Geometry,
+            EffectiveScale.At(1),
+            payload: null,
+            primarySource);
+        RenderFragmentReference maskSource = Fragment(
+            RenderFragmentKind.MaterializedInput,
+            EffectiveScale.At(1),
+            payload: null);
+        RenderFragmentReference maskDependency = Fragment(
+            RenderFragmentKind.Geometry,
+            EffectiveScale.At(1),
+            payload: null,
+            maskSource);
+        RenderFragmentReference opacityMask = Fragment(
+            RenderFragmentKind.OpacityMask,
+            EffectiveScale.At(1),
+            payload: null,
+            primary,
+            maskDependency);
+        ImmutableArray<RenderFragmentReference> roots = [opacityMask];
+        RecordedRenderGraph graph = BuildGraph(
+            requestId,
+            [primarySource, primary, maskSource, maskDependency, opacityMask],
+            roots);
+        var plan = new ExecutionIslandPlan(
+            [
+                new ExecutionIsland(
+                    new ExecutionIslandId(1),
+                    ExecutionIslandKind.Compatibility,
+                    [primary.Id!.Value],
+                    plansGpuPass: true),
+                new ExecutionIsland(
+                    new ExecutionIslandId(2),
+                    ExecutionIslandKind.Compatibility,
+                    [maskDependency.Id!.Value],
+                    plansGpuPass: true),
+                new ExecutionIsland(
+                    new ExecutionIslandId(3),
+                    ExecutionIslandKind.Compatibility,
+                    [opacityMask.Id!.Value],
+                    plansGpuPass: true),
+            ],
+            []);
+        ExecutionIslandExecutionLedger ledger = plan.CreateExecutionLedger(
+            graph,
+            roots,
+            new RenderCacheResolution([]));
+
+        ExecutionIsland dependencyIsland = ledger.Begin(maskDependency);
+        ledger.Complete(dependencyIsland);
+        ExecutionIsland primaryIsland = ledger.Begin(primary);
+        ledger.Complete(primaryIsland);
+        ExecutionIsland maskIsland = ledger.Begin(opacityMask);
+        ledger.Complete(maskIsland);
+
+        Assert.That(() => ledger.ValidateCompleted(), Throws.Nothing);
+    }
+
+    [Test]
+    public void PlanLedger_RejectsIncompleteSuccessfulExecution()
+    {
+        var fixture = CreateReversePublicationFixture();
+        ExecutionIslandExecutionLedger ledger = fixture.Plan.CreateExecutionLedger(
+            fixture.Graph,
+            fixture.Roots,
+            new RenderCacheResolution([]));
+
+        ExecutionIsland second = ledger.Begin(fixture.Second);
+        ledger.Complete(second);
+
+        Assert.That(
+            () => ledger.ValidateCompleted(),
+            Throws.InvalidOperationException.With.Message.Contains("must complete"));
+    }
+
+    private static RenderNodeRenderer CreateRenderer(
+        RenderNode node,
+        IRenderPipelineDiagnosticsState? diagnostics = null)
+        => new(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_bounds,
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    FusionMode = FusionMode.Enabled,
+                    Purpose = RenderRequestPurpose.Frame,
+                    Diagnostics = diagnostics,
+                },
+            });
+
+    private static CompiledRenderRequest CompileTerminalOpacity()
+    {
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            targetDomain: s_bounds,
+            cachePolicy: RenderCacheOptions.Disabled,
+            fusionMode: FusionMode.Enabled);
+        var request = new RenderRequest(options);
+        RenderFragmentReference source = Fragment(
+            RenderFragmentKind.MaterializedInput,
+            EffectiveScale.At(1),
+            payload: null);
+        ShaderDescription shader = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return half4(color.bgr, color.a); }");
+        RenderFragmentReference stage = Fragment(
+            RenderFragmentKind.Shader,
+            EffectiveScale.Unbounded,
+            new ShaderRenderFragmentPayload(shader, shader.CreateRuntimeIdentity()),
+            source);
+        RenderFragmentReference opacity = Fragment(
+            RenderFragmentKind.Opacity,
+            EffectiveScale.Unbounded,
+            new OpacityRenderFragmentPayload(
+                0.625f,
+                OpacityRenderNode.CreateFusionDescription(0.625f)),
+            stage);
+        RecordedRenderGraph graph = BuildGraph(request.Id, [source, stage, opacity], [opacity]);
+        request.TransitionTo(RenderRequestState.Recording);
+        request.TransitionTo(RenderRequestState.Recorded);
+        return new RenderRequestCompiler().Compile(request, graph);
+    }
+
+    private static CompiledRenderRequest CompileOpacityOnly()
+    {
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            targetDomain: s_bounds,
+            cachePolicy: RenderCacheOptions.Disabled,
+            fusionMode: FusionMode.Enabled);
+        var request = new RenderRequest(options);
+        RenderFragmentReference source = Fragment(
+            RenderFragmentKind.MaterializedInput,
+            EffectiveScale.At(1),
+            payload: null);
+        RenderFragmentReference opacity = Fragment(
+            RenderFragmentKind.Opacity,
+            EffectiveScale.At(1),
+            new OpacityRenderFragmentPayload(
+                0.625f,
+                OpacityRenderNode.CreateFusionDescription(0.625f)),
+            source);
+        RecordedRenderGraph graph = BuildGraph(request.Id, [source, opacity], [opacity]);
+        request.TransitionTo(RenderRequestState.Recording);
+        request.TransitionTo(RenderRequestState.Recorded);
+        return new RenderRequestCompiler().Compile(request, graph);
+    }
+
+    private static (
+        RecordedRenderGraph Graph,
+        ImmutableArray<RenderFragmentReference> Roots,
+        ExecutionIslandPlan Plan,
+        RenderFragmentReference First,
+        RenderFragmentReference Second) CreateReversePublicationFixture()
+    {
+        var requestId = new RenderRequestId(1);
+        RenderFragmentReference firstSource = Fragment(
+            RenderFragmentKind.MaterializedInput,
+            EffectiveScale.At(1),
+            payload: null);
+        RenderFragmentReference first = Fragment(
+            RenderFragmentKind.Geometry,
+            EffectiveScale.At(1),
+            payload: null,
+            firstSource);
+        RenderFragmentReference secondSource = Fragment(
+            RenderFragmentKind.MaterializedInput,
+            EffectiveScale.At(1),
+            payload: null);
+        RenderFragmentReference second = Fragment(
+            RenderFragmentKind.Geometry,
+            EffectiveScale.At(1),
+            payload: null,
+            secondSource);
+        ImmutableArray<RenderFragmentReference> roots = [second, first];
+        RecordedRenderGraph graph = BuildGraph(
+            requestId,
+            [firstSource, first, secondSource, second],
+            roots);
+        var plan = new ExecutionIslandPlan(
+            [
+                new ExecutionIsland(
+                    new ExecutionIslandId(1),
+                    ExecutionIslandKind.Compatibility,
+                    [first.Id!.Value],
+                    plansGpuPass: true),
+                new ExecutionIsland(
+                    new ExecutionIslandId(2),
+                    ExecutionIslandKind.Compatibility,
+                    [second.Id!.Value],
+                    plansGpuPass: true),
+            ],
+            []);
+        return (graph, roots, plan, first, second);
+    }
+
+    private static RenderFragmentReference Find(RecordedRenderGraph graph, RenderFragmentId id)
+        => (RenderFragmentReference)graph.Fragments.Single(fragment => fragment.Id == id).Payload!;
+
+    private static RenderFragmentReference Fragment(
+        RenderFragmentKind kind,
+        EffectiveScale scale,
+        object? payload,
+        params RenderFragmentReference[] inputs)
+        => new(
+            kind,
+            s_bounds,
+            scale,
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: false,
+            hasOpaqueExternalWork: false,
+            inputs,
+            payload,
+            static _ => true);
+
+    private static RecordedRenderGraph BuildGraph(
+        RenderRequestId requestId,
+        IReadOnlyList<RenderFragmentReference> references,
+        IReadOnlyList<RenderFragmentReference> roots)
+    {
+        var builder = new RecordedRenderGraphBuilder(requestId);
+        RenderProvenanceId provenance = builder.AddProvenance(
+            typeof(ExecutionIslandAuthorityTests),
+            "execution-island-authority-test");
+        foreach (RenderFragmentReference reference in references)
+        {
+            RenderValueId[] inputs = reference.Inputs.SelectMany(static input => input.ValueIds).ToArray();
+            reference.ValueIds = [builder.AddValue(inputs, provenance, reference)];
+            reference.Id = builder.AddFragment(reference.ValueIds, provenance, reference);
+        }
+
+        foreach (RenderFragmentReference root in roots)
+            builder.PublishRoot(root.Id!.Value);
+        return builder.Build();
+    }
+
+    private sealed class TerminalOpacityNode(RenderTarget source) : RenderNode
+    {
+        private static readonly ShaderDescription s_shader = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return half4(color.bgr, color.a); }");
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<RenderTarget> resource = context.Borrow(
+                source,
+                (typeof(TerminalOpacityNode), "source"),
+                version: 1);
+            RenderFragmentHandle current = context.MaterializedInput(
+                MaterializedInputDescription.FromRenderTarget(
+                    resource,
+                    s_bounds,
+                    EffectiveScale.At(1),
+                    PixelRect.FromRect(s_bounds, 1),
+                    default,
+                    RenderHitTestContract.OutputBounds));
+            current = context.Shader(current, s_shader);
+            current = context.Opacity(current, 0.625f);
+            context.Publish(current);
+        }
+    }
+
+    private sealed class OpacityOnlyNode(RenderTarget source) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<RenderTarget> resource = context.Borrow(
+                source,
+                (typeof(OpacityOnlyNode), "source"),
+                version: 1);
+            RenderFragmentHandle current = context.MaterializedInput(
+                MaterializedInputDescription.FromRenderTarget(
+                    resource,
+                    s_bounds,
+                    EffectiveScale.At(1),
+                    PixelRect.FromRect(s_bounds, 1),
+                    default,
+                    RenderHitTestContract.OutputBounds));
+            current = context.Opacity(current, 0.625f);
+            context.Publish(current);
+        }
+    }
+
+    private sealed class DeclaredInputReadbackNode(RenderTarget source, bool opaque) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<RenderTarget> resource = context.Borrow(
+                source,
+                (typeof(DeclaredInputReadbackNode), opaque, "source"),
+                version: 1);
+            RenderFragmentHandle current = context.MaterializedInput(
+                MaterializedInputDescription.FromRenderTarget(
+                    resource,
+                    s_bounds,
+                    EffectiveScale.At(1),
+                    PixelRect.FromRect(s_bounds, 1),
+                    default,
+                    RenderHitTestContract.OutputBounds));
+            current = opaque
+                ? context.OpaqueMap(
+                    current,
+                    OpaqueRenderDescription.Create(
+                        "opaque-readback",
+                        static (session, _) =>
+                        {
+                            RenderExecutionInput input = session.Inputs.Single();
+                            input.UseSnapshot(static _ => { });
+                            using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                            output.Canvas.Use(input.Draw);
+                            session.Publish(output);
+                        },
+                        OpaqueRenderBoundsContract.Map(RenderBoundsContract.Identity),
+                        RenderHitTestContract.AnyInput,
+                        RenderValueCardinality.Single,
+                        RenderScaleContract.PreserveInputSupply,
+                        structuralKey: (typeof(DeclaredInputReadbackNode), "opaque"),
+                        inputReadbacks: [RenderInputReadback.All]))
+                : context.Geometry(
+                    current,
+                    GeometryDescription.Create(
+                        "geometry-readback",
+                        static (session, _) =>
+                        {
+                            session.Input.UseSnapshot(static _ => { });
+                            session.Canvas.Use(session.Input.Draw);
+                        },
+                        RenderBoundsContract.Identity,
+                        RenderHitTestContract.AnyInput,
+                        structuralKey: (typeof(DeclaredInputReadbackNode), "geometry"),
+                        requiresReadback: true));
+            context.Publish(current);
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Fusion/FusionBoundaryExecutionTestSupport.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Fusion/FusionBoundaryExecutionTestSupport.cs
@@ -1,0 +1,410 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Fusion;
+
+internal enum FusionBoundaryRuntimeScenario
+{
+    MaterializedInput,
+    WholeSource,
+    Geometry,
+    OpaqueCallback,
+    TargetReadback,
+    DestinationBlend,
+    DynamicExpansion,
+    Graphics3D,
+}
+
+internal sealed class FusionBoundaryRuntimeNode(
+    RenderTarget source,
+    Rect bounds,
+    FusionBoundaryRuntimeScenario scenario) : RenderNode
+{
+    private static readonly ShaderDescription s_firstShader = ShaderDescription.CurrentPixel(
+        "half4 apply(half4 color) { return half4(color.rg * 0.875, color.ba); }");
+
+    private static readonly ShaderDescription s_secondShader = ShaderDescription.CurrentPixel(
+        "half4 apply(half4 color) { return half4(color.b, color.g, color.r, color.a); }");
+
+    public override void Process(RenderNodeContext context)
+    {
+        RenderResource<RenderTarget> resource = context.Borrow(
+            source,
+            (typeof(FusionBoundaryRuntimeNode), scenario, "source"),
+            1);
+        RenderFragmentHandle current = context.MaterializedInput(
+            MaterializedInputDescription.FromRenderTarget(
+                resource,
+                bounds,
+                EffectiveScale.At(1),
+                PixelRect.FromRect(bounds, 1),
+                default,
+                RenderHitTestContract.OutputBounds));
+        current = context.Shader(current, s_firstShader);
+
+        switch (scenario)
+        {
+            case FusionBoundaryRuntimeScenario.MaterializedInput:
+                context.Publish(current);
+                return;
+
+            case FusionBoundaryRuntimeScenario.WholeSource:
+                current = context.Shader(current, ShaderDescription.WholeSource(
+                    "uniform shader src; half4 main(float2 coord) { return src.eval(coord); }",
+                    RenderBoundsContract.Identity));
+                break;
+
+            case FusionBoundaryRuntimeScenario.Geometry:
+                current = context.Geometry(current, GeometryDescription.CreateRequestLocal(
+                    session => session.Canvas.Use(session.Input.Draw),
+                    RenderBoundsContract.Identity,
+                    RenderHitTestContract.AnyInput));
+                break;
+
+            case FusionBoundaryRuntimeScenario.OpaqueCallback:
+                current = context.OpaqueMap(current, CreateOpaqueMap(
+                    RenderBackendBoundary.None,
+                    RenderValueCardinality.Single,
+                    "opaque-identity"));
+                break;
+
+            case FusionBoundaryRuntimeScenario.TargetReadback:
+                context.Publish(current);
+                context.Publish(context.TargetCommand(
+                    [current],
+                    TargetCommandDescription.CreateRequestLocal(
+                        session => session.UseSnapshot(static _ => { }),
+                        TargetRegion.Full,
+                        Rect.Empty,
+                        RenderHitTestContract.None,
+                        TargetAccess.Readback)));
+                return;
+
+            case FusionBoundaryRuntimeScenario.DestinationBlend:
+                context.Publish(context.Blend(current, BlendMode.DstOver));
+                return;
+
+            case FusionBoundaryRuntimeScenario.DynamicExpansion:
+                current = context.OpaqueExpand(
+                    [current],
+                    OpaqueRenderDescription.CreateRequestLocal(
+                        CopySingleInput,
+                        OpaqueRenderBoundsContract.FullInputs(
+                            static inputs => inputs.Single()),
+                        RenderHitTestContract.AnyInput,
+                        RenderValueCardinality.Dynamic,
+                        RenderScaleContract.MaterializeAtWorkingScale,
+                        structuralKey: (typeof(FusionBoundaryRuntimeNode), "dynamic")));
+                break;
+
+            case FusionBoundaryRuntimeScenario.Graphics3D:
+                current = context.OpaqueMap(current, CreateOpaqueMap(
+                    RenderBackendBoundary.Graphics3D,
+                    RenderValueCardinality.Single,
+                    "graphics-3d"));
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+
+        context.Publish(context.Shader(current, s_secondShader));
+    }
+
+    private static OpaqueRenderDescription CreateOpaqueMap(
+        RenderBackendBoundary backendBoundary,
+        RenderValueCardinality cardinality,
+        string identity)
+    {
+        if (backendBoundary == RenderBackendBoundary.None)
+        {
+            return OpaqueRenderDescription.CreateRequestLocal(
+                CopySingleInput,
+                OpaqueRenderBoundsContract.Map(RenderBoundsContract.Identity),
+                RenderHitTestContract.AnyInput,
+                cardinality,
+                RenderScaleContract.PreserveInputSupply,
+                structuralKey: (typeof(FusionBoundaryRuntimeNode), identity));
+        }
+
+        return OpaqueRenderDescription.CreateBackendBoundary(
+            backendBoundary,
+            CopySingleInput,
+            OpaqueRenderBoundsContract.Map(RenderBoundsContract.Identity),
+            RenderHitTestContract.AnyInput,
+            cardinality,
+            RenderScaleContract.PreserveInputSupply,
+            deviceGridSensitivity: RenderDeviceGridSensitivity.Insensitive,
+            structuralKey: (typeof(FusionBoundaryRuntimeNode), identity),
+            runtimeIdentity: new RenderRuntimeIdentity(identity));
+    }
+
+    private static void CopySingleInput(OpaqueRenderSession session)
+    {
+        using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+        output.Canvas.Use(session.Inputs.Single().Draw);
+        session.Publish(output);
+    }
+}
+
+internal sealed class AntialiasedCoverageBoundaryNode(Rect bounds) : RenderNode
+{
+    public override void Process(RenderNodeContext context)
+    {
+        OpaqueRenderDescription source = OpaqueRenderDescription.CreateRequestLocal(
+            session =>
+            {
+                using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                output.Canvas.Use(canvas =>
+                {
+                    using var paint = new SKPaint
+                    {
+                        Color = new SKColor(196, 96, 224, 208),
+                        IsAntialias = true,
+                        StrokeWidth = 1,
+                        Style = SKPaintStyle.Stroke,
+                    };
+                    canvas.Canvas.DrawLine(2.25f, 2.75f, 21.25f, 13.25f, paint);
+                });
+                session.Publish(output);
+            },
+            OpaqueRenderBoundsContract.Source(bounds),
+            RenderHitTestContract.OutputBounds,
+            RenderValueCardinality.Single,
+            RenderScaleContract.MaterializeAtWorkingScale);
+        RenderFragmentHandle current = context.OpaqueSource(source);
+        current = context.Shader(current, ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return color * color.a; }"));
+        context.Publish(current);
+    }
+}
+
+internal sealed class CachedBoundaryRoot(RenderTarget source, Rect bounds) : RenderNode
+{
+    private readonly CachedBoundaryShaderNode _cached = new();
+    private readonly BoundaryShaderNode _after = new(
+        ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return half4(color.bgr, color.a); }"));
+
+    public CachedBoundaryShaderNode Cached => _cached;
+
+    public override void Process(RenderNodeContext context)
+    {
+        RenderResource<RenderTarget> resource = context.Borrow(
+            source,
+            (typeof(CachedBoundaryRoot), "source"),
+            1);
+        RenderFragmentHandle current = context.MaterializedInput(
+            MaterializedInputDescription.FromRenderTarget(
+                resource,
+                bounds,
+                EffectiveScale.At(1),
+                PixelRect.FromRect(bounds, 1),
+                default,
+                RenderHitTestContract.OutputBounds));
+        current = context.RecordNode(_cached, [current]).Single();
+        current = context.RecordNode(_after, [current]).Single();
+        context.Publish(current);
+    }
+
+    protected override void OnDispose(bool disposing)
+    {
+        _after.Dispose();
+        _cached.Dispose();
+        base.OnDispose(disposing);
+    }
+}
+
+internal sealed class CachedBoundaryShaderNode : RenderNode
+{
+    private static readonly ShaderDescription s_description = ShaderDescription.CurrentPixel(
+        "half4 apply(half4 color) { return color * 0.75; }");
+
+    public override void Process(RenderNodeContext context)
+    {
+        context.Publish(context.Shader(context.Inputs.Single(), s_description));
+    }
+}
+
+internal sealed class BoundaryShaderNode(ShaderDescription description) : RenderNode
+{
+    public override void Process(RenderNodeContext context)
+    {
+        context.Publish(context.Shader(context.Inputs.Single(), description));
+    }
+}
+
+internal sealed class BackendOverflowBoundaryNode(RenderTarget source, Rect bounds) : RenderNode
+{
+    public override void Process(RenderNodeContext context)
+    {
+        RenderResource<RenderTarget> resource = context.Borrow(
+            source,
+            (typeof(BackendOverflowBoundaryNode), "source"),
+            1);
+        RenderFragmentHandle current = context.MaterializedInput(
+            MaterializedInputDescription.FromRenderTarget(
+                resource,
+                bounds,
+                EffectiveScale.At(1),
+                PixelRect.FromRect(bounds, 1),
+                default,
+                RenderHitTestContract.OutputBounds));
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            "uniform float gain; half4 apply(half4 color) { return color * gain; }",
+            static bindings => bindings.Uniform("gain", 0.625f));
+        context.Publish(context.Shader(current, description));
+    }
+}
+
+internal sealed record FusionBoundaryExecutionResult(
+    Bitmap Bitmap,
+    RenderExecutionStatistics Statistics,
+    RenderPipelineDiagnosticSnapshot Diagnostics) : IDisposable
+{
+    public void Dispose() => Bitmap.Dispose();
+}
+
+internal static class FusionBoundaryExecutionTestSupport
+{
+    public static RenderTarget CreatePatternSource(Rect bounds)
+    {
+        RenderTarget target = RenderTarget.Create((int)bounds.Width, (int)bounds.Height)
+            ?? throw new InvalidOperationException("Could not allocate the fusion-boundary source.");
+        target.Value.Canvas.Clear(new SKColor(20, 32, 56, 112));
+        using var paint = new SKPaint
+        {
+            Color = new SKColor(176, 92, 212, 192),
+            IsAntialias = true,
+        };
+        target.Value.Canvas.DrawOval(SKRect.Create(3, 2, 16, 11), paint);
+        return target;
+    }
+
+    public static FusionBoundaryExecutionResult Execute(
+        RenderNode node,
+        Rect bounds,
+        FusionMode fusionMode,
+        bool useRenderCache = false)
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = bounds,
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                    CacheOptions = new Beutl.Graphics.Rendering.Cache.RenderCacheOptions(useRenderCache, Beutl.Graphics.Rendering.Cache.RenderCacheRules.Default),
+                    FusionMode = fusionMode,
+                    Purpose = RenderRequestPurpose.Frame,
+                    Diagnostics = diagnostics,
+                },
+            });
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        Bitmap bitmap = rasterization.Bitmap?.Clone()
+            ?? throw new InvalidOperationException("The fusion-boundary render unexpectedly produced no bitmap.");
+        return new FusionBoundaryExecutionResult(
+            bitmap,
+            renderer.LastExecutionStatistics,
+            diagnostics.Latest);
+    }
+
+    public static FusionBoundaryExecutionResult ExecuteWithBudget(
+        RenderNode node,
+        Rect bounds,
+        FusionMode fusionMode,
+        SkslBackendBudget budget)
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            targetDomain: bounds,
+            outputScale: 1,
+            maxWorkingScale: 1,
+            cachePolicy: RenderCacheOptions.Disabled,
+            fusionMode: fusionMode,
+            diagnostics: diagnostics);
+        var request = new RenderRequest(options);
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        using CompiledRenderRequest compiled = new RenderRequestCompiler().Compile(request, graph, budget);
+        using var targetRegistry = new RenderTargetLeaseRegistry(factory: null);
+        using RenderTargetLeaseSession targets = targetRegistry.BeginSession(
+            RenderIntent.Preview,
+            RenderAllocationBudget.Default);
+        PixelRect deviceBounds = PixelRect.FromRect(compiled.ExecutionTargetBounds, 1);
+        using RenderTargetLease root = targets.Acquire(deviceBounds.Size);
+        using var canvas = new ImmediateCanvas(root.Target, 1, 1, compiled.ExecutionTargetBounds.Size);
+        canvas.Clear();
+        using (canvas.PushTransform(Matrix.CreateTranslation(
+                   -compiled.ExecutionTargetBounds.X,
+                   -compiled.ExecutionTargetBounds.Y)))
+        {
+            var executor = new RenderRequestExecutor(targets);
+            executor.Execute(compiled, canvas);
+            using Bitmap complete = root.Target.Snapshot();
+            Bitmap bitmap = complete.Clone();
+            return new FusionBoundaryExecutionResult(bitmap, executor.Statistics, diagnostics.Latest);
+        }
+    }
+
+    public static double SumAbsoluteChannels(Bitmap bitmap)
+    {
+        double result = 0;
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        for (int index = 0; index < pixels.Length; index++)
+        {
+            float value = (float)BitConverter.UInt16BitsToHalf(pixels[index]);
+            if (!float.IsFinite(value))
+            {
+                throw new AssertionException(
+                    $"Fusion-boundary bitmap channel {index} is non-finite: {value}.");
+            }
+
+            result += Math.Abs(value);
+        }
+
+        return result;
+    }
+
+    public static int CountFractionalAlphaPixels(Bitmap bitmap)
+    {
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        int result = 0;
+        for (int index = 3; index < pixels.Length; index += 4)
+        {
+            float alpha = (float)BitConverter.UInt16BitsToHalf(pixels[index]);
+            if (alpha > 0.001f && alpha < 0.999f)
+                result++;
+        }
+        return result;
+    }
+}
+
+[TestFixture]
+public sealed class FusionBoundaryExecutionTestSupportTests
+{
+    [TestCase(float.PositiveInfinity)]
+    [TestCase(float.NegativeInfinity)]
+    public void SumAbsoluteChannels_RejectsInfiniteChannel(float value)
+    {
+        using var bitmap = new Bitmap(
+            1,
+            1,
+            BitmapColorType.RgbaF16,
+            BitmapAlphaType.Premul,
+            BitmapColorSpace.LinearSrgb);
+        bitmap.GetPixelSpan<ushort>()[0] = BitConverter.HalfToUInt16Bits((Half)value);
+
+        AssertionException? exception = Assert.Throws<AssertionException>(
+            () => FusionBoundaryExecutionTestSupport.SumAbsoluteChannels(bitmap));
+        Assert.That(exception!.Message, Does.Contain("channel 0").And.Contain("non-finite"));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Fusion/FusionBoundaryTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Fusion/FusionBoundaryTests.cs
@@ -1,0 +1,825 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+using Beutl.UnitTests.Engine.Graphics.Rendering.Golden;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Fusion;
+
+[TestFixture]
+[NonParallelizable]
+public sealed class FusionBoundaryTests
+{
+    private static readonly Rect s_bounds = new(0, 0, 24, 16);
+
+    public static IEnumerable<TestCaseData> RuntimeBarrierCases()
+    {
+        yield return RuntimeBarrierCase(
+            FusionBoundaryRuntimeScenario.MaterializedInput,
+            RenderPipelineBoundaryReason.CacheInput,
+            expectedIntermediates: 0,
+            expectedShaderRuns: 1);
+        yield return RuntimeBarrierCase(
+            FusionBoundaryRuntimeScenario.WholeSource,
+            RenderPipelineBoundaryReason.UnsafeComposite,
+            expectedIntermediates: 2,
+            expectedShaderRuns: 2);
+        yield return RuntimeBarrierCase(
+            FusionBoundaryRuntimeScenario.Geometry,
+            RenderPipelineBoundaryReason.Geometry,
+            expectedIntermediates: 3,
+            expectedShaderRuns: 1);
+        yield return RuntimeBarrierCase(
+            FusionBoundaryRuntimeScenario.OpaqueCallback,
+            RenderPipelineBoundaryReason.Opaque,
+            expectedIntermediates: 2,
+            expectedShaderRuns: 2);
+        yield return RuntimeBarrierCase(
+            FusionBoundaryRuntimeScenario.TargetReadback,
+            RenderPipelineBoundaryReason.Readback,
+            expectedIntermediates: 1,
+            expectedShaderRuns: 1);
+        yield return RuntimeBarrierCase(
+            FusionBoundaryRuntimeScenario.DestinationBlend,
+            RenderPipelineBoundaryReason.UnsafeComposite,
+            expectedIntermediates: 1,
+            expectedShaderRuns: 1);
+        yield return RuntimeBarrierCase(
+            FusionBoundaryRuntimeScenario.DynamicExpansion,
+            RenderPipelineBoundaryReason.DynamicTopology,
+            expectedIntermediates: 3,
+            expectedShaderRuns: 1);
+        yield return RuntimeBarrierCase(
+            FusionBoundaryRuntimeScenario.Graphics3D,
+            RenderPipelineBoundaryReason.ThreeD,
+            expectedIntermediates: 2,
+            expectedShaderRuns: 2);
+    }
+
+    [TestCaseSource(nameof(RuntimeBarrierCases))]
+    [Category("GpuPassFusionGpu")]
+    public void RuntimeBarrier_PreservesDisabledEnabledParityAndExactMaterialization(
+        int scenarioValue,
+        int expectedReasonValue,
+        int expectedIntermediates,
+        int expectedShaderRuns)
+    {
+        var scenario = (FusionBoundaryRuntimeScenario)scenarioValue;
+        var expectedReason = (RenderPipelineBoundaryReason)expectedReasonValue;
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using RenderTarget source = FusionBoundaryExecutionTestSupport.CreatePatternSource(s_bounds);
+            using var node = new FusionBoundaryRuntimeNode(source, s_bounds, scenario);
+            using FusionBoundaryExecutionResult disabled = FusionBoundaryExecutionTestSupport.Execute(
+                node,
+                s_bounds,
+                FusionMode.Disabled);
+            using FusionBoundaryExecutionResult enabled = FusionBoundaryExecutionTestSupport.Execute(
+                node,
+                s_bounds,
+                FusionMode.Enabled);
+
+            RgbaMaximumError maximum = ImageMetrics.MaximumAbsoluteErrorPerChannel(
+                disabled.Bitmap,
+                enabled.Bitmap);
+            Assert.Multiple(() =>
+            {
+                Assert.That(FusionBoundaryExecutionTestSupport.SumAbsoluteChannels(enabled.Bitmap),
+                    Is.GreaterThan(1), "The barrier parity oracle must be non-vacuous.");
+                Assert.That(maximum.Maximum, Is.LessThanOrEqualTo(0.02));
+                Assert.That(enabled.Statistics.FusedShaderRunExecutions, Is.Zero,
+                    "A hard boundary must not be crossed by a merged Shader run.");
+                Assert.That(enabled.Statistics.ShaderRunExecutions, Is.EqualTo(expectedShaderRuns));
+                Assert.That(disabled.Statistics.ShaderRunExecutions, Is.EqualTo(expectedShaderRuns));
+                Assert.That(enabled.Statistics.IntermediateTargetAcquisitions,
+                    Is.EqualTo(expectedIntermediates));
+                Assert.That(disabled.Statistics.IntermediateTargetAcquisitions,
+                    Is.EqualTo(expectedIntermediates));
+                Assert.That(enabled.Diagnostics[RenderPipelineCounter.FullFrameMaterializations],
+                    Is.EqualTo(expectedIntermediates));
+                Assert.That(disabled.Diagnostics[RenderPipelineCounter.FullFrameMaterializations],
+                    Is.EqualTo(expectedIntermediates));
+                Assert.That(enabled.Diagnostics[RenderPipelineCounter.IntermediateAcquires],
+                    Is.EqualTo(expectedIntermediates));
+                Assert.That(disabled.Diagnostics[RenderPipelineCounter.IntermediateAcquires],
+                    Is.EqualTo(expectedIntermediates));
+                Assert.That(enabled.Diagnostics[RenderPipelineCounter.ExternalRootResources], Is.EqualTo(1));
+                Assert.That(disabled.Diagnostics[RenderPipelineCounter.ExternalRootResources], Is.EqualTo(1));
+                Assert.That(enabled.Diagnostics.Events,
+                    Has.Some.Matches<RenderPipelineDiagnosticEvent>(item =>
+                        item.Kind == RenderPipelineDiagnosticEventKind.BoundaryPlanned
+                        && item.BoundaryReason == expectedReason));
+            });
+
+            if (scenario == FusionBoundaryRuntimeScenario.TargetReadback)
+            {
+                Assert.Multiple(() =>
+                {
+                    Assert.That(enabled.Diagnostics[RenderPipelineCounter.Synchronizations], Is.EqualTo(1));
+                    Assert.That(disabled.Diagnostics[RenderPipelineCounter.Synchronizations], Is.EqualTo(1));
+                });
+            }
+            else if (scenario == FusionBoundaryRuntimeScenario.Graphics3D)
+            {
+                Assert.Multiple(() =>
+                {
+                    Assert.That(enabled.Diagnostics[RenderPipelineCounter.ExecutedBackendTransitions],
+                        Is.EqualTo(1));
+                    Assert.That(enabled.Statistics.Synchronizations, Is.EqualTo(1));
+                });
+            }
+        });
+    }
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void AntialiasedThinStroke_NonlinearShaderPreservesCoverageAtTheExactBoundary()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var node = new AntialiasedCoverageBoundaryNode(s_bounds);
+            using FusionBoundaryExecutionResult disabled = FusionBoundaryExecutionTestSupport.Execute(
+                node,
+                s_bounds,
+                FusionMode.Disabled);
+            using FusionBoundaryExecutionResult enabled = FusionBoundaryExecutionTestSupport.Execute(
+                node,
+                s_bounds,
+                FusionMode.Enabled);
+
+            RgbaMaximumError maximum = ImageMetrics.EdgeBandMaximumAbsoluteErrorPerChannel(
+                disabled.Bitmap,
+                enabled.Bitmap);
+            Assert.Multiple(() =>
+            {
+                Assert.That(FusionBoundaryExecutionTestSupport.CountFractionalAlphaPixels(enabled.Bitmap),
+                    Is.GreaterThan(0), "The control must contain antialiased fractional-coverage edge pixels.");
+                Assert.That(FusionBoundaryExecutionTestSupport.SumAbsoluteChannels(enabled.Bitmap), Is.GreaterThan(1));
+                Assert.That(maximum.Maximum, Is.LessThanOrEqualTo(0.02));
+                Assert.That(enabled.Statistics.ShaderRunExecutions, Is.EqualTo(1));
+                Assert.That(enabled.Statistics.FusedShaderRunExecutions, Is.Zero);
+                Assert.That(enabled.Statistics.IntermediateTargetAcquisitions, Is.EqualTo(1));
+                Assert.That(enabled.Diagnostics[RenderPipelineCounter.FullFrameMaterializations], Is.EqualTo(1));
+                Assert.That(enabled.Diagnostics[RenderPipelineCounter.IntermediateAcquires], Is.EqualTo(1));
+                Assert.That(enabled.Diagnostics[RenderPipelineCounter.ExternalRootResources], Is.EqualTo(1));
+                Assert.That(enabled.Diagnostics.Events,
+                    Has.Some.Matches<RenderPipelineDiagnosticEvent>(static item =>
+                        item.Kind == RenderPipelineDiagnosticEventKind.BoundaryPlanned
+                        && item.BoundaryReason == RenderPipelineBoundaryReason.UnsafeComposite));
+            });
+        });
+    }
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void SelectedRenderCacheBoundary_PreservesParityAndPreventsCrossBoundaryFusion()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using RenderTarget source = FusionBoundaryExecutionTestSupport.CreatePatternSource(s_bounds);
+            using var disabledNode = new CachedBoundaryRoot(source, s_bounds);
+            using var enabledNode = new CachedBoundaryRoot(source, s_bounds);
+            disabledNode.Cached.Cache.ReportRenderCount(RenderNodeCache.Count);
+            enabledNode.Cached.Cache.ReportRenderCount(RenderNodeCache.Count);
+            var disabledDiagnostics = new RenderPipelineDiagnosticsState();
+            var enabledDiagnostics = new RenderPipelineDiagnosticsState();
+            using var disabledRenderer = CreateBoundaryRenderer(
+                disabledNode,
+                FusionMode.Disabled,
+                disabledDiagnostics,
+                useRenderCache: true);
+            using var enabledRenderer = CreateBoundaryRenderer(
+                enabledNode,
+                FusionMode.Enabled,
+                enabledDiagnostics,
+                useRenderCache: true);
+
+            using RenderNodeRasterization disabledWarm = disabledRenderer.Rasterize();
+            using RenderNodeRasterization enabledWarm = enabledRenderer.Rasterize();
+            using RenderNodeRasterization disabled = disabledRenderer.Rasterize();
+            using RenderNodeRasterization enabled = enabledRenderer.Rasterize();
+            Assert.That(disabled.Bitmap, Is.Not.Null);
+            Assert.That(enabled.Bitmap, Is.Not.Null);
+
+            RgbaMaximumError maximum = ImageMetrics.MaximumAbsoluteErrorPerChannel(
+                disabled.Bitmap!,
+                enabled.Bitmap!);
+            Assert.Multiple(() =>
+            {
+                Assert.That(FusionBoundaryExecutionTestSupport.SumAbsoluteChannels(enabled.Bitmap!), Is.GreaterThan(1));
+                Assert.That(maximum.Maximum, Is.LessThanOrEqualTo(0.02));
+                Assert.That(enabledRenderer.LastExecutionStatistics.FusedShaderRunExecutions, Is.Zero);
+                Assert.That(enabledRenderer.LastExecutionStatistics.ShaderRunExecutions, Is.EqualTo(1));
+                Assert.That(disabledRenderer.LastExecutionStatistics.ShaderRunExecutions, Is.EqualTo(1));
+                Assert.That(enabledDiagnostics.Latest[RenderPipelineCounter.RenderCacheHits], Is.EqualTo(1));
+                Assert.That(disabledDiagnostics.Latest[RenderPipelineCounter.RenderCacheHits], Is.EqualTo(1));
+                Assert.That(enabledDiagnostics.Latest.Events,
+                    Has.Some.Matches<RenderPipelineDiagnosticEvent>(static item =>
+                        item.Kind == RenderPipelineDiagnosticEventKind.BoundaryPlanned
+                        && item.BoundaryReason == RenderPipelineBoundaryReason.CacheInput));
+                Assert.That(enabledDiagnostics.Latest.Events,
+                    Has.None.Matches<RenderPipelineDiagnosticEvent>(static item =>
+                        item.Kind == RenderPipelineDiagnosticEventKind.BoundaryPlanned
+                        && item.BoundaryReason == RenderPipelineBoundaryReason.CacheCapture));
+            });
+        });
+    }
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void StandaloneBackendOverflow_ExecutesCompatibilityPathWithParityAndExactReason()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using RenderTarget source = FusionBoundaryExecutionTestSupport.CreatePatternSource(s_bounds);
+            using var node = new BackendOverflowBoundaryNode(source, s_bounds);
+            SkslBackendBudget budget = new(
+                capabilityClass: (typeof(FusionBoundaryTests), "runtime-standalone-overflow"),
+                maxStages: int.MaxValue,
+                maxUniformVectors: 0,
+                maxSamplers: int.MaxValue,
+                maxChildren: int.MaxValue,
+                maxSourceBytes: int.MaxValue,
+                maxProgramTokens: int.MaxValue);
+            using FusionBoundaryExecutionResult disabled = FusionBoundaryExecutionTestSupport.ExecuteWithBudget(
+                node,
+                s_bounds,
+                FusionMode.Disabled,
+                budget);
+            using FusionBoundaryExecutionResult enabled = FusionBoundaryExecutionTestSupport.ExecuteWithBudget(
+                node,
+                s_bounds,
+                FusionMode.Enabled,
+                budget);
+
+            RgbaMaximumError maximum = ImageMetrics.MaximumAbsoluteErrorPerChannel(
+                disabled.Bitmap,
+                enabled.Bitmap);
+            RenderPipelineDiagnosticEvent[] boundaries = enabled.Diagnostics.Events
+                .Where(static item => item.Kind == RenderPipelineDiagnosticEventKind.BoundaryPlanned)
+                .ToArray();
+            Assert.Multiple(() =>
+            {
+                Assert.That(FusionBoundaryExecutionTestSupport.SumAbsoluteChannels(enabled.Bitmap), Is.GreaterThan(1));
+                Assert.That(maximum.Maximum, Is.LessThanOrEqualTo(0.02));
+                Assert.That(enabled.Statistics.ShaderRunExecutions, Is.Zero);
+                Assert.That(disabled.Statistics.ShaderRunExecutions, Is.Zero);
+                Assert.That(boundaries.Count(static item =>
+                        item.BoundaryReason == RenderPipelineBoundaryReason.BackendLimit),
+                    Is.EqualTo(1));
+                Assert.That(boundaries, Has.None.Matches<RenderPipelineDiagnosticEvent>(static item =>
+                    item.BoundaryReason == RenderPipelineBoundaryReason.UnsafeComposite));
+            });
+        });
+    }
+
+    [Test]
+    public void NonlinearCurrentPixel_AfterCoverageProducerRequiresMaterializationBoundary()
+    {
+        using CompiledRenderRequest compiled = Compile((requestId, cache) =>
+        {
+            RenderFragmentReference source = Fragment(
+                RenderFragmentKind.OpaqueSource,
+                OpaquePayload(
+                    OpaqueRenderTopology.Source,
+                    RenderValueCardinality.Single));
+            ShaderDescription nonlinear = ShaderDescription.CurrentPixel(
+                "half4 apply(half4 color) { return color * color.a; }");
+            RenderFragmentReference shader = Fragment(
+                RenderFragmentKind.Shader,
+                new ShaderRenderFragmentPayload(nonlinear, nonlinear.CreateRuntimeIdentity()),
+                source);
+            return BuildGraph(requestId, [source, shader], [shader], cache);
+        });
+
+        CompiledShaderRun run = compiled.ExecutionPlan.ShaderRuns.Single();
+        Assert.Multiple(() =>
+        {
+            Assert.That(run.CoverageSource, Is.EqualTo(ShaderRunCoverageSource.CompatibilityMaterialization));
+            Assert.That(run.Stages.Single().CoverageBehavior,
+                Is.EqualTo(SkslCoverageBehavior.RequiresResolvedCoverage));
+            Assert.That(compiled.ExecutionPlan.Boundaries, Has.Some.Matches<ExecutionIslandBoundary>(
+                static boundary => boundary.Reason == ExecutionIslandBoundaryReason.Opaque));
+            Assert.That(compiled.ExecutionPlan.Boundaries, Has.Some.Matches<ExecutionIslandBoundary>(
+                static boundary => boundary.Reason == ExecutionIslandBoundaryReason.CoverageResolution));
+        });
+    }
+
+    [Test]
+    public void ScopeMetadataMismatch_RemainsAnExplicitCompatibilityBoundary()
+    {
+        using CompiledRenderRequest compiled = Compile((requestId, cache) =>
+        {
+            RenderFragmentReference source = Fragment(RenderFragmentKind.MaterializedInput, payload: null);
+            RenderFragmentReference first = CurrentPixel(source, "return color * 0.75;");
+            ShaderDescription description = ShaderDescription.CurrentPixel(
+                "half4 apply(half4 color) { return color.bgra; }");
+            var mismatched = new RenderFragmentReference(
+                RenderFragmentKind.Shader,
+                s_bounds,
+                EffectiveScale.Unbounded,
+                RenderValueCardinality.Single,
+                contributesValuesToTarget: true,
+                canBeUsedAsValueInput: true,
+                hasTargetEffects: true,
+                hasOpaqueExternalWork: false,
+                [first],
+                new ShaderRenderFragmentPayload(description, description.CreateRuntimeIdentity()),
+                static _ => true);
+            return BuildGraph(requestId, [source, first, mismatched], [mismatched], cache);
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(compiled.ExecutionPlan.ShaderRuns, Has.Exactly(1).Items);
+            Assert.That(compiled.ExecutionPlan.ShaderRuns.Single().Output,
+                Is.SameAs(compiled.Graph.Fragments[1].Payload));
+            Assert.That(compiled.ExecutionPlan.Boundaries, Has.Some.Matches<ExecutionIslandBoundary>(
+                static boundary => boundary.Reason == ExecutionIslandBoundaryReason.ScopeMismatch));
+        });
+    }
+
+    [Test]
+    public void WholeSourceGeometryAndTargetCaptureRemainExplicitBarriers()
+    {
+        AssertBarrier(
+            RenderFragmentKind.Shader,
+            WholeSourcePayload(),
+            ExecutionIslandBoundaryReason.WholeSourceShader);
+        AssertBarrier(
+            RenderFragmentKind.Geometry,
+            GeometryPayload(),
+            expected: ExecutionIslandBoundaryReason.Geometry);
+        AssertBarrier(
+            RenderFragmentKind.TargetCapture,
+            TargetCapturePayload(),
+            expected: ExecutionIslandBoundaryReason.TargetCapture);
+    }
+
+    [Test]
+    public void Graphics3DMetadata_ProducesExplicitThreeDAndBackendTransitionBoundaries()
+    {
+        OpaqueRenderDescription description = OpaqueRenderDescription.CreateBackendBoundary(
+            RenderBackendBoundary.Graphics3D,
+            static _ => { },
+            OpaqueRenderBoundsContract.Source(s_bounds),
+            RenderHitTestContract.OutputBounds,
+            RenderValueCardinality.ZeroOrOne,
+            RenderScaleContract.MaterializeAtWorkingScale,
+            RenderDeviceGridSensitivity.Insensitive,
+            typeof(FusionBoundaryTests),
+            new RenderRuntimeIdentity("3d-test"));
+        using CompiledRenderRequest compiled = Compile((requestId, cache) =>
+        {
+            RenderFragmentReference threeD = Fragment(
+                RenderFragmentKind.OpaqueSource,
+                new OpaqueRenderFragmentPayload(
+                    OpaqueRenderTopology.Source,
+                    description,
+                    Array.Empty<RenderInputReadback>()));
+            RenderFragmentReference shader = CurrentPixel(threeD, "return color.bgra;");
+            return BuildGraph(requestId, [threeD, shader], [shader], cache);
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(compiled.ExecutionPlan.Boundaries, Has.Some.Matches<ExecutionIslandBoundary>(
+                static boundary => boundary.Reason == ExecutionIslandBoundaryReason.ThreeD));
+            Assert.That(compiled.ExecutionPlan.Boundaries, Has.Some.Matches<ExecutionIslandBoundary>(
+                static boundary => boundary.Reason == ExecutionIslandBoundaryReason.BackendTransition));
+            Assert.That(compiled.ExecutionPlan.ShaderRuns, Has.Exactly(1).Items,
+                "Eligible 2D work may resume after the explicit materialized 3D boundary.");
+        });
+    }
+
+    [Test]
+    public void BypassedCacheCandidate_DoesNotSplitOtherwiseCompatibleRun()
+    {
+        using CompiledRenderRequest compiled = Compile((requestId, cache) =>
+        {
+            RenderFragmentReference source = Fragment(RenderFragmentKind.MaterializedInput, payload: null);
+            RenderFragmentReference first = CurrentPixel(source, "return color * 0.75;");
+            RenderFragmentReference second = CurrentPixel(first, "return half4(color.bgr, color.a);");
+            cache.Add(first);
+            return BuildGraph(requestId, [source, first, second], [second], cache);
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(compiled.ExecutionPlan.ShaderRuns.Select(static run => run.Stages.Length),
+                Is.EqualTo(new[] { 2 }));
+            Assert.That(compiled.ExecutionPlan.Boundaries, Has.None.Matches<ExecutionIslandBoundary>(
+                static boundary => boundary.Reason is ExecutionIslandBoundaryReason.CacheInput
+                    or ExecutionIslandBoundaryReason.CacheCapture));
+        });
+    }
+
+    [Test]
+    public void BackendStageBudget_SplitsBeforeOverflowAndPreservesOrderDeterministically()
+    {
+        SkslBackendBudget budget = Budget(maxStages: 2);
+        using CompiledRenderRequest first = Compile(FiveStageGraph, budget: budget);
+        using CompiledRenderRequest second = Compile(FiveStageGraph, budget: budget);
+
+        CompiledShaderRun[] firstRuns = first.ExecutionPlan.ShaderRuns.ToArray();
+        CompiledShaderRun[] secondRuns = second.ExecutionPlan.ShaderRuns.ToArray();
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstRuns.Select(static run => run.Stages.Length), Is.EqualTo(new[] { 2, 2, 1 }));
+            Assert.That(firstRuns.SelectMany(static run => run.Stages)
+                .Select(static stage => stage.Description.Source.Text),
+                Is.EqualTo(secondRuns.SelectMany(static run => run.Stages)
+                    .Select(static stage => stage.Description.Source.Text)));
+            Assert.That(first.ExecutionPlan.Boundaries.Count(static boundary =>
+                    boundary.Reason == ExecutionIslandBoundaryReason.BackendLimit),
+                Is.EqualTo(2));
+            Assert.That(first.ExecutionPlan.Boundaries
+                    .Where(static boundary => boundary.Reason == ExecutionIslandBoundaryReason.BackendLimit),
+                Has.All.Matches<ExecutionIslandBoundary>(static boundary =>
+                    boundary.BackendLimits.Contains(SkslBackendLimit.StageCount)));
+        });
+    }
+
+    [Test]
+    public void DefaultCompiler_UsesFinitePortableBudgetAndSplitsBeforeOverflow()
+    {
+        SkslBackendBudget budget = SkslBackendBudgetResolver.Portable;
+        using CompiledRenderRequest compiled = CompileWithProductionDefaults(
+            (requestId, cache) => StageGraph(requestId, cache, budget.MaxStages + 1));
+
+        CompiledShaderRun[] runs = compiled.ExecutionPlan.ShaderRuns.ToArray();
+        ExecutionIslandBoundary[] backendBoundaries = compiled.ExecutionPlan.Boundaries
+            .Where(static boundary => boundary.Reason == ExecutionIslandBoundaryReason.BackendLimit)
+            .ToArray();
+        Assert.Multiple(() =>
+        {
+            Assert.That(runs.Select(static run => run.Stages.Length),
+                Is.EqualTo(new[] { budget.MaxStages, 1 }));
+            Assert.That(runs, Has.All.Matches<CompiledShaderRun>(
+                run => run.Program.Budget.Equals(budget)));
+            Assert.That(backendBoundaries, Has.Exactly(1).Items);
+            Assert.That(backendBoundaries[0].BackendLimits,
+                Does.Contain(SkslBackendLimit.StageCount));
+        });
+    }
+
+    [Test]
+    public void CompileAfterMetadata_UsesFinitePortableBudgetAndSplitsBeforeOverflow()
+    {
+        SkslBackendBudget budget = SkslBackendBudgetResolver.Portable;
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            targetDomain: s_bounds,
+            fusionMode: FusionMode.Enabled);
+        var request = new RenderRequest(options);
+        var cache = new HashSet<RenderFragmentReference>(ReferenceEqualityComparer.Instance);
+        RecordedRenderGraph graph = StageGraph(request.Id, cache, budget.MaxStages + 1);
+        request.TransitionTo(RenderRequestState.Recording);
+        request.TransitionTo(RenderRequestState.Recorded);
+        var compiler = new RenderRequestCompiler();
+        RenderNodeMeasurement measurement = compiler.ResolveMetadata(request, graph);
+
+        using CompiledRenderRequest compiled = compiler.CompileAfterMetadata(
+            request,
+            graph,
+            measurement);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(compiled.ExecutionPlan.ShaderRuns.Select(static run => run.Stages.Length),
+                Is.EqualTo(new[] { budget.MaxStages, 1 }));
+            Assert.That(compiled.ExecutionPlan.ShaderRuns, Has.All.Matches<CompiledShaderRun>(
+                run => run.Program.Budget.Equals(budget)));
+        });
+    }
+
+    [Test]
+    public void StandaloneBackendOverflow_ReportsOnlyTheExactBackendLimitBoundary()
+    {
+        SkslBackendBudget budget = new(
+            capabilityClass: (typeof(FusionBoundaryTests), "standalone-uniform-overflow"),
+            maxStages: int.MaxValue,
+            maxUniformVectors: 0,
+            maxSamplers: int.MaxValue,
+            maxChildren: int.MaxValue,
+            maxSourceBytes: int.MaxValue,
+            maxProgramTokens: int.MaxValue);
+        using CompiledRenderRequest compiled = Compile((requestId, cache) =>
+        {
+            RenderFragmentReference source = Fragment(RenderFragmentKind.MaterializedInput, payload: null);
+            ShaderDescription description = ShaderDescription.CurrentPixel(
+                "uniform float gain; half4 apply(half4 color) { return color * gain; }",
+                static bindings => bindings.Uniform("gain", 0.5f));
+            RenderFragmentReference shader = Fragment(
+                RenderFragmentKind.Shader,
+                new ShaderRenderFragmentPayload(description, description.CreateRuntimeIdentity()),
+                source);
+            return BuildGraph(requestId, [source, shader], [shader], cache);
+        }, budget: budget);
+
+        ExecutionIslandBoundary[] backendBoundaries = compiled.ExecutionPlan.Boundaries
+            .Where(static boundary => boundary.Reason == ExecutionIslandBoundaryReason.BackendLimit)
+            .ToArray();
+        Assert.Multiple(() =>
+        {
+            Assert.That(compiled.ExecutionPlan.ShaderRuns, Is.Empty);
+            Assert.That(compiled.ExecutionPlan.Islands, Has.Exactly(1).Items);
+            Assert.That(backendBoundaries, Has.Exactly(1).Items);
+            Assert.That(backendBoundaries[0].BackendLimits,
+                Is.EqualTo(new[] { SkslBackendLimit.UniformVectors }));
+            Assert.That(compiled.ExecutionPlan.Boundaries, Has.None.Matches<ExecutionIslandBoundary>(
+                static boundary => boundary.Reason == ExecutionIslandBoundaryReason.WholeSourceShader));
+        });
+    }
+
+    [Test]
+    public void DynamicCardinalityAndGroupOpacityDoNotClaimShaderEligibility()
+    {
+        using CompiledRenderRequest dynamic = Compile((requestId, cache) =>
+        {
+            RenderFragmentReference source = Fragment(
+                RenderFragmentKind.OpaqueExpand,
+                OpaquePayload(
+                    OpaqueRenderTopology.Expand,
+                    RenderValueCardinality.Dynamic),
+                cardinality: RenderValueCardinality.Dynamic);
+            ShaderDescription description = ShaderDescription.CurrentPixel(
+                "half4 apply(half4 color) { return color; }");
+            RenderFragmentReference shader = Fragment(
+                RenderFragmentKind.Shader,
+                new ShaderRenderFragmentPayload(description, description.CreateRuntimeIdentity()),
+                RenderValueCardinality.Dynamic,
+                source);
+            return BuildGraph(requestId, [source, shader], [shader], cache);
+        });
+        using CompiledRenderRequest groupOpacity = Compile((requestId, cache) =>
+        {
+            RenderFragmentReference source = Fragment(
+                RenderFragmentKind.OpaqueExpand,
+                OpaquePayload(
+                    OpaqueRenderTopology.Expand,
+                    RenderValueCardinality.Exactly(2)),
+                cardinality: RenderValueCardinality.Exactly(2));
+            RenderFragmentReference opacity = Fragment(
+                RenderFragmentKind.Opacity,
+                new OpacityRenderFragmentPayload(0.5f, OpacityRenderNode.CreateFusionDescription(0.5f)),
+                RenderValueCardinality.Exactly(2),
+                source);
+            return BuildGraph(requestId, [source, opacity], [opacity], cache);
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(dynamic.ExecutionPlan.ShaderRuns, Is.Empty);
+            Assert.That(dynamic.ExecutionPlan.Boundaries, Has.Some.Matches<ExecutionIslandBoundary>(
+                static boundary => boundary.Reason == ExecutionIslandBoundaryReason.DynamicTopology));
+            Assert.That(groupOpacity.ExecutionPlan.ShaderRuns, Is.Empty,
+                "Group opacity over multiple values is not equivalent to per-value color multiplication.");
+            Assert.That(groupOpacity.ExecutionPlan.Boundaries, Has.Some.Matches<ExecutionIslandBoundary>(
+                static boundary => boundary.Reason == ExecutionIslandBoundaryReason.DynamicTopology));
+        });
+    }
+
+    private static void AssertBarrier(
+        RenderFragmentKind barrierKind,
+        object? payload,
+        ExecutionIslandBoundaryReason expected)
+    {
+        using CompiledRenderRequest compiled = Compile((requestId, cache) =>
+        {
+            RenderFragmentReference source = Fragment(RenderFragmentKind.MaterializedInput, payload: null);
+            RenderFragmentReference barrier = Fragment(barrierKind, payload, source);
+            RenderFragmentReference shader = CurrentPixel(barrier, "return color * color.a;");
+            return BuildGraph(requestId, [source, barrier, shader], [shader], cache);
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(compiled.ExecutionPlan.ShaderRuns, Has.Exactly(1).Items);
+            Assert.That(compiled.ExecutionPlan.Boundaries, Has.Some.Matches<ExecutionIslandBoundary>(
+                boundary => boundary.Reason == expected));
+            Assert.That(compiled.ExecutionPlan.Boundaries, Has.Some.Matches<ExecutionIslandBoundary>(
+                static boundary => boundary.Reason == ExecutionIslandBoundaryReason.CoverageResolution));
+        });
+    }
+
+    private static RecordedRenderGraph FiveStageGraph(
+        RenderRequestId requestId,
+        HashSet<RenderFragmentReference> cache)
+        => StageGraph(requestId, cache, 5);
+
+    private static RecordedRenderGraph StageGraph(
+        RenderRequestId requestId,
+        HashSet<RenderFragmentReference> cache,
+        int stageCount)
+    {
+        RenderFragmentReference source = Fragment(RenderFragmentKind.MaterializedInput, payload: null);
+        var references = new List<RenderFragmentReference> { source };
+        RenderFragmentReference current = source;
+        for (int index = 0; index < stageCount; index++)
+        {
+            current = CurrentPixel(current, $"return color * {index + 1}.0;");
+            references.Add(current);
+        }
+        return BuildGraph(requestId, references, [current], cache);
+    }
+
+    private static object WholeSourcePayload()
+    {
+        ShaderDescription description = ShaderDescription.WholeSource(
+            "uniform shader src; half4 main(float2 coord) { return src.eval(coord); }",
+            RenderBoundsContract.Identity);
+        return new ShaderRenderFragmentPayload(description, description.CreateRuntimeIdentity());
+    }
+
+    private static object TargetCapturePayload()
+    {
+        TargetCaptureDescription description = TargetCaptureDescription.Create(
+            TargetRegion.Full,
+            s_bounds,
+            RenderHitTestContract.None,
+            TargetCaptureScaleContract.MaterializeAtWorkingScale);
+        return new TargetCaptureRenderFragmentPayload(description);
+    }
+
+    private static RenderFragmentReference CurrentPixel(
+        RenderFragmentReference input,
+        string body)
+    {
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            $"half4 apply(half4 color) {{ {body} }}");
+        return Fragment(
+            RenderFragmentKind.Shader,
+            new ShaderRenderFragmentPayload(description, description.CreateRuntimeIdentity()),
+            input);
+    }
+
+    private static GeometryRenderFragmentPayload GeometryPayload()
+    {
+        GeometryDescription description = GeometryDescription.CreateRequestLocal(
+            static _ => { },
+            RenderBoundsContract.Identity,
+            RenderHitTestContract.OutputBounds);
+        return new GeometryRenderFragmentPayload(description, new object());
+    }
+
+    private static OpaqueRenderFragmentPayload OpaquePayload(
+        OpaqueRenderTopology topology,
+        RenderValueCardinality cardinality)
+    {
+        OpaqueRenderBoundsContract bounds = topology switch
+        {
+            OpaqueRenderTopology.Source => OpaqueRenderBoundsContract.Source(s_bounds),
+            OpaqueRenderTopology.Map => OpaqueRenderBoundsContract.Map(RenderBoundsContract.Identity),
+            OpaqueRenderTopology.Combine or OpaqueRenderTopology.Expand
+                => OpaqueRenderBoundsContract.FullInputs(static _ => s_bounds),
+            _ => throw new ArgumentOutOfRangeException(nameof(topology)),
+        };
+        OpaqueRenderDescription description = OpaqueRenderDescription.CreateRequestLocal(
+            static _ => { },
+            bounds,
+            RenderHitTestContract.OutputBounds,
+            cardinality,
+            RenderScaleContract.MaterializeAtWorkingScale);
+        IReadOnlyList<RenderInputReadback> inputReadbacks = topology == OpaqueRenderTopology.Map
+            ? [RenderInputReadback.None]
+            : Array.Empty<RenderInputReadback>();
+        return new OpaqueRenderFragmentPayload(topology, description, inputReadbacks);
+    }
+
+    private static RenderFragmentReference Fragment(
+        RenderFragmentKind kind,
+        object? payload,
+        params RenderFragmentReference[] inputs)
+        => Fragment(kind, payload, RenderValueCardinality.Single, inputs);
+
+    private static RenderFragmentReference Fragment(
+        RenderFragmentKind kind,
+        object? payload,
+        RenderValueCardinality cardinality,
+        params RenderFragmentReference[] inputs)
+    {
+        return new RenderFragmentReference(
+            kind,
+            s_bounds,
+            kind == RenderFragmentKind.MaterializedInput ? EffectiveScale.At(1) : EffectiveScale.Unbounded,
+            cardinality,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: kind == RenderFragmentKind.TargetCapture
+                || inputs.Any(static input => input.HasTargetEffects),
+            hasOpaqueExternalWork: kind is RenderFragmentKind.OpaqueSource
+                    or RenderFragmentKind.OpaqueMap
+                    or RenderFragmentKind.OpaqueCombine
+                    or RenderFragmentKind.OpaqueExpand
+                || inputs.Any(static input => input.HasOpaqueExternalWork),
+            inputs,
+            payload,
+            static _ => true);
+    }
+
+    private static CompiledRenderRequest Compile(
+        Func<RenderRequestId, HashSet<RenderFragmentReference>, RecordedRenderGraph> createGraph,
+        FusionMode fusionMode = FusionMode.Enabled,
+        SkslBackendBudget? budget = null)
+    {
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            targetDomain: s_bounds,
+            fusionMode: fusionMode);
+        var request = new RenderRequest(options);
+        var cache = new HashSet<RenderFragmentReference>(ReferenceEqualityComparer.Instance);
+        RecordedRenderGraph graph = createGraph(request.Id, cache);
+        request.TransitionTo(RenderRequestState.Recording);
+        request.TransitionTo(RenderRequestState.Recorded);
+        return new RenderRequestCompiler().Compile(
+            request,
+            graph,
+            budget ?? SkslBackendBudget.Unlimited);
+    }
+
+    private static CompiledRenderRequest CompileWithProductionDefaults(
+        Func<RenderRequestId, HashSet<RenderFragmentReference>, RecordedRenderGraph> createGraph)
+    {
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            targetDomain: s_bounds,
+            fusionMode: FusionMode.Enabled);
+        var request = new RenderRequest(options);
+        var cache = new HashSet<RenderFragmentReference>(ReferenceEqualityComparer.Instance);
+        RecordedRenderGraph graph = createGraph(request.Id, cache);
+        request.TransitionTo(RenderRequestState.Recording);
+        request.TransitionTo(RenderRequestState.Recorded);
+        return new RenderRequestCompiler().Compile(request, graph);
+    }
+
+    private static RecordedRenderGraph BuildGraph(
+        RenderRequestId requestId,
+        IReadOnlyList<RenderFragmentReference> references,
+        IReadOnlyList<RenderFragmentReference> roots,
+        IReadOnlySet<RenderFragmentReference> cache)
+    {
+        var builder = new RecordedRenderGraphBuilder(requestId);
+        RenderProvenanceId provenance = builder.AddProvenance(typeof(FusionBoundaryTests), "test");
+        foreach (RenderFragmentReference reference in references)
+        {
+            RenderValueId[] inputs = reference.Inputs.SelectMany(static input => input.ValueIds).ToArray();
+            reference.ValueIds = reference.ValueCardinality.Maximum == 0
+                ? []
+                : [builder.AddValue(inputs, provenance, reference)];
+            reference.Id = builder.AddFragment(reference.ValueIds, provenance, reference);
+            if (cache.Contains(reference))
+                builder.AddCacheCandidate(reference.Id.Value, (typeof(FusionBoundaryTests), reference.Id.Value.Value));
+        }
+        foreach (RenderFragmentReference root in roots)
+            builder.PublishRoot(root.Id!.Value);
+        return builder.Build();
+    }
+
+    private static SkslBackendBudget Budget(int maxStages)
+        => new(
+            capabilityClass: (typeof(FusionBoundaryTests), maxStages),
+            maxStages,
+            maxUniformVectors: int.MaxValue,
+            maxSamplers: int.MaxValue,
+            maxChildren: int.MaxValue,
+            maxSourceBytes: int.MaxValue,
+            maxProgramTokens: int.MaxValue);
+
+    private static TestCaseData RuntimeBarrierCase(
+        FusionBoundaryRuntimeScenario scenario,
+        RenderPipelineBoundaryReason reason,
+        int expectedIntermediates,
+        int expectedShaderRuns)
+        => new TestCaseData((int)scenario, (int)reason, expectedIntermediates, expectedShaderRuns)
+            .SetName($"RuntimeBarrier_{scenario}_PreservesParityAndMaterialization");
+
+    private static RenderNodeRenderer CreateBoundaryRenderer(
+        RenderNode node,
+        FusionMode fusionMode,
+        IRenderPipelineDiagnosticsState diagnostics,
+        bool useRenderCache)
+        => new(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_bounds,
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                    CacheOptions = new Beutl.Graphics.Rendering.Cache.RenderCacheOptions(useRenderCache, Beutl.Graphics.Rendering.Cache.RenderCacheRules.Default),
+                    FusionMode = fusionMode,
+                    Purpose = RenderRequestPurpose.Frame,
+                    Diagnostics = diagnostics,
+                },
+            });
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Fusion/ShaderDescriptionTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Fusion/ShaderDescriptionTests.cs
@@ -1,0 +1,497 @@
+﻿using System.Numerics;
+using System.Reflection;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Fusion;
+
+[TestFixture]
+public sealed class ShaderDescriptionTests
+{
+    private const string IdentityCurrentPixel = "half4 apply(half4 color) { return color; }";
+
+    [Test]
+    public void CurrentPixel_NormalizesSourceAndRejectsUnsafeGrammar()
+    {
+        ShaderDescription first = ShaderDescription.CurrentPixel(
+            "\r\nhalf4 apply(half4 color) {\r\n    return color;\r\n}\r\n");
+        ShaderDescription second = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) {\n    return color;\n}");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Kind, Is.EqualTo(ShaderDescriptionKind.CurrentPixel));
+            Assert.That(first.Source.Text, Is.EqualTo(second.Source.Text));
+            Assert.That(first.Source.IdentityHash, Is.EqualTo(second.Source.IdentityHash));
+            Assert.That(first.Bounds, Is.EqualTo(RenderBoundsContract.Identity));
+            Assert.That(
+                typeof(ShaderDescription).GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                    .Select(static property => property.Name),
+                Does.Not.Contain("IsCoverageHomogeneous"));
+        });
+
+        string[] invalidSources =
+        [
+            "half4 main(float2 coord) { return half4(1); }",
+            "half4 apply(half4 pixel) { return pixel; }",
+            "half4 apply(half4 color) { return half4(sk_FragCoord.xy, 0, 1); }",
+            "uniform shader src; half4 apply(half4 color) { return src.eval(color.rg); }",
+            "uniform float left, right; half4 apply(half4 color) { return color; }",
+            "struct Payload { float value; }; half4 apply(half4 color) { return color; }",
+            "half4 apply(half4 color) { return color; } half4 apply(half4 color) { return color; }",
+        ];
+
+        foreach (string source in invalidSources)
+        {
+            Assert.That(
+                () => ShaderDescription.CurrentPixel(source),
+                Throws.TypeOf<ArgumentException>(),
+                source);
+        }
+    }
+
+    [Test]
+    public void CurrentPixel_AcceptsOnlyRenameSafeValueDerivedGrammar()
+    {
+        using var registry = new RenderRequestResourceRegistry();
+        RenderResource<object> resource = registry.RegisterBorrowed(new object(), "lut", 1);
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            """
+            uniform float gain;
+            uniform float2 offset;
+            uniform shader lut;
+            const float bias = 0.125;
+            const float weights[2] = float[2](0.25, 0.75);
+
+            half3 adjust(half3 value, float amount)
+            {
+                half3 adjusted = clamp(value * amount + bias, 0.0, 1.0);
+                return adjusted;
+            }
+
+            half4 apply(half4 color)
+            {
+                float2 lookup = color.rg + offset;
+                half3 rgb = adjust(color.rgb, gain) * weights[0] + color.rgb * weights[1];
+                return half4(lut.eval(lookup).rgb * rgb, color.a);
+            }
+            """,
+            bindings =>
+            {
+                bindings.Uniform("gain", 0.5f);
+                bindings.Uniform("offset", Vector2.Zero);
+                bindings.Resource(
+                    "lut",
+                    resource,
+                    ShaderResourceCoordinateSpace.Value,
+                    static (writer, _, _) => writer.Set(SKShader.CreateColor(SKColors.White)));
+            });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(description.Kind, Is.EqualTo(ShaderDescriptionKind.CurrentPixel));
+            Assert.That(description.Uniforms, Has.Count.EqualTo(2));
+            Assert.That(description.Resources, Has.Count.EqualTo(1));
+        });
+    }
+
+    [TestCase("float leaked; half4 apply(half4 color) { return color; }")]
+    [TestCase("layout(color) uniform half4 tint; half4 apply(half4 color) { return color; }")]
+    [TestCase("#define GAIN 2\nhalf4 apply(half4 color) { return color * GAIN; }")]
+    [TestCase("half4 helper(half4 value); half4 apply(half4 color) { return helper(color); }")]
+    [TestCase("half4 helper(inout half4 value) { return value; } half4 apply(half4 color) { return helper(color); }")]
+    [TestCase("half4 apply(half4 color) { float left = 1, right = 2; return color * left; }")]
+    [TestCase("half4 apply(half4 color) { for (int x = 0, y = 0; x < 1; ++x) { } return color; }")]
+    [TestCase("half4 apply(half4 color) { float color = 1; return half4(color); }")]
+    [TestCase("half4 apply(half4 color) { return half4(dFdx(color.r)); }")]
+    [TestCase("uniform shader lut; half4 apply(half4 color) { return lut.eval(sk_FragCoord.xy); }")]
+    [TestCase("uniform shader lut; half4 apply(half4 color) { return lut.eval(unknownValue); }")]
+    [TestCase("uniform shader lut; half4 apply(half4 color) { float2 position; return lut.eval(position); }")]
+    [TestCase("uniform shader lut; half4 apply(half4 color) { return lut.eval(); }")]
+    [TestCase("uniform shader lut; half4 apply(half4 color) { return lut.eval(color.rg, color.ba); }")]
+    [TestCase("uniform shader lut; const half4 sampled = lut.eval(); half4 apply(half4 color) { return sampled; }")]
+    [TestCase("uniform shader lut; half4 apply(half4 color) { return half4(lut); }")]
+    [TestCase("uniform float __beutl_value; half4 apply(half4 color) { return color; }")]
+    public void CurrentPixel_RejectsGrammarThatCannotBeProvenValueOnly(string source)
+    {
+        Assert.That(
+            () => new SkslSource(source, ShaderDescriptionKind.CurrentPixel),
+            Throws.TypeOf<ArgumentException>());
+    }
+
+    [Test]
+    public void WholeSource_RemainsACompleteCoordinateShader()
+    {
+        RenderBoundsContract bounds = RenderBoundsContract.Create(
+            static input => input,
+            static requested => requested,
+            "whole-source-coordinate-test");
+
+        ShaderDescription description = ShaderDescription.WholeSource(
+            """
+            uniform shader src;
+            half4 sampleSource(float2 position) { return src.eval(position); }
+            half4 main(float2 coord)
+            {
+                float2 first = coord, second = coord + float2(1);
+                return sampleSource(mix(first, second, 0.5));
+            }
+            """,
+            bounds);
+
+        Assert.That(description.Kind, Is.EqualTo(ShaderDescriptionKind.WholeSource));
+    }
+
+    [Test]
+    public void WholeSource_RequiresImplicitSourceAndExplicitBounds()
+    {
+        RenderBoundsContract bounds = RenderBoundsContract.Create(
+            static input => input.Inflate(new Thickness(2)),
+            static requested => requested.Inflate(new Thickness(2)),
+            "whole-source-bounds");
+        ShaderDescription description = ShaderDescription.WholeSource(
+            "uniform shader src; half4 main(float2 coord) { return src.eval(coord); }",
+            bounds,
+            sourceTileMode: SKShaderTileMode.Clamp);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(description.Kind, Is.EqualTo(ShaderDescriptionKind.WholeSource));
+            Assert.That(description.Bounds, Is.EqualTo(bounds));
+            Assert.That(description.SourceTileMode, Is.EqualTo(SKShaderTileMode.Clamp));
+            Assert.That(
+                () => ShaderDescription.WholeSource(
+                    "half4 main(float2 coord) { return half4(1); }",
+                    bounds),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => ShaderDescription.WholeSource(
+                    "uniform shader src; half4 main(float2 coord) { return src.eval(coord); }",
+                    default),
+                Throws.TypeOf<ArgumentException>());
+        });
+    }
+
+    [Test]
+    public void WholeSource_RejectsAnExplicitBindingForItsImplicitSource()
+    {
+        using var registry = new RenderRequestResourceRegistry();
+        RenderResource<object> resource = registry.RegisterBorrowed(new object(), "explicit-src", 1);
+
+        ArgumentException? exception = Assert.Throws<ArgumentException>(
+            () => ShaderDescription.WholeSource(
+                "uniform shader src; half4 main(float2 coord) { return src.eval(coord); }",
+                RenderBoundsContract.Identity,
+                bindings => bindings.Resource(
+                    "src",
+                    resource,
+                    ShaderResourceCoordinateSpace.Value,
+                    static (writer, _, _) => writer.Set(SKShader.CreateColor(SKColors.White)))));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception!.ParamName, Is.EqualTo("resources"));
+            Assert.That(exception.Message, Does.Contain("implicit WholeSource input 'src'"));
+        });
+    }
+
+    [Test]
+    public void DirectUniforms_AreCanonicalAndValidatedAgainstDeclarations()
+    {
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            "uniform float amount; uniform float2 offset; uniform float4 tint; "
+            + "half4 apply(half4 color) { return color * amount + half4(offset, 0, 0) + tint; }",
+            bindings =>
+            {
+                bindings.Uniform("amount", 0.5f);
+                bindings.Uniform("offset", new Vector2(1, 2));
+                bindings.Uniform("tint", new float[] { 0, 0, 0, 0 });
+            });
+
+        Assert.That(description.Uniforms, Has.Count.EqualTo(3));
+        Assert.That(
+            () => ShaderDescription.CurrentPixel(
+                "uniform float2 value; half4 apply(half4 color) { return color; }",
+                bindings => bindings.Uniform("value", 1f)),
+            Throws.TypeOf<ArgumentException>()
+                .Or.TypeOf<InvalidOperationException>());
+        Assert.That(
+            () => ShaderDescription.CurrentPixel(
+                "uniform float value; half4 apply(half4 color) { return color; }",
+                bindings => bindings.Uniform("value", 1L)),
+            Throws.TypeOf<ArgumentException>());
+        Assert.That(
+            () => ShaderDescription.CurrentPixel(
+                "uniform float value; half4 apply(half4 color) { return color; }",
+                bindings =>
+                {
+                    bindings.Uniform("value", 1f);
+                    bindings.Uniform("value", 2f);
+                }),
+            Throws.TypeOf<ArgumentException>());
+        Assert.That(
+            () => ShaderDescription.CurrentPixel(
+                "uniform float value; half4 apply(half4 color) { return color; }",
+                bindings => bindings.Uniform("not-valid!", 1f)),
+            Throws.TypeOf<ArgumentException>());
+    }
+
+    [Test]
+    public void DirectUniform_UInt32AboveInt32MaxValueReportsRangeError()
+    {
+        ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(
+            () => ShaderDescription.CurrentPixel(
+                "uniform int value; half4 apply(half4 color) { return color; }",
+                bindings => bindings.Uniform("value", uint.MaxValue)))!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.ParamName, Is.EqualTo("value"));
+            Assert.That(exception.ActualValue, Is.EqualTo(uint.MaxValue));
+            Assert.That(exception.Message, Does.Contain("Int32.MaxValue"));
+        });
+    }
+
+    [Test]
+    public void ResourceBindings_EnforceCoordinateSpaceAndDeclaredType()
+    {
+        using var registry = new RenderRequestResourceRegistry();
+        var resource = new object();
+        RenderResource<object> token = registry.RegisterBorrowed(resource, "resource", 1);
+
+        ShaderDescription current = ShaderDescription.CurrentPixel(
+            "uniform shader lut; half4 apply(half4 color) { return lut.eval(color.rg); }",
+            bindings => bindings.Resource(
+                "lut",
+                token,
+                ShaderResourceCoordinateSpace.Value,
+                static (writer, _, _) => writer.Set(SKShader.CreateColor(SKColors.White)),
+                structuralKey: "lut"));
+        Assert.That(current.Resources.Single().CoordinateSpace, Is.EqualTo(ShaderResourceCoordinateSpace.Value));
+
+        Assert.That(
+            () => ShaderDescription.CurrentPixel(
+                "uniform shader lut; half4 apply(half4 color) { return lut.eval(color.rg); }",
+                bindings => bindings.Resource(
+                    "lut",
+                    token,
+                    ShaderResourceCoordinateSpace.OutputDevice,
+                    static (writer, _, _) => writer.Set(SKShader.CreateColor(SKColors.White)))),
+            Throws.TypeOf<ArgumentException>());
+        Assert.That(
+            () => ShaderDescription.CurrentPixel(
+                "uniform float value; half4 apply(half4 color) { return color * value; }",
+                bindings => bindings.Resource(
+                    "value",
+                    token,
+                    ShaderResourceCoordinateSpace.Value,
+                    static (writer, _, _) => writer.Set(SKShader.CreateColor(SKColors.White)))),
+            Throws.TypeOf<ArgumentException>());
+    }
+
+    [Test]
+    public void ScopedCustomBinder_CannotRetainWriterAndDefaultCachePolicyIsRequestUnique()
+    {
+        ShaderUniformWriter? retained = null;
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            "uniform float amount; half4 apply(half4 color) { return color * amount; }",
+            bindings => bindings.Uniform(
+                "amount",
+                0.25f,
+                (writer, value, _) =>
+                {
+                    retained = writer;
+                    writer.Set(value);
+                },
+                structuralKey: "custom-amount"));
+        var token = new RenderExecutionSessionToken();
+        var execution = new ShaderExecutionContext(
+            token,
+            new Rect(0, 0, 10, 10),
+            new Rect(0, 0, 10, 10),
+            new Rect(0, 0, 10, 10),
+            new PixelRect(0, 0, 10, 10),
+            EffectiveScale.At(1),
+            outputScale: 1,
+            workingScale: 1,
+            maxWorkingScale: 2,
+            intent: RenderIntent.Preview,
+            purpose: RenderRequestPurpose.Frame);
+
+        _ = description.Uniforms.Single().Bind(
+            new SkslUniformDeclaration("float", null),
+            execution);
+        token.Complete();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => retained!.Set(0.5f), Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => _ = execution.OutputBounds, Throws.TypeOf<InvalidOperationException>());
+            Assert.That(
+                description.Uniforms.Single().CachePolicy,
+                Is.EqualTo(ShaderBindingCachePolicy.RequestUnique));
+        });
+    }
+
+    [Test]
+    public void StructuralIdentity_UsesFullEqualityAfterHashCollision()
+    {
+        ShaderDescription first = ShaderDescription.CurrentPixel(
+            "uniform float amount; " + IdentityCurrentPixel,
+            bindings => bindings.Uniform(
+                "amount",
+                1f,
+                static (writer, value, _) => writer.Set(value),
+                new CollisionKey("first"),
+                ShaderBindingCachePolicy.ReuseFromSnapshot));
+        ShaderDescription second = ShaderDescription.CurrentPixel(
+            "uniform float amount; " + IdentityCurrentPixel,
+            bindings => bindings.Uniform(
+                "amount",
+                1f,
+                static (writer, value, _) => writer.Set(value),
+                new CollisionKey("second"),
+                ShaderBindingCachePolicy.ReuseFromSnapshot));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.StructuralIdentity.GetHashCode(), Is.EqualTo(second.StructuralIdentity.GetHashCode()));
+            Assert.That(first.StructuralIdentity, Is.Not.EqualTo(second.StructuralIdentity));
+        });
+    }
+
+    [Test]
+    public void CustomUniformCachePolicy_UsesCopiedValueOrRequestUniqueIdentity()
+    {
+        static ShaderDescription Create(float value, ShaderBindingCachePolicy cachePolicy)
+            => ShaderDescription.CurrentPixel(
+                "uniform float amount; " + IdentityCurrentPixel,
+                bindings => bindings.Uniform(
+                    "amount",
+                    value,
+                    static (writer, item, _) => writer.Set(item),
+                    structuralKey: "custom-amount",
+                    cachePolicy: cachePolicy));
+
+        object first = Create(1f, ShaderBindingCachePolicy.ReuseFromSnapshot).CreateRuntimeIdentity();
+        object equal = Create(1f, ShaderBindingCachePolicy.ReuseFromSnapshot).CreateRuntimeIdentity();
+        object changedValue = Create(2f, ShaderBindingCachePolicy.ReuseFromSnapshot).CreateRuntimeIdentity();
+        object requestUnique = Create(1f, ShaderBindingCachePolicy.RequestUnique).CreateRuntimeIdentity();
+        object anotherRequestUnique = Create(1f, ShaderBindingCachePolicy.RequestUnique).CreateRuntimeIdentity();
+        float mutableMultiplier = 2;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(equal, Is.EqualTo(first));
+            Assert.That(changedValue, Is.Not.EqualTo(first));
+            Assert.That(requestUnique, Is.Not.EqualTo(anotherRequestUnique));
+            Assert.That(
+                () => ShaderDescription.CurrentPixel(
+                    "uniform float amount; " + IdentityCurrentPixel,
+                    bindings => bindings.Uniform(
+                        "amount",
+                        1f,
+                        (writer, item, _) => writer.Set(item * mutableMultiplier),
+                        cachePolicy: ShaderBindingCachePolicy.ReuseFromSnapshot)),
+                Throws.TypeOf<ArgumentException>());
+        });
+    }
+
+    // SkSL reads matrix uniform data column-major, so a canonical matrix value must be the column-major encoding
+    // of the SkSL matrix that reproduces the source type's own transform convention.
+    [Test]
+    public void CanonicalMatrixValues_AreColumnMajorForTheEquivalentSkslMatrix()
+    {
+        // SKMatrix transforms column vectors (p' = M * p) and stores its rows contiguously, so the canonical
+        // value is its storage order transposed. A translation must therefore land in the last column.
+        var skMatrix = SKMatrix.CreateTranslation(50, 70);
+        float[] skValues = ShaderCanonicalValue.Create(skMatrix).Values!;
+
+        // Matrix4x4 transforms row vectors (p' = p * M) and stores its rows contiguously. The equivalent
+        // column-vector matrix is its transpose, whose column-major encoding is that same storage order.
+        Matrix4x4 numericsMatrix = Matrix4x4.CreateTranslation(50, 70, 90);
+        float[] numericsValues = ShaderCanonicalValue.Create(numericsMatrix).Values!;
+
+        // Matrix3x2 has no SkSL matrix type. Its six floats bind to float2[3]: x basis, y basis, translation.
+        var affine = Matrix3x2.CreateScale(2, 3) * Matrix3x2.CreateTranslation(50, 70);
+        float[] affineValues = ShaderCanonicalValue.Create(affine).Values!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(skValues, Is.EqualTo(new float[]
+            {
+                1, 0, 0,
+                0, 1, 0,
+                50, 70, 1,
+            }));
+            Assert.That(numericsValues, Is.EqualTo(new float[]
+            {
+                1, 0, 0, 0,
+                0, 1, 0, 0,
+                0, 0, 1, 0,
+                50, 70, 90, 1,
+            }));
+            Assert.That(affineValues, Is.EqualTo(new float[]
+            {
+                2, 0,
+                0, 3,
+                50, 70,
+            }));
+        });
+    }
+
+    // The two conventions agree once both are expressed as an SkSL matrix, so a transform built either way must
+    // produce the same canonical value. This is what makes the differing member order above correct.
+    [Test]
+    public void CanonicalMatrixValues_AgreeBetweenSkiaAndNumericsForTheSameTransform()
+    {
+        var skMatrix = SKMatrix.CreateScaleTranslation(2, 3, 50, 70);
+        Matrix4x4 numericsMatrix = Matrix4x4.CreateScale(2, 3, 1) * Matrix4x4.CreateTranslation(50, 70, 0);
+
+        float[] skValues = ShaderCanonicalValue.Create(skMatrix).Values!;
+        float[] numericsValues = ShaderCanonicalValue.Create(numericsMatrix).Values!;
+
+        // The 3x3 columns are the 4x4 columns with the z row and column dropped.
+        float[] projected =
+        [
+            numericsValues[0], numericsValues[1], numericsValues[3],
+            numericsValues[4], numericsValues[5], numericsValues[7],
+            numericsValues[12], numericsValues[13], numericsValues[15],
+        ];
+
+        Assert.That(skValues, Is.EqualTo(projected));
+    }
+
+    [Test]
+    public void CanonicalMatrixValues_BindToTheDeclaredSkslMatrixType()
+    {
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            "uniform float3x3 xform; uniform float2 basis[3]; "
+            + "half4 apply(half4 color) { return color * (xform[0][0] + basis[2].x); }",
+            bindings =>
+            {
+                bindings.Uniform("xform", SKMatrix.CreateTranslation(50, 70));
+                bindings.Uniform("basis", Matrix3x2.Identity);
+            });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(description.Uniforms, Has.Count.EqualTo(2));
+
+            // float3x3 takes nine floats; a Matrix4x4 supplies sixteen and must be rejected.
+            Assert.That(
+                () => ShaderDescription.CurrentPixel(
+                    "uniform float3x3 xform; half4 apply(half4 color) { return color * xform[0][0]; }",
+                    bindings => bindings.Uniform("xform", Matrix4x4.Identity)),
+                Throws.TypeOf<InvalidOperationException>().Or.TypeOf<ArgumentException>());
+        });
+    }
+
+    private sealed record CollisionKey(string Value)
+    {
+        public override int GetHashCode() => 7;
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Fusion/ShaderFallbackTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Fusion/ShaderFallbackTests.cs
@@ -1,0 +1,312 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Fusion;
+
+[TestFixture]
+public sealed class ShaderFallbackTests
+{
+    private static readonly Rect s_bounds = new(0, 0, 6, 4);
+
+    [TestCase(ShaderDescriptionKind.CurrentPixel)]
+    [TestCase(ShaderDescriptionKind.WholeSource)]
+    public void OrdinaryCpuBackend_RendersEveryPublicShaderFormWithoutSkipping(
+        ShaderDescriptionKind kind)
+    {
+        using var source = new CpuRenderTarget(6, 4);
+        source.Value.Canvas.Clear(new SKColor(64, 128, 192, 160));
+        using Bitmap sourceBitmap = source.Snapshot();
+        ShaderDescription description = kind == ShaderDescriptionKind.CurrentPixel
+            ? ShaderDescription.CurrentPixel(
+                "half4 apply(half4 color) { return half4(color.bgr, color.a); }")
+            : ShaderDescription.WholeSource(
+                "uniform shader src; half4 main(float2 p) { return src.eval(p).bgra; }",
+                RenderBoundsContract.Identity);
+        using var node = new ShaderNode(source, description);
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_bounds,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    FusionMode = FusionMode.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rasterization.Bitmap, Is.Not.Null);
+            Assert.That(rasterization.Bounds, Is.EqualTo(s_bounds));
+            Assert.That(SumAbsoluteChannels(rasterization.Bitmap!), Is.GreaterThan(1));
+            AssertBlueRedSwap(sourceBitmap, rasterization.Bitmap!);
+        });
+    }
+
+    [Test]
+    public void FusedCurrentPixelStages_ReceiveTheSameRoiCroppedInputBoundsAsUnfusedStages()
+    {
+        var requestedRegion = new Rect(2, 1, 2, 2);
+        using var source = new CpuRenderTarget(6, 4);
+        source.Value.Canvas.Clear(new SKColor(64, 128, 192, 160));
+        var disabledInputBounds = new List<Rect>();
+        var enabledInputBounds = new List<Rect>();
+        using var disabledNode = new BoundShaderChainNode(source, disabledInputBounds);
+        using var enabledNode = new BoundShaderChainNode(source, enabledInputBounds);
+        using var disabled = CreateRenderer(disabledNode, requestedRegion, FusionMode.Disabled);
+        using var enabled = CreateRenderer(enabledNode, requestedRegion, FusionMode.Enabled);
+
+        using RenderNodeRasterization disabledRaster = disabled.Rasterize();
+        using RenderNodeRasterization enabledRaster = enabled.Rasterize();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(disabledInputBounds[1], Is.EqualTo(requestedRegion));
+            Assert.That(enabledInputBounds, Is.EqualTo(disabledInputBounds));
+            Assert.That(enabled.LastExecutionStatistics.FusedShaderRunExecutions, Is.EqualTo(1));
+            Assert.That(disabledRaster.Bounds, Is.EqualTo(requestedRegion));
+            Assert.That(enabledRaster.Bounds, Is.EqualTo(requestedRegion));
+        });
+    }
+
+    [Test]
+    public void OrdinaryCpuBackend_PreservesExplicitProgramValidationFailure()
+    {
+        using var source = new CpuRenderTarget(6, 4);
+        ShaderDescription invalid = ShaderDescription.WholeSource(
+            "uniform shader src; half4 main(float2 p) { this is not valid SkSL; }",
+            RenderBoundsContract.Identity);
+        using var node = new ShaderNode(source, invalid);
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_bounds,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    FusionMode = FusionMode.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        Assert.That(
+            () => renderer.Rasterize(),
+            Throws.TypeOf<InvalidOperationException>()
+                .With.Message.StartsWith("SkSL program validation failed:"));
+    }
+
+    [TestCase(ShaderDescriptionKind.WholeSource)]
+    [TestCase(ShaderDescriptionKind.CurrentPixel)]
+    public void CompatibilityShaderProgramCache_ColdMissThenWarmHit(
+        ShaderDescriptionKind kind)
+    {
+        using var source = new CpuRenderTarget(6, 4);
+        source.Value.Canvas.Clear(new SKColor(64, 128, 192, 160));
+        using Bitmap sourceBitmap = source.Snapshot();
+        ShaderDescription description;
+        if (kind == ShaderDescriptionKind.WholeSource)
+        {
+            description = ShaderDescription.WholeSource(
+                "uniform shader src; half4 main(float2 p) { return src.eval(p).bgra; }",
+                RenderBoundsContract.Identity);
+        }
+        else
+        {
+            string currentPixelSource =
+                $"/*{new string('界', 22_000)}*/\n"
+                + "half4 apply(half4 color) { return color.bgra; }";
+            description = ShaderDescription.CurrentPixel(currentPixelSource);
+            SkslMergedProgram fallback = SkslSnippetMerger.MergeAndSplit(
+                [new SkslSnippetStage(description)],
+                SkslBackendBudgetResolver.Portable)[0];
+            Assert.That(
+                fallback.OverflowReasons,
+                Does.Contain(SkslBackendLimit.SourceBytes),
+                "the test must exercise the backend-overflow compatibility path");
+        }
+
+        using var node = new ShaderNode(source, description);
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_bounds,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    FusionMode = FusionMode.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        using RenderNodeRasterization cold = renderer.Rasterize();
+        ProgramCacheStatistics coldStatistics = renderer.ProgramCacheStatistics;
+        using RenderNodeRasterization warm = renderer.Rasterize();
+        ProgramCacheStatistics warmStatistics = renderer.ProgramCacheStatistics;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cold.Bitmap, Is.Not.Null);
+            Assert.That(warm.Bitmap, Is.Not.Null);
+            AssertBlueRedSwap(sourceBitmap, cold.Bitmap!);
+            AssertBlueRedSwap(sourceBitmap, warm.Bitmap!);
+            Assert.That(coldStatistics.Creations, Is.EqualTo(1));
+            Assert.That(coldStatistics.Misses, Is.EqualTo(1));
+            Assert.That(coldStatistics.Hits, Is.Zero);
+            Assert.That(warmStatistics.Creations, Is.EqualTo(1));
+            Assert.That(warmStatistics.Misses, Is.EqualTo(1));
+            Assert.That(warmStatistics.Hits, Is.EqualTo(1));
+            Assert.That(renderer.LastExecutionStatistics.ProgramCacheHits, Is.EqualTo(1));
+        });
+    }
+
+    private static double SumAbsoluteChannels(Bitmap bitmap)
+    {
+        double result = 0;
+        foreach (ushort bits in bitmap.GetPixelSpan<ushort>())
+            result += Math.Abs((float)BitConverter.UInt16BitsToHalf(bits));
+        return result;
+    }
+
+    private static void AssertBlueRedSwap(Bitmap source, Bitmap actual)
+    {
+        (float sourceRed, float sourceGreen, float sourceBlue, float sourceAlpha) = ChannelsAt(source, 0, 0);
+        (float actualRed, float actualGreen, float actualBlue, float actualAlpha) = ChannelsAt(actual, 0, 0);
+        Assert.Multiple(() =>
+        {
+            Assert.That(sourceRed, Is.Not.EqualTo(sourceBlue).Within(0.001f),
+                "the source fixture must distinguish a skipped shader from a red/blue swap");
+            Assert.That(actualRed, Is.EqualTo(sourceBlue).Within(0.002f));
+            Assert.That(actualGreen, Is.EqualTo(sourceGreen).Within(0.002f));
+            Assert.That(actualBlue, Is.EqualTo(sourceRed).Within(0.002f));
+            Assert.That(actualAlpha, Is.EqualTo(sourceAlpha).Within(0.002f));
+        });
+    }
+
+    private static (float Red, float Green, float Blue, float Alpha) ChannelsAt(
+        Bitmap bitmap,
+        int x,
+        int y)
+    {
+        Span<ushort> row = bitmap.GetRow<ushort>(y);
+        int offset = x * 4;
+        return (
+            (float)BitConverter.UInt16BitsToHalf(row[offset]),
+            (float)BitConverter.UInt16BitsToHalf(row[offset + 1]),
+            (float)BitConverter.UInt16BitsToHalf(row[offset + 2]),
+            (float)BitConverter.UInt16BitsToHalf(row[offset + 3]));
+    }
+
+    private static RenderNodeRenderer CreateRenderer(
+        RenderNode node,
+        Rect requestedRegion,
+        FusionMode fusionMode)
+        => new(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_bounds,
+                    RequestedRegion = requestedRegion,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    FusionMode = fusionMode,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+    private sealed class ShaderNode(RenderTarget source, ShaderDescription description) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<RenderTarget> resource = context.Borrow(source, "fallback-source", 1);
+            RenderFragmentHandle input = context.MaterializedInput(
+                MaterializedInputDescription.FromRenderTarget(
+                    resource,
+                    s_bounds,
+                    EffectiveScale.At(1),
+                    PixelRect.FromRect(s_bounds, 1),
+                    default,
+                    RenderHitTestContract.OutputBounds));
+            context.Publish(context.Shader(input, description));
+        }
+    }
+
+    private sealed class BoundShaderChainNode : RenderNode
+    {
+        private readonly RenderTarget _source;
+        private readonly IReadOnlyList<ShaderDescription> _stages;
+
+        public BoundShaderChainNode(RenderTarget source, ICollection<Rect> observedInputBounds)
+        {
+            _source = source;
+            _stages =
+            [
+                CreateStage(0, observedInputBounds),
+                CreateStage(1, observedInputBounds),
+            ];
+        }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<RenderTarget> resource = context.Borrow(
+                _source,
+                "bound-fallback-source",
+                1);
+            RenderFragmentHandle current = context.MaterializedInput(
+                MaterializedInputDescription.FromRenderTarget(
+                    resource,
+                    s_bounds,
+                    EffectiveScale.At(1),
+                    PixelRect.FromRect(s_bounds, 1),
+                    default,
+                    RenderHitTestContract.OutputBounds));
+            foreach (ShaderDescription stage in _stages)
+                current = context.Shader(current, stage);
+            context.Publish(current);
+        }
+
+        private static ShaderDescription CreateStage(
+            int stage,
+            ICollection<Rect> observedInputBounds)
+            => ShaderDescription.CurrentPixel(
+                "uniform float gain; half4 apply(half4 color) { return color * gain; }",
+                bindings => bindings.Uniform(
+                    "gain",
+                    1f,
+                    (writer, value, execution) =>
+                    {
+                        observedInputBounds.Add(execution.InputBounds);
+                        writer.Set(value);
+                    },
+                    structuralKey: (typeof(BoundShaderChainNode), stage)));
+    }
+
+    private sealed class CpuTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+            => new CpuRenderTarget(allocation.DeviceSize.Width, allocation.DeviceSize.Height);
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Fusion/SkslBackendBudgetResolverTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Fusion/SkslBackendBudgetResolverTests.cs
@@ -1,0 +1,98 @@
+﻿using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Fusion;
+
+[TestFixture]
+public sealed class SkslBackendBudgetResolverTests
+{
+    [Test]
+    public void PortableProfile_UsesFiniteConservativeFusionLimits()
+    {
+        SkslBackendBudget budget = SkslBackendBudgetResolver.Portable;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(budget.CapabilityClass, Is.EqualTo(SkslBackendCapabilityClass.Portable));
+            Assert.That(budget.MaxStages, Is.EqualTo(16));
+            Assert.That(budget.MaxUniformVectors, Is.EqualTo(128));
+            Assert.That(budget.MaxSamplers, Is.EqualTo(8));
+            Assert.That(budget.MaxChildren, Is.EqualTo(8));
+            Assert.That(budget.MaxSourceBytes, Is.EqualTo(64 * 1024));
+            Assert.That(budget.MaxProgramTokens, Is.EqualTo(16 * 1024));
+        });
+    }
+
+    [TestCase(GRBackend.Vulkan, "Vulkan")]
+    [TestCase(GRBackend.Metal, "Metal")]
+    [TestCase(GRBackend.OpenGL, "Portable")]
+    [TestCase(GRBackend.Direct3D, "Portable")]
+    [TestCase(GRBackend.Dawn, "Portable")]
+    [TestCase(GRBackend.Unsupported, "Portable")]
+    public void Resolve_MapsBackendToStableCapabilityClass(
+        GRBackend backend,
+        string expected)
+    {
+        SkslBackendBudget first = SkslBackendBudgetResolver.Resolve(backend);
+        SkslBackendBudget second = SkslBackendBudgetResolver.Resolve(backend);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first, Is.SameAs(second));
+            Assert.That(first.CapabilityClass.ToString(), Is.EqualTo(expected));
+        });
+    }
+
+    [Test]
+    public void Resolve_NullAndUnknownBackendUsePortableProfile()
+    {
+        SkslBackendBudget portable = SkslBackendBudgetResolver.Portable;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(SkslBackendBudgetResolver.Resolve(null), Is.SameAs(portable));
+            Assert.That(SkslBackendBudgetResolver.Resolve((GRBackend)int.MaxValue), Is.SameAs(portable));
+            Assert.That(
+                SkslBackendBudgetResolver.Resolve(GRBackend.Vulkan).CapabilityClass,
+                Is.Not.EqualTo(portable.CapabilityClass));
+            Assert.That(
+                SkslBackendBudgetResolver.Resolve(GRBackend.Metal).CapabilityClass,
+                Is.Not.EqualTo(portable.CapabilityClass));
+        });
+    }
+
+    [Test]
+    public void PortableLimitsAreCommonFloorAndCapabilityClassesSeparateProgramIdentity()
+    {
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return color; }");
+        var stage = new SkslSnippetStage(description);
+        SkslBackendBudget portable = SkslBackendBudgetResolver.Portable;
+        SkslBackendBudget vulkan = SkslBackendBudgetResolver.Resolve(GRBackend.Vulkan);
+        SkslBackendBudget metal = SkslBackendBudgetResolver.Resolve(GRBackend.Metal);
+
+        SkslMergedProgram portableProgram = SkslSnippetMerger.MergeAndSplit([stage], portable).Single();
+        SkslMergedProgram vulkanProgram = SkslSnippetMerger.MergeAndSplit([stage], vulkan).Single();
+        SkslMergedProgram metalProgram = SkslSnippetMerger.MergeAndSplit([stage], metal).Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(vulkan.MaxStages, Is.GreaterThanOrEqualTo(portable.MaxStages));
+            Assert.That(vulkan.MaxUniformVectors, Is.GreaterThanOrEqualTo(portable.MaxUniformVectors));
+            Assert.That(vulkan.MaxSamplers, Is.GreaterThanOrEqualTo(portable.MaxSamplers));
+            Assert.That(vulkan.MaxChildren, Is.GreaterThanOrEqualTo(portable.MaxChildren));
+            Assert.That(vulkan.MaxSourceBytes, Is.GreaterThanOrEqualTo(portable.MaxSourceBytes));
+            Assert.That(vulkan.MaxProgramTokens, Is.GreaterThanOrEqualTo(portable.MaxProgramTokens));
+            Assert.That(metal.MaxStages, Is.GreaterThanOrEqualTo(portable.MaxStages));
+            Assert.That(metal.MaxUniformVectors, Is.GreaterThanOrEqualTo(portable.MaxUniformVectors));
+            Assert.That(metal.MaxSamplers, Is.GreaterThanOrEqualTo(portable.MaxSamplers));
+            Assert.That(metal.MaxChildren, Is.GreaterThanOrEqualTo(portable.MaxChildren));
+            Assert.That(metal.MaxSourceBytes, Is.GreaterThanOrEqualTo(portable.MaxSourceBytes));
+            Assert.That(metal.MaxProgramTokens, Is.GreaterThanOrEqualTo(portable.MaxProgramTokens));
+            Assert.That(portableProgram.Identity, Is.Not.EqualTo(vulkanProgram.Identity));
+            Assert.That(portableProgram.Identity, Is.Not.EqualTo(metalProgram.Identity));
+            Assert.That(vulkanProgram.Identity, Is.Not.EqualTo(metalProgram.Identity));
+        });
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Fusion/SkslSnippetMergerTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Fusion/SkslSnippetMergerTests.cs
@@ -1,0 +1,508 @@
+﻿using System.Text;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Fusion;
+
+[TestFixture]
+public sealed class SkslSnippetMergerTests
+{
+    private const string Identity = "half4 apply(half4 color) { return color; }";
+
+    [Test]
+    public void Merge_IsolatesTopLevelSymbolsWithoutRenamingMembersOrComments()
+    {
+        const string source =
+            "uniform float gain;\n"
+            + "const float weights[2] = float[2](0.25, 0.75);\n"
+            + "half3 adjust(half3 value) { return value * gain * weights[0]; }\n"
+            + "half4 apply(half4 color) { /* gain weights adjust */ "
+            + "return half4(adjust(color.rgb) + color.rrr * weights[1], color.a); }";
+
+        ShaderDescription first = ShaderDescription.CurrentPixel(
+            source,
+            static bindings => bindings.Uniform("gain", 0.5f));
+        ShaderDescription second = ShaderDescription.CurrentPixel(
+            source,
+            static bindings => bindings.Uniform("gain", 0.75f));
+
+        SkslMergedProgram program = SkslSnippetMerger.Merge(
+            [new(first), new(second)]);
+        string firstPrefix = program.Stages[0].Prefix;
+        string secondPrefix = program.Stages[1].Prefix;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstPrefix, Is.Not.EqualTo(secondPrefix));
+            Assert.That(program.Source, Does.Contain($"uniform float {firstPrefix}gain;")
+                .And.Contain($"uniform float {secondPrefix}gain;"));
+            Assert.That(program.Source, Does.Contain($"{firstPrefix}weights[2]")
+                .And.Contain($"{secondPrefix}weights[2]"));
+            Assert.That(program.Source, Does.Contain($"{firstPrefix}adjust")
+                .And.Contain($"{secondPrefix}adjust"));
+            Assert.That(program.Source, Does.Contain("color.rrr")
+                .And.Not.Contain($"color.{firstPrefix}")
+                .And.Not.Contain($"color.{secondPrefix}"));
+            Assert.That(program.Source, Does.Contain("/* gain weights adjust */"),
+                "comments are copied verbatim rather than interpreted as identifiers");
+        });
+    }
+
+    [Test]
+    public void Merge_UsesValidatedPrecisionQualifiedTopLevelSymbols()
+    {
+        const string source =
+            "uniform highp float gain;\n"
+            + "const mediump float bias = 0.25;\n"
+            + "highp float4 helper(highp float4 value) { return value * gain + bias; }\n"
+            + "half4 apply(half4 color) { return half4(helper(float4(color))); }";
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            source,
+            static bindings => bindings.Uniform("gain", 0.5f));
+
+        SkslMergedProgram program = SkslSnippetMerger.Merge(
+            [new(description), new(description)]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                description.Source.TopLevelSymbols,
+                Is.EquivalentTo(new[] { "gain", "bias", "helper", "apply" }));
+            foreach (SkslMergedStageLayout stage in program.Stages)
+            {
+                Assert.That(program.Source, Does.Contain($"uniform highp float {stage.Prefix}gain;"));
+                Assert.That(program.Source, Does.Contain($"const mediump float {stage.Prefix}bias"));
+                Assert.That(program.Source, Does.Contain($"highp float4 {stage.Prefix}helper("));
+                Assert.That(program.Source, Does.Contain($"half4 {stage.Prefix}apply("));
+            }
+        });
+
+        using SKRuntimeEffect? effect = SKRuntimeEffect.CreateShader(program.Source, out string? error);
+        Assert.Multiple(() =>
+        {
+            Assert.That(error, Is.Null);
+            Assert.That(effect, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public void Merge_PreservesAuthoredStageOrder()
+    {
+        ShaderDescription red = ShaderDescription.CurrentPixel(
+            "half4 red(half4 value) { return half4(value.r, 0, 0, value.a); } "
+            + "half4 apply(half4 color) { return red(color); }");
+        ShaderDescription blue = ShaderDescription.CurrentPixel(
+            "half4 blue(half4 value) { return half4(0, 0, value.b, value.a); } "
+            + "half4 apply(half4 color) { return blue(color); }");
+
+        SkslMergedProgram program = SkslSnippetMerger.Merge([new(red), new(blue)]);
+        string firstPrefix = program.Stages[0].Prefix;
+        string secondPrefix = program.Stages[1].Prefix;
+
+        int firstCall = program.Source.IndexOf(
+            $"__beutl_pixel = {firstPrefix}apply(__beutl_pixel);",
+            StringComparison.Ordinal);
+        int secondCall = program.Source.IndexOf(
+            $"__beutl_pixel = {secondPrefix}apply(__beutl_pixel);",
+            StringComparison.Ordinal);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstCall, Is.GreaterThanOrEqualTo(0));
+            Assert.That(secondCall, Is.GreaterThan(firstCall));
+            Assert.That(program.Stages.Select(static stage => stage.StageIndex), Is.EqualTo(new[] { 0, 1 }));
+        });
+    }
+
+    [Test]
+    public void Merge_ProducesDeterministicBindingLayout()
+    {
+        using var registry = new RenderRequestResourceRegistry();
+        RenderResource<object> lookup = registry.RegisterBorrowed(new object(), "lookup", 3);
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            "uniform float gain; uniform float2 offset; uniform shader lookup; "
+            + "half4 apply(half4 color) { return lookup.eval(color.rg + offset) * gain; }",
+            bindings =>
+            {
+                bindings.Uniform("gain", 0.5f);
+                bindings.Uniform("offset", new System.Numerics.Vector2(1, 2));
+                bindings.Resource(
+                    "lookup",
+                    lookup,
+                    ShaderResourceCoordinateSpace.Value,
+                    static (writer, _, _) => writer.Set(SKShader.CreateColor(SKColors.White)));
+            });
+
+        SkslMergedProgram first = SkslSnippetMerger.Merge([new(description)]);
+        SkslMergedProgram second = SkslSnippetMerger.Merge([new(description)]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                first.Bindings.Select(static binding =>
+                    (binding.StageIndex, binding.Kind, binding.OriginalName, binding.MergedName,
+                        binding.Type, binding.ArrayExtent, binding.CoordinateSpace)),
+                Is.EqualTo(new[]
+                {
+                    (0, SkslBindingKind.Uniform, "gain", "__beutl_s0_gain", "float", (int?)null,
+                        (ShaderResourceCoordinateSpace?)null),
+                    (0, SkslBindingKind.Uniform, "offset", "__beutl_s0_offset", "float2", (int?)null,
+                        (ShaderResourceCoordinateSpace?)null),
+                    (0, SkslBindingKind.Resource, "lookup", "__beutl_s0_lookup", "shader", (int?)null,
+                        (ShaderResourceCoordinateSpace?)ShaderResourceCoordinateSpace.Value),
+                }));
+            Assert.That(second.Bindings, Is.EqualTo(first.Bindings));
+            Assert.That(second.Identity, Is.EqualTo(first.Identity));
+        });
+    }
+
+    [Test]
+    public void MergeAndSplit_SplitsBeforeStageLimitDeterministically()
+    {
+        var stages = Enumerable.Range(0, 5)
+            .Select(_ => new SkslSnippetStage(ShaderDescription.CurrentPixel(Identity)))
+            .ToArray();
+        SkslBackendBudget budget = Budget(maxStages: 2);
+
+        IReadOnlyList<SkslMergedProgram> first = SkslSnippetMerger.MergeAndSplit(stages, budget);
+        IReadOnlyList<SkslMergedProgram> second = SkslSnippetMerger.MergeAndSplit(stages, budget);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Select(static program => program.StageCount), Is.EqualTo(new[] { 2, 2, 1 }));
+            Assert.That(
+                first.Select(static program => program.Stages.Select(static stage => stage.StageIndex).ToArray()),
+                Is.EqualTo(new[] { new[] { 0, 1 }, new[] { 2, 3 }, new[] { 4 } }));
+            Assert.That(second.Select(static program => program.Source),
+                Is.EqualTo(first.Select(static program => program.Source)));
+            Assert.That(first, Has.All.Matches<SkslMergedProgram>(static program => !program.RequiresStandaloneExecution));
+        });
+    }
+
+    [Test]
+    public void MergeAndSplit_AccountsForUniformVectorLimitsIncludingArraysAndMatrices()
+    {
+        ShaderDescription first = ShaderDescription.CurrentPixel(
+            "uniform float4 values[2]; half4 apply(half4 color) { return color * values[0]; }",
+            static bindings => bindings.Uniform("values", (ReadOnlySpan<float>)[1, 1, 1, 1, 1, 1, 1, 1]));
+        ShaderDescription second = ShaderDescription.CurrentPixel(
+            "uniform float2x2 matrix; half4 apply(half4 color) { return color * matrix[0][0]; }",
+            static bindings => bindings.Uniform("matrix", (ReadOnlySpan<float>)[1, 0, 0, 1]));
+
+        IReadOnlyList<SkslMergedProgram> programs = SkslSnippetMerger.MergeAndSplit(
+            [new(first), new(second)],
+            Budget(maxUniformVectors: 2));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(programs, Has.Count.EqualTo(2));
+            Assert.That(programs.Select(static program => program.UniformVectorCount), Is.EqualTo(new[] { 2, 2 }));
+            Assert.That(programs, Has.All.Matches<SkslMergedProgram>(static program => !program.RequiresStandaloneExecution));
+        });
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MergeAndSplit_AccountsForSamplerAndChildLimits(bool samplerLimit)
+    {
+        using var registry = new RenderRequestResourceRegistry();
+        RenderResource<object> firstResource = registry.RegisterBorrowed(new object(), "first", 1);
+        RenderResource<object> secondResource = registry.RegisterBorrowed(new object(), "second", 1);
+        ShaderDescription first = ResourceShader("lookup", firstResource);
+        ShaderDescription second = ResourceShader("lookup", secondResource);
+        SkslBackendBudget budget = samplerLimit
+            ? Budget(maxSamplers: 2)
+            : Budget(maxChildren: 2);
+
+        IReadOnlyList<SkslMergedProgram> programs = SkslSnippetMerger.MergeAndSplit(
+            [new(first), new(second)],
+            budget);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(programs, Has.Count.EqualTo(2));
+            Assert.That(programs.Select(static program => program.SamplerCount), Is.EqualTo(new[] { 2, 2 }));
+            Assert.That(programs.Select(static program => program.ChildCount), Is.EqualTo(new[] { 2, 2 }));
+            Assert.That(programs, Has.All.Matches<SkslMergedProgram>(static program => !program.RequiresStandaloneExecution));
+        });
+    }
+
+    [Test]
+    public void PortableBudget_ReservesOneSamplerAndChildForTheImplicitSource()
+    {
+        using var registry = new RenderRequestResourceRegistry();
+        SkslSnippetStage[] stages = Enumerable.Range(0, 8)
+            .Select(index =>
+            {
+                RenderResource<object> resource = registry.RegisterBorrowed(
+                    new object(),
+                    $"resource-{index}",
+                    1);
+                return new SkslSnippetStage(ResourceShader($"lookup{index}", resource));
+            })
+            .ToArray();
+
+        IReadOnlyList<SkslMergedProgram> programs = SkslSnippetMerger.MergeAndSplit(
+            stages,
+            SkslBackendBudgetResolver.Portable);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(programs.Select(static program => program.StageCount),
+                Is.EqualTo(new[] { 7, 1 }));
+            Assert.That(programs.Select(static program => program.SamplerCount),
+                Is.EqualTo(new[] { 8, 2 }));
+            Assert.That(programs.Select(static program => program.ChildCount),
+                Is.EqualTo(new[] { 8, 2 }));
+            Assert.That(programs, Has.All.Matches<SkslMergedProgram>(
+                static program => !program.RequiresStandaloneExecution));
+        });
+    }
+
+    [Test]
+    public void MergeAndSplit_AccountsForGeneratedSourceLimit()
+    {
+        SkslSnippetStage first = new(ShaderDescription.CurrentPixel(Identity));
+        SkslSnippetStage second = new(ShaderDescription.CurrentPixel(
+            "half4 helper(half4 value) { return value; } "
+            + "half4 apply(half4 color) { return helper(color); }"));
+        SkslMergedProgram firstOnly = SkslSnippetMerger.Merge([first]);
+        SkslMergedProgram secondOnly = SkslSnippetMerger.Merge([second]);
+        int limit = Math.Max(firstOnly.SourceByteCount, secondOnly.SourceByteCount);
+
+        IReadOnlyList<SkslMergedProgram> programs = SkslSnippetMerger.MergeAndSplit(
+            [first, second],
+            Budget(maxSourceBytes: limit));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(programs, Has.Count.EqualTo(2));
+            Assert.That(programs, Has.All.Matches<SkslMergedProgram>(program => program.SourceByteCount <= limit));
+            Assert.That(programs.SelectMany(static program => program.Stages)
+                .Select(static stage => stage.StageIndex), Is.EqualTo(new[] { 0, 1 }));
+        });
+    }
+
+    [Test]
+    public void MergeAndSplit_AccountsForBackendProgramTokenLimit()
+    {
+        SkslSnippetStage first = new(ShaderDescription.CurrentPixel(Identity));
+        SkslSnippetStage second = new(ShaderDescription.CurrentPixel(
+            "half4 helper(half4 value) { return value; } "
+            + "half4 apply(half4 color) { return helper(color); }"));
+        SkslMergedProgram firstOnly = SkslSnippetMerger.Merge([first]);
+        SkslMergedProgram secondOnly = SkslSnippetMerger.Merge([second]);
+        int limit = Math.Max(firstOnly.ProgramTokenCount, secondOnly.ProgramTokenCount);
+
+        IReadOnlyList<SkslMergedProgram> programs = SkslSnippetMerger.MergeAndSplit(
+            [first, second],
+            Budget(maxProgramTokens: limit));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(programs, Has.Count.EqualTo(2));
+            Assert.That(programs, Has.All.Matches<SkslMergedProgram>(program => program.ProgramTokenCount <= limit));
+            Assert.That(programs.SelectMany(static program => program.Stages)
+                .Select(static stage => stage.StageIndex), Is.EqualTo(new[] { 0, 1 }));
+        });
+    }
+
+    [Test]
+    public void MergeAndSplit_UsesExactUtf8AndTokenMetricsAcrossStageIndexDigitBoundary()
+    {
+        const string source =
+            "// UTF-8 境界コメント\r\n"
+            + "const highp float gain = 1.0;\r\n"
+            + "half4 apply(half4 color) { return color * gain; }\r\n";
+        ShaderDescription description = ShaderDescription.CurrentPixel(source);
+        SkslSnippetStage[] stages = Enumerable.Range(0, 11)
+            .Select(_ => new SkslSnippetStage(description))
+            .ToArray();
+        SkslMergedProgram merged = SkslSnippetMerger.Merge(stages);
+
+        IReadOnlyList<SkslMergedProgram> atBoundary = SkslSnippetMerger.MergeAndSplit(
+            stages,
+            Budget(
+                maxSourceBytes: merged.SourceByteCount,
+                maxProgramTokens: merged.ProgramTokenCount));
+        IReadOnlyList<SkslMergedProgram> belowByteBoundary = SkslSnippetMerger.MergeAndSplit(
+            stages,
+            Budget(
+                maxSourceBytes: merged.SourceByteCount - 1,
+                maxProgramTokens: merged.ProgramTokenCount));
+        IReadOnlyList<SkslMergedProgram> belowTokenBoundary = SkslSnippetMerger.MergeAndSplit(
+            stages,
+            Budget(
+                maxSourceBytes: merged.SourceByteCount,
+                maxProgramTokens: merged.ProgramTokenCount - 1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(merged.Source, Does.Contain("__beutl_s9_apply")
+                .And.Contain("__beutl_s10_apply"));
+            Assert.That(merged.Source, Does.Not.Contain('\r'));
+            Assert.That(merged.SourceByteCount, Is.EqualTo(Encoding.UTF8.GetByteCount(merged.Source)));
+            Assert.That(merged.ProgramTokenCount, Is.EqualTo(SkslLexer.Tokenize(merged.Source).Count));
+            Assert.That(atBoundary, Has.Count.EqualTo(1));
+            Assert.That(belowByteBoundary, Has.Count.EqualTo(2));
+            Assert.That(belowTokenBoundary, Has.Count.EqualTo(2));
+        });
+
+        foreach (SkslMergedProgram program in atBoundary
+                     .Concat(belowByteBoundary)
+                     .Concat(belowTokenBoundary))
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(program.SourceByteCount, Is.EqualTo(Encoding.UTF8.GetByteCount(program.Source)));
+                Assert.That(program.ProgramTokenCount, Is.EqualTo(SkslLexer.Tokenize(program.Source).Count));
+            });
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                belowByteBoundary.SelectMany(static program => program.Stages)
+                    .Select(static stage => stage.StageIndex),
+                Is.EqualTo(Enumerable.Range(0, 11)));
+            Assert.That(
+                belowTokenBoundary.SelectMany(static program => program.Stages)
+                    .Select(static stage => stage.StageIndex),
+                Is.EqualTo(Enumerable.Range(0, 11)));
+        });
+    }
+
+    [Test]
+    public void MergeAndSplit_ReportsSingleStageBackendOverflowForStandaloneFallback()
+    {
+        SkslSnippetStage stage = new(ShaderDescription.CurrentPixel(
+            "uniform float gain; half4 apply(half4 color) { return color * gain; }",
+            static bindings => bindings.Uniform("gain", 0.5f)));
+
+        SkslMergedProgram program = SkslSnippetMerger.MergeAndSplit(
+            [stage],
+            Budget(maxUniformVectors: 0))[0];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(program.RequiresStandaloneExecution, Is.True);
+            Assert.That(program.OverflowReasons, Does.Contain(SkslBackendLimit.UniformVectors));
+            Assert.That(program.Stages, Has.Count.EqualTo(1),
+                "an individually unsupported stage remains visible to the ordinary unfused fallback");
+        });
+    }
+
+    [Test]
+    public void ProgramIdentity_UsesHashOnlyAsBucketAndComparesFullSourceAndLayout()
+    {
+        SkslMergedProgram first = SkslSnippetMerger.Merge(
+            [new(ShaderDescription.CurrentPixel(Identity))]);
+        SkslMergedProgram second = SkslSnippetMerger.Merge(
+            [new(ShaderDescription.CurrentPixel(
+                "half4 apply(half4 color) { return half4(color.a - color.rgb, color.a); }"))]);
+        SkslMergedProgramIdentity firstCollision = new(
+            first.Source,
+            first.Bindings,
+            first.Budget,
+            bucketHashOverride: 17);
+        SkslMergedProgramIdentity secondCollision = new(
+            second.Source,
+            second.Bindings,
+            second.Budget,
+            bucketHashOverride: 17);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstCollision.GetHashCode(), Is.EqualTo(secondCollision.GetHashCode()));
+            Assert.That(firstCollision, Is.Not.EqualTo(secondCollision));
+            Assert.That(new HashSet<SkslMergedProgramIdentity> { firstCollision, secondCollision }, Has.Count.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void CoverageMetadata_RequiresEveryStageToHaveAnEngineProof()
+    {
+        ShaderDescription description = ShaderDescription.CurrentPixel(Identity);
+        SkslMergedProgram homogeneous = SkslSnippetMerger.Merge(
+            [
+                new(description, SkslCoverageBehavior.PremultipliedCoverageHomogeneous),
+                new(description, SkslCoverageBehavior.PremultipliedCoverageHomogeneous),
+            ]);
+        SkslMergedProgram mixed = SkslSnippetMerger.Merge(
+            [
+                new(description, SkslCoverageBehavior.PremultipliedCoverageHomogeneous),
+                new(description),
+            ]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(homogeneous.IsPremultipliedCoverageHomogeneous, Is.True);
+            Assert.That(homogeneous.RequiresResolvedCoverage, Is.False);
+            Assert.That(mixed.IsPremultipliedCoverageHomogeneous, Is.False);
+            Assert.That(mixed.RequiresResolvedCoverage, Is.True);
+            Assert.That(mixed.Stages[1].CoverageBehavior,
+                Is.EqualTo(SkslCoverageBehavior.RequiresResolvedCoverage));
+        });
+    }
+
+    [Test]
+    public void Stage_RejectsWholeSourceBecauseItIsAnExplicitBarrier()
+    {
+        ShaderDescription wholeSource = ShaderDescription.WholeSource(
+            "uniform shader src; half4 main(float2 coord) { return src.eval(coord); }",
+            RenderBoundsContract.Identity);
+
+        Assert.That(
+            () => new SkslSnippetStage(wholeSource),
+            Throws.TypeOf<ArgumentException>());
+    }
+
+    [Test]
+    public void Merge_EmitsSkiaCompilableCurrentPixelProgram()
+    {
+        ShaderDescription first = ShaderDescription.CurrentPixel(
+            "uniform float gain; half4 apply(half4 color) { return color * gain; }",
+            static bindings => bindings.Uniform("gain", 0.5f));
+        ShaderDescription second = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return half4(color.a - color.rgb, color.a); }");
+        SkslMergedProgram program = SkslSnippetMerger.Merge([new(first), new(second)]);
+
+        using SKRuntimeEffect? effect = SKRuntimeEffect.CreateShader(program.Source, out string? error);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(error, Is.Null);
+            Assert.That(effect, Is.Not.Null);
+        });
+    }
+
+    private static ShaderDescription ResourceShader(string name, RenderResource<object> resource)
+    {
+        return ShaderDescription.CurrentPixel(
+            $"uniform shader {name}; half4 apply(half4 color) {{ return {name}.eval(color.rg); }}",
+            bindings => bindings.Resource(
+                name,
+                resource,
+                ShaderResourceCoordinateSpace.Value,
+                static (writer, _, _) => writer.Set(SKShader.CreateColor(SKColors.White))));
+    }
+
+    private static SkslBackendBudget Budget(
+        int maxStages = int.MaxValue,
+        int maxUniformVectors = int.MaxValue,
+        int maxSamplers = int.MaxValue,
+        int maxChildren = int.MaxValue,
+        int maxSourceBytes = int.MaxValue,
+        int maxProgramTokens = int.MaxValue)
+    {
+        return new SkslBackendBudget(
+            "unit-test-backend",
+            maxStages,
+            maxUniformVectors,
+            maxSamplers,
+            maxChildren,
+            maxSourceBytes,
+            maxProgramTokens);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/GeometryClipRenderNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/GeometryClipRenderNodeTests.cs
@@ -1,0 +1,100 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+[TestFixture]
+public sealed class GeometryClipRenderNodeTests
+{
+    [Test]
+    public void Update_ShouldNotMarkChanges_WhenAllPropertiesMatch()
+    {
+        Geometry.Resource clip = CreateClip(30, 40);
+        using var node = new GeometryClipRenderNode(clip, ClipOperation.Intersect);
+        node.HasChanges = false;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.Update(clip, ClipOperation.Intersect), Is.False);
+            Assert.That(node.HasChanges, Is.False);
+        });
+    }
+
+    [Test]
+    public void Update_ShouldMarkChanges_WhenPropertiesDoNotMatch()
+    {
+        Geometry.Resource clip = CreateClip(30, 40);
+        using var node = new GeometryClipRenderNode(clip, ClipOperation.Intersect);
+        node.HasChanges = false;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.Update(clip, ClipOperation.Difference), Is.True);
+            Assert.That(node.HasChanges, Is.True);
+        });
+    }
+
+    [Test]
+    public void UnchangedReRecording_ShouldAdmitTheClipScopeToTheCache()
+    {
+        Geometry.Resource clip = CreateClip(30, 40);
+        using var node = new GeometryClipRenderNode(clip, ClipOperation.Intersect);
+
+        for (int frame = 0; frame < RenderNodeCache.Count; frame++)
+        {
+            node.Update(clip, ClipOperation.Intersect);
+            node.Cache.IncrementRenderCount();
+            node.HasChanges = false;
+        }
+
+        Assert.That(node.Cache.CanCache(), Is.True);
+    }
+
+    private static Geometry.Resource CreateClip(float width, float height)
+    {
+        var geometry = new RectGeometry
+        {
+            Width = { CurrentValue = width },
+            Height = { CurrentValue = height },
+        };
+        return geometry.ToResource(CompositionContext.Default);
+    }
+
+    [Test]
+    public void Intersect_ClipsOutputBoundsAndHitTesting()
+    {
+        var geometry = new RectGeometry
+        {
+            Width = { CurrentValue = 30 },
+            Height = { CurrentValue = 40 },
+        };
+        Geometry.Resource resource = geometry.ToResource(CompositionContext.Default);
+        using var node = new GeometryClipRenderNode(resource, ClipOperation.Intersect);
+        node.AddChild(new RectangleRenderNode(
+            new Rect(0, 0, 100, 100),
+            Brushes.Resource.White,
+            null));
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+            });
+
+        RenderNodeMeasurement measurement = renderer.Measure();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(measurement.OutputBounds, Is.EqualTo(new Rect(0, 0, 30, 40)));
+            Assert.That(measurement.QueryBounds, Is.EqualTo(new Rect(0, 0, 30, 40)));
+            Assert.That(renderer.HitTest(new Point(20, 20)), Is.True);
+            Assert.That(renderer.HitTest(new Point(50, 20)), Is.False);
+        });
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/CurrentPixelQuantizationTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/CurrentPixelQuantizationTests.cs
@@ -1,0 +1,161 @@
+﻿using System.Numerics;
+using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Shapes;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Golden;
+
+[NonParallelizable]
+[TestFixture]
+public sealed class CurrentPixelQuantizationTests
+{
+    private static readonly PixelSize s_frame = new(32, 32);
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void DoubleInvert_MatchesIdentityMaterialization(bool fusionEnabled)
+    {
+        FusionMode fusionMode = fusionEnabled ? FusionMode.Enabled : FusionMode.Disabled;
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Bitmap control = Render(CreateDrawable(invertCount: 0), fusionMode);
+            using Bitmap identity = Render(CreateDrawable(invertCount: -1), fusionMode);
+            using Bitmap inverted = Render(CreateDrawable(invertCount: 2), fusionMode);
+
+            byte controlRed = ReadRed(control);
+            byte identityRed = ReadRed(identity);
+            byte invertedRed = ReadRed(inverted);
+            (float controlLinear, float controlAlpha) = ReadLinear(control);
+            (float identityLinear, float identityAlpha) = ReadLinear(identity);
+            (float invertedLinear, float invertedAlpha) = ReadLinear(inverted);
+            TestContext.WriteLine(
+                $"fusion={fusionEnabled}, control={controlRed} ({controlLinear:R}, a={controlAlpha:R}), "
+                + $"identity-stage={identityRed} ({identityLinear:R}, a={identityAlpha:R}), "
+                + $"double-invert={invertedRed} ({invertedLinear:R}, a={invertedAlpha:R})");
+            Assert.Multiple(() =>
+            {
+                Assert.That(controlLinear, Is.GreaterThan(0), "The unfiltered control must contain visible color.");
+                Assert.That(controlAlpha, Is.GreaterThan(0), "The unfiltered control must contain visible alpha.");
+                Assert.That(identityRed, Is.EqualTo(controlRed).Within(2),
+                    "Identity materialization must preserve the rendered control color "
+                    + "within the RGBA16F round-trip quantization this fixture characterizes.");
+                Assert.That(identityLinear, Is.EqualTo(controlLinear).Within(0.003f),
+                    "Identity materialization must preserve the rendered control in linear space.");
+                Assert.That(identityAlpha, Is.EqualTo(controlAlpha).Within(0.001f),
+                    "Identity materialization must preserve the rendered control alpha.");
+                Assert.That(invertedRed, Is.EqualTo(identityRed),
+                    $"Two full Invert stages must not add quantization beyond the materialization boundary; identity={identityRed}, inverted={invertedRed}.");
+                Assert.That(invertedLinear, Is.EqualTo(identityLinear).Within(0.001f),
+                    "Two full Invert stages must preserve the identity materialization in linear space.");
+                Assert.That(invertedAlpha, Is.EqualTo(identityAlpha).Within(0.001f),
+                    "Two full Invert stages must preserve the identity materialization alpha.");
+            });
+        });
+    }
+
+    private static Drawable.Resource CreateDrawable(int invertCount)
+    {
+        var shape = new RectShape
+        {
+            Width = { CurrentValue = s_frame.Width },
+            Height = { CurrentValue = s_frame.Height },
+            Fill = { CurrentValue = new SolidColorBrush(new Color(255, 51, 51, 51)) },
+            AlignmentX = { CurrentValue = AlignmentX.Center },
+            AlignmentY = { CurrentValue = AlignmentY.Center },
+        };
+        if (invertCount < 0)
+        {
+            shape.FilterEffect.CurrentValue = new IdentityTypedShaderEffect();
+        }
+        else if (invertCount > 0)
+        {
+            var group = new FilterEffectGroup();
+            for (int index = 0; index < invertCount; index++)
+            {
+                group.Children.Add(new InvertTypedShaderEffect());
+            }
+
+            shape.FilterEffect.CurrentValue = group;
+        }
+
+        return shape.ToResource(CompositionContext.Default);
+    }
+
+    private static Bitmap Render(Drawable.Resource resource, FusionMode fusionMode)
+    {
+        using (resource)
+        using (var node = new DrawableRenderNode(resource))
+        {
+            using (var graphics = new GraphicsContext2D(node, s_frame.ToSize(1), 1))
+            {
+                resource.GetOriginal().Render(graphics, resource);
+            }
+
+            using RenderTarget target = RenderTarget.Create(s_frame.Width, s_frame.Height)
+                                        ?? throw new InvalidOperationException("RenderTarget.Create returned null.");
+            using var canvas = new ImmediateCanvas(target, 1, logicalSize: s_frame.ToSize(1));
+            canvas.Clear();
+            using var renderer = new RenderNodeRenderer(
+                node,
+                new RenderNodeRendererOptions
+                {
+                    DefaultRequest = new RenderNodeRenderRequest
+                    {
+                        Intent = RenderIntent.Delivery,
+                        TargetDomain = new Rect(default, s_frame.ToSize(1)),
+                        OutputScale = 1,
+                        CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                        FusionMode = fusionMode,
+                    },
+                });
+            renderer.Render(canvas);
+            return target.Snapshot();
+        }
+    }
+
+    private static byte ReadRed(Bitmap bitmap)
+    {
+        (float red, _) = ReadLinear(bitmap);
+        return Color.FromLinear(new Vector4(red, red, red, 1)).R;
+    }
+
+    private static (float Red, float Alpha) ReadLinear(Bitmap bitmap)
+    {
+        int offset = ((bitmap.Height / 2 * bitmap.Width) + bitmap.Width / 2) * 4;
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        return (
+            (float)BitConverter.UInt16BitsToHalf(pixels[offset]),
+            (float)BitConverter.UInt16BitsToHalf(pixels[offset + 3]));
+    }
+
+    [SuppressResourceClassGeneration]
+    private sealed partial class InvertTypedShaderEffect : FilterEffect
+    {
+        public override void ApplyTo(FilterEffectContext context, FilterEffect.Resource resource)
+        {
+            context.Shader(ShaderDescription.CurrentPixel(
+                "half4 apply(half4 color) { return half4(color.a - color.rgb, color.a); }"));
+        }
+
+        public override Resource ToResource(CompositionContext context)
+        {
+            var resource = new Resource();
+            bool updateOnly = false;
+            resource.Update(this, context, ref updateOnly);
+            return resource;
+        }
+
+        public new sealed class Resource : FilterEffect.Resource
+        {
+            public Resource()
+            {
+            }
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/DelayAnimationNestedBrushTimeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/DelayAnimationNestedBrushTimeTests.cs
@@ -1,0 +1,112 @@
+﻿using Beutl.Animation;
+using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Shapes;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Golden;
+
+// LowerNestedEffectBrushes records the child's DrawableBrush content once, at the parent's composition time,
+// because the recorder only exists then. Every delayed target therefore paints that one snapshot: the nested
+// drawable content does not follow the per-target delayed time the child's other properties do.
+[NonParallelizable]
+[TestFixture]
+public class DelayAnimationNestedBrushTimeTests
+{
+    private static readonly PixelSize Frame = new(200, 200);
+
+    private static readonly TimeSpan CompositionTime = TimeSpan.FromSeconds(1);
+
+    [Test]
+    public void DelayedNestedDrawableBrush_PaintsTheCompositionTimeContentOnEveryTarget()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Bitmap rendered = GoldenImageHarness.RenderAtScale(MakeSplitDelayedBrush(), Frame, 1f);
+
+            SKColor left = rendered.SKBitmap.GetPixel(50, 100);
+            SKColor gap = rendered.SKBitmap.GetPixel(100, 100);
+            SKColor right = rendered.SKBitmap.GetPixel(150, 100);
+            TestContext.WriteLine($"left={left}, gap={gap}, right={right}");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    gap.Blue,
+                    Is.LessThan(60),
+                    "the split spacing must stay empty, or the two samples are not two separate targets");
+                AssertIsCompositionTimeContent(left, "the undelayed target");
+                AssertIsCompositionTimeContent(right, "the one-second-delayed target");
+            });
+        });
+    }
+
+    private static void AssertIsCompositionTimeContent(SKColor color, string label)
+    {
+        Assert.That(
+            color.Blue,
+            Is.GreaterThan(200),
+            $"{label} did not paint the brush content recorded at the parent's composition time");
+        Assert.That(
+            color.Red,
+            Is.LessThan(60),
+            $"{label} painted delayed brush content, which the recorder cannot produce");
+    }
+
+    // Two tiles from one split, then a one-second-per-tile delay: the second tile re-applies the child at t=0.
+    private static Drawable.Resource MakeSplitDelayedBrush()
+    {
+        var split = new SplitEffect();
+        split.HorizontalDivisions.CurrentValue = 2;
+        split.VerticalDivisions.CurrentValue = 1;
+        split.HorizontalSpacing.CurrentValue = 20;
+
+        var blend = new BlendEffect();
+        blend.Brush.CurrentValue = MakeTimeColouredDrawableBrush();
+        blend.BlendMode.CurrentValue = BlendMode.SrcIn;
+
+        var delay = new DelayAnimationEffect();
+        delay.Delay.CurrentValue = 1000f;
+        delay.Effect.CurrentValue = blend;
+
+        var group = new FilterEffectGroup();
+        group.Children.Add(split);
+        group.Children.Add(delay);
+
+        var shape = new RectShape();
+        shape.AlignmentX.CurrentValue = AlignmentX.Center;
+        shape.AlignmentY.CurrentValue = AlignmentY.Center;
+        shape.Width.CurrentValue = 160;
+        shape.Height.CurrentValue = 120;
+        shape.Fill.CurrentValue = Brushes.White;
+        shape.FilterEffect.CurrentValue = group;
+        return shape.ToResource(new CompositionContext(CompositionTime));
+    }
+
+    // Red at t=0, blue at the composition time: a delayed re-application would tint its tile red.
+    private static Brush MakeTimeColouredDrawableBrush()
+    {
+        var fill = new SolidColorBrush();
+        var animation = new KeyFrameAnimation<Color>();
+        animation.KeyFrames.Add(new KeyFrame<Color> { Value = Colors.Red, KeyTime = TimeSpan.Zero });
+        animation.KeyFrames.Add(new KeyFrame<Color> { Value = Colors.Blue, KeyTime = CompositionTime });
+        fill.Color.Animation = animation;
+
+        var content = new RectShape();
+        content.AlignmentX.CurrentValue = AlignmentX.Center;
+        content.AlignmentY.CurrentValue = AlignmentY.Center;
+        content.Width.CurrentValue = 200;
+        content.Height.CurrentValue = 200;
+        content.Fill.CurrentValue = fill;
+
+        var brush = new DrawableBrush();
+        brush.Drawable.CurrentValue = content;
+        brush.Stretch.CurrentValue = Stretch.Fill;
+        brush.TileMode.CurrentValue = TileMode.Tile;
+        return brush;
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/DrawableGroupIsolationTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/DrawableGroupIsolationTests.cs
@@ -1,0 +1,661 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Shapes;
+using Beutl.Graphics.Transformation;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Golden;
+
+[NonParallelizable]
+[TestFixture]
+public sealed class DrawableGroupIsolationTests
+{
+    private static readonly PixelSize s_frame = new(400, 400);
+
+    [Test]
+    public void OverlappingChildren_GroupOpacityAppliesOnceToComposite()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Drawable.Resource group = CreateGroup(
+                opacity: 50,
+                effect: null,
+                CreateRectangle(240, 240, Brushes.White, alignmentX: AlignmentX.Left),
+                CreateRectangle(240, 240, Brushes.White, alignmentX: AlignmentX.Right));
+            using Drawable.Resource control = CreateRectangle(
+                    400,
+                    240,
+                    Brushes.White,
+                    opacity: 50)
+                .ToResource(CompositionContext.Default);
+            using Bitmap actual = RenderScene(group);
+            using Bitmap expected = RenderScene(control);
+
+            AssertByteIdentical(expected, actual, "overlapping children at group opacity 50%");
+            Assert.Multiple(() =>
+            {
+                Assert.That(ReadPixel(actual, 40, 200).Alpha, Is.EqualTo(0.5f).Within(0.003f));
+                Assert.That(ReadPixel(actual, 200, 200).Alpha, Is.EqualTo(0.5f).Within(0.003f));
+                Assert.That(ReadPixel(actual, 360, 200).Alpha, Is.EqualTo(0.5f).Within(0.003f));
+            });
+        });
+    }
+
+    [Test]
+    public void IdentityEffect_DoesNotChangeGroupOpacityComposition()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var identity = new Brightness();
+            identity.Amount.CurrentValue = 100;
+            using Drawable.Resource plain = CreateGroup(
+                opacity: 50,
+                effect: null,
+                CreateRectangle(240, 240, Brushes.White, alignmentX: AlignmentX.Left),
+                CreateRectangle(240, 240, Brushes.White, alignmentX: AlignmentX.Right));
+            using Drawable.Resource filtered = CreateGroup(
+                opacity: 50,
+                identity,
+                CreateRectangle(240, 240, Brushes.White, alignmentX: AlignmentX.Left),
+                CreateRectangle(240, 240, Brushes.White, alignmentX: AlignmentX.Right));
+            using Bitmap expected = RenderScene(plain);
+            using Bitmap actual = RenderScene(filtered);
+
+            AssertByteIdentical(expected, actual, "identity effect on an overlapping group");
+        });
+    }
+
+    [TestCase(100f)]
+    [TestCase(99f)]
+    public void MultiplyChild_CompositesAgainstIsolatedGroupContent(float opacity)
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Drawable.Resource backdrop = CreateRectangle(400, 400, Brushes.Cyan)
+                .ToResource(CompositionContext.Default);
+            using Drawable.Resource multiplyGroup = CreateGroup(
+                opacity,
+                effect: null,
+                CreateRectangle(240, 240, Brushes.Magenta, blendMode: BlendMode.Multiply));
+            using Drawable.Resource sourceOverBackdrop = CreateRectangle(400, 400, Brushes.Cyan)
+                .ToResource(CompositionContext.Default);
+            using Drawable.Resource sourceOverGroup = CreateGroup(
+                opacity,
+                effect: null,
+                CreateRectangle(240, 240, Brushes.Magenta));
+            using Bitmap actual = RenderScene(backdrop, multiplyGroup);
+            using Bitmap expected = RenderScene(sourceOverBackdrop, sourceOverGroup);
+
+            AssertByteIdentical(
+                expected,
+                actual,
+                $"Multiply child against an isolated group at opacity {opacity}%");
+            Assert.That(
+                ReadPixel(actual, 20, 20),
+                Is.EqualTo(ReadPixel(expected, 20, 20)),
+                "Pixels outside the group content must remain backdrop-only.");
+        });
+    }
+
+    [Test]
+    public void HalfAlphaDstIn_MasksTheGroupComposite()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var halfWhite = new SolidColorBrush(new Color(128, 255, 255, 255));
+            using Drawable.Resource group = CreateGroup(
+                opacity: 100,
+                effect: null,
+                CreateRectangle(240, 240, Brushes.White),
+                CreateRectangle(240, 240, halfWhite, blendMode: BlendMode.DstIn));
+            using Bitmap actual = RenderScene(group);
+
+            Rgba center = ReadPixel(actual, 200, 200);
+            Assert.Multiple(() =>
+            {
+                Assert.That(center.Alpha, Is.EqualTo(128f / 255f).Within(0.002f));
+                Assert.That(center.Red, Is.EqualTo(center.Alpha).Within(0.002f));
+                Assert.That(ReadPixel(actual, 20, 20).Alpha, Is.Zero);
+            });
+        });
+    }
+
+    [Test]
+    public void HalfOpacityGradientDstIn_MasksTheGroupCompositeAtHalfStrength()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var gradient = new LinearGradientBrush();
+            gradient.Opacity.CurrentValue = 50;
+            gradient.GradientStops.Add(new GradientStop(Colors.White, 0));
+            gradient.GradientStops.Add(new GradientStop(Colors.White, 1));
+            using Drawable.Resource group = CreateGroup(
+                opacity: 100,
+                effect: null,
+                CreateRectangle(240, 240, Brushes.White),
+                CreateRectangle(240, 240, gradient, blendMode: BlendMode.DstIn));
+            using Bitmap actual = RenderScene(group);
+
+            Rgba center = ReadPixel(actual, 200, 200);
+            Assert.Multiple(() =>
+            {
+                Assert.That(center.Alpha, Is.EqualTo(0.5f).Within(0.003f));
+                Assert.That(center.Red, Is.EqualTo(center.Alpha).Within(0.003f));
+            });
+        });
+    }
+
+    [TestCase(BlendMode.DstIn, 0f, 120f)]
+    [TestCase(BlendMode.DstIn, 120f, 0f)]
+    [TestCase(BlendMode.DstOut, 0f, 120f)]
+    [TestCase(BlendMode.DstOut, 120f, 0f)]
+    public void FractionalZeroAreaDestructiveRectangle_HasNoEffect(
+        BlendMode blendMode,
+        float width,
+        float height)
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var geometry = new RectGeometry
+            {
+                Width = { CurrentValue = width },
+                Height = { CurrentValue = height },
+            };
+            using Geometry.Resource geometryResource = geometry.ToResource(CompositionContext.Default);
+            var nonEmptyGeometry = new RectGeometry
+            {
+                Width = { CurrentValue = 4 },
+                Height = { CurrentValue = 4 },
+            };
+            using Geometry.Resource nonEmptyGeometryResource =
+                nonEmptyGeometry.ToResource(CompositionContext.Default);
+
+            Bitmap Render(bool includeZeroAreaRectangle)
+            {
+                using RenderTarget target = RenderTarget.Create(32, 32)
+                                            ?? throw new InvalidOperationException(
+                                                "RenderTarget.Create returned null.");
+                using var canvas = new ImmediateCanvas(target);
+                canvas.Clear(Colors.White);
+                using PushedState blend = blendMode == BlendMode.DstOut
+                    ? canvas.PushDirectBlendMode(blendMode)
+                    : canvas.PushBlendMode(blendMode);
+
+                if (blendMode == BlendMode.DstIn)
+                {
+                    using (canvas.PushTransform(Matrix.CreateTranslation(2, 2)))
+                    {
+                        canvas.DrawGeometry(
+                            nonEmptyGeometryResource,
+                            Brushes.Resource.White,
+                            pen: null);
+                    }
+                }
+
+                if (includeZeroAreaRectangle)
+                {
+                    using (canvas.PushTransform(Matrix.CreateTranslation(16.5f, 8.5f)))
+                    {
+                        canvas.DrawGeometry(geometryResource, Brushes.Resource.White, pen: null);
+                    }
+                }
+
+                return target.Snapshot();
+            }
+
+            using Bitmap expected = Render(includeZeroAreaRectangle: false);
+            using Bitmap actual = Render(includeZeroAreaRectangle: true);
+
+            AssertByteIdentical(
+                expected,
+                actual,
+                $"fractional {width}x{height} {blendMode} rectangle");
+        });
+    }
+
+    [Test]
+    public void WindowDstIn_RemovesGroupContentOutsideTheWindow()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Drawable.Resource group = CreateGroup(
+                opacity: 100,
+                effect: null,
+                CreateRectangle(320, 320, Brushes.White),
+                CreateRectangle(160, 160, Brushes.White, blendMode: BlendMode.DstIn));
+            using Bitmap isolated = RenderScene(group);
+
+            using Drawable.Resource backdrop = CreateRectangle(400, 400, Brushes.Blue)
+                .ToResource(CompositionContext.Default);
+            using Drawable.Resource groupOverBackdrop = CreateGroup(
+                opacity: 100,
+                effect: null,
+                CreateRectangle(320, 320, Brushes.White),
+                CreateRectangle(160, 160, Brushes.White, blendMode: BlendMode.DstIn));
+            using Bitmap composited = RenderScene(backdrop, groupOverBackdrop);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ReadPixel(isolated, 200, 200).Alpha, Is.EqualTo(1).Within(0.001f));
+                Assert.That(
+                    ReadPixel(isolated, 80, 200).Alpha,
+                    Is.Zero,
+                    "Content outside the DstIn window must be removed across the group scope.");
+                Assert.That(
+                    ReadPixel(composited, 20, 20),
+                    Is.EqualTo(ReadPixel(composited, 80, 200)),
+                    "Removing group content must reveal, not modify, the outer backdrop.");
+            });
+        });
+    }
+
+    [Test]
+    public void FractionalDstInCorners_IdentityEffectPreservesTwoDimensionalCoverage()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Drawable.Resource plain = CreateTranslatedMaskGroup(effect: null);
+            var identity = new Brightness();
+            identity.Amount.CurrentValue = 100;
+            using Drawable.Resource filtered = CreateTranslatedMaskGroup(identity);
+
+            using Bitmap expected = RenderScene(plain);
+            using Bitmap actual = RenderScene(filtered);
+
+            Assert.Multiple(() =>
+            {
+                AssertByteIdentical(
+                    expected,
+                    actual,
+                    "fractionally translated DstIn mask with an identity group effect");
+                Assert.That(
+                    ReadPixel(expected, 150, 150).Alpha,
+                    Is.EqualTo(0.75f * 0.75f).Within(0.003f),
+                    "A corner pixel must contain the product of the horizontal and vertical mask coverage.");
+                Assert.That(
+                    ReadPixel(actual, 150, 150).Alpha,
+                    Is.EqualTo(0.75f * 0.75f).Within(0.003f),
+                    "The effect path must preserve two-dimensional mask coverage.");
+            });
+        });
+    }
+
+    [Test]
+    public void FractionalDstOutEdges_IdentityEffectDoesNotChangeCoverage()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Drawable.Resource plain = CreateTranslatedDstOutGroup(effect: null);
+            var identity = new Brightness();
+            identity.Amount.CurrentValue = 100;
+            using Drawable.Resource filtered = CreateTranslatedDstOutGroup(identity);
+
+            using Bitmap expected = RenderScene(plain);
+            using Bitmap actual = RenderScene(filtered);
+
+            Assert.Multiple(() =>
+            {
+                AssertByteIdentical(
+                    expected,
+                    actual,
+                    "fractionally translated DstOut mask with and without an identity group effect");
+                Assert.That(
+                    ReadPixel(expected, 120, 200).Alpha,
+                    Is.EqualTo(0.5f).Within(0.003f),
+                    "The leading vertical eraser edge must preserve its absolute half-pixel coverage.");
+                Assert.That(
+                    ReadPixel(expected, 200, 120).Alpha,
+                    Is.EqualTo(0.25f).Within(0.003f),
+                    "The leading horizontal eraser edge must retain one minus 75% eraser coverage.");
+                Assert.That(
+                    ReadPixel(expected, 120, 120).Alpha,
+                    Is.EqualTo(1 - (0.5f * 0.75f)).Within(0.003f),
+                    "The leading corner must use the product of both eraser coverage axes.");
+                Assert.That(
+                    ReadPixel(expected, 280, 280).Alpha,
+                    Is.EqualTo(1 - (0.5f * 0.25f)).Within(0.003f),
+                    "The trailing corner must use the product of both eraser coverage axes.");
+            });
+        });
+    }
+
+    [Test]
+    public void QuarterScaleDstInMask_IdentityEffectDoesNotCreateADevicePixelFringe()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Drawable.Resource plain = CreateTranslatedMaskGroup(effect: null);
+            var identity = new Brightness();
+            identity.Amount.CurrentValue = 100;
+            using Drawable.Resource filtered = CreateTranslatedMaskGroup(identity);
+            using Bitmap expected = RenderScene(0.25f, plain);
+            using Bitmap actual = RenderScene(0.25f, filtered);
+
+            Assert.Multiple(() =>
+            {
+                AssertByteIdentical(
+                    expected,
+                    actual,
+                    "quarter-scale DstIn mask with and without an identity group effect");
+                Assert.That(
+                    ReadPixel(expected, 37, 50).Alpha,
+                    Is.GreaterThan(0),
+                    "The first covered device column must remain present.");
+                Assert.That(
+                    ReadPixel(expected, 36, 50).Alpha,
+                    Is.Zero.Within(0.001f),
+                    "No leading one-device-pixel fringe may escape the mask footprint.");
+                Assert.That(
+                    ReadPixel(expected, 63, 50).Alpha,
+                    Is.Zero.Within(0.001f),
+                    "No trailing one-device-pixel fringe may escape the mask footprint.");
+            });
+        });
+    }
+
+    [Test]
+    public void DstOutChild_RemovesOnlyItsIntersectionWithGroupContent()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Drawable.Resource backdrop = CreateRectangle(400, 400, Brushes.Blue)
+                .ToResource(CompositionContext.Default);
+            using Drawable.Resource group = CreateTranslatedDstOutGroup(effect: null);
+            using Bitmap actual = RenderScene(backdrop, group);
+
+            Rgba backdropOnly = ReadPixel(actual, 20, 20);
+            Rgba content = ReadPixel(actual, 80, 200);
+            Rgba erased = ReadPixel(actual, 200, 200);
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    backdropOnly,
+                    Is.EqualTo(new Rgba(0, 0, 1, 1)),
+                    "The isolated group must not modify the outer backdrop.");
+                Assert.That(
+                    content,
+                    Is.EqualTo(new Rgba(1, 1, 1, 1)),
+                    "Group content outside the DstOut child bounds must remain opaque.");
+                Assert.That(
+                    erased,
+                    Is.EqualTo(backdropOnly),
+                    "The DstOut child must reveal the backdrop inside its intersection with group content.");
+            });
+        });
+    }
+
+    [Test]
+    public void NestedGroupOpacity_MultipliesCompositeOpacity()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var sourceColor = new Color(255, 128, 64, 32);
+            var inner = new DrawableGroup();
+            inner.Opacity.CurrentValue = 50;
+            inner.Children.Add(CreateRectangle(
+                240,
+                240,
+                new SolidColorBrush(sourceColor)));
+
+            var outer = new DrawableGroup();
+            outer.Opacity.CurrentValue = 50;
+            outer.Children.Add(inner);
+
+            using Drawable.Resource resource = outer.ToResource(CompositionContext.Default);
+            using Bitmap actual = RenderScene(resource);
+            Rgba center = ReadPixel(actual, 200, 200);
+            const float expectedAlpha = 0.25f;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(center.Alpha, Is.EqualTo(expectedAlpha).Within(0.003f));
+                Assert.That(
+                    center.Red,
+                    Is.EqualTo(Color.SrgbToLinear(sourceColor.R / 255f) * expectedAlpha).Within(0.001f));
+                Assert.That(
+                    center.Green,
+                    Is.EqualTo(Color.SrgbToLinear(sourceColor.G / 255f) * expectedAlpha).Within(0.001f));
+                Assert.That(
+                    center.Blue,
+                    Is.EqualTo(Color.SrgbToLinear(sourceColor.B / 255f) * expectedAlpha).Within(0.001f));
+            });
+        });
+    }
+
+    [TestCase(0.75f)]
+    [TestCase(1f)]
+    [TestCase(2f)]
+    public void Opacity100Group_IsByteIdenticalToBareAntialiasedContent(float outputScale)
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Drawable.Resource group = CreateGroup(
+                opacity: 100,
+                effect: null,
+                CreateEllipse(241, 163, Brushes.White));
+            using Drawable.Resource bare = CreateEllipse(241, 163, Brushes.White)
+                .ToResource(CompositionContext.Default);
+            using Bitmap fusedGroup = RenderScene(outputScale, FusionMode.Enabled, group);
+            using Bitmap fusedBare = RenderScene(outputScale, FusionMode.Enabled, bare);
+            using Bitmap replayGroup = RenderScene(outputScale, FusionMode.Disabled, group);
+            using Bitmap replayBare = RenderScene(outputScale, FusionMode.Disabled, bare);
+
+            AssertByteIdentical(
+                fusedBare,
+                fusedGroup,
+                $"fused 100%-opacity group antialiasing at scale {outputScale}");
+            AssertByteIdentical(
+                replayBare,
+                replayGroup,
+                $"replayed 100%-opacity group antialiasing at scale {outputScale}");
+            AssertByteIdentical(
+                fusedGroup,
+                replayGroup,
+                $"fused/replayed group parity at scale {outputScale}");
+        });
+    }
+
+    [Test]
+    public void BareMultiplyDrawable_StillBlendsAgainstBackdrop()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Drawable.Resource backdrop = CreateRectangle(400, 400, Brushes.Cyan)
+                .ToResource(CompositionContext.Default);
+            using Drawable.Resource multiply = CreateRectangle(
+                    240,
+                    240,
+                    Brushes.Magenta,
+                    blendMode: BlendMode.Multiply)
+                .ToResource(CompositionContext.Default);
+            using Bitmap actual = RenderScene(backdrop, multiply);
+
+            Rgba overlap = ReadPixel(actual, 200, 200);
+            Assert.Multiple(() =>
+            {
+                Assert.That(overlap.Red, Is.Zero.Within(0.001f));
+                Assert.That(overlap.Green, Is.Zero.Within(0.001f));
+                Assert.That(overlap.Blue, Is.EqualTo(1).Within(0.001f));
+                Assert.That(overlap.Alpha, Is.EqualTo(1).Within(0.001f));
+            });
+        });
+    }
+
+    private static Drawable.Resource CreateGroup(
+        float opacity,
+        FilterEffect? effect,
+        params Drawable[] children)
+    {
+        var group = new DrawableGroup();
+        group.Opacity.CurrentValue = opacity;
+        group.FilterEffect.CurrentValue = effect;
+        foreach (Drawable child in children)
+            group.Children.Add(child);
+        return group.ToResource(CompositionContext.Default);
+    }
+
+    private static Drawable.Resource CreateTranslatedMaskGroup(FilterEffect? effect)
+    {
+        var group = new DrawableGroup();
+        group.FilterEffect.CurrentValue = effect;
+        group.Transform.CurrentValue = new TranslateTransform(0.25f, 0.25f);
+        group.Children.Add(CreateRectangle(200, 200, Brushes.Blue));
+        group.Children.Add(CreateRectangle(100, 100, Brushes.White, blendMode: BlendMode.DstIn));
+        return group.ToResource(CompositionContext.Default);
+    }
+
+    private static Drawable.Resource CreateTranslatedDstOutGroup(
+        FilterEffect? effect,
+        float eraserOpacity = 100)
+    {
+        var eraser = CreateRectangle(
+            160,
+            160,
+            Brushes.White,
+            opacity: eraserOpacity,
+            blendMode: BlendMode.DstOut);
+        eraser.Transform.CurrentValue = new TranslateTransform(0.25f, 0.25f);
+
+        var group = new DrawableGroup();
+        group.FilterEffect.CurrentValue = effect;
+        group.Transform.CurrentValue = new TranslateTransform(0.25f, 0);
+        group.Children.Add(CreateRectangle(320, 320, Brushes.White));
+        group.Children.Add(eraser);
+        return group.ToResource(CompositionContext.Default);
+    }
+
+    private static RectShape CreateRectangle(
+        float width,
+        float height,
+        Brush fill,
+        float opacity = 100,
+        BlendMode blendMode = BlendMode.SrcOver,
+        AlignmentX alignmentX = AlignmentX.Center,
+        AlignmentY alignmentY = AlignmentY.Center)
+    {
+        var shape = new RectShape();
+        shape.Width.CurrentValue = width;
+        shape.Height.CurrentValue = height;
+        shape.Fill.CurrentValue = fill;
+        shape.Opacity.CurrentValue = opacity;
+        shape.BlendMode.CurrentValue = blendMode;
+        shape.AlignmentX.CurrentValue = alignmentX;
+        shape.AlignmentY.CurrentValue = alignmentY;
+        return shape;
+    }
+
+    private static EllipseShape CreateEllipse(float width, float height, Brush fill)
+    {
+        var shape = new EllipseShape();
+        shape.Width.CurrentValue = width;
+        shape.Height.CurrentValue = height;
+        shape.Fill.CurrentValue = fill;
+        return shape;
+    }
+
+    private static Bitmap RenderScene(params Drawable.Resource[] resources)
+        => RenderScene(1, resources);
+
+    private static Bitmap RenderScene(float outputScale, params Drawable.Resource[] resources)
+        => RenderScene(outputScale, FusionMode.Enabled, resources);
+
+    private static Bitmap RenderScene(
+        float outputScale,
+        FusionMode fusionMode,
+        params Drawable.Resource[] resources)
+    {
+        int width = (int)MathF.Ceiling(s_frame.Width * outputScale);
+        int height = (int)MathF.Ceiling(s_frame.Height * outputScale);
+        using RenderTarget target = RenderTarget.Create(width, height)
+                                    ?? throw new InvalidOperationException("RenderTarget.Create returned null.");
+        using var canvas = new ImmediateCanvas(target, outputScale, logicalSize: s_frame.ToSize(1));
+        canvas.Clear();
+
+        using var root = new DrawableRenderNode(resources[0]);
+        using (var context = new GraphicsContext2D(root, s_frame.ToSize(1), outputScale))
+        {
+            foreach (Drawable.Resource resource in resources)
+                context.DrawDrawable(resource);
+        }
+
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    Intent = RenderIntent.Delivery,
+                    TargetDomain = new Rect(default, s_frame.ToSize(1)),
+                    OutputScale = outputScale,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    FusionMode = fusionMode,
+                },
+            });
+        renderer.Render(canvas);
+        return target.Snapshot();
+    }
+
+    private static Rgba ReadPixel(Bitmap bitmap, int x, int y)
+    {
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        int offset = ((y * bitmap.Width) + x) * 4;
+        return new Rgba(
+            (float)BitConverter.UInt16BitsToHalf(pixels[offset]),
+            (float)BitConverter.UInt16BitsToHalf(pixels[offset + 1]),
+            (float)BitConverter.UInt16BitsToHalf(pixels[offset + 2]),
+            (float)BitConverter.UInt16BitsToHalf(pixels[offset + 3]));
+    }
+
+    private static void AssertByteIdentical(Bitmap expected, Bitmap actual, string scenario)
+    {
+        ReadOnlySpan<byte> expectedPixels = expected.GetPixelSpan();
+        ReadOnlySpan<byte> actualPixels = actual.GetPixelSpan();
+        bool identical = actualPixels.SequenceEqual(expectedPixels);
+        Assert.Multiple(() =>
+        {
+            Assert.That(actual.Width, Is.EqualTo(expected.Width));
+            Assert.That(actual.Height, Is.EqualTo(expected.Height));
+            Assert.That(
+                identical,
+                Is.True,
+                $"{scenario} must be byte-identical.");
+            Assert.That(
+                HasFiniteVisibleContent(expected),
+                Is.True,
+                $"{scenario} must render finite visible content (SC-013 non-vacuity).");
+        });
+    }
+
+    private static bool HasFiniteVisibleContent(Bitmap bitmap)
+    {
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        for (int i = 3; i < pixels.Length; i += 4)
+        {
+            float a = (float)BitConverter.UInt16BitsToHalf(pixels[i]);
+            if (float.IsFinite(a) && a > 0f)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private readonly record struct Rgba(float Red, float Green, float Blue, float Alpha);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/EffectDrawableBrushLoweringTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/EffectDrawableBrushLoweringTests.cs
@@ -1,0 +1,298 @@
+﻿using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Shapes;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Golden;
+
+// Every effect that paints with a user-settable brush or pen must register it so nested DrawableBrush content is
+// lowered into the recorded graph. A registered drawable brush whose content is a flat colour must therefore
+// render like the equivalent solid brush, and must not render like an absent brush.
+[NonParallelizable]
+[TestFixture]
+public class EffectDrawableBrushLoweringTests
+{
+    private static readonly PixelSize Frame = new(200, 200);
+
+    private const double EquivalenceTolerance = 0.02;
+
+    public static IEnumerable<TestCaseData> Effects()
+    {
+        yield return new TestCaseData(
+            "FlatShadow",
+            (Func<Brush?, FilterEffect>)(brush =>
+            {
+                var effect = new FlatShadow();
+                effect.Angle.CurrentValue = 0;
+                effect.Length.CurrentValue = 40;
+                effect.Brush.CurrentValue = brush;
+                return effect;
+            }));
+        yield return new TestCaseData(
+            "BlendEffect",
+            (Func<Brush?, FilterEffect>)(brush =>
+            {
+                var effect = new BlendEffect();
+                effect.Brush.CurrentValue = brush;
+                effect.BlendMode.CurrentValue = BlendMode.SrcIn;
+                return effect;
+            }));
+        yield return new TestCaseData(
+            "StrokeEffect",
+            (Func<Brush?, FilterEffect>)(brush =>
+            {
+                var effect = new StrokeEffect();
+                if (brush is not null)
+                {
+                    var pen = new Pen();
+                    pen.Thickness.CurrentValue = 14;
+                    pen.Brush.CurrentValue = brush;
+                    effect.Pen.CurrentValue = pen;
+                }
+
+                return effect;
+            }));
+        yield return new TestCaseData(
+            "NestedActivate",
+            (Func<Brush?, FilterEffect>)(brush =>
+            {
+                var effect = new NestedActivateBrushEffect();
+                effect.Brush.CurrentValue = brush;
+                return effect;
+            }));
+        yield return new TestCaseData(
+            "TypedOperationBeforeBrush",
+            (Func<Brush?, FilterEffect>)(brush =>
+            {
+                var effect = new TypedOperationBeforeBrushEffect();
+                effect.Brush.CurrentValue = brush;
+                return effect;
+            }));
+        yield return new TestCaseData(
+            "DisplacementMap-ShowMap",
+            (Func<Brush?, FilterEffect>)(brush =>
+            {
+                var effect = new DisplacementMapEffect();
+                effect.DisplacementMap.CurrentValue = brush;
+                effect.ShowDisplacementMap.CurrentValue = true;
+                return effect;
+            }));
+    }
+
+    // DelayAnimationEffect re-applies its child effect from an execution-time callback, where the recorder is
+    // no longer reachable. Its child's brush content must therefore be lowered while the parent is recorded.
+    public static IEnumerable<TestCaseData> DelayedEffects()
+    {
+        foreach (TestCaseData data in Effects())
+        {
+            var name = (string)data.Arguments[0]!;
+            var makeEffect = (Func<Brush?, FilterEffect>)data.Arguments[1]!;
+            yield return new TestCaseData(
+                $"DelayAnimation-{name}",
+                (Func<Brush?, FilterEffect>)(brush =>
+                {
+                    var group = new FilterEffectGroup();
+                    group.Children.Add(makeEffect(brush));
+                    var delay = new DelayAnimationEffect();
+                    delay.Effect.CurrentValue = group;
+                    return delay;
+                }));
+        }
+    }
+
+    [TestCaseSource(nameof(Effects))]
+    [TestCaseSource(nameof(DelayedEffects))]
+    public void EffectOwnedDrawableBrush_RendersLikeTheEquivalentSolidBrush(
+        string name,
+        Func<Brush?, FilterEffect> makeEffect)
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Bitmap solid = GoldenImageHarness.RenderAtScale(
+                Make(() => makeEffect(MakeSolid())),
+                Frame,
+                1f);
+            using Bitmap drawable = GoldenImageHarness.RenderAtScale(
+                Make(() => makeEffect(MakeDrawableBrush())),
+                Frame,
+                1f);
+            using Bitmap absent = GoldenImageHarness.RenderAtScale(
+                Make(() => makeEffect(null)),
+                Frame,
+                1f);
+
+            Assert.That(
+                ImageMetrics.FirstNonFinite(
+                    ("solid", solid),
+                    ("drawable", drawable),
+                    ("absent", absent)),
+                Is.Null,
+                $"{name}: the drawable-brush comparison requires finite renders");
+
+            double equivalence = ImageMetrics.MeanAbsoluteError(solid, drawable);
+            double vacuity = ImageMetrics.MeanAbsoluteError(absent, drawable);
+            TestContext.WriteLine(
+                $"[{name}] drawable vs solid MAE={equivalence:F4}, drawable vs absent MAE={vacuity:F4}");
+
+            Assert.That(
+                vacuity,
+                Is.GreaterThan(0.001),
+                $"{name}: the effect-owned DrawableBrush rendered like an absent brush, so its nested content "
+                + "was never materialized");
+            Assert.That(
+                equivalence,
+                Is.LessThan(EquivalenceTolerance),
+                $"{name}: the effect-owned DrawableBrush did not render like the equivalent solid brush");
+        });
+    }
+
+    private static Brush MakeSolid()
+    {
+        var brush = new SolidColorBrush();
+        brush.Color.CurrentValue = Colors.Red;
+        return brush;
+    }
+
+    private static Brush MakeDrawableBrush()
+    {
+        var content = new RectShape();
+        content.AlignmentX.CurrentValue = AlignmentX.Center;
+        content.AlignmentY.CurrentValue = AlignmentY.Center;
+        content.Width.CurrentValue = 200;
+        content.Height.CurrentValue = 200;
+        content.Fill.CurrentValue = MakeSolid();
+        var brush = new DrawableBrush();
+        brush.Drawable.CurrentValue = content;
+        brush.Stretch.CurrentValue = Stretch.Fill;
+        // A stroke paints outside the brush frame, where TileMode.None decals to transparent; tiling keeps the
+        // comparison against a solid brush apples-to-apples.
+        brush.TileMode.CurrentValue = TileMode.Tile;
+        return brush;
+    }
+
+    private static Drawable.Resource Make(Func<FilterEffect> makeEffect)
+    {
+        var shape = new RectShape();
+        shape.AlignmentX.CurrentValue = AlignmentX.Center;
+        shape.AlignmentY.CurrentValue = AlignmentY.Center;
+        shape.Width.CurrentValue = 140;
+        shape.Height.CurrentValue = 90;
+        shape.Fill.CurrentValue = Brushes.White;
+        shape.FilterEffect.CurrentValue = makeEffect();
+        return shape.ToResource(CompositionContext.Default);
+    }
+}
+
+// RegisterBrush states no ordering requirement: a typed operation authored between the registration and the
+// operation that paints with the handle is lowered as its own fragment, and the handle must still reach the
+// legacy segment behind it.
+internal sealed partial class TypedOperationBeforeBrushEffect : FilterEffect
+{
+    private const string IdentityShader = "half4 apply(half4 color) { return color; }";
+
+    public TypedOperationBeforeBrushEffect()
+    {
+        ScanProperties<TypedOperationBeforeBrushEffect>();
+    }
+
+    public IProperty<Brush?> Brush { get; } = Property.Create<Brush?>();
+
+    public override void ApplyTo(FilterEffectContext context, FilterEffect.Resource resource)
+    {
+        var r = (Resource)resource;
+        FilterEffectBrush handle = context.RegisterBrush(r.Brush);
+        context.Shader(ShaderDescription.CurrentPixel(IdentityShader));
+        context.CustomEffect(handle, PaintBrush, static (_, bounds) => bounds);
+    }
+
+    private static void PaintBrush(FilterEffectBrush handle, CustomFilterEffectContext context)
+    {
+        for (int i = 0; i < context.Targets.Count; i++)
+        {
+            EffectTarget target = context.Targets[i];
+            if (target.RenderTarget is null)
+                continue;
+
+            Size size = target.Bounds.Size;
+            EffectTarget newTarget = context.CreateTarget(target.Bounds);
+            using var paint = new SKPaint();
+            context.ConfigureBrushPaint(paint, handle, new Rect(size), BlendMode.SrcIn, newTarget.Scale.Value);
+            using (ImmediateCanvas canvas = context.Open(newTarget))
+            {
+                canvas.Clear();
+                using (canvas.PushDeviceSpace())
+                {
+                    canvas.DrawRenderTarget(target.RenderTarget, default);
+                }
+
+                canvas.Canvas.DrawRect(SKRect.Create(size.ToSKSize()), paint);
+            }
+
+            target.Dispose();
+            context.Targets[i] = newTarget;
+        }
+    }
+}
+
+// Exercises the public FilterEffectActivator.Activate(FilterEffectContext) seam: a registered brush must stay
+// resolvable inside the nested activator that seam builds.
+internal sealed partial class NestedActivateBrushEffect : FilterEffect
+{
+    public NestedActivateBrushEffect()
+    {
+        ScanProperties<NestedActivateBrushEffect>();
+    }
+
+    public IProperty<Brush?> Brush { get; } = Property.Create<Brush?>();
+
+    public override void ApplyTo(FilterEffectContext context, FilterEffect.Resource resource)
+    {
+        var r = (Resource)resource;
+        context.AppendSkiaFilter(
+            context.RegisterBrush(r.Brush),
+            static (handle, _, activator) =>
+            {
+                using var nested = new FilterEffectContext(
+                    activator.CurrentTargets.CalculateBounds(),
+                    activator.OutputScale,
+                    activator.WorkingScale);
+                nested.CustomEffect(handle, PaintBrush, static (_, bounds) => bounds);
+                return activator.Activate(nested);
+            },
+            static (_, bounds) => bounds);
+    }
+
+    private static void PaintBrush(FilterEffectBrush handle, CustomFilterEffectContext context)
+    {
+        for (int i = 0; i < context.Targets.Count; i++)
+        {
+            EffectTarget target = context.Targets[i];
+            if (target.RenderTarget is null)
+                continue;
+
+            Size size = target.Bounds.Size;
+            EffectTarget newTarget = context.CreateTarget(target.Bounds);
+            float w = newTarget.Scale.Value;
+            using var paint = new SKPaint();
+            context.ConfigureBrushPaint(paint, handle, new Rect(size), BlendMode.SrcIn, w);
+            using (ImmediateCanvas canvas = context.Open(newTarget))
+            {
+                canvas.Clear();
+                using (canvas.PushDeviceSpace())
+                {
+                    canvas.DrawRenderTarget(target.RenderTarget, default);
+                }
+
+                canvas.Canvas.DrawRect(SKRect.Create(size.ToSKSize()), paint);
+            }
+
+            target.Dispose();
+            context.Targets[i] = newTarget;
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/EffectScaleParityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/EffectScaleParityTests.cs
@@ -15,14 +15,15 @@ namespace Beutl.UnitTests.Engine.Graphics.Rendering.Golden;
 public class EffectScaleParityTests
 {
     private static readonly PixelSize Frame = new(200, 200);
+    private const double EffectNonVacuityTolerance = 0.02;
 
     public static IEnumerable<TestCaseData> Effects()
     {
         yield return new TestCaseData("InnerShadow", (Func<FilterEffect>)(() =>
         {
             var e = new InnerShadow();
-            e.Position.CurrentValue = new Point(20, 20);
-            e.Sigma.CurrentValue = new Size(10, 10);
+            e.Position.CurrentValue = new Point(6, 6);
+            e.Sigma.CurrentValue = new Size(6, 6);
             e.Color.CurrentValue = Colors.Black;
             return e;
         }));
@@ -140,8 +141,8 @@ public class EffectScaleParityTests
             return e;
         }));
         yield return new TestCaseData("PartsSplit", (Func<FilterEffect>)(() =>
-            // Contour readback: contours in device px must convert to logical via /w.
-            new PartsSplitEffect()));
+            // Contour readback: the per-target shrink makes every split contour visibly load-bearing.
+            MakePartsSplitEffect()));
         yield return new TestCaseData("LayerEffect-AfterSplit", (Func<FilterEffect>)(() =>
         {
             // Split into 9 parts so LayerEffect flattens multiple targets at the working density.
@@ -179,9 +180,10 @@ public class EffectScaleParityTests
             noise.Octaves.CurrentValue = 2;
             noise.Seed.CurrentValue = 1f;
             var e = new FlatShadow();
-            e.Angle.CurrentValue = 0;
-            e.Length.CurrentValue = 40;
+            e.Angle.CurrentValue = 35;
+            e.Length.CurrentValue = 80;
             e.Brush.CurrentValue = noise;
+            e.ShadowOnly.CurrentValue = true;
             return e;
         }));
         yield return new TestCaseData("Mosaic-AbsoluteOrigin", (Func<FilterEffect>)(() =>
@@ -192,35 +194,84 @@ public class EffectScaleParityTests
             e.Origin.CurrentValue = new RelativePoint(50, 30, RelativeUnit.Absolute);
             return e;
         }));
-        yield return new TestCaseData("DisplacementMap-DrawableMap", (Func<FilterEffect>)(() =>
+        foreach (TestCaseData testCase in DisplacementMapEffects())
+            yield return testCase;
+    }
+
+    public static IEnumerable<TestCaseData> DisplacementMapEffects()
+    {
+        yield return new TestCaseData(
+            "DisplacementMap-DrawableMap",
+            (Func<FilterEffect>)MakeDrawableDisplacementMapEffect);
+    }
+
+    private static FilterEffect MakeDrawableDisplacementMapEffect()
+    {
+        // Non-gradient (DrawableBrush) displacement map: exercises the tile-brush density path.
+        var stripes = new LinearGradientBrush();
+        stripes.StartPoint.CurrentValue = new RelativePoint(0, 0, RelativeUnit.Absolute);
+        stripes.EndPoint.CurrentValue = new RelativePoint(24, 0, RelativeUnit.Absolute);
+        stripes.SpreadMethod.CurrentValue = GradientSpreadMethod.Repeat;
+        stripes.GradientStops.Add(new GradientStop(Colors.White, 0));
+        stripes.GradientStops.Add(new GradientStop(Colors.White, 0.5f));
+        stripes.GradientStops.Add(new GradientStop(Colors.Black, 0.5f));
+        stripes.GradientStops.Add(new GradientStop(Colors.Black, 1));
+        var mapContent = new RectShape();
+        mapContent.AlignmentX.CurrentValue = AlignmentX.Center;
+        mapContent.AlignmentY.CurrentValue = AlignmentY.Center;
+        mapContent.Width.CurrentValue = 200;
+        mapContent.Height.CurrentValue = 200;
+        mapContent.Fill.CurrentValue = stripes;
+        var map = new DrawableBrush();
+        map.Drawable.CurrentValue = mapContent;
+        map.Stretch.CurrentValue = Stretch.Fill;
+        var transform = new DisplacementMapTranslateTransform();
+        transform.X.CurrentValue = 16;
+        transform.Y.CurrentValue = 0;
+        var effect = new DisplacementMapEffect();
+        effect.DisplacementMap.CurrentValue = map;
+        effect.Transform.CurrentValue = transform;
+        effect.Channel.CurrentValue = DisplacementMapChannel.Luminance;
+        return effect;
+    }
+
+    private static FilterEffect MakeNoDisplacementMapEffect()
+    {
+        var effect = new DisplacementMapEffect();
+        effect.DisplacementMap.CurrentValue = null;
+        return effect;
+    }
+
+    [TestCaseSource(nameof(DisplacementMapEffects))]
+    public void DisplacementMapEffect_ChangesIdentityOutput(string name, Func<FilterEffect> makeEffect)
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
         {
-            // Non-gradient (DrawableBrush) displacement map: exercises the tile-brush density path.
-            var stripes = new LinearGradientBrush();
-            stripes.StartPoint.CurrentValue = new RelativePoint(0, 0, RelativeUnit.Absolute);
-            stripes.EndPoint.CurrentValue = new RelativePoint(24, 0, RelativeUnit.Absolute);
-            stripes.SpreadMethod.CurrentValue = GradientSpreadMethod.Repeat;
-            stripes.GradientStops.Add(new GradientStop(Colors.White, 0));
-            stripes.GradientStops.Add(new GradientStop(Colors.White, 0.5f));
-            stripes.GradientStops.Add(new GradientStop(Colors.Black, 0.5f));
-            stripes.GradientStops.Add(new GradientStop(Colors.Black, 1));
-            var mapContent = new RectShape();
-            mapContent.AlignmentX.CurrentValue = AlignmentX.Center;
-            mapContent.AlignmentY.CurrentValue = AlignmentY.Center;
-            mapContent.Width.CurrentValue = 200;
-            mapContent.Height.CurrentValue = 200;
-            mapContent.Fill.CurrentValue = stripes;
-            var map = new DrawableBrush();
-            map.Drawable.CurrentValue = mapContent;
-            map.Stretch.CurrentValue = Stretch.Fill;
-            var transform = new DisplacementMapTranslateTransform();
-            transform.X.CurrentValue = 16;
-            transform.Y.CurrentValue = 0;
-            var e = new DisplacementMapEffect();
-            e.DisplacementMap.CurrentValue = map;
-            e.Transform.CurrentValue = transform;
-            e.Channel.CurrentValue = DisplacementMapChannel.Luminance;
-            return e;
-        }));
+            // A translate displacement over a flat fill is invisible under clamp sampling, so the source
+            // carries its own stripes; only a materialized map can move them.
+            using Bitmap mapped = GoldenImageHarness.RenderAtScale(
+                Make(makeEffect, MakeStripes(20)),
+                Frame,
+                1f);
+            using Bitmap identity = GoldenImageHarness.RenderAtScale(
+                Make(MakeNoDisplacementMapEffect, MakeStripes(20)),
+                Frame,
+                1f);
+
+            Assert.That(
+                ImageMetrics.FirstNonFinite(("mapped", mapped), ("identity", identity)),
+                Is.Null,
+                $"{name}: the drawable-map vacuity comparison requires finite renders");
+            double mae = ImageMetrics.MeanAbsoluteError(mapped, identity);
+            double ssim = ImageMetrics.Ssim(mapped, identity);
+            TestContext.WriteLine($"[{name}] mapped vs identity MAE={mae:F4} SSIM={ssim:F4}");
+            Assert.That(
+                mae,
+                Is.GreaterThan(0.001),
+                $"{name}: the drawable displacement map did not change the identity render; "
+                + "transparent map materialization would make the scale-parity case vacuous");
+        });
     }
 
     // Border whose thickness is a fixed logical width (10 px): iScale and iResolution are both load-bearing.
@@ -248,7 +299,56 @@ public class EffectScaleParityTests
         return e;
     }
 
-    private static Drawable.Resource Make(Func<FilterEffect> makeEffect)
+    private static LinearGradientBrush MakeStripes(float period)
+    {
+        var stripes = new LinearGradientBrush();
+        stripes.StartPoint.CurrentValue = new RelativePoint(0, 0, RelativeUnit.Absolute);
+        stripes.EndPoint.CurrentValue = new RelativePoint(period, 0, RelativeUnit.Absolute);
+        stripes.SpreadMethod.CurrentValue = GradientSpreadMethod.Repeat;
+        stripes.GradientStops.Add(new GradientStop(Colors.White, 0));
+        stripes.GradientStops.Add(new GradientStop(Colors.White, 0.5f));
+        stripes.GradientStops.Add(new GradientStop(Colors.Gray, 0.5f));
+        stripes.GradientStops.Add(new GradientStop(Colors.Gray, 1));
+        return stripes;
+    }
+
+    private static LinearGradientBrush MakeAlphaStripes(float period)
+    {
+        var stripes = new LinearGradientBrush();
+        stripes.StartPoint.CurrentValue = new RelativePoint(0, 0, RelativeUnit.Absolute);
+        stripes.EndPoint.CurrentValue = new RelativePoint(period, 0, RelativeUnit.Absolute);
+        stripes.SpreadMethod.CurrentValue = GradientSpreadMethod.Repeat;
+        stripes.GradientStops.Add(new GradientStop(Colors.White, 0));
+        stripes.GradientStops.Add(new GradientStop(Colors.White, 0.45f));
+        stripes.GradientStops.Add(new GradientStop(Colors.Transparent, 0.45f));
+        stripes.GradientStops.Add(new GradientStop(Colors.Transparent, 1));
+        return stripes;
+    }
+
+    private static FilterEffect MakePartsSplitEffect()
+    {
+        var group = new FilterEffectGroup();
+        group.Children.Add(new PartsSplitEffect());
+        group.Children.Add(MakePartsSplitDifferentiator());
+        return group;
+    }
+
+    private static FilterEffect MakePartsSplitControlEffect()
+        => MakePartsSplitDifferentiator();
+
+    private static TransformEffect MakePartsSplitDifferentiator()
+    {
+        var scale = new ScaleTransform();
+        scale.ScaleX.CurrentValue = 85;
+        scale.ScaleY.CurrentValue = 85;
+        var effect = new TransformEffect();
+        effect.Transform.CurrentValue = scale;
+        return effect;
+    }
+
+    private static Drawable.Resource Make(Func<FilterEffect> makeEffect) => Make(makeEffect, Brushes.White);
+
+    private static Drawable.Resource Make(Func<FilterEffect> makeEffect, Brush fill)
     {
         var shape = new RectShape();
         shape.AlignmentX.CurrentValue = AlignmentX.Center;
@@ -256,7 +356,7 @@ public class EffectScaleParityTests
         shape.TransformOrigin.CurrentValue = RelativePoint.Center;
         shape.Width.CurrentValue = 140;
         shape.Height.CurrentValue = 90;
-        shape.Fill.CurrentValue = Brushes.White;
+        shape.Fill.CurrentValue = fill;
         var rotation = new RotationTransform();
         rotation.Rotation.CurrentValue = 21f;
         shape.Transform.CurrentValue = rotation;
@@ -268,7 +368,6 @@ public class EffectScaleParityTests
     public void Effect_Supersampled_KeepsLogicalAppearance(string name, Func<FilterEffect> makeEffect)
     {
         VulkanTestEnvironment.EnsureAvailable();
-
         // Non-finite pixels (SwiftShader blur artifact vs real scale defect) are distinguished by
         // determinism: same location on every attempt = real defect (FAIL); moving = artifact (INCONCLUSIVE).
         // Reference and scaled renders are scanned separately so a broken reference does not mask a scaled defect.
@@ -278,12 +377,20 @@ public class EffectScaleParityTests
         {
             for (int attempt = 1; ; attempt++)
             {
-                using Bitmap r1 = GoldenImageHarness.RenderAtScale(Make(makeEffect), Frame, 1f);
-                using Bitmap hi = GoldenImageHarness.RenderAtScale(Make(makeEffect), Frame, 2f);
+                using Bitmap r1 = GoldenImageHarness.RenderAtScale(MakeForCase(name, makeEffect), Frame, 1f);
+                using Bitmap hi = GoldenImageHarness.RenderAtScale(MakeForCase(name, makeEffect), Frame, 2f);
                 using Bitmap delivered = GoldenImageHarness.MitchellResampleTo(hi, Frame);
+                using Bitmap control = GoldenImageHarness.RenderAtScale(
+                    MakeForCase(name, ControlForCase(name)),
+                    Frame,
+                    1f);
 
                 string? refNonFinite = ImageMetrics.FirstNonFinite(("1:1", r1));
                 string? scaledNonFinite = ImageMetrics.FirstNonFinite(("2x", hi), ("2x-delivered", delivered));
+                Assert.That(
+                    ImageMetrics.FirstNonFinite(("effect-free-control", control)),
+                    Is.Null,
+                    $"{name}: the effect-free non-vacuity control must be finite");
                 if (refNonFinite is not null || scaledNonFinite is not null)
                 {
                     TestContext.WriteLine(
@@ -297,6 +404,16 @@ public class EffectScaleParityTests
 
                 // Parity is measurable: discard earlier transient non-finite records.
                 attempts.Clear();
+                Assert.That(
+                    HasFiniteVisibleContent(r1),
+                    $"{name}: the 1:1 reference must render finite visible content (SC-013 non-vacuity).");
+                double effectDelta = Math.Max(
+                    ImageMetrics.MeanAbsoluteError(r1, control),
+                    1 - ImageMetrics.Ssim(r1, control));
+                Assert.That(
+                    effectDelta,
+                    Is.GreaterThan(EffectNonVacuityTolerance),
+                    $"{name}: the fixture is indistinguishable from its effect-free control.");
                 double ssim = ImageMetrics.Ssim(r1, delivered);
                 // Windowed SSIM logged as diagnostic only (no universal floor; structural effects can be low).
                 double windowed = ImageMetrics.WindowedSsim(r1, delivered, 16);
@@ -313,12 +430,14 @@ public class EffectScaleParityTests
             bool refEverFinite = attempts.Any(a => a.Ref is null);
 
             // Compare location only (strip value), not the exact NaN/Inf bit pattern.
-            bool scaledAllNonFinite = attempts.All(a => a.Scaled is not null);
-            string[] scaledLocations = attempts
-                .Where(a => a.Scaled is not null)
-                .Select(a => a.Scaled!.Split(" = ", StringSplitOptions.None)[0])
-                .ToArray();
-            bool scaledDeterministic = scaledAllNonFinite && scaledLocations.Distinct().Count() == 1;
+            bool scaledDeterministic = HasStableNonFiniteLocation(attempts.Select(static item => item.Scaled));
+            bool refDeterministic = HasStableNonFiniteLocation(attempts.Select(static item => item.Ref));
+            if (refDeterministic)
+            {
+                Assert.Fail($"{name}: the 1x reference produced a non-finite pixel at the same location on all "
+                    + $"{maxAttempts} attempts [{attempts[0].Ref}]; deterministic invalid reference output is a "
+                    + "renderer defect, not a run-varying software-Vulkan artifact.");
+            }
 
             // Deterministic non-finite in scaled render with finite reference = real scale defect.
             if (scaledDeterministic && refEverFinite)
@@ -343,12 +462,60 @@ public class EffectScaleParityTests
         }
     }
 
+    private static bool HasFiniteVisibleContent(Bitmap bitmap)
+    {
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        for (int i = 3; i < pixels.Length; i += 4)
+        {
+            float a = (float)BitConverter.UInt16BitsToHalf(pixels[i]);
+            if (float.IsFinite(a) && a > 0f)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Drawable.Resource MakeForCase(string name, Func<FilterEffect> makeEffect)
+    {
+        if (name.StartsWith("InnerShadow", StringComparison.Ordinal))
+            return MakeInnerShadowFixture(makeEffect);
+
+        Brush fill = name.StartsWith("PartsSplit", StringComparison.Ordinal)
+            ? MakeAlphaStripes(60)
+            : name.StartsWith("Mosaic-AbsoluteOrigin", StringComparison.Ordinal)
+              || name.StartsWith("DisplacementMap-DrawableMap", StringComparison.Ordinal)
+                ? MakeStripes(20)
+                : Brushes.White;
+        return Make(makeEffect, fill);
+    }
+
+    private static Drawable.Resource MakeInnerShadowFixture(Func<FilterEffect> makeEffect)
+    {
+        // Reuse the finite axis-aligned InnerShadow survey input so this fixture isolates density scaling;
+        // transformed-edge rendering is a separate renderer contract.
+        var shape = new EllipseShape();
+        shape.AlignmentX.CurrentValue = AlignmentX.Center;
+        shape.AlignmentY.CurrentValue = AlignmentY.Center;
+        shape.TransformOrigin.CurrentValue = RelativePoint.Center;
+        shape.Width.CurrentValue = 150;
+        shape.Height.CurrentValue = 110;
+        shape.Fill.CurrentValue = Brushes.White;
+        shape.FilterEffect.CurrentValue = makeEffect();
+        return shape.ToResource(CompositionContext.Default);
+    }
+
+    private static Func<FilterEffect> ControlForCase(string name)
+        => name.StartsWith("PartsSplit", StringComparison.Ordinal)
+            ? MakePartsSplitControlEffect
+            : static () => new FilterEffectGroup();
+
     public static IEnumerable<TestCaseData> RepresentativeEffectsWithScales()
     {
         float[] scales = [1.5f, 3f];
         (string Name, Func<FilterEffect> Make)[] effects =
         [
-            ("InnerShadow", () => { var e = new InnerShadow(); e.Position.CurrentValue = new Point(20, 20); e.Sigma.CurrentValue = new Size(10, 10); e.Color.CurrentValue = Colors.Black; return e; }),
+            ("InnerShadow", () => { var e = new InnerShadow(); e.Position.CurrentValue = new Point(6, 6); e.Sigma.CurrentValue = new Size(6, 6); e.Color.CurrentValue = Colors.Black; return e; }),
             ("StrokeEffect-Offset", () => { var pen = new Pen(); pen.Thickness.CurrentValue = 14; pen.Brush.CurrentValue = Brushes.Red; var e = new StrokeEffect(); e.Pen.CurrentValue = pen; e.Offset.CurrentValue = new Point(20, 12); return e; }),
             ("Mosaic-AbsoluteOrigin", () => { var e = new MosaicEffect(); e.TileSize.CurrentValue = new Size(16, 16); e.Origin.CurrentValue = new RelativePoint(50, 30, RelativeUnit.Absolute); return e; }),
             ("FlatShadow", () => { var e = new FlatShadow(); e.Angle.CurrentValue = 0; e.Length.CurrentValue = 40; e.Brush.CurrentValue = Brushes.Red; return e; }),
@@ -369,12 +536,20 @@ public class EffectScaleParityTests
         {
             for (int attempt = 1; ; attempt++)
             {
-                using Bitmap r1 = GoldenImageHarness.RenderAtScale(Make(makeEffect), Frame, 1f);
-                using Bitmap hi = GoldenImageHarness.RenderAtScale(Make(makeEffect), Frame, scale);
+                using Bitmap r1 = GoldenImageHarness.RenderAtScale(MakeForCase(label, makeEffect), Frame, 1f);
+                using Bitmap hi = GoldenImageHarness.RenderAtScale(MakeForCase(label, makeEffect), Frame, scale);
                 using Bitmap delivered = GoldenImageHarness.MitchellResampleTo(hi, Frame);
+                using Bitmap control = GoldenImageHarness.RenderAtScale(
+                    MakeForCase(label, ControlForCase(label)),
+                    Frame,
+                    1f);
 
                 string? refNonFinite = ImageMetrics.FirstNonFinite(("1:1", r1));
                 string? scaledNonFinite = ImageMetrics.FirstNonFinite(($"{scale}x", hi), ($"{scale}x-delivered", delivered));
+                Assert.That(
+                    ImageMetrics.FirstNonFinite(("effect-free-control", control)),
+                    Is.Null,
+                    $"{label}: the effect-free non-vacuity control must be finite");
                 if (refNonFinite is not null || scaledNonFinite is not null)
                 {
                     TestContext.WriteLine(
@@ -386,6 +561,16 @@ public class EffectScaleParityTests
                 }
 
                 attempts.Clear();
+                Assert.That(
+                    HasFiniteVisibleContent(r1),
+                    $"{label}: the 1x reference must contain visible output.");
+                double effectDelta = Math.Max(
+                    ImageMetrics.MeanAbsoluteError(r1, control),
+                    1 - ImageMetrics.Ssim(r1, control));
+                Assert.That(
+                    effectDelta,
+                    Is.GreaterThan(EffectNonVacuityTolerance),
+                    $"{label}: the fixture is indistinguishable from its effect-free control.");
                 double ssim = ImageMetrics.Ssim(r1, delivered);
                 TestContext.WriteLine($"[{label}] {scale}x-delivered vs 1:1 SSIM={ssim:F4}");
                 Assert.That(ssim, Is.GreaterThan(0.95),
@@ -397,12 +582,13 @@ public class EffectScaleParityTests
         if (attempts.Count == maxAttempts)
         {
             bool refEverFinite = attempts.Any(a => a.Ref is null);
-            bool scaledAllNonFinite = attempts.All(a => a.Scaled is not null);
-            string[] scaledLocations = attempts
-                .Where(a => a.Scaled is not null)
-                .Select(a => a.Scaled!.Split(" = ", StringSplitOptions.None)[0])
-                .ToArray();
-            bool scaledDeterministic = scaledAllNonFinite && scaledLocations.Distinct().Count() == 1;
+            bool scaledDeterministic = HasStableNonFiniteLocation(attempts.Select(static item => item.Scaled));
+            bool refDeterministic = HasStableNonFiniteLocation(attempts.Select(static item => item.Ref));
+            if (refDeterministic)
+            {
+                Assert.Fail($"{label}: deterministic non-finite output in the 1x reference "
+                    + $"[{attempts[0].Ref}] is a renderer defect.");
+            }
 
             if (scaledDeterministic && refEverFinite)
             {
@@ -428,10 +614,70 @@ public class EffectScaleParityTests
             using Bitmap bordered = GoldenImageHarness.RenderAtScale(Make(MakeSkslBorderEffect), Frame, 1f);
             // An empty FilterEffectGroup is an identity effect: same fixture, no shader.
             using Bitmap plain = GoldenImageHarness.RenderAtScale(Make(() => new FilterEffectGroup()), Frame, 1f);
+            (int redBorderPixels, int preservedInteriorPixels) = CountSkslBorderPixels(bordered);
             double ssim = ImageMetrics.Ssim(bordered, plain);
             TestContext.WriteLine($"[SKSLScript guard] bordered vs plain SSIM={ssim:F4}");
-            Assert.That(ssim, Is.LessThan(0.99),
-                "SKSL border did not change the render — the script likely failed to compile/apply, which would make the SKSLScript-Border parity case vacuous");
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    ImageMetrics.FirstNonFinite(("bordered", bordered), ("plain", plain)),
+                    Is.Null,
+                    "the SKSL vacuity guard requires finite output");
+                Assert.That(redBorderPixels, Is.GreaterThan(0),
+                    "the SKSL output must contain the expected opaque red border");
+                Assert.That(preservedInteriorPixels, Is.GreaterThan(0),
+                    "the SKSL output must preserve visible interior source content");
+                Assert.That(ssim, Is.LessThan(0.99),
+                    "SKSL border did not change the render — the script likely failed to compile/apply, which would make the SKSLScript-Border parity case vacuous");
+            });
         });
+    }
+
+    private static (int RedBorderPixels, int PreservedInteriorPixels) CountSkslBorderPixels(Bitmap bitmap)
+    {
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        int redBorderPixels = 0;
+        int preservedInteriorPixels = 0;
+        for (int index = 0; index < pixels.Length; index += 4)
+        {
+            float red = (float)BitConverter.UInt16BitsToHalf(pixels[index]);
+            float green = (float)BitConverter.UInt16BitsToHalf(pixels[index + 1]);
+            float blue = (float)BitConverter.UInt16BitsToHalf(pixels[index + 2]);
+            float alpha = (float)BitConverter.UInt16BitsToHalf(pixels[index + 3]);
+            if (alpha > 0.9f && red > 0.9f && green < 0.1f && blue < 0.1f)
+                redBorderPixels++;
+            if (alpha > 0.9f && red > 0.8f && green > 0.8f && blue > 0.8f)
+                preservedInteriorPixels++;
+        }
+        return (redBorderPixels, preservedInteriorPixels);
+    }
+
+    [Test]
+    public void NonFiniteClassifier_DistinguishesStableFromRunVaryingLocations()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(HasStableNonFiniteLocation([
+                "1:1 @(4,5) = NaN",
+                "1:1 @(4,5) = Infinity",
+                "1:1 @(4,5) = NaN",
+            ]), Is.True);
+            Assert.That(HasStableNonFiniteLocation([
+                "1:1 @(4,5) = NaN",
+                "1:1 @(6,5) = NaN",
+                "1:1 @(4,5) = NaN",
+            ]), Is.False);
+            Assert.That(HasStableNonFiniteLocation(["1:1 @(4,5) = NaN", null, null]), Is.False);
+        });
+    }
+
+    private static bool HasStableNonFiniteLocation(IEnumerable<string?> samples)
+    {
+        string?[] values = samples.ToArray();
+        return values.Length > 0
+               && values.All(static value => value is not null)
+               && values.Select(static value => value!.Split(" = ", StringSplitOptions.None)[0])
+                   .Distinct(StringComparer.Ordinal)
+                   .Count() == 1;
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/GpuPassFusionFeature003RegressionTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/GpuPassFusionFeature003RegressionTests.cs
@@ -1,0 +1,482 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Shapes;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Golden;
+
+[NonParallelizable]
+[TestFixture]
+public sealed class GpuPassFusionFeature003RegressionTests
+{
+    private static readonly PixelSize s_frame = new(192, 128);
+
+    public static IEnumerable<TestCaseData> DensityCases()
+    {
+        yield return DensityCase(
+            "all-vector uses the output floor",
+            [EffectiveScale.Unbounded, EffectiveScale.Unbounded],
+            outputScale: 0.5f,
+            maxWorkingScale: float.PositiveInfinity,
+            expected: 0.5f);
+        yield return DensityCase(
+            "sub-output proxy is floored for delivery",
+            [EffectiveScale.At(0.5f)],
+            outputScale: 1,
+            maxWorkingScale: float.PositiveInfinity,
+            expected: 1);
+        yield return DensityCase(
+            "matching proxy stays cheap in preview",
+            [EffectiveScale.At(0.5f)],
+            outputScale: 0.5f,
+            maxWorkingScale: 1,
+            expected: 0.5f);
+        yield return DensityCase(
+            "dense bitmap supply is not capped by output",
+            [EffectiveScale.At(4), EffectiveScale.Unbounded],
+            outputScale: 1,
+            maxWorkingScale: float.PositiveInfinity,
+            expected: 4);
+        yield return DensityCase(
+            "densest concrete input wins",
+            [EffectiveScale.At(0.5f), EffectiveScale.At(2), EffectiveScale.Unbounded],
+            outputScale: 1,
+            maxWorkingScale: float.PositiveInfinity,
+            expected: 2);
+        yield return DensityCase(
+            "preview maximum working scale caps dense supply",
+            [EffectiveScale.At(8), EffectiveScale.At(1)],
+            outputScale: 1,
+            maxWorkingScale: 2,
+            expected: 2);
+        yield return DensityCase(
+            "supersample output is a floor",
+            [EffectiveScale.At(0.5f), EffectiveScale.Unbounded],
+            outputScale: 2,
+            maxWorkingScale: float.PositiveInfinity,
+            expected: 2);
+    }
+
+    [TestCaseSource(nameof(DensityCases))]
+    public void Feature003SupplyDrivenDensityMatrix_RemainsStable(
+        EffectiveScale[] inputs,
+        float outputScale,
+        float maxWorkingScale,
+        float expected)
+    {
+        float resolved = RenderScaleUtilities.ResolveWorkingScale(
+            inputs,
+            outputScale,
+            maxWorkingScale);
+
+        Assert.That(resolved, Is.EqualTo(expected).Within(1e-6));
+    }
+
+    [Test]
+    public void Feature003TransformDensityAndDimensionRounding_RemainStable()
+    {
+        EffectiveScale anisotropic = TransformRenderNode.RescaleDensity(
+            EffectiveScale.At(2),
+            Matrix.CreateScale(0.5f, 0.25f));
+        EffectiveScale rotation = TransformRenderNode.RescaleDensity(
+            EffectiveScale.At(2),
+            Matrix.CreateRotation(MathF.PI / 3));
+        (int width, int height) scaleOne = CustomFilterEffectContext.DeviceBufferSize(
+            new Rect(0, 0, 100.7f, 50.2f),
+            1);
+        (int width, int height) dense = CustomFilterEffectContext.DeviceBufferSize(
+            new Rect(0, 0, 100.3f, 50.1f),
+            2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(anisotropic, Is.EqualTo(EffectiveScale.At(8)),
+                "the most detailed transformed axis defines available density");
+            Assert.That(rotation, Is.EqualTo(EffectiveScale.At(2)),
+                "a pure rotation must not invent or discard density");
+            Assert.That(scaleOne, Is.EqualTo((100, 50)),
+                "the scale-one legacy allocation truncates fractional dimensions");
+            Assert.That(dense, Is.EqualTo((201, 101)),
+                "non-unit device allocation uses ceil after scaling");
+        });
+    }
+
+    [Test]
+    public void Feature003BufferClampAndCacheIdentity_IncludeResolvedDensity()
+    {
+        var bounds = new Rect(0, 0, 10_000.25f, 20);
+        float clamped = RenderScaleUtilities.ClampWorkingScaleToBufferBudget(bounds, 4);
+        RenderOutputCacheIdentity atOne = CreateCacheIdentity(bounds, density: 1);
+        RenderOutputCacheIdentity atTwo = CreateCacheIdentity(bounds, density: 2);
+        RenderOutputCacheIdentity atTwoAgain = CreateCacheIdentity(bounds, density: 2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(clamped, Is.LessThan(4));
+            Assert.That(Math.Ceiling(bounds.Width * clamped),
+                Is.LessThanOrEqualTo(RenderScaleUtilities.MaxBufferDimension));
+            Assert.That(atOne, Is.Not.EqualTo(atTwo),
+                "a density change must invalidate a materialized output cache entry");
+            Assert.That(atTwo, Is.EqualTo(atTwoAgain),
+                "equal resolved density and runtime components must be cache-stable");
+        });
+    }
+
+    [TestCase(RepresentativeContent.Vector)]
+    [TestCase(RepresentativeContent.Bitmap)]
+    [TestCase(RepresentativeContent.Text)]
+    [Category("GpuPassFusionGpu")]
+    public void Feature003ScaleOneGoldenAnchor_IsByteStableAndNonVacuous(
+        RepresentativeContent content)
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Bitmap first = RenderRepresentative(content, 1);
+            using Bitmap second = RenderRepresentative(content, 1);
+
+            GoldenImageHarness.AssertByteIdentical(first, second);
+            Assert.That(SumAbsoluteRgb(first), Is.GreaterThan(1),
+                "a byte-stable opaque-black result is not a useful golden anchor");
+        });
+    }
+
+    [TestCase(float.PositiveInfinity)]
+    [TestCase(float.NegativeInfinity)]
+    public void Feature003ScaleOneGoldenEnergy_RejectsInfiniteRgb(float value)
+    {
+        using var bitmap = new Bitmap(
+            1,
+            1,
+            BitmapColorType.RgbaF16,
+            BitmapAlphaType.Premul,
+            BitmapColorSpace.LinearSrgb);
+        bitmap.GetPixelSpan<ushort>()[1] = BitConverter.HalfToUInt16Bits((Half)value);
+
+        AssertionException? exception = Assert.Throws<AssertionException>(() => SumAbsoluteRgb(bitmap));
+        Assert.That(exception!.Message, Does.Contain("pixel 0 channel 1").And.Contain("non-finite"));
+    }
+
+    [TestCase(float.PositiveInfinity)]
+    [TestCase(float.NegativeInfinity)]
+    public void Feature003ScaleOneGoldenEnergy_RejectsInfiniteAlpha(float value)
+    {
+        using var bitmap = new Bitmap(
+            1,
+            1,
+            BitmapColorType.RgbaF16,
+            BitmapAlphaType.Premul,
+            BitmapColorSpace.LinearSrgb);
+        bitmap.GetPixelSpan<ushort>()[3] = BitConverter.HalfToUInt16Bits((Half)value);
+
+        AssertionException? exception = Assert.Throws<AssertionException>(() => SumAbsoluteRgb(bitmap));
+        Assert.That(exception!.Message, Does.Contain("pixel 0 channel 3").And.Contain("non-finite"));
+    }
+
+    [Test]
+    public void Feature003ScaleOneGoldenEnergy_RejectsTransparentNonzeroRgb()
+    {
+        using var bitmap = new Bitmap(
+            1,
+            1,
+            BitmapColorType.RgbaF16,
+            BitmapAlphaType.Premul,
+            BitmapColorSpace.LinearSrgb);
+        bitmap.GetPixelSpan<ushort>()[1] = BitConverter.HalfToUInt16Bits((Half)0.25f);
+
+        AssertionException? exception = Assert.Throws<AssertionException>(() => SumAbsoluteRgb(bitmap));
+        Assert.That(
+            exception!.Message,
+            Does.Contain("transparent pixel 0").And.Contain("non-zero premultiplied RGB"));
+    }
+
+    [TestCase(RepresentativeContent.Vector)]
+    [TestCase(RepresentativeContent.Bitmap)]
+    [TestCase(RepresentativeContent.Text)]
+    [Category("GpuPassFusionGpu")]
+    public void Feature003HalfPreviewAndDoubleSupersample_PreserveLogicalContentAndDeviceSizes(
+        RepresentativeContent content)
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Bitmap full = RenderRepresentative(content, 1);
+            using Bitmap half = RenderRepresentative(content, 0.5f);
+            using Bitmap halfDelivered = GoldenImageHarness.MitchellResampleTo(half, s_frame);
+            using Bitmap supersampled = RenderRepresentative(content, 2);
+            using Bitmap doubleDelivered = GoldenImageHarness.MitchellResampleTo(supersampled, s_frame);
+
+            double halfSsim = ImageMetrics.Ssim(full, halfDelivered);
+            double halfMae = ImageMetrics.MeanAbsoluteError(full, halfDelivered);
+            double doubleSsim = ImageMetrics.Ssim(full, doubleDelivered);
+            double doubleMae = ImageMetrics.MeanAbsoluteError(full, doubleDelivered);
+            TestContext.WriteLine(
+                $"{content}: half SSIM={halfSsim:F4} MAE={halfMae:F4}; "
+                + $"double SSIM={doubleSsim:F4} MAE={doubleMae:F4}");
+            GoldenLimits limits = GoldenLimits.For(content);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(half.Width, Is.EqualTo(96));
+                Assert.That(half.Height, Is.EqualTo(64));
+                Assert.That(supersampled.Width, Is.EqualTo(384));
+                Assert.That(supersampled.Height, Is.EqualTo(256));
+                Assert.That(halfSsim, Is.GreaterThanOrEqualTo(limits.HalfSsim),
+                    "reduced preview lost the representative logical structure");
+                Assert.That(halfMae, Is.LessThanOrEqualTo(limits.HalfMae));
+                Assert.That(doubleSsim, Is.GreaterThanOrEqualTo(limits.DoubleSsim),
+                    "supersampled output diverged from the scale-one logical anchor");
+                Assert.That(doubleMae, Is.LessThanOrEqualTo(limits.DoubleMae));
+            });
+        });
+    }
+
+    [Test]
+    public void CharacterizedPreviewAllocationFailure_DropsTheEffectOutputWithoutThrowing()
+    {
+        using EffectTargets targets = CreateNonAllocatableTargets();
+        using var builder = new SKImageFilterBuilder();
+        using var activator = new FilterEffectActivator(
+            targets,
+            builder,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            outputScale: 1,
+            workingScale: 1,
+            maxWorkingScale: 2);
+
+        Assert.That(() => activator.Flush(), Throws.Nothing);
+        Assert.That(activator.CurrentTargets, Is.Empty,
+            "preview keeps the current-main drop-on-allocation-failure outcome");
+    }
+
+    [Test]
+    public void CharacterizedDeliveryAllocationFailure_FailsFastInsteadOfDroppingContent()
+    {
+        using EffectTargets targets = CreateNonAllocatableTargets();
+        using var builder = new SKImageFilterBuilder();
+        using var activator = new FilterEffectActivator(
+            targets,
+            builder,
+            RenderIntent.Delivery,
+            RenderRequestPurpose.Auxiliary,
+            outputScale: 1,
+            workingScale: 1,
+            maxWorkingScale: float.PositiveInfinity);
+
+        InvalidOperationException? exception = Assert.Throws<InvalidOperationException>(() => activator.Flush());
+        Assert.That(exception!.Message, Does.StartWith("Effect flush buffer allocation failed"));
+    }
+
+    private static TestCaseData DensityCase(
+        string name,
+        EffectiveScale[] inputs,
+        float outputScale,
+        float maxWorkingScale,
+        float expected)
+        => new TestCaseData(inputs, outputScale, maxWorkingScale, expected).SetName(name);
+
+    private static RenderOutputCacheIdentity CreateCacheIdentity(Rect bounds, float density)
+    {
+        var fragment = new RenderFragmentReference(
+            RenderFragmentKind.MaterializedInput,
+            bounds,
+            EffectiveScale.At(density),
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: false,
+            hasOpaqueExternalWork: false,
+            inputs: null,
+            payload: null,
+            hitTest: null);
+        var requestId = new RenderRequestId(1);
+        return new RenderOutputCacheIdentity(
+            candidateKey: "feature-003-density",
+            RenderFragmentOutputIdentity.Create(fragment, requestId),
+            bounds,
+            RequiredRegion.Region(bounds),
+            density,
+            RenderCacheFormatIdentity.LinearPremultipliedRgba16Float,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            FusionMode.Enabled,
+            new RenderCacheDeviceContextIdentity("device", "context"));
+    }
+
+    private static Bitmap RenderRepresentative(RepresentativeContent content, float scale)
+    {
+        if (content == RepresentativeContent.Bitmap)
+            return RenderMaterializedBitmap(scale);
+
+        using Drawable.Resource resource = content switch
+        {
+            RepresentativeContent.Vector => CreateVector(),
+            RepresentativeContent.Text => CreateText(),
+            _ => throw new ArgumentOutOfRangeException(nameof(content), content, null),
+        };
+        return GoldenImageHarness.RenderAtScale(resource, s_frame, scale);
+    }
+
+    private static Drawable.Resource CreateVector()
+    {
+        var shape = new EllipseShape();
+        shape.AlignmentX.CurrentValue = AlignmentX.Center;
+        shape.AlignmentY.CurrentValue = AlignmentY.Center;
+        shape.Width.CurrentValue = 126;
+        shape.Height.CurrentValue = 78;
+        shape.Fill.CurrentValue = Brushes.OrangeRed;
+        return shape.ToResource(CompositionContext.Default);
+    }
+
+    private static Bitmap RenderMaterializedBitmap(float scale)
+    {
+        var sourceSize = new PixelSize(96, 64);
+        using RenderTarget source = RenderTarget.Create(sourceSize.Width, sourceSize.Height)
+                                    ?? throw new InvalidOperationException("Could not allocate bitmap source.");
+        using (var sourceCanvas = new ImmediateCanvas(source, 1, logicalSize: sourceSize.ToSize(1)))
+        {
+            sourceCanvas.Clear(Colors.CornflowerBlue);
+            sourceCanvas.DrawRectangle(new Rect(12, 10, 72, 44), Brushes.Resource.OrangeRed, null);
+        }
+
+        int width = (int)MathF.Ceiling(s_frame.Width * scale);
+        int height = (int)MathF.Ceiling(s_frame.Height * scale);
+        using RenderTarget destination = RenderTarget.Create(width, height)
+                                         ?? throw new InvalidOperationException("Could not allocate bitmap destination.");
+        using (var destinationCanvas = new ImmediateCanvas(
+                   destination,
+                   scale,
+                   logicalSize: s_frame.ToSize(1)))
+        {
+            destinationCanvas.Clear(Colors.Black);
+            using var node = new MaterializedBitmapNode(source);
+            using var renderer = new RenderNodeRenderer(
+                node,
+                new RenderNodeRendererOptions
+                {
+                    DefaultRequest = new RenderNodeRenderRequest
+                    {
+                        Intent = RenderIntent.Delivery,
+                        TargetDomain = new Rect(default, s_frame.ToSize(1)),
+                        OutputScale = scale,
+                        MaxWorkingScale = float.PositiveInfinity,
+                        CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    },
+                });
+            renderer.Render(destinationCanvas);
+        }
+
+        return destination.Snapshot();
+    }
+
+    private static Drawable.Resource CreateText()
+    {
+        Typeface typeface = TypefaceProvider.Typeface();
+        var text = new TextBlock();
+        text.AlignmentX.CurrentValue = AlignmentX.Center;
+        text.AlignmentY.CurrentValue = AlignmentY.Center;
+        text.FontFamily.CurrentValue = typeface.FontFamily;
+        text.FontStyle.CurrentValue = typeface.Style;
+        text.FontWeight.CurrentValue = typeface.Weight;
+        text.Size.CurrentValue = 34;
+        text.Fill.CurrentValue = Brushes.White;
+        text.Text.CurrentValue = "Density";
+        return text.ToResource(CompositionContext.Default);
+    }
+
+    private static EffectTargets CreateNonAllocatableTargets()
+    {
+        using RenderTarget source = RenderTarget.CreateNull(1, 1);
+        return new EffectTargets
+        {
+            new EffectTarget(
+                source,
+                new Rect(10, 8, -1, 92),
+                EffectiveScale.At(1)),
+        };
+    }
+
+    private static double SumAbsoluteRgb(Bitmap bitmap)
+    {
+        double result = 0;
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        for (int offset = 0; offset < pixels.Length; offset += 4)
+        {
+            int pixelIndex = offset / 4;
+            float red = DecodeFiniteChannel(pixels, offset, pixelIndex, channel: 0);
+            float green = DecodeFiniteChannel(pixels, offset, pixelIndex, channel: 1);
+            float blue = DecodeFiniteChannel(pixels, offset, pixelIndex, channel: 2);
+            float alpha = DecodeFiniteChannel(pixels, offset, pixelIndex, channel: 3);
+            if (alpha == 0 && (red != 0 || green != 0 || blue != 0))
+            {
+                throw new AssertionException(
+                    $"Scale-one golden transparent pixel {pixelIndex} contains non-zero premultiplied RGB: "
+                    + $"({red}, {green}, {blue}).");
+            }
+
+            result += Math.Abs(red) + Math.Abs(green) + Math.Abs(blue);
+        }
+
+        return result;
+    }
+
+    private static float DecodeFiniteChannel(
+        ReadOnlySpan<ushort> pixels,
+        int offset,
+        int pixelIndex,
+        int channel)
+    {
+        float value = (float)BitConverter.UInt16BitsToHalf(pixels[offset + channel]);
+        if (!float.IsFinite(value))
+        {
+            throw new AssertionException(
+                $"Scale-one golden pixel {pixelIndex} channel {channel} is non-finite: {value}.");
+        }
+
+        return value;
+    }
+
+    private sealed class MaterializedBitmapNode(RenderTarget source) : RenderNode
+    {
+        private static readonly Rect s_bounds = new(48, 32, 96, 64);
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<RenderTarget> target = context.Borrow(
+                source,
+                "feature-003-materialized-bitmap",
+                version: 1);
+            context.Publish(context.MaterializedInput(MaterializedInputDescription.FromRenderTarget(
+                target,
+                s_bounds,
+                EffectiveScale.At(1),
+                PixelRect.FromRect(s_bounds, 1),
+                default,
+                RenderHitTestContract.OutputBounds)));
+        }
+    }
+
+    private readonly record struct GoldenLimits(
+        double HalfSsim,
+        double HalfMae,
+        double DoubleSsim,
+        double DoubleMae)
+    {
+        public static GoldenLimits For(RepresentativeContent content)
+            => content == RepresentativeContent.Text
+                // Full-hinted glyph rasterization is intentionally resolution-sensitive under feature 003.
+                ? new GoldenLimits(0.75, 0.04, 0.92, 0.025)
+                : new GoldenLimits(0.95, 0.035, 0.98, 0.02);
+    }
+
+    public enum RepresentativeContent
+    {
+        Vector,
+        Bitmap,
+        Text,
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/GpuPassFusionScaleRegionTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/GpuPassFusionScaleRegionTests.cs
@@ -1,0 +1,984 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+using Beutl.Media.TextFormatting;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+using Beutl.UnitTests.Engine.Graphics.Rendering.Baseline;
+using Beutl.UnitTests.Engine.Graphics.Rendering.Fusion;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Golden;
+
+[NonParallelizable]
+[TestFixture]
+public sealed class GpuPassFusionScaleRegionTests
+{
+    private static readonly Rect s_domain = new(0, 0, 96, 64);
+
+    // The stage runs in half precision and stores RGBA16F, so the CPU oracle and the GPU may disagree by a few
+    // half-precision ulps (~4.9e-4 relative near 1.0). Vulkan measures 0.000000; this keeps room for a backend
+    // that rounds differently while staying two orders of magnitude below the effect size.
+    private const double MaximumSelfAlphaProductDeviation = 0.005;
+
+    // Per premultiplied channel the stage changes a pixel by a - a^2, which peaks at 0.25 for a = 0.5. An
+    // antialiased stroke edge sweeps through that coverage, so the observed maximum is 0.2406. This floor sits
+    // well under it and far above the 0 that a stage which never ran would produce.
+    private const double MinimumSelfAlphaProductChange = 0.10;
+
+    [Test]
+    public void MixedVectorBitmapAndTextInputs_ResolveDensestSupplyThenMaximumWorkingScale()
+    {
+        using var root = new MixedDensityNode();
+        using var owner = new RenderRequestOwner();
+        var request = new RenderRequest(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Bounds,
+            targetDomain: s_domain,
+            outputScale: 1,
+            maxWorkingScale: 2.5f,
+            owner: owner));
+        using (request)
+        {
+            RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(root);
+            RenderFragmentReference combined = graph.Fragments
+                .Select(static fragment => (RenderFragmentReference)fragment.Payload!)
+                .Single(static reference => reference.Kind == RenderFragmentKind.OpaqueCombine);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(combined.Inputs, Has.Length.EqualTo(4));
+                Assert.That(combined.Inputs.Count(static input => input.EffectiveScale.IsUnbounded),
+                    Is.EqualTo(2), "vector geometry and text must remain re-rasterizable");
+                Assert.That(
+                    combined.Inputs
+                        .Where(static input => !input.EffectiveScale.IsUnbounded)
+                        .Select(static input => input.EffectiveScale.Value),
+                    Is.EquivalentTo(new[] { 0.5f, 2.5f }),
+                    "each concrete source is capped as it is recorded before the combined boundary resolves");
+                Assert.That(combined.EffectiveScale.IsUnbounded, Is.False);
+                Assert.That(combined.EffectiveScale.Value, Is.EqualTo(2.5f),
+                    "the dense bitmap supply wins before the request ceiling is applied");
+            });
+        }
+    }
+
+    [Test]
+    public void CompleteBoundsClamp_PrecedesRequestedRegionAndNeverExceedsTheAxisBudget()
+    {
+        var completeBounds = new Rect(123.25f, 9, 10_000.25f, 12);
+        var requestedRegion = new Rect(9_000, 9, 8, 8);
+        using RenderNode root = ScaleRecordingTestHelper.Source(EffectiveScale.At(4), completeBounds);
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = completeBounds,
+                    RequestedRegion = requestedRegion,
+                    OutputScale = 1,
+                    MaxWorkingScale = float.PositiveInfinity,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+            });
+
+        RenderNodeMeasurement measurement = renderer.Measure();
+        float expected = RenderScaleUtilities.ClampWorkingScaleToExactBufferBudget(completeBounds, 4);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(expected, Is.LessThan(4), "the fixture must exercise the 16,384-axis clamp");
+            Assert.That(measurement.EffectiveScale.IsUnbounded, Is.False);
+            Assert.That(measurement.EffectiveScale.Value, Is.EqualTo(expected));
+            Assert.That(
+                Math.Ceiling(completeBounds.Width * measurement.EffectiveScale.Value),
+                Is.LessThanOrEqualTo(RenderScaleUtilities.MaxBufferDimension));
+            Assert.That(
+                measurement.EffectiveScale.Value,
+                Is.LessThan(RenderScaleUtilities.ClampWorkingScaleToBufferBudget(requestedRegion, 4)),
+                "a late ROI crop must not raise a density already clamped against complete bounds");
+        });
+    }
+
+    [Test]
+    public void RequestedRegionOutsideRootOutputExtent_RasterizesWithoutABitmap()
+    {
+        var outputBounds = new Rect(10, 20, 30, 40);
+        using RenderNode root = ScaleRecordingTestHelper.Source(EffectiveScale.At(1), outputBounds);
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = new Rect(0, 0, 200, 300),
+                    RequestedRegion = new Rect(100, 200, 25, 20),
+                    OutputScale = 1,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    Purpose = RenderRequestPurpose.Frame,
+                    Diagnostics = diagnostics,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rasterization.Bounds, Is.EqualTo(Rect.Empty));
+            Assert.That(rasterization.Bitmap, Is.Null);
+            Assert.That(snapshot.Succeeded, Is.True);
+            Assert.That(snapshot[RenderPipelineCounter.RecordedFragments], Is.GreaterThan(0));
+            Assert.That(
+                snapshot[RenderPipelineCounter.SkippedOutcomes],
+                Is.EqualTo(snapshot[RenderPipelineCounter.RecordedFragments]));
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedOutcomes], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedGpuPasses], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.IntermediateAcquires], Is.Zero);
+            Assert.That(snapshot.Events[^1].Kind, Is.EqualTo(RenderPipelineDiagnosticEventKind.RequestCompleted));
+            Assert.That(diagnostics.LatestFrame, Is.SameAs(snapshot));
+        });
+    }
+
+    [Test]
+    public void ShiftedGuardedCallback_LateBindsRequiredAndDeviceRegionsWithoutRunningDuringMeasure()
+    {
+        var declaredBounds = new Rect(10.25f, 20.5f, 8, 6);
+        var requestedRegion = new Rect(12.25f, 22.5f, 3, 2);
+        using var node = new ShiftedCallbackNode(declaredBounds);
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = new Rect(0, 0, 40, 40),
+                    RequestedRegion = requestedRegion,
+                    OutputScale = 1,
+                    MaxWorkingScale = 4,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        RenderNodeMeasurement measurement = renderer.Measure();
+        Assert.That(node.CallbackCount, Is.Zero, "metadata resolution must not execute guarded work");
+        Assert.That(measurement.OutputBounds, Is.EqualTo(declaredBounds));
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        PixelRect expectedDeviceBounds = PixelRect.FromRect(requestedRegion, 2);
+        var expectedOrigin = new Point(expectedDeviceBounds.X / 2f, expectedDeviceBounds.Y / 2f);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.CallbackCount, Is.EqualTo(1));
+            Assert.That(node.ObservedOutputBounds, Is.EqualTo(declaredBounds));
+            Assert.That(node.ObservedRequiredRegion, Is.EqualTo(requestedRegion));
+            Assert.That(node.ObservedSessionDeviceBounds, Is.EqualTo(expectedDeviceBounds));
+            Assert.That(node.ObservedCanvasBounds, Is.EqualTo(requestedRegion));
+            Assert.That(node.ObservedCanvasDeviceBounds, Is.EqualTo(expectedDeviceBounds));
+            Assert.That(node.ObservedCanvasOrigin, Is.EqualTo(expectedOrigin));
+            Assert.That(node.ObservedDensity, Is.EqualTo(2));
+            Assert.That(rasterization.Bounds, Is.EqualTo(PixelRect.FromRect(requestedRegion, 1).ToRect(1)));
+            Assert.That(rasterization.Bitmap, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public void TypedGeometryShaderAndTargetScope_ReceiveTheCroppedRuntimeRequirement()
+    {
+        var declaredBounds = new Rect(10, 20, 12, 8);
+        var requestedRegion = new Rect(12, 22, 4, 3);
+        using var node = new TypedValueRoiNode(declaredBounds);
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = new Rect(0, 0, 40, 40),
+                    RequestedRegion = requestedRegion,
+                    OutputScale = 2,
+                    MaxWorkingScale = 4,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        RenderNodeMeasurement measurement = renderer.Measure();
+        Assert.That(node.TotalCallbackCount, Is.Zero);
+        Assert.That(measurement.OutputBounds, Is.EqualTo(declaredBounds));
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        PixelRect expectedDeviceBounds = PixelRect.FromRect(requestedRegion, 2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.GeometryOutputBounds, Is.EqualTo(declaredBounds));
+            Assert.That(node.GeometryRequiredRegion, Is.EqualTo(requestedRegion));
+            Assert.That(node.GeometryDeviceBounds, Is.EqualTo(expectedDeviceBounds));
+            Assert.That(node.GeometryCanvasBounds, Is.EqualTo(requestedRegion));
+            Assert.That(node.ShaderInputBounds, Is.EqualTo(requestedRegion));
+            Assert.That(node.ShaderOutputBounds, Is.EqualTo(declaredBounds));
+            Assert.That(node.ShaderRequiredRegion, Is.EqualTo(requestedRegion));
+            Assert.That(node.ShaderDeviceBounds, Is.EqualTo(expectedDeviceBounds));
+            Assert.That(node.TargetScopeOutputBounds, Is.EqualTo(declaredBounds));
+            Assert.That(node.TargetScopeRequiredRegion, Is.EqualTo(requestedRegion));
+            Assert.That(node.TargetScopeCanvasBounds, Is.EqualTo(requestedRegion));
+            Assert.That(node.TargetScopeCanvasDeviceBounds, Is.EqualTo(expectedDeviceBounds));
+            Assert.That(rasterization.Bounds, Is.EqualTo(requestedRegion));
+            Assert.That(rasterization.Bitmap, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public void TargetReadback_ExpandsThePrecedingSnapshotAndCanvasToItsDeclaredReadRegion()
+    {
+        var declaredBounds = new Rect(10, 20, 12, 8);
+        var requestedRegion = new Rect(12, 22, 4, 3);
+        using var node = new TargetReadbackRoiNode(declaredBounds);
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = new Rect(0, 0, 40, 40),
+                    RequestedRegion = requestedRegion,
+                    OutputScale = 2,
+                    MaxWorkingScale = 4,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        RenderNodeMeasurement measurement = renderer.Measure();
+        Assert.That(node.CallbackCount, Is.Zero);
+        Assert.That(measurement.OutputBounds, Is.EqualTo(declaredBounds));
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        PixelRect expectedDeviceBounds = PixelRect.FromRect(declaredBounds, 2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.CallbackCount, Is.EqualTo(1));
+            Assert.That(node.SourceRequiredRegion, Is.EqualTo(declaredBounds));
+            Assert.That(node.AffectedBounds, Is.EqualTo(declaredBounds));
+            Assert.That(node.RequiredRegion, Is.EqualTo(declaredBounds));
+            Assert.That(node.CanvasBounds, Is.EqualTo(declaredBounds));
+            Assert.That(node.CanvasDeviceBounds, Is.EqualTo(expectedDeviceBounds));
+            Assert.That(node.SnapshotSize, Is.EqualTo(expectedDeviceBounds.Size));
+            Assert.That(node.SnapshotOpaquePixelCount,
+                Is.EqualTo(expectedDeviceBounds.Width * expectedDeviceBounds.Height));
+            Assert.That(node.SnapshotCornerAlpha, Is.GreaterThan(0.99f),
+                "the target-read apron must contain the preceding target pixels, not only an expanded allocation");
+            Assert.That(rasterization.Bounds, Is.EqualTo(requestedRegion));
+            Assert.That(rasterization.Bitmap, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public void RenderWithTargetReadApron_CommitsOnlyTheRequestedRegionToTheBorrowedTarget()
+    {
+        var declaredBounds = new Rect(10, 20, 12, 8);
+        var requestedRegion = new Rect(12, 22, 4, 3);
+        using var node = new TargetReadbackRoiNode(declaredBounds);
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    RequestedRegion = requestedRegion,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+        using var target = new CpuRenderTarget(80, 80);
+        using var canvas = new ImmediateCanvas(
+            target,
+            density: 2,
+            logicalSize: new Size(40, 40));
+        canvas.Clear(Colors.Red);
+
+        renderer.Render(canvas);
+        using Bitmap completed = target.Snapshot();
+        (float outsideRed, float outsideBlue) = RedBlueAt(completed, 21, 41);
+        (float insideRed, float insideBlue) = RedBlueAt(completed, 26, 46);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.SourceRequiredRegion, Is.EqualTo(declaredBounds));
+            Assert.That(node.SnapshotCornerBlue, Is.GreaterThan(node.SnapshotCornerRed),
+                "the readback apron must observe the preceding blue graph output, not the borrowed red target");
+            Assert.That(outsideRed, Is.GreaterThan(outsideBlue),
+                "pixels outside the final commit crop must retain the borrowed target content");
+            Assert.That(insideBlue, Is.GreaterThan(insideRed),
+                "pixels inside the final commit crop must receive the completed graph output");
+        });
+    }
+
+    [Test]
+    public void ExpandedExecution_RejectsAnActiveCanvasSaveLayerBeforeCopyingStalePixels()
+    {
+        var declaredBounds = new Rect(10, 20, 12, 8);
+        var requestedRegion = new Rect(12, 22, 4, 3);
+        using var node = new TargetReadbackRoiNode(declaredBounds);
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    RequestedRegion = requestedRegion,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+        using var target = new CpuRenderTarget(80, 80);
+        using var canvas = new ImmediateCanvas(
+            target,
+            density: 2,
+            logicalSize: new Size(40, 40));
+        using var opacity = canvas.PushOpacity(0.5f);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => renderer.Render(canvas));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Does.Contain("SaveLayer scope is active"));
+            Assert.That(node.CallbackCount, Is.Zero,
+                "the request must fail before it copies or executes against a stale root-surface snapshot");
+        });
+    }
+
+    [TestCase(CaptureContainer.FiniteLayer)]
+    [TestCase(CaptureContainer.TargetLayerScope)]
+    public void DeclaredTargetCaptureResamplesWhileBackdropLateBindsToDenserScopeAndCacheIdentity(
+        CaptureContainer container)
+    {
+        using var node = new CaptureDensityNode(container);
+
+        RenderFragmentOutputIdentity declaredAtOne = RecordCaptureIdentity(node, outputScale: 1, builtIn: false);
+        RenderFragmentOutputIdentity declaredAtTwo = RecordCaptureIdentity(node, outputScale: 2, builtIn: false);
+        RenderFragmentOutputIdentity backdropIdentity = RecordCaptureIdentity(node, outputScale: 1, builtIn: true);
+
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_domain,
+                    OutputScale = 1,
+                    MaxWorkingScale = 2,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.PublicCaptureInputDensity, Is.EqualTo(1),
+                "a public capture uses its no-input, output-derived declared density");
+            Assert.That(node.BuiltInCaptureInputDensity, Is.EqualTo(2),
+                "the engine backdrop must bind to the actual denser owning target");
+            Assert.That(node.CommittedBackdropDensity, Is.EqualTo(2));
+            Assert.That(declaredAtOne, Is.Not.EqualTo(declaredAtTwo),
+                "declared capture density must participate in the output-cache identity");
+            Assert.That(declaredAtOne, Is.Not.EqualTo(backdropIdentity),
+                "a late-bound backdrop is request-local and cannot alias a public declared-density capture");
+            Assert.That(rasterization.Bitmap, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void AntialiasedThinStroke_CurrentPixelBoundaryPreservesEdgeCoverage()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var node = new ThinStrokeShaderNode();
+            GpuPassFusionParityResult result = GpuPassFusionSameProcessParityHarness.AssertParity(
+                mode => RenderThinStroke(node, mode),
+                new PixelRect(18, 16, 156, 76));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.AaEdge, Is.Not.Null);
+                Assert.That(result.AaEdge!.Value.EdgeBandMeanError,
+                    Is.LessThanOrEqualTo(GpuPassFusionSameProcessParityHarness.MaximumAaEdgeMeanError));
+                Assert.That(result.AaEdge.Value.MaximumError.Maximum,
+                    Is.LessThanOrEqualTo(GpuPassFusionSameProcessParityHarness.MaximumAaEdgeChannelError));
+                using Bitmap shaderFree = RenderThinStroke(node.SourceWithoutShader, FusionMode.Disabled);
+                using Bitmap shaderApplied = RenderThinStroke(node, FusionMode.Disabled);
+                Assert.That(
+                    ImageMetrics.FirstNonFinite(("shader-free", shaderFree), ("shader-applied", shaderApplied)),
+                    Is.Null,
+                    "thin-stroke control and shader-applied outputs must be finite RGBA16F.");
+
+                // A CurrentPixel stage runs after coverage resolution, so the applied image must equal the
+                // control image put through color * color.a. Running the stage before antialiasing instead
+                // would yield (c * c.a) * coverage rather than (c * coverage) * (c.a * coverage), which differs
+                // on exactly the partially covered edge pixels this test exists to guard.
+                using Bitmap expected = MultiplyByOwnAlpha(shaderFree);
+                RgbaMaximumError deviation =
+                    ImageMetrics.MaximumAbsoluteErrorPerChannel(expected, shaderApplied);
+                RgbaMaximumError change =
+                    ImageMetrics.MaximumAbsoluteErrorPerChannel(shaderFree, shaderApplied);
+                TestContext.WriteLine(
+                    $"[color*alpha] oracle deviation={deviation.Maximum:F6} change={change.Maximum:F6} "
+                    + $"changeAlpha={change.Alpha:F6}");
+
+                // A whole-region mean cannot serve here: the stroke covers ~2% of the probe region, so even a
+                // total change of every covered pixel stays under the harness parity ceiling.
+                Assert.That(
+                    deviation.Maximum,
+                    Is.LessThanOrEqualTo(MaximumSelfAlphaProductDeviation),
+                    "the CurrentPixel stage must apply color * color.a to coverage-resolved pixels.");
+                Assert.That(
+                    change.Maximum,
+                    Is.GreaterThanOrEqualTo(MinimumSelfAlphaProductChange),
+                    "the color*alpha CurrentPixel shader must actually change the thin-stroke image.");
+            });
+        });
+    }
+
+    private static RenderFragmentOutputIdentity RecordCaptureIdentity(
+        RenderNode root,
+        float outputScale,
+        bool builtIn)
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = new RenderRequest(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            targetDomain: s_domain,
+            outputScale: outputScale,
+            maxWorkingScale: 2,
+            owner: owner));
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(root);
+        RenderFragmentReference reference = graph.Fragments
+            .Select(static fragment => (RenderFragmentReference)fragment.Payload!)
+            .Single(item => item.Kind == (builtIn
+                ? RenderFragmentKind.BuiltInBackdropCapture
+                : RenderFragmentKind.TargetCapture));
+        return RenderFragmentOutputIdentity.Create(reference, request.Id);
+    }
+
+    /// <summary>CPU oracle for the <c>color * color.a</c> CurrentPixel stage over premultiplied RGBA16F.</summary>
+    private static Bitmap MultiplyByOwnAlpha(Bitmap source)
+    {
+        var result = new Bitmap(
+            source.Width,
+            source.Height,
+            BitmapColorType.RgbaF16,
+            BitmapAlphaType.Premul,
+            BitmapColorSpace.LinearSrgb);
+        for (int y = 0; y < source.Height; y++)
+        {
+            ReadOnlySpan<ushort> sourceRow = source.GetRow<ushort>(y);
+            Span<ushort> resultRow = result.GetRow<ushort>(y);
+            for (int x = 0; x < source.Width; x++)
+            {
+                int offset = x * 4;
+                var alpha = (float)BitConverter.UInt16BitsToHalf(sourceRow[offset + 3]);
+                for (int channel = 0; channel < 4; channel++)
+                {
+                    var value = (float)BitConverter.UInt16BitsToHalf(sourceRow[offset + channel]);
+                    resultRow[offset + channel] = BitConverter.HalfToUInt16Bits((Half)(value * alpha));
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static Bitmap RenderThinStroke(RenderNode node, FusionMode mode)
+    {
+        const int width = 192;
+        const int height = 108;
+        using RenderTarget target = RenderTarget.Create(width, height)
+            ?? throw new InvalidOperationException("Could not allocate the thin-stroke target.");
+        using (var canvas = new ImmediateCanvas(target, 1, 2, new Size(width, height)))
+        {
+            canvas.Clear();
+            using var renderer = new RenderNodeRenderer(
+                node,
+                new RenderNodeRendererOptions
+                {
+                    DefaultRequest = new RenderNodeRenderRequest
+                    {
+                        TargetDomain = new Rect(0, 0, width, height),
+                        OutputScale = 1,
+                        MaxWorkingScale = 2,
+                        CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                        FusionMode = mode,
+                    },
+                });
+            renderer.Render(canvas);
+        }
+
+        Bitmap result = target.Snapshot();
+        Assert.That(
+            FusionBoundaryExecutionTestSupport.CountFractionalAlphaPixels(result),
+            Is.GreaterThan(0),
+            $"The {mode} thin-stroke fixture must contain antialiased coverage before parity is evaluated.");
+        return result;
+    }
+
+    public enum CaptureContainer
+    {
+        FiniteLayer,
+        TargetLayerScope,
+    }
+
+    private sealed class MixedDensityNode : RenderNode
+    {
+        private readonly RenderNode _lowDensity = ScaleRecordingTestHelper.Source(EffectiveScale.At(0.5f));
+        private readonly RenderNode _highDensity = ScaleRecordingTestHelper.Source(EffectiveScale.At(4));
+        private readonly RectangleRenderNode _vector = new(
+            new Rect(4, 6, 60, 38),
+            Brushes.Resource.White,
+            null);
+        private readonly FormattedText _text;
+        private readonly TextRenderNode _textNode;
+
+        public MixedDensityNode()
+        {
+            Typeface typeface = TypefaceProvider.Typeface();
+            _text = new FormattedText
+            {
+                Font = typeface.FontFamily,
+                Style = typeface.Style,
+                Weight = typeface.Weight,
+                Size = 18,
+                Text = "density",
+            };
+            _textNode = new TextRenderNode(_text, Brushes.Resource.White, null);
+        }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle[] inputs =
+            [
+                context.RecordNode(_lowDensity, [])[0],
+                context.RecordNode(_highDensity, [])[0],
+                context.RecordNode(_vector, [])[0],
+                context.RecordNode(_textNode, [])[0],
+            ];
+            context.Publish(context.OpaqueCombine(inputs, CreateCombineDescription(typeof(MixedDensityNode))));
+        }
+
+        protected override void OnDispose(bool disposing)
+        {
+            _lowDensity.Dispose();
+            _highDensity.Dispose();
+            _vector.Dispose();
+            _textNode.Dispose();
+            _text.Dispose();
+            base.OnDispose(disposing);
+        }
+    }
+
+    private sealed class ShiftedCallbackNode(Rect bounds) : RenderNode
+    {
+        public int CallbackCount { get; private set; }
+
+        public Rect ObservedOutputBounds { get; private set; }
+
+        public Rect ObservedRequiredRegion { get; private set; }
+
+        public PixelRect ObservedSessionDeviceBounds { get; private set; }
+
+        public Rect ObservedCanvasBounds { get; private set; }
+
+        public PixelRect ObservedCanvasDeviceBounds { get; private set; }
+
+        public Point ObservedCanvasOrigin { get; private set; }
+
+        public float ObservedDensity { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            OpaqueRenderDescription description = OpaqueRenderDescription.CreateRequestLocal(
+                execute: session =>
+                {
+                    CallbackCount++;
+                    ObservedOutputBounds = session.OutputBounds;
+                    ObservedRequiredRegion = session.RequiredRegion;
+                    ObservedSessionDeviceBounds = session.DeviceBounds;
+                    ObservedDensity = session.WorkingScale;
+                    using OpaqueRenderOutput output = session.CreateOutput(session.RequiredRegion);
+                    ObservedCanvasBounds = output.Canvas.LogicalBounds;
+                    ObservedCanvasDeviceBounds = output.Canvas.DeviceBounds;
+                    ObservedCanvasOrigin = output.Canvas.LogicalOrigin;
+                    output.Canvas.Use(static _ => { });
+                    session.Publish(output);
+                },
+                bounds: OpaqueRenderBoundsContract.Source(bounds),
+                hitTest: RenderHitTestContract.OutputBounds,
+                valueCardinality: RenderValueCardinality.Single,
+                scale: RenderScaleContract.Custom(static _ => 2, typeof(ShiftedCallbackNode)));
+            context.Publish(context.OpaqueSource(description));
+        }
+    }
+
+    private sealed class TypedValueRoiNode(Rect bounds) : RenderNode
+    {
+        public int TotalCallbackCount { get; private set; }
+
+        public Rect GeometryOutputBounds { get; private set; }
+
+        public Rect GeometryRequiredRegion { get; private set; }
+
+        public PixelRect GeometryDeviceBounds { get; private set; }
+
+        public Rect GeometryCanvasBounds { get; private set; }
+
+        public Rect ShaderInputBounds { get; private set; }
+
+        public Rect ShaderOutputBounds { get; private set; }
+
+        public Rect ShaderRequiredRegion { get; private set; }
+
+        public PixelRect ShaderDeviceBounds { get; private set; }
+
+        public Rect TargetScopeOutputBounds { get; private set; }
+
+        public Rect TargetScopeRequiredRegion { get; private set; }
+
+        public Rect TargetScopeCanvasBounds { get; private set; }
+
+        public PixelRect TargetScopeCanvasDeviceBounds { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle source = context.OpaqueSource(CreateRoiSourceDescription(
+                bounds,
+                typeof(TypedValueRoiNode)));
+            GeometryDescription geometry = GeometryDescription.CreateRequestLocal(
+                session =>
+                {
+                    TotalCallbackCount++;
+                    GeometryOutputBounds = session.OutputBounds;
+                    GeometryRequiredRegion = session.RequiredRegion;
+                    GeometryDeviceBounds = session.DeviceBounds;
+                    GeometryCanvasBounds = session.Canvas.LogicalBounds;
+                    session.Canvas.Use(session.Input.Draw);
+                },
+                RenderBoundsContract.Identity,
+                RenderHitTestContract.AnyInput);
+            RenderFragmentHandle current = context.Geometry(source, geometry);
+            ShaderDescription shader = ShaderDescription.CurrentPixel(
+                "uniform float gain; half4 apply(half4 color) { return color * gain; }",
+                bindings => bindings.Uniform(
+                    "gain",
+                    1f,
+                    (writer, value, execution) =>
+                    {
+                        TotalCallbackCount++;
+                        ShaderInputBounds = execution.InputBounds;
+                        ShaderOutputBounds = execution.OutputBounds;
+                        ShaderRequiredRegion = execution.RequiredRegion;
+                        ShaderDeviceBounds = execution.DeviceBounds;
+                        writer.Set(value);
+                    }));
+            current = context.Shader(current, shader);
+            TargetScopeDescription scope = TargetScopeDescription.CreateRequestLocal(
+                session =>
+                {
+                    TotalCallbackCount++;
+                    TargetScopeOutputBounds = session.OutputBounds;
+                    TargetScopeRequiredRegion = session.RequiredRegion;
+                    TargetScopeCanvasBounds = session.Canvas.LogicalBounds;
+                    TargetScopeCanvasDeviceBounds = session.Canvas.DeviceBounds;
+                    session.Canvas.Use(_ => session.ReplayInput());
+                },
+                RenderBoundsContract.Identity,
+                RenderHitTestContract.AnyInput,
+                RenderScaleContract.PreserveInputSupply,
+                deviceGridSensitivity: RenderDeviceGridSensitivity.PhaseDependent);
+            context.Publish(context.TargetScope(current, scope));
+        }
+    }
+
+    private sealed class TargetReadbackRoiNode(Rect bounds) : RenderNode
+    {
+        public int CallbackCount { get; private set; }
+
+        public Rect SourceRequiredRegion { get; private set; }
+
+        public Rect AffectedBounds { get; private set; }
+
+        public Rect RequiredRegion { get; private set; }
+
+        public Rect CanvasBounds { get; private set; }
+
+        public PixelRect CanvasDeviceBounds { get; private set; }
+
+        public PixelSize SnapshotSize { get; private set; }
+
+        public float SnapshotCornerAlpha { get; private set; }
+
+        public float SnapshotCornerRed { get; private set; }
+
+        public float SnapshotCornerBlue { get; private set; }
+
+        public int SnapshotOpaquePixelCount { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle source = context.OpaqueSource(OpaqueRenderDescription.CreateRequestLocal(
+                session =>
+                {
+                    SourceRequiredRegion = session.RequiredRegion;
+                    using OpaqueRenderOutput output = session.CreateOutput(session.RequiredRegion);
+                    output.Canvas.Use(static canvas => canvas.Clear(Colors.CornflowerBlue));
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.Source(bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.Custom(static _ => 2, typeof(TargetReadbackRoiNode))));
+            context.Publish(source);
+            context.Publish(context.TargetCommand(
+                [],
+                TargetCommandDescription.CreateRequestLocal(
+                    session =>
+                    {
+                        CallbackCount++;
+                        AffectedBounds = session.AffectedBounds;
+                        RequiredRegion = session.RequiredRegion;
+                        CanvasBounds = session.Canvas.LogicalBounds;
+                        CanvasDeviceBounds = session.Canvas.DeviceBounds;
+                        session.UseSnapshot(bitmap =>
+                        {
+                            SnapshotSize = new PixelSize(bitmap.Width, bitmap.Height);
+                            Span<ushort> firstRow = bitmap.GetRow<ushort>(0);
+                            SnapshotCornerRed = (float)BitConverter.UInt16BitsToHalf(firstRow[0]);
+                            SnapshotCornerBlue = (float)BitConverter.UInt16BitsToHalf(firstRow[2]);
+                            SnapshotCornerAlpha = (float)BitConverter.UInt16BitsToHalf(firstRow[3]);
+                            for (int y = 0; y < bitmap.Height; y++)
+                            {
+                                Span<ushort> row = bitmap.GetRow<ushort>(y);
+                                for (int x = 0; x < bitmap.Width; x++)
+                                {
+                                    if ((float)BitConverter.UInt16BitsToHalf(row[(x * 4) + 3]) > 0.99f)
+                                        SnapshotOpaquePixelCount++;
+                                }
+                            }
+                        });
+                    },
+                    TargetRegion.Region(bounds),
+                    Rect.Empty,
+                    RenderHitTestContract.None,
+                    TargetAccess.Readback)));
+        }
+    }
+
+    private static (float Red, float Blue) RedBlueAt(Bitmap bitmap, int x, int y)
+    {
+        Span<ushort> row = bitmap.GetRow<ushort>(y);
+        int offset = x * 4;
+        return (
+            (float)BitConverter.UInt16BitsToHalf(row[offset]),
+            (float)BitConverter.UInt16BitsToHalf(row[offset + 2]));
+    }
+
+    private static OpaqueRenderDescription CreateRoiSourceDescription(Rect bounds, object key)
+        => OpaqueRenderDescription.CreateRequestLocal(
+            session =>
+            {
+                using OpaqueRenderOutput output = session.CreateOutput(session.RequiredRegion);
+                output.Canvas.Use(static canvas => canvas.Clear(Colors.CornflowerBlue));
+                session.Publish(output);
+            },
+            OpaqueRenderBoundsContract.Source(bounds),
+            RenderHitTestContract.OutputBounds,
+            RenderValueCardinality.Single,
+            RenderScaleContract.Custom(static _ => 2, key),
+            structuralKey: key);
+
+    private sealed class CaptureDensityNode(CaptureContainer container)
+        : RenderNode, IBuiltInBackdropCaptureSink
+    {
+        private readonly RenderNode _localSource = ScaleRecordingTestHelper.Source(EffectiveScale.Unbounded, s_domain);
+        private readonly RenderNode _denseSource = ScaleRecordingTestHelper.Source(EffectiveScale.At(2), s_domain);
+        private Bitmap? _committedBackdrop;
+
+        public float PublicCaptureInputDensity { get; private set; }
+
+        public float BuiltInCaptureInputDensity { get; private set; }
+
+        public float CommittedBackdropDensity { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle source = context.RecordNode(_localSource, [])[0];
+            RenderFragmentHandle publicCapture = context.TargetCapture(TargetCaptureDescription.Create(
+                TargetRegion.Region(s_domain),
+                s_domain,
+                RenderHitTestContract.None,
+                TargetCaptureScaleContract.MaterializeAtWorkingScale));
+            RenderFragmentHandle publicReplay = context.ContributeValues(
+                context.OpaqueMap(publicCapture, CreateCaptureObserver(CaptureKind.Public)));
+
+            RenderFragmentHandle builtInCapture = context.BuiltInBackdropCapture(this);
+            RenderFragmentHandle builtInReplay = context.ContributeValues(
+                context.OpaqueMap(builtInCapture, CreateCaptureObserver(CaptureKind.BuiltIn)));
+            RenderFragmentHandle[] localInputs =
+                [source, publicCapture, publicReplay, builtInCapture, builtInReplay];
+
+            RenderFragmentHandle layer = container switch
+            {
+                CaptureContainer.FiniteLayer => context.Layer(localInputs, s_domain),
+                CaptureContainer.TargetLayerScope => context.Layer(
+                    [context.TargetLayerScope(localInputs, TargetRegion.Region(s_domain))],
+                    s_domain),
+                _ => throw new ArgumentOutOfRangeException(),
+            };
+            RenderFragmentHandle dense = context.RecordNode(_denseSource, [])[0];
+            context.Publish(context.OpaqueCombine(
+                [layer, dense],
+                CreateCombineDescription(typeof(CaptureDensityNode))));
+        }
+
+        void IBuiltInBackdropCaptureSink.CommitBackdropCapture(Bitmap bitmap, float density)
+        {
+            _committedBackdrop?.Dispose();
+            _committedBackdrop = bitmap;
+            CommittedBackdropDensity = density;
+        }
+
+        protected override void OnDispose(bool disposing)
+        {
+            _committedBackdrop?.Dispose();
+            _committedBackdrop = null;
+            _localSource.Dispose();
+            _denseSource.Dispose();
+            base.OnDispose(disposing);
+        }
+
+        private OpaqueRenderDescription CreateCaptureObserver(CaptureKind kind)
+        {
+            return OpaqueRenderDescription.CreateRequestLocal(
+                execute: session =>
+                {
+                    float density = session.Inputs.Single().EffectiveScale.Value;
+                    if (kind == CaptureKind.Public)
+                        PublicCaptureInputDensity = density;
+                    else
+                        BuiltInCaptureInputDensity = density;
+
+                    using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                    output.Canvas.Use(session.Inputs[0].Draw);
+                    session.Publish(output);
+                },
+                bounds: OpaqueRenderBoundsContract.Map(RenderBoundsContract.Identity),
+                hitTest: RenderHitTestContract.AnyInput,
+                valueCardinality: RenderValueCardinality.Single,
+                scale: RenderScaleContract.PreserveInputSupply,
+                structuralKey: new CaptureObserverIdentity(kind));
+        }
+
+        private enum CaptureKind
+        {
+            Public,
+            BuiltIn,
+        }
+
+        private readonly record struct CaptureObserverIdentity(CaptureKind Kind);
+    }
+
+    private sealed class ThinStrokeShaderNode : RenderNode
+    {
+        private static readonly ShaderDescription s_colorTimesAlpha = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return color * color.a; }");
+
+        private readonly PathGeometry _geometry;
+        private readonly Geometry.Resource _geometryResource;
+        private readonly Pen.Resource _penResource;
+        private readonly GeometryRenderNode _source;
+
+        public ThinStrokeShaderNode()
+        {
+            _geometry = PathGeometry.Parse(
+                "M18.25,83.6 C51.75,12.4 119.5,96.2 174.4,22.75");
+            _geometryResource = _geometry.ToResource(CompositionContext.Default);
+            var pen = new Pen
+            {
+                Thickness = { CurrentValue = 1.25f },
+                Brush = { CurrentValue = new SolidColorBrush(new Color(205, 225, 85, 30)) },
+                StrokeCap = { CurrentValue = StrokeCap.Round },
+                StrokeJoin = { CurrentValue = StrokeJoin.Round },
+            };
+            _penResource = pen.ToResource(CompositionContext.Default);
+            _source = new GeometryRenderNode(_geometryResource, null, _penResource);
+        }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle source = context.RecordNode(_source, [])[0];
+            context.Publish(context.Shader(source, s_colorTimesAlpha));
+        }
+
+        internal RenderNode SourceWithoutShader => _source;
+
+        protected override void OnDispose(bool disposing)
+        {
+            _source.Dispose();
+            _penResource.Dispose();
+            _geometryResource.Dispose();
+            base.OnDispose(disposing);
+        }
+    }
+
+    private static OpaqueRenderDescription CreateCombineDescription(object structuralKey)
+    {
+        return OpaqueRenderDescription.CreateRequestLocal(
+            execute: static session =>
+            {
+                using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                output.Canvas.Use(canvas =>
+                {
+                    foreach (RenderExecutionInput input in session.Inputs)
+                        input.Draw(canvas);
+                });
+                session.Publish(output);
+            },
+            bounds: OpaqueRenderBoundsContract.FullInputs(
+                static inputs => inputs.Aggregate(Rect.Empty, static (result, input) => result.Union(input)),
+                structuralKey),
+            hitTest: RenderHitTestContract.AnyInput,
+            valueCardinality: RenderValueCardinality.Single,
+            scale: RenderScaleContract.MaterializeAtWorkingScale,
+            structuralKey: structuralKey);
+    }
+
+    private sealed class CpuTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+            => new CpuRenderTarget(allocation.DeviceSize.Width, allocation.DeviceSize.Height);
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/LosslessCompositeCoverageTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/LosslessCompositeCoverageTests.cs
@@ -1,0 +1,688 @@
+﻿using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Graphics.Shapes;
+using Beutl.Graphics.Transformation;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Golden;
+
+/// <summary>
+/// Guards the "rasterize once at the final density" contract: content whose buffer already lands on
+/// exact device pixels must be copied, never resampled, and a genuine resample must stay inside the
+/// range of the samples it interpolated.
+/// </summary>
+[NonParallelizable]
+[TestFixture]
+public sealed class LosslessCompositeCoverageTests
+{
+    private static readonly PixelSize s_frame = new(200, 140);
+    private static readonly PixelSize s_fractionalFrame = new(800, 400);
+
+    [TestCase(1f)]
+    [TestCase(2f)]
+    public void EffectFreeCurvedGeometry_MatchesDirectRasterization(float density)
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Drawable.Resource resource = CreateEllipse(effect: null);
+            using Bitmap expected = RenderDirect(resource, density);
+            using Bitmap actual = RenderThroughPipeline(resource, density);
+
+            AssertByteIdentical(expected, actual, $"effect-free ellipse at density {density}");
+        });
+    }
+
+    [TestCase(1f)]
+    [TestCase(2f)]
+    public void IdentityColorEffect_PreservesEdgeCoverage(float density)
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var identity = new Brightness();
+            identity.Amount.CurrentValue = 100;
+            using Drawable.Resource plain = CreateRectangle(effect: null);
+            using Drawable.Resource filtered = CreateRectangle(identity);
+            using Bitmap expected = RenderThroughPipeline(plain, density);
+            using Bitmap actual = RenderThroughPipeline(filtered, density);
+
+            AssertByteIdentical(expected, actual, $"identity Brightness at density {density}");
+        });
+    }
+
+    [TestCase(0.25f)]
+    [TestCase(0.75f)]
+    public void IdentityColorEffect_AtFractionalDevicePosition_IsByteIdenticalToUnfiltered(float density)
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var identity = new Brightness();
+            identity.Amount.CurrentValue = 100;
+            using Drawable.Resource plain = CreateRectangle(
+                width: 301,
+                height: 201,
+                effect: null);
+            using Drawable.Resource filtered = CreateRectangle(
+                width: 301,
+                height: 201,
+                identity);
+            using Bitmap expected = RenderThroughPipeline(plain, density, s_fractionalFrame);
+            using Bitmap actual = RenderThroughPipeline(filtered, density, s_fractionalFrame);
+
+            AssertByteIdentical(
+                expected,
+                actual,
+                $"identity Brightness at fractional device position and density {density}");
+        });
+    }
+
+    [TestCase(0.25f)]
+    [TestCase(0.75f)]
+    public void IdentityColorEffect_OnFractionallyPositionedText_IsByteIdenticalToUnfiltered(float density)
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var identity = new Brightness();
+            identity.Amount.CurrentValue = 100;
+            using Drawable.Resource plain = CreateText(effect: null);
+            using Drawable.Resource filtered = CreateText(identity);
+            using Bitmap expected = RenderThroughPipeline(plain, density, s_fractionalFrame);
+            using Bitmap actual = RenderThroughPipeline(filtered, density, s_fractionalFrame);
+
+            AssertByteIdentical(
+                expected,
+                actual,
+                $"identity Brightness on fractionally positioned text at density {density}");
+        });
+    }
+
+    [TestCase(0.25f)]
+    [TestCase(0.75f)]
+    public void IdentityTypedShader_AtFractionalDevicePosition_IsByteIdenticalToUnfiltered(float density)
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Drawable.Resource plain = CreateRectangle(
+                width: 301,
+                height: 201,
+                effect: null);
+            using Drawable.Resource filtered = CreateRectangle(
+                width: 301,
+                height: 201,
+                new IdentityTypedShaderEffect());
+            using Bitmap expected = RenderThroughPipeline(plain, density, s_fractionalFrame);
+            using Bitmap actual = RenderThroughPipeline(filtered, density, s_fractionalFrame);
+
+            AssertByteIdentical(
+                expected,
+                actual,
+                $"identity typed shader at fractional device position and density {density}");
+        });
+    }
+
+    [TestCase(false, TestName = "FractionalTranslationCacheMove_LegacyFilter_MatchesUncached")]
+    [TestCase(true, TestName = "FractionalTranslationCacheMove_TypedShader_MatchesUncached")]
+    public void FractionalTranslationCacheMove_MatchesUncached(bool typedShader)
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using FilterEffect.Resource effect = CreateIdentityEffectResource(typedShader);
+            using TransformRenderNode cachedRoot = CreateCachedEffectTree(effect, translation: 0.25f);
+            using var cachedRenderer = CreateNodeRenderer(cachedRoot, useRenderCache: true);
+            using Bitmap warm = RenderNodeRendererToBitmap(cachedRenderer);
+
+            cachedRoot.Update(
+                Matrix.CreateTranslation(0.75f, 0.75f),
+                TransformOperator.Prepend);
+            using Bitmap actual = RenderNodeRendererToBitmap(cachedRenderer);
+
+            using FilterEffect.Resource controlEffect = CreateIdentityEffectResource(typedShader);
+            using TransformRenderNode controlRoot = CreateCachedEffectTree(
+                controlEffect,
+                translation: 0.75f,
+                enableCaches: false);
+            using var controlRenderer = CreateNodeRenderer(controlRoot, useRenderCache: false);
+            using Bitmap expected = RenderNodeRendererToBitmap(controlRenderer);
+
+            AssertByteIdentical(
+                expected,
+                actual,
+                $"{(typedShader ? "typed shader" : "legacy filter")} after a device-phase cache move");
+            Assert.That(
+                cachedRoot.Children[0].Cache.IsCached,
+                Is.False,
+                "A subtree rasterized against an ambient device grid must not publish a phase-ambiguous cache.");
+        });
+    }
+
+    [Test]
+    public void IntegralDestinationTranslation_UsesEffectDensityWhenRejectingPhaseAmbiguousCache()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using FilterEffect.Resource effect = CreateIdentityEffectResource(typedShader: false);
+            using TransformRenderNode cachedRoot = CreateCachedEffectTree(effect, translation: 0);
+            using var cachedRenderer = CreateNodeRenderer(
+                cachedRoot,
+                useRenderCache: true,
+                maxWorkingScale: 0.75f);
+            using Bitmap warm = RenderNodeRendererToBitmap(cachedRenderer, destinationTranslation: 1);
+            using Bitmap actual = RenderNodeRendererToBitmap(cachedRenderer, destinationTranslation: 2);
+
+            using FilterEffect.Resource controlEffect = CreateIdentityEffectResource(typedShader: false);
+            using TransformRenderNode controlRoot = CreateCachedEffectTree(
+                controlEffect,
+                translation: 0,
+                enableCaches: false);
+            using var controlRenderer = CreateNodeRenderer(
+                controlRoot,
+                useRenderCache: false,
+                maxWorkingScale: 0.75f);
+            using Bitmap expected = RenderNodeRendererToBitmap(
+                controlRenderer,
+                destinationTranslation: 2);
+
+            Assert.Multiple(() =>
+            {
+                AssertByteIdentical(
+                    expected,
+                    actual,
+                    "identity effect after an integral destination move at density 0.75");
+                Assert.That(
+                    cachedRoot.Children[0].Cache.IsCached,
+                    Is.False,
+                    "The logical destination offset must be evaluated at the effect's working density.");
+            });
+        });
+    }
+
+    [Test]
+    public void CancellingTransformChain_DoesNotPublishPhaseAmbiguousEffectCache()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using FilterEffect.Resource effect = CreateIdentityEffectResource(typedShader: true);
+            var source = new RectangleRenderNode(
+                new Rect(20, 20, 101, 81),
+                Brushes.Resource.White,
+                pen: null);
+            var filter = new FilterEffectRenderNode(effect);
+            filter.AddChild(source);
+            var inner = new TransformRenderNode(
+                Matrix.CreateScale(new Vector(0.5f, 0.5f))
+                    .Append(Matrix.CreateTranslation(0.75f, 0.75f)),
+                TransformOperator.Prepend);
+            inner.AddChild(filter);
+            using var root = new TransformRenderNode(
+                Matrix.CreateScale(new Vector(2, 2)),
+                TransformOperator.Prepend);
+            root.AddChild(inner);
+            source.Cache.ReportRenderCount(RenderNodeCache.Count);
+            filter.Cache.ReportRenderCount(RenderNodeCache.Count);
+            inner.Cache.ReportRenderCount(RenderNodeCache.Count);
+            root.Cache.ReportRenderCount(RenderNodeCache.Count);
+            using var renderer = CreateNodeRenderer(root, useRenderCache: true);
+
+            using Bitmap first = RenderNodeRendererToBitmap(renderer);
+            using Bitmap second = RenderNodeRendererToBitmap(renderer);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    filter.Cache.IsCached,
+                    Is.False,
+                    "The composed transform is translation-only even though neither transform is.");
+                AssertByteIdentical(first, second, "repeated cancelling-transform render");
+            });
+        });
+    }
+
+    [Test]
+    public void FusedShaderStages_ReportTheSameGridAwareFootprintsAsStandaloneStages()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var fusedChain = new FootprintObservingShaderChainNode();
+            using TransformRenderNode fusedRoot = WrapInFractionalTranslation(fusedChain);
+            using var fusedRenderer = CreateNodeRenderer(
+                fusedRoot,
+                useRenderCache: false,
+                fusionMode: FusionMode.Enabled);
+            using Bitmap fusedBitmap = RenderNodeRendererToBitmap(fusedRenderer);
+
+            using var standaloneChain = new FootprintObservingShaderChainNode();
+            using TransformRenderNode standaloneRoot = WrapInFractionalTranslation(standaloneChain);
+            using var standaloneRenderer = CreateNodeRenderer(
+                standaloneRoot,
+                useRenderCache: false,
+                fusionMode: FusionMode.Disabled);
+            using Bitmap standaloneBitmap = RenderNodeRendererToBitmap(standaloneRenderer);
+
+            Assert.That(fusedChain.Observations, Has.Count.EqualTo(2));
+            Assert.That(standaloneChain.Observations, Has.Count.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(fusedChain.Observations, Is.EqualTo(standaloneChain.Observations));
+                foreach (ShaderFootprintObservation observation in fusedChain.Observations)
+                {
+                    Assert.That(
+                        observation.DeviceBounds
+                            .ToRect(observation.WorkingScale)
+                            .Translate(-observation.DeviceGridOffset)
+                            .Position,
+                        Is.EqualTo(observation.LogicalOrigin));
+                }
+            });
+        });
+    }
+
+    [Test]
+    public void ScaledComposite_StaysInsideTheSourceRange()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using RenderTarget source = RenderTarget.Create(16, 16)
+                                        ?? throw new InvalidOperationException("RenderTarget.Create returned null.");
+            using (var sourceCanvas = new ImmediateCanvas(source, 1f, logicalSize: new Size(16, 16)))
+            {
+                sourceCanvas.Clear();
+                using var dark = new SKPaint { IsAntialias = false, Color = new SKColor(64, 64, 64) };
+                using var bright = new SKPaint { IsAntialias = false, Color = new SKColor(192, 192, 192) };
+                sourceCanvas.Canvas.DrawRect(SKRect.Create(0, 0, 16, 8), dark);
+                sourceCanvas.Canvas.DrawRect(SKRect.Create(0, 8, 16, 8), bright);
+            }
+
+            using RenderTarget destination = RenderTarget.Create(64, 64)
+                                             ?? throw new InvalidOperationException(
+                                                 "RenderTarget.Create returned null.");
+            using (var canvas = new ImmediateCanvas(destination, 1f, logicalSize: new Size(64, 64)))
+            {
+                canvas.Clear();
+                canvas.DrawRenderTargetScaled(source, new Rect(4, 4, 40, 40));
+            }
+
+            using Bitmap result = destination.Snapshot();
+            double darkPlateau = ReadRed(result, 22, 10);
+            double brightPlateau = ReadRed(result, 22, 38);
+            double minimum = double.PositiveInfinity;
+            double maximum = double.NegativeInfinity;
+            for (int y = 6; y < 42; y++)
+            {
+                for (int x = 6; x < 42; x++)
+                {
+                    double value = ReadRed(result, x, y);
+                    minimum = Math.Min(minimum, value);
+                    maximum = Math.Max(maximum, value);
+                }
+            }
+
+            // One RgbaF16 step near the bright plateau is ~4.9e-4, so only a real kernel lobe clears this.
+            const double halfFloatTolerance = 1e-3;
+            TestContext.WriteLine(
+                $"plateaus [{darkPlateau:F6}, {brightPlateau:F6}], resampled [{minimum:F6}, {maximum:F6}]");
+            Assert.Multiple(() =>
+            {
+                Assert.That(darkPlateau, Is.GreaterThan(0),
+                    "The scaled composite must retain the nonzero dark source plateau.");
+                Assert.That(brightPlateau, Is.GreaterThan(darkPlateau + halfFloatTolerance),
+                    "The scaled composite must retain two distinct source plateaus.");
+                Assert.That(maximum, Is.LessThanOrEqualTo(brightPlateau + halfFloatTolerance),
+                    "The resample kernel overshot the brightest sample it interpolated.");
+                Assert.That(minimum, Is.GreaterThanOrEqualTo(darkPlateau - halfFloatTolerance),
+                    "The resample kernel undershot the darkest sample it interpolated.");
+            });
+        });
+    }
+
+    private static double ReadRed(Bitmap bitmap, int x, int y)
+        => (double)BitConverter.UInt16BitsToHalf(bitmap.GetPixelSpan<ushort>()[((y * bitmap.Width) + x) * 4]);
+
+    private static PixelRect MeasureAlphaBounds(Bitmap bitmap)
+    {
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        int left = bitmap.Width;
+        int top = bitmap.Height;
+        int right = 0;
+        int bottom = 0;
+        for (int y = 0; y < bitmap.Height; y++)
+        {
+            for (int x = 0; x < bitmap.Width; x++)
+            {
+                int pixelOffset = ((y * bitmap.Width) + x) * 4;
+                float alpha = (float)BitConverter.UInt16BitsToHalf(pixels[pixelOffset + 3]);
+                Assert.That(
+                    float.IsFinite(alpha),
+                    Is.True,
+                    $"The footprint alpha at ({x}, {y}) must be finite.");
+                if (alpha <= 0)
+                    continue;
+                left = Math.Min(left, x);
+                top = Math.Min(top, y);
+                right = Math.Max(right, x + 1);
+                bottom = Math.Max(bottom, y + 1);
+            }
+        }
+
+        Assert.That(right, Is.GreaterThan(left), "The footprint fixture must render non-transparent pixels.");
+        Assert.That(bottom, Is.GreaterThan(top), "The footprint fixture must render non-transparent pixels.");
+        return new PixelRect(left, top, right - left, bottom - top);
+    }
+
+    private static void AssertByteIdentical(Bitmap expected, Bitmap actual, string scenario)
+    {
+        int differing = 0;
+        double maximum = 0;
+        ReadOnlySpan<ushort> a = expected.GetPixelSpan<ushort>();
+        ReadOnlySpan<ushort> b = actual.GetPixelSpan<ushort>();
+        for (int index = 0; index < a.Length; index++)
+        {
+            double left = (double)BitConverter.UInt16BitsToHalf(a[index]);
+            double right = (double)BitConverter.UInt16BitsToHalf(b[index]);
+            if (a[index] != b[index])
+                differing++;
+            maximum = Math.Max(maximum, Math.Abs(left - right));
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(actual.Width, Is.EqualTo(expected.Width));
+            Assert.That(actual.Height, Is.EqualTo(expected.Height));
+            Assert.That(differing, Is.Zero,
+                $"{scenario}: {differing} channels differ, maximum delta {maximum:F6}.");
+        });
+    }
+
+    private static Drawable.Resource CreateEllipse(FilterEffect? effect)
+    {
+        var shape = new EllipseShape();
+        shape.Width.CurrentValue = 120;
+        shape.Height.CurrentValue = 80;
+        return Configure(shape, effect);
+    }
+
+    private static Drawable.Resource CreateRectangle(FilterEffect? effect)
+        => CreateRectangle(120, 80, effect);
+
+    private static Drawable.Resource CreateRectangle(
+        float width,
+        float height,
+        FilterEffect? effect,
+        AlignmentX alignmentX = AlignmentX.Center,
+        AlignmentY alignmentY = AlignmentY.Center)
+    {
+        var shape = new RectShape();
+        shape.Width.CurrentValue = width;
+        shape.Height.CurrentValue = height;
+        shape.AlignmentX.CurrentValue = alignmentX;
+        shape.AlignmentY.CurrentValue = alignmentY;
+        return Configure(shape, effect);
+    }
+
+    private static Drawable.Resource CreateText(FilterEffect? effect)
+    {
+        Typeface typeface = TypefaceProvider.Typeface();
+        var text = new TextBlock();
+        text.AlignmentX.CurrentValue = AlignmentX.Center;
+        text.AlignmentY.CurrentValue = AlignmentY.Center;
+        text.FontFamily.CurrentValue = typeface.FontFamily;
+        text.FontStyle.CurrentValue = typeface.Style;
+        text.FontWeight.CurrentValue = typeface.Weight;
+        text.Size.CurrentValue = 160;
+        text.Fill.CurrentValue = Brushes.White;
+        text.Text.CurrentValue = "Phase";
+        if (effect is not null)
+            text.FilterEffect.CurrentValue = effect;
+        return text.ToResource(CompositionContext.Default);
+    }
+
+    private static Drawable.Resource Configure(Shape shape, FilterEffect? effect)
+    {
+        shape.AlignmentX.CurrentValue = AlignmentX.Center;
+        shape.AlignmentY.CurrentValue = AlignmentY.Center;
+        shape.Fill.CurrentValue = Brushes.White;
+        if (effect is not null)
+            shape.FilterEffect.CurrentValue = effect;
+        return shape.ToResource(CompositionContext.Default);
+    }
+
+    private static FilterEffect.Resource CreateIdentityEffectResource(bool typedShader)
+    {
+        FilterEffect effect;
+        if (typedShader)
+        {
+            effect = new IdentityTypedShaderEffect();
+        }
+        else
+        {
+            var brightness = new Brightness();
+            brightness.Amount.CurrentValue = 100;
+            effect = brightness;
+        }
+
+        return effect.ToResource(CompositionContext.Default);
+    }
+
+    private static TransformRenderNode CreateCachedEffectTree(
+        FilterEffect.Resource effect,
+        float translation,
+        bool enableCaches = true)
+    {
+        var source = new RectangleRenderNode(
+            new Rect(20, 20, 101, 81),
+            Brushes.Resource.White,
+            pen: null);
+        var filter = new FilterEffectRenderNode(effect);
+        filter.AddChild(source);
+        var transform = new TransformRenderNode(
+            Matrix.CreateTranslation(translation, translation),
+            TransformOperator.Prepend);
+        transform.AddChild(filter);
+        if (enableCaches)
+        {
+            source.Cache.ReportRenderCount(RenderNodeCache.Count);
+            filter.Cache.ReportRenderCount(RenderNodeCache.Count);
+            transform.Cache.ReportRenderCount(RenderNodeCache.Count);
+        }
+
+        return transform;
+    }
+
+    private static RenderNodeRenderer CreateNodeRenderer(
+        RenderNode root,
+        bool useRenderCache,
+        FusionMode fusionMode = FusionMode.Enabled,
+        float maxWorkingScale = 1)
+        => new(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    Intent = RenderIntent.Delivery,
+                    TargetDomain = new Rect(0, 0, 180, 140),
+                    OutputScale = 1,
+                    MaxWorkingScale = maxWorkingScale,
+                    CacheOptions = new Beutl.Graphics.Rendering.Cache.RenderCacheOptions(useRenderCache, Beutl.Graphics.Rendering.Cache.RenderCacheRules.Default),
+                    FusionMode = fusionMode,
+                    Purpose = RenderRequestPurpose.Frame,
+                },
+            });
+
+    private static Bitmap RenderNodeRendererToBitmap(
+        RenderNodeRenderer renderer,
+        float destinationTranslation = 0)
+    {
+        using RenderTarget target = RenderTarget.Create(180, 140)
+            ?? throw new InvalidOperationException("RenderTarget.Create returned null.");
+        using var canvas = new ImmediateCanvas(target, logicalSize: new Size(180, 140));
+        canvas.Clear();
+        using (canvas.PushTransform(
+                   Matrix.CreateTranslation(destinationTranslation, destinationTranslation)))
+        {
+            renderer.Render(canvas);
+        }
+
+        return target.Snapshot();
+    }
+
+    private static TransformRenderNode WrapInFractionalTranslation(RenderNode child)
+    {
+        var transform = new TransformRenderNode(
+            Matrix.CreateTranslation(0.75f, 0.75f),
+            TransformOperator.Prepend);
+        transform.AddChild(child);
+        return transform;
+    }
+
+    private readonly record struct ShaderFootprintObservation(
+        PixelRect DeviceBounds,
+        PixelSize DeviceSize,
+        Point LogicalOrigin,
+        Vector DeviceGridOffset,
+        float WorkingScale);
+
+    private sealed class FootprintObservingShaderChainNode : ContainerRenderNode
+    {
+        public FootprintObservingShaderChainNode()
+        {
+            AddChild(new RectangleRenderNode(
+                new Rect(20, 20, 101, 81),
+                Brushes.Resource.White,
+                pen: null));
+        }
+
+        public List<ShaderFootprintObservation> Observations { get; } = [];
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle current = context.Inputs.Single();
+            for (int stage = 0; stage < 2; stage++)
+            {
+                int capturedStage = stage;
+                ShaderDescription description = ShaderDescription.CurrentPixel(
+                    "uniform float gain; half4 apply(half4 color) { return color * gain; }",
+                    bindings => bindings.Uniform(
+                        "gain",
+                        1f,
+                        (writer, value, execution) =>
+                        {
+                            Observations.Add(new ShaderFootprintObservation(
+                                execution.DeviceBounds,
+                                execution.DeviceSize,
+                                execution.LogicalOrigin,
+                                execution.DeviceGridOffset,
+                                execution.WorkingScale));
+                            writer.Set(value);
+                        },
+                        structuralKey: (typeof(FootprintObservingShaderChainNode), capturedStage)));
+                current = context.Shader(current, description);
+            }
+
+            context.Publish(current);
+        }
+    }
+
+    private static Bitmap RenderDirect(Drawable.Resource resource, float density)
+    {
+        Shape shape = (Shape)resource.GetOriginal();
+        var shapeResource = (Shape.Resource)resource;
+        Size frameSize = s_frame.ToSize(1);
+        Size shapeSize = shape.MeasureInternal(frameSize, resource);
+        Matrix transform = shape.GetTransformMatrix(frameSize, shapeSize, resource);
+        Geometry.Resource geometry = shapeResource.GetGeometry()
+                                     ?? throw new InvalidOperationException("The shape produced no geometry.");
+
+        using RenderTarget target = CreateFrameTarget(density);
+        using var canvas = new ImmediateCanvas(target, density, logicalSize: frameSize);
+        canvas.Clear();
+        using (canvas.PushTransform(transform))
+        {
+            canvas.DrawGeometry(geometry, shapeResource.Fill, shapeResource.Pen);
+        }
+
+        return target.Snapshot();
+    }
+
+    private static Bitmap RenderThroughPipeline(Drawable.Resource resource, float density)
+        => RenderThroughPipeline(resource, density, s_frame);
+
+    private static Bitmap RenderThroughPipeline(
+        Drawable.Resource resource,
+        float density,
+        PixelSize frame)
+    {
+        using var node = new DrawableRenderNode(resource);
+        using (var context = new GraphicsContext2D(node, frame.ToSize(1), density))
+        {
+            resource.GetOriginal().Render(context, resource);
+        }
+
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    Intent = RenderIntent.Delivery,
+                    TargetDomain = new Rect(default, frame.ToSize(1)),
+                    OutputScale = density,
+                    MaxWorkingScale = density,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    Purpose = RenderRequestPurpose.Frame,
+                },
+            });
+
+        using RenderTarget target = CreateFrameTarget(density, frame);
+        using var canvas = new ImmediateCanvas(target, density, logicalSize: frame.ToSize(1));
+        canvas.Clear();
+        renderer.Render(canvas);
+        return target.Snapshot();
+    }
+
+    private static RenderTarget CreateFrameTarget(float density)
+        => CreateFrameTarget(density, s_frame);
+
+    private static RenderTarget CreateFrameTarget(float density, PixelSize frame)
+        => RenderTarget.Create(
+               (int)MathF.Ceiling(frame.Width * density),
+               (int)MathF.Ceiling(frame.Height * density))
+           ?? throw new InvalidOperationException("RenderTarget.Create returned null.");
+}
+
+[SuppressResourceClassGeneration]
+internal sealed partial class IdentityTypedShaderEffect : FilterEffect
+{
+    public override void ApplyTo(FilterEffectContext context, FilterEffect.Resource resource)
+        => context.Shader(ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return color; }"));
+
+    public override Resource ToResource(CompositionContext context)
+    {
+        var resource = new Resource();
+        bool updateOnly = true;
+        resource.Update(this, context, ref updateOnly);
+        return resource;
+    }
+
+    public new sealed class Resource : FilterEffect.Resource
+    {
+        public Resource()
+        {
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/OpaqueSourceCoverageTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/OpaqueSourceCoverageTests.cs
@@ -1,0 +1,395 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Graphics.Shapes;
+using Beutl.Graphics.Transformation;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Golden;
+
+[NonParallelizable]
+[TestFixture]
+public sealed class OpaqueSourceCoverageTests
+{
+    private static readonly PixelSize s_frame = new(200, 200);
+
+    [TestCase(1f, false)]
+    [TestCase(2f, false)]
+    [TestCase(4f, false)]
+    [TestCase(1f, true)]
+    [TestCase(2f, true)]
+    [TestCase(4f, true)]
+    public void RotatedVectorSource_PreservesDirectAntialiasedCoverage(float density, bool shifted)
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Drawable.Resource resource = CreateAliasingProneSource(shifted, legacyIdentityEffect: false);
+            using Bitmap expected = RenderDirectSource(resource, density);
+            using Bitmap actual = RenderProductionSource(resource, density, useRenderCache: false);
+
+            AssertCoverageParity(expected, actual, $"density={density}, shifted={shifted}");
+        });
+    }
+
+    [TestCase(1f)]
+    [TestCase(2f)]
+    public void LegacyIdentityFilterChain_PreservesDirectAntialiasedCoverage(float density)
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Drawable.Resource resource = CreateAliasingProneSource(
+                shifted: true,
+                legacyIdentityEffect: true);
+            using Bitmap expected = RenderDirectSource(resource, density);
+            using Bitmap actual = RenderProductionSource(resource, density, useRenderCache: false);
+
+            AssertCoverageParity(expected, actual, $"legacy identity filter, density={density}");
+        });
+    }
+
+    [Test]
+    public void RenderCacheBypass_PreservesFractionalAntialiasedCoverage()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            const float density = 2;
+            using Drawable.Resource resource = CreateAliasingProneSource(
+                shifted: true,
+                legacyIdentityEffect: false);
+            using Bitmap expected = RenderDirectSource(resource, density);
+            using DrawableRenderNode node = CreateProductionNode(resource, density);
+            node.Cache.ReportRenderCount(RenderNodeCache.Count);
+            var diagnostics = new RenderPipelineDiagnosticsState();
+            using var renderer = CreateRenderer(node, density, useRenderCache: true, diagnostics);
+            using Bitmap first = RenderWithRenderer(renderer, density);
+
+            Assert.That(
+                node.Cache.IsCached,
+                Is.False,
+                "The remapped phase-dependent source must not publish a reusable cache candidate.");
+
+            using Bitmap second = RenderWithRenderer(renderer, density);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(diagnostics.Latest[RenderPipelineCounter.RenderCacheHits], Is.Zero);
+                Assert.That(GetNonBlackExtent(second), Is.EqualTo(GetNonBlackExtent(first)));
+            });
+            AssertCoverageParity(expected, first, "first cache-bypassed render");
+            AssertCoverageParity(expected, second, "second cache-bypassed render");
+        });
+    }
+
+    [TestCase(1f)]
+    [TestCase(2f)]
+    public void RotatedDrawableBrushSource_PreservesDirectAntialiasedCoverage(float density)
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Drawable.Resource resource = CreateDrawableBrushSource();
+            using Bitmap expected = RenderDirectSource(resource, density);
+            using Bitmap actual = RenderProductionSource(resource, density, useRenderCache: false);
+
+            AssertCoverageParity(expected, actual, $"rotated DrawableBrush, density={density}");
+        });
+    }
+
+    [TestCase(1f)]
+    [TestCase(2f)]
+    public void RotatedFallbackBrushSource_PreservesTransparentCompatibility(float density)
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Drawable.Resource resource = CreateFallbackBrushSource();
+            using Bitmap expected = RenderDirectSource(resource, density);
+            using Bitmap actual = RenderProductionSource(resource, density, useRenderCache: false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetNonBlackExtent(expected), Is.EqualTo(default(PixelRect)),
+                    "The in-tree fallback for an unknown Brush resource is transparent.");
+                Assert.That(GetNonBlackExtent(actual), Is.EqualTo(default(PixelRect)));
+                Assert.That(
+                    actual.GetPixelSpan<ushort>().SequenceEqual(expected.GetPixelSpan<ushort>()),
+                    Is.True);
+            });
+        });
+    }
+
+    private static Bitmap RenderDirectSource(Drawable.Resource resource, float density)
+    {
+        RectShape shape = (RectShape)resource.GetOriginal();
+        var shapeResource = (RectShape.Resource)resource;
+        Size frameSize = s_frame.ToSize(1);
+        Size shapeSize = shape.MeasureInternal(frameSize, resource);
+        Matrix transform = shape.GetTransformMatrix(frameSize, shapeSize, resource);
+
+        int deviceWidth = (int)MathF.Ceiling(s_frame.Width * density);
+        int deviceHeight = (int)MathF.Ceiling(s_frame.Height * density);
+        using RenderTarget target = RenderTarget.Create(deviceWidth, deviceHeight)
+                                    ?? throw new InvalidOperationException("RenderTarget.Create returned null.");
+        using var canvas = new ImmediateCanvas(target, density, logicalSize: frameSize);
+        canvas.Clear();
+        Geometry.Resource geometry = shapeResource.GetGeometry()
+            ?? throw new InvalidOperationException("RectShape did not produce geometry.");
+        using (canvas.PushTransform(transform))
+        {
+            if (shapeResource.Fill is DrawableBrush.Resource drawableBrush
+                && drawableBrush.Drawable is { } drawable)
+            {
+                using RenderNodeRasterization content = RasterizeDrawableBrushContent(
+                    drawable,
+                    geometry.Bounds.Size,
+                    density);
+                Bitmap bitmap = content.Bitmap
+                    ?? throw new InvalidOperationException("DrawableBrush content rasterized empty.");
+                PixelRect deviceBounds = PixelRect.FromRect(content.Bounds, density);
+                using SKImage image = SKImage.FromBitmap(bitmap.SKBitmap);
+                using SKShader shader = image.ToShader(
+                    SKShaderTileMode.Decal,
+                    SKShaderTileMode.Decal,
+                    SKSamplingOptions.Default,
+                    SKMatrix.CreateScaleTranslation(
+                        1f / density,
+                        1f / density,
+                        deviceBounds.X / density,
+                        deviceBounds.Y / density));
+                var fill = new LoweredBrush(
+                    null,
+                    shapeResource.Fill,
+                    new BrushTileContent(shader, content.Bounds, EffectiveScale.At(density)));
+                canvas.DrawGeometry(geometry, fill, LoweredPen.Empty);
+            }
+            else
+            {
+                canvas.DrawGeometry(geometry, shapeResource.Fill, shapeResource.Pen);
+            }
+        }
+
+        return target.Snapshot();
+    }
+
+    private static RenderNodeRasterization RasterizeDrawableBrushContent(
+        Drawable.Resource drawable,
+        Size brushSize,
+        float density)
+    {
+        using var node = new DrawableRenderNode(drawable);
+        using (var context = new GraphicsContext2D(node, brushSize, density))
+        {
+            drawable.GetOriginal().Render(context, drawable);
+        }
+
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    Intent = RenderIntent.Delivery,
+                    OutputScale = density,
+                    MaxWorkingScale = density,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    Purpose = RenderRequestPurpose.Auxiliary,
+                },
+            });
+        return renderer.Rasterize();
+    }
+
+    private static Bitmap RenderProductionSource(
+        Drawable.Resource resource,
+        float density,
+        bool useRenderCache)
+    {
+        using DrawableRenderNode node = CreateProductionNode(resource, density);
+        using var renderer = CreateRenderer(node, density, useRenderCache, diagnostics: null);
+        return RenderWithRenderer(renderer, density);
+    }
+
+    private static DrawableRenderNode CreateProductionNode(Drawable.Resource resource, float density)
+    {
+        var node = new DrawableRenderNode(resource);
+        using var context = new GraphicsContext2D(node, s_frame.ToSize(1), density);
+        resource.GetOriginal().Render(context, resource);
+        return node;
+    }
+
+    private static RenderNodeRenderer CreateRenderer(
+        RenderNode node,
+        float density,
+        bool useRenderCache,
+        IRenderPipelineDiagnosticsState? diagnostics)
+        => new(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    Intent = RenderIntent.Delivery,
+                    TargetDomain = new Rect(default, s_frame.ToSize(1)),
+                    OutputScale = density,
+                    MaxWorkingScale = density,
+                    CacheOptions = new Beutl.Graphics.Rendering.Cache.RenderCacheOptions(useRenderCache, Beutl.Graphics.Rendering.Cache.RenderCacheRules.Default),
+                    Purpose = RenderRequestPurpose.Frame,
+                    Diagnostics = diagnostics,
+                },
+            });
+
+    private static Bitmap RenderWithRenderer(RenderNodeRenderer renderer, float density)
+    {
+        int deviceWidth = (int)MathF.Ceiling(s_frame.Width * density);
+        int deviceHeight = (int)MathF.Ceiling(s_frame.Height * density);
+        using RenderTarget target = RenderTarget.Create(deviceWidth, deviceHeight)
+                                    ?? throw new InvalidOperationException("RenderTarget.Create returned null.");
+        using var canvas = new ImmediateCanvas(target, density, logicalSize: s_frame.ToSize(1));
+        canvas.Clear();
+        renderer.Render(canvas);
+        return target.Snapshot();
+    }
+
+    private static Drawable.Resource CreateAliasingProneSource(bool shifted, bool legacyIdentityEffect)
+    {
+        var shape = new RectShape();
+        shape.AlignmentX.CurrentValue = AlignmentX.Center;
+        shape.AlignmentY.CurrentValue = AlignmentY.Center;
+        shape.TransformOrigin.CurrentValue = RelativePoint.Center;
+        shape.Width.CurrentValue = 150;
+        shape.Height.CurrentValue = 18;
+        shape.Fill.CurrentValue = Brushes.White;
+        var transform = new TransformGroup();
+        transform.Children.Add(new RotationTransform(27));
+        if (shifted)
+            transform.Children.Add(new TranslateTransform(0.25f, 0.5f));
+        shape.Transform.CurrentValue = transform;
+        if (legacyIdentityEffect)
+        {
+            var effect = new TransformEffect();
+            effect.Transform.CurrentValue = new MatrixTransform(Matrix.Identity);
+            shape.FilterEffect.CurrentValue = effect;
+        }
+
+        return shape.ToResource(CompositionContext.Default);
+    }
+
+    private static Drawable.Resource CreateDrawableBrushSource()
+    {
+        var content = new RectShape();
+        content.AlignmentX.CurrentValue = AlignmentX.Center;
+        content.AlignmentY.CurrentValue = AlignmentY.Center;
+        content.Width.CurrentValue = 76;
+        content.Height.CurrentValue = 44;
+        content.Fill.CurrentValue = Brushes.White;
+
+        var brush = new DrawableBrush(content);
+        brush.Stretch.CurrentValue = Stretch.Fill;
+        brush.TileMode.CurrentValue = TileMode.None;
+        brush.DestinationRect.CurrentValue = RelativeRect.Fill;
+
+        var shape = new RectShape();
+        shape.AlignmentX.CurrentValue = AlignmentX.Center;
+        shape.AlignmentY.CurrentValue = AlignmentY.Center;
+        shape.TransformOrigin.CurrentValue = RelativePoint.Center;
+        shape.Width.CurrentValue = 146;
+        shape.Height.CurrentValue = 82;
+        shape.Fill.CurrentValue = brush;
+        var transform = new TransformGroup();
+        transform.Children.Add(new RotationTransform(27));
+        transform.Children.Add(new TranslateTransform(0.25f, 0.5f));
+        shape.Transform.CurrentValue = transform;
+        return shape.ToResource(CompositionContext.Default);
+    }
+
+    private static Drawable.Resource CreateFallbackBrushSource()
+    {
+        var shape = new RectShape();
+        shape.AlignmentX.CurrentValue = AlignmentX.Center;
+        shape.AlignmentY.CurrentValue = AlignmentY.Center;
+        shape.TransformOrigin.CurrentValue = RelativePoint.Center;
+        shape.Width.CurrentValue = 146;
+        shape.Height.CurrentValue = 82;
+        shape.Fill.CurrentValue = new FallbackBrush();
+        var transform = new TransformGroup();
+        transform.Children.Add(new RotationTransform(27));
+        transform.Children.Add(new TranslateTransform(0.25f, 0.5f));
+        shape.Transform.CurrentValue = transform;
+        return shape.ToResource(CompositionContext.Default);
+    }
+
+    private static void AssertCoverageParity(Bitmap expected, Bitmap actual, string scenario)
+    {
+        RgbaMaximumError maximum = ImageMetrics.MaximumAbsoluteErrorPerChannel(expected, actual);
+        RgbaMaximumError edgeMaximum = ImageMetrics.EdgeBandMaximumAbsoluteErrorPerChannel(expected, actual);
+        PixelRect expectedExtent = GetNonBlackExtent(expected);
+        int fractionalReferencePixels = CountFractionalAlphaPixels(expected);
+        TestContext.WriteLine(
+            $"{scenario}: extent={GetNonBlackExtent(actual)}, max={maximum.Maximum:F6}, edge-max={edgeMaximum.Maximum:F6}");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(actual.Width, Is.EqualTo(expected.Width));
+            Assert.That(actual.Height, Is.EqualTo(expected.Height));
+            Assert.That(expectedExtent, Is.Not.EqualTo(default(PixelRect)),
+                "The antialiased reference must have nonempty visible coverage.");
+            Assert.That(fractionalReferencePixels, Is.GreaterThan(0),
+                "The antialiased reference must contain fractional-alpha edge coverage.");
+            Assert.That(
+                GetNonBlackExtent(actual),
+                Is.EqualTo(expectedExtent),
+                "Materialization must retain the complete antialiased coverage fringe.");
+            Assert.That(maximum.Maximum, Is.LessThanOrEqualTo(0.02),
+                "Materialization introduced a visible whole-frame pixel error.");
+            Assert.That(edgeMaximum.Maximum, Is.LessThanOrEqualTo(0.02),
+                "Materialization changed an antialiased edge pixel.");
+        });
+    }
+
+    private static int CountFractionalAlphaPixels(Bitmap bitmap)
+    {
+        int count = 0;
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        for (int index = 3; index < pixels.Length; index += 4)
+        {
+            float alpha = (float)BitConverter.UInt16BitsToHalf(pixels[index]);
+            Assert.That(float.IsFinite(alpha), Is.True, "Reference alpha must be finite.");
+            if (alpha > 0 && alpha < 1)
+                count++;
+        }
+
+        return count;
+    }
+
+    private static PixelRect GetNonBlackExtent(Bitmap bitmap)
+    {
+        int minX = bitmap.Width;
+        int minY = bitmap.Height;
+        int maxX = -1;
+        int maxY = -1;
+        for (int y = 0; y < bitmap.Height; y++)
+        {
+            for (int x = 0; x < bitmap.Width; x++)
+            {
+                var color = bitmap.SKBitmap.GetPixel(x, y);
+                if (color.Red <= 1 && color.Green <= 1 && color.Blue <= 1)
+                    continue;
+
+                minX = Math.Min(minX, x);
+                minY = Math.Min(minY, y);
+                maxX = Math.Max(maxX, x);
+                maxY = Math.Max(maxY, y);
+            }
+        }
+
+        if (maxX < minX)
+            return default;
+        return new PixelRect(minX, minY, maxX - minX + 1, maxY - minY + 1);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/Rgba16fGoldenStore.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/Rgba16fGoldenStore.cs
@@ -1,0 +1,190 @@
+﻿using System.Buffers.Binary;
+using System.Security.Cryptography;
+
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Golden;
+
+/// <summary>
+/// Reads and writes immutable, row-packed, linear-premultiplied RGBA16F golden images.
+/// </summary>
+/// <remarks>
+/// The artifact is the raw payload required by the evidence contract: row-major RGBA half-float bit patterns
+/// encoded little-endian, without a header. Dimensions live in the provenance manifest and are required when
+/// reading. Row padding and host byte order never enter the artifact.
+/// </remarks>
+internal static class Rgba16fGoldenStore
+{
+    private const int BytesPerChannel = sizeof(ushort);
+    private const int ChannelCount = 4;
+    private const int BytesPerPixel = BytesPerChannel * ChannelCount;
+
+    public const string Extension = ".rgba16f";
+
+    /// <summary>
+    /// Writes a new golden artifact. An existing artifact is never replaced.
+    /// </summary>
+    public static void Write(string path, Bitmap bitmap)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(bitmap);
+        EnsureCanonicalBitmap(bitmap, nameof(bitmap));
+
+        string fullPath = Path.GetFullPath(path);
+        string directory = Path.GetDirectoryName(fullPath)!;
+        Directory.CreateDirectory(directory);
+
+        string temporaryPath = Path.Combine(
+            directory,
+            $".{Path.GetFileName(fullPath)}.{Guid.NewGuid():N}.tmp");
+
+        try
+        {
+            using (var stream = new FileStream(
+                       temporaryPath,
+                       FileMode.CreateNew,
+                       FileAccess.Write,
+                       FileShare.None,
+                       bufferSize: 64 * 1024,
+                       FileOptions.SequentialScan))
+            {
+                WritePixels(stream, bitmap);
+                stream.Flush(flushToDisk: true);
+            }
+
+            File.Move(temporaryPath, fullPath, overwrite: false);
+        }
+        finally
+        {
+            File.Delete(temporaryPath);
+        }
+    }
+
+    /// <summary>
+    /// Reads a raw golden artifact into an owned linear-premultiplied RGBA16F bitmap.
+    /// </summary>
+    public static Bitmap Read(string path, int width, int height)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        if (width <= 0)
+            throw new ArgumentOutOfRangeException(nameof(width));
+        if (height <= 0)
+            throw new ArgumentOutOfRangeException(nameof(height));
+
+        using var stream = new FileStream(
+            path,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 64 * 1024,
+            FileOptions.SequentialScan);
+
+        long payloadLength;
+        try
+        {
+            payloadLength = checked((long)width * height * BytesPerPixel);
+        }
+        catch (OverflowException ex)
+        {
+            throw new InvalidDataException($"RGBA16F golden dimensions overflow in {path}.", ex);
+        }
+
+        if (stream.Length != payloadLength)
+        {
+            throw new InvalidDataException(
+                $"RGBA16F golden length mismatch in {path}: expected {payloadLength} bytes for {width}x{height}, "
+                + $"found {stream.Length}.");
+        }
+
+        var bitmap = new Bitmap(
+            width,
+            height,
+            BitmapColorType.RgbaF16,
+            BitmapAlphaType.Premul,
+            BitmapColorSpace.LinearSrgb);
+
+        try
+        {
+            ReadPixels(stream, bitmap, path);
+            return bitmap;
+        }
+        catch
+        {
+            bitmap.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>Computes the lowercase SHA-256 digest of the complete canonical artifact.</summary>
+    public static string ComputeSha256(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        using FileStream stream = File.OpenRead(path);
+        return Convert.ToHexStringLower(SHA256.HashData(stream));
+    }
+
+    private static void WritePixels(Stream stream, Bitmap bitmap)
+    {
+        byte[] encodedRow = GC.AllocateUninitializedArray<byte>(checked(bitmap.Width * BytesPerPixel));
+        for (int y = 0; y < bitmap.Height; y++)
+        {
+            ReadOnlySpan<ushort> source = bitmap.GetRow<ushort>(y);
+            for (int i = 0; i < source.Length; i++)
+            {
+                BinaryPrimitives.WriteUInt16LittleEndian(encodedRow.AsSpan(i * BytesPerChannel), source[i]);
+            }
+
+            stream.Write(encodedRow);
+        }
+    }
+
+    private static void ReadPixels(Stream stream, Bitmap bitmap, string path)
+    {
+        byte[] encodedRow = GC.AllocateUninitializedArray<byte>(checked(bitmap.Width * BytesPerPixel));
+        for (int y = 0; y < bitmap.Height; y++)
+        {
+            ReadExactly(stream, encodedRow, path);
+            Span<ushort> destination = bitmap.GetRow<ushort>(y);
+            for (int i = 0; i < destination.Length; i++)
+            {
+                destination[i] = BinaryPrimitives.ReadUInt16LittleEndian(encodedRow.AsSpan(i * BytesPerChannel));
+            }
+        }
+    }
+
+    private static void ReadExactly(Stream stream, Span<byte> destination, string path)
+    {
+        int read = 0;
+        while (read < destination.Length)
+        {
+            int count = stream.Read(destination[read..]);
+            if (count == 0)
+            {
+                throw new InvalidDataException(
+                    $"Truncated RGBA16F golden artifact {path}: read {read} of {destination.Length} requested bytes.");
+            }
+
+            read += count;
+        }
+    }
+
+    private static void EnsureCanonicalBitmap(Bitmap bitmap, string parameterName)
+    {
+        if (bitmap.Width <= 0 || bitmap.Height <= 0)
+        {
+            throw new ArgumentException(
+                "Golden images must have positive dimensions.",
+                parameterName);
+        }
+
+        if (bitmap.ColorType != BitmapColorType.RgbaF16
+            || bitmap.AlphaType != BitmapAlphaType.Premul
+            || bitmap.ColorSpace != BitmapColorSpace.LinearSrgb)
+        {
+            throw new ArgumentException(
+                "Golden images must use linear-sRGB, premultiplied RgbaF16 pixels.",
+                parameterName);
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/Rgba16fGoldenStoreTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/Rgba16fGoldenStoreTests.cs
@@ -1,0 +1,171 @@
+﻿using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Golden;
+
+[TestFixture]
+public sealed class Rgba16fGoldenStoreTests
+{
+    private string _temporaryDirectory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _temporaryDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"beutl-rgba16f-golden-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_temporaryDirectory);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_temporaryDirectory))
+            Directory.Delete(_temporaryDirectory, recursive: true);
+    }
+
+    [Test]
+    public void WriteAndRead_RoundTripsRawHalfBitsAndMetadata()
+    {
+        const int width = 3;
+        const int height = 2;
+        using var source = new Bitmap(
+            width,
+            height,
+            BitmapColorType.RgbaF16,
+            BitmapAlphaType.Premul,
+            BitmapColorSpace.LinearSrgb);
+
+        for (int y = 0; y < height; y++)
+        {
+            Span<ushort> row = source.GetRow<ushort>(y);
+            for (int i = 0; i < row.Length; i++)
+            {
+                row[i] = unchecked((ushort)(0x1000 + y * row.Length + i));
+            }
+        }
+
+        string path = Path.Combine(_temporaryDirectory, "round-trip" + Rgba16fGoldenStore.Extension);
+        Rgba16fGoldenStore.Write(path, source);
+        using Bitmap restored = Rgba16fGoldenStore.Read(path, width, height);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(new FileInfo(path).Length, Is.EqualTo(width * height * 8));
+            Assert.That(restored.Width, Is.EqualTo(width));
+            Assert.That(restored.Height, Is.EqualTo(height));
+            Assert.That(restored.ColorType, Is.EqualTo(BitmapColorType.RgbaF16));
+            Assert.That(restored.AlphaType, Is.EqualTo(BitmapAlphaType.Premul));
+            Assert.That(restored.ColorSpace, Is.EqualTo(BitmapColorSpace.LinearSrgb));
+        });
+
+        for (int y = 0; y < height; y++)
+        {
+            Assert.That(restored.GetRow<ushort>(y).ToArray(), Is.EqualTo(source.GetRow<ushort>(y).ToArray()));
+        }
+    }
+
+    [Test]
+    public void Write_UsesHeaderlessLittleEndianPayload_AndHashesCompleteBlob()
+    {
+        using var source = new Bitmap(
+            1,
+            1,
+            BitmapColorType.RgbaF16,
+            BitmapAlphaType.Premul,
+            BitmapColorSpace.LinearSrgb);
+        Span<ushort> pixel = source.GetRow<ushort>(0);
+        pixel[0] = BitConverter.HalfToUInt16Bits((Half)0.5f);
+        pixel[1] = BitConverter.HalfToUInt16Bits((Half)0.25f);
+        pixel[2] = BitConverter.HalfToUInt16Bits((Half)0f);
+        pixel[3] = BitConverter.HalfToUInt16Bits((Half)1f);
+
+        string path = Path.Combine(_temporaryDirectory, "canonical" + Rgba16fGoldenStore.Extension);
+        Rgba16fGoldenStore.Write(path, source);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                File.ReadAllBytes(path),
+                Is.EqualTo(new byte[] { 0x00, 0x38, 0x00, 0x34, 0x00, 0x00, 0x00, 0x3c }));
+            Assert.That(
+                Rgba16fGoldenStore.ComputeSha256(path),
+                Is.EqualTo("0def1baa18cbddd7a49b5460d10dd76b2131885086197380111c3e3ed51408a9"));
+        });
+    }
+
+    [Test]
+    public void Write_ExistingArtifactIsNeverReplaced()
+    {
+        using var original = CreateFlat(0.25f);
+        using var replacement = CreateFlat(0.75f);
+        string path = Path.Combine(_temporaryDirectory, "immutable" + Rgba16fGoldenStore.Extension);
+
+        Rgba16fGoldenStore.Write(path, original);
+        byte[] frozen = File.ReadAllBytes(path);
+
+        Assert.That(() => Rgba16fGoldenStore.Write(path, replacement), Throws.InstanceOf<IOException>());
+        Assert.That(File.ReadAllBytes(path), Is.EqualTo(frozen));
+        Assert.That(Directory.GetFiles(_temporaryDirectory, "*.tmp", SearchOption.TopDirectoryOnly), Is.Empty);
+    }
+
+    [Test]
+    public void Read_RejectsLengthThatDoesNotMatchManifestDimensions()
+    {
+        using var source = CreateFlat(0.5f);
+        string path = Path.Combine(_temporaryDirectory, "length" + Rgba16fGoldenStore.Extension);
+        Rgba16fGoldenStore.Write(path, source);
+
+        Assert.That(() => Rgba16fGoldenStore.Read(path, 2, 1), Throws.TypeOf<InvalidDataException>());
+    }
+
+    [Test]
+    public void Write_RejectsNoncanonicalBitmapMetadata()
+    {
+        using var unpremultiplied = new Bitmap(
+            1,
+            1,
+            BitmapColorType.RgbaF16,
+            BitmapAlphaType.Unpremul,
+            BitmapColorSpace.LinearSrgb);
+        string path = Path.Combine(_temporaryDirectory, "invalid" + Rgba16fGoldenStore.Extension);
+
+        Assert.That(
+            () => Rgba16fGoldenStore.Write(path, unpremultiplied),
+            Throws.ArgumentException.With.Property("ParamName").EqualTo("bitmap"));
+        Assert.That(File.Exists(path), Is.False);
+    }
+
+    [TestCase(0, 1)]
+    [TestCase(1, 0)]
+    public void Write_RejectsNonpositiveBitmapDimensions(int width, int height)
+    {
+        using var empty = new Bitmap(
+            width,
+            height,
+            BitmapColorType.RgbaF16,
+            BitmapAlphaType.Premul,
+            BitmapColorSpace.LinearSrgb);
+        string path = Path.Combine(_temporaryDirectory, "empty" + Rgba16fGoldenStore.Extension);
+
+        Assert.That(
+            () => Rgba16fGoldenStore.Write(path, empty),
+            Throws.ArgumentException.With.Property("ParamName").EqualTo("bitmap"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(File.Exists(path), Is.False);
+            Assert.That(Directory.GetFiles(_temporaryDirectory), Is.Empty);
+        });
+    }
+
+    private static Bitmap CreateFlat(float value)
+    {
+        var bitmap = new Bitmap(
+            1,
+            1,
+            BitmapColorType.RgbaF16,
+            BitmapAlphaType.Premul,
+            BitmapColorSpace.LinearSrgb);
+        bitmap.GetRow<ushort>(0).Fill(BitConverter.HalfToUInt16Bits((Half)value));
+        return bitmap;
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/ShaderMatrixUniformTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/ShaderMatrixUniformTests.cs
@@ -1,0 +1,246 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Golden;
+
+// SkSL reads matrix uniform data column-major. A canonical SKMatrix value that kept Skia's row-major storage
+// order would reach the shader transposed, which for an affine matrix silently drops the translation column.
+[NonParallelizable]
+[TestFixture]
+public class ShaderMatrixUniformTests
+{
+    private const int Width = 200;
+    private const int Height = 200;
+
+    // Chosen so the shifted rect stays fully inside the frame and no probe lands on an antialiased edge.
+    private const int TranslationX = 60;
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void SkMatrixUniform_TranslatesSampledCoordinatesByItsTranslationColumn()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var identity = new SampleOffsetNode(SKMatrix.CreateIdentity());
+            using var translated = new SampleOffsetNode(SKMatrix.CreateTranslation(TranslationX, 0));
+
+            using Bitmap unshifted = Render(identity);
+            using Bitmap shifted = Render(translated);
+
+            (int dx, int dy, double error) = BestIntegerShift(unshifted, shifted, 96);
+            TestContext.WriteLine(
+                $"identity coverage={CoveredPixelCount(unshifted)} shifted coverage={CoveredPixelCount(shifted)} "
+                + $"best shift=({dx},{dy}) error={error:F6} error@0={ShiftedMeanAbsoluteError(unshifted, shifted, 0, 0):F6}");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    ImageMetrics.FirstNonFinite(("unshifted", unshifted), ("shifted", shifted)),
+                    Is.Null);
+
+                // Non-vacuity: an empty source would match at every candidate shift.
+                Assert.That(
+                    CoveredPixelCount(unshifted),
+                    Is.GreaterThan(Width * Height / 8),
+                    "the identity-matrix render must contain substantial opaque coverage.");
+
+                // A dropped translation column leaves the best match at (0, 0).
+                Assert.That(dx, Is.EqualTo(-TranslationX));
+                Assert.That(dy, Is.Zero);
+
+                // An integer translation resolves to exact texel fetches; measured 0.000000 on Vulkan.
+                Assert.That(error, Is.LessThan(0.005));
+            });
+        });
+    }
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void SkMatrixUniform_MatchesAnExplicitColumnMajorFloatSequence()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var matrix = SKMatrix.CreateScaleTranslation(0.5f, 2f, TranslationX, 24);
+            using var viaMatrix = new SampleOffsetNode(matrix);
+            using var viaFloats = new SampleOffsetNode(
+            [
+                matrix.ScaleX, matrix.SkewY, matrix.Persp0,
+                matrix.SkewX, matrix.ScaleY, matrix.Persp1,
+                matrix.TransX, matrix.TransY, matrix.Persp2,
+            ]);
+
+            using Bitmap fromMatrix = Render(viaMatrix);
+            using Bitmap fromFloats = Render(viaFloats);
+
+            GoldenImageHarness.AssertByteIdentical(fromFloats, fromMatrix);
+        });
+    }
+
+    private static Bitmap Render(RenderNode node)
+    {
+        using RenderTarget target = RenderTarget.Create(Width, Height)
+            ?? throw new InvalidOperationException("Could not allocate the matrix-uniform target.");
+        using (var canvas = new ImmediateCanvas(target, 1, 1, new Size(Width, Height)))
+        {
+            canvas.Clear();
+            using var renderer = new RenderNodeRenderer(
+                node,
+                new RenderNodeRendererOptions
+                {
+                    DefaultRequest = new RenderNodeRenderRequest
+                    {
+                        TargetDomain = new Rect(0, 0, Width, Height),
+                        OutputScale = 1,
+                        MaxWorkingScale = 1,
+                        CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    },
+                });
+            renderer.Render(canvas);
+        }
+
+        return target.Snapshot();
+    }
+
+    /// <summary>
+    /// Returns the integer shift within <paramref name="radius"/> that best aligns <paramref name="shifted"/>
+    /// onto <paramref name="reference"/>, together with the mean absolute error at that shift.
+    /// </summary>
+    private static (int Dx, int Dy, double Error) BestIntegerShift(Bitmap reference, Bitmap shifted, int radius)
+    {
+        int bestDx = 0;
+        int bestDy = 0;
+        double bestError = double.PositiveInfinity;
+
+        for (int dy = -radius; dy <= radius; dy++)
+        {
+            for (int dx = -radius; dx <= radius; dx++)
+            {
+                double error = ShiftedMeanAbsoluteError(reference, shifted, dx, dy);
+                if (error < bestError)
+                {
+                    bestError = error;
+                    bestDx = dx;
+                    bestDy = dy;
+                }
+            }
+        }
+
+        return (bestDx, bestDy, bestError);
+    }
+
+    // Every output pixel contributes, with out-of-frame reference samples read as transparent. Averaging over
+    // the overlap instead would make a large shift with a near-empty overlap the cheapest match.
+    private static double ShiftedMeanAbsoluteError(Bitmap reference, Bitmap shifted, int dx, int dy)
+    {
+        double sum = 0;
+        for (int y = 0; y < Height; y++)
+        {
+            int sourceY = y - dy;
+            bool rowInRange = sourceY >= 0 && sourceY < Height;
+            ReadOnlySpan<ushort> referenceRow = rowInRange ? reference.GetRow<ushort>(sourceY) : default;
+            ReadOnlySpan<ushort> shiftedRow = shifted.GetRow<ushort>(y);
+            for (int x = 0; x < Width; x++)
+            {
+                int sourceX = x - dx;
+                bool inRange = rowInRange && sourceX >= 0 && sourceX < Width;
+                for (int channel = 0; channel < 4; channel++)
+                {
+                    float a = inRange
+                        ? (float)BitConverter.UInt16BitsToHalf(referenceRow[(sourceX * 4) + channel])
+                        : 0f;
+                    float b = (float)BitConverter.UInt16BitsToHalf(shiftedRow[(x * 4) + channel]);
+                    sum += Math.Abs(a - b);
+                }
+            }
+        }
+
+        return sum / ((double)Width * Height * 4);
+    }
+
+    private static long CoveredPixelCount(Bitmap bitmap)
+    {
+        long count = 0;
+        for (int y = 0; y < Height; y++)
+        {
+            ReadOnlySpan<ushort> row = bitmap.GetRow<ushort>(y);
+            for (int x = 0; x < Width; x++)
+            {
+                if ((float)BitConverter.UInt16BitsToHalf(row[(x * 4) + 3]) > 0.5f)
+                    count++;
+            }
+        }
+
+        return count;
+    }
+
+    // Samples the upstream source through a float3x3 uniform. The bounds contract keeps the full frame so a
+    // translated sample stays inside the stage output instead of being cropped away.
+    private sealed class SampleOffsetNode : RenderNode
+    {
+        private const string Source =
+            """
+            uniform shader src;
+            uniform float3x3 xform;
+
+            half4 main(float2 coord) {
+                float3 mapped = xform * float3(coord, 1.0);
+                return src.eval(mapped.xy);
+            }
+            """;
+
+        private static readonly RenderBoundsContract s_bounds = RenderBoundsContract.CreateFullInput(
+            static input => input.Inflate(96),
+            "matrix-uniform-probe");
+
+        private readonly RectGeometry _geometry;
+        private readonly Geometry.Resource _geometryResource;
+        private readonly Brush.Resource _fillResource;
+        private readonly GeometryRenderNode _source;
+        private readonly ShaderDescription _description;
+
+        public SampleOffsetNode(SKMatrix matrix)
+            : this(bindings => bindings.Uniform("xform", matrix))
+        {
+        }
+
+        public SampleOffsetNode(float[] columnMajor)
+            : this(bindings => bindings.Uniform("xform", columnMajor))
+        {
+        }
+
+        private SampleOffsetNode(Action<ShaderBindingBuilder> bindings)
+        {
+            _geometry = new RectGeometry
+            {
+                Width = { CurrentValue = 96 },
+                Height = { CurrentValue = 96 },
+            };
+            _geometryResource = _geometry.ToResource(CompositionContext.Default);
+            _fillResource = new SolidColorBrush(new Color(255, 220, 120, 40))
+                .ToResource(CompositionContext.Default);
+            _source = new GeometryRenderNode(_geometryResource, _fillResource, null);
+            _description = ShaderDescription.WholeSource(Source, s_bounds, bindings);
+        }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle source = context.RecordNode(_source, [])[0];
+            context.Publish(context.Shader(source, _description));
+        }
+
+        protected override void OnDispose(bool disposing)
+        {
+            _source.Dispose();
+            _fillResource.Dispose();
+            _geometryResource.Dispose();
+            base.OnDispose(disposing);
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/SplitTransformEffectCombinationTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/SplitTransformEffectCombinationTests.cs
@@ -1,0 +1,215 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Shapes;
+using Beutl.Graphics.Transformation;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Golden;
+
+// Guards SplitEffect combined with TransformEffect(ApplyToTarget=false) in both orders.
+//
+// The two orders reach different branches of FilterEffectContext.Transform. SplitEffect is a CustomEffect, so
+// it leaves the context bounds symbolic: a TransformEffect placed after it resolves one shared matrix from the
+// combined target bounds at execution time, while a TransformEffect placed before it resolves from the still
+// concrete bounds immediately. Each order therefore gets an oracle rendered in this same process, which keeps
+// the gate free of any checked-in baseline, machine-local snapshot directory, or inter-test ordering.
+[NonParallelizable]
+[TestFixture]
+public class SplitTransformEffectCombinationTests
+{
+    private static readonly PixelSize Frame = new(200, 200);
+
+    private const float ShapeRotation = 21f;
+    private const float EffectRotation = 45f;
+    private const float EffectScaleX = 120f;
+    private const float EffectScaleY = 100f;
+
+    // Each oracle reaches the same geometry through a different blit, so resampling differs at tile edges.
+    // TransformEffectEquivalenceTests uses the same bound against the same drawable-transform oracle.
+    // Measured on Vulkan: 0.9964 for the deferred order, 0.9995 for the concrete order.
+    private const double MinimumOracleSsim = 0.97;
+
+    // Measured order divergence is 0.2633, two orders of magnitude above this floor.
+    private const double MinimumOrderDivergence = 0.01;
+
+    // A transformed 140x90 shape split into nine tiles fills well over this share of a 200x200 frame.
+    private const double MinimumCoverageRatio = 0.05;
+
+    // The transform resolves at execution time here, so its oracle is the same transform applied once to the
+    // whole split result through the drawable's own Transform, a path with no deferred resolution at all.
+    [Test]
+    public void SplitThenTransformFilter_ExecutionTimeBoundsMatchTheDrawableTransform()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Bitmap viaEffect = Render(SplitThenTransform(), ShapeTransform());
+            using Bitmap viaDrawableTransform = Render(MakeSplit(), ShapeThenEffectTransform());
+
+            AssertOracleMatch(viaEffect, viaDrawableTransform, "SplitThenTransform");
+        });
+    }
+
+    // The transform resolves from concrete bounds here, so ApplyToTarget=true — which computes the same matrix
+    // from the single target it is handed — is an equivalent independent path.
+    [Test]
+    public void TransformFilterThenSplit_ConcreteBoundsMatchTheApplyToTargetPath()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Bitmap deferred = Render(TransformThenSplit(applyToTarget: false), ShapeTransform());
+            using Bitmap eager = Render(TransformThenSplit(applyToTarget: true), ShapeTransform());
+
+            AssertOracleMatch(deferred, eager, "TransformThenSplit");
+        });
+    }
+
+    [Test]
+    public void SplitTransformCombination_IsDeterministicAndOrderSensitive()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Bitmap splitFirst = Render(SplitThenTransform(), ShapeTransform());
+            using Bitmap splitFirstAgain = Render(SplitThenTransform(), ShapeTransform());
+            using Bitmap transformFirst = Render(TransformThenSplit(applyToTarget: false), ShapeTransform());
+
+            double divergence = ImageMetrics.MeanAbsoluteError(splitFirst, transformFirst);
+            TestContext.WriteLine($"order divergence MAE={divergence:F6}");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    ImageMetrics.FirstNonFinite(("split-first", splitFirst), ("transform-first", transformFirst)),
+                    Is.Null);
+                GoldenImageHarness.AssertByteIdentical(splitFirst, splitFirstAgain);
+                Assert.That(CoveredPixelRatio(splitFirst), Is.GreaterThan(MinimumCoverageRatio));
+                Assert.That(
+                    divergence,
+                    Is.GreaterThan(MinimumOrderDivergence),
+                    "the two effect orders must not collapse onto one image.");
+            });
+        });
+    }
+
+    private static void AssertOracleMatch(Bitmap actual, Bitmap oracle, string label)
+    {
+        double ssim = ImageMetrics.Ssim(actual, oracle);
+        double mae = ImageMetrics.MeanAbsoluteError(actual, oracle);
+        TestContext.WriteLine($"{label} vs oracle SSIM={ssim:F4} MAE={mae:F6}");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ImageMetrics.FirstNonFinite((label, actual), ($"{label}-oracle", oracle)), Is.Null);
+
+            // Without this both sides could agree on a blank frame.
+            Assert.That(
+                CoveredPixelRatio(actual),
+                Is.GreaterThan(MinimumCoverageRatio),
+                $"{label} must produce substantial coverage.");
+            Assert.That(
+                ssim,
+                Is.GreaterThan(MinimumOracleSsim),
+                $"{label} diverged from its independently rendered oracle");
+        });
+    }
+
+    private static FilterEffect SplitThenTransform()
+    {
+        var group = new FilterEffectGroup();
+        group.Children.Add(MakeSplit());
+        group.Children.Add(MakeTransform(applyToTarget: false));
+        return group;
+    }
+
+    private static FilterEffect TransformThenSplit(bool applyToTarget)
+    {
+        var group = new FilterEffectGroup();
+        group.Children.Add(MakeTransform(applyToTarget));
+        group.Children.Add(MakeSplit());
+        return group;
+    }
+
+    private static SplitEffect MakeSplit()
+    {
+        var effect = new SplitEffect();
+        effect.HorizontalDivisions.CurrentValue = 3;
+        effect.VerticalDivisions.CurrentValue = 3;
+        effect.HorizontalSpacing.CurrentValue = 12;
+        effect.VerticalSpacing.CurrentValue = 12;
+        return effect;
+    }
+
+    private static TransformEffect MakeTransform(bool applyToTarget)
+    {
+        var effect = new TransformEffect();
+        effect.Transform.CurrentValue = EffectTransformGroup();
+        effect.TransformOrigin.CurrentValue = RelativePoint.Center;
+        effect.ApplyToTarget.CurrentValue = applyToTarget;
+        return effect;
+    }
+
+    private static TransformGroup EffectTransformGroup()
+    {
+        var group = new TransformGroup();
+        var rotation = new RotationTransform();
+        rotation.Rotation.CurrentValue = EffectRotation;
+        var scale = new ScaleTransform();
+        scale.ScaleX.CurrentValue = EffectScaleX;
+        scale.ScaleY.CurrentValue = EffectScaleY;
+        group.Children.Add(rotation);
+        group.Children.Add(scale);
+        return group;
+    }
+
+    private static Transform ShapeTransform()
+    {
+        var rotation = new RotationTransform();
+        rotation.Rotation.CurrentValue = ShapeRotation;
+        return rotation;
+    }
+
+    private static Transform ShapeThenEffectTransform()
+    {
+        var group = new TransformGroup();
+        group.Children.Add(ShapeTransform());
+        foreach (Transform child in EffectTransformGroup().Children)
+            group.Children.Add(child);
+
+        return group;
+    }
+
+    private static Bitmap Render(FilterEffect effect, Transform transform)
+    {
+        var shape = new RectShape();
+        shape.AlignmentX.CurrentValue = AlignmentX.Center;
+        shape.AlignmentY.CurrentValue = AlignmentY.Center;
+        shape.TransformOrigin.CurrentValue = RelativePoint.Center;
+        shape.Width.CurrentValue = 140;
+        shape.Height.CurrentValue = 90;
+        shape.Fill.CurrentValue = Brushes.White;
+        shape.Transform.CurrentValue = transform;
+        shape.FilterEffect.CurrentValue = effect;
+
+        return GoldenImageHarness.RenderAtScale(shape.ToResource(CompositionContext.Default), Frame, 1f);
+    }
+
+    private static double CoveredPixelRatio(Bitmap bitmap)
+    {
+        long covered = 0;
+        for (int y = 0; y < bitmap.Height; y++)
+        {
+            ReadOnlySpan<ushort> row = bitmap.GetRow<ushort>(y);
+            for (int x = 0; x < bitmap.Width; x++)
+            {
+                if ((float)BitConverter.UInt16BitsToHalf(row[(x * 4) + 3]) > 0.5f)
+                    covered++;
+            }
+        }
+
+        return covered / ((double)bitmap.Width * bitmap.Height);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/TargetCaptureValueWrapperTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/TargetCaptureValueWrapperTests.cs
@@ -1,0 +1,181 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Golden;
+
+[NonParallelizable]
+[TestFixture]
+public sealed class TargetCaptureValueWrapperTests
+{
+    private static readonly Rect s_bounds = new(0, 0, 16, 12);
+
+    [Test]
+    public void MaterializedOpacity_TargetCaptureReadsCallerTargetAndCompositesCapturedValue()
+    {
+        using RenderNodeRasterization raster = Render(ValueWrapper.Opacity);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(raster.Bounds, Is.EqualTo(s_bounds));
+            Assert.That(AlphaAt(raster.Bitmap!, 8, 6), Is.EqualTo(0.627f).Within(0.03f));
+        });
+    }
+
+    [Test]
+    public void MaterializedOpacityMask_TargetCaptureReadsCallerTargetAndCompositesCapturedValue()
+    {
+        using RenderNodeRasterization raster = Render(ValueWrapper.OpacityMask);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(raster.Bounds, Is.EqualTo(s_bounds));
+            Assert.That(AlphaAt(raster.Bitmap!, 8, 6), Is.EqualTo(0.752f).Within(0.03f));
+        });
+    }
+
+    [Test]
+    public void TargetCapture_CropsTheDeclaredRegionWithoutResamplingTheWholeTarget()
+    {
+        var captureBounds = new Rect(8, 0, 8, 12);
+        using Brush.Resource red = Brushes.Red.ToResource(CompositionContext.Default);
+        using Brush.Resource blue = Brushes.Blue.ToResource(CompositionContext.Default);
+        using var root = new ContainerRenderNode();
+        root.AddChild(new RectangleRenderNode(new Rect(0, 0, 8, 12), red, null));
+        root.AddChild(new RectangleRenderNode(captureBounds, blue, null));
+        root.AddChild(new ContributingTargetCaptureNode(captureBounds));
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_bounds,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    FusionMode = FusionMode.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        using RenderNodeRasterization raster = renderer.Rasterize();
+        (float leftRed, float leftBlue) = RedBlueAt(raster.Bitmap!, 2, 6);
+        (float capturedLeftRed, float capturedLeftBlue) = RedBlueAt(raster.Bitmap!, 9, 6);
+        (float capturedRightRed, float capturedRightBlue) = RedBlueAt(raster.Bitmap!, 14, 6);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(leftRed, Is.GreaterThan(leftBlue));
+            Assert.That(capturedLeftBlue, Is.GreaterThan(capturedLeftRed),
+                "the left edge of the capture must come from the declared right-half source region");
+            Assert.That(capturedRightBlue, Is.GreaterThan(capturedRightRed));
+        });
+    }
+
+    private static RenderNodeRasterization Render(ValueWrapper wrapper)
+    {
+        using Brush.Resource fill = new SolidColorBrush(new Color(128, 255, 0, 0))
+            .ToResource(CompositionContext.Default);
+        using var root = new ContainerRenderNode();
+        root.AddChild(new RectangleRenderNode(s_bounds, fill, null));
+        root.AddChild(new TargetCaptureValueWrapperNode(wrapper));
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_bounds,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    FusionMode = FusionMode.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        return renderer.Rasterize();
+    }
+
+    private static float AlphaAt(Bitmap bitmap, int x, int y)
+    {
+        Span<ushort> row = bitmap.GetRow<ushort>(y);
+        return (float)BitConverter.UInt16BitsToHalf(row[(x * 4) + 3]);
+    }
+
+    private static (float Red, float Blue) RedBlueAt(Bitmap bitmap, int x, int y)
+    {
+        Span<ushort> row = bitmap.GetRow<ushort>(y);
+        int offset = x * 4;
+        return (
+            (float)BitConverter.UInt16BitsToHalf(row[offset]),
+            (float)BitConverter.UInt16BitsToHalf(row[offset + 2]));
+    }
+
+    private enum ValueWrapper
+    {
+        Opacity,
+        OpacityMask,
+    }
+
+    private sealed class TargetCaptureValueWrapperNode(ValueWrapper wrapper) : RenderNode
+    {
+        private static readonly GeometryDescription s_identityGeometry = GeometryDescription.Create(
+            "target-capture-value-wrapper-identity",
+            static (session, _) => session.Canvas.Use(session.Input.Draw),
+            RenderBoundsContract.Identity,
+            RenderHitTestContract.AnyInput);
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle capture = context.TargetCapture(TargetCaptureDescription.Create(
+                TargetRegion.Region(s_bounds),
+                s_bounds,
+                RenderHitTestContract.OutputBounds,
+                TargetCaptureScaleContract.MaterializeAtWorkingScale));
+            RenderFragmentHandle wrapped = wrapper switch
+            {
+                ValueWrapper.Opacity => context.Opacity(capture, 0.5f),
+                ValueWrapper.OpacityMask => context.OpacityMask(
+                    capture,
+                    Brushes.Resource.White,
+                    s_bounds),
+                _ => throw new InvalidOperationException("The value-wrapper fixture is invalid."),
+            };
+            RenderFragmentHandle materialized = context.Geometry(wrapped, s_identityGeometry);
+            context.Publish(context.ContributeValues(materialized));
+        }
+    }
+
+    private sealed class ContributingTargetCaptureNode(Rect bounds) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle capture = context.TargetCapture(TargetCaptureDescription.Create(
+                TargetRegion.Region(bounds),
+                bounds,
+                RenderHitTestContract.OutputBounds,
+                TargetCaptureScaleContract.MaterializeAtWorkingScale));
+            context.Publish(context.ContributeValues(capture));
+        }
+    }
+
+    private sealed class CpuTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+            => new CpuRenderTarget(allocation.DeviceSize.Width, allocation.DeviceSize.Height);
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/LegacyFilterRequiredRegionTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/LegacyFilterRequiredRegionTests.cs
@@ -1,0 +1,246 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+[TestFixture]
+public sealed class LegacyFilterRequiredRegionTests
+{
+    [Test]
+    public void SubRegionRequest_RestrictsLegacyFilterSourceToBackwardRegion()
+    {
+        var sourceBounds = new Rect(0, 0, 400, 400);
+        var requestedRegion = new Rect(0, 0, 50, 50);
+        var observed = new List<Rect>();
+        using FilterEffectRenderNode filter = CreateBlurNode(sigma: 2);
+        filter.AddChild(ScaleRecordingTestHelper.Source(
+            EffectiveScale.At(1),
+            sourceBounds,
+            session => observed.Add(session.RequiredRegion)));
+        using var renderer = new RenderNodeRenderer(
+            filter,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    RequestedRegion = requestedRegion,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new BudgetedCpuTargetFactory(int.MaxValue),
+            });
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        // Blur declares a 3σ footprint, so the destination's 50×50 region can only be reached by the
+        // matching 6-unit apron of the source.
+        Assert.That(observed, Is.EqualTo(new[] { new Rect(0, 0, 56, 56) }));
+    }
+
+    [Test]
+    public void SubRegionRequest_RestrictsErodeSourceToItsRadiusNeighbourhood()
+    {
+        var sourceBounds = new Rect(0, 0, 400, 400);
+        var requestedRegion = new Rect(0, 0, 50, 50);
+        var observed = new List<Rect>();
+        using FilterEffectRenderNode filter = CreateErodeNode(radius: 6);
+        filter.AddChild(ScaleRecordingTestHelper.Source(
+            EffectiveScale.At(1),
+            sourceBounds,
+            session => observed.Add(session.RequiredRegion)));
+        using var renderer = new RenderNodeRenderer(
+            filter,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    RequestedRegion = requestedRegion,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new BudgetedCpuTargetFactory(int.MaxValue),
+            });
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        // Erode declares an identity output map yet reads the whole radius neighbourhood, so the
+        // destination's 50×50 region still needs the source's matching 6-unit apron.
+        Assert.That(observed, Is.EqualTo(new[] { new Rect(0, 0, 56, 56) }));
+    }
+
+    [Test]
+    public void ErodeUnderAPartialRegion_MatchesTheCompleteRenderRestrictedToThatRegion()
+    {
+        var sourceBounds = new Rect(0, 0, 100, 100);
+        var requestedRegion = new Rect(30, 30, 40, 40);
+
+        (Rect completeBounds, float[] completeAlpha, int completeWidth) =
+            RasterizeErodedSquare(sourceBounds, radius: 6, requestedRegion: null);
+        (Rect partialBounds, float[] partialAlpha, int partialWidth) =
+            RasterizeErodedSquare(sourceBounds, radius: 6, requestedRegion);
+
+        Assert.That(partialBounds, Is.EqualTo(requestedRegion));
+        Assert.That(completeBounds, Is.EqualTo(sourceBounds));
+
+        var offsetX = (int)(partialBounds.X - completeBounds.X);
+        var offsetY = (int)(partialBounds.Y - completeBounds.Y);
+        var partialHeight = partialAlpha.Length / partialWidth;
+        var mismatches = 0;
+        for (int y = 0; y < partialHeight; y++)
+        {
+            for (int x = 0; x < partialWidth; x++)
+            {
+                float expected = completeAlpha[((y + offsetY) * completeWidth) + x + offsetX];
+                float actual = partialAlpha[(y * partialWidth) + x];
+                if (MathF.Abs(expected - actual) > 0.01f)
+                    mismatches++;
+            }
+        }
+
+        Assert.That(mismatches, Is.Zero,
+            "a partially requested erode must match the complete render inside the same region");
+    }
+
+    [Test]
+    public void OversizedElementAtHighScale_RendersWithoutExceedingTheDestinationFootprint()
+    {
+        const float scale = 4;
+        var frame = new PixelSize(400, 300);
+        var requestedSizes = new List<PixelSize>();
+        using FilterEffectRenderNode filter = CreateBlurNode(sigma: 4);
+        filter.AddChild(new RectangleRenderNode(
+            new Rect(0, 0, 4200, 4200),
+            Brushes.Resource.White,
+            null));
+        // A materialization that ignores the destination's needs asks for the element's complete
+        // 4200×4200 footprint at density 4, which no backend can satisfy.
+        var factory = new BudgetedCpuTargetFactory(8192, requestedSizes);
+        using var destination = new CpuRenderTarget(
+            (int)(frame.Width * scale),
+            (int)(frame.Height * scale));
+        using var canvas = new ImmediateCanvas(destination, scale, logicalSize: frame.ToSize(1));
+        using var renderer = new RenderNodeRenderer(
+            filter,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    Intent = RenderIntent.Preview,
+                    TargetDomain = new Rect(default, frame.ToSize(1)),
+                    OutputScale = scale,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = factory,
+            });
+
+        renderer.Render(canvas);
+
+        using Bitmap result = destination.Snapshot();
+        Assert.Multiple(() =>
+        {
+            Assert.That(CountCoveredPixels(result), Is.EqualTo(frame.Width * scale * frame.Height * scale),
+                "the blurred element must still cover the frame");
+            Assert.That(
+                requestedSizes.Select(static size => Math.Max(size.Width, size.Height)),
+                Is.All.LessThanOrEqualTo(2048),
+                "no intermediate may exceed what the destination region needs");
+        });
+    }
+
+    private static FilterEffectRenderNode CreateBlurNode(float sigma)
+    {
+        var blur = new Blur();
+        blur.Sigma.CurrentValue = new Size(sigma, sigma);
+        return new FilterEffectRenderNode(blur.ToResource(CompositionContext.Default));
+    }
+
+    private static FilterEffectRenderNode CreateErodeNode(float radius)
+    {
+        var erode = new Erode();
+        erode.RadiusX.CurrentValue = radius;
+        erode.RadiusY.CurrentValue = radius;
+        return new FilterEffectRenderNode(erode.ToResource(CompositionContext.Default));
+    }
+
+    private static (Rect Bounds, float[] Alpha, int Width) RasterizeErodedSquare(
+        Rect sourceBounds,
+        float radius,
+        Rect? requestedRegion)
+    {
+        using FilterEffectRenderNode filter = CreateErodeNode(radius);
+        filter.AddChild(new RectangleRenderNode(sourceBounds, Brushes.Resource.White, null));
+        using var renderer = new RenderNodeRenderer(
+            filter,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    RequestedRegion = requestedRegion,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new BudgetedCpuTargetFactory(int.MaxValue),
+            });
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        Bitmap bitmap = rasterization.Bitmap
+                        ?? throw new InvalidOperationException("The erode render produced no bitmap.");
+        Assert.That(bitmap.ColorType, Is.EqualTo(BitmapColorType.RgbaF16));
+
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        var alpha = new float[bitmap.Width * bitmap.Height];
+        for (int index = 0; index < alpha.Length; index++)
+            alpha[index] = (float)BitConverter.UInt16BitsToHalf(pixels[(index * 4) + 3]);
+
+        return (rasterization.Bounds, alpha, bitmap.Width);
+    }
+
+    private static long CountCoveredPixels(Bitmap bitmap)
+    {
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        long count = 0;
+        for (int index = 0; index + 3 < pixels.Length; index += 4)
+        {
+            float alpha = (float)BitConverter.UInt16BitsToHalf(pixels[index + 3]);
+            // The floor rejects NaN/subnormal/negative-zero alpha while accommodating the
+            // bilinear tail a budget-clamped materialization leaves at buffer edges.
+            if (float.IsFinite(alpha) && alpha >= 0.01f)
+                count++;
+        }
+
+        return count;
+    }
+
+    private sealed class BudgetedCpuTargetFactory(int maximumDimension, List<PixelSize>? requestedSizes = null)
+        : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => maximumDimension;
+
+        public RenderTarget? Create(RenderTargetAllocationDescriptor allocation)
+        {
+            PixelSize deviceSize = allocation.DeviceSize;
+            requestedSizes?.Add(deviceSize);
+            return deviceSize.Width > maximumDimension || deviceSize.Height > maximumDimension
+                ? null
+                : new CpuRenderTarget(deviceSize.Width, deviceSize.Height);
+        }
+    }
+
+    private sealed class CpuRenderTarget : RenderTarget
+    {
+        public CpuRenderTarget(int width, int height)
+            : base(CreateSurface(width, height), width, height)
+        {
+        }
+
+        private static SKSurface CreateSurface(int width, int height)
+            => SKSurface.Create(new SKImageInfo(
+                   width,
+                   height,
+                   SKColorType.RgbaF16,
+                   SKAlphaType.Premul,
+                   SKColorSpace.CreateSrgbLinear()))
+               ?? throw new InvalidOperationException("Failed to create a CPU surface.");
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/LegacyFilterTypedSuffixExecutionTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/LegacyFilterTypedSuffixExecutionTests.cs
@@ -1,0 +1,892 @@
+﻿using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+[TestFixture]
+[NonParallelizable]
+public sealed class LegacyFilterTypedSuffixExecutionTests
+{
+    private const string BlueShader =
+        "half4 apply(half4 color) { return half4(0.0, 0.0, color.a, color.a); }";
+
+    [Test]
+    public void ShaderAfterUnknownCustomEffect_ExecutesAgainstMaterializedTarget()
+    {
+        Rect runtimeBounds = new(14, 25, 8, 6);
+        Rect observedInput = default;
+        Rect observedOutput = default;
+        RenderIntent? observedIntent = null;
+        RenderRequestPurpose? observedPurpose = null;
+        var effect = new LegacySuffixCallbackFilterEffect((context, _) =>
+        {
+            context.CustomEffect(
+                runtimeBounds,
+                static (bounds, execution) =>
+                {
+                    foreach (EffectTarget target in execution.Targets)
+                        target.Bounds = bounds;
+                });
+            context.Shader(ShaderDescription.CurrentPixel(
+                "uniform float marker; "
+                + "half4 apply(half4 color) { return half4(0.0, 0.0, color.a * marker, color.a); }",
+                bindings => bindings.Uniform(
+                    "marker",
+                    1f,
+                    (writer, value, execution) =>
+                    {
+                        observedInput = execution.InputBounds;
+                        observedOutput = execution.OutputBounds;
+                        observedIntent = execution.Intent;
+                        observedPurpose = execution.Purpose;
+                        writer.Set(value);
+                    },
+                    structuralKey: "legacy-suffix-shader-binder")));
+        });
+        Rect inputBounds = new(10, 20, 8, 6);
+
+        using EffectTargets targets = CreateSolidTargets(inputBounds, Colors.Red);
+        Apply(effect, inputBounds, targets);
+
+        Assert.That(targets, Has.Count.EqualTo(1));
+        SKColor color = ReadCenterPixel(targets[0]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(targets[0].Bounds, Is.EqualTo(runtimeBounds));
+            Assert.That(observedInput, Is.EqualTo(runtimeBounds));
+            Assert.That(observedOutput, Is.EqualTo(runtimeBounds));
+            Assert.That(observedIntent, Is.EqualTo(RenderIntent.Preview));
+            Assert.That(observedPurpose, Is.EqualTo(RenderRequestPurpose.Auxiliary));
+            Assert.That(color.Red, Is.LessThan(16));
+            Assert.That(color.Green, Is.LessThan(16));
+            Assert.That(color.Blue, Is.GreaterThan(239));
+            Assert.That(color.Alpha, Is.GreaterThan(239));
+        });
+    }
+
+    [Test]
+    public void ShaderAfterUnknownCustomEffect_UsesRendererProgramCacheAcrossFrames()
+    {
+        var effect = new LegacySuffixCallbackFilterEffect(static (context, _) =>
+        {
+            context.CustomEffect(0, static (_, _) => { });
+            context.Shader(ShaderDescription.CurrentPixel(BlueShader));
+        });
+        Rect bounds = new(0, 0, 8, 6);
+        using var root = new FilterEffectRenderNode(
+            effect.ToResource(CompositionContext.Default));
+        root.AddChild(new RectangleRenderNode(
+            bounds,
+            Brushes.Resource.Red,
+            null));
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = bounds,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        using RenderNodeRasterization cold = renderer.Rasterize();
+        ProgramCacheStatistics coldStatistics = renderer.ProgramCacheStatistics;
+        using RenderNodeRasterization warm = renderer.Rasterize();
+        ProgramCacheStatistics warmStatistics = renderer.ProgramCacheStatistics;
+        SKColor coldColor = ReadCenterPixel(cold.Bitmap
+            ?? throw new AssertionException("The cold typed-suffix render produced no bitmap."));
+        SKColor warmColor = ReadCenterPixel(warm.Bitmap
+            ?? throw new AssertionException("The warm typed-suffix render produced no bitmap."));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(coldColor.Red, Is.LessThan(16));
+            Assert.That(coldColor.Green, Is.LessThan(16));
+            Assert.That(coldColor.Blue, Is.GreaterThan(239));
+            Assert.That(coldColor.Alpha, Is.GreaterThan(239));
+            Assert.That(warmColor.Red, Is.LessThan(16));
+            Assert.That(warmColor.Green, Is.LessThan(16));
+            Assert.That(warmColor.Blue, Is.GreaterThan(239));
+            Assert.That(warmColor.Alpha, Is.GreaterThan(239));
+            Assert.That(coldStatistics.Creations, Is.EqualTo(1));
+            Assert.That(coldStatistics.Misses, Is.EqualTo(1));
+            Assert.That(coldStatistics.Hits, Is.Zero);
+            Assert.That(warmStatistics.Creations, Is.EqualTo(1));
+            Assert.That(warmStatistics.Misses, Is.EqualTo(1));
+            Assert.That(warmStatistics.Hits, Is.EqualTo(1));
+            Assert.That(renderer.LastExecutionStatistics.ProgramCacheHits, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void MaterializedInput_CustomEffect_UsesAmbientGridWithoutReanchoringInput()
+    {
+        var translation = new Vector(0.25f, 0.75f);
+        Vector observedAmbientGrid = default;
+        Vector observedInputGrid = default;
+        var effect = new LegacySuffixCallbackFilterEffect((context, _) =>
+            context.CustomEffect(
+                0,
+                (_, execution) =>
+                {
+                    observedAmbientGrid = execution.DeviceGridOffset;
+                    observedInputGrid = execution.Targets.Single().DeviceGridOffset;
+                },
+                static (_, bounds) => bounds));
+
+        RenderMaterializedEffect(effect, translation);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(observedAmbientGrid, Is.EqualTo(translation));
+            Assert.That(observedInputGrid, Is.EqualTo(default(Vector)));
+        });
+    }
+
+    [Test]
+    public void CompatibilityShader_ProgramAcquirerReceivesExecutionDestination()
+    {
+        Rect bounds = new(0, 0, 8, 6);
+        using EffectTargets targets = CreateSolidTargets(bounds, Colors.Red);
+        EffectTarget input = targets[0];
+        using ProgramCache<CachedSkRuntimeEffect> cache = SkRuntimeEffectProgramCache.Create();
+        EffectTarget? observedTarget = null;
+
+        LegacyFilterEffectCompatibilityExecutor.ApplyShader(
+            targets,
+            ShaderDescription.CurrentPixel(BlueShader),
+            outputScale: 1,
+            workingScale: 1,
+            maxWorkingScale: 1,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            (target, source) =>
+            {
+                observedTarget = target;
+                return SkRuntimeEffectProgramCache.AcquireForDestination(
+                    cache,
+                    target.RenderTarget!,
+                    source);
+            });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(observedTarget, Is.SameAs(targets[0]));
+            Assert.That(observedTarget, Is.Not.SameAs(input));
+            Assert.That(observedTarget!.RenderTarget, Is.Not.Null);
+            Assert.That(input.IsEmpty, Is.True);
+        });
+    }
+
+    // The compatibility executor had the request intent in scope but opened every canvas on the
+    // RenderIntent.Preview default, so a delivery render degraded there instead of failing.
+    [TestCase(RenderIntent.Preview)]
+    [TestCase(RenderIntent.Delivery)]
+    public void CompatibilityGeometry_CallbackCanvasCarriesTheRequestIntent(RenderIntent intent)
+    {
+        Rect bounds = new(0, 0, 8, 6);
+        using EffectTargets targets = CreateSolidTargets(bounds, Colors.Red);
+        RenderIntent? observedIntent = null;
+
+        LegacyFilterEffectCompatibilityExecutor.ApplyGeometry(
+            targets,
+            GeometryDescription.CreateRequestLocal(
+                session => session.Canvas.Use(canvas => observedIntent = canvas.Intent),
+                RenderBoundsContract.Identity,
+                RenderHitTestContract.AnyInput,
+                structuralKey: "legacy-compat-intent-geometry"),
+            outputScale: 1,
+            workingScale: 1,
+            maxWorkingScale: 1,
+            intent,
+            RenderRequestPurpose.Auxiliary);
+
+        Assert.That(observedIntent, Is.EqualTo(intent));
+    }
+
+    [Test]
+    public void GeometryAfterUnknownCustomEffect_UsesRuntimeBoundsAndPublishesShrink()
+    {
+        Rect runtimeBounds = new(30, 40, 8, 6);
+        Rect mappedBounds = runtimeBounds.Inflate(new Thickness(2));
+        Rect selectedBounds = mappedBounds.Inflate(new Thickness(-1));
+        Rect observedInput = default;
+        var effect = new LegacySuffixCallbackFilterEffect((context, _) =>
+        {
+            context.CustomEffect(
+                runtimeBounds,
+                static (bounds, execution) =>
+                {
+                    foreach (EffectTarget target in execution.Targets)
+                        target.Bounds = bounds;
+                });
+            context.Geometry(GeometryDescription.CreateRequestLocal(
+                session =>
+                {
+                    observedInput = session.Input.Bounds;
+                    session.Canvas.Use(static canvas => canvas.Clear(Colors.Lime));
+                    session.SetOutputBounds(session.OutputBounds.Inflate(new Thickness(-1)));
+                },
+                RenderBoundsContract.Create(
+                    static bounds => bounds.Inflate(new Thickness(2)),
+                    static bounds => bounds.Inflate(new Thickness(2)),
+                    "legacy-suffix-inflate"),
+                RenderHitTestContract.AnyInput,
+                structuralKey: "legacy-suffix-geometry"));
+        });
+        Rect recordedBounds = new(10, 20, 8, 6);
+
+        using EffectTargets targets = CreateSolidTargets(recordedBounds, Colors.Red);
+        Apply(effect, recordedBounds, targets);
+
+        Assert.That(targets, Has.Count.EqualTo(1));
+        SKColor color = ReadCenterPixel(targets[0]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(observedInput, Is.EqualTo(runtimeBounds));
+            Assert.That(targets[0].Bounds, Is.EqualTo(selectedBounds));
+            Assert.That(color.Red, Is.LessThan(16));
+            Assert.That(color.Green, Is.GreaterThan(239));
+            Assert.That(color.Blue, Is.LessThan(16));
+            Assert.That(color.Alpha, Is.GreaterThan(239));
+        });
+    }
+
+    [Test]
+    public void DelayAnimationEffect_ExecutesTypedChildEffect()
+    {
+        var child = new LegacySuffixCallbackFilterEffect(static (context, _) =>
+            context.Shader(ShaderDescription.CurrentPixel(BlueShader)));
+        var delay = new DelayAnimationEffect
+        {
+            Delay = { CurrentValue = 0 },
+            Effect = { CurrentValue = child },
+        };
+        Rect bounds = new(4, 7, 8, 6);
+
+        using EffectTargets targets = CreateSolidTargets(bounds, Colors.Red);
+        Apply(delay, bounds, targets);
+
+        Assert.That(targets, Has.Count.EqualTo(1));
+        SKColor color = ReadCenterPixel(targets[0]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(color.Red, Is.LessThan(16));
+            Assert.That(color.Blue, Is.GreaterThan(239));
+            Assert.That(color.Alpha, Is.GreaterThan(239));
+        });
+    }
+
+    [Test]
+    public void DelayAnimationEffect_ChildRollbackPreservesPrimaryFailureOverCleanupFailure()
+    {
+        var primary = new InvalidOperationException("delay-child-primary");
+        var cleanup = new ThrowingDisposable();
+        var child = new LegacySuffixCallbackFilterEffect((context, _) =>
+        {
+            context.Own(cleanup, "delay-child-owned", 1);
+            context.Shader(ShaderDescription.CurrentPixel(BlueShader));
+            throw primary;
+        });
+        var delay = new DelayAnimationEffect
+        {
+            Delay = { CurrentValue = 0 },
+            Effect = { CurrentValue = child },
+        };
+        Rect bounds = new(0, 0, 8, 6);
+        using FilterEffect.Resource resource = delay.ToResource(CompositionContext.Default);
+        using var context = new FilterEffectContext(bounds);
+        context.ApplyTransactional(delay, resource);
+        using EffectTargets targets = CreateSolidTargets(bounds, Colors.Red);
+        using var builder = new SKImageFilterBuilder();
+        using var activator = new FilterEffectActivator(
+            targets,
+            builder,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            outputScale: 1,
+            workingScale: 1,
+            maxWorkingScale: 1);
+
+        InvalidOperationException? thrown = Assert.Throws<InvalidOperationException>(
+            () => activator.Apply(context));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(thrown, Is.SameAs(primary));
+            Assert.That(cleanup.DisposeCount, Is.EqualTo(1));
+            Assert.That(
+                primary.Data["FilterEffectResourceRollbackFailure"],
+                Is.TypeOf<AggregateException>());
+        });
+    }
+
+    [Test]
+    public void UnknownCustomEffect_FinalValueIsCroppedToOwningDomainAfterInternalAllocation()
+    {
+        Rect domain = new(0, 0, 20, 10);
+        Rect expandedBounds = new(-5, -3, 30, 16);
+        PixelSize observedInternalAllocation = default;
+        Rect observedDownstreamInput = default;
+        var expandingEffect = new LegacySuffixCallbackFilterEffect((context, _) =>
+            context.CustomEffect(
+                0,
+                (_, execution) => execution.ForEach((_, _) =>
+                {
+                    EffectTarget expanded = execution.CreateTarget(expandedBounds);
+                    observedInternalAllocation = expanded.DeviceBounds.Size;
+                    using ImmediateCanvas canvas = execution.Open(expanded);
+                    canvas.Clear(Colors.Magenta);
+                    return expanded;
+                })));
+        var downstreamEffect = new LegacySuffixCallbackFilterEffect((context, _) =>
+            context.Geometry(GeometryDescription.CreateRequestLocal(
+                session =>
+                {
+                    observedDownstreamInput = session.Input.Bounds;
+                    session.Canvas.Use(session.Input.Draw);
+                },
+                RenderBoundsContract.Identity,
+                RenderHitTestContract.AnyInput,
+                structuralKey: "legacy-final-domain-observer")));
+        var inner = new FilterEffectRenderNode(expandingEffect.ToResource(CompositionContext.Default));
+        inner.AddChild(new RectangleRenderNode(
+            new Rect(4, 2, 6, 4),
+            Brushes.Resource.White,
+            null));
+        using var root = new FilterEffectRenderNode(
+            downstreamEffect.ToResource(CompositionContext.Default));
+        root.AddChild(inner);
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = domain,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        Bitmap bitmap = rasterization.Bitmap!;
+        SKColor center = bitmap.SKBitmap.GetPixel(bitmap.Width / 2, bitmap.Height / 2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(observedInternalAllocation, Is.EqualTo(new PixelSize(30, 16)));
+            Assert.That(observedDownstreamInput, Is.EqualTo(domain));
+            Assert.That(rasterization.Bounds, Is.EqualTo(domain));
+            Assert.That(bitmap.Width, Is.EqualTo(20));
+            Assert.That(bitmap.Height, Is.EqualTo(10));
+            Assert.That(center.Red, Is.GreaterThan(239));
+            Assert.That(center.Blue, Is.GreaterThan(239));
+            Assert.That(center.Alpha, Is.GreaterThan(239));
+        });
+    }
+
+    [Test]
+    public void UnknownCustomEffect_OwningDomainNarrowingKeepsLegacyRasterPlacement()
+    {
+        var domain = new Rect(0, 0, 20, 14);
+        var expandedBounds = new Rect(-3.5f, -2.25f, 26, 18.5f);
+        RenderTarget? retainedAllocation = null;
+        var expandingEffect = new LegacySuffixCallbackFilterEffect((context, _) =>
+            context.CustomEffect(
+                0,
+                (_, execution) => execution.ForEach((_, _) =>
+                {
+                    EffectTarget expanded = execution.CreateTarget(expandedBounds);
+                    using (ImmediateCanvas canvas = execution.Open(expanded))
+                    {
+                        canvas.Clear(Colors.Magenta);
+                        canvas.DrawRectangle(
+                            new Rect(7.5f, 5.25f, 4, 3),
+                            Brushes.Resource.White,
+                            null);
+                    }
+
+                    retainedAllocation = expanded.RenderTarget!.ShallowCopy();
+                    return expanded;
+                })));
+        using var root = new FilterEffectRenderNode(
+            expandingEffect.ToResource(CompositionContext.Default));
+        root.AddChild(new RectangleRenderNode(
+            new Rect(4, 2, 6, 4),
+            Brushes.Resource.Red,
+            null));
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = domain,
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        using var actualTarget = new CpuRenderTarget((int)domain.Width, (int)domain.Height);
+        using (var actualCanvas = new ImmediateCanvas(actualTarget, logicalSize: domain.Size))
+        {
+            actualCanvas.Clear();
+            renderer.Render(actualCanvas);
+        }
+
+        using RenderTarget allocation = retainedAllocation
+            ?? throw new AssertionException("The custom effect did not allocate an expanded target.");
+        using var expectedTarget = new CpuRenderTarget((int)domain.Width, (int)domain.Height);
+        using (var expectedCanvas = new ImmediateCanvas(expectedTarget, logicalSize: domain.Size))
+        {
+            expectedCanvas.Clear();
+            expectedCanvas.DrawRenderTarget(allocation, expandedBounds.Position);
+        }
+
+        using Bitmap actual = actualTarget.Snapshot();
+        using Bitmap expected = expectedTarget.Snapshot();
+        Assert.That(
+            actual.GetPixelSpan<ushort>().SequenceEqual(expected.GetPixelSpan<ushort>()),
+            Is.True,
+            "narrowing a legacy raster-placement value to the owning domain must relabel its bounds "
+            + "instead of re-allocating and re-anchoring its pixels");
+    }
+
+    [Test]
+    public void FirstCustomEffect_MovedSemanticBoundsRetainPreCallbackBacking()
+    {
+        var inputBounds = new Rect(0, 0, 12, 10);
+        var movedBounds = new Rect(4.5f, 3.5f, 4, 3);
+        Rect observedBounds = default;
+        Rect observedRasterBounds = default;
+        PixelRect observedDeviceBounds = default;
+        var movingEffect = new LegacySuffixCallbackFilterEffect((context, _) =>
+            context.CustomEffect(
+                movedBounds,
+                static (bounds, execution) =>
+                {
+                    foreach (EffectTarget target in execution.Targets)
+                        target.Bounds = bounds;
+                },
+                static (bounds, _) => bounds));
+        var observingEffect = new LegacySuffixCallbackFilterEffect((context, _) =>
+            context.Geometry(GeometryDescription.CreateRequestLocal(
+                session =>
+                {
+                    observedBounds = session.Input.Bounds;
+                    observedDeviceBounds = session.Input.DeviceBounds;
+                    observedRasterBounds = session.Input.RasterBounds;
+                    session.Canvas.Use(session.Input.Draw);
+                },
+                RenderBoundsContract.Identity,
+                RenderHitTestContract.AnyInput,
+                structuralKey: "legacy-retained-backing-observer")));
+        using var source = new CpuRenderTarget((int)inputBounds.Width, (int)inputBounds.Height);
+        source.Value.Canvas.Clear(SKColors.White);
+        source.Value.Flush();
+        var movingNode = new FilterEffectRenderNode(
+            movingEffect.ToResource(CompositionContext.Default));
+        movingNode.AddChild(new MaterializedInputNode(source, inputBounds));
+        using var root = new FilterEffectRenderNode(
+            observingEffect.ToResource(CompositionContext.Default));
+        root.AddChild(movingNode);
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = new Rect(0, 0, 24, 20),
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        Rect movedInputRaster = inputBounds.Translate(movedBounds.Position - inputBounds.Position);
+        var expectedDeviceBounds = new PixelRect(
+            default,
+            new PixelSize((int)inputBounds.Width, (int)inputBounds.Height));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rasterization.IsEmpty, Is.False);
+            Assert.That(observedBounds, Is.EqualTo(movedBounds));
+            Assert.That(observedDeviceBounds, Is.EqualTo(expectedDeviceBounds));
+            Assert.That(observedRasterBounds, Is.EqualTo(movedInputRaster));
+            Assert.That(observedDeviceBounds.Size, Is.EqualTo(new PixelSize(12, 10)));
+        });
+    }
+
+    [TestCase(1)]
+    [TestCase(2)]
+    public void FractionalLegacyTarget_ReplaysExactlyLikeDirectPointComposite(int customCount)
+    {
+        var domain = new Rect(0, 0, 20, 14);
+        var legacyBounds = new Rect(2.5f, 1.5f, 9.75f, 7.25f);
+        var effect = new LegacySuffixCallbackFilterEffect((context, _) =>
+        {
+            context.CustomEffect(
+                legacyBounds,
+                static (bounds, execution) => execution.ForEach((_, _) =>
+                {
+                    EffectTarget output = execution.CreateTarget(bounds);
+                    using ImmediateCanvas canvas = execution.Open(output);
+                    DrawLegacyPattern(canvas);
+                    return output;
+                }),
+                static (bounds, _) => bounds);
+            if (customCount == 2)
+            {
+                context.CustomEffect(
+                    0,
+                    static (_, _) => { },
+                    static (_, bounds) => bounds);
+            }
+        });
+        using var root = new FilterEffectRenderNode(
+            effect.ToResource(CompositionContext.Default));
+        root.AddChild(new RectangleRenderNode(
+            new Rect(0, 0, 1, 1),
+            Brushes.Resource.White,
+            null));
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = domain,
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+        using var actualTarget = new CpuRenderTarget((int)domain.Width, (int)domain.Height);
+        using (var actualCanvas = new ImmediateCanvas(actualTarget, logicalSize: domain.Size))
+        {
+            actualCanvas.Clear();
+            renderer.Render(actualCanvas);
+        }
+
+        using var localTarget = new CpuRenderTarget(9, 7);
+        using (var localCanvas = new ImmediateCanvas(localTarget, logicalSize: legacyBounds.Size))
+        {
+            DrawLegacyPattern(localCanvas);
+        }
+
+        using var expectedTarget = new CpuRenderTarget((int)domain.Width, (int)domain.Height);
+        using (var expectedCanvas = new ImmediateCanvas(expectedTarget, logicalSize: domain.Size))
+        {
+            expectedCanvas.Clear();
+            expectedCanvas.DrawRenderTarget(localTarget, legacyBounds.Position);
+        }
+
+        using Bitmap actual = actualTarget.Snapshot();
+        using Bitmap expected = expectedTarget.Snapshot();
+        Assert.That(
+            actual.GetPixelSpan<ushort>().SequenceEqual(expected.GetPixelSpan<ushort>()),
+            Is.True,
+            $"{customCount} legacy CustomEffect boundary/boundaries changed direct point-blit pixels");
+    }
+
+    [Test]
+    public void FractionalLegacyInput_RetainsDirectPlacementWhenCallbackMovesBounds()
+    {
+        var domain = new Rect(0, 0, 20, 14);
+        var sourceBounds = new Rect(2.5f, 1.5f, 9.75f, 7.25f);
+        var movedBounds = new Rect(5.25f, 3.75f, sourceBounds.Width, sourceBounds.Height);
+        RenderTarget? retainedInput = null;
+        var effect = new LegacySuffixCallbackFilterEffect((context, _) =>
+            context.CustomEffect(
+                movedBounds,
+                (bounds, execution) => execution.ForEach((_, target) =>
+                {
+                    retainedInput = target.RenderTarget!.ShallowCopy();
+                    target.Bounds = bounds;
+                    return target;
+                }),
+                static (bounds, _) => bounds));
+        using var root = new FilterEffectRenderNode(
+            effect.ToResource(CompositionContext.Default));
+        root.AddChild(new RectangleRenderNode(
+            sourceBounds,
+            Brushes.Resource.OrangeRed,
+            null));
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = domain,
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+        using var actualTarget = new CpuRenderTarget((int)domain.Width, (int)domain.Height);
+        using (var actualCanvas = new ImmediateCanvas(actualTarget, logicalSize: domain.Size))
+        {
+            actualCanvas.Clear();
+            renderer.Render(actualCanvas);
+        }
+
+        using RenderTarget localTarget = retainedInput
+            ?? throw new AssertionException("The legacy callback did not receive a materialized input.");
+        Assert.That(localTarget.Width, Is.EqualTo(9));
+        Assert.That(localTarget.Height, Is.EqualTo(7));
+
+        using var expectedTarget = new CpuRenderTarget((int)domain.Width, (int)domain.Height);
+        using (var expectedCanvas = new ImmediateCanvas(expectedTarget, logicalSize: domain.Size))
+        {
+            expectedCanvas.Clear();
+            expectedCanvas.DrawRenderTarget(localTarget, movedBounds.Position);
+        }
+
+        using Bitmap actual = actualTarget.Snapshot();
+        using Bitmap expected = expectedTarget.Snapshot();
+        Assert.That(
+            actual.GetPixelSpan<ushort>().SequenceEqual(expected.GetPixelSpan<ushort>()),
+            Is.True,
+            "moving retained legacy input pixels must not insert a canonical normalization pass");
+    }
+
+    [Test]
+    public void PolicyBearingNoOpSkiaItem_MaterializesAtResolvedWorkingScale()
+    {
+        const float inputDensity = 0.5f;
+        var bounds = new Rect(0, 0, 12, 10);
+        EffectiveScale observedScale = default;
+        PixelRect observedDeviceBounds = default;
+        var noOpSkiaEffect = new LegacySuffixCallbackFilterEffect((context, _) =>
+            context.AppendSkiaFilter(
+                0,
+                static (_, _, _) => null,
+                static (_, current) => current));
+        var observingEffect = new LegacySuffixCallbackFilterEffect((context, _) =>
+            context.Geometry(GeometryDescription.CreateRequestLocal(
+                session =>
+                {
+                    observedScale = session.Input.EffectiveScale;
+                    observedDeviceBounds = session.Input.DeviceBounds;
+                    session.Canvas.Use(session.Input.Draw);
+                },
+                RenderBoundsContract.Identity,
+                RenderHitTestContract.AnyInput,
+                structuralKey: "legacy-policy-materialization-observer")));
+        PixelRect inputDeviceBounds = PixelRect.FromRect(bounds, inputDensity);
+        using var source = new CpuRenderTarget(inputDeviceBounds.Width, inputDeviceBounds.Height);
+        source.Value.Canvas.Clear(SKColors.White);
+        source.Value.Flush();
+        var noOpNode = new FilterEffectRenderNode(
+            noOpSkiaEffect.ToResource(CompositionContext.Default));
+        noOpNode.AddChild(new MaterializedInputNode(source, bounds, inputDensity));
+        using var root = new FilterEffectRenderNode(
+            observingEffect.ToResource(CompositionContext.Default));
+        root.AddChild(noOpNode);
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = bounds,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rasterization.IsEmpty, Is.False);
+            Assert.That(observedScale, Is.EqualTo(EffectiveScale.At(1)));
+            Assert.That(observedDeviceBounds, Is.EqualTo(PixelRect.FromRect(bounds, 1)));
+        });
+    }
+
+    private static void Apply(FilterEffect effect, Rect bounds, EffectTargets targets)
+    {
+        using FilterEffect.Resource resource = effect.ToResource(CompositionContext.Default);
+        using var context = new FilterEffectContext(bounds);
+        context.ApplyTransactional(effect, resource);
+        using var builder = new SKImageFilterBuilder();
+        using var activator = new FilterEffectActivator(
+            targets,
+            builder,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            outputScale: 1,
+            workingScale: 1,
+            maxWorkingScale: 1);
+        activator.Apply(context);
+        activator.Flush(false);
+    }
+
+    private static EffectTargets CreateSolidTargets(Rect bounds, Color color)
+    {
+        using RenderTarget renderTarget = RenderTarget.Create((int)bounds.Width, (int)bounds.Height)
+            ?? throw new InvalidOperationException("A CPU render target is required for this test.");
+        using (var canvas = new ImmediateCanvas(
+                   renderTarget,
+                   density: 1,
+                   maxWorkingScale: 1,
+                   logicalSize: bounds.Size))
+        {
+            canvas.Clear(color);
+        }
+
+        return new EffectTargets
+        {
+            new EffectTarget(renderTarget, bounds, EffectiveScale.At(1)),
+        };
+    }
+
+    private static SKColor ReadCenterPixel(EffectTarget target)
+    {
+        using Bitmap bitmap = target.RenderTarget!.Snapshot();
+        return bitmap.SKBitmap.GetPixel(bitmap.Width / 2, bitmap.Height / 2);
+    }
+
+    private static SKColor ReadCenterPixel(Bitmap bitmap)
+        => bitmap.SKBitmap.GetPixel(bitmap.Width / 2, bitmap.Height / 2);
+
+    private static void DrawLegacyPattern(ImmediateCanvas canvas)
+    {
+        canvas.Clear();
+        canvas.DrawRectangle(
+            new Rect(0.25f, 0.25f, 8.25f, 6.25f),
+            Brushes.Resource.OrangeRed,
+            null);
+        canvas.DrawRectangle(
+            new Rect(2.25f, 1.75f, 3.5f, 2.5f),
+            Brushes.Resource.White,
+            null);
+    }
+
+    private static void RenderMaterializedEffect(FilterEffect effect, Vector translation)
+    {
+        var bounds = new Rect(8, 6, 12, 10);
+        using var source = new CpuRenderTarget(12, 10);
+        source.Value.Canvas.Clear(SKColors.White);
+        source.Value.Flush();
+        using var root = new FilterEffectRenderNode(
+            effect.ToResource(CompositionContext.Default));
+        root.AddChild(new MaterializedInputNode(source, bounds));
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = new Rect(0, 0, 32, 24),
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+        using var destination = new CpuRenderTarget(32, 24);
+        using var canvas = new ImmediateCanvas(
+            destination,
+            logicalSize: new Size(32, 24));
+        canvas.Clear();
+        using (canvas.PushTransform(Matrix.CreateTranslation(translation)))
+        {
+            renderer.Render(canvas);
+        }
+    }
+
+    private sealed class ThrowingDisposable : IDisposable
+    {
+        public int DisposeCount { get; private set; }
+
+        public void Dispose()
+        {
+            DisposeCount++;
+            throw new InvalidOperationException("delay-child-cleanup");
+        }
+    }
+
+    private sealed class CpuTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+            => new CpuRenderTarget(allocation.DeviceSize.Width, allocation.DeviceSize.Height);
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height);
+
+    private sealed class MaterializedInputNode(
+        RenderTarget source,
+        Rect bounds,
+        float density = 1) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<RenderTarget> target = context.Borrow(
+                source,
+                "legacy-custom-materialized-input",
+                version: 1);
+            context.Publish(context.MaterializedInput(
+                MaterializedInputDescription.FromRenderTarget(
+                    target,
+                    bounds,
+                    EffectiveScale.At(density),
+                    PixelRect.FromRect(bounds, density),
+                    default,
+                    RenderHitTestContract.OutputBounds)));
+        }
+    }
+}
+
+[SuppressResourceClassGeneration]
+internal sealed partial class LegacySuffixCallbackFilterEffect(
+    Action<FilterEffectContext, FilterEffect.Resource> apply) : FilterEffect
+{
+    public override void ApplyTo(FilterEffectContext context, FilterEffect.Resource resource)
+        => apply(context, resource);
+
+    public override Resource ToResource(CompositionContext context)
+    {
+        var resource = new Resource();
+        bool updateOnly = true;
+        resource.Update(this, context, ref updateOnly);
+        return resource;
+    }
+
+    public new sealed class Resource : FilterEffect.Resource
+    {
+        public Resource()
+        {
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/OffFrameFilterEffectExecutionTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/OffFrameFilterEffectExecutionTests.cs
@@ -1,0 +1,248 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Shapes;
+using Beutl.Graphics.Transformation;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+[TestFixture]
+public sealed class OffFrameFilterEffectExecutionTests
+{
+    private static readonly Rect s_frame = new(0, 0, 320, 180);
+
+    [Test]
+    public void FullyOffFrameBlur_IsEquivalentToOmittingTheElement()
+    {
+        using SceneGraph control = CreateScene(visibleCount: 1, includeOffFrameEffect: false);
+        using SceneGraph actual = CreateScene(visibleCount: 1, includeOffFrameEffect: true);
+
+        byte[] expected = Render(control.Root);
+        byte[] rendered = Render(actual.Root);
+        Assert.Multiple(() =>
+        {
+            Assert.That(expected, Has.Some.Not.Zero,
+                "The single visible control drawable must contribute pixels before off-frame parity is compared.");
+            Assert.That(rendered, Is.EqualTo(expected));
+        });
+    }
+
+    [Test]
+    public void FullyOffFrameBlur_DoesNotSuppressFiveVisibleElements()
+    {
+        using SceneGraph control = CreateScene(visibleCount: 5, includeOffFrameEffect: false);
+        using SceneGraph actual = CreateScene(visibleCount: 5, includeOffFrameEffect: true);
+
+        byte[] expected = Render(control.Root);
+        byte[] rendered = Render(actual.Root);
+        Assert.Multiple(() =>
+        {
+            Assert.That(rendered, Has.Some.Not.Zero);
+            Assert.That(rendered, Is.EqualTo(expected));
+        });
+    }
+
+    [Test]
+    public void StraddlingBlur_StillRendersItsVisibleFootprint()
+    {
+        const float sigma = 4;
+        const int sampleX = 3;
+        using SceneGraph scene = CreateScene(visibleCount: 0, includeOffFrameEffect: true, offFrameX: -78);
+
+        byte[] rendered = Render(scene.Root);
+
+        // The source body occupies x=-78..2. Column 3 is an on-frame tail sample less than
+        // one sigma from the frame edge and contains no unblurred source coverage.
+        float actualTail = MaximumAlphaInColumn(rendered, sampleX, yStart: 56, yEnd: 88);
+        double sampleCenter = sampleX + 0.5;
+        double expectedTail = GaussianIntervalCoverage(
+            sourceStart: -78,
+            sourceEnd: 2,
+            sampleCenter,
+            sigma);
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                actualTail,
+                Is.GreaterThan(0.05f),
+                "The visible blur tail inside one sigma of the frame edge was dropped.");
+            Assert.That(
+                actualTail,
+                Is.EqualTo(expectedTail).Within(0.04),
+                "The clipped on-frame tail must follow the Gaussian interval profile.");
+        });
+    }
+
+    private static SceneGraph CreateScene(
+        int visibleCount,
+        bool includeOffFrameEffect,
+        float offFrameX = -1_500)
+    {
+        var drawables = new List<Drawable.Resource>();
+        for (int index = 0; index < visibleCount; index++)
+        {
+            float x = 12 + (index * 58);
+            float y = 18 + ((index % 2) * 66);
+            var visible = new RectShape
+            {
+                Width = { CurrentValue = 44 },
+                Height = { CurrentValue = 52 },
+                Fill =
+                {
+                    CurrentValue = index % 2 == 0
+                        ? Brushes.White
+                        : Brushes.OrangeRed,
+                },
+                Transform = { CurrentValue = new TranslateTransform(x, y) },
+            };
+            drawables.Add(visible.ToResource(CompositionContext.Default));
+        }
+
+        if (includeOffFrameEffect)
+        {
+            var offFrame = new RectShape
+            {
+                Width = { CurrentValue = 80 },
+                Height = { CurrentValue = 64 },
+                Fill = { CurrentValue = Brushes.CornflowerBlue },
+                AlignmentX = { CurrentValue = AlignmentX.Left },
+                AlignmentY = { CurrentValue = AlignmentY.Top },
+                Transform = { CurrentValue = new TranslateTransform(offFrameX, 40) },
+                FilterEffect =
+                {
+                    CurrentValue = new Blur
+                    {
+                        Sigma = { CurrentValue = new Size(4, 4) },
+                    },
+                },
+            };
+            drawables.Add(offFrame.ToResource(CompositionContext.Default));
+        }
+
+        if (drawables.Count == 0)
+            throw new InvalidOperationException("The scene fixture must contain at least one drawable.");
+
+        var root = new DrawableRenderNode(drawables[0]);
+        using (var context = new GraphicsContext2D(root, s_frame.Size))
+        {
+            context.Clear();
+            foreach (Drawable.Resource drawable in drawables)
+            {
+                context.DrawDrawable(drawable);
+            }
+        }
+
+        return new SceneGraph(root, drawables);
+    }
+
+    private static byte[] Render(RenderNode root)
+    {
+        using var target = new CpuRenderTarget((int)s_frame.Width, (int)s_frame.Height);
+        using var destination = new ImmediateCanvas(target, logicalSize: s_frame.Size);
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_frame,
+                    RequestedRegion = s_frame,
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+        renderer.Render(destination);
+        using Bitmap result = target.Snapshot();
+        return result.GetPixelSpan().ToArray();
+    }
+
+    private static float MaximumAlphaInColumn(byte[] pixels, int x, int yStart, int yEnd)
+    {
+        float maximum = 0;
+        for (int y = yStart; y < yEnd; y++)
+        {
+            maximum = Math.Max(maximum, ReadAlpha(pixels, x, y));
+        }
+
+        return maximum;
+    }
+
+    private static double GaussianIntervalCoverage(
+        double sourceStart,
+        double sourceEnd,
+        double sampleCenter,
+        double sigma)
+    {
+        static double NormalCdf(double value)
+            => 0.5 * (1 + ErrorFunction(value / Math.Sqrt(2)));
+
+        return NormalCdf((sourceEnd - sampleCenter) / sigma)
+               - NormalCdf((sourceStart - sampleCenter) / sigma);
+    }
+
+    private static double ErrorFunction(double value)
+    {
+        const double p = 0.3275911;
+        const double a1 = 0.254829592;
+        const double a2 = -0.284496736;
+        const double a3 = 1.421413741;
+        const double a4 = -1.453152027;
+        const double a5 = 1.061405429;
+
+        double sign = Math.Sign(value);
+        double x = Math.Abs(value);
+        double t = 1 / (1 + p * x);
+        double approximation = 1
+                               - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1)
+                               * t
+                               * Math.Exp(-x * x);
+        return sign * approximation;
+    }
+
+    private static float ReadAlpha(byte[] pixels, int x, int y)
+    {
+        int offset = ((y * (int)s_frame.Width) + x) * 8;
+        ushort bits = BitConverter.ToUInt16(pixels, offset + 6);
+        return (float)BitConverter.UInt16BitsToHalf(bits);
+    }
+
+    private sealed class SceneGraph(
+        DrawableRenderNode root,
+        IReadOnlyList<Drawable.Resource> drawables) : IDisposable
+    {
+        public DrawableRenderNode Root { get; } = root;
+
+        public void Dispose()
+        {
+            Root.Dispose();
+            foreach (Drawable.Resource drawable in drawables)
+            {
+                drawable.Dispose();
+            }
+        }
+    }
+
+    private sealed class CpuTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+            => new CpuRenderTarget(allocation.DeviceSize.Width, allocation.DeviceSize.Height);
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/BackdropOrderingTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/BackdropOrderingTests.cs
@@ -1,0 +1,296 @@
+﻿using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Planning;
+
+[TestFixture]
+public sealed class BackdropOrderingTests
+{
+    private static readonly Rect s_domain = new(0, 0, 160, 90);
+    private static readonly Rect s_drawBounds = new(12, 8, 80, 48);
+
+    [TestCase(BackdropScope.Root)]
+    [TestCase(BackdropScope.Blend)]
+    [TestCase(BackdropScope.Transform)]
+    [TestCase(BackdropScope.Filter)]
+    public void SnapshotClearDraw_PreservesOneCaptureAndItsTargetTokenOrder(BackdropScope scope)
+    {
+        using ContainerRenderNode root = CreateTree(scope);
+        using var owner = new RenderRequestOwner();
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            targetDomain: s_domain,
+            owner: owner);
+        var request = new RenderRequest(options);
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(root);
+        using CompiledRenderRequest compiled = new RenderRequestCompiler().Compile(request, graph);
+
+        IReadOnlyDictionary<RenderFragmentId, RenderFragmentReference> references = graph.Fragments
+            .ToDictionary(
+                static fragment => fragment.Id,
+                static fragment => (RenderFragmentReference)fragment.Payload!);
+        TargetDependencyStep[] steps = compiled.TargetDependencies.Steps.ToArray();
+
+        RenderFragmentReference[] captures = references.Values
+            .Where(static reference => reference.Kind == RenderFragmentKind.BuiltInBackdropCapture)
+            .ToArray();
+        Assert.That(captures, Has.Length.EqualTo(1),
+            "SnapshotBackdrop must create one request-local target capture.");
+
+        RenderFragmentReference capture = captures[0];
+        TargetDependencyStep captureStep = steps.Single(step =>
+            references[step.FragmentId].Kind == RenderFragmentKind.BuiltInBackdropCapture);
+        TargetDependencyStep[] commandSteps = steps.Where(step =>
+            references[step.FragmentId].Kind == RenderFragmentKind.TargetCommand).ToArray();
+        TargetDependencyStep drawStep = commandSteps.Single(step =>
+            step.TargetReadValueId == captureStep.TargetReadValueId);
+        TargetDependencyStep clearStep = commandSteps.Single(step =>
+            step.TargetReadValueId is null);
+        RenderFragmentReference draw = references[drawStep.FragmentId];
+
+        int captureIndex = Array.IndexOf(steps, captureStep);
+        int clearIndex = Array.IndexOf(steps, clearStep);
+        int drawIndex = Array.IndexOf(steps, drawStep);
+        int captureUses = draw.Inputs.Count(input => ReferenceEquals(input, capture));
+        int implicitContributions = references.Values.Count(reference =>
+            reference.Kind == RenderFragmentKind.ContributeValues
+            && reference.Inputs.Any(input => ReferenceEquals(input, capture)));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(captureStep.TargetReadValueId, Is.Not.Null,
+                "The capture must name the request-owned value read by DrawBackdrop.");
+            Assert.That(capture.ContributesValuesToTarget, Is.False,
+                "A target capture anchors pixels but must not redraw them implicitly.");
+            Assert.That(implicitContributions, Is.Zero);
+            Assert.That(captureIndex, Is.LessThan(clearIndex));
+            Assert.That(clearIndex, Is.LessThan(drawIndex));
+            Assert.That(captureUses, Is.EqualTo(1),
+                "DrawBackdrop must consume exactly the value produced by this capture.");
+            Assert.That(drawStep.TargetReadValueId, Is.EqualTo(captureStep.TargetReadValueId));
+            Assert.That(clearStep.ScopeId, Is.EqualTo(captureStep.ScopeId));
+        });
+
+        if (scope == BackdropScope.Root)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(drawStep.ScopeId, Is.EqualTo(captureStep.ScopeId));
+                Assert.That(clearStep.InputToken, Is.EqualTo(captureStep.OutputToken));
+                Assert.That(drawStep.InputToken, Is.EqualTo(clearStep.OutputToken));
+            });
+        }
+        else
+        {
+            Assert.That(drawStep.ScopeId, Is.Not.EqualTo(captureStep.ScopeId),
+                "The nested draw must consume the capture from inside its own authored scope.");
+
+            if (scope == BackdropScope.Filter)
+            {
+                RenderFragmentReference isolation = references.Values
+                    .Single(static reference => reference.Kind == RenderFragmentKind.Layer);
+                var payload = (LayerRenderFragmentPayload)isolation.Payload!;
+                Assert.Multiple(() =>
+                {
+                    Assert.That(payload.Domain, Is.EqualTo(s_drawBounds),
+                        "A finite target write must use its affected region rather than a symbolic capture hint.");
+                    Assert.That(isolation.BoundsRequirement,
+                        Is.EqualTo(RenderFragmentBoundsRequirement.Finite));
+                    Assert.That(references.Values.Any(static reference =>
+                        reference.Kind == RenderFragmentKind.LegacyFilterEffect), Is.True,
+                        "The filter must remain present after target-dependent input isolation.");
+                });
+            }
+        }
+    }
+
+    [Test]
+    public void SnapshotDraw_WithoutCurrentCapture_UsesPersistedFallbackPath()
+    {
+        using var snapshot = new SnapshotBackdropRenderNode();
+        var fallback = new Bitmap((int)s_domain.Width, (int)s_domain.Height);
+        fallback.GetPixelSpan().Fill(byte.MaxValue);
+        ((IBuiltInBackdropCaptureSink)snapshot).CommitBackdropCapture(fallback, density: 1f);
+        using var draw = new DrawBackdropRenderNode(snapshot, s_drawBounds);
+        using var renderer = new RenderNodeRenderer(
+            draw,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_domain,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+            });
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        Bitmap bitmap = rasterization.Bitmap
+            ?? throw new AssertionException("The persisted fallback produced no bitmap.");
+        int sampleX = (int)(s_drawBounds.Center.X - rasterization.Bounds.X);
+        int sampleY = (int)(s_drawBounds.Center.Y - rasterization.Bounds.Y);
+        var sample = bitmap.SKBitmap.GetPixel(sampleX, sampleY);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rasterization.Bounds.Contains(s_drawBounds), Is.True,
+                "The raw fallback may conservatively retain the full target domain.");
+            Assert.That(sample.Red, Is.EqualTo(byte.MaxValue));
+            Assert.That(sample.Green, Is.EqualTo(byte.MaxValue));
+            Assert.That(sample.Blue, Is.EqualTo(byte.MaxValue));
+            Assert.That(sample.Alpha, Is.EqualTo(byte.MaxValue),
+                "A point inside the draw bounds must contain the committed opaque-white fallback.");
+        });
+    }
+
+    [Test]
+    public void SnapshotSubclass_UsesTheSameRequestCapture()
+    {
+        using var root = new ContainerRenderNode();
+        var snapshot = new DerivedSnapshotBackdropRenderNode();
+        root.AddChild(snapshot);
+        root.AddChild(new DrawBackdropRenderNode(snapshot, s_drawBounds));
+        using var request = new RenderRequest(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            targetDomain: s_domain));
+
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(root);
+        RenderFragmentReference[] references = graph.Fragments
+            .Select(static fragment => (RenderFragmentReference)fragment.Payload!)
+            .ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(references.Count(static item => item.Kind == RenderFragmentKind.BuiltInBackdropCapture),
+                Is.EqualTo(1));
+            Assert.That(references.Count(static item => item.Kind == RenderFragmentKind.TargetCommand),
+                Is.EqualTo(1));
+            Assert.That(references, Has.None.Matches<RenderFragmentReference>(
+                static item => item.Kind == RenderFragmentKind.RawTargetCommand));
+        });
+    }
+
+    [Test]
+    public void DisposedSnapshot_RejectsPersistedFallbackWithoutTakingOwnership()
+    {
+        var snapshot = new SnapshotBackdropRenderNode();
+        snapshot.Dispose();
+        using var fallback = new Bitmap((int)s_domain.Width, (int)s_domain.Height);
+
+        bool accepted = ((IBuiltInBackdropCaptureSink)snapshot)
+            .TryCommitBackdropCapture(fallback, density: 1f);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(accepted, Is.False);
+            Assert.That(fallback.IsDisposed, Is.False);
+        });
+    }
+
+    [Test]
+    public void TemporaryBackdropSubtree_CanBeDisposedAfterRecording()
+    {
+        using var root = new TemporaryBackdropSubtreeNode();
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_domain,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+            });
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        Bitmap bitmap = rasterization.Bitmap
+            ?? throw new AssertionException("The recorded temporary backdrop produced no bitmap.");
+        Assert.That(rasterization.Bounds.Contains(s_drawBounds.Center), Is.True,
+            "The temporary backdrop rasterization must contain the requested draw sample.");
+        int sampleX = (int)(s_drawBounds.Center.X - rasterization.Bounds.X);
+        int sampleY = (int)(s_drawBounds.Center.Y - rasterization.Bounds.Y);
+        var sample = bitmap.SKBitmap.GetPixel(sampleX, sampleY);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sample.Red, Is.EqualTo(byte.MaxValue));
+            Assert.That(sample.Green, Is.EqualTo(byte.MaxValue));
+            Assert.That(sample.Blue, Is.EqualTo(byte.MaxValue));
+            Assert.That(sample.Alpha, Is.EqualTo(byte.MaxValue),
+                "The draw must retain the opaque-white backdrop captured before the contrasting clear.");
+        });
+    }
+
+    private static ContainerRenderNode CreateTree(BackdropScope scope)
+    {
+        var root = new ContainerRenderNode();
+        var snapshot = new SnapshotBackdropRenderNode();
+        var clear = new ClearRenderNode(Colors.Transparent);
+        var draw = new DrawBackdropRenderNode(snapshot, s_drawBounds);
+
+        root.AddChild(snapshot);
+        root.AddChild(clear);
+        root.AddChild(WrapDraw(draw, scope));
+        return root;
+    }
+
+    private static RenderNode WrapDraw(DrawBackdropRenderNode draw, BackdropScope scope)
+    {
+        ContainerRenderNode? wrapper = scope switch
+        {
+            BackdropScope.Root => null,
+            BackdropScope.Blend => new BlendModeRenderNode(BlendMode.Multiply),
+            BackdropScope.Transform => new TransformRenderNode(
+                Matrix.CreateTranslation(7, 11),
+                TransformOperator.Prepend),
+            BackdropScope.Filter => CreateFilterScope(),
+            _ => throw new ArgumentOutOfRangeException(nameof(scope), scope, null),
+        };
+
+        if (wrapper is null)
+            return draw;
+
+        wrapper.AddChild(draw);
+        return wrapper;
+    }
+
+    private static FilterEffectRenderNode CreateFilterScope()
+    {
+        var effect = new MosaicEffect();
+        effect.TileSize.CurrentValue = new Size(8, 8);
+        return new FilterEffectRenderNode(effect.ToResource(CompositionContext.Default));
+    }
+
+    private sealed class TemporaryBackdropSubtreeNode : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            using var subtree = new ContainerRenderNode();
+            var snapshot = new SnapshotBackdropRenderNode();
+            subtree.AddChild(new ClearRenderNode(Colors.White));
+            subtree.AddChild(snapshot);
+            subtree.AddChild(new ClearRenderNode(Colors.Transparent));
+            subtree.AddChild(new DrawBackdropRenderNode(snapshot, s_drawBounds));
+
+            IReadOnlyList<RenderFragmentHandle> outputs = context.RecordSubtree(subtree);
+            context.Publish(context.Layer(outputs, s_domain));
+        }
+    }
+
+    private sealed class DerivedSnapshotBackdropRenderNode : SnapshotBackdropRenderNode
+    {
+    }
+
+    public enum BackdropScope
+    {
+        Root,
+        Blend,
+        Transform,
+        Filter,
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/ExecutionIslandPlannerCacheBoundaryTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/ExecutionIslandPlannerCacheBoundaryTests.cs
@@ -1,0 +1,324 @@
+﻿using System.Collections.Immutable;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Planning;
+
+[TestFixture]
+public sealed class ExecutionIslandPlannerCacheBoundaryTests
+{
+    private static readonly Rect s_bounds = new(0, 0, 32, 24);
+
+    [TestCase((int)RenderCacheBypassReason.CacheDisabled)]
+    [TestCase((int)RenderCacheBypassReason.CapturePublicationDisabled)]
+    [TestCase((int)RenderCacheBypassReason.OutsideCacheRules)]
+    [TestCase((int)RenderCacheBypassReason.UnstableBoundaryPlan)]
+    public void BypassedCandidate_DoesNotSplitMaximalCompatibleRun(
+        int bypassReasonValue)
+    {
+        var bypassReason = (RenderCacheBypassReason)bypassReasonValue;
+        GraphFixture fixture = CreateShaderGraph(includeGeometryPrefix: false);
+        RenderCacheResolution resolution = CreateResolution(
+            fixture,
+            RenderCacheResolutionKind.Bypass,
+            bypassReason);
+
+        ExecutionIslandPlan plan = Plan(fixture, resolution, FusionMode.Enabled);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(plan.ShaderRuns, Has.Exactly(1).Items);
+            Assert.That(plan.ShaderRuns.Single().Stages.Select(static stage => stage.FragmentId),
+                Is.EqualTo(new[] { fixture.CachedProducer.Id, fixture.Tail.Id }));
+            Assert.That(plan.Boundaries, Has.None.Matches<ExecutionIslandBoundary>(static boundary =>
+                boundary.Reason is ExecutionIslandBoundaryReason.CacheInput
+                    or ExecutionIslandBoundaryReason.CacheCapture));
+        });
+    }
+
+    [Test]
+    public void BypassedCandidate_WithFusionDisabledUsesOnlyFusionDisabledSplit()
+    {
+        GraphFixture fixture = CreateShaderGraph(includeGeometryPrefix: false);
+        RenderCacheResolution resolution = CreateResolution(
+            fixture,
+            RenderCacheResolutionKind.Bypass,
+            RenderCacheBypassReason.CacheDisabled);
+
+        ExecutionIslandPlan plan = Plan(fixture, resolution, FusionMode.Disabled);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(plan.ShaderRuns.Select(static run => run.Stages.Length),
+                Is.EqualTo(new[] { 1, 1 }));
+            Assert.That(plan.Boundaries.Count(static boundary =>
+                boundary.Reason == ExecutionIslandBoundaryReason.FusionDisabled), Is.EqualTo(1));
+            Assert.That(plan.Boundaries, Has.None.Matches<ExecutionIslandBoundary>(static boundary =>
+                boundary.Reason is ExecutionIslandBoundaryReason.CacheInput
+                    or ExecutionIslandBoundaryReason.CacheCapture));
+        });
+    }
+
+    [Test]
+    public void SelectedMissCapture_SplitsAfterProducerWithExactCacheCaptureReason()
+    {
+        GraphFixture fixture = CreateShaderGraph(includeGeometryPrefix: false);
+        RenderCacheResolution resolution = CreateResolution(
+            fixture,
+            RenderCacheResolutionKind.MissCapture);
+
+        ExecutionIslandPlan plan = Plan(fixture, resolution, FusionMode.Enabled);
+        ExecutionIslandBoundary[] cacheBoundaries = plan.Boundaries
+            .Where(static boundary => boundary.Reason is ExecutionIslandBoundaryReason.CacheInput
+                or ExecutionIslandBoundaryReason.CacheCapture)
+            .ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(plan.ShaderRuns.Select(static run => run.Stages.Length),
+                Is.EqualTo(new[] { 1, 1 }));
+            Assert.That(cacheBoundaries, Has.Exactly(1).Items);
+            Assert.That(cacheBoundaries[0].BeforeFragmentId, Is.EqualTo(fixture.CachedProducer.Id));
+            Assert.That(cacheBoundaries[0].AfterFragmentId, Is.Null);
+            Assert.That(cacheBoundaries[0].Reason,
+                Is.EqualTo(ExecutionIslandBoundaryReason.CacheCapture));
+        });
+    }
+
+    [Test]
+    public void SelectedHit_OmitsReplacedProducerAndPrivateSubtreeFromExecutablePlan()
+    {
+        GraphFixture fixture = CreateShaderGraph(includeGeometryPrefix: true);
+        RenderCacheResolution resolution = CreateResolution(
+            fixture,
+            RenderCacheResolutionKind.Hit);
+
+        ExecutionIslandPlan plan = Plan(fixture, resolution, FusionMode.Enabled);
+        ExecutionIslandBoundary[] cacheBoundaries = plan.Boundaries
+            .Where(static boundary => boundary.Reason is ExecutionIslandBoundaryReason.CacheInput
+                or ExecutionIslandBoundaryReason.CacheCapture)
+            .ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(plan.Islands, Has.Exactly(1).Items);
+            Assert.That(plan.Islands.Single().Fragments, Is.EqualTo(new[] { fixture.Tail.Id }));
+            Assert.That(plan.ShaderRuns.Single().Stages.Select(static stage => stage.FragmentId),
+                Is.EqualTo(new[] { fixture.Tail.Id }));
+            Assert.That(plan.ShaderRuns.Single().CoverageSource,
+                Is.EqualTo(ShaderRunCoverageSource.MaterializedInput));
+            Assert.That(plan.Islands.SelectMany(static island => island.Fragments),
+                Has.None.EqualTo(fixture.CachedProducer.Id));
+            Assert.That(plan.Islands.SelectMany(static island => island.Fragments),
+                Has.None.EqualTo(fixture.Prefix.Id));
+            Assert.That(plan.Boundaries, Has.None.Matches<ExecutionIslandBoundary>(static boundary =>
+                boundary.Reason == ExecutionIslandBoundaryReason.Geometry));
+            Assert.That(cacheBoundaries, Has.Exactly(1).Items);
+            Assert.That(cacheBoundaries[0].BeforeFragmentId, Is.Null);
+            Assert.That(cacheBoundaries[0].AfterFragmentId, Is.EqualTo(fixture.CachedProducer.Id));
+            Assert.That(cacheBoundaries[0].Reason,
+                Is.EqualTo(ExecutionIslandBoundaryReason.CacheInput));
+        });
+    }
+
+    [Test]
+    public void SelectedHit_DoesNotPruneSubtreeStillPublishedByAnotherRoot()
+    {
+        GraphFixture fixture = CreateShaderGraph(
+            includeGeometryPrefix: true,
+            publishPrefix: true);
+        RenderCacheResolution resolution = CreateResolution(
+            fixture,
+            RenderCacheResolutionKind.Hit);
+
+        ExecutionIslandPlan plan = Plan(fixture, resolution, FusionMode.Enabled);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(plan.Islands.SelectMany(static island => island.Fragments),
+                Has.Some.EqualTo(fixture.Prefix.Id));
+            Assert.That(plan.Islands.SelectMany(static island => island.Fragments),
+                Has.None.EqualTo(fixture.CachedProducer.Id));
+            Assert.That(plan.Boundaries, Has.Some.Matches<ExecutionIslandBoundary>(static boundary =>
+                boundary.Reason == ExecutionIslandBoundaryReason.Geometry));
+            Assert.That(plan.Boundaries.Count(static boundary =>
+                boundary.Reason == ExecutionIslandBoundaryReason.CacheInput), Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void StructuralIdentity_DistinguishesHitFromMissCaptureAtSameCandidate()
+    {
+        GraphFixture fixture = CreateShaderGraph(includeGeometryPrefix: false);
+        RenderCacheResolution hit = CreateResolution(fixture, RenderCacheResolutionKind.Hit);
+        RenderCacheResolution miss = CreateResolution(fixture, RenderCacheResolutionKind.MissCapture);
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            targetDomain: s_bounds);
+
+        StructuralPlanIdentity hitIdentity = StructuralPlanIdentity.Create(
+            options.PlanIdentity,
+            fixture.Graph,
+            SkslBackendBudget.Unlimited,
+            hit);
+        StructuralPlanIdentity missIdentity = StructuralPlanIdentity.Create(
+            options.PlanIdentity,
+            fixture.Graph,
+            SkslBackendBudget.Unlimited,
+            miss);
+
+        Assert.That(hitIdentity, Is.Not.EqualTo(missIdentity));
+    }
+
+    private static ExecutionIslandPlan Plan(
+        GraphFixture fixture,
+        RenderCacheResolution resolution,
+        FusionMode fusionMode)
+        => new ExecutionIslandPlanner().Plan(
+            fixture.Graph,
+            RenderRequestCompiler.ResolveRoots(fixture.Graph),
+            resolution,
+            fusionMode,
+            SkslBackendBudget.Unlimited);
+
+    private static RenderCacheResolution CreateResolution(
+        GraphFixture fixture,
+        RenderCacheResolutionKind kind,
+        RenderCacheBypassReason bypassReason = RenderCacheBypassReason.None)
+    {
+        RenderCacheCandidate candidate = fixture.Graph.CacheCandidates.Single();
+        RecordedRenderFragment recorded = fixture.Graph.Fragments.Single(fragment =>
+            fragment.Id == candidate.FragmentId);
+        var identity = new RenderOutputCacheIdentity(
+            candidate.CacheKey,
+            RenderFragmentOutputIdentity.Create(fixture.CachedProducer, fixture.Graph.RequestId),
+            fixture.CachedProducer.Bounds,
+            RequiredRegion.Full,
+            density: 1,
+            RenderCacheFormatIdentity.LinearPremultipliedRgba16Float,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            FusionMode.Enabled,
+            new RenderCacheDeviceContextIdentity("planner-test-device", "planner-test-context"));
+
+        RenderCacheDecision decision = kind switch
+        {
+            RenderCacheResolutionKind.Bypass => new RenderCacheDecision(
+                candidate,
+                kind,
+                bypassReason,
+                identity,
+                null,
+                null,
+                null),
+            RenderCacheResolutionKind.Hit => new RenderCacheDecision(
+                candidate,
+                kind,
+                RenderCacheBypassReason.None,
+                identity,
+                new RenderCacheHitSubstitution(
+                    candidate.Id,
+                    recorded.Id,
+                    recorded.Values,
+                    recorded.ProvenanceId,
+                    identity,
+                    new RenderCacheEntry(identity, new object())),
+                null,
+                null),
+            RenderCacheResolutionKind.MissCapture => new RenderCacheDecision(
+                candidate,
+                kind,
+                RenderCacheBypassReason.None,
+                identity,
+                null,
+                new RenderCacheMissCapture(
+                    candidate.Id,
+                    recorded.Id,
+                    recorded.Values,
+                    recorded.ProvenanceId,
+                    identity),
+                null),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+        return new RenderCacheResolution([decision]);
+    }
+
+    private static GraphFixture CreateShaderGraph(
+        bool includeGeometryPrefix,
+        bool publishPrefix = false)
+    {
+        var requestId = new RenderRequestId(1);
+        RenderFragmentReference source = Fragment(
+            RenderFragmentKind.MaterializedInput,
+            payload: null,
+            EffectiveScale.At(1));
+        RenderFragmentReference prefix = includeGeometryPrefix
+            ? Fragment(RenderFragmentKind.Geometry, payload: null, EffectiveScale.At(1), source)
+            : source;
+        RenderFragmentReference cachedProducer = CurrentPixel(prefix, "return color * 0.75;");
+        RenderFragmentReference tail = CurrentPixel(cachedProducer, "return half4(color.bgr, color.a);");
+        RenderFragmentReference[] references = includeGeometryPrefix
+            ? [source, prefix, cachedProducer, tail]
+            : [source, cachedProducer, tail];
+
+        var builder = new RecordedRenderGraphBuilder(requestId);
+        RenderProvenanceId provenance = builder.AddProvenance(
+            typeof(ExecutionIslandPlannerCacheBoundaryTests),
+            "planner-cache-boundary-test");
+        foreach (RenderFragmentReference reference in references)
+        {
+            RenderValueId[] inputs = reference.Inputs
+                .SelectMany(static input => input.ValueIds)
+                .ToArray();
+            reference.ValueIds = [builder.AddValue(inputs, provenance, reference)];
+            reference.Id = builder.AddFragment(reference.ValueIds, provenance, reference);
+        }
+
+        builder.AddCacheCandidate(cachedProducer.Id!.Value, "selected-candidate");
+        builder.PublishRoot(tail.Id!.Value);
+        if (publishPrefix)
+            builder.PublishRoot(prefix.Id!.Value);
+
+        return new GraphFixture(builder.Build(), prefix, cachedProducer, tail);
+    }
+
+    private static RenderFragmentReference CurrentPixel(
+        RenderFragmentReference input,
+        string body)
+    {
+        ShaderDescription description = ShaderDescription.CurrentPixel(
+            $"half4 apply(half4 color) {{ {body} }}");
+        return Fragment(
+            RenderFragmentKind.Shader,
+            new ShaderRenderFragmentPayload(description, description.CreateRuntimeIdentity()),
+            EffectiveScale.Unbounded,
+            input);
+    }
+
+    private static RenderFragmentReference Fragment(
+        RenderFragmentKind kind,
+        object? payload,
+        EffectiveScale scale,
+        params RenderFragmentReference[] inputs)
+        => new(
+            kind,
+            s_bounds,
+            scale,
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: inputs.Any(static input => input.HasTargetEffects),
+            hasOpaqueExternalWork: inputs.Any(static input => input.HasOpaqueExternalWork),
+            inputs,
+            payload,
+            static _ => true);
+
+    private sealed record GraphFixture(
+        RecordedRenderGraph Graph,
+        RenderFragmentReference Prefix,
+        RenderFragmentReference CachedProducer,
+        RenderFragmentReference Tail);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/InTreeDeclaredTraitTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/InTreeDeclaredTraitTests.cs
@@ -1,0 +1,228 @@
+﻿using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Graphics.Transformation;
+using Beutl.Media;
+using Beutl.Media.TextFormatting;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Planning;
+
+/// <summary>
+/// Pins the planner traits the in-tree render nodes declare and the cache decisions they produce, so a
+/// reversed mapping is caught instead of silently changing which fragments survive a remapping scope.
+/// </summary>
+[TestFixture]
+public sealed class InTreeDeclaredTraitTests
+{
+    private static readonly Rect s_domain = new(0, 0, 256, 128);
+
+    private static readonly Matrix s_subpixelShift = Matrix.CreateTranslation(3.25f, 4.5f);
+
+    [TestCase(TransformOperator.Prepend, false, true, RenderDeviceGridMapping.Remapped)]
+    [TestCase(TransformOperator.Prepend, true, true, RenderDeviceGridMapping.Preserved)]
+    [TestCase(TransformOperator.Append, false, false, RenderDeviceGridMapping.Remapped)]
+    [TestCase(TransformOperator.Append, true, false, RenderDeviceGridMapping.Preserved)]
+    [TestCase(TransformOperator.Set, false, false, RenderDeviceGridMapping.Remapped)]
+    [TestCase(TransformOperator.Set, true, false, RenderDeviceGridMapping.Remapped)]
+    public void TransformRenderNode_DeclaresEligibilityAndGridMappingIndependently(
+        TransformOperator transformOperator,
+        bool identityMatrix,
+        bool expectedValueReplayMap,
+        RenderDeviceGridMapping expectedMapping)
+    {
+        using var transform = new TransformRenderNode(
+            identityMatrix ? Matrix.Identity : s_subpixelShift,
+            transformOperator);
+        transform.AddChild(NewRectangleNode());
+
+        TargetScopeDescription description = RecordSingleScope(transform);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(description.IsValueReplayMap, Is.EqualTo(expectedValueReplayMap));
+            Assert.That(description.DeviceGridMapping, Is.EqualTo(expectedMapping));
+        });
+    }
+
+    [TestCase(false, RenderDeviceGridMapping.Remapped)]
+    [TestCase(true, RenderDeviceGridMapping.Preserved)]
+    public void DrawableGroupTransform_DeclaresItsGridMappingFromTheResolvedMatrix(
+        bool identityMatrix,
+        RenderDeviceGridMapping expectedMapping)
+    {
+        using DrawableGroup.CustomTransformRenderNode transform = NewGroupTransformNode(identityMatrix);
+        transform.AddChild(NewRectangleNode());
+
+        TargetScopeDescription description = RecordSingleScope(transform);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(description.IsValueReplayMap, Is.True);
+            Assert.That(description.DeviceGridMapping, Is.EqualTo(expectedMapping));
+        });
+    }
+
+    [TestCase(false, true)]
+    [TestCase(true, false)]
+    public void DrawableGroupTransform_BypassesTheTextCacheOnlyWhenItRemapsTheGrid(
+        bool identityMatrix,
+        bool expectBypass)
+    {
+        using DrawableGroup.CustomTransformRenderNode transform = NewGroupTransformNode(identityMatrix);
+        RenderNode text = NewTextNode();
+        text.Cache.ReportRenderCount(RenderNodeCache.Count);
+        transform.AddChild(text);
+
+        Assert.That(ResolveSingleCacheDecision(transform).BypassReason, Is.EqualTo(
+            expectBypass ? RenderCacheBypassReason.DeviceGridDependentOutput : RenderCacheBypassReason.None));
+    }
+
+    [Test]
+    public void VectorSourcesConservativelyDeclareDeviceGridPhaseDependence()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                DeclaredSensitivity(NewTextNode()),
+                Is.EqualTo(RenderDeviceGridSensitivity.PhaseDependent));
+            Assert.That(
+                DeclaredSensitivity(NewRectangleNode()),
+                Is.EqualTo(RenderDeviceGridSensitivity.PhaseDependent));
+            Assert.That(
+                DeclaredSensitivity(new EllipseRenderNode(
+                    new Rect(0, 0, 40, 30),
+                    Brushes.Resource.White,
+                    null)),
+                Is.EqualTo(RenderDeviceGridSensitivity.PhaseDependent));
+        });
+    }
+
+    [TestCase(true, TransformOperator.Prepend, false, true)]
+    [TestCase(true, TransformOperator.Prepend, true, false)]
+    [TestCase(true, TransformOperator.Append, false, true)]
+    [TestCase(true, TransformOperator.Append, true, false)]
+    [TestCase(false, TransformOperator.Prepend, false, true)]
+    public void TransformOverASource_BypassesPhaseDependentContentUnderARemappingScope(
+        bool useText,
+        TransformOperator transformOperator,
+        bool identityMatrix,
+        bool expectBypass)
+    {
+        RenderNode source = useText ? NewTextNode() : NewRectangleNode();
+        source.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using var transform = new TransformRenderNode(
+            identityMatrix ? Matrix.Identity : s_subpixelShift,
+            transformOperator);
+        transform.AddChild(source);
+
+        Assert.That(ResolveSingleCacheDecision(transform).BypassReason, Is.EqualTo(
+            expectBypass ? RenderCacheBypassReason.DeviceGridDependentOutput : RenderCacheBypassReason.None));
+    }
+
+    [Test]
+    public void TheGridPreservingInTreeScopesDeclareThatTheyPreserveTheGrid()
+    {
+        using var push = new PushRenderNode();
+        push.AddChild(NewRectangleNode());
+        using var rectClip = new RectClipRenderNode(s_domain, ClipOperation.Intersect);
+        rectClip.AddChild(NewRectangleNode());
+        using var geometryClip = new GeometryClipRenderNode(
+            new RectGeometry
+            {
+                Width = { CurrentValue = s_domain.Width },
+                Height = { CurrentValue = s_domain.Height },
+            }.ToResource(CompositionContext.Default),
+            ClipOperation.Intersect);
+        geometryClip.AddChild(NewRectangleNode());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                RecordSingleScope(push).DeviceGridMapping,
+                Is.EqualTo(RenderDeviceGridMapping.Preserved));
+            Assert.That(
+                RecordSingleScope(rectClip).DeviceGridMapping,
+                Is.EqualTo(RenderDeviceGridMapping.Preserved));
+            Assert.That(
+                RecordSingleScope(geometryClip).DeviceGridMapping,
+                Is.EqualTo(RenderDeviceGridMapping.Preserved));
+        });
+    }
+
+    private static TargetScopeDescription RecordSingleScope(RenderNode node)
+    {
+        using RenderRequest request = CreateRequest(cacheEnabled: false);
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        return ((TargetScopeRenderFragmentPayload)GetSingleRoot(graph).Payload!).Description;
+    }
+
+    private static RenderCacheDecision ResolveSingleCacheDecision(RenderNode node)
+    {
+        using RenderRequest request = CreateRequest(cacheEnabled: true, RenderRequestPurpose.Frame);
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        using CompiledRenderRequest compiled = new RenderRequestCompiler(
+            renderCacheContext: new RenderCacheResolutionContext(
+                RenderCacheFormatIdentity.LinearPremultipliedRgba16Float,
+                new RenderCacheDeviceContextIdentity("device", "context")))
+            .Compile(request, graph);
+        return compiled.CacheResolution.Decisions.Single();
+    }
+
+    private static RenderDeviceGridSensitivity DeclaredSensitivity(RenderNode node)
+    {
+        using (node)
+        {
+            using RenderRequest request = CreateRequest(cacheEnabled: false);
+            RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+            var payload = (OpaqueRenderFragmentPayload)GetSingleRoot(graph).Payload!;
+            return payload.Description.DeviceGridSensitivity;
+        }
+    }
+
+    private static DrawableGroup.CustomTransformRenderNode NewGroupTransformNode(bool identityMatrix)
+        => new(
+            identityMatrix
+                ? null
+                : new TranslateTransform(s_subpixelShift.M31, s_subpixelShift.M32)
+                    .ToResource(CompositionContext.Default),
+            default,
+            s_domain.Size,
+            AlignmentX.Left,
+            AlignmentY.Top,
+            new MemoryNode<Rect>(s_domain));
+
+    private static RectangleRenderNode NewRectangleNode()
+        => new(new Rect(0, 0, 40, 30), Brushes.Resource.White, null);
+
+    private static TextRenderNode NewTextNode()
+    {
+        var text = new FormattedText
+        {
+            Font = TypefaceProvider.Typeface().FontFamily,
+            Size = 48f,
+            Text = "ab",
+        };
+        return new TextRenderNode(text, Brushes.Resource.White, null);
+    }
+
+    private static RenderRequest CreateRequest(
+        bool cacheEnabled,
+        RenderRequestPurpose purpose = RenderRequestPurpose.Auxiliary)
+        => new(new RenderRequestOptions(
+            RenderIntent.Preview,
+            purpose,
+            targetDomain: s_domain,
+            outputScale: 1,
+            maxWorkingScale: 1,
+            cachePolicy: cacheEnabled ? RenderCacheOptions.Enabled : RenderCacheOptions.Disabled));
+
+    private static RenderFragmentReference GetSingleRoot(RecordedRenderGraph graph)
+    {
+        RenderFragmentId rootId = graph.PublicationRoots.Single();
+        return (RenderFragmentReference)graph.Fragments
+            .Single(fragment => fragment.Id == rootId)
+            .Payload!;
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/MaterializedInputCompositeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/MaterializedInputCompositeTests.cs
@@ -1,0 +1,280 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Planning;
+
+[TestFixture]
+[NonParallelizable]
+public sealed class MaterializedInputCompositeTests
+{
+    private static readonly Rect s_sourceBounds = new(0, 0, 7, 5);
+
+    [Test]
+    public void ExternalInput_WithExactOneToOneMapping_PreservesSourcePixelBytes()
+    {
+        using var source = new CpuRenderTarget(7, 5);
+        FillHighFrequencyPattern(source);
+        using Bitmap expected = source.Snapshot();
+
+        using Bitmap actual = RenderExternalInput(
+            source,
+            sourceDensity: 1,
+            destinationDensity: 1,
+            destinationSize: new PixelSize(7, 5),
+            transform: Matrix.Identity);
+
+        Assert.Multiple(() =>
+        {
+            AssertContainsVisibleContent(expected);
+            Assert.That(
+                actual.GetPixelSpan().SequenceEqual(expected.GetPixelSpan()),
+                Is.True,
+                "An exact external input must retain every source pixel byte.");
+        });
+    }
+
+    [Test]
+    public void ExternalInput_WithDifferentDestinationDensity_UsesScaledComposite()
+    {
+        using var source = new CpuRenderTarget(7, 5);
+        FillHighFrequencyPattern(source);
+        var destinationSize = new PixelSize(14, 10);
+
+        using Bitmap expected = RenderScaledReference(
+            source,
+            destinationDensity: 2,
+            destinationSize,
+            transform: Matrix.Identity);
+        using Bitmap actual = RenderExternalInput(
+            source,
+            sourceDensity: 1,
+            destinationDensity: 2,
+            destinationSize,
+            transform: Matrix.Identity);
+
+        Assert.Multiple(() =>
+        {
+            AssertContainsVisibleContent(expected);
+            Assert.That(
+                actual.GetPixelSpan().SequenceEqual(expected.GetPixelSpan()),
+                Is.True,
+                "A density mismatch must retain the Mitchell-scaled fallback.");
+        });
+    }
+
+    [Test]
+    public void ExternalInput_WithFractionalTransform_UsesScaledComposite()
+    {
+        using var source = new CpuRenderTarget(7, 5);
+        FillHighFrequencyPattern(source);
+        var destinationSize = new PixelSize(9, 7);
+        Matrix transform = Matrix.CreateTranslation(0.5f, 0.25f);
+
+        using Bitmap expected = RenderScaledReference(
+            source,
+            destinationDensity: 1,
+            destinationSize,
+            transform);
+        using Bitmap actual = RenderExternalInput(
+            source,
+            sourceDensity: 1,
+            destinationDensity: 1,
+            destinationSize,
+            transform);
+
+        Assert.Multiple(() =>
+        {
+            AssertContainsVisibleContent(expected);
+            Assert.That(
+                actual.GetPixelSpan().SequenceEqual(expected.GetPixelSpan()),
+                Is.True,
+                "A fractional device mapping must retain the transformed scaled fallback.");
+        });
+    }
+
+    [Test]
+    public void ExternalInput_PreservesDeclaredDeviceGridPlacementAndApron()
+    {
+        var bounds = new Rect(2.25f, 1.5f, 7, 5);
+        var deviceGridOffset = new Vector(0.5f, 0.25f);
+        PixelRect deviceBounds = PixelRect.FromRect(bounds.Translate(deviceGridOffset), 1);
+        Rect rasterBounds = deviceBounds.ToRect(1).Translate(-deviceGridOffset);
+        using var source = new CpuRenderTarget(deviceBounds.Width, deviceBounds.Height);
+        FillHighFrequencyPattern(source);
+        var destinationSize = new PixelSize(12, 9);
+
+        using Bitmap expected = RenderScaledReference(
+            source,
+            destinationDensity: 1,
+            destinationSize,
+            transform: Matrix.Identity,
+            rasterBounds);
+        using Bitmap actual = RenderExternalInput(
+            source,
+            sourceDensity: 1,
+            destinationDensity: 1,
+            destinationSize,
+            transform: Matrix.Identity,
+            bounds,
+            deviceBounds,
+            deviceGridOffset);
+
+        Assert.Multiple(() =>
+        {
+            AssertContainsVisibleContent(expected);
+            Assert.That(
+                actual.GetPixelSpan().SequenceEqual(expected.GetPixelSpan()),
+                Is.True,
+                "Materialization must preserve the supplied physical footprint and fractional device-grid phase.");
+        });
+    }
+
+    private static Bitmap RenderExternalInput(
+        RenderTarget source,
+        float sourceDensity,
+        float destinationDensity,
+        PixelSize destinationSize,
+        Matrix transform,
+        Rect? bounds = null,
+        PixelRect? deviceBounds = null,
+        Vector deviceGridOffset = default)
+    {
+        Rect sourceBounds = bounds ?? s_sourceBounds;
+        PixelRect sourceDeviceBounds = deviceBounds ?? PixelRect.FromRect(sourceBounds, sourceDensity);
+        using var node = new MaterializedInputNode(
+            source,
+            sourceBounds,
+            sourceDensity,
+            sourceDeviceBounds,
+            deviceGridOffset);
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            targetDomain: sourceBounds,
+            outputScale: destinationDensity,
+            maxWorkingScale: destinationDensity,
+            cachePolicy: RenderCacheOptions.Disabled);
+        using var request = new RenderRequest(options);
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        using CompiledRenderRequest compiled = new RenderRequestCompiler().Compile(request, graph);
+        using var destination = new CpuRenderTarget(destinationSize.Width, destinationSize.Height);
+        using var canvas = new ImmediateCanvas(
+            destination,
+            destinationDensity,
+            destinationDensity,
+            destinationSize.ToSize(destinationDensity));
+        canvas.Clear();
+        using var registry = new RenderTargetLeaseRegistry(factory: null);
+        using RenderTargetLeaseSession targets =
+            registry.BeginSession(
+                RenderIntent.Preview,
+                RenderAllocationBudget.Default,
+                destination);
+        using (canvas.PushTransform(transform))
+        {
+            new RenderRequestExecutor(targets).Execute(compiled, canvas);
+        }
+
+        return destination.Snapshot();
+    }
+
+    private static Bitmap RenderScaledReference(
+        RenderTarget source,
+        float destinationDensity,
+        PixelSize destinationSize,
+        Matrix transform,
+        Rect? rasterBounds = null)
+    {
+        using var destination = new CpuRenderTarget(destinationSize.Width, destinationSize.Height);
+        using var canvas = new ImmediateCanvas(
+            destination,
+            destinationDensity,
+            destinationDensity,
+            destinationSize.ToSize(destinationDensity));
+        canvas.Clear();
+        using (canvas.PushTransform(transform))
+        {
+            canvas.DrawRenderTargetScaledWithoutFlush(source, rasterBounds ?? s_sourceBounds);
+        }
+
+        return destination.Snapshot();
+    }
+
+    private static void FillHighFrequencyPattern(RenderTarget target)
+    {
+        using var paint = new SKPaint
+        {
+            IsAntialias = false,
+        };
+        for (int y = 0; y < target.Height; y++)
+        {
+            for (int x = 0; x < target.Width; x++)
+            {
+                paint.Color = ((x + y) & 1) == 0
+                    ? new SKColor(255, 24, 8, 255)
+                    : new SKColor(4, 40, 255, 255);
+                target.Value.Canvas.DrawRect(x, y, 1, 1, paint);
+            }
+        }
+        target.Value.Flush();
+    }
+
+    private static void AssertContainsVisibleContent(Bitmap bitmap)
+    {
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        bool hasVisiblePixel = false;
+        for (int index = 3; index < pixels.Length; index += 4)
+        {
+            float alpha = (float)BitConverter.UInt16BitsToHalf(pixels[index]);
+            if (float.IsFinite(alpha) && alpha > 0)
+            {
+                hasVisiblePixel = true;
+                break;
+            }
+        }
+
+        Assert.That(
+            hasVisiblePixel,
+            Is.True,
+            "The composite reference must contain visible source content.");
+    }
+
+    private sealed class MaterializedInputNode(
+        RenderTarget source,
+        Rect bounds,
+        float density,
+        PixelRect deviceBounds,
+        Vector deviceGridOffset) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<RenderTarget> resource = context.Borrow(
+                source,
+                cacheKey: "materialized-input-composite-source",
+                version: 1);
+            context.Publish(context.MaterializedInput(
+                MaterializedInputDescription.FromRenderTarget(
+                    resource,
+                    bounds,
+                    EffectiveScale.At(density),
+                    deviceBounds,
+                    deviceGridOffset,
+                    RenderHitTestContract.OutputBounds)));
+        }
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                    width,
+                    height,
+                    SKColorType.RgbaF16,
+                    SKAlphaType.Premul,
+                    SKColorSpace.CreateSrgbLinear()))
+                ?? throw new InvalidOperationException("Could not create the CPU test surface."),
+            width,
+            height);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/ProductionResourceLifetimeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/ProductionResourceLifetimeTests.cs
@@ -1,0 +1,195 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Planning;
+
+[TestFixture]
+public sealed class ProductionResourceLifetimeTests
+{
+    private static readonly Rect s_bounds = new(0, 0, 16, 16);
+
+    [TestCase(3)]
+    [TestCase(10)]
+    public void LinearOpaqueChain_KeepsPeakLiveConstantAndWarmsExactSizeSlots(int stageCount)
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var node = new LinearOpaqueChainNode(stageCount);
+        using var renderer = CreateRenderer(node, diagnostics);
+        using RenderTarget target = new CpuRenderTarget(16, 16);
+        using var canvas = new ImmediateCanvas(target);
+
+        renderer.Render(canvas);
+        RenderPipelineDiagnosticSnapshot first = diagnostics.Latest;
+        renderer.Render(canvas);
+        RenderPipelineDiagnosticSnapshot warmed = diagnostics.Latest;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Succeeded, Is.True);
+            Assert.That(first[RenderPipelineCounter.IntermediateAcquires], Is.EqualTo(stageCount + 1));
+            Assert.That(first[RenderPipelineCounter.IntermediateCreates], Is.EqualTo(2));
+            Assert.That(first[RenderPipelineCounter.PeakLiveIntermediates], Is.EqualTo(2));
+            Assert.That(first[RenderPipelineCounter.IntermediateDischarges], Is.EqualTo(stageCount + 1));
+            Assert.That(warmed.Succeeded, Is.True);
+            Assert.That(warmed[RenderPipelineCounter.IntermediateAcquires], Is.EqualTo(stageCount + 1));
+            Assert.That(warmed[RenderPipelineCounter.IntermediateCreates], Is.Zero);
+            Assert.That(warmed[RenderPipelineCounter.PoolHits], Is.EqualTo(stageCount + 1));
+            Assert.That(warmed[RenderPipelineCounter.PeakLiveIntermediates], Is.EqualTo(2));
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void FanOut_RetainsProducerThroughEveryConsumerThenReusesItsSlot()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var node = new FanOutOpaqueNode();
+        using var renderer = CreateRenderer(node, diagnostics);
+        using RenderTarget target = new CpuRenderTarget(16, 16);
+        using var canvas = new ImmediateCanvas(target);
+
+        Assert.That(() => renderer.Render(canvas), Throws.Nothing);
+        RenderPipelineDiagnosticSnapshot first = diagnostics.Latest;
+        renderer.Render(canvas);
+        RenderPipelineDiagnosticSnapshot warmed = diagnostics.Latest;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.ExecutionCount, Is.EqualTo(8));
+            Assert.That(first[RenderPipelineCounter.IntermediateAcquires], Is.EqualTo(4));
+            Assert.That(first[RenderPipelineCounter.IntermediateCreates], Is.EqualTo(3));
+            Assert.That(first[RenderPipelineCounter.PeakLiveIntermediates], Is.EqualTo(3));
+            Assert.That(first[RenderPipelineCounter.IntermediateDischarges], Is.EqualTo(4));
+            Assert.That(warmed[RenderPipelineCounter.IntermediateCreates], Is.Zero);
+            Assert.That(warmed[RenderPipelineCounter.PoolHits], Is.EqualTo(4));
+            Assert.That(warmed[RenderPipelineCounter.PeakLiveIntermediates], Is.EqualTo(3));
+            Assert.That(renderer.TargetPoolStatistics.LeasedTargets, Is.Zero);
+        });
+    }
+
+    private static RenderNodeRenderer CreateRenderer(
+        RenderNode node,
+        IRenderPipelineDiagnosticsState diagnostics)
+        => new(node, new RenderNodeRendererOptions
+        {
+            DefaultRequest = new RenderNodeRenderRequest
+            {
+                TargetDomain = s_bounds,
+                OutputScale = 1,
+                MaxWorkingScale = 1,
+                Diagnostics = diagnostics,
+                CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+            },
+            TargetFactory = new CpuTargetFactory(),
+        });
+
+    private sealed class LinearOpaqueChainNode(int stageCount) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle current = context.OpaqueSource(CreateSourceDescription("linear-source"));
+            for (int index = 0; index < stageCount; index++)
+                current = context.OpaqueMap(current, CreateMapDescription(("linear-map", index)));
+            context.Publish(current);
+        }
+    }
+
+    private sealed class FanOutOpaqueNode : RenderNode
+    {
+        public int ExecutionCount { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle source = context.OpaqueSource(CreateSourceDescription(
+                "fan-out-source",
+                () => ExecutionCount++));
+            RenderFragmentHandle left = context.OpaqueMap(
+                source,
+                CreateMapDescription("fan-out-left", () => ExecutionCount++));
+            RenderFragmentHandle right = context.OpaqueMap(
+                source,
+                CreateMapDescription("fan-out-right", () => ExecutionCount++));
+            context.Publish(context.OpaqueCombine(
+                [left, right],
+                CreateCombineDescription("fan-out-combine", () => ExecutionCount++)));
+        }
+    }
+
+    private static OpaqueRenderDescription CreateSourceDescription(
+        object key,
+        Action? onExecute = null)
+        => OpaqueRenderDescription.CreateRequestLocal(
+            session =>
+            {
+                onExecute?.Invoke();
+                using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                output.Canvas.Use(static canvas => canvas.Clear(Colors.CornflowerBlue));
+                session.Publish(output);
+            },
+            OpaqueRenderBoundsContract.Source(s_bounds),
+            RenderHitTestContract.OutputBounds,
+            RenderValueCardinality.Single,
+            RenderScaleContract.MaterializeAtWorkingScale,
+            structuralKey: key);
+
+    private static OpaqueRenderDescription CreateMapDescription(
+        object key,
+        Action? onExecute = null)
+        => OpaqueRenderDescription.CreateRequestLocal(
+            session =>
+            {
+                onExecute?.Invoke();
+                using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                output.Canvas.Use(session.Inputs.Single().Draw);
+                session.Publish(output);
+            },
+            OpaqueRenderBoundsContract.Map(RenderBoundsContract.Identity),
+            RenderHitTestContract.AnyInput,
+            RenderValueCardinality.Single,
+            RenderScaleContract.PreserveInputSupply,
+            structuralKey: key);
+
+    private static OpaqueRenderDescription CreateCombineDescription(
+        object key,
+        Action? onExecute = null)
+        => OpaqueRenderDescription.CreateRequestLocal(
+            session =>
+            {
+                onExecute?.Invoke();
+                using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                output.Canvas.Use(canvas =>
+                {
+                    foreach (RenderExecutionInput input in session.Inputs)
+                        input.Draw(canvas);
+                });
+                session.Publish(output);
+            },
+            OpaqueRenderBoundsContract.FullInputs(
+                static inputs => inputs.Aggregate(Rect.Empty, static (result, input) => result.Union(input)),
+                key),
+            RenderHitTestContract.AnyInput,
+            RenderValueCardinality.Single,
+            RenderScaleContract.MaterializeAtWorkingScale,
+            structuralKey: key);
+
+    private sealed class CpuTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+            => new CpuRenderTarget(allocation.DeviceSize.Width, allocation.DeviceSize.Height);
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/RawScopeNestingAndCaptureOffsetTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/RawScopeNestingAndCaptureOffsetTests.cs
@@ -1,0 +1,484 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Rendering.Failure;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Planning;
+
+[TestFixture]
+public sealed class RawScopeNestingAndCaptureOffsetTests
+{
+    private static readonly Rect s_domain = new(0, 0, 64, 64);
+    private static readonly Rect s_mark = new(8, 8, 8, 8);
+    private const float Shift = 10;
+
+    // Half-transparent so a capture drawn back over the mark is observable: a direct draw alone
+    // leaves alpha 128, an in-place round trip composites 128 over 128 and leaves alpha ~192.
+    private static readonly Color s_markColor = Color.FromArgb(128, 255, 0, 0);
+    private const byte RoundTripAlpha = 192;
+    // Well above the fringe a resampled round trip leaves around the mark, well below a real copy.
+    private const byte StrayAlpha = 64;
+
+    [Test]
+    public void RawTargetScope_ExecutesNestedTargetWorkInsideItsReplay()
+    {
+        using var node = new NestedRawCommandNode();
+        using var renderer = CreateRenderer(node);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        Bitmap bitmap = rasterization.Bitmap
+            ?? throw new AssertionException("The nested raw target work produced no bitmap.");
+        var sample = bitmap.SKBitmap.GetPixel(
+            (int)(s_mark.Center.X - rasterization.Bounds.X),
+            (int)(s_mark.Center.Y - rasterization.Bounds.Y));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.NestedExecutions, Is.EqualTo(1),
+                "A raw target scope must let its replayed subtree perform nested target work.");
+            Assert.That(sample.Red, Is.EqualTo(byte.MaxValue));
+            Assert.That(sample.Alpha, Is.EqualTo(byte.MaxValue));
+        });
+    }
+
+    [Test]
+    public void RawTargetScope_RemainsAnOpaqueExternalBarrierWhileNestingIsAllowed()
+    {
+        using var node = new NestedRawCommandNode();
+        using var request = new RenderRequest(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            targetDomain: s_domain));
+
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        RenderFragmentReference scope = graph.Fragments
+            .Select(static fragment => (RenderFragmentReference)fragment.Payload!)
+            .Single(static reference => reference.Kind == RenderFragmentKind.RawTargetScope);
+
+        Assert.That(scope.HasOpaqueExternalWork, Is.True,
+            "Nested target work must not relax the raw scope's opaque-external barrier.");
+    }
+
+    [Test]
+    public void TargetCapture_UnderANonZeroDeviceGridOffset_CopiesTheTargetWithoutDisplacingIt()
+    {
+        using var root = new ContainerRenderNode();
+        root.AddChild(new MarkNode());
+        var scope = new TransformRenderNode(
+            Matrix.CreateTranslation(Shift, 0),
+            TransformOperator.Append);
+        // Local (-10, 0, 64, 64) covers the whole target, so the round trip must land in place.
+        scope.AddChild(new CaptureRoundTripNode(new Rect(-Shift, 0, s_domain.Width, s_domain.Height)));
+        root.AddChild(scope);
+        using var renderer = CreateRenderer(root);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        AssertCaptureLandedOnTheMark(rasterization);
+    }
+
+    [Test]
+    public void TargetCapture_UnderAScaledAndTranslatedTarget_CopiesTheTargetWithoutDisplacingIt()
+    {
+        using var root = new ContainerRenderNode();
+        root.AddChild(new MarkNode());
+        var scope = new TransformRenderNode(
+            Matrix.CreateScale(2, 2) * Matrix.CreateTranslation(Shift, 0),
+            TransformOperator.Append);
+        // Local (-5, 0, 32, 32) covers the whole target, so the round trip must land in place.
+        scope.AddChild(new CaptureRoundTripNode(new Rect(-5, 0, 32, 32)));
+        root.AddChild(scope);
+        using var renderer = CreateRenderer(root);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        AssertCaptureLandedOnTheMark(rasterization);
+    }
+
+    [Test]
+    public void TargetCapture_UnderAScaledTarget_MaterializesAtTheTargetsPixelSupply()
+    {
+        using var root = new ContainerRenderNode();
+        root.AddChild(new MarkNode());
+        var scope = new TransformRenderNode(
+            Matrix.CreateScale(2, 2),
+            TransformOperator.Append);
+        // Local (0, 0, 32, 32) covers the whole target, so the round trip must land in place.
+        scope.AddChild(new CaptureRoundTripNode(new Rect(0, 0, 32, 32)));
+        root.AddChild(scope);
+        using var renderer = CreateRenderer(root);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        Bitmap bitmap = rasterization.Bitmap
+            ?? throw new AssertionException("The scaled target capture produced no bitmap.");
+        var origin = new PixelPoint((int)rasterization.Bounds.X, (int)rasterization.Bounds.Y);
+        var mark = bitmap.SKBitmap.GetPixel(
+            (int)s_mark.Center.X - origin.X,
+            (int)s_mark.Center.Y - origin.Y);
+
+        // A capture taken below the target's supply comes back through a 2x upsample, which leaves a
+        // one-pixel fringe of half the mark's alpha around it.
+        int fringe = 0;
+        for (int y = 0; y < bitmap.Height; y++)
+        {
+            for (int x = 0; x < bitmap.Width; x++)
+            {
+                if (bitmap.SKBitmap.GetPixel(x, y).Alpha == 0)
+                    continue;
+                if (!s_mark.Contains(new Point(x + origin.X, y + origin.Y)))
+                    fringe++;
+            }
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(mark.Alpha, Is.EqualTo(RoundTripAlpha).Within(8),
+                "Replaying a capture of the target back into the same place must reproduce the mark there.");
+            Assert.That(fringe, Is.Zero,
+                "A capture under a scaled target must materialize at the target's own pixel supply.");
+        });
+    }
+
+    [Test]
+    [TestCase(0f)]
+    [TestCase(0.0005f)]
+    public void BuiltInBackdropCapture_UnderADegenerateTargetTransform_RendersTheRestOfTheFrame(float scale)
+    {
+        using var root = new ContainerRenderNode();
+        root.AddChild(new MarkNode());
+        var scope = new TransformRenderNode(
+            Matrix.CreateScale(scale, scale),
+            TransformOperator.Append);
+        var snapshot = new SnapshotBackdropRenderNode();
+        scope.AddChild(snapshot);
+        scope.AddChild(new DrawBackdropRenderNode(snapshot, s_domain));
+        root.AddChild(scope);
+        using var renderer = CreateRenderer(root);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        Bitmap bitmap = rasterization.Bitmap
+            ?? throw new AssertionException("The degenerate backdrop round trip produced no bitmap.");
+        var origin = new PixelPoint((int)rasterization.Bounds.X, (int)rasterization.Bounds.Y);
+        var mark = bitmap.SKBitmap.GetPixel(
+            (int)s_mark.Center.X - origin.X,
+            (int)s_mark.Center.Y - origin.Y);
+
+        int ink = 0;
+        for (int y = 0; y < bitmap.Height; y++)
+        {
+            for (int x = 0; x < bitmap.Width; x++)
+            {
+                if (bitmap.SKBitmap.GetPixel(x, y).Alpha == 0)
+                    continue;
+                if (!s_mark.Contains(new Point(x + origin.X, y + origin.Y)))
+                    ink++;
+            }
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(mark.Alpha, Is.EqualTo(s_markColor.A),
+                "A backdrop under a degenerate transform must leave the rest of the frame untouched.");
+            Assert.That(ink, Is.Zero,
+                "A capture with no readable preimage must contribute no pixels.");
+        });
+    }
+
+    [Test]
+    [TestCase(2f, 2f, 2f)]
+    [TestCase(4f, 0.25f, 4f)]
+    [TestCase(8f, 0.125f, 8f)]
+    public void BuiltInBackdropCapture_UnderAnAnisotropicTargetTransform_UsesTheFinerAxis(
+        float scaleX,
+        float scaleY,
+        float maximumSingularValue)
+    {
+        var domain = new Rect(0, 0, 64, 64);
+        Matrix transform = Matrix.CreateScale(scaleX, scaleY);
+        using var root = new ContainerRenderNode();
+        var scope = new TransformRenderNode(
+            transform,
+            TransformOperator.Append);
+        var probe = new CaptureSizeProbeNode();
+        scope.AddChild(probe);
+        scope.AddChild(new DrawBackdropRenderNode(probe, domain));
+        root.AddChild(scope);
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    Intent = RenderIntent.Preview,
+                    TargetDomain = domain,
+                    OutputScale = 1,
+                    CacheOptions = RenderCacheOptions.Disabled,
+                },
+            });
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        Rect captureBounds = domain.TransformToAABB(transform.Invert());
+        PixelRect expectedFootprint = PixelRect.FromRect(captureBounds, maximumSingularValue);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(probe.CapturedDensity, Is.EqualTo(maximumSingularValue).Within(1e-4f),
+                "A capture preserving the target's supply must retain the affine transform's maximum singular value.");
+            Assert.That(probe.CapturedDeviceSize, Is.EqualTo(expectedFootprint.Size));
+            Assert.That(expectedFootprint.Width, Is.LessThanOrEqualTo(RenderScaleUtilities.MaxBufferDimension));
+            Assert.That(expectedFootprint.Height, Is.LessThanOrEqualTo(RenderScaleUtilities.MaxBufferDimension));
+        });
+    }
+
+    [Test]
+    public void BuiltInBackdropCapture_ClampsTheMaximumSingularValueToTheCaptureFootprint()
+    {
+        var domain = new Rect(0, 0, 1920, 1080);
+        Matrix transform = Matrix.CreateScale(4, 0.25f);
+        using var root = new ContainerRenderNode();
+        var scope = new TransformRenderNode(transform, TransformOperator.Append);
+        var probe = new CaptureSizeProbeNode();
+        scope.AddChild(probe);
+        scope.AddChild(new DrawBackdropRenderNode(probe, domain));
+        root.AddChild(scope);
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    Intent = RenderIntent.Preview,
+                    TargetDomain = domain,
+                    OutputScale = 1,
+                    CacheOptions = RenderCacheOptions.Disabled,
+                    AllocationBudget = new RenderAllocationBudget(
+                        2L * 1024 * 1024 * 1024,
+                        256),
+                },
+            });
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        Rect captureBounds = domain.TransformToAABB(transform.Invert());
+        float expectedDensity = RenderScaleUtilities.ClampWorkingScaleToBufferBudget(captureBounds, 4);
+        PixelRect expectedFootprint = PixelRect.FromRect(captureBounds, expectedDensity);
+        Assert.Multiple(() =>
+        {
+            Assert.That(probe.CapturedDensity, Is.EqualTo(expectedDensity).Within(1e-4f));
+            Assert.That(probe.CapturedDensity, Is.LessThan(4));
+            Assert.That(probe.CapturedDeviceSize, Is.EqualTo(expectedFootprint.Size));
+            Assert.That(expectedFootprint.Width, Is.LessThanOrEqualTo(RenderScaleUtilities.MaxBufferDimension));
+            Assert.That(expectedFootprint.Height, Is.LessThanOrEqualTo(RenderScaleUtilities.MaxBufferDimension));
+        });
+    }
+
+    [Test]
+    public void BuiltInBackdropCapture_UnderShear_UsesTheMaximumSingularValue()
+    {
+        var domain = new Rect(0, 0, 256, 128);
+        var transform = new Matrix(1, 1, 0, 1, 0, 0);
+        using var root = new ContainerRenderNode();
+        var scope = new TransformRenderNode(
+            transform,
+            TransformOperator.Append);
+        var probe = new CaptureSizeProbeNode();
+        scope.AddChild(probe);
+        scope.AddChild(new DrawBackdropRenderNode(probe, domain));
+        root.AddChild(scope);
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    Intent = RenderIntent.Preview,
+                    TargetDomain = domain,
+                    OutputScale = 1,
+                    CacheOptions = RenderCacheOptions.Disabled,
+                },
+            });
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        float expectedDensity = MathF.Sqrt((3 + MathF.Sqrt(5)) / 2);
+        Rect captureBounds = domain.TransformToAABB(transform.Invert());
+        PixelSize expectedSize = PixelRect.FromRect(captureBounds, expectedDensity).Size;
+        Assert.Multiple(() =>
+        {
+            Assert.That(probe.CapturedDensity, Is.EqualTo(expectedDensity).Within(1e-4f));
+            Assert.That(probe.CapturedDeviceSize, Is.EqualTo(expectedSize));
+        });
+    }
+
+    [Test]
+    public void BuiltInBackdropCapture_UnderPerspective_RejectsBeforeAllocatingTheCapture()
+    {
+        var domain = new Rect(0, 0, 64, 64);
+        using var root = new ContainerRenderNode();
+        var scope = new TransformRenderNode(
+            new Matrix(
+                1, 0, 0.01f,
+                0, 1, 0,
+                0, 0, 1),
+            TransformOperator.Append);
+        var probe = new CaptureSizeProbeNode();
+        scope.AddChild(probe);
+        scope.AddChild(new DrawBackdropRenderNode(probe, domain));
+        root.AddChild(scope);
+        var factory = new FailureTestTargetFactory();
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    Intent = RenderIntent.Preview,
+                    TargetDomain = domain,
+                    OutputScale = 1,
+                    CacheOptions = RenderCacheOptions.Disabled,
+                },
+                TargetFactory = factory,
+            });
+
+        NotSupportedException? failure = Assert.Throws<NotSupportedException>(() => renderer.Rasterize());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Does.Contain("perspective"));
+            Assert.That(factory.CreateCalls, Is.EqualTo(1),
+                "only the root execution target may be acquired before perspective capture rejection");
+            Assert.That(probe.CapturedDeviceSize, Is.EqualTo(default(PixelSize)));
+        });
+    }
+
+    private sealed class CaptureSizeProbeNode : SnapshotBackdropRenderNode, IBuiltInBackdropCaptureSink
+    {
+        public PixelSize CapturedDeviceSize { get; private set; }
+
+        public float CapturedDensity { get; private set; }
+
+        bool IBuiltInBackdropCaptureSink.TryCommitBackdropCapture(Bitmap bitmap, float density)
+        {
+            Record(bitmap, density);
+            return true;
+        }
+
+        void IBuiltInBackdropCaptureSink.CommitBackdropCapture(Bitmap bitmap, float density)
+            => Record(bitmap, density);
+
+        private void Record(Bitmap bitmap, float density)
+        {
+            CapturedDeviceSize = new PixelSize(bitmap.Width, bitmap.Height);
+            CapturedDensity = density;
+            bitmap.Dispose();
+        }
+    }
+
+    private static void AssertCaptureLandedOnTheMark(RenderNodeRasterization rasterization)
+    {
+        Bitmap bitmap = rasterization.Bitmap
+            ?? throw new AssertionException("The offset target capture produced no bitmap.");
+        var origin = new PixelPoint((int)rasterization.Bounds.X, (int)rasterization.Bounds.Y);
+        var mark = bitmap.SKBitmap.GetPixel(
+            (int)s_mark.Center.X - origin.X,
+            (int)s_mark.Center.Y - origin.Y);
+
+        // A resampled round trip bleeds a pixel or so past the mark.
+        var tolerated = s_mark.Inflate(2);
+        int strays = 0;
+        for (int y = 0; y < bitmap.Height; y++)
+        {
+            for (int x = 0; x < bitmap.Width; x++)
+            {
+                if (bitmap.SKBitmap.GetPixel(x, y).Alpha < StrayAlpha)
+                    continue;
+                if (!tolerated.Contains(new Point(x + origin.X, y + origin.Y)))
+                    strays++;
+            }
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(mark.Alpha, Is.EqualTo(RoundTripAlpha).Within(8),
+                "Replaying a capture of the target back into the same place must reproduce the mark there.");
+            Assert.That(strays, Is.Zero,
+                "The captured copy must not land displaced from the region it was read from.");
+        });
+    }
+
+    private static RenderNodeRenderer CreateRenderer(RenderNode node)
+        => new(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    Intent = RenderIntent.Preview,
+                    TargetDomain = s_domain,
+                    OutputScale = 1,
+                    CacheOptions = RenderCacheOptions.Disabled,
+                },
+            });
+
+    private sealed class MarkNode : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+            => context.Publish(context.OpaqueSource(OpaqueRenderDescription.Create(
+                "capture-offset-mark",
+                static (session, _) =>
+                {
+                    using OpaqueRenderOutput output = session.CreateOutput(s_mark);
+                    output.Canvas.Use(static canvas => canvas.Clear(s_markColor));
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.Source(s_mark),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: "capture-offset-mark")));
+    }
+
+    private sealed class NestedRawCommandNode : RenderNode
+    {
+        public int NestedExecutions { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle nested = context.RawTargetCommand(RawTargetCommandDescription.CreateRequestLocal(
+                session =>
+                {
+                    NestedExecutions++;
+                    session.Canvas.Clear(Colors.Red);
+                },
+                s_domain,
+                RenderHitTestContract.OutputBounds,
+                structuralKey: "raw-scope-nested-command"));
+            context.Publish(context.RawTargetScope(
+                nested,
+                RawTargetScopeDescription.CreateRequestLocal(
+                    static session => session.ReplayInput(),
+                    RenderBoundsContract.FullInput,
+                    RenderHitTestContract.AnyInput,
+                    RenderScaleContract.PreserveInputSupply,
+                    structuralKey: "raw-scope-nesting")));
+        }
+    }
+
+    private sealed class CaptureRoundTripNode(Rect captureBounds) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle capture = context.TargetCapture(TargetCaptureDescription.Create(
+                TargetRegion.Region(captureBounds),
+                captureBounds,
+                RenderHitTestContract.OutputBounds,
+                TargetCaptureScaleContract.PreserveTargetSupply));
+            context.Publish(context.ContributeValues(capture));
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/RegionAnalyzerTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/RegionAnalyzerTests.cs
@@ -1,0 +1,386 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Planning;
+
+[TestFixture]
+public sealed class RegionAnalyzerTests
+{
+    [Test]
+    public void Analyze_MapsShiftedRequestBackwardThroughForwardGrowth()
+    {
+        var graph = new FragmentGraph();
+        RenderFragmentReference source = graph.Source(
+            new Rect(10, 10, 100, 100),
+            EffectiveScale.At(2));
+        RenderBoundsContract grow = RenderBoundsContract.Create(
+            static input => input.Inflate(new Thickness(5)),
+            static requested => requested.Inflate(new Thickness(5)),
+            "region-grow");
+        RenderFragmentReference output = graph.Map(source, grow);
+        var options = Options(requestedRegion: new Rect(0, 0, 20, 20));
+
+        RegionAnalysis result = new RegionAnalyzer().Analyze(options, [output]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.RootOutputExtent, Is.EqualTo(new Rect(5, 5, 110, 110)));
+            Assert.That(result.FinalCommitBounds, Is.EqualTo(new Rect(5, 5, 15, 15)));
+            Assert.That(result.GetFragmentRequirement(output),
+                Is.EqualTo(RequiredRegion.Region(new Rect(5, 5, 15, 15))));
+            Assert.That(result.GetFragmentRequirement(source),
+                Is.EqualTo(RequiredRegion.Region(new Rect(10, 10, 15, 15))));
+            Assert.That(result.GetMetadata(source).EffectiveScale, Is.EqualTo(EffectiveScale.At(2)));
+            Assert.That(result.GetMetadata(output).EffectiveScale, Is.EqualTo(EffectiveScale.At(2)));
+        });
+    }
+
+    [Test]
+    public void Analyze_NullRequestSelectsCompleteForwardShrinkWithoutPromotingItToFullFallback()
+    {
+        var graph = new FragmentGraph();
+        RenderFragmentReference source = graph.Source(
+            new Rect(0, 0, 100, 100),
+            EffectiveScale.At(3));
+        RenderBoundsContract shrink = RenderBoundsContract.Create(
+            static input => input.Deflate(new Thickness(10)),
+            static requested => requested.Inflate(new Thickness(10)),
+            "region-shrink");
+        RenderFragmentReference output = graph.Map(source, shrink);
+
+        RegionAnalysis result = new RegionAnalyzer().Analyze(Options(), [output]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.RootOutputExtent, Is.EqualTo(new Rect(10, 10, 80, 80)));
+            Assert.That(result.FinalCommitBounds, Is.EqualTo(result.RootOutputExtent));
+            Assert.That(result.FinalCommitRegion,
+                Is.EqualTo(RequiredRegion.Region(new Rect(10, 10, 80, 80))));
+            Assert.That(result.GetFragmentRequirement(source),
+                Is.EqualTo(RequiredRegion.Region(new Rect(0, 0, 100, 100))));
+            Assert.That(result.GetFragmentRequirement(source), Is.Not.EqualTo(RequiredRegion.Full));
+            Assert.That(result.GetMetadata(output).EffectiveScale, Is.EqualTo(EffectiveScale.At(3)));
+        });
+    }
+
+    [Test]
+    public void Analyze_ClipsOutsideAndShiftedEmptyCommitBoundsToTheRootOutputExtent()
+    {
+        var graph = new FragmentGraph();
+        RenderFragmentReference source = graph.Source(new Rect(10, 20, 30, 40));
+        var analyzer = new RegionAnalyzer();
+
+        RegionAnalysis outside = analyzer.Analyze(
+            Options(requestedRegion: new Rect(100, 200, 7, 9)),
+            [source]);
+        RegionAnalysis empty = analyzer.Analyze(
+            Options(requestedRegion: new Rect(70, 80, 0, 10)),
+            [source]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(outside.FinalCommitBounds, Is.EqualTo(Rect.Empty));
+            Assert.That(outside.FinalCommitRegion, Is.EqualTo(RequiredRegion.Empty));
+            Assert.That(outside.GetFragmentRequirement(source), Is.EqualTo(RequiredRegion.Empty));
+            Assert.That(empty.FinalCommitBounds, Is.EqualTo(new Rect(70, 80, 0, 10)));
+            Assert.That(empty.FinalCommitRegion, Is.EqualTo(RequiredRegion.Empty));
+            Assert.That(empty.GetFragmentRequirement(source), Is.EqualTo(RequiredRegion.Empty));
+        });
+    }
+
+    [Test]
+    public void Analyze_UsesExplicitFullForConservativeFullInputFallback()
+    {
+        var graph = new FragmentGraph();
+        RenderFragmentReference source = graph.Source(new Rect(0, 0, 100, 80));
+        RenderFragmentReference identity = graph.Map(source, RenderBoundsContract.Identity);
+        RenderFragmentReference output = graph.Map(identity, RenderBoundsContract.FullInput);
+
+        RegionAnalysis result = new RegionAnalyzer().Analyze(
+            Options(requestedRegion: new Rect(30, 20, 10, 10)),
+            [output]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.GetFragmentRequirement(output),
+                Is.EqualTo(RequiredRegion.Region(new Rect(30, 20, 10, 10))));
+            Assert.That(result.GetFragmentRequirement(identity), Is.EqualTo(RequiredRegion.Full));
+            Assert.That(result.GetFragmentRequirement(source), Is.EqualTo(RequiredRegion.Full));
+            Assert.That(result.GetValueRequirement(source.ValueIds.Single()), Is.EqualTo(RequiredRegion.Full));
+        });
+    }
+
+    [Test]
+    public void Analyze_UnionsFanOutRequirementsBeforeVisitingSharedProducer()
+    {
+        var graph = new FragmentGraph();
+        RenderFragmentReference source = graph.Source(new Rect(0, 0, 100, 20));
+        RenderBoundsContract leftBounds = RenderBoundsContract.Create(
+            static _ => new Rect(0, 0, 40, 20),
+            static requested => requested,
+            "fanout-left");
+        RenderBoundsContract rightBounds = RenderBoundsContract.Create(
+            static _ => new Rect(60, 0, 40, 20),
+            static requested => requested,
+            "fanout-right");
+        RenderFragmentReference left = graph.Map(source, leftBounds);
+        RenderFragmentReference right = graph.Map(source, rightBounds);
+
+        RegionAnalysis result = new RegionAnalyzer().Analyze(
+            Options(requestedRegion: new Rect(10, 0, 80, 20)),
+            [left, right]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.GetFragmentRequirement(left),
+                Is.EqualTo(RequiredRegion.Region(new Rect(10, 0, 30, 20))));
+            Assert.That(result.GetFragmentRequirement(right),
+                Is.EqualTo(RequiredRegion.Region(new Rect(60, 0, 30, 20))));
+            Assert.That(result.GetFragmentRequirement(source),
+                Is.EqualTo(RequiredRegion.Region(new Rect(10, 0, 80, 20))));
+        });
+    }
+
+    [Test]
+    public void Analyze_ExpandsTargetReadApronWithoutChangingDeclaredDensity()
+    {
+        var graph = new FragmentGraph();
+        Rect domain = new(0, 0, 100, 100);
+        RenderFragmentReference capture = graph.Capture(domain, EffectiveScale.At(2));
+        RenderBoundsContract blur = RenderBoundsContract.Create(
+            static input => input.Inflate(new Thickness(10)),
+            static requested => requested.Inflate(new Thickness(10)),
+            "target-read-apron");
+        RenderFragmentReference output = graph.Map(capture, blur, contributes: true);
+
+        RegionAnalysis result = new RegionAnalyzer().Analyze(
+            Options(targetDomain: domain, requestedRegion: new Rect(40, 40, 10, 10)),
+            [output]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.GetFragmentRequirement(capture),
+                Is.EqualTo(RequiredRegion.Region(new Rect(30, 30, 30, 30))));
+            Assert.That(result.GetTargetAccessRequirement(capture),
+                Is.EqualTo(RequiredRegion.Region(new Rect(30, 30, 30, 30))));
+            Assert.That(result.GetMetadata(capture).EffectiveScale, Is.EqualTo(EffectiveScale.At(2)));
+            Assert.That(result.GetMetadata(output).EffectiveScale, Is.EqualTo(EffectiveScale.At(2)));
+        });
+    }
+
+    [Test]
+    public void Analyze_RejectsInvalidForwardAndBackwardMappings()
+    {
+        var forwardGraph = new FragmentGraph();
+        RenderFragmentReference forwardSource = forwardGraph.Source(new Rect(0, 0, 10, 10));
+        RenderBoundsContract invalidForward = RenderBoundsContract.Create(
+            static _ => new Rect(float.NaN, 0, 10, 10),
+            static requested => requested,
+            "invalid-forward");
+        RenderFragmentReference invalidForwardOutput = forwardGraph.Map(
+            forwardSource,
+            invalidForward,
+            recordedBounds: new Rect(0, 0, 10, 10));
+
+        var backwardGraph = new FragmentGraph();
+        RenderFragmentReference backwardSource = backwardGraph.Source(new Rect(0, 0, 10, 10));
+        RenderBoundsContract invalidBackward = RenderBoundsContract.Create(
+            static input => input,
+            static _ => new Rect(0, 0, -1, 10),
+            "invalid-backward");
+        RenderFragmentReference invalidBackwardOutput = backwardGraph.Map(backwardSource, invalidBackward);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => new RegionAnalyzer().Analyze(Options(), [invalidForwardOutput]),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(
+                () => new RegionAnalyzer().Analyze(
+                    Options(requestedRegion: new Rect(0, 0, 5, 5)),
+                    [invalidBackwardOutput]),
+                Throws.TypeOf<InvalidOperationException>());
+        });
+    }
+
+    [Test]
+    public void Analyze_RejectsNonDeterministicConcreteForwardMapping()
+    {
+        var graph = new FragmentGraph();
+        RenderFragmentReference source = graph.Source(new Rect(0, 0, 10, 10));
+        int calls = 0;
+        RenderBoundsContract nonDeterministic = RenderBoundsContract.Create(
+            input => calls++ == 0 ? input : input.Translate(new Point(0.25f, 0)),
+            static requested => requested,
+            "non-deterministic-forward");
+        RenderFragmentReference output = graph.Map(source, nonDeterministic);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => new RegionAnalyzer().Analyze(Options(), [output]));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                failure!.Message,
+                Does.Contain("changed between recording and graph-wide metadata resolution"));
+            Assert.That(calls, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void Analyze_KeepsOutputQueryTargetRequestedAndCommitDomainsIndependent()
+    {
+        var graph = new FragmentGraph();
+        RenderFragmentReference value = graph.Source(new Rect(0, 0, 20, 20));
+        RenderFragmentReference command = graph.Command(
+            TargetRegion.Region(new Rect(50, 50, 10, 10)),
+            queryBounds: new Rect(100, 100, 5, 5));
+        Rect targetDomain = new(0, 0, 200, 160);
+        Rect requested = new(140, 120, 30, 20);
+
+        RegionAnalysis result = new RegionAnalyzer().Analyze(
+            Options(targetDomain, requested),
+            [value, command]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.RootOutputExtent, Is.EqualTo(new Rect(0, 0, 60, 60)));
+            Assert.That(result.QueryBounds, Is.EqualTo(new Rect(0, 0, 105, 105)));
+            Assert.That(result.Measurement.OutputBounds, Is.EqualTo(result.RootOutputExtent));
+            Assert.That(result.Measurement.QueryBounds, Is.EqualTo(result.QueryBounds));
+            Assert.That(result.TargetDomain, Is.EqualTo(targetDomain));
+            Assert.That(result.RequestedRegion, Is.EqualTo(requested));
+            Assert.That(result.FinalCommitBounds, Is.EqualTo(Rect.Empty));
+            Assert.That(result.GetFragmentRequirement(value), Is.EqualTo(RequiredRegion.Empty));
+            Assert.That(result.GetTargetAccessRequirement(command), Is.EqualTo(RequiredRegion.Empty));
+        });
+    }
+
+    private static RenderRequestOptions Options(
+        Rect? targetDomain = null,
+        Rect? requestedRegion = null)
+        => new(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            targetDomain,
+            requestedRegion,
+            cachePolicy: Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled);
+
+    private sealed class FragmentGraph
+    {
+        private readonly RenderRequestId _requestId = new(1);
+        private long _nextId;
+
+        public RenderFragmentReference Source(
+            Rect bounds,
+            EffectiveScale? scale = null)
+        {
+            OpaqueRenderDescription description = OpaqueRenderDescription.CreateRequestLocal(
+                static _ => { },
+                OpaqueRenderBoundsContract.Source(bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: ("region-source", ++_nextId));
+            return Stamp(new RenderFragmentReference(
+                RenderFragmentKind.OpaqueSource,
+                bounds,
+                scale ?? EffectiveScale.At(1),
+                RenderValueCardinality.Single,
+                contributesValuesToTarget: true,
+                canBeUsedAsValueInput: true,
+                hasTargetEffects: false,
+                hasOpaqueExternalWork: true,
+                inputs: null,
+                new OpaqueRenderFragmentPayload(
+                    OpaqueRenderTopology.Source,
+                    description,
+                    Array.Empty<RenderInputReadback>()),
+                bounds.Contains));
+        }
+
+        public RenderFragmentReference Map(
+            RenderFragmentReference input,
+            RenderBoundsContract bounds,
+            bool? contributes = null,
+            Rect? recordedBounds = null)
+        {
+            Rect outputBounds = recordedBounds ?? bounds.TransformBounds(input.Bounds);
+            OpaqueRenderDescription description = OpaqueRenderDescription.CreateRequestLocal(
+                static _ => { },
+                OpaqueRenderBoundsContract.Map(bounds),
+                RenderHitTestContract.AnyInput,
+                RenderValueCardinality.Single,
+                RenderScaleContract.PreserveInputSupply,
+                structuralKey: ("region-map", ++_nextId));
+            return Stamp(new RenderFragmentReference(
+                RenderFragmentKind.OpaqueMap,
+                outputBounds,
+                input.EffectiveScale,
+                RenderValueCardinality.Single,
+                contributes ?? input.ContributesValuesToTarget,
+                canBeUsedAsValueInput: true,
+                hasTargetEffects: input.HasTargetEffects,
+                hasOpaqueExternalWork: true,
+                [input],
+                new OpaqueRenderFragmentPayload(
+                    OpaqueRenderTopology.Map,
+                    description,
+                    [RenderInputReadback.None]),
+                outputBounds.Contains));
+        }
+
+        public RenderFragmentReference Capture(Rect bounds, EffectiveScale scale)
+        {
+            TargetCaptureDescription description = TargetCaptureDescription.Create(
+                TargetRegion.Full,
+                bounds,
+                RenderHitTestContract.None,
+                TargetCaptureScaleContract.MaterializeAtWorkingScale);
+            return Stamp(new RenderFragmentReference(
+                RenderFragmentKind.TargetCapture,
+                bounds,
+                scale,
+                RenderValueCardinality.Single,
+                contributesValuesToTarget: false,
+                canBeUsedAsValueInput: true,
+                hasTargetEffects: true,
+                hasOpaqueExternalWork: false,
+                inputs: null,
+                new TargetCaptureRenderFragmentPayload(description),
+                hitTest: null));
+        }
+
+        public RenderFragmentReference Command(TargetRegion affectedRegion, Rect queryBounds)
+        {
+            TargetCommandDescription description = TargetCommandDescription.CreateRequestLocal(
+                static _ => { },
+                affectedRegion,
+                queryBounds,
+                RenderHitTestContract.OutputBounds,
+                structuralKey: ("region-command", ++_nextId));
+            return Stamp(new RenderFragmentReference(
+                RenderFragmentKind.TargetCommand,
+                queryBounds,
+                EffectiveScale.Unbounded,
+                RenderValueCardinality.None,
+                contributesValuesToTarget: false,
+                canBeUsedAsValueInput: false,
+                hasTargetEffects: true,
+                hasOpaqueExternalWork: false,
+                inputs: null,
+                new TargetCommandRenderFragmentPayload(description, []),
+                queryBounds.Contains));
+        }
+
+        private RenderFragmentReference Stamp(RenderFragmentReference reference)
+        {
+            long id = ++_nextId;
+            reference.Id = new RenderFragmentId(_requestId, id);
+            if (reference.ValueCardinality.Maximum != 0 || reference.ValueCardinality.Minimum != 0)
+                reference.ValueIds = [new RenderValueId(_requestId, id)];
+            return reference;
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/RenderPipelineDiagnosticsTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/RenderPipelineDiagnosticsTests.cs
@@ -1,0 +1,930 @@
+﻿using Beutl.Graphics.Rendering;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Planning;
+
+[TestFixture]
+public sealed class RenderPipelineDiagnosticsTests
+{
+    [Test]
+    public void DiagnosticsTypes_AreInternal()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(typeof(IRenderPipelineDiagnosticsState).IsNotPublic, Is.True);
+            Assert.That(typeof(RenderPipelineDiagnosticsState).IsNotPublic, Is.True);
+            Assert.That(typeof(RenderPipelineDiagnosticSnapshot).IsNotPublic, Is.True);
+            Assert.That(typeof(RenderPipelineDiagnosticEvent).IsNotPublic, Is.True);
+            Assert.That(typeof(RenderPipelineDiagnosticEventKind).IsNotPublic, Is.True);
+            Assert.That(typeof(RenderPipelineBoundaryReason).IsNotPublic, Is.True);
+            Assert.That(typeof(RenderPipelineOutcome).IsNotPublic, Is.True);
+            Assert.That(typeof(RenderPipelineFailurePhase).IsNotPublic, Is.True);
+            Assert.That(typeof(RenderPipelineCounter).IsNotPublic, Is.True);
+        });
+    }
+
+    [Test]
+    public void EmptySnapshot_IsStableAndReadsMissingCountersAsZero()
+    {
+        RenderPipelineDiagnosticSnapshot snapshot = RenderPipelineDiagnosticSnapshot.Empty;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(RenderPipelineDiagnosticSnapshot.Empty, Is.SameAs(snapshot));
+            Assert.That(snapshot.RequestId, Is.Zero);
+            Assert.That(snapshot.ParentRequestId, Is.Null);
+            Assert.That(snapshot.RootTargetClass, Is.Empty);
+            Assert.That(snapshot.Counters, Is.Empty);
+            Assert.That(snapshot.Events, Is.Empty);
+            Assert.That(snapshot[RenderPipelineCounter.RecordedFragments], Is.Zero);
+        });
+    }
+
+    [Test]
+    public void Create_CopiesInputsAndExposesAnImmutableSnapshot()
+    {
+        var counters = CreateCounters();
+        var events = CreateDefaultEvents(
+            succeeded: true,
+            failurePhase: null,
+            RenderRequestPurpose.Frame,
+            counters);
+
+        RenderPipelineDiagnosticSnapshot snapshot = CreateSnapshot(
+            requestId: 7,
+            parentRequestId: 3,
+            intent: RenderIntent.Delivery,
+            purpose: RenderRequestPurpose.Frame,
+            rootTargetClass: "Presentation",
+            counters: counters,
+            events: events);
+
+        counters[RenderPipelineCounter.RecordedFragments] = 99;
+        events.Clear();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot.RequestId, Is.EqualTo(7));
+            Assert.That(snapshot.ParentRequestId, Is.EqualTo(3));
+            Assert.That(snapshot.Intent, Is.EqualTo(RenderIntent.Delivery));
+            Assert.That(snapshot.Purpose, Is.EqualTo(RenderRequestPurpose.Frame));
+            Assert.That(snapshot.Succeeded, Is.True);
+            Assert.That(snapshot.HasOpaqueExternalWork, Is.False);
+            Assert.That(snapshot.RootTargetClass, Is.EqualTo("Presentation"));
+            Assert.That(snapshot.FailurePhase, Is.Null);
+            Assert.That(snapshot[RenderPipelineCounter.RecordedFragments], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.ProgramHits], Is.Zero);
+            Assert.That(snapshot.Events, Has.Count.EqualTo(4));
+            Assert.That(snapshot.Events.Select(item => item.Sequence), Is.EqualTo(new long[] { 0, 1, 2, 3 }));
+        });
+
+        if (snapshot.Counters is IDictionary<RenderPipelineCounter, long> mutableCounters)
+        {
+            Assert.That(
+                () => mutableCounters[RenderPipelineCounter.RecordedFragments] = 2,
+                Throws.TypeOf<NotSupportedException>());
+        }
+
+        if (snapshot.Events is IList<RenderPipelineDiagnosticEvent> mutableEvents)
+        {
+            Assert.That(
+                () => mutableEvents.Clear(),
+                Throws.TypeOf<NotSupportedException>());
+        }
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void Create_RejectsNonPositiveRequestId(long requestId)
+    {
+        Assert.That(
+            () => CreateSnapshot(requestId: requestId),
+            Throws.InstanceOf<ArgumentException>());
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    [TestCase(5)]
+    public void Create_RejectsInvalidParentRequestId(long parentRequestId)
+    {
+        Assert.That(
+            () => CreateSnapshot(requestId: 5, parentRequestId: parentRequestId),
+            Throws.InstanceOf<ArgumentException>());
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void Create_RejectsEmptyRootTargetClass(string? rootTargetClass)
+    {
+        Assert.That(
+            () => CreateSnapshot(rootTargetClass: rootTargetClass!),
+            Throws.InstanceOf<ArgumentException>());
+    }
+
+    [Test]
+    public void Create_RejectsNegativeCounter()
+    {
+        var counters = CreateCounters();
+        counters[RenderPipelineCounter.ProgramHits] = -1;
+
+        Assert.That(
+            () => CreateSnapshot(counters: counters),
+            Throws.InstanceOf<ArgumentException>());
+    }
+
+    [Test]
+    public void Create_RejectsNonGapFreeEventSequence()
+    {
+        List<RenderPipelineDiagnosticEvent> events =
+        [
+            Event(0, RenderPipelineDiagnosticEventKind.RequestStarted),
+            Event(2, RenderPipelineDiagnosticEventKind.RequestCompleted),
+        ];
+
+        Assert.That(
+            () => CreateSnapshot(events: events),
+            Throws.InstanceOf<ArgumentException>());
+    }
+
+    [Test]
+    public void Create_RejectsMissingDuplicateOrMisorderedLifecycleEvents()
+    {
+        RenderPipelineDiagnosticEvent[] missingStart =
+        [
+            Event(0, RenderPipelineDiagnosticEventKind.FragmentRecorded, 1),
+            Event(1, RenderPipelineDiagnosticEventKind.OutcomeAssigned, 1,
+                outcome: RenderPipelineOutcome.Executed),
+            Event(2, RenderPipelineDiagnosticEventKind.RequestCompleted),
+        ];
+        RenderPipelineDiagnosticEvent[] duplicateStart =
+        [
+            Event(0, RenderPipelineDiagnosticEventKind.RequestStarted),
+            Event(1, RenderPipelineDiagnosticEventKind.RequestStarted),
+            Event(2, RenderPipelineDiagnosticEventKind.FragmentRecorded, 1),
+            Event(3, RenderPipelineDiagnosticEventKind.OutcomeAssigned, 1,
+                outcome: RenderPipelineOutcome.Executed),
+            Event(4, RenderPipelineDiagnosticEventKind.RequestCompleted),
+        ];
+        RenderPipelineDiagnosticEvent[] eventAfterCompletion =
+        [
+            Event(0, RenderPipelineDiagnosticEventKind.RequestStarted),
+            Event(1, RenderPipelineDiagnosticEventKind.FragmentRecorded, 1),
+            Event(2, RenderPipelineDiagnosticEventKind.RequestCompleted),
+            Event(3, RenderPipelineDiagnosticEventKind.OutcomeAssigned, 1,
+                outcome: RenderPipelineOutcome.Executed),
+        ];
+        RenderPipelineDiagnosticEvent[] duplicateCompletion =
+        [
+            Event(0, RenderPipelineDiagnosticEventKind.RequestStarted),
+            Event(1, RenderPipelineDiagnosticEventKind.FragmentRecorded, 1),
+            Event(2, RenderPipelineDiagnosticEventKind.OutcomeAssigned, 1,
+                outcome: RenderPipelineOutcome.Executed),
+            Event(3, RenderPipelineDiagnosticEventKind.RequestCompleted),
+            Event(4, RenderPipelineDiagnosticEventKind.RequestCompleted),
+        ];
+
+        Assert.Multiple(() =>
+        {
+            AssertInvalidEvents(missingStart);
+            AssertInvalidEvents(duplicateStart);
+            AssertInvalidEvents(eventAfterCompletion);
+            AssertInvalidEvents(duplicateCompletion);
+        });
+    }
+
+    [Test]
+    public void Create_RejectsInvalidEventOptionalFields()
+    {
+        Assert.Multiple(() =>
+        {
+            AssertInvalidEvents(Event(0, RenderPipelineDiagnosticEventKind.BoundaryPlanned));
+            AssertInvalidEvents(Event(0, RenderPipelineDiagnosticEventKind.OutcomeAssigned));
+            AssertInvalidEvents(Event(0, RenderPipelineDiagnosticEventKind.Failure));
+            AssertInvalidEvents(Event(0, RenderPipelineDiagnosticEventKind.CleanupFailure));
+            AssertInvalidEvents(Event(0, RenderPipelineDiagnosticEventKind.NestedRequest));
+            AssertInvalidEvents(Event(
+                0,
+                RenderPipelineDiagnosticEventKind.RequestStarted,
+                boundaryReason: RenderPipelineBoundaryReason.Opaque));
+            AssertInvalidEvents(Event(
+                0,
+                RenderPipelineDiagnosticEventKind.FragmentRecorded,
+                outcome: RenderPipelineOutcome.Executed));
+            AssertInvalidEvents(Event(
+                0,
+                RenderPipelineDiagnosticEventKind.PassExecuted,
+                failurePhase: RenderPipelineFailurePhase.Execution));
+            AssertInvalidEvents(Event(
+                0,
+                RenderPipelineDiagnosticEventKind.CacheDecision,
+                relatedRequestId: 2));
+        });
+    }
+
+    [Test]
+    public void Create_AcceptsEachEventSpecificOptionalField()
+    {
+        List<RenderPipelineDiagnosticEvent> events =
+        [
+            Event(0, RenderPipelineDiagnosticEventKind.RequestStarted),
+            Event(1, RenderPipelineDiagnosticEventKind.FragmentRecorded, 1),
+            Event(2, RenderPipelineDiagnosticEventKind.BoundaryPlanned, 1,
+                boundaryReason: RenderPipelineBoundaryReason.Geometry),
+            Event(3, RenderPipelineDiagnosticEventKind.OutcomeAssigned, 1,
+                outcome: RenderPipelineOutcome.Executed),
+            Event(4, RenderPipelineDiagnosticEventKind.NestedRequest, 1, relatedRequestId: 2),
+            Event(5, RenderPipelineDiagnosticEventKind.Failure, 0,
+                failurePhase: RenderPipelineFailurePhase.Execution),
+            Event(6, RenderPipelineDiagnosticEventKind.CleanupFailure, 0,
+                failurePhase: RenderPipelineFailurePhase.Cleanup),
+            Event(7, RenderPipelineDiagnosticEventKind.RequestCompleted),
+        ];
+
+        RenderPipelineDiagnosticSnapshot snapshot = CreateSnapshot(
+            succeeded: false,
+            failurePhase: RenderPipelineFailurePhase.Execution,
+            counters: CreateCounters(failures: 1, cleanupFailures: 1, opaqueBoundaries: 1),
+            events: events);
+
+        Assert.That(snapshot.Events, Is.EqualTo(events));
+    }
+
+    [TestCase(
+        (int)RenderPipelineDiagnosticEventKind.PassPlanned,
+        (int)RenderPipelineDiagnosticEventKind.PassExecuted)]
+    [TestCase(
+        (int)RenderPipelineDiagnosticEventKind.SynchronizationPlanned,
+        (int)RenderPipelineDiagnosticEventKind.SynchronizationExecuted)]
+    [TestCase(
+        (int)RenderPipelineDiagnosticEventKind.BackendTransitionPlanned,
+        (int)RenderPipelineDiagnosticEventKind.BackendTransitionExecuted)]
+    public void Create_RejectsExecutionBeforeCorrespondingPlan(
+        int plannedKindValue,
+        int executedKindValue)
+    {
+        var plannedKind = (RenderPipelineDiagnosticEventKind)plannedKindValue;
+        var executedKind = (RenderPipelineDiagnosticEventKind)executedKindValue;
+        RenderPipelineDiagnosticEvent[] orderedEvents =
+        [
+            Event(0, RenderPipelineDiagnosticEventKind.RequestStarted),
+            Event(1, RenderPipelineDiagnosticEventKind.FragmentRecorded, 1),
+            Event(2, plannedKind, 1),
+            Event(3, executedKind, 1),
+            Event(4, RenderPipelineDiagnosticEventKind.OutcomeAssigned, 1,
+                outcome: RenderPipelineOutcome.Executed),
+            Event(5, RenderPipelineDiagnosticEventKind.RequestCompleted),
+        ];
+        RenderPipelineDiagnosticEvent[] misorderedEvents =
+        [
+            Event(0, RenderPipelineDiagnosticEventKind.RequestStarted),
+            Event(1, RenderPipelineDiagnosticEventKind.FragmentRecorded, 1),
+            Event(2, executedKind, 1),
+            Event(3, plannedKind, 1),
+            Event(4, RenderPipelineDiagnosticEventKind.OutcomeAssigned, 1,
+                outcome: RenderPipelineOutcome.Executed),
+            Event(5, RenderPipelineDiagnosticEventKind.RequestCompleted),
+        ];
+        Dictionary<RenderPipelineCounter, long> counters = CreateCounters();
+        switch (executedKind)
+        {
+            case RenderPipelineDiagnosticEventKind.PassExecuted:
+                counters[RenderPipelineCounter.PlannedGpuPasses] = 1;
+                counters[RenderPipelineCounter.ExecutedGpuPasses] = 1;
+                break;
+            case RenderPipelineDiagnosticEventKind.SynchronizationExecuted:
+                counters[RenderPipelineCounter.Synchronizations] = 1;
+                break;
+            case RenderPipelineDiagnosticEventKind.BackendTransitionExecuted:
+                counters[RenderPipelineCounter.PlannedBackendTransitions] = 1;
+                counters[RenderPipelineCounter.ExecutedBackendTransitions] = 1;
+                break;
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => CreateSnapshot(counters: counters, events: orderedEvents),
+                Throws.Nothing,
+                "The control stream must be valid apart from event ordering.");
+            Assert.That(
+                () => CreateSnapshot(counters: counters, events: misorderedEvents),
+                Throws.ArgumentException.With.Message.Contains(
+                    "must follow its corresponding planned event"));
+        });
+    }
+
+    [Test]
+    public void Create_RejectsOutcomeReconciliationMismatch()
+    {
+        var counters = CreateCounters(recordedFragments: 2, executedOutcomes: 1);
+
+        Assert.That(
+            () => CreateSnapshot(counters: counters),
+            Throws.InstanceOf<ArgumentException>());
+    }
+
+    [Test]
+    public void Create_RejectsFragmentOutcomeEvidenceMismatch()
+    {
+        RenderPipelineDiagnosticEvent[] duplicateOutcome =
+        [
+            Event(0, RenderPipelineDiagnosticEventKind.RequestStarted),
+            Event(1, RenderPipelineDiagnosticEventKind.FragmentRecorded, 1),
+            Event(2, RenderPipelineDiagnosticEventKind.OutcomeAssigned, 1,
+                outcome: RenderPipelineOutcome.Executed),
+            Event(3, RenderPipelineDiagnosticEventKind.OutcomeAssigned, 1,
+                outcome: RenderPipelineOutcome.Executed),
+            Event(4, RenderPipelineDiagnosticEventKind.RequestCompleted),
+        ];
+        RenderPipelineDiagnosticEvent[] missingOutcome =
+        [
+            Event(0, RenderPipelineDiagnosticEventKind.RequestStarted),
+            Event(1, RenderPipelineDiagnosticEventKind.FragmentRecorded, 1),
+            Event(2, RenderPipelineDiagnosticEventKind.FragmentRecorded, 2),
+            Event(3, RenderPipelineDiagnosticEventKind.OutcomeAssigned, 1,
+                outcome: RenderPipelineOutcome.Executed),
+            Event(4, RenderPipelineDiagnosticEventKind.RequestCompleted),
+        ];
+        RenderPipelineDiagnosticEvent[] wrongCounter =
+        [
+            Event(0, RenderPipelineDiagnosticEventKind.RequestStarted),
+            Event(1, RenderPipelineDiagnosticEventKind.FragmentRecorded, 1),
+            Event(2, RenderPipelineDiagnosticEventKind.OutcomeAssigned, 1,
+                outcome: RenderPipelineOutcome.Executed),
+            Event(3, RenderPipelineDiagnosticEventKind.RequestCompleted),
+        ];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => CreateSnapshot(events: duplicateOutcome),
+                Throws.InstanceOf<ArgumentException>());
+            Assert.That(
+                () => CreateSnapshot(
+                    counters: CreateCounters(recordedFragments: 2, executedOutcomes: 2),
+                    events: missingOutcome),
+                Throws.InstanceOf<ArgumentException>());
+            Assert.That(
+                () => CreateSnapshot(
+                    counters: CreateCounters(executedOutcomes: 0, cachedOutcomes: 1),
+                    events: wrongCounter),
+                Throws.InstanceOf<ArgumentException>());
+            Assert.That(
+                () => CreateSnapshot(
+                    purpose: RenderRequestPurpose.Bounds,
+                    counters: CreateCounters(),
+                    events: wrongCounter),
+                Throws.InstanceOf<ArgumentException>());
+        });
+    }
+
+    [Test]
+    public void Create_RejectsIntermediateOwnershipReconciliationMismatch()
+    {
+        var counters = CreateCounters(intermediateAcquires: 2, intermediateDischarges: 1);
+
+        Assert.That(
+            () => CreateSnapshot(counters: counters),
+            Throws.InstanceOf<ArgumentException>());
+    }
+
+    [Test]
+    public void Create_RejectsInconsistentSuccessFailureState()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => CreateSnapshot(
+                    succeeded: true,
+                    failurePhase: RenderPipelineFailurePhase.Execution,
+                    counters: CreateCounters(failures: 1)),
+                Throws.InstanceOf<ArgumentException>());
+            Assert.That(
+                () => CreateSnapshot(
+                    succeeded: false,
+                    failurePhase: null,
+                    counters: CreateCounters(failures: 1)),
+                Throws.InstanceOf<ArgumentException>());
+            Assert.That(
+                () => CreateSnapshot(
+                    succeeded: false,
+                    failurePhase: RenderPipelineFailurePhase.Execution,
+                    counters: CreateCounters(failures: 0)),
+                Throws.InstanceOf<ArgumentException>());
+            Assert.That(
+                () => CreateSnapshot(
+                    succeeded: false,
+                    failurePhase: RenderPipelineFailurePhase.Execution,
+                    counters: CreateCounters(failures: 2)),
+                Throws.InstanceOf<ArgumentException>());
+        });
+    }
+
+    [Test]
+    public void Create_RejectsInconsistentFailureEvents()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => CreateSnapshot(events: CreateEventStream(
+                    primaryFailurePhase: RenderPipelineFailurePhase.Execution)),
+                Throws.InstanceOf<ArgumentException>());
+            Assert.That(
+                () => CreateSnapshot(
+                    succeeded: false,
+                    failurePhase: RenderPipelineFailurePhase.Execution,
+                    counters: CreateCounters(failures: 1),
+                    events: CreateEventStream(
+                        primaryFailurePhase: RenderPipelineFailurePhase.Allocation)),
+                Throws.InstanceOf<ArgumentException>());
+            Assert.That(
+                () => CreateSnapshot(
+                    succeeded: false,
+                    failurePhase: RenderPipelineFailurePhase.Execution,
+                    counters: CreateCounters(failures: 1, cleanupFailures: 1),
+                    events: CreateEventStream(
+                        primaryFailurePhase: RenderPipelineFailurePhase.Execution)),
+                Throws.InstanceOf<ArgumentException>());
+            Assert.That(
+                () => CreateSnapshot(
+                    succeeded: false,
+                    failurePhase: RenderPipelineFailurePhase.Cleanup,
+                    counters: CreateCounters(failures: 1, cleanupFailures: 1),
+                    events: CreateEventStream(
+                        primaryFailurePhase: RenderPipelineFailurePhase.Cleanup,
+                        cleanupFailurePhases: [RenderPipelineFailurePhase.Execution])),
+                Throws.InstanceOf<ArgumentException>());
+        });
+    }
+
+    [Test]
+    public void Create_ValidatesCleanupFailureAndCachePublicationState()
+    {
+        RenderPipelineDiagnosticSnapshot cleanupOnlyFailure = CreateSnapshot(
+            succeeded: false,
+            failurePhase: RenderPipelineFailurePhase.Cleanup,
+            counters: CreateCounters(failures: 1, cleanupFailures: 1));
+        RenderPipelineDiagnosticSnapshot secondaryCleanupFailure = CreateSnapshot(
+            succeeded: false,
+            failurePhase: RenderPipelineFailurePhase.Execution,
+            counters: CreateCounters(failures: 1, cleanupFailures: 2));
+        RenderPipelineDiagnosticEvent[] acceptedCleanupEvents =
+        [
+            Event(0, RenderPipelineDiagnosticEventKind.RequestStarted),
+            Event(1, RenderPipelineDiagnosticEventKind.FragmentRecorded, 1),
+            Event(2, RenderPipelineDiagnosticEventKind.OutcomeAssigned, 1,
+                outcome: RenderPipelineOutcome.Executed),
+            Event(3, RenderPipelineDiagnosticEventKind.Failure,
+                failurePhase: RenderPipelineFailurePhase.Cleanup),
+            Event(4, RenderPipelineDiagnosticEventKind.CleanupFailure,
+                failurePhase: RenderPipelineFailurePhase.Cleanup),
+            Event(5, RenderPipelineDiagnosticEventKind.CacheCapturePublished, 1),
+            Event(6, RenderPipelineDiagnosticEventKind.RequestCompleted),
+        ];
+        RenderPipelineDiagnosticSnapshot acceptedPostCommitCleanup = CreateSnapshot(
+            succeeded: false,
+            failurePhase: RenderPipelineFailurePhase.Cleanup,
+            counters: CreateCounters(failures: 1, cleanupFailures: 1, renderCacheCaptures: 1),
+            events: acceptedCleanupEvents);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cleanupOnlyFailure.FailurePhase, Is.EqualTo(RenderPipelineFailurePhase.Cleanup));
+            Assert.That(secondaryCleanupFailure.FailurePhase, Is.EqualTo(RenderPipelineFailurePhase.Execution));
+            Assert.That(acceptedPostCommitCleanup[RenderPipelineCounter.RenderCacheCaptures], Is.EqualTo(1));
+            Assert.That(
+                () => CreateSnapshot(
+                    succeeded: true,
+                    counters: CreateCounters(cleanupFailures: 1)),
+                Throws.InstanceOf<ArgumentException>());
+            Assert.That(
+                () => CreateSnapshot(
+                    succeeded: false,
+                    failurePhase: RenderPipelineFailurePhase.Cleanup,
+                    counters: CreateCounters(failures: 1)),
+                Throws.InstanceOf<ArgumentException>());
+            Assert.That(
+                () => CreateSnapshot(
+                    succeeded: false,
+                    failurePhase: RenderPipelineFailurePhase.Execution,
+                    counters: CreateCounters(failures: 1, cleanupFailures: 1, renderCacheCaptures: 1),
+                    events: acceptedCleanupEvents),
+                Throws.InstanceOf<ArgumentException>());
+        });
+    }
+
+    [Test]
+    public void Create_ReconcilesSuccessfulCachePublicationEvidence()
+    {
+        RenderPipelineDiagnosticEvent[] publishedEvents =
+        [
+            Event(0, RenderPipelineDiagnosticEventKind.RequestStarted),
+            Event(1, RenderPipelineDiagnosticEventKind.FragmentRecorded, 1),
+            Event(2, RenderPipelineDiagnosticEventKind.OutcomeAssigned, 1,
+                outcome: RenderPipelineOutcome.Executed),
+            Event(3, RenderPipelineDiagnosticEventKind.CacheCapturePublished, 1),
+            Event(4, RenderPipelineDiagnosticEventKind.RequestCompleted),
+        ];
+        RenderPipelineDiagnosticSnapshot snapshot = CreateSnapshot(
+            counters: CreateCounters(renderCacheCaptures: 1),
+            events: publishedEvents);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot[RenderPipelineCounter.RenderCacheCaptures], Is.EqualTo(1));
+            Assert.That(
+                () => CreateSnapshot(counters: CreateCounters(renderCacheCaptures: 1)),
+                Throws.InstanceOf<ArgumentException>());
+            Assert.That(
+                () => CreateSnapshot(events: publishedEvents),
+                Throws.InstanceOf<ArgumentException>());
+        });
+    }
+
+    [Test]
+    public void Create_ValidatesOpaqueExternalExecutionState()
+    {
+        List<RenderPipelineDiagnosticEvent> opaqueBoundary = CreateEventStream(
+            boundaryReason: RenderPipelineBoundaryReason.LegacyRawCanvas);
+        RenderPipelineDiagnosticSnapshot skippedOpaqueWork = CreateSnapshot(
+            hasOpaqueExternalWork: true,
+            counters: CreateCounters(opaqueBoundaries: 1),
+            events: opaqueBoundary);
+        RenderPipelineDiagnosticSnapshot executedOpaqueWork = CreateSnapshot(
+            hasOpaqueExternalWork: true,
+            counters: CreateCounters(opaqueExternalExecutions: 1, opaqueBoundaries: 1),
+            events: opaqueBoundary);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(skippedOpaqueWork.HasOpaqueExternalWork, Is.True);
+            Assert.That(skippedOpaqueWork[RenderPipelineCounter.OpaqueExternalExecutions], Is.Zero);
+            Assert.That(executedOpaqueWork[RenderPipelineCounter.OpaqueExternalExecutions], Is.EqualTo(1));
+            Assert.That(
+                () => CreateSnapshot(hasOpaqueExternalWork: true),
+                Throws.InstanceOf<ArgumentException>());
+            Assert.That(
+                () => CreateSnapshot(
+                    hasOpaqueExternalWork: false,
+                    counters: CreateCounters(opaqueExternalExecutions: 1, opaqueBoundaries: 1),
+                    events: opaqueBoundary),
+                Throws.InstanceOf<ArgumentException>());
+            Assert.That(
+                () => CreateSnapshot(
+                    hasOpaqueExternalWork: true,
+                    counters: CreateCounters(),
+                    events: opaqueBoundary),
+                Throws.InstanceOf<ArgumentException>());
+            Assert.That(
+                () => CreateSnapshot(
+                    hasOpaqueExternalWork: true,
+                    counters: CreateCounters(opaqueExternalExecutions: 1)),
+                Throws.InstanceOf<ArgumentException>());
+        });
+    }
+
+    [Test]
+    public void State_TracksLatestAndLatestFrameIndependently()
+    {
+        var state = new RenderPipelineDiagnosticsState();
+        RenderPipelineDiagnosticSnapshot firstFrame = CreateSnapshot(requestId: 1);
+        RenderPipelineDiagnosticSnapshot bounds = CreateSnapshot(
+            requestId: 2,
+            purpose: RenderRequestPurpose.Bounds);
+        RenderPipelineDiagnosticSnapshot secondFrame = CreateSnapshot(requestId: 3);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(state.Latest, Is.SameAs(RenderPipelineDiagnosticSnapshot.Empty));
+            Assert.That(state.LatestFrame, Is.SameAs(RenderPipelineDiagnosticSnapshot.Empty));
+        });
+
+        state.Complete(firstFrame);
+        state.Complete(bounds);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(state.Latest, Is.SameAs(bounds));
+            Assert.That(state.LatestFrame, Is.SameAs(firstFrame));
+        });
+
+        state.Complete(secondFrame);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(state.Latest, Is.SameAs(secondFrame));
+            Assert.That(state.LatestFrame, Is.SameAs(secondFrame));
+        });
+    }
+
+    [Test]
+    public void Reset_ClearsBothSnapshotsButKeepsSubscribers()
+    {
+        var state = new RenderPipelineDiagnosticsState();
+        var observed = new List<long>();
+        state.RequestCompleted += snapshot => observed.Add(snapshot.RequestId);
+        state.Complete(CreateSnapshot(requestId: 1));
+
+        state.Reset();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(state.Latest, Is.SameAs(RenderPipelineDiagnosticSnapshot.Empty));
+            Assert.That(state.LatestFrame, Is.SameAs(RenderPipelineDiagnosticSnapshot.Empty));
+        });
+
+        RenderPipelineDiagnosticSnapshot bounds = CreateSnapshot(
+            requestId: 2,
+            purpose: RenderRequestPurpose.Bounds);
+        state.Complete(bounds);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(state.Latest, Is.SameAs(bounds));
+            Assert.That(state.LatestFrame, Is.SameAs(RenderPipelineDiagnosticSnapshot.Empty));
+            Assert.That(observed, Is.EqualTo(new long[] { 1, 2 }));
+        });
+    }
+
+    [Test]
+    public void Complete_IsolatesObserverFailuresAndStillPublishesState()
+    {
+        var state = new RenderPipelineDiagnosticsState();
+        RenderPipelineDiagnosticSnapshot snapshot = CreateSnapshot(requestId: 9);
+        var observed = new List<RenderPipelineDiagnosticSnapshot>();
+        state.RequestCompleted += _ => throw new InvalidOperationException("observer failure");
+        state.RequestCompleted += observed.Add;
+
+        Assert.That(() => state.Complete(snapshot), Throws.Nothing);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(state.Latest, Is.SameAs(snapshot));
+            Assert.That(state.LatestFrame, Is.SameAs(snapshot));
+            Assert.That(observed, Is.EqualTo(new[] { snapshot }));
+        });
+    }
+
+    [Test]
+    public void RequestDiagnostics_NullStateRemainsDisabled()
+    {
+        using var request = new RenderRequest(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            diagnostics: null));
+
+        RenderPipelineDiagnosticRecorder? recorder = RenderRequestDiagnostics.Start(request, "Root");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(request.Options.Diagnostics, Is.Null);
+            Assert.That(recorder, Is.Null);
+            Assert.That(RenderRequestDiagnostics.TryGet(request), Is.Null);
+        });
+    }
+
+    [Test]
+    public void Recorder_CleanupOnlyFailureBecomesPrimaryAndReconciles()
+    {
+        var state = new RenderPipelineDiagnosticsState();
+        RenderPipelineDiagnosticRecorder recorder = RenderPipelineDiagnosticRecorder.Start(
+            state,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            "Root")!;
+        long subjectId = recorder.RecordFragments(1, RenderPipelineOutcome.Executed).Single();
+
+        recorder.RecordCleanupFailure(subjectId);
+        recorder.Complete();
+
+        RenderPipelineDiagnosticSnapshot snapshot = state.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot.Succeeded, Is.False);
+            Assert.That(snapshot.FailurePhase, Is.EqualTo(RenderPipelineFailurePhase.Cleanup));
+            Assert.That(snapshot[RenderPipelineCounter.Failures], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.CleanupFailures], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.FailedOutcomes], Is.EqualTo(1));
+            Assert.That(
+                snapshot.Events.Count(item => item.Kind == RenderPipelineDiagnosticEventKind.Failure),
+                Is.EqualTo(1));
+            Assert.That(
+                snapshot.Events.Count(item => item.Kind == RenderPipelineDiagnosticEventKind.CleanupFailure),
+                Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void Recorder_InvalidSnapshotCannotEscapeIntoRendering()
+    {
+        var state = new RenderPipelineDiagnosticsState();
+        RenderPipelineDiagnosticRecorder recorder = RenderPipelineDiagnosticRecorder.Start(
+            state,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            rootTargetClass: " ")!;
+        long subjectId = recorder.RecordFragments(1, RenderPipelineOutcome.Executed).Single();
+        recorder.RecordOutcome(subjectId, RenderPipelineOutcome.Executed);
+
+        Assert.That(recorder.Complete, Throws.Nothing);
+        Assert.That(state.Latest, Is.SameAs(RenderPipelineDiagnosticSnapshot.Empty));
+    }
+
+    [Test]
+    public void State_AllowsConcurrentCompletionAndReset()
+    {
+        var state = new RenderPipelineDiagnosticsState();
+        int observed = 0;
+        state.RequestCompleted += _ => Interlocked.Increment(ref observed);
+        RenderPipelineDiagnosticSnapshot[] snapshots = Enumerable.Range(1, 64)
+            .Select(index => CreateSnapshot(
+                requestId: index,
+                purpose: index % 3 == 0 ? RenderRequestPurpose.Bounds : RenderRequestPurpose.Frame))
+            .ToArray();
+
+        Parallel.ForEach(snapshots, snapshot =>
+        {
+            state.Complete(snapshot);
+            if (snapshot.RequestId % 8 == 0)
+            {
+                state.Reset();
+            }
+
+            _ = state.Latest;
+            _ = state.LatestFrame;
+        });
+
+        Assert.That(observed, Is.EqualTo(64),
+            "the concurrent phase must publish all 64 completions before the sequential repair.");
+
+        state.Complete(CreateSnapshot(requestId: 65));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(observed, Is.EqualTo(65));
+            Assert.That(state.Latest.RequestId, Is.EqualTo(65));
+            Assert.That(state.LatestFrame.RequestId, Is.EqualTo(65));
+        });
+    }
+
+    private static RenderPipelineDiagnosticSnapshot CreateSnapshot(
+        long requestId = 1,
+        long? parentRequestId = null,
+        RenderIntent intent = RenderIntent.Preview,
+        RenderRequestPurpose purpose = RenderRequestPurpose.Frame,
+        bool succeeded = true,
+        bool hasOpaqueExternalWork = false,
+        string rootTargetClass = "Root",
+        RenderPipelineFailurePhase? failurePhase = null,
+        IReadOnlyDictionary<RenderPipelineCounter, long>? counters = null,
+        IEnumerable<RenderPipelineDiagnosticEvent>? events = null)
+    {
+        IReadOnlyDictionary<RenderPipelineCounter, long> effectiveCounters = counters
+            ?? (purpose is RenderRequestPurpose.Bounds or RenderRequestPurpose.HitTest
+                ? CreateCounters(executedOutcomes: 0, metadataOutcomes: 1)
+                : CreateCounters());
+        return RenderPipelineDiagnosticSnapshot.Create(
+            requestId,
+            parentRequestId,
+            intent,
+            purpose,
+            succeeded,
+            hasOpaqueExternalWork,
+            rootTargetClass,
+            failurePhase,
+            effectiveCounters,
+            events ?? CreateDefaultEvents(succeeded, failurePhase, purpose, effectiveCounters));
+    }
+
+    private static Dictionary<RenderPipelineCounter, long> CreateCounters(
+        long recordedFragments = 1,
+        long executedOutcomes = 1,
+        long cachedOutcomes = 0,
+        long metadataOutcomes = 0,
+        long skippedOutcomes = 0,
+        long failedOutcomes = 0,
+        long intermediateAcquires = 1,
+        long intermediateDischarges = 1,
+        long failures = 0,
+        long cleanupFailures = 0,
+        long opaqueExternalExecutions = 0,
+        long opaqueBoundaries = 0,
+        long opaque3DBoundaries = 0,
+        long renderCacheCaptures = 0)
+    {
+        return new Dictionary<RenderPipelineCounter, long>
+        {
+            [RenderPipelineCounter.RecordedFragments] = recordedFragments,
+            [RenderPipelineCounter.ExecutedOutcomes] = executedOutcomes,
+            [RenderPipelineCounter.CachedOutcomes] = cachedOutcomes,
+            [RenderPipelineCounter.MetadataOutcomes] = metadataOutcomes,
+            [RenderPipelineCounter.SkippedOutcomes] = skippedOutcomes,
+            [RenderPipelineCounter.FailedOutcomes] = failedOutcomes,
+            [RenderPipelineCounter.IntermediateAcquires] = intermediateAcquires,
+            [RenderPipelineCounter.IntermediateDischarges] = intermediateDischarges,
+            [RenderPipelineCounter.Failures] = failures,
+            [RenderPipelineCounter.CleanupFailures] = cleanupFailures,
+            [RenderPipelineCounter.OpaqueExternalExecutions] = opaqueExternalExecutions,
+            [RenderPipelineCounter.OpaqueBoundaries] = opaqueBoundaries,
+            [RenderPipelineCounter.Opaque3DBoundaries] = opaque3DBoundaries,
+            [RenderPipelineCounter.RenderCacheCaptures] = renderCacheCaptures,
+        };
+    }
+
+    private static List<RenderPipelineDiagnosticEvent> CreateDefaultEvents(
+        bool succeeded,
+        RenderPipelineFailurePhase? failurePhase,
+        RenderRequestPurpose purpose,
+        IReadOnlyDictionary<RenderPipelineCounter, long> counters)
+    {
+        counters.TryGetValue(RenderPipelineCounter.CleanupFailures, out long cleanupFailures);
+        var cleanupFailurePhases = new List<RenderPipelineFailurePhase>();
+        for (long i = 0; i < cleanupFailures; i++)
+        {
+            cleanupFailurePhases.Add(RenderPipelineFailurePhase.Cleanup);
+        }
+
+        return CreateEventStream(
+            outcome: purpose is RenderRequestPurpose.Bounds or RenderRequestPurpose.HitTest
+                ? RenderPipelineOutcome.Metadata
+                : RenderPipelineOutcome.Executed,
+            primaryFailurePhase: succeeded ? null : failurePhase,
+            cleanupFailurePhases: cleanupFailurePhases);
+    }
+
+    private static List<RenderPipelineDiagnosticEvent> CreateEventStream(
+        RenderPipelineOutcome outcome = RenderPipelineOutcome.Executed,
+        RenderPipelineFailurePhase? primaryFailurePhase = null,
+        IReadOnlyList<RenderPipelineFailurePhase>? cleanupFailurePhases = null,
+        RenderPipelineBoundaryReason? boundaryReason = null)
+    {
+        List<RenderPipelineDiagnosticEvent> result =
+        [
+            Event(0, RenderPipelineDiagnosticEventKind.RequestStarted),
+            Event(1, RenderPipelineDiagnosticEventKind.FragmentRecorded, 1),
+        ];
+
+        if (boundaryReason is { } reason)
+        {
+            result.Add(Event(
+                result.Count,
+                RenderPipelineDiagnosticEventKind.BoundaryPlanned,
+                1,
+                boundaryReason: reason));
+        }
+
+        result.Add(Event(
+            result.Count,
+            RenderPipelineDiagnosticEventKind.OutcomeAssigned,
+            1,
+            outcome: outcome));
+
+        if (primaryFailurePhase is { } primaryPhase)
+        {
+            result.Add(Event(
+                result.Count,
+                RenderPipelineDiagnosticEventKind.Failure,
+                failurePhase: primaryPhase));
+        }
+
+        if (cleanupFailurePhases is not null)
+        {
+            foreach (RenderPipelineFailurePhase cleanupPhase in cleanupFailurePhases)
+            {
+                result.Add(Event(
+                    result.Count,
+                    RenderPipelineDiagnosticEventKind.CleanupFailure,
+                    failurePhase: cleanupPhase));
+            }
+        }
+
+        result.Add(Event(result.Count, RenderPipelineDiagnosticEventKind.RequestCompleted));
+        return result;
+    }
+
+    private static RenderPipelineDiagnosticEvent Event(
+        long sequence,
+        RenderPipelineDiagnosticEventKind kind,
+        long subjectId = 0,
+        long? relatedRequestId = null,
+        RenderPipelineBoundaryReason? boundaryReason = null,
+        RenderPipelineOutcome? outcome = null,
+        RenderPipelineFailurePhase? failurePhase = null)
+    {
+        return new RenderPipelineDiagnosticEvent(
+            sequence,
+            kind,
+            subjectId,
+            relatedRequestId,
+            boundaryReason,
+            outcome,
+            failurePhase);
+    }
+
+    private static void AssertInvalidEvents(params RenderPipelineDiagnosticEvent[] events)
+    {
+        Assert.That(
+            () => CreateSnapshot(events: events),
+            Throws.InstanceOf<ArgumentException>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/RenderPipelineReconciliationTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/RenderPipelineReconciliationTests.cs
@@ -1,0 +1,1374 @@
+﻿using System.Collections.Immutable;
+
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Planning;
+
+[TestFixture]
+public sealed class RenderPipelineReconciliationTests
+{
+    [Test]
+    public void MetadataPipeline_PublishesMetadataOnlySnapshotFromRecorderAndCompilerHooks()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var node = new ClearRenderNode(new Color(255, 12, 34, 56));
+        using var renderer = new RenderNodeRenderer(node, new RenderNodeRendererOptions
+        {
+            DefaultRequest = new RenderNodeRenderRequest
+            {
+                TargetDomain = new Rect(0, 0, 32, 24),
+                Diagnostics = diagnostics,
+                CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+            },
+        });
+
+        RenderNodeMeasurement measurement = renderer.Measure();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(measurement.OutputBounds, Is.EqualTo(new Rect(0, 0, 32, 24)));
+            Assert.That(diagnostics.Latest.Purpose, Is.EqualTo(RenderRequestPurpose.Bounds));
+            Assert.That(diagnostics.Latest.Succeeded, Is.True);
+            Assert.That(diagnostics.Latest[RenderPipelineCounter.RecordedFragments], Is.EqualTo(1));
+            Assert.That(diagnostics.Latest[RenderPipelineCounter.RecordedTargetCommands], Is.EqualTo(1));
+            Assert.That(diagnostics.Latest[RenderPipelineCounter.MetadataOutcomes], Is.EqualTo(1));
+            Assert.That(diagnostics.LatestFrame, Is.SameAs(RenderPipelineDiagnosticSnapshot.Empty));
+        });
+    }
+
+    [Test]
+    public void HitTest_OutsideRequestedRegion_PublishesMetadataSnapshotWithoutReplacingLatestFrame()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        RenderPipelineDiagnosticSnapshot latestFrame = diagnostics.LatestFrame;
+        using var node = new ClearRenderNode(new Color(255, 12, 34, 56));
+        using var renderer = new RenderNodeRenderer(node, new RenderNodeRendererOptions
+        {
+            DefaultRequest = new RenderNodeRenderRequest
+            {
+                TargetDomain = new Rect(0, 0, 32, 24),
+                RequestedRegion = new Rect(8, 8, 12, 10),
+                Diagnostics = diagnostics,
+                CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+            },
+        });
+
+        bool hit = renderer.HitTest(new Point(2, 2));
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(hit, Is.False);
+            Assert.That(snapshot.Purpose, Is.EqualTo(RenderRequestPurpose.HitTest));
+            Assert.That(snapshot.Succeeded, Is.True);
+            Assert.That(snapshot[RenderPipelineCounter.RecordedFragments], Is.GreaterThan(0));
+            Assert.That(
+                snapshot[RenderPipelineCounter.MetadataOutcomes],
+                Is.EqualTo(snapshot[RenderPipelineCounter.RecordedFragments]));
+            Assert.That(snapshot.Events[^1].Kind, Is.EqualTo(RenderPipelineDiagnosticEventKind.RequestCompleted));
+            Assert.That(diagnostics.LatestFrame, Is.SameAs(latestFrame));
+        });
+    }
+
+    [Test]
+    public void ExecutionPipeline_PublishesAfterExecutionAndIsolatesObserverFailures()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        var observed = new List<RenderPipelineDiagnosticSnapshot>();
+        diagnostics.RequestCompleted += _ => throw new InvalidOperationException("observer-fault");
+        diagnostics.RequestCompleted += observed.Add;
+        using var node = new ClearRenderNode(new Color(255, 12, 34, 56));
+        using var renderer = new RenderNodeRenderer(node, new RenderNodeRendererOptions
+        {
+            DefaultRequest = new RenderNodeRenderRequest
+            {
+                TargetDomain = new Rect(0, 0, 16, 16),
+                Diagnostics = diagnostics,
+                CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+            },
+        });
+        using RenderTarget target = RenderTarget.CreateNull(16, 16);
+        using var canvas = new ImmediateCanvas(target);
+
+        Assert.That(() => renderer.Render(canvas), Throws.Nothing);
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(observed, Is.EqualTo(new[] { snapshot }));
+            Assert.That(snapshot.Purpose, Is.EqualTo(RenderRequestPurpose.Auxiliary));
+            Assert.That(snapshot.Succeeded, Is.True);
+            Assert.That(snapshot[RenderPipelineCounter.RecordedFragments], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedOutcomes], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.ExternalRootResources], Is.EqualTo(1));
+            Assert.That(snapshot.Events[^1].Kind, Is.EqualTo(RenderPipelineDiagnosticEventKind.RequestCompleted));
+        });
+    }
+
+    [Test]
+    public void WarmedExecution_ClassifiesPoolCreateThenExactSizeHit()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var node = new CacheableWorkNode();
+        using var renderer = new RenderNodeRenderer(node, new RenderNodeRendererOptions
+        {
+            DefaultRequest = new RenderNodeRenderRequest
+            {
+                TargetDomain = new Rect(0, 0, 16, 16),
+                Diagnostics = diagnostics,
+                CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+            },
+        });
+        using RenderTarget target = RenderTarget.CreateNull(16, 16);
+        using var canvas = new ImmediateCanvas(target);
+
+        renderer.Render(canvas);
+        RenderPipelineDiagnosticSnapshot first = diagnostics.Latest;
+        renderer.Render(canvas);
+        RenderPipelineDiagnosticSnapshot warmed = diagnostics.Latest;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first[RenderPipelineCounter.IntermediateAcquires], Is.EqualTo(1));
+            Assert.That(first[RenderPipelineCounter.IntermediateCreates], Is.EqualTo(1));
+            Assert.That(first[RenderPipelineCounter.PoolMisses], Is.EqualTo(1));
+            Assert.That(first[RenderPipelineCounter.PoolHits], Is.Zero);
+            Assert.That(warmed[RenderPipelineCounter.IntermediateAcquires], Is.EqualTo(1));
+            Assert.That(warmed[RenderPipelineCounter.IntermediateCreates], Is.Zero);
+            Assert.That(warmed[RenderPipelineCounter.PoolMisses], Is.Zero);
+            Assert.That(warmed[RenderPipelineCounter.PoolHits], Is.EqualTo(1));
+            Assert.That(warmed[RenderPipelineCounter.IntermediateDischarges], Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void WarmedRenderCache_ReconcilesTheProducerAsCachedWithoutExecutingItAgain()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var node = new CacheableWorkNode();
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using var renderer = new RenderNodeRenderer(node, new RenderNodeRendererOptions
+        {
+            DefaultRequest = new RenderNodeRenderRequest
+            {
+                TargetDomain = new Rect(0, 0, 16, 16),
+                Diagnostics = diagnostics,
+                CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Enabled,
+                Purpose = RenderRequestPurpose.Frame,
+            },
+        });
+
+        using RenderNodeRasterization cold = renderer.Rasterize();
+        RenderPipelineDiagnosticSnapshot coldSnapshot = diagnostics.Latest;
+        using RenderNodeRasterization warmed = renderer.Rasterize();
+        RenderPipelineDiagnosticSnapshot warmedSnapshot = diagnostics.Latest;
+
+        long terminalOutcomes =
+            warmedSnapshot[RenderPipelineCounter.ExecutedOutcomes]
+            + warmedSnapshot[RenderPipelineCounter.CachedOutcomes]
+            + warmedSnapshot[RenderPipelineCounter.MetadataOutcomes]
+            + warmedSnapshot[RenderPipelineCounter.SkippedOutcomes]
+            + warmedSnapshot[RenderPipelineCounter.FailedOutcomes];
+        Assert.Multiple(() =>
+        {
+            Assert.That(cold.IsEmpty, Is.False);
+            Assert.That(warmed.IsEmpty, Is.False);
+            Assert.That(coldSnapshot[RenderPipelineCounter.ExecutedOutcomes], Is.EqualTo(1));
+            Assert.That(coldSnapshot[RenderPipelineCounter.RenderCacheCaptures], Is.EqualTo(1));
+            Assert.That(coldSnapshot[RenderPipelineCounter.RejectedRenderCacheCaptures], Is.Zero);
+            Assert.That(warmedSnapshot[RenderPipelineCounter.CachedOutcomes], Is.EqualTo(1));
+            Assert.That(warmedSnapshot[RenderPipelineCounter.ExecutedGpuPasses], Is.Zero);
+            Assert.That(node.ExecuteCount, Is.EqualTo(1),
+                "A selected warmed cache entry must not execute its producer again.");
+            Assert.That(
+                terminalOutcomes,
+                Is.EqualTo(warmedSnapshot[RenderPipelineCounter.RecordedFragments]));
+        });
+    }
+
+    [Test]
+    public void OpaqueCallbackWithoutOutput_ExecutesWithoutInventingAGpuPass()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var node = new NoOutputOpaqueNode();
+        using var renderer = CreateRenderer(node, diagnostics);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.ExecuteCount, Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.PlannedGpuPasses], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedGpuPasses], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedOutcomes], Is.EqualTo(1));
+            Assert.That(snapshot.Events, Has.None.Matches<RenderPipelineDiagnosticEvent>(static item =>
+                item.Kind == RenderPipelineDiagnosticEventKind.PassExecuted));
+        });
+    }
+
+    [Test]
+    public void TargetCommandWithNoOpCanvasUse_ExecutesWithoutInventingAGpuPass()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var node = new NoDrawTargetCommandNode();
+        using var renderer = CreateRenderer(node, diagnostics);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.ExecuteCount, Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.PlannedGpuPasses], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedGpuPasses], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedOutcomes], Is.EqualTo(1));
+            Assert.That(snapshot.Events, Has.None.Matches<RenderPipelineDiagnosticEvent>(static item =>
+                item.Kind == RenderPipelineDiagnosticEventKind.PassExecuted));
+        });
+    }
+
+    [Test]
+    public void EmptyTargetCommand_ExecutesForOrderingWithoutPlanningOrExecutingAGpuPass()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var node = new EmptyTargetCommandNode();
+        using var renderer = CreateRenderer(node, diagnostics);
+        using RenderTarget target = RenderTarget.CreateNull(16, 16);
+        using var canvas = new ImmediateCanvas(target);
+
+        renderer.Render(canvas);
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.ExecuteCount, Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.PlannedGpuPasses], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedGpuPasses], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedOutcomes], Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void OpaqueAllocatedThenUnpublished_RecordsTheAllocationPass()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var node = new UnpublishedOutputOpaqueNode();
+        using var renderer = CreateRenderer(node, diagnostics);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.ExecuteCount, Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.PlannedGpuPasses], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedGpuPasses], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedOutcomes], Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void GeometryDiscardAfterAllocation_RecordsTheAllocationPass()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var node = new DiscardingGeometryNode();
+        using var renderer = CreateRenderer(node, diagnostics);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.GeometryExecutions, Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.PlannedGpuPasses], Is.EqualTo(2));
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedGpuPasses], Is.EqualTo(2));
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedOutcomes], Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void GeometryWithNoRuntimeInput_IsSkippedWithoutInventingAGpuPass()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var node = new EmptyInputGeometryNode();
+        using var renderer = CreateRenderer(node, diagnostics);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.SourceExecutions, Is.EqualTo(1));
+            Assert.That(node.GeometryExecutions, Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.PlannedGpuPasses], Is.EqualTo(2));
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedGpuPasses], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedOutcomes], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.SkippedOutcomes], Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void DegenerateCompiledShaderRun_IsSkippedWithoutPassOrFusedStageEvidence()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var node = new DegenerateShaderRunNode();
+        using var renderer = CreateRenderer(node, diagnostics);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.SourceExecutions, Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.PlannedGpuPasses], Is.EqualTo(4));
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedGpuPasses], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.FusedStages], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedOutcomes], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.SkippedOutcomes], Is.EqualTo(3));
+        });
+    }
+
+    [Test]
+    public void DeclaredReadbackWithoutSnapshot_PlansButDoesNotExecuteSynchronization()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var node = new UnusedReadbackNode();
+        using var renderer = CreateRenderer(node, diagnostics);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.GeometryExecutions, Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.Synchronizations], Is.Zero);
+            Assert.That(snapshot.Events, Has.Some.Matches<RenderPipelineDiagnosticEvent>(static item =>
+                item.Kind == RenderPipelineDiagnosticEventKind.SynchronizationPlanned));
+            Assert.That(snapshot.Events, Has.None.Matches<RenderPipelineDiagnosticEvent>(static item =>
+                item.Kind == RenderPipelineDiagnosticEventKind.SynchronizationExecuted));
+        });
+    }
+
+    [Test]
+    public void CacheableProducerFailureBeforeStaging_DoesNotRejectASelectedOnlyCapture()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var node = new ThrowingCacheableWorkNode();
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using var renderer = new RenderNodeRenderer(node, new RenderNodeRendererOptions
+        {
+            DefaultRequest = new RenderNodeRenderRequest
+            {
+                TargetDomain = new Rect(0, 0, 16, 16),
+                Diagnostics = diagnostics,
+                CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Enabled,
+                Purpose = RenderRequestPurpose.Frame,
+            },
+        });
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => renderer.Rasterize())!;
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Message, Is.EqualTo("producer-fault"));
+            Assert.That(node.ExecuteCount, Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.RenderCacheMisses], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.RenderCacheCaptures], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.RejectedRenderCacheCaptures], Is.Zero);
+        });
+    }
+
+    [Test]
+    public void AllocationFailure_RecordsPoolMissWithoutInventingOwnedLease()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var node = new CacheableWorkNode();
+        using var renderer = new RenderNodeRenderer(node, new RenderNodeRendererOptions
+        {
+            DefaultRequest = new RenderNodeRenderRequest
+            {
+                TargetDomain = new Rect(0, 0, 16, 16),
+                Diagnostics = diagnostics,
+                CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+            },
+            TargetFactory = new ThrowingTargetFactory(),
+        });
+        using RenderTarget target = RenderTarget.CreateNull(16, 16);
+        using var canvas = new ImmediateCanvas(target);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => renderer.Render(canvas))!;
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Message, Is.EqualTo("allocation-fault"));
+            Assert.That(snapshot.FailurePhase, Is.EqualTo(RenderPipelineFailurePhase.Allocation));
+            Assert.That(snapshot[RenderPipelineCounter.PoolMisses], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.IntermediateAcquires], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.IntermediateCreates], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.IntermediateDischarges], Is.Zero);
+        });
+    }
+
+    [Test]
+    public void DestinationInvalidatedDuringRecording_IsClassifiedAsExecutionValidation()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using RenderTarget target = RenderTarget.CreateNull(16, 16);
+        using var destination = new ImmediateCanvas(target);
+        using var node = new DestinationInvalidatingNode(destination);
+        using var renderer = new RenderNodeRenderer(node, new RenderNodeRendererOptions
+        {
+            DefaultRequest = new RenderNodeRenderRequest
+            {
+                TargetDomain = new Rect(0, 0, 16, 16),
+                Diagnostics = diagnostics,
+                CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+            },
+        });
+
+        ObjectDisposedException exception = Assert.Throws<ObjectDisposedException>(
+            () => renderer.Render(destination))!;
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.ObjectName, Is.Not.Empty);
+            Assert.That(node.ExecuteCount, Is.Zero);
+            Assert.That(snapshot.FailurePhase, Is.EqualTo(RenderPipelineFailurePhase.Execution));
+            Assert.That(snapshot[RenderPipelineCounter.IntermediateAcquires], Is.Zero);
+        });
+    }
+
+    [Test]
+    public void ExternalRootCleanupFailure_IsPublishedBeforeFamilyDiagnosticsComplete()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        var cleanupFailure = new InvalidOperationException("external-root-cleanup");
+        using var owner = new RenderRequestOwner();
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            targetDomain: new Rect(0, 0, 16, 16),
+            cachePolicy: RenderCacheOptions.Disabled,
+            owner: owner,
+            diagnostics: diagnostics);
+        using var request = new RenderRequest(options);
+        using var node = new CacheableWorkNode();
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        using CompiledRenderRequest compiled = new RenderRequestCompiler().Compile(request, graph);
+        using RenderTarget destination = RenderTarget.CreateNull(16, 16);
+        using var canvas = new ImmediateCanvas(destination);
+        using var registry = new RenderTargetLeaseRegistry(factory: null);
+        using RenderTargetLeaseSession targets = registry.BeginSession(
+            RenderIntent.Preview,
+            RenderAllocationBudget.Default,
+            destination);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => new RenderRequestExecutor(targets).Execute(
+                compiled,
+                canvas,
+                finalizeExternalResources: () => throw cleanupFailure))!;
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception, Is.SameAs(cleanupFailure));
+            Assert.That(request.State, Is.EqualTo(RenderRequestState.Failed));
+            Assert.That(owner.PrimaryFailure?.SourceException, Is.SameAs(cleanupFailure));
+            Assert.That(owner.CleanupFailures, Is.EqualTo(new[] { cleanupFailure }));
+            Assert.That(snapshot.Succeeded, Is.False);
+            Assert.That(snapshot.FailurePhase, Is.EqualTo(RenderPipelineFailurePhase.Cleanup));
+            Assert.That(snapshot[RenderPipelineCounter.CleanupFailures], Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void ExternalRootCleanupFailure_DoesNotReplaceTheExecutionPrimary()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        var cleanupFailure = new InvalidOperationException("external-root-cleanup");
+        using var owner = new RenderRequestOwner();
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            targetDomain: new Rect(0, 0, 16, 16),
+            cachePolicy: RenderCacheOptions.Disabled,
+            owner: owner,
+            diagnostics: diagnostics);
+        using var request = new RenderRequest(options);
+        using var node = new ThrowingCacheableWorkNode();
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        using CompiledRenderRequest compiled = new RenderRequestCompiler().Compile(request, graph);
+        using RenderTarget destination = RenderTarget.CreateNull(16, 16);
+        using var canvas = new ImmediateCanvas(destination);
+        using var registry = new RenderTargetLeaseRegistry(factory: null);
+        using RenderTargetLeaseSession targets = registry.BeginSession(
+            RenderIntent.Preview,
+            RenderAllocationBudget.Default,
+            destination);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => new RenderRequestExecutor(targets).Execute(
+                compiled,
+                canvas,
+                finalizeExternalResources: () => throw cleanupFailure))!;
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Message, Is.EqualTo("producer-fault"));
+            Assert.That(owner.PrimaryFailure?.SourceException, Is.SameAs(exception));
+            Assert.That(owner.CleanupFailures, Is.EqualTo(new[] { cleanupFailure }));
+            Assert.That(snapshot.Succeeded, Is.False);
+            Assert.That(snapshot.FailurePhase, Is.EqualTo(RenderPipelineFailurePhase.Execution));
+            Assert.That(snapshot[RenderPipelineCounter.CleanupFailures], Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void RecordingFailure_PreservesOriginalExceptionAndPublishesRecordingPhase()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var node = new ThrowingNode();
+        using var renderer = new RenderNodeRenderer(node, new RenderNodeRendererOptions
+        {
+            DefaultRequest = new RenderNodeRenderRequest
+            {
+                Diagnostics = diagnostics,
+                CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+            },
+        });
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => renderer.Measure())!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Message, Is.EqualTo("recording-fault"));
+            Assert.That(diagnostics.Latest.Succeeded, Is.False);
+            Assert.That(diagnostics.Latest.FailurePhase, Is.EqualTo(RenderPipelineFailurePhase.Recording));
+            Assert.That(diagnostics.Latest[RenderPipelineCounter.RecordedFragments], Is.Zero);
+            Assert.That(diagnostics.Latest[RenderPipelineCounter.Failures], Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void CompleteRequest_ReconcilesOverlappingClassificationsAndLeaseOwnership()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var request = CreateRequest(diagnostics);
+        RenderPipelineDiagnosticRecorder recorder = Start(request);
+        RenderFragmentReference[] fragments =
+        [
+            CreateFragment(request, 1, RenderFragmentKind.MaterializedInput, hasValue: true),
+            CreateFragment(request, 2, RenderFragmentKind.TargetCommand, hasValue: false),
+            CreateFragment(request, 3, RenderFragmentKind.TargetCapture, hasValue: true),
+            CreateFragment(request, 4, RenderFragmentKind.TargetScope, hasValue: false),
+            CreateFragment(request, 5, RenderFragmentKind.Layer, hasValue: true),
+        ];
+        recorder.RecordCommittedFragments(ToEntries(fragments));
+
+        recorder.RecordExternalRootResource();
+        recorder.RecordIntermediateAcquired(created: true, poolHit: false);
+        foreach (RenderFragmentReference fragment in fragments)
+            recorder.RecordFragmentExecuted(fragment.Id!.Value.Value);
+        recorder.RecordIntermediateDischarged();
+        recorder.Complete();
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot.Succeeded, Is.True);
+            Assert.That(snapshot[RenderPipelineCounter.RecordedFragments], Is.EqualTo(5));
+            Assert.That(snapshot[RenderPipelineCounter.RecordedMaterializableValues], Is.EqualTo(3));
+            Assert.That(snapshot[RenderPipelineCounter.RecordedTargetCommands], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.RecordedTargetCaptures], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.RecordedTargetScopes], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.RecordedLayers], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedOutcomes], Is.EqualTo(5));
+            Assert.That(snapshot[RenderPipelineCounter.IntermediateAcquires], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.IntermediateCreates], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.PoolMisses], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.IntermediateDischarges], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.PeakLiveIntermediates], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.ExternalRootResources], Is.EqualTo(1));
+            Assert.That(snapshot.Events.Select(static item => item.Sequence),
+                Is.EqualTo(Enumerable.Range(0, snapshot.Events.Count).Select(static item => (long)item)));
+        });
+    }
+
+    [Test]
+    public void PlannedAndExecutedWork_EmitsExactPassSynchronizationBoundaryAndProgramEvidence()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var request = CreateRequest(diagnostics);
+        RenderPipelineDiagnosticRecorder recorder = Start(request);
+        RenderFragmentReference pass = CreateFragment(request, 1, RenderFragmentKind.Geometry, hasValue: true);
+        RenderFragmentReference readback = CreateFragment(request, 2, RenderFragmentKind.TargetCommand, hasValue: false);
+        recorder.RecordCommittedFragments(ToEntries([pass, readback]));
+
+        var plan = new ExecutionIslandPlan(
+            [
+                new ExecutionIsland(
+                    new ExecutionIslandId(1),
+                    ExecutionIslandKind.Compatibility,
+                    [pass.Id!.Value],
+                    plansGpuPass: true),
+                new ExecutionIsland(
+                    new ExecutionIslandId(2),
+                    ExecutionIslandKind.Readback,
+                    [readback.Id!.Value],
+                    plansGpuPass: true),
+            ],
+            [
+                new ExecutionIslandBoundary(
+                    null,
+                    pass.Id,
+                    ExecutionIslandBoundaryReason.Geometry,
+                    []),
+                new ExecutionIslandBoundary(
+                    pass.Id,
+                    readback.Id,
+                    ExecutionIslandBoundaryReason.Readback,
+                    []),
+            ]);
+        recorder.RecordPlan(plan);
+        recorder.RecordProgramCacheDecision(pass.Id.Value.Value, cacheHit: false);
+        recorder.RecordGpuPassExecuted(pass.Id.Value.Value);
+        recorder.RecordFragmentExecuted(pass.Id.Value.Value);
+        recorder.RecordSynchronizationExecuted(readback.Id.Value.Value);
+        recorder.RecordFragmentExecuted(readback.Id.Value.Value);
+        recorder.Complete();
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot[RenderPipelineCounter.ExecutionIslands], Is.EqualTo(2));
+            Assert.That(snapshot[RenderPipelineCounter.PlannedGpuPasses], Is.EqualTo(2));
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedGpuPasses], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.Synchronizations], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.ProgramMisses], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.ProgramCreations], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.OpaqueBoundaries], Is.EqualTo(2));
+            Assert.That(snapshot.Events.Count(static item => item.Kind == RenderPipelineDiagnosticEventKind.PassPlanned),
+                Is.EqualTo(2));
+            Assert.That(snapshot.Events.Count(static item => item.Kind == RenderPipelineDiagnosticEventKind.PassExecuted),
+                Is.EqualTo(1));
+            Assert.That(snapshot.Events.Count(static item =>
+                    item.Kind == RenderPipelineDiagnosticEventKind.SynchronizationPlanned),
+                Is.EqualTo(1));
+            Assert.That(snapshot.Events.Count(static item =>
+                    item.Kind == RenderPipelineDiagnosticEventKind.SynchronizationExecuted),
+                Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void ExecutedOutcome_DoesNotInferGpuPassExecution()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var request = CreateRequest(diagnostics);
+        RenderPipelineDiagnosticRecorder recorder = Start(request);
+        RenderFragmentReference fragment = CreateFragment(
+            request,
+            1,
+            RenderFragmentKind.Geometry,
+            hasValue: true);
+        recorder.RecordCommittedFragments(ToEntries([fragment]));
+        recorder.RecordPlan(new ExecutionIslandPlan(
+            [new ExecutionIsland(
+                new ExecutionIslandId(1),
+                ExecutionIslandKind.Compatibility,
+                [fragment.Id!.Value],
+                plansGpuPass: true)],
+            [new ExecutionIslandBoundary(
+                null,
+                fragment.Id,
+                ExecutionIslandBoundaryReason.Geometry,
+                [])]));
+
+        recorder.RecordFragmentExecuted(fragment.Id.Value.Value);
+        recorder.Complete();
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot[RenderPipelineCounter.PlannedGpuPasses], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedGpuPasses], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedOutcomes], Is.EqualTo(1));
+            Assert.That(snapshot.Events, Has.None.Matches<RenderPipelineDiagnosticEvent>(static item =>
+                item.Kind == RenderPipelineDiagnosticEventKind.PassExecuted));
+        });
+    }
+
+    [Test]
+    public void DynamicOpaqueExpand_MarksPlannedGpuPassCountAsInexact()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var request = CreateRequest(diagnostics);
+        RenderPipelineDiagnosticRecorder recorder = Start(request);
+        RenderFragmentReference fragment = CreateFragment(
+            request,
+            1,
+            RenderFragmentKind.OpaqueExpand,
+            hasValue: true,
+            valueCardinality: RenderValueCardinality.Dynamic);
+        recorder.RecordCommittedFragments(ToEntries([fragment]));
+        recorder.RecordPlan(new ExecutionIslandPlan(
+            [new ExecutionIsland(
+                new ExecutionIslandId(1),
+                ExecutionIslandKind.Compatibility,
+                [fragment.Id!.Value],
+                plansGpuPass: true)],
+            [new ExecutionIslandBoundary(
+                null,
+                fragment.Id,
+                ExecutionIslandBoundaryReason.Opaque,
+                [])]));
+        recorder.Complete();
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot.HasOpaqueExternalWork, Is.False);
+            Assert.That(snapshot.HasRuntimeDynamicGpuPassWork, Is.True);
+            Assert.That(snapshot.HasExactGpuPassCount, Is.False);
+            Assert.That(snapshot[RenderPipelineCounter.PlannedGpuPasses], Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void Failure_PreservesPrimaryPhaseSkipsDependentsRejectsCaptureAndDischargesLease()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var request = CreateRequest(diagnostics);
+        RenderPipelineDiagnosticRecorder recorder = Start(request);
+        RenderFragmentReference[] fragments =
+        [
+            CreateFragment(request, 1, RenderFragmentKind.MaterializedInput, hasValue: true),
+            CreateFragment(request, 2, RenderFragmentKind.Geometry, hasValue: true),
+            CreateFragment(request, 3, RenderFragmentKind.ContributeValues, hasValue: true),
+        ];
+        recorder.RecordCommittedFragments(ToEntries(fragments));
+        recorder.RecordIntermediateAcquired(created: true, poolHit: false);
+        recorder.RecordFragmentExecuted(1);
+        recorder.RecordFailure(RenderPipelineFailurePhase.Allocation, 2);
+        recorder.RecordCacheCaptureStaged(1);
+        recorder.RecordCleanupFailure();
+        recorder.RecordIntermediateDischarged();
+        recorder.Complete();
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        int failureIndex = snapshot.Events.ToList().FindIndex(
+            static item => item.Kind == RenderPipelineDiagnosticEventKind.Failure);
+        int cleanupIndex = snapshot.Events.ToList().FindIndex(
+            static item => item.Kind == RenderPipelineDiagnosticEventKind.CleanupFailure);
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot.Succeeded, Is.False);
+            Assert.That(snapshot.FailurePhase, Is.EqualTo(RenderPipelineFailurePhase.Allocation));
+            Assert.That(snapshot[RenderPipelineCounter.Failures], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.CleanupFailures], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedOutcomes], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.FailedOutcomes], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.SkippedOutcomes], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.IntermediateAcquires], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.IntermediateDischarges], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.RenderCacheCaptures], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.RejectedRenderCacheCaptures], Is.EqualTo(1));
+            Assert.That(failureIndex, Is.GreaterThanOrEqualTo(0));
+            Assert.That(cleanupIndex, Is.GreaterThan(failureIndex));
+        });
+    }
+
+    [Test]
+    public void NestedAndMetadataRequests_PublishIndependentScopesWithoutReplacingLatestFrame()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        var observed = new List<RenderPipelineDiagnosticSnapshot>();
+        diagnostics.RequestCompleted += observed.Add;
+        using var parent = CreateRequest(diagnostics);
+        using var binding = new NestedRenderTargetBinding();
+        using var child = new RenderRequest(parent.Options.CreateNested(binding), parent);
+        RenderPipelineDiagnosticRecorder parentRecorder = Start(parent);
+        RenderPipelineDiagnosticRecorder childRecorder = Start(child);
+        parentRecorder.RecordCommittedFragments(ToEntries(
+            [CreateFragment(parent, 1, RenderFragmentKind.Layer, hasValue: true)]));
+        childRecorder.RecordCommittedFragments(ToEntries(
+            [CreateFragment(child, 1, RenderFragmentKind.Geometry, hasValue: true)]));
+        parentRecorder.RecordNestedRequest(child.Id);
+
+        childRecorder.RecordFragmentExecuted(1);
+        childRecorder.Complete();
+        parentRecorder.RecordFragmentExecuted(1);
+        parentRecorder.Complete();
+        RenderPipelineDiagnosticSnapshot frame = diagnostics.LatestFrame;
+
+        using var bounds = CreateRequest(diagnostics, RenderRequestPurpose.Bounds);
+        RenderPipelineDiagnosticRecorder boundsRecorder = Start(bounds);
+        boundsRecorder.RecordCommittedFragments(ToEntries(
+            [CreateFragment(bounds, 1, RenderFragmentKind.Geometry, hasValue: true)]));
+        boundsRecorder.RecordAllOutcomes(RenderPipelineOutcome.Metadata);
+        boundsRecorder.Complete();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(observed, Has.Count.EqualTo(3));
+            Assert.That(observed[0].ParentRequestId, Is.EqualTo(parent.Id.Value));
+            Assert.That(observed[1].Events.Single(static item =>
+                    item.Kind == RenderPipelineDiagnosticEventKind.NestedRequest).RelatedRequestId,
+                Is.EqualTo(child.Id.Value));
+            Assert.That(diagnostics.Latest.Purpose, Is.EqualTo(RenderRequestPurpose.Bounds));
+            Assert.That(diagnostics.Latest[RenderPipelineCounter.MetadataOutcomes], Is.EqualTo(1));
+            Assert.That(diagnostics.LatestFrame, Is.SameAs(frame));
+            Assert.That(frame.RequestId, Is.EqualTo(parent.Id.Value));
+        });
+    }
+
+    [Test]
+    public void OpaqueExternalWork_DistinguishesRecordedBoundaryFromCallbackEntry()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var request = CreateRequest(diagnostics);
+        RenderPipelineDiagnosticRecorder recorder = Start(request);
+        RenderFragmentReference fragment = CreateFragment(
+            request,
+            1,
+            RenderFragmentKind.LegacyFilterEffect,
+            hasValue: true);
+        recorder.RecordCommittedFragments(ToEntries([fragment]));
+        recorder.RecordPlan(new ExecutionIslandPlan(
+            [new ExecutionIsland(
+                new ExecutionIslandId(1),
+                ExecutionIslandKind.Compatibility,
+                [fragment.Id!.Value],
+                plansGpuPass: false)],
+            [new ExecutionIslandBoundary(
+                null,
+                fragment.Id,
+                ExecutionIslandBoundaryReason.LegacyCustomEffect,
+                [])]));
+        recorder.RecordOpaqueExecution(1);
+        recorder.RecordFragmentExecuted(1);
+        recorder.Complete();
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot.HasOpaqueExternalWork, Is.True);
+            Assert.That(snapshot[RenderPipelineCounter.PlannedGpuPasses], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedGpuPasses], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.OpaqueBoundaries], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.OpaqueExternalExecutions], Is.EqualTo(1));
+            Assert.That(snapshot.Events, Has.None.Matches<RenderPipelineDiagnosticEvent>(static item =>
+                item.Kind is RenderPipelineDiagnosticEventKind.PassPlanned
+                    or RenderPipelineDiagnosticEventKind.PassExecuted));
+            Assert.That(snapshot.Events.Single(static item =>
+                    item.Kind == RenderPipelineDiagnosticEventKind.BoundaryPlanned).BoundaryReason,
+                Is.EqualTo(RenderPipelineBoundaryReason.LegacyCustomEffect));
+        });
+    }
+
+    [Test]
+    public void OpaqueExternalBoundary_WithoutCallbackEntryReconcilesAsSkipped()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var request = CreateRequest(diagnostics);
+        RenderPipelineDiagnosticRecorder recorder = Start(request);
+        RenderFragmentReference fragment = CreateFragment(
+            request,
+            1,
+            RenderFragmentKind.LegacyFilterEffect,
+            hasValue: true);
+        recorder.RecordCommittedFragments(ToEntries([fragment]));
+        recorder.RecordPlan(new ExecutionIslandPlan(
+            [new ExecutionIsland(
+                new ExecutionIslandId(1),
+                ExecutionIslandKind.Compatibility,
+                [fragment.Id!.Value],
+                plansGpuPass: false)],
+            [new ExecutionIslandBoundary(
+                null,
+                fragment.Id,
+                ExecutionIslandBoundaryReason.LegacyCustomEffect,
+                [])]));
+        recorder.Complete();
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot.HasOpaqueExternalWork, Is.True);
+            Assert.That(snapshot[RenderPipelineCounter.OpaqueBoundaries], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.OpaqueExternalExecutions], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.SkippedOutcomes], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedOutcomes], Is.Zero);
+            Assert.That(snapshot.Events.Single(static item =>
+                    item.Kind == RenderPipelineDiagnosticEventKind.BoundaryPlanned).BoundaryReason,
+                Is.EqualTo(RenderPipelineBoundaryReason.LegacyCustomEffect));
+        });
+    }
+
+    [Test]
+    public void LegacyFilterSetupFailureBeforeCallbackEntry_DoesNotRecordOpaqueExecution()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var owner = new RenderRequestOwner();
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            targetDomain: new Rect(0, 0, 16, 16),
+            owner: owner,
+            diagnostics: diagnostics);
+        using var request = new RenderRequest(options);
+        using var node = new LegacyFilterSetupFailureNode();
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        using CompiledRenderRequest compiled = new RenderRequestCompiler().Compile(request, graph);
+        RenderFragmentReference legacy = graph.Fragments
+            .Select(static item => (RenderFragmentReference)item.Payload!)
+            .Single(static item => item.Kind == RenderFragmentKind.LegacyFilterEffect);
+        var payload = (LegacyFilterEffectRenderFragmentPayload)legacy.Payload!;
+        owner.ResourceRegistry.Release(payload.Context);
+        using RenderTarget destination = RenderTarget.CreateNull(16, 16);
+        using var canvas = new ImmediateCanvas(destination);
+        using var registry = new RenderTargetLeaseRegistry(factory: null);
+        using RenderTargetLeaseSession targets = registry.BeginSession(
+            RenderIntent.Preview,
+            RenderAllocationBudget.Default,
+            destination);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => new RenderRequestExecutor(targets).Execute(compiled, canvas))!;
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Message, Does.Contain("not committed"));
+            Assert.That(snapshot.HasOpaqueExternalWork, Is.True);
+            Assert.That(snapshot[RenderPipelineCounter.OpaqueExternalExecutions], Is.Zero);
+        });
+    }
+
+    [Test]
+    public void UnpublishedFragment_IsSkippedWithoutPlanningOrExecutingItsCallback()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var node = new UnpublishedWorkNode();
+        using var renderer = new RenderNodeRenderer(node, new RenderNodeRendererOptions
+        {
+            DefaultRequest = new RenderNodeRenderRequest
+            {
+                TargetDomain = new Rect(0, 0, 16, 16),
+                Diagnostics = diagnostics,
+                CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+            },
+        });
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(rasterization.IsEmpty, Is.False);
+            Assert.That(node.PublishedExecutions, Is.EqualTo(1));
+            Assert.That(node.UnpublishedExecutions, Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.RecordedFragments], Is.EqualTo(2));
+            Assert.That(snapshot[RenderPipelineCounter.PlannedGpuPasses], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedOutcomes], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.SkippedOutcomes], Is.EqualTo(1));
+        });
+    }
+
+    private static RenderRequest CreateRequest(
+        IRenderPipelineDiagnosticsState diagnostics,
+        RenderRequestPurpose purpose = RenderRequestPurpose.Frame)
+        => new(new RenderRequestOptions(
+            RenderIntent.Preview,
+            purpose,
+            targetDomain: new Rect(0, 0, 64, 64),
+            diagnostics: diagnostics));
+
+    private static RenderPipelineDiagnosticRecorder Start(RenderRequest request)
+        => RenderPipelineDiagnosticRecorder.Start(request, "ReconciliationRoot")!;
+
+    private static RenderNodeRenderer CreateRenderer(
+        RenderNode node,
+        IRenderPipelineDiagnosticsState diagnostics)
+        => new(node, new RenderNodeRendererOptions
+        {
+            DefaultRequest = new RenderNodeRenderRequest
+            {
+                TargetDomain = new Rect(0, 0, 16, 16),
+                Diagnostics = diagnostics,
+                CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+            },
+        });
+
+    private static RenderFragmentReference CreateFragment(
+        RenderRequest request,
+        long id,
+        RenderFragmentKind kind,
+        bool hasValue,
+        RenderValueCardinality? valueCardinality = null)
+    {
+        var result = new RenderFragmentReference(
+            kind,
+            new Rect(0, 0, 16, 16),
+            EffectiveScale.At(1),
+            valueCardinality ?? (hasValue ? RenderValueCardinality.Single : RenderValueCardinality.None),
+            contributesValuesToTarget: hasValue,
+            canBeUsedAsValueInput: hasValue,
+            hasTargetEffects: !hasValue,
+            hasOpaqueExternalWork: kind is RenderFragmentKind.LegacyFilterEffect
+                or RenderFragmentKind.RawTargetCommand
+                or RenderFragmentKind.RawTargetScope,
+            inputs: null,
+            payload: null,
+            hitTest: null)
+        {
+            Id = new RenderFragmentId(request.Id, id),
+            ValueIds = hasValue ? [new RenderValueId(request.Id, id)] : [],
+        };
+        return result;
+    }
+
+    private static ImmutableArray<RecordedRenderFragmentEntry> ToEntries(
+        IEnumerable<RenderFragmentReference> fragments)
+        => [.. fragments.Select(static item => new RecordedRenderFragmentEntry(item, item, "Test"))];
+
+    private sealed class ThrowingNode : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+            => throw new InvalidOperationException("recording-fault");
+    }
+
+    private sealed class DestinationInvalidatingNode(ImmediateCanvas destination) : RenderNode
+    {
+        public int ExecuteCount { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            destination.Dispose();
+            context.Publish(context.OpaqueSource(OpaqueRenderDescription.CreateRequestLocal(
+                _ => ExecuteCount++,
+                OpaqueRenderBoundsContract.Source(new Rect(0, 0, 16, 16)),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale)));
+        }
+    }
+
+    private sealed class CacheableWorkNode : RenderNode
+    {
+        private readonly ExecutionProbe _probe = new();
+        private readonly object _probeKey = new();
+
+        public int ExecuteCount => _probe.Count;
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<ExecutionProbe> probeResource = context.Borrow(_probe, _probeKey, version: 1);
+            context.Publish(context.OpaqueSource(OpaqueRenderDescription.Create(
+                typeof(CacheableWorkNode),
+                static (session, _) => session.UseDeclaredResource<ExecutionProbe>("probe", probe =>
+                {
+                    probe.Record();
+                    using OpaqueRenderOutput output = session.CreateOutput(new Rect(0, 0, 16, 16));
+                    output.Canvas.Use(canvas => canvas.Clear(Colors.CornflowerBlue));
+                    session.Publish(output);
+                }),
+                OpaqueRenderBoundsContract.Source(new Rect(0, 0, 16, 16)),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                resources: [probeResource.Bind("probe")])));
+        }
+    }
+
+    private sealed class NoOutputOpaqueNode : RenderNode
+    {
+        public int ExecuteCount { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            context.Publish(context.OpaqueSource(OpaqueRenderDescription.CreateRequestLocal(
+                _ => ExecuteCount++,
+                OpaqueRenderBoundsContract.Source(new Rect(0, 0, 16, 16)),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.ZeroOrOne,
+                RenderScaleContract.MaterializeAtWorkingScale)));
+        }
+    }
+
+    private sealed class EmptyInputGeometryNode : RenderNode
+    {
+        public int SourceExecutions { get; private set; }
+
+        public int GeometryExecutions { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle empty = context.OpaqueSource(OpaqueRenderDescription.CreateRequestLocal(
+                _ => SourceExecutions++,
+                OpaqueRenderBoundsContract.Source(new Rect(0, 0, 16, 16)),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.ZeroOrOne,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: (typeof(EmptyInputGeometryNode), "source")));
+            context.Publish(context.Geometry(empty, GeometryDescription.CreateRequestLocal(
+                session =>
+                {
+                    GeometryExecutions++;
+                    session.Canvas.Use(session.Input.Draw);
+                },
+                RenderBoundsContract.Identity,
+                RenderHitTestContract.AnyInput,
+                structuralKey: (typeof(EmptyInputGeometryNode), "geometry"))));
+        }
+    }
+
+    private sealed class NoDrawTargetCommandNode : RenderNode
+    {
+        public int ExecuteCount { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            context.Publish(context.TargetCommand([], TargetCommandDescription.CreateRequestLocal(
+                session =>
+                {
+                    ExecuteCount++;
+                    session.Canvas.Use(_ => { });
+                },
+                TargetRegion.Full,
+                Rect.Empty,
+                RenderHitTestContract.None)));
+        }
+    }
+
+    private sealed class EmptyTargetCommandNode : RenderNode
+    {
+        public int ExecuteCount { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            context.Publish(context.TargetCommand([], TargetCommandDescription.CreateRequestLocal(
+                _ => ExecuteCount++,
+                TargetRegion.Empty,
+                Rect.Empty,
+                RenderHitTestContract.None)));
+        }
+    }
+
+    private sealed class UnpublishedOutputOpaqueNode : RenderNode
+    {
+        public int ExecuteCount { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            context.Publish(context.OpaqueSource(OpaqueRenderDescription.CreateRequestLocal(
+                session =>
+                {
+                    ExecuteCount++;
+                    using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                },
+                OpaqueRenderBoundsContract.Source(new Rect(0, 0, 16, 16)),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.ZeroOrOne,
+                RenderScaleContract.MaterializeAtWorkingScale)));
+        }
+    }
+
+    private sealed class DiscardingGeometryNode : RenderNode
+    {
+        public int GeometryExecutions { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle source = context.OpaqueSource(OpaqueRenderDescription.CreateRequestLocal(
+                session =>
+                {
+                    using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.Source(new Rect(0, 0, 16, 16)),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: (typeof(DiscardingGeometryNode), "source")));
+            context.Publish(context.Geometry(source, GeometryDescription.CreateRequestLocal(
+                session =>
+                {
+                    GeometryExecutions++;
+                    session.DiscardOutput();
+                },
+                RenderBoundsContract.Identity,
+                RenderHitTestContract.AnyInput,
+                structuralKey: (typeof(DiscardingGeometryNode), "geometry"))));
+        }
+    }
+
+    private sealed class DegenerateShaderRunNode : RenderNode
+    {
+        private static readonly ShaderDescription s_first = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return color; }");
+        private static readonly ShaderDescription s_second = ShaderDescription.CurrentPixel(
+            "half4 apply(half4 color) { return half4(color.bgr, color.a); }");
+
+        public int SourceExecutions { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle source = context.OpaqueSource(OpaqueRenderDescription.CreateRequestLocal(
+                _ => SourceExecutions++,
+                OpaqueRenderBoundsContract.Source(new Rect(4, 5, 0, 6)),
+                RenderHitTestContract.None,
+                RenderValueCardinality.ZeroOrOne,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: (typeof(DegenerateShaderRunNode), "source")));
+            RenderFragmentHandle current = context.Shader(source, s_first);
+            current = context.Shader(current, s_second);
+            context.Publish(current);
+            context.Publish(context.TargetCommand([], TargetCommandDescription.CreateRequestLocal(
+                session => session.Canvas.Use(canvas => canvas.Clear(Colors.Transparent)),
+                TargetRegion.Full,
+                Rect.Empty,
+                RenderHitTestContract.None,
+                structuralKey: (typeof(DegenerateShaderRunNode), "clear"))));
+        }
+    }
+
+    private sealed class UnusedReadbackNode : RenderNode
+    {
+        public int GeometryExecutions { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle source = context.OpaqueSource(OpaqueRenderDescription.CreateRequestLocal(
+                session =>
+                {
+                    using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                    output.Canvas.Use(canvas => canvas.Clear(Colors.CornflowerBlue));
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.Source(new Rect(0, 0, 16, 16)),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: (typeof(UnusedReadbackNode), "source")));
+            context.Publish(context.Geometry(source, GeometryDescription.CreateRequestLocal(
+                session =>
+                {
+                    GeometryExecutions++;
+                    session.Canvas.Use(session.Input.Draw);
+                },
+                RenderBoundsContract.Identity,
+                RenderHitTestContract.AnyInput,
+                structuralKey: (typeof(UnusedReadbackNode), "geometry"),
+                requiresReadback: true)));
+        }
+    }
+
+    private sealed class ThrowingCacheableWorkNode : RenderNode
+    {
+        public int ExecuteCount { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            context.Publish(context.OpaqueSource(OpaqueRenderDescription.CreateRequestLocal(
+                _ =>
+                {
+                    ExecuteCount++;
+                    throw new InvalidOperationException("producer-fault");
+                },
+                OpaqueRenderBoundsContract.Source(new Rect(0, 0, 16, 16)),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale)));
+        }
+    }
+
+    private sealed class LegacyFilterSetupFailureNode : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle source = context.OpaqueSource(OpaqueRenderDescription.CreateRequestLocal(
+                session =>
+                {
+                    using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                    output.Canvas.Use(canvas => canvas.Clear(Colors.CornflowerBlue));
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.Source(new Rect(0, 0, 16, 16)),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: (typeof(LegacyFilterSetupFailureNode), "source")));
+            FilterEffectContext? effectContext = new(new Rect(0, 0, 16, 16));
+            try
+            {
+                RenderResource<FilterEffectContext> resource = context.Own(
+                    effectContext,
+                    (typeof(LegacyFilterSetupFailureNode), "effect"),
+                    version: 1);
+                effectContext = null;
+                context.Publish(context.LegacyFilterEffect(
+                    [source],
+                    resource,
+                    new Rect(0, 0, 16, 16)));
+            }
+            finally
+            {
+                effectContext?.Dispose();
+            }
+        }
+    }
+
+    private sealed class UnpublishedWorkNode : RenderNode
+    {
+        public int PublishedExecutions { get; private set; }
+
+        public int UnpublishedExecutions { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle published = context.OpaqueSource(CreateDescription(
+                "published",
+                () => PublishedExecutions++));
+            _ = context.OpaqueSource(CreateDescription(
+                "unpublished",
+                () => UnpublishedExecutions++));
+            context.Publish(published);
+        }
+
+        private static OpaqueRenderDescription CreateDescription(string key, Action onExecute)
+            => OpaqueRenderDescription.CreateRequestLocal(
+                session =>
+                {
+                    onExecute();
+                    using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                    output.Canvas.Use(canvas => canvas.Clear(Colors.CornflowerBlue));
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.Source(new Rect(0, 0, 16, 16)),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: key);
+    }
+
+    private sealed class ThrowingTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+            => throw new InvalidOperationException("allocation-fault");
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/RenderRequestModelTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/RenderRequestModelTests.cs
@@ -1,0 +1,288 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Planning;
+
+[TestFixture]
+public sealed class RenderRequestModelTests
+{
+    [Test]
+    public void Options_SanitizeScalesSnapshotCacheAndValidateRegions()
+    {
+        var cache = new RenderCacheOptions(true, new RenderCacheRules(400, 4));
+        var requestedRegion = new Rect(17, 19, 0, 23);
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            targetDomain: new Rect(0, 0, 100, 80),
+            requestedRegion: requestedRegion,
+            outputScale: float.NaN,
+            maxWorkingScale: 0,
+            cachePolicy: cache);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(options.OutputScale, Is.EqualTo(1));
+            Assert.That(options.MaxWorkingScale, Is.EqualTo(float.PositiveInfinity));
+            Assert.That(options.RequestedRegion, Is.EqualTo(requestedRegion));
+            Assert.That(options.CachePolicy, Is.Not.SameAs(cache));
+            Assert.That(options.CachePolicy, Is.EqualTo(cache));
+            Assert.That(
+                () => new RenderRequestOptions(
+                    RenderIntent.Preview,
+                    RenderRequestPurpose.Auxiliary,
+                    targetDomain: Rect.Empty),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => new RenderRequestOptions(
+                    RenderIntent.Preview,
+                    RenderRequestPurpose.Auxiliary,
+                    requestedRegion: new Rect(0, 0, -1, 2)),
+                Throws.TypeOf<ArgumentException>());
+        });
+    }
+
+    [Test]
+    public void NestedOptions_InheritSharedPolicyOwnerDiagnosticsAndFusionMode()
+    {
+        using var owner = new RenderRequestOwner();
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        var parent = new RenderRequestOptions(
+            RenderIntent.Delivery,
+            RenderRequestPurpose.Frame,
+            outputScale: 2,
+            maxWorkingScale: 3,
+            cachePolicy: RenderCacheOptions.Disabled,
+            fusionMode: FusionMode.Disabled,
+            owner: owner,
+            diagnostics: diagnostics);
+
+        using var binding = new NestedRenderTargetBinding();
+        RenderRequestOptions nested = parent.CreateNested(binding);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(nested.Intent, Is.EqualTo(RenderIntent.Delivery));
+            Assert.That(nested.Purpose, Is.EqualTo(RenderRequestPurpose.Frame));
+            Assert.That(nested.OutputScale, Is.EqualTo(2));
+            Assert.That(nested.MaxWorkingScale, Is.EqualTo(3));
+            Assert.That(nested.CachePolicy, Is.EqualTo(RenderCacheOptions.Disabled));
+            Assert.That(nested.FusionMode, Is.EqualTo(FusionMode.Disabled));
+            Assert.That(nested.Owner, Is.SameAs(owner));
+            Assert.That(nested.Diagnostics, Is.SameAs(diagnostics));
+            Assert.That(nested.TargetBinding, Is.SameAs(binding));
+            Assert.That(nested.PlanIdentity, Is.EqualTo(parent.PlanIdentity));
+        });
+    }
+
+    [Test]
+    public void NestedOptions_AllowAnExplicitConcreteTargetScaleWithoutPolicyDrift()
+    {
+        using var owner = new RenderRequestOwner();
+        var parentOptions = new RenderRequestOptions(
+            RenderIntent.Delivery,
+            RenderRequestPurpose.Frame,
+            outputScale: 1.75f,
+            maxWorkingScale: 0.75f,
+            cachePolicy: RenderCacheOptions.Disabled,
+            fusionMode: FusionMode.Disabled,
+            owner: owner);
+        using var parent = new RenderRequest(parentOptions);
+        using var binding = new NestedRenderTargetBinding();
+        RenderRequestOptions nestedOptions = parentOptions.CreateNestedAtScale(binding, 0.5f);
+        using var nested = new RenderRequest(nestedOptions, parent);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(nestedOptions.OutputScale, Is.EqualTo(0.5f));
+            Assert.That(nestedOptions.MaxWorkingScale, Is.EqualTo(0.5f));
+            Assert.That(nestedOptions.Owner, Is.SameAs(owner));
+            Assert.That(
+                () => parentOptions.CreateNestedAtScale(binding, float.PositiveInfinity),
+                Throws.TypeOf<ArgumentOutOfRangeException>());
+        });
+    }
+
+    [Test]
+    public void NestedOptions_DoNotInheritParentRequestedRegionWithoutAnExplicitMapping()
+    {
+        var parentRegion = new Rect(10, 20, 30, 40);
+        var mappedChildRegion = new Rect(1, 2, 3, 4);
+        var parent = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            requestedRegion: parentRegion);
+        using var binding = new NestedRenderTargetBinding();
+
+        RenderRequestOptions implicitScale = parent.CreateNested(binding);
+        RenderRequestOptions explicitScale = parent.CreateNestedAtScale(binding, 0.5f);
+        RenderRequestOptions mapped = parent.CreateNested(binding, requestedRegion: mappedChildRegion);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(implicitScale.RequestedRegion, Is.Null);
+            Assert.That(explicitScale.RequestedRegion, Is.Null);
+            Assert.That(mapped.RequestedRegion, Is.EqualTo(mappedChildRegion));
+        });
+    }
+
+    [Test]
+    public void Request_RejectsNestedPolicyDriftOutsideTheNestedFactory()
+    {
+        using var owner = new RenderRequestOwner();
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        var parentOptions = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            outputScale: 2,
+            maxWorkingScale: 3,
+            fusionMode: FusionMode.Disabled,
+            owner: owner,
+            diagnostics: diagnostics);
+        using var parent = new RenderRequest(parentOptions);
+        using var binding = new NestedRenderTargetBinding();
+        var drifted = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            outputScale: 2,
+            maxWorkingScale: 3,
+            fusionMode: FusionMode.Enabled,
+            owner: owner,
+            diagnostics: diagnostics,
+            targetBinding: binding);
+
+        Assert.That(
+            () => new RenderRequest(drifted, parent),
+            Throws.TypeOf<ArgumentException>());
+    }
+
+    [Test]
+    public void FusionMode_ParticipatesInPlanIdentityWithoutBecomingPublicRendererPolicy()
+    {
+        var enabled = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            fusionMode: FusionMode.Enabled);
+        var disabled = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            fusionMode: FusionMode.Disabled);
+
+        Assert.That(enabled.PlanIdentity, Is.Not.EqualTo(disabled.PlanIdentity));
+        enabled.Owner.Dispose();
+        disabled.Owner.Dispose();
+    }
+
+    [Test]
+    public void Request_EnforcesLifecycleAndMetadataOnlyShortcut()
+    {
+        using var owner = new RenderRequestOwner();
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            owner: owner);
+        using var request = new RenderRequest(options);
+
+        request.TransitionTo(RenderRequestState.Recording);
+        request.TransitionTo(RenderRequestState.Recorded);
+        request.TransitionTo(RenderRequestState.TargetDependenciesLowered);
+        request.TransitionTo(RenderRequestState.MetadataResolved);
+        request.TransitionTo(RenderRequestState.RegionsResolved);
+        request.TransitionTo(RenderRequestState.CachesResolved);
+        request.TransitionTo(RenderRequestState.Planned);
+        request.TransitionTo(RenderRequestState.Executing);
+        request.TransitionTo(RenderRequestState.Completed);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(request.State, Is.EqualTo(RenderRequestState.Completed));
+            Assert.That(request.Id.Value, Is.GreaterThan(0));
+            Assert.That(
+                () => request.TransitionTo(RenderRequestState.Executing),
+                Throws.TypeOf<InvalidOperationException>());
+        });
+
+        var queryOptions = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Bounds,
+            owner: owner);
+        using var query = new RenderRequest(queryOptions);
+        query.TransitionTo(RenderRequestState.Recording);
+        query.TransitionTo(RenderRequestState.Recorded);
+        query.TransitionTo(RenderRequestState.TargetDependenciesLowered);
+        query.TransitionTo(RenderRequestState.MetadataResolved);
+        query.CompleteMetadataOnly();
+
+        Assert.That(query.State, Is.EqualTo(RenderRequestState.Completed));
+    }
+
+    [Test]
+    public void Failure_PreservesTheFirstFailureAndAllowsOnlyDisposalAfterward()
+    {
+        var primary = new InvalidOperationException("primary");
+        using var owner = new RenderRequestOwner();
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            owner: owner);
+        using var request = new RenderRequest(options);
+        request.TransitionTo(RenderRequestState.Recording);
+
+        request.Fail(primary);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(request.State, Is.EqualTo(RenderRequestState.Failed));
+            Assert.That(owner.PrimaryFailure?.SourceException, Is.SameAs(primary));
+            Assert.That(
+                () => request.TransitionTo(RenderRequestState.Recorded),
+                Throws.TypeOf<InvalidOperationException>());
+        });
+    }
+
+    [Test]
+    public void GraphBuilder_IssuesUniqueIdsAndPreservesAuthoredOrder()
+    {
+        var requestId = new RenderRequestId(42);
+        var builder = new RecordedRenderGraphBuilder(requestId);
+        RenderProvenanceId provenance = builder.AddProvenance("root", "renderer-entry");
+        RenderValueId source = builder.AddValue([], provenance, payload: "source");
+        RenderValueId mapped = builder.AddValue([source], provenance, payload: "map");
+        RenderFragmentId first = builder.AddFragment([source], provenance, payload: "first");
+        RenderFragmentId second = builder.AddFragment([mapped], provenance, payload: "second");
+        builder.PublishRoot(second);
+        RenderCacheCandidateId candidate = builder.AddCacheCandidate(first, "candidate-key");
+
+        RecordedRenderGraph graph = builder.Build();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(graph.RequestId, Is.EqualTo(requestId));
+            Assert.That(source, Is.Not.EqualTo(mapped));
+            Assert.That(first, Is.Not.EqualTo(second));
+            Assert.That(graph.Fragments.Select(static item => item.AuthoredOrder), Is.EqualTo(new[] { 0, 1 }));
+            Assert.That(graph.Fragments.Select(static item => item.Id), Is.EqualTo(new[] { first, second }));
+            Assert.That(graph.Values[1].Inputs, Is.EqualTo(new[] { source }));
+            Assert.That(graph.PublicationRoots, Is.EqualTo(new[] { second }));
+            Assert.That(graph.Provenance.Single().Origin, Is.EqualTo("root"));
+            Assert.That(graph.CacheCandidates.Single().Id, Is.EqualTo(candidate));
+            Assert.That(graph.CacheCandidates.Single().FragmentId, Is.EqualTo(first));
+            Assert.That(() => builder.AddFragment([], provenance), Throws.TypeOf<InvalidOperationException>());
+        });
+    }
+
+    [Test]
+    public void GraphBuilder_RejectsIdsFromAnotherRequest()
+    {
+        var first = new RecordedRenderGraphBuilder(new RenderRequestId(1));
+        var second = new RecordedRenderGraphBuilder(new RenderRequestId(2));
+        RenderProvenanceId firstProvenance = first.AddProvenance("one", "root");
+        RenderProvenanceId secondProvenance = second.AddProvenance("two", "root");
+        RenderValueId foreign = first.AddValue([], firstProvenance);
+
+        Assert.That(
+            () => second.AddValue([foreign], secondProvenance),
+            Throws.TypeOf<InvalidOperationException>());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/RenderTargetPoolTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/RenderTargetPoolTests.cs
@@ -1,0 +1,1055 @@
+﻿using System.Runtime.ExceptionServices;
+
+using Beutl.Graphics;
+using Beutl.Graphics.Backend;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Planning;
+
+[TestFixture]
+public sealed class RenderTargetPoolTests
+{
+    [Test]
+    public void StableExactSize_WarmsOnce_WhileChangingSizeMisses()
+    {
+        var factory = new TrackingTargetFactory();
+        using var pool = new RenderTargetPool(factory);
+        TrackingRenderTarget firstTarget;
+        long firstGeneration;
+
+        using (RenderTargetPoolRequest request = pool.BeginRequest())
+        {
+            PooledRenderTargetLease lease = request.Acquire(new PixelSize(8, 6));
+            firstTarget = (TrackingRenderTarget)lease.Target;
+            firstGeneration = lease.Generation;
+            Assert.That(lease.WasReused, Is.False);
+            lease.Dispose();
+        }
+
+        using (RenderTargetPoolRequest request = pool.BeginRequest())
+        {
+            PooledRenderTargetLease lease = request.Acquire(new PixelSize(8, 6));
+            Assert.Multiple(() =>
+            {
+                Assert.That(lease.Target, Is.SameAs(firstTarget));
+                Assert.That(lease.Generation, Is.GreaterThan(firstGeneration));
+                Assert.That(lease.WasReused, Is.True);
+            });
+            lease.Dispose();
+        }
+
+        using (RenderTargetPoolRequest request = pool.BeginRequest())
+        {
+            PooledRenderTargetLease lease = request.Acquire(new PixelSize(9, 6));
+            Assert.That(lease.WasReused, Is.False);
+            lease.Dispose();
+        }
+
+        RenderTargetPoolStatistics statistics = pool.Statistics;
+        Assert.Multiple(() =>
+        {
+            Assert.That(statistics.Creates, Is.EqualTo(2));
+            Assert.That(statistics.Misses, Is.EqualTo(2));
+            Assert.That(statistics.Reuses, Is.EqualTo(1));
+            Assert.That(statistics.AvailableTargets, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void ByteCap_EvictsTheLeastRecentlyReleasedTarget()
+    {
+        var factory = new TrackingTargetFactory();
+        using var pool = new RenderTargetPool(
+            factory,
+            new RenderTargetPoolOptions
+            {
+                MaximumRetainedBytes = 80,
+                MaximumIdleRequests = int.MaxValue,
+            });
+        PooledRenderTargetLease firstLease;
+        PooledRenderTargetLease secondLease;
+        PooledRenderTargetLease thirdLease;
+        TrackingRenderTarget firstTarget;
+        using (RenderTargetPoolRequest request = pool.BeginRequest())
+        {
+            firstLease = request.Acquire(new PixelSize(2, 2)); // 32 bytes
+            secondLease = request.Acquire(new PixelSize(3, 2)); // 48 bytes
+            thirdLease = request.Acquire(new PixelSize(1, 1)); // 8 bytes
+            firstTarget = (TrackingRenderTarget)firstLease.Target;
+            firstLease.Dispose();
+            secondLease.Dispose();
+            thirdLease.Dispose();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstLease.State, Is.EqualTo(PooledRenderTargetLeaseState.Evicted));
+            Assert.That(firstTarget.IsDisposed, Is.True);
+            Assert.That(secondLease.State, Is.EqualTo(PooledRenderTargetLeaseState.Available));
+            Assert.That(thirdLease.State, Is.EqualTo(PooledRenderTargetLeaseState.Available));
+            Assert.That(pool.Statistics.RetainedBytes, Is.EqualTo(56));
+            Assert.That(pool.Statistics.Evictions, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void IdleLimit_EvictsOnlyAfterTheConfiguredNumberOfRequests()
+    {
+        var factory = new TrackingTargetFactory();
+        using var pool = new RenderTargetPool(
+            factory,
+            new RenderTargetPoolOptions
+            {
+                MaximumRetainedBytes = long.MaxValue,
+                MaximumIdleRequests = 1,
+            });
+        PooledRenderTargetLease oldLease;
+        TrackingRenderTarget oldTarget;
+        using (RenderTargetPoolRequest request = pool.BeginRequest())
+        {
+            oldLease = request.Acquire(new PixelSize(2, 2));
+            oldTarget = (TrackingRenderTarget)oldLease.Target;
+            oldLease.Dispose();
+        }
+
+        using (RenderTargetPoolRequest request = pool.BeginRequest())
+            request.Acquire(new PixelSize(3, 3)).Dispose();
+
+        Assert.That(oldTarget.IsDisposed, Is.False);
+        using (pool.BeginRequest())
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(oldLease.State, Is.EqualTo(PooledRenderTargetLeaseState.Evicted));
+                Assert.That(oldTarget.IsDisposed, Is.True);
+            });
+        }
+    }
+
+    [Test]
+    public void PreviewAllocationPressure_ReclaimsRetainedTargets_AndKeepsRenderingTheFrame()
+    {
+        var factory = new BudgetedTargetFactory(budgetBytes: 640);
+        using var registry = new RenderTargetLeaseRegistry(factory);
+        using (RenderTargetLeaseSession warmup = registry.BeginSession(
+                   RenderIntent.Preview,
+                   RenderAllocationBudget.Default))
+        {
+            warmup.Acquire(new PixelSize(4, 4)).Dispose();
+            warmup.Acquire(new PixelSize(2, 2)).Dispose();
+        }
+
+        Assert.That(registry.Statistics.RetainedBytes, Is.EqualTo(160));
+
+        using RenderTargetLeaseSession frame = registry.BeginSession(
+            RenderIntent.Preview,
+            RenderAllocationBudget.Default);
+        RenderTargetLease pressured = frame.Acquire(new PixelSize(8, 8));
+        RenderTargetLease rest = frame.Acquire(new PixelSize(4, 4));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(pressured.Target.Width, Is.EqualTo(8));
+            Assert.That(rest.Target.Width, Is.EqualTo(4));
+            Assert.That(factory.DeclinedRequests, Is.EqualTo(1));
+            Assert.That(registry.Statistics.RetainedBytes, Is.Zero);
+            Assert.That(registry.Statistics.Evictions, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void DeclinedAllocation_DegradesForPreview_AndFailsFastForDelivery()
+    {
+        using var registry = new RenderTargetLeaseRegistry(new SizeRejectingTargetFactory(rejectedWidth: 9));
+
+        using (RenderTargetLeaseSession preview = registry.BeginSession(
+                   RenderIntent.Preview,
+                   RenderAllocationBudget.Default))
+        {
+            Assert.That(preview.TryAcquire(new PixelSize(9, 9)), Is.Null);
+            using RenderTargetLease rest = preview.Acquire(new PixelSize(4, 4));
+            Assert.That(rest.Target.Width, Is.EqualTo(4));
+        }
+
+        using RenderTargetLeaseSession delivery = registry.BeginSession(
+            RenderIntent.Delivery,
+            RenderAllocationBudget.Default);
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => delivery.TryAcquire(new PixelSize(9, 9)),
+                Throws.InvalidOperationException.With.Message.Contains("could not allocate 9x9 pixels"));
+            Assert.DoesNotThrow(() => delivery.Acquire(new PixelSize(4, 4)).Dispose());
+        });
+    }
+
+    [Test]
+    public void IdleReclamation_ReleasesRetainedTargetsWithoutARequest_AndKeepsLeasedOnes()
+    {
+        var factory = new TrackingTargetFactory();
+        using var registry = new RenderTargetLeaseRegistry(factory);
+        TrackingRenderTarget idleTarget;
+        using (RenderTargetLeaseSession session = registry.BeginSession(
+                   RenderIntent.Preview,
+                   RenderAllocationBudget.Default))
+        {
+            RenderTargetLease lease = session.Acquire(new PixelSize(4, 4));
+            idleTarget = (TrackingRenderTarget)lease.Target;
+            lease.Dispose();
+        }
+
+        Assert.That(registry.Statistics.RetainedBytes, Is.EqualTo(4 * 4 * 8));
+
+        long releasedBytes = registry.ReleaseRetainedTargets();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(releasedBytes, Is.EqualTo(4 * 4 * 8));
+            Assert.That(idleTarget.IsDisposed, Is.True);
+            Assert.That(idleTarget.DisposeCalls, Is.EqualTo(1));
+            Assert.That(registry.Statistics.RetainedBytes, Is.Zero);
+            Assert.That(registry.Statistics.OwnedTargets, Is.Zero);
+        });
+
+        using RenderTargetLeaseSession active = registry.BeginSession(
+            RenderIntent.Preview,
+            RenderAllocationBudget.Default);
+        using RenderTargetLease leased = active.Acquire(new PixelSize(2, 2));
+        var leasedTarget = (TrackingRenderTarget)leased.Target;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(registry.ReleaseRetainedTargets(), Is.Zero);
+            Assert.That(leasedTarget.IsDisposed, Is.False);
+            Assert.That(registry.Statistics.LeasedTargets, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void Reuse_IncrementsGeneration_AndOldOrDoubleReleaseFails()
+    {
+        using var pool = new RenderTargetPool(new TrackingTargetFactory());
+        PooledRenderTargetLease first;
+        RenderTarget firstTarget;
+        using (RenderTargetPoolRequest request = pool.BeginRequest())
+        {
+            first = request.Acquire(new PixelSize(4, 4));
+            firstTarget = first.Target;
+            first.Dispose();
+        }
+
+        using RenderTargetPoolRequest secondRequest = pool.BeginRequest();
+        PooledRenderTargetLease second = secondRequest.Acquire(new PixelSize(4, 4));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(second.Target, Is.SameAs(firstTarget));
+            Assert.That(second.Generation, Is.GreaterThan(first.Generation));
+            Assert.That(
+                () => first.Dispose(),
+                Throws.InvalidOperationException.With.Message.Contains("already been discharged"));
+        });
+
+        second.Dispose();
+        Assert.That(
+            () => second.Dispose(),
+            Throws.InvalidOperationException.With.Message.Contains("already been discharged"));
+    }
+
+    [Test]
+    public void SessionDisposalFailure_EndsBothSessionAndPoolRequest()
+    {
+        var factory = new TrackingTargetFactory();
+        using var registry = new RenderTargetLeaseRegistry(factory);
+        RenderTargetLeaseSession session = registry.BeginSession(
+            RenderIntent.Preview,
+            RenderAllocationBudget.Default);
+        RenderTargetLease lease = session.Acquire(new PixelSize(4, 4));
+        var staleTarget = (TrackingRenderTarget)lease.Target;
+        lease.PooledLease.Slot.Generation++;
+
+        Assert.That(
+            session.Dispose,
+            Throws.InvalidOperationException.With.Message.Contains("generation is stale"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(staleTarget.IsDisposed, Is.True);
+            Assert.That(staleTarget.DisposeCalls, Is.EqualTo(1));
+            Assert.That(registry.Statistics.OwnedTargets, Is.Zero);
+            Assert.That(registry.Statistics.LeasedTargets, Is.Zero);
+            Assert.That(registry.Statistics.OwnedBytes, Is.Zero);
+            Assert.That(registry.Statistics.Evictions, Is.EqualTo(1));
+        });
+        Assert.DoesNotThrow(() => registry.BeginSession(
+            RenderIntent.Preview,
+            RenderAllocationBudget.Default).Dispose());
+    }
+
+    [Test]
+    public void CleanupFailureCheckpoint_TracksSessionAndRequestFailuresIndependently()
+    {
+        using var registry = new RenderTargetLeaseRegistry(factory: null);
+        using RenderTargetLeaseSession session = registry.BeginSession(
+            RenderIntent.Preview,
+            RenderAllocationBudget.Default);
+        var priorSessionFailure = new InvalidOperationException("prior-session");
+        var priorRequestFailure = new InvalidOperationException("prior-request");
+        var nextSessionFailure = new InvalidOperationException("next-session");
+        var nextRequestFailure = new InvalidOperationException("next-request");
+        session.RecordCleanupFailure(priorSessionFailure);
+        session.Request.RecordCleanupFailure(priorRequestFailure);
+        RenderTargetCleanupFailureCheckpoint checkpoint = session.CaptureCleanupFailureCheckpoint();
+
+        session.RecordCleanupFailure(nextSessionFailure);
+        session.Request.RecordCleanupFailure(nextRequestFailure);
+
+        Assert.That(
+            session.GetCleanupFailuresSince(checkpoint),
+            Is.EqualTo(new[] { nextSessionFailure, nextRequestFailure }));
+    }
+
+    [Test]
+    public void RegistryDisposal_PreservesSessionAndPoolFailures()
+    {
+        var poolFailure = new InvalidOperationException("pool-target-cleanup");
+        var factory = new TrackingTargetFactory(
+            (size, _) => new TrackingRenderTarget(
+                size.Width,
+                size.Height,
+                disposeFailure: size.Width == 3 ? poolFailure : null));
+        var registry = new RenderTargetLeaseRegistry(factory);
+        RenderTargetLeaseSession session = registry.BeginSession(
+            RenderIntent.Preview,
+            RenderAllocationBudget.Default);
+        RenderTargetLease stale = session.Acquire(new PixelSize(4, 4));
+        RenderTargetLease available = session.Acquire(new PixelSize(3, 3));
+        available.Dispose();
+        stale.PooledLease.Slot.Generation++;
+
+        AggregateException? failure = Assert.Throws<AggregateException>(registry.Dispose);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                failure!.InnerExceptions.Select(static exception => exception.Message),
+                Is.EquivalentTo(new[] { "The render-target lease generation is stale.", poolFailure.Message }));
+            Assert.That(
+                factory.Created.Cast<TrackingRenderTarget>().Select(static target => target.IsDisposed),
+                Is.All.True);
+            Assert.That(
+                factory.Created.Cast<TrackingRenderTarget>().Select(static target => target.DisposeCalls),
+                Is.All.EqualTo(1));
+            Assert.That(registry.Statistics.OwnedTargets, Is.Zero);
+            Assert.That(registry.Statistics.LeasedTargets, Is.Zero);
+        });
+        Assert.DoesNotThrow(registry.Dispose);
+    }
+
+    [Test]
+    public void RequestDisposalFailure_EvictsTheFailedLeaseAndContinuesCleanup()
+    {
+        var cleanup = new InvalidOperationException("stale-target-cleanup");
+        var factory = new TrackingTargetFactory(
+            (size, _) => new TrackingRenderTarget(
+                size.Width,
+                size.Height,
+                disposeFailure: size.Width == 4 ? cleanup : null));
+        using var pool = new RenderTargetPool(factory);
+        RenderTargetPoolRequest request = pool.BeginRequest();
+        PooledRenderTargetLease releasable = request.Acquire(new PixelSize(3, 3));
+        PooledRenderTargetLease stale = request.Acquire(new PixelSize(4, 4));
+        var staleTarget = (TrackingRenderTarget)stale.Target;
+        stale.Slot.Generation++;
+
+        Assert.That(
+            request.Dispose,
+            Throws.InvalidOperationException.With.Message.Contains("generation is stale"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stale.State, Is.EqualTo(PooledRenderTargetLeaseState.Evicted));
+            Assert.That(releasable.State, Is.EqualTo(PooledRenderTargetLeaseState.Available));
+            Assert.That(staleTarget.IsDisposed, Is.True);
+            Assert.That(staleTarget.DisposeCalls, Is.EqualTo(1));
+            Assert.That(request.CleanupFailures, Is.EqualTo(new[] { cleanup }));
+            Assert.That(pool.Statistics.OwnedTargets, Is.EqualTo(1));
+            Assert.That(pool.Statistics.AvailableTargets, Is.EqualTo(1));
+            Assert.That(pool.Statistics.LeasedTargets, Is.Zero);
+            Assert.That(pool.Statistics.OwnedBytes, Is.EqualTo(3 * 3 * 8));
+            Assert.That(pool.Statistics.RetainedBytes, Is.EqualTo(3 * 3 * 8));
+            Assert.That(pool.Statistics.Evictions, Is.EqualTo(1));
+        });
+        Assert.DoesNotThrow(() => pool.BeginRequest().Dispose());
+    }
+
+    [Test]
+    public void PoolDisposal_ContinuesAfterActiveRequestFailure()
+    {
+        var factory = new TrackingTargetFactory();
+        var pool = new RenderTargetPool(factory);
+        using (RenderTargetPoolRequest warmup = pool.BeginRequest())
+            warmup.Acquire(new PixelSize(3, 3)).Dispose();
+        RenderTargetPoolRequest active = pool.BeginRequest();
+        PooledRenderTargetLease stale = active.Acquire(new PixelSize(4, 4));
+        stale.Slot.Generation++;
+
+        Assert.That(
+            pool.Dispose,
+            Throws.InvalidOperationException.With.Message.Contains("generation is stale"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(factory.Created.Cast<TrackingRenderTarget>().Select(static target => target.IsDisposed),
+                Is.All.True);
+            Assert.That(factory.Created.Cast<TrackingRenderTarget>().Select(static target => target.DisposeCalls),
+                Is.All.EqualTo(1));
+            Assert.That(pool.Statistics.OwnedTargets, Is.Zero);
+            Assert.That(pool.Statistics.AvailableTargets, Is.Zero);
+            Assert.That(pool.Statistics.LeasedTargets, Is.Zero);
+            Assert.That(pool.Statistics.OwnedBytes, Is.Zero);
+            Assert.That(pool.Statistics.RetainedBytes, Is.Zero);
+        });
+        Assert.DoesNotThrow(() => pool.Dispose());
+    }
+
+    [Test]
+    public void PoolDisposal_AggregatesActiveRequestAndTargetCleanupFailures()
+    {
+        var targetCleanup = new InvalidOperationException("available-target-cleanup");
+        var factory = new TrackingTargetFactory(
+            (size, _) => new TrackingRenderTarget(
+                size.Width,
+                size.Height,
+                disposeFailure: size.Width == 3 ? targetCleanup : null));
+        var pool = new RenderTargetPool(factory);
+        using (RenderTargetPoolRequest warmup = pool.BeginRequest())
+            warmup.Acquire(new PixelSize(3, 3)).Dispose();
+        RenderTargetPoolRequest active = pool.BeginRequest();
+        PooledRenderTargetLease stale = active.Acquire(new PixelSize(4, 4));
+        stale.Slot.Generation++;
+
+        AggregateException? failure = Assert.Throws<AggregateException>(pool.Dispose);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                failure!.Flatten().InnerExceptions.Select(static exception => exception.Message),
+                Is.EquivalentTo(new[] { "The render-target lease generation is stale.", targetCleanup.Message }));
+            Assert.That(
+                factory.Created.Cast<TrackingRenderTarget>().Select(static target => target.DisposeCalls),
+                Is.All.EqualTo(1));
+            Assert.That(pool.Statistics.OwnedTargets, Is.Zero);
+            Assert.That(pool.Statistics.LeasedTargets, Is.Zero);
+        });
+        Assert.DoesNotThrow(pool.Dispose);
+    }
+
+    [TestCase((int)RenderTargetPoolRegistrationStage.OwnedSlot)]
+    [TestCase((int)RenderTargetPoolRegistrationStage.KnownTarget)]
+    [TestCase((int)RenderTargetPoolRegistrationStage.KnownSurface)]
+    public void FreshTargetRegistrationFailure_RollsBackEveryBookkeepingStageAndAllowsRetry(
+        int failureStageValue)
+    {
+        var failureStage = (RenderTargetPoolRegistrationStage)failureStageValue;
+        var primary = new InvalidOperationException($"target-registration-{failureStage}");
+        bool failNextRegistration = true;
+        var factory = new TrackingTargetFactory();
+        using var pool = new RenderTargetPool(
+            factory,
+            new RenderTargetPoolOptions
+            {
+                AfterTargetRegistrationStep = stage =>
+                {
+                    if (failNextRegistration && stage == failureStage)
+                    {
+                        failNextRegistration = false;
+                        throw primary;
+                    }
+                },
+            });
+        using RenderTargetPoolRequest request = pool.BeginRequest();
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => request.Acquire(new PixelSize(4, 4)));
+        var rejected = (TrackingRenderTarget)factory.Created.Single();
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.SameAs(primary));
+            Assert.That(rejected.IsDisposed, Is.True);
+            Assert.That(rejected.DisposeCalls, Is.EqualTo(1));
+            Assert.That(pool.Statistics.Creates, Is.Zero);
+            Assert.That(pool.Statistics.Misses, Is.EqualTo(1));
+            Assert.That(pool.Statistics.Evictions, Is.Zero);
+            Assert.That(pool.Statistics.OwnedTargets, Is.Zero);
+            Assert.That(pool.Statistics.AvailableTargets, Is.Zero);
+            Assert.That(pool.Statistics.LeasedTargets, Is.Zero);
+            Assert.That(pool.Statistics.OwnedBytes, Is.Zero);
+            Assert.That(pool.Statistics.RetainedBytes, Is.Zero);
+            Assert.That(pool.Statistics.PeakLiveTargets, Is.Zero);
+        });
+
+        using PooledRenderTargetLease retry = request.Acquire(new PixelSize(4, 4));
+        Assert.Multiple(() =>
+        {
+            Assert.That(retry.Target, Is.Not.SameAs(rejected));
+            Assert.That(pool.Statistics.Creates, Is.EqualTo(1));
+            Assert.That(pool.Statistics.Misses, Is.EqualTo(2));
+            Assert.That(pool.Statistics.OwnedTargets, Is.EqualTo(1));
+            Assert.That(pool.Statistics.LeasedTargets, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void FreshLeaseRegistrationFailure_EvictsTheSlotAndAllowsRetry()
+    {
+        var primary = new InvalidOperationException("lease-registration-failure");
+        var cleanup = new InvalidOperationException("lease-registration-cleanup");
+        bool failNextRegistration = true;
+        int leasedTargetsAtFailure = -1;
+        RenderTargetPool? observedPool = null;
+        var factory = new TrackingTargetFactory(
+            (size, index) => new TrackingRenderTarget(
+                size.Width,
+                size.Height,
+                disposeFailure: index == 0 ? cleanup : null));
+        using var pool = new RenderTargetPool(
+            factory,
+            new RenderTargetPoolOptions
+            {
+                BeforeLeaseRegistration = () =>
+                {
+                    if (failNextRegistration)
+                    {
+                        failNextRegistration = false;
+                        leasedTargetsAtFailure = observedPool!.Statistics.LeasedTargets;
+                        throw primary;
+                    }
+                },
+            });
+        observedPool = pool;
+        using RenderTargetPoolRequest request = pool.BeginRequest();
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => request.Acquire(new PixelSize(4, 4)));
+        TrackingRenderTarget rejected = (TrackingRenderTarget)factory.Created.Single();
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.SameAs(primary));
+            Assert.That(leasedTargetsAtFailure, Is.EqualTo(1));
+            Assert.That(rejected.IsDisposed, Is.True);
+            Assert.That(rejected.DisposeCalls, Is.EqualTo(1));
+            Assert.That(request.CleanupFailures, Is.EqualTo(new[] { cleanup }));
+            Assert.That(pool.Statistics.Creates, Is.EqualTo(1));
+            Assert.That(pool.Statistics.Misses, Is.EqualTo(1));
+            Assert.That(pool.Statistics.Reuses, Is.Zero);
+            Assert.That(pool.Statistics.Evictions, Is.EqualTo(1));
+            Assert.That(pool.Statistics.OwnedTargets, Is.Zero);
+            Assert.That(pool.Statistics.AvailableTargets, Is.Zero);
+            Assert.That(pool.Statistics.LeasedTargets, Is.Zero);
+            Assert.That(pool.Statistics.OwnedBytes, Is.Zero);
+            Assert.That(pool.Statistics.RetainedBytes, Is.Zero);
+            Assert.That(pool.Statistics.PeakLiveTargets, Is.EqualTo(1));
+        });
+
+        using PooledRenderTargetLease retry = request.Acquire(new PixelSize(4, 4));
+        Assert.Multiple(() =>
+        {
+            Assert.That(retry.Target, Is.Not.SameAs(rejected));
+            Assert.That(pool.Statistics.Creates, Is.EqualTo(2));
+            Assert.That(pool.Statistics.Misses, Is.EqualTo(2));
+            Assert.That(pool.Statistics.Evictions, Is.EqualTo(1));
+            Assert.That(pool.Statistics.OwnedTargets, Is.EqualTo(1));
+            Assert.That(pool.Statistics.LeasedTargets, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void ReusedLeaseRegistrationFailure_EvictsTheSlotAndAllowsRetry()
+    {
+        var primary = new InvalidOperationException("reused-lease-registration-failure");
+        bool failNextRegistration = false;
+        int leasedTargetsAtFailure = -1;
+        RenderTargetPool? observedPool = null;
+        var factory = new TrackingTargetFactory();
+        using var pool = new RenderTargetPool(
+            factory,
+            new RenderTargetPoolOptions
+            {
+                BeforeLeaseRegistration = () =>
+                {
+                    if (failNextRegistration)
+                    {
+                        failNextRegistration = false;
+                        leasedTargetsAtFailure = observedPool!.Statistics.LeasedTargets;
+                        throw primary;
+                    }
+                },
+            });
+        observedPool = pool;
+        PooledRenderTargetLease available;
+        TrackingRenderTarget rejected;
+        using (RenderTargetPoolRequest request = pool.BeginRequest())
+        {
+            available = request.Acquire(new PixelSize(4, 4));
+            rejected = (TrackingRenderTarget)available.Target;
+            available.Dispose();
+        }
+
+        failNextRegistration = true;
+        using RenderTargetPoolRequest retryRequest = pool.BeginRequest();
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => retryRequest.Acquire(new PixelSize(4, 4)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.SameAs(primary));
+            Assert.That(leasedTargetsAtFailure, Is.EqualTo(1));
+            Assert.That(rejected.IsDisposed, Is.True);
+            Assert.That(rejected.DisposeCalls, Is.EqualTo(1));
+            Assert.That(pool.Statistics.Creates, Is.EqualTo(1));
+            Assert.That(pool.Statistics.Misses, Is.EqualTo(1));
+            Assert.That(pool.Statistics.Reuses, Is.EqualTo(1));
+            Assert.That(pool.Statistics.Evictions, Is.EqualTo(1));
+            Assert.That(pool.Statistics.OwnedTargets, Is.Zero);
+            Assert.That(pool.Statistics.AvailableTargets, Is.Zero);
+            Assert.That(pool.Statistics.LeasedTargets, Is.Zero);
+            Assert.That(pool.Statistics.OwnedBytes, Is.Zero);
+            Assert.That(pool.Statistics.RetainedBytes, Is.Zero);
+            Assert.That(pool.Statistics.PeakLiveTargets, Is.EqualTo(1));
+        });
+
+        using PooledRenderTargetLease retry = retryRequest.Acquire(new PixelSize(4, 4));
+        Assert.Multiple(() =>
+        {
+            Assert.That(retry.Target, Is.Not.SameAs(rejected));
+            Assert.That(pool.Statistics.Creates, Is.EqualTo(2));
+            Assert.That(pool.Statistics.Misses, Is.EqualTo(2));
+            Assert.That(pool.Statistics.Reuses, Is.EqualTo(1));
+            Assert.That(pool.Statistics.Evictions, Is.EqualTo(1));
+            Assert.That(pool.Statistics.OwnedTargets, Is.EqualTo(1));
+            Assert.That(pool.Statistics.LeasedTargets, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void DeferredGpuDraw_PreservesSnapshotAcrossSameSlotReuse()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var pool = new RenderTargetPool(factory: null);
+            using RenderTargetPoolRequest request = pool.BeginRequest();
+            PooledRenderTargetLease source = request.Acquire(new PixelSize(4, 4));
+            using PooledRenderTargetLease destination = request.Acquire(new PixelSize(4, 4));
+            RenderTarget releasedTarget = source.Target;
+            releasedTarget.Value.Canvas.Clear(SKColors.Red);
+            destination.Target.Value.Canvas.Clear(SKColors.Transparent);
+            using var canvas = ImmediateCanvas.CreateExecutorManaged(
+                destination.Target,
+                density: 1f,
+                maxWorkingScale: float.PositiveInfinity,
+                logicalSize: new Size(4, 4),
+                intent: RenderIntent.Preview);
+            var observedFlushes = new List<ImmediateCanvasFlushKind>();
+
+            using (ImmediateCanvas.ObserveFlushes(observedFlushes.Add))
+            {
+                canvas.DrawRenderTargetPixelsWithoutFlush(releasedTarget, 0, 0);
+                source.Dispose();
+                using PooledRenderTargetLease reused = request.Acquire(new PixelSize(4, 4));
+                Assert.That(reused.Target, Is.SameAs(releasedTarget));
+                reused.Target.Value.Canvas.Clear(SKColors.Blue);
+                Assert.That(observedFlushes, Is.Empty,
+                    "Recording the draw and reusing its source slot must not add an executor-managed flush.");
+
+                using Bitmap snapshot = destination.Target.Snapshot();
+                ReadOnlySpan<ushort> pixels = snapshot.GetPixelSpan<ushort>();
+                float red = (float)BitConverter.UInt16BitsToHalf(pixels[0]);
+                float blue = (float)BitConverter.UInt16BitsToHalf(pixels[2]);
+                float alpha = (float)BitConverter.UInt16BitsToHalf(pixels[3]);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(red, Is.GreaterThan(0.99f));
+                    Assert.That(blue, Is.LessThan(0.01f));
+                    Assert.That(alpha, Is.GreaterThan(0.99f));
+                });
+            }
+        });
+    }
+
+    [Test]
+    public void DischargedLease_RejectsTargetAndDeviceSizeAccess()
+    {
+        using var pool = new RenderTargetPool(new TrackingTargetFactory());
+        using RenderTargetPoolRequest request = pool.BeginRequest();
+        PooledRenderTargetLease lease = request.Acquire(new PixelSize(4, 4));
+        lease.Dispose();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => _ = lease.Target,
+                Throws.InvalidOperationException.With.Message.Contains("already been discharged"));
+            Assert.That(
+                () => _ = lease.DeviceSize,
+                Throws.InvalidOperationException.With.Message.Contains("already been discharged"));
+        });
+    }
+
+    [Test]
+    public void ContextRecreation_EvictsOldBucketsBeforeAllocation()
+    {
+        var factory = new TrackingTargetFactory();
+        using var pool = new RenderTargetPool(factory);
+        object firstContext = new();
+        object secondContext = new();
+        PooledRenderTargetLease firstLease;
+        TrackingRenderTarget firstTarget;
+        using (RenderTargetPoolRequest request = pool.BeginRequestForContext(firstContext, 0))
+        {
+            firstLease = request.Acquire(new PixelSize(5, 5));
+            firstTarget = (TrackingRenderTarget)firstLease.Target;
+            firstLease.Dispose();
+        }
+
+        using RenderTargetPoolRequest secondRequest = pool.BeginRequestForContext(secondContext, 0);
+        PooledRenderTargetLease secondLease = secondRequest.Acquire(new PixelSize(5, 5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstLease.State, Is.EqualTo(PooledRenderTargetLeaseState.Evicted));
+            Assert.That(firstTarget.IsDisposed, Is.True);
+            Assert.That(secondLease.Target, Is.Not.SameAs(firstTarget));
+            Assert.That(pool.Statistics.Creates, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void BoundCpuContext_IsForwardedToSubsequentTargetlessFactoryMiss()
+    {
+        var factory = new TrackingTargetFactory();
+        using var pool = new RenderTargetPool(factory);
+
+        using (RenderTargetPoolRequest request = pool.BeginRequestForContext(new object(), 0))
+            request.Acquire(new PixelSize(2, 2)).Dispose();
+        using (RenderTargetPoolRequest request = pool.BeginRequest())
+            request.Acquire(new PixelSize(3, 3)).Dispose();
+
+        Assert.That(factory.Allocations, Has.Count.EqualTo(2));
+        Assert.That(factory.Allocations, Has.All.Matches<RenderTargetAllocationDescriptor>(allocation =>
+            allocation.PixelFormat == RenderTargetPixelFormat.LinearPremultipliedRgba16Float
+            && allocation.GraphicsContext is null
+            && allocation.GraphicsContextHandle == 0
+            && allocation.GraphicsBackend is null));
+    }
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void TargetlessGpuBinding_ForwardsLiveContextOnLaterMissAndRecreation()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using IGraphicsContext recreatedContext = GraphicsContextFactory.CreateContext();
+            var factory = new DescriptorTargetFactory();
+            using var pool = new RenderTargetPool(factory);
+            GRRecordingContext firstContext;
+
+            using (RenderTargetPoolRequest request = pool.BeginRequest())
+            {
+                using PooledRenderTargetLease lease = request.Acquire(new PixelSize(2, 2));
+                firstContext = lease.Target.Value.Context
+                    ?? throw new AssertionException("The first target-less allocation must bind a GPU context.");
+            }
+
+            factory.ExpectedContext = firstContext;
+            using (RenderTargetPoolRequest request = pool.BeginRequest())
+                request.Acquire(new PixelSize(3, 3)).Dispose();
+
+            factory.ExpectedContext = recreatedContext.SkiaContext;
+            using (RenderTargetPoolRequest request = pool.BeginRequestForContext(
+                       recreatedContext.SkiaContext,
+                       recreatedContext.SkiaContext.Handle))
+            {
+                request.Acquire(new PixelSize(4, 4)).Dispose();
+            }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(factory.Observations, Has.Count.EqualTo(3));
+                Assert.That(factory.Observations, Has.All.Matches<AllocationObservation>(observation =>
+                    observation.PixelFormat == RenderTargetPixelFormat.LinearPremultipliedRgba16Float
+                    && observation.ContextMatchedExpectation));
+                Assert.That(factory.Observations[0].HasGraphicsContext, Is.False);
+                Assert.That(factory.Observations[0].GraphicsContextHandle, Is.Null);
+                Assert.That(factory.Observations[0].GraphicsBackend, Is.Null);
+                Assert.That(factory.Observations[1].HasGraphicsContext, Is.True);
+                Assert.That(factory.Observations[1].GraphicsContextHandle, Is.EqualTo(firstContext.Handle));
+                Assert.That(factory.Observations[1].GraphicsBackend, Is.EqualTo(firstContext.Backend));
+                Assert.That(factory.Observations[2].HasGraphicsContext, Is.True);
+                Assert.That(factory.Observations[2].GraphicsContextHandle,
+                    Is.EqualTo(recreatedContext.SkiaContext.Handle));
+                Assert.That(factory.Observations[2].GraphicsBackend,
+                    Is.EqualTo(recreatedContext.SkiaContext.Backend));
+            });
+        });
+    }
+
+    [Test]
+    public void FactoryTarget_MustMatchSizeAndRgba16fContract()
+    {
+        var wrongSizeFactory = new TrackingTargetFactory(
+            (_, _) => new TrackingRenderTarget(2, 2));
+        using (var pool = new RenderTargetPool(wrongSizeFactory))
+        using (RenderTargetPoolRequest request = pool.BeginRequest())
+        {
+            Assert.That(
+                () => request.Acquire(new PixelSize(3, 3)),
+                Throws.InvalidOperationException.With.Message.Contains("exact device size"));
+            Assert.That(wrongSizeFactory.Created.Single().IsDisposed, Is.True);
+        }
+
+        var wrongFormatFactory = new TrackingTargetFactory(
+            (size, _) => new TrackingRenderTarget(size.Width, size.Height, SKColorType.Rgba8888));
+        using (var pool = new RenderTargetPool(wrongFormatFactory))
+        using (RenderTargetPoolRequest request = pool.BeginRequest())
+        {
+            Assert.That(
+                () => request.Acquire(new PixelSize(3, 3)),
+                Throws.InvalidOperationException.With.Message.Contains("RGBA16F"));
+            Assert.That(wrongFormatFactory.Created.Single().IsDisposed, Is.True);
+        }
+    }
+
+    [Test]
+    public void FactoryCannotReturnBorrowedDestination_AndPoolDoesNotDisposeIt()
+    {
+        using var external = new TrackingRenderTarget(4, 4);
+        var factory = new TrackingTargetFactory((_, _) => external);
+        using var pool = new RenderTargetPool(factory);
+        using RenderTargetPoolRequest request = pool.BeginRequest(external);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => request.Acquire(new PixelSize(4, 4)),
+                Throws.InvalidOperationException.With.Message.Contains("borrowed destination"));
+            Assert.That(external.IsDisposed, Is.False);
+            Assert.That(external.DisposeCalls, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void FactoryCannotReturnAnAlreadyLeasedTarget()
+    {
+        TrackingRenderTarget? shared = null;
+        var factory = new TrackingTargetFactory(
+            (size, _) => shared ??= new TrackingRenderTarget(size.Width, size.Height));
+        using var pool = new RenderTargetPool(factory);
+        using RenderTargetPoolRequest request = pool.BeginRequest();
+        PooledRenderTargetLease first = request.Acquire(new PixelSize(4, 4));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => request.Acquire(new PixelSize(5, 4)),
+                Throws.InvalidOperationException.With.Message.Contains("already owned"));
+            Assert.That(first.Target.IsDisposed, Is.False);
+            Assert.That(first.State, Is.EqualTo(PooledRenderTargetLeaseState.Leased));
+        });
+    }
+
+    [Test]
+    public void AcceptedCacheTransfer_RemovesTargetFromPoolOwnershipExactlyOnce()
+    {
+        using var pool = new RenderTargetPool(new TrackingTargetFactory());
+        TrackingRenderTarget target;
+        using (RenderTargetPoolRequest request = pool.BeginRequest())
+        {
+            PooledRenderTargetLease lease = request.Acquire(new PixelSize(4, 4));
+            target = (TrackingRenderTarget)lease.TransferToAcceptedCache();
+            Assert.Multiple(() =>
+            {
+                Assert.That(lease.State, Is.EqualTo(PooledRenderTargetLeaseState.CacheTransferred));
+                Assert.That(pool.Statistics.OwnedTargets, Is.Zero);
+                Assert.That(pool.Statistics.LeasedTargets, Is.Zero);
+                Assert.That(
+                    () => lease.TransferToAcceptedCache(),
+                    Throws.InvalidOperationException.With.Message.Contains("already been discharged"));
+            });
+        }
+
+        pool.Dispose();
+        Assert.That(target.IsDisposed, Is.False);
+        target.Dispose();
+    }
+
+    [Test]
+    public void PoolDisposal_ContinuesAfterEveryTargetFailure()
+    {
+        var factory = new TrackingTargetFactory(
+            (size, index) => new TrackingRenderTarget(
+                size.Width,
+                size.Height,
+                disposeFailure: new InvalidOperationException($"dispose-{index}")));
+        var pool = new RenderTargetPool(factory);
+        using (RenderTargetPoolRequest request = pool.BeginRequest())
+        {
+            request.Acquire(new PixelSize(2, 2)).Dispose();
+            request.Acquire(new PixelSize(3, 3)).Dispose();
+        }
+
+        AggregateException? failure = Assert.Throws<AggregateException>(() => pool.Dispose());
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                failure!.InnerExceptions.Select(static exception => exception.Message),
+                Is.EquivalentTo(new[] { "dispose-0", "dispose-1" }));
+            Assert.That(factory.Created.Cast<TrackingRenderTarget>().Select(static target => target.DisposeCalls),
+                Is.All.EqualTo(1));
+        });
+
+        Assert.DoesNotThrow(() => pool.Dispose());
+    }
+
+    private sealed class TrackingTargetFactory(
+        Func<PixelSize, int, RenderTarget>? create = null) : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public List<RenderTarget> Created { get; } = [];
+
+        public List<RenderTargetAllocationDescriptor> Allocations { get; } = [];
+
+        public RenderTarget? Create(RenderTargetAllocationDescriptor allocation)
+        {
+            PixelSize deviceSize = allocation.DeviceSize;
+            Allocations.Add(allocation);
+            RenderTarget target = create?.Invoke(deviceSize, Created.Count)
+                ?? new TrackingRenderTarget(deviceSize.Width, deviceSize.Height);
+            Created.Add(target);
+            return target;
+        }
+    }
+
+    private sealed class SizeRejectingTargetFactory(int rejectedWidth) : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public RenderTarget? Create(RenderTargetAllocationDescriptor allocation)
+            => allocation.DeviceSize.Width == rejectedWidth
+                ? null
+                : new TrackingRenderTarget(allocation.DeviceSize.Width, allocation.DeviceSize.Height);
+    }
+
+    private sealed class BudgetedTargetFactory(long budgetBytes) : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        private readonly List<TrackingRenderTarget> _live = [];
+
+        public int DeclinedRequests { get; private set; }
+
+        public RenderTarget? Create(RenderTargetAllocationDescriptor allocation)
+        {
+            PixelSize deviceSize = allocation.DeviceSize;
+            _live.RemoveAll(static target => target.IsDisposed);
+            long requested = (long)deviceSize.Width * deviceSize.Height * 8;
+            long live = _live.Sum(static target => (long)target.Width * target.Height * 8);
+            if (live + requested > budgetBytes)
+            {
+                DeclinedRequests++;
+                return null;
+            }
+
+            var created = new TrackingRenderTarget(deviceSize.Width, deviceSize.Height);
+            _live.Add(created);
+            return created;
+        }
+    }
+
+    private sealed class DescriptorTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public GRRecordingContext? ExpectedContext { get; set; }
+
+        public List<AllocationObservation> Observations { get; } = [];
+
+        public RenderTarget? Create(RenderTargetAllocationDescriptor allocation)
+        {
+            Observations.Add(new AllocationObservation(
+                allocation.PixelFormat,
+                allocation.GraphicsContext is not null,
+                allocation.GraphicsContextHandle,
+                allocation.GraphicsBackend,
+                ReferenceEquals(allocation.GraphicsContext, ExpectedContext)));
+            PixelSize size = allocation.DeviceSize;
+            if (allocation.GraphicsContext is null)
+                return RenderTarget.Create(size.Width, size.Height);
+
+            SKSurface? surface = SKSurface.Create(
+                allocation.GraphicsContext,
+                false,
+                new SKImageInfo(
+                    size.Width,
+                    size.Height,
+                    SKColorType.RgbaF16,
+                    SKAlphaType.Premul,
+                    SKColorSpace.CreateSrgbLinear()));
+            return surface is null ? null : new TrackingRenderTarget(surface, size.Width, size.Height);
+        }
+    }
+
+    private readonly record struct AllocationObservation(
+        RenderTargetPixelFormat PixelFormat,
+        bool HasGraphicsContext,
+        nint? GraphicsContextHandle,
+        GRBackend? GraphicsBackend,
+        bool ContextMatchedExpectation);
+
+    private sealed class TrackingRenderTarget : RenderTarget
+    {
+        private readonly Exception? _disposeFailure;
+
+        public TrackingRenderTarget(SKSurface surface, int width, int height)
+            : base(surface, width, height)
+        {
+        }
+
+        public TrackingRenderTarget(
+            int width,
+            int height,
+            SKColorType colorType = SKColorType.RgbaF16,
+            Exception? disposeFailure = null)
+            : base(
+                SKSurface.Create(new SKImageInfo(
+                    width,
+                    height,
+                    colorType,
+                    SKAlphaType.Premul,
+                    SKColorSpace.CreateSrgbLinear())),
+                width,
+                height)
+        {
+            _disposeFailure = disposeFailure;
+        }
+
+        public int DisposeCalls { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            bool fail = disposing && !IsDisposed && _disposeFailure is not null;
+            if (disposing && !IsDisposed)
+                DisposeCalls++;
+            base.Dispose(disposing);
+            if (fail)
+                throw _disposeFailure!;
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/RendererWideRecordingTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/RendererWideRecordingTests.cs
@@ -1,0 +1,1443 @@
+﻿using System.Collections.Immutable;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Graphics.Shapes;
+using Beutl.Graphics.Transformation;
+using Beutl.Media;
+using Beutl.Threading;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Planning;
+
+[TestFixture]
+public sealed class RendererWideRecordingTests
+{
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void ProductionFrameRenderer_PreservesPlanLifetimeAcrossFrames()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var renderer = new Renderer(8, 8);
+            var frame = new CompositionFrame(
+                ImmutableArray<EngineObject.Resource>.Empty,
+                new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)),
+                new PixelSize(8, 8));
+
+            renderer.Render(frame);
+            renderer.Render(frame);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.FrameStructuralPlanCacheStatistics.Compilations, Is.EqualTo(1));
+                Assert.That(renderer.FrameStructuralPlanCacheStatistics.Misses, Is.EqualTo(1));
+                Assert.That(renderer.FrameStructuralPlanCacheStatistics.Hits, Is.EqualTo(1));
+            });
+        });
+    }
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void ProductionFrameRenderer_DisablesDiagnosticsByDefault()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var renderer = new Renderer(8, 8);
+
+            Assert.That(renderer.Diagnostics, Is.Null);
+        });
+    }
+
+    [Test]
+    public void ProductionFrameRenderer_UsesExplicitDiagnostics()
+    {
+        RenderThread.Dispatcher.Invoke(() =>
+        {
+            var diagnostics = new RenderPipelineDiagnosticsState();
+            using var renderer = new Renderer(
+                width: 8,
+                height: 8,
+                renderScale: 1,
+                maxWorkingScale: float.PositiveInfinity,
+                diagnostics: diagnostics,
+                surface: new CpuRenderTarget(8, 8));
+            var frame = new CompositionFrame(
+                ImmutableArray<EngineObject.Resource>.Empty,
+                new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)),
+                new PixelSize(8, 8));
+
+            renderer.Render(frame);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.Diagnostics, Is.SameAs(diagnostics));
+                Assert.That(diagnostics.LatestFrame.Succeeded, Is.True);
+                Assert.That(diagnostics.LatestFrame.Purpose, Is.EqualTo(RenderRequestPurpose.Frame));
+            });
+        });
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void ProductionFrameRenderer_DisposedFromOwnerThread_ReleasesSurfaceOnRenderThread()
+    {
+        var surface = new DisposalThreadProbeRenderTarget(8, 8);
+        var renderer = new Renderer(
+            width: 8,
+            height: 8,
+            renderScale: 1,
+            maxWorkingScale: 1,
+            diagnostics: null,
+            surface: surface);
+        var frame = new CompositionFrame(
+            ImmutableArray<EngineObject.Resource>.Empty,
+            new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)),
+            new PixelSize(8, 8));
+        RenderThread.Dispatcher.Invoke(() => renderer.Render(frame));
+
+        Assert.That(RenderThread.Dispatcher.CheckAccess(), Is.False,
+            "the fixture must dispose from the renderer owner's non-render thread");
+        renderer.Dispose();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(surface.DisposeCount, Is.EqualTo(1));
+            Assert.That(surface.DisposedOnRenderThread, Is.True);
+        });
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void ProductionFrameRenderer_DisposeAfterDispatcherShutdown_ReleasesOwnedResources()
+    {
+        Dispatcher dispatcher = Dispatcher.Spawn();
+        var state = new DispatcherDisposalState(dispatcher);
+        Renderer? renderer = null;
+        try
+        {
+            DispatcherDisposalProbeRenderTarget surface = dispatcher.Invoke(
+                () => new DispatcherDisposalProbeRenderTarget(state));
+            renderer = new Renderer(
+                width: 8,
+                height: 8,
+                renderScale: 1,
+                maxWorkingScale: 1,
+                diagnostics: null,
+                surface: surface,
+                dispatcher: dispatcher);
+
+            dispatcher.Shutdown();
+            Assert.That(dispatcher.Thread.Join(TimeSpan.FromSeconds(5)), Is.True);
+
+            Assert.DoesNotThrow(renderer.Dispose);
+            Assert.Multiple(() =>
+            {
+                Assert.That(state.DisposeCount, Is.EqualTo(1));
+                Assert.That(state.DisposedAfterShutdown, Is.True);
+            });
+        }
+        finally
+        {
+            if (!dispatcher.HasShutdownStarted)
+                dispatcher.Shutdown();
+            dispatcher.Thread.Join(TimeSpan.FromSeconds(5));
+            renderer?.Dispose();
+        }
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void ProductionFrameRenderer_ConcurrentDispose_ReleasesOwnedResourcesOnce()
+    {
+        Dispatcher dispatcher = Dispatcher.Spawn();
+        var disposalState = new DispatcherDisposalState(dispatcher);
+        var hookState = new ConcurrentDisposeState();
+        ConcurrentDisposeProbeRenderer? renderer = null;
+        using var start = new ManualResetEventSlim(false);
+        try
+        {
+            DispatcherDisposalProbeRenderTarget surface = dispatcher.Invoke(
+                () => new DispatcherDisposalProbeRenderTarget(disposalState));
+            renderer = new ConcurrentDisposeProbeRenderer(dispatcher, surface, hookState);
+            dispatcher.Shutdown();
+            Assert.That(dispatcher.Thread.Join(TimeSpan.FromSeconds(5)), Is.True);
+
+            Task[] disposals = Enumerable.Range(0, 8)
+                .Select(_ => Task.Run(() =>
+                {
+                    start.Wait(TimeSpan.FromSeconds(5));
+                    renderer.Dispose();
+                }))
+                .ToArray();
+            start.Set();
+            Assert.That(Task.WaitAll(disposals, TimeSpan.FromSeconds(5)), Is.True);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(hookState.CallCount, Is.EqualTo(1));
+                Assert.That(disposalState.DisposeCount, Is.EqualTo(1));
+            });
+        }
+        finally
+        {
+            start.Set();
+            if (!dispatcher.HasShutdownStarted)
+                dispatcher.Shutdown();
+            dispatcher.Thread.Join(TimeSpan.FromSeconds(5));
+            renderer?.Dispose();
+        }
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void ProductionFrameRenderer_CacheApisAfterDispatcherShutdown_FailWithoutWaiting()
+    {
+        Dispatcher dispatcher = Dispatcher.Spawn();
+        Renderer? renderer = null;
+        try
+        {
+            var surface = dispatcher.Invoke(() => new DispatcherDisposalProbeRenderTarget(
+                new DispatcherDisposalState(dispatcher)));
+            renderer = new Renderer(
+                width: 8,
+                height: 8,
+                renderScale: 1,
+                maxWorkingScale: 1,
+                diagnostics: null,
+                surface: surface,
+                dispatcher: dispatcher);
+
+            void AssertCacheApisAreRejected()
+            {
+                static void AssertRejected(Action operation)
+                {
+                    Task task = Task.Run(operation);
+                    Assert.That(
+                        SpinWait.SpinUntil(() => task.IsCompleted, TimeSpan.FromSeconds(1)),
+                        Is.True,
+                        "a cache API waited on a dispatcher that can no longer accept work");
+                    Assert.That(task.Exception?.GetBaseException(), Is.TypeOf<InvalidOperationException>());
+                }
+
+                Assert.Multiple(() =>
+                {
+                    AssertRejected(renderer.ClearAllCaches);
+                    AssertRejected(() => renderer.CacheOptions = RenderCacheOptions.Disabled);
+                    AssertRejected(() => renderer.ReleaseRetainedRenderTargets());
+                });
+            }
+
+            dispatcher.Invoke(() =>
+            {
+                dispatcher.Shutdown();
+                AssertCacheApisAreRejected();
+            });
+            Assert.That(dispatcher.Thread.Join(TimeSpan.FromSeconds(5)), Is.True);
+            AssertCacheApisAreRejected();
+        }
+        finally
+        {
+            if (!dispatcher.HasShutdownStarted)
+                dispatcher.Shutdown();
+            dispatcher.Thread.Join(TimeSpan.FromSeconds(5));
+            renderer?.Dispose();
+        }
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void ProductionFrameRenderer_FinalizerCompletesCleanupAcrossDispatcherShutdown()
+    {
+        Dispatcher dispatcher = Dispatcher.Spawn();
+        var state = new DispatcherDisposalState(dispatcher);
+        using var entered = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+        WeakReference? renderer = null;
+        bool dispatcherJoined;
+        try
+        {
+            renderer = AbandonRenderer(dispatcher, state);
+            dispatcher.Dispatch(() =>
+            {
+                entered.Set();
+                release.Wait(TimeSpan.FromSeconds(30));
+            }, DispatchPriority.High);
+            Assert.That(entered.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+            dispatcher.Shutdown();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            Assert.That(state.DisposeCount, Is.Zero);
+        }
+        finally
+        {
+            release.Set();
+            if (!dispatcher.HasShutdownStarted)
+                dispatcher.Shutdown();
+            dispatcherJoined = dispatcher.Thread.Join(TimeSpan.FromSeconds(5));
+        }
+
+        GC.Collect();
+        Assert.Multiple(() =>
+        {
+            Assert.That(dispatcherJoined, Is.True);
+            Assert.That(renderer!.IsAlive, Is.False);
+            Assert.That(state.DisposeCount, Is.EqualTo(1));
+            Assert.That(state.DisposedOnOwnerThread, Is.True);
+        });
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void ProductionFrameRenderer_FinalizerReleasesOwnedResourcesOnRenderThread()
+    {
+        var state = new DisposalThreadState();
+        WeakReference renderer = AbandonRenderer(state);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        RenderThread.Dispatcher.Invoke(static () => { });
+        GC.Collect();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(renderer.IsAlive, Is.False);
+            Assert.That(state.DisposeCount, Is.EqualTo(1));
+            Assert.That(state.DisposedOnRenderThread, Is.True);
+        });
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void ProductionFrameRenderer_FinalizerCallsDerivedHookInlineBeforeRenderThreadCleanup()
+    {
+        var state = new FinalizerHookState();
+        WeakReference renderer = AbandonFinalizerHookProbe(state);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        bool hookCompletedBeforeRenderThreadBarrier = state.Completed;
+        RenderThread.Dispatcher.Invoke(static () => { });
+        GC.Collect();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(renderer.IsAlive, Is.False);
+            Assert.That(hookCompletedBeforeRenderThreadBarrier, Is.True);
+            Assert.That(state.CallCount, Is.EqualTo(1));
+            Assert.That(state.CalledOnRenderThread, Is.False);
+        });
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void ProductionFrameRenderer_FailedConstruction_FinalizerCleanupKeepsRenderThreadAlive()
+    {
+        Dispatcher dispatcher = RenderThread.Dispatcher;
+        Exception? unhandledException = null;
+        EventHandler<DispatcherUnhandledExceptionEventArgs> handler = (_, args) =>
+        {
+            Interlocked.CompareExchange(ref unhandledException, args.Exception, null);
+            args.Handled = true;
+        };
+        dispatcher.UnhandledException += handler;
+        try
+        {
+            FailRendererConstructionAfterRenderResourcesAreCreated();
+            FailRendererConstructionBeforeFrameRendererIsAssigned();
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            dispatcher.Invoke(static () => { });
+        }
+        finally
+        {
+            dispatcher.UnhandledException -= handler;
+        }
+
+        Assert.That(Volatile.Read(ref unhandledException), Is.Null);
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void ClearAllCaches_QueuedBeforeDispose_DoesNotReplaceDisposedFrameRenderer()
+    {
+        var renderer = new Renderer(
+            width: 8,
+            height: 8,
+            renderScale: 1,
+            maxWorkingScale: 1,
+            diagnostics: null,
+            surface: new CpuRenderTarget(8, 8));
+        FieldInfo frameRendererField = typeof(Renderer).GetField(
+            "_frameRenderer",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var initialFrameRenderer = (RenderNodeRenderer)frameRendererField.GetValue(renderer)!;
+        var renderThreadBlocked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRenderThread = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var blockerCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var clearStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Exception? clearFailure = null;
+        var clearThread = new Thread(() =>
+        {
+            clearStarted.TrySetResult();
+            try
+            {
+                renderer.ClearAllCaches();
+            }
+            catch (Exception ex)
+            {
+                clearFailure = ex;
+            }
+        })
+        {
+            IsBackground = true,
+        };
+        bool renderThreadWasBlocked = false;
+        bool clearDidStart = false;
+        bool clearWasQueued = false;
+        bool blockerWasDrained;
+        bool clearCompleted;
+        bool renderThreadWasDrained = false;
+        try
+        {
+            RenderThread.Dispatcher.Dispatch(
+                () =>
+                {
+                    try
+                    {
+                        renderThreadBlocked.TrySetResult();
+                        releaseRenderThread.Task.GetAwaiter().GetResult();
+                    }
+                    finally
+                    {
+                        blockerCompleted.TrySetResult();
+                    }
+                },
+                DispatchPriority.High);
+            renderThreadWasBlocked = renderThreadBlocked.Task.Wait(TimeSpan.FromSeconds(5));
+
+            clearThread.Start();
+            clearDidStart = clearStarted.Task.Wait(TimeSpan.FromSeconds(5));
+            clearWasQueued = SpinWait.SpinUntil(
+                () => (clearThread.ThreadState & ThreadState.WaitSleepJoin) != 0,
+                TimeSpan.FromSeconds(5));
+
+            RenderThread.Dispatcher.Dispatch(renderer.Dispose, DispatchPriority.High);
+        }
+        finally
+        {
+            releaseRenderThread.TrySetResult();
+            blockerWasDrained = blockerCompleted.Task.Wait(TimeSpan.FromSeconds(5));
+            clearCompleted = (clearThread.ThreadState & ThreadState.Unstarted) != 0
+                || clearThread.Join(TimeSpan.FromSeconds(5));
+            if (blockerWasDrained)
+            {
+                renderThreadWasDrained = RenderThread.Dispatcher
+                    .InvokeAsync(static () => { })
+                    .Wait(TimeSpan.FromSeconds(5));
+            }
+        }
+
+        Exception[] failures = clearFailure is AggregateException aggregate
+            ? [.. aggregate.Flatten().InnerExceptions]
+            : clearFailure is null ? [] : [clearFailure];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(renderThreadWasBlocked, Is.True);
+            Assert.That(clearDidStart, Is.True);
+            Assert.That(clearWasQueued, Is.True);
+            Assert.That(blockerWasDrained, Is.True);
+            Assert.That(clearCompleted, Is.True);
+            Assert.That(renderThreadWasDrained, Is.True);
+            Assert.That(failures.Any(static ex => ex is ObjectDisposedException), Is.True);
+            Assert.That(frameRendererField.GetValue(renderer), Is.SameAs(initialFrameRenderer));
+            Assert.That(initialFrameRenderer.IsDisposed, Is.True);
+        });
+    }
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void ProductionFrameRenderer_ClearAllCachesColdResetsFrameCachesWithoutChangingPolicy()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var state = new RendererWideTreeState(1) { UseShaderProgram = true };
+            var drawable = new RendererWideProbeDrawable(0, state);
+            using Drawable.Resource resource =
+                (Drawable.Resource)drawable.ToResource(CompositionContext.Default);
+            var frame = new CompositionFrame(
+                ImmutableArray.Create<EngineObject.Resource>(resource),
+                new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)),
+                new PixelSize(8, 8));
+            using var renderer = new Renderer(8, 8)
+            {
+                CacheOptions = RenderCacheOptions.Disabled,
+            };
+            RenderCacheOptions expectedOptions = renderer.CacheOptions;
+
+            renderer.Render(frame);
+            renderer.Render(frame);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.FrameStructuralPlanCacheStatistics.RetainedPlans, Is.EqualTo(1));
+                Assert.That(renderer.FrameStructuralPlanCacheStatistics.Hits, Is.EqualTo(1));
+                Assert.That(renderer.FrameProgramCacheStatistics.RetainedPrograms, Is.GreaterThan(0));
+                Assert.That(renderer.FrameTargetPoolStatistics.RetainedBytes, Is.GreaterThan(0));
+            });
+
+            renderer.ClearAllCaches();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.CacheOptions, Is.SameAs(expectedOptions));
+                Assert.That(renderer.FrameStructuralPlanCacheStatistics, Is.EqualTo(default(StructuralPlanCacheStatistics)));
+                Assert.That(renderer.FrameProgramCacheStatistics, Is.EqualTo(default(ProgramCacheStatistics)));
+                Assert.That(renderer.FrameTargetPoolStatistics, Is.EqualTo(default(RenderTargetPoolStatistics)));
+            });
+
+            renderer.Render(frame);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.FrameStructuralPlanCacheStatistics.Compilations, Is.EqualTo(1));
+                Assert.That(renderer.FrameStructuralPlanCacheStatistics.Misses, Is.EqualTo(1));
+                Assert.That(renderer.FrameStructuralPlanCacheStatistics.Hits, Is.Zero);
+                Assert.That(renderer.FrameProgramCacheStatistics.RetainedPrograms, Is.GreaterThan(0));
+                Assert.That(renderer.FrameTargetPoolStatistics.RetainedBytes, Is.GreaterThan(0));
+            });
+        });
+    }
+
+    [Test]
+    [NonParallelizable]
+    [Category("GpuPassFusionGpu")]
+    public void CacheMutations_FromCallerThread_DisposeCachedTreesOnRenderThread()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        var state = new CacheMutationThreadState();
+        var drawable = new CacheMutationThreadProbeDrawable(state);
+        using var resource = (Drawable.Resource)drawable.ToResource(CompositionContext.Default);
+        var frame = new CompositionFrame(
+            ImmutableArray.Create<EngineObject.Resource>(resource),
+            new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)),
+            new PixelSize(8, 8));
+        Renderer renderer = VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var result = new Renderer(8, 8);
+            result.Render(frame);
+            return result;
+        });
+
+        try
+        {
+            Assert.That(RenderThread.Dispatcher.CheckAccess(), Is.False);
+
+            renderer.ClearAllCaches();
+            Assert.That(state.DisposedOnRenderThread, Is.EqualTo(new[] { true }));
+
+            VulkanTestEnvironment.InvokeOnRenderThread(() => renderer.Render(frame));
+            renderer.CacheOptions = RenderCacheOptions.Disabled;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(state.DisposedOnRenderThread, Is.EqualTo(new[] { true, true }));
+                Assert.That(renderer.CacheOptions, Is.EqualTo(RenderCacheOptions.Disabled));
+            });
+        }
+        finally
+        {
+            VulkanTestEnvironment.InvokeOnRenderThread(renderer.Dispose);
+        }
+    }
+
+    [Test]
+    [NonParallelizable]
+    [Category("GpuPassFusionGpu")]
+    public void Detachment_FromCallerThread_DisposesCachedTreeOnRenderThread()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        var state = new CacheMutationThreadState();
+        var root = new CacheMutationHierarchyRoot();
+        var drawable = new CacheMutationThreadProbeDrawable(state);
+        root.Attach(drawable);
+        using var resource = (Drawable.Resource)drawable.ToResource(CompositionContext.Default);
+        var frame = new CompositionFrame(
+            ImmutableArray.Create<EngineObject.Resource>(resource),
+            new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)),
+            new PixelSize(8, 8));
+        Renderer renderer = VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var result = new Renderer(8, 8);
+            result.Render(frame);
+            return result;
+        });
+
+        try
+        {
+            Assert.That(RenderThread.Dispatcher.CheckAccess(), Is.False);
+
+            root.Detach(drawable);
+            VulkanTestEnvironment.InvokeOnRenderThread(static () => { });
+
+            Assert.That(state.DisposedOnRenderThread, Is.EqualTo(new[] { true }));
+        }
+        finally
+        {
+            VulkanTestEnvironment.InvokeOnRenderThread(renderer.Dispose);
+        }
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void DetachmentAfterDispatcherShutdown_DoesNotRetainRendererOrDrawable()
+    {
+        (Dispatcher dispatcher, WeakReference renderer, WeakReference drawable) =
+            AbandonDetachedRendererAfterShutdown();
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(renderer.IsAlive, Is.False);
+            Assert.That(drawable.IsAlive, Is.False);
+        });
+        GC.KeepAlive(dispatcher);
+    }
+
+    [Test]
+    public void CompleteTarget_RecordsEveryOrderedRootBeforeAnyExecution()
+    {
+        bool[] recorded = new bool[3];
+        var executed = new List<int>();
+        using var first = new DeferredProbeNode(0, recorded, executed);
+        using var second = new DeferredProbeNode(1, recorded, executed);
+        using var third = new DeferredProbeNode(2, recorded, executed);
+        using var completeTarget = new CompleteTargetRenderNode(first, [second, third]);
+        using var destination = new CpuRenderTarget(8, 8);
+        using var canvas = new ImmediateCanvas(destination);
+        using var renderer = new RenderNodeRenderer(
+            completeTarget,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = new Rect(0, 0, 8, 8),
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        renderer.Render(canvas);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(recorded, Is.All.True);
+            Assert.That(executed, Is.EqualTo(new[] { 0, 1, 2 }));
+        });
+    }
+
+    [Test]
+    public void CompleteTarget_RecordsClearCommandsCaptureAndPainterOrderBeforeExecution()
+    {
+        bool[] recorded = new bool[4];
+        var executed = new List<string>();
+        using var clear = new RecordingRootNode(0, recorded, new ClearRenderNode(Colors.Transparent));
+        using var source = new OrderedSourceNode(1, recorded, executed);
+        using var command = new OrderedTargetCommandNode(2, recorded, executed);
+        using var capture = new OrderedCaptureNode(3, recorded, executed);
+        using var completeTarget = new CompleteTargetRenderNode(clear, [source, command, capture]);
+        using var destination = new CpuRenderTarget(8, 8);
+        using var canvas = new ImmediateCanvas(destination);
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var renderer = new RenderNodeRenderer(
+            completeTarget,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = new Rect(0, 0, 8, 8),
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    Diagnostics = diagnostics,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        renderer.Render(canvas);
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        int lastRecorded = snapshot.Events.ToList().FindLastIndex(
+            static item => item.Kind == RenderPipelineDiagnosticEventKind.FragmentRecorded);
+        int firstExecutedPass = snapshot.Events.ToList().FindIndex(
+            static item => item.Kind == RenderPipelineDiagnosticEventKind.PassExecuted);
+        Assert.Multiple(() =>
+        {
+            Assert.That(recorded, Is.All.True);
+            Assert.That(executed, Is.EqualTo(new[] { "source", "command", "capture" }));
+            Assert.That(snapshot[RenderPipelineCounter.RecordedTargetCommands], Is.EqualTo(2),
+                "The complete request must include both the root clear and authored target command.");
+            Assert.That(snapshot[RenderPipelineCounter.RecordedTargetCaptures], Is.EqualTo(1));
+            Assert.That(firstExecutedPass, Is.GreaterThan(lastRecorded),
+                "Every complete-target fragment must be committed before planner-controlled execution starts.");
+        });
+    }
+
+    [Test]
+    [Category("GpuPassFusionGpu")]
+    public void ProductionRenderer_BuildsRecordsAndCommitsEveryTreeAsOneRequest()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var state = new RendererWideTreeState(2);
+            var first = new RendererWideProbeDrawable(0, state);
+            var second = new RendererWideProbeDrawable(1, state);
+            var resources = ImmutableArray.Create<EngineObject.Resource>(
+                (Drawable.Resource)first.ToResource(CompositionContext.Default),
+                (Drawable.Resource)second.ToResource(CompositionContext.Default));
+            var frame = new CompositionFrame(
+                resources,
+                new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)),
+                new PixelSize(8, 8));
+            using var renderer = new Renderer(8, 8);
+
+            renderer.Render(frame);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(state.BuildCalls, Is.EqualTo(new[] { 1, 1 }));
+                Assert.That(state.RecordCalls, Is.EqualTo(new[] { 1, 1 }),
+                    "Rendering must record each drawable tree only once in the complete frame request.");
+                Assert.That(state.FrameRecordCalls, Is.EqualTo(new[] { 1, 1 }));
+                Assert.That(state.ExecutionOrder, Is.EqualTo(new[] { 0, 1 }));
+                Assert.That(state.Nodes, Has.All.Not.Null);
+                Assert.That(state.Nodes, Has.All.Matches<ProductionTreeProbeNode>(
+                    static node => !node.HasChanges && node.Cache.CanCache()),
+                    "Successful complete-request execution must commit every tree's render-count/cache state.");
+            });
+        });
+    }
+
+    [Test]
+    public void ProductionRenderer_LazilyCachesBoundariesForCurrentFrame()
+    {
+        RenderThread.Dispatcher.Invoke(() =>
+        {
+            var state = new RendererWideTreeState(2);
+            var first = new RendererWideProbeDrawable(0, state);
+            var second = new RendererWideProbeDrawable(1, state);
+            using Drawable.Resource firstResource =
+                (Drawable.Resource)first.ToResource(CompositionContext.Default);
+            using Drawable.Resource secondResource =
+                (Drawable.Resource)second.ToResource(CompositionContext.Default);
+            var frame = new CompositionFrame(
+                ImmutableArray.Create<EngineObject.Resource>(firstResource, secondResource),
+                new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)),
+                new PixelSize(8, 8));
+            using var renderer = new Renderer(
+                width: 8,
+                height: 8,
+                renderScale: 1,
+                maxWorkingScale: float.PositiveInfinity,
+                diagnostics: null,
+                surface: new CpuRenderTarget(8, 8))
+            {
+                CacheOptions = RenderCacheOptions.Disabled,
+            };
+            var expectedBounds = new Rect(0, 0, 8, 8);
+
+            renderer.Render(frame);
+            Assert.That(state.RecordCalls, Is.EqualTo(new[] { 1, 1 }));
+
+            Assert.That(renderer.GetBoundary(first), Is.EqualTo(expectedBounds));
+            Assert.That(state.RecordCalls, Is.EqualTo(new[] { 2, 1 }));
+            Assert.That(renderer.GetBoundary(first), Is.EqualTo(expectedBounds));
+            Assert.That(state.RecordCalls, Is.EqualTo(new[] { 2, 1 }),
+                "A repeated single-drawable query must reuse the current-frame bounds.");
+
+            Assert.That(renderer.GetBoundaries(0), Is.EqualTo(new[] { expectedBounds, expectedBounds }));
+            Assert.That(state.RecordCalls, Is.EqualTo(new[] { 2, 2 }));
+            Assert.That(renderer.GetBoundaries(0), Is.EqualTo(new[] { expectedBounds, expectedBounds }));
+            Assert.That(state.RecordCalls, Is.EqualTo(new[] { 2, 2 }),
+                "A repeated layer query must reuse every current-frame bound.");
+
+            renderer.UpdateFrame(frame);
+            Assert.That(state.RecordCalls, Is.EqualTo(new[] { 2, 2 }));
+            Assert.That(renderer.GetBoundaries(0), Is.EqualTo(new[] { expectedBounds, expectedBounds }));
+            Assert.That(state.RecordCalls, Is.EqualTo(new[] { 3, 3 }),
+                "Updating the current frame must invalidate every lazy bound.");
+
+            renderer.Render(frame);
+            Assert.That(state.RecordCalls, Is.EqualTo(new[] { 4, 4 }));
+            Assert.That(renderer.GetBoundary(first), Is.EqualTo(expectedBounds));
+            Assert.That(state.RecordCalls, Is.EqualTo(new[] { 5, 4 }),
+                "A successful render must invalidate every lazy bound.");
+            Assert.That(renderer.GetBoundary(first), Is.EqualTo(expectedBounds));
+            Assert.That(state.RecordCalls, Is.EqualTo(new[] { 5, 4 }));
+
+            Assert.That(renderer.RecalculateBoundaries(0), Is.EqualTo(new[] { expectedBounds, expectedBounds }));
+            Assert.That(state.RecordCalls, Is.EqualTo(new[] { 6, 5 }),
+                "Forced recalculation must record every matching drawable even when one bound is cached.");
+            Assert.That(state.ExecutionOrder, Is.EqualTo(new[] { 0, 1, 0, 1 }));
+
+            renderer.ClearAllCaches();
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.GetBoundaries(0), Is.Empty);
+                Assert.That(renderer.GetBoundary(first), Is.Null);
+                Assert.That(state.RecordCalls, Is.EqualTo(new[] { 6, 5 }),
+                    "Clearing caches must not measure disposed current-frame entries.");
+            });
+        });
+    }
+
+    [Test]
+    public void ProductionRenderer_UsesQueryBoundsForAFullTargetDrawable()
+    {
+        RenderThread.Dispatcher.Invoke(() =>
+        {
+            var group = new DrawableGroup();
+            group.Children.Add(new RectShape
+            {
+                Width = { CurrentValue = 3 },
+                Height = { CurrentValue = 2 },
+                AlignmentX = { CurrentValue = AlignmentX.Left },
+                AlignmentY = { CurrentValue = AlignmentY.Top },
+                Transform = { CurrentValue = new TranslateTransform(2, 1) },
+                Fill = { CurrentValue = Brushes.White },
+            });
+            using Drawable.Resource resource =
+                (Drawable.Resource)group.ToResource(CompositionContext.Default);
+            var frame = new CompositionFrame(
+                ImmutableArray.Create<EngineObject.Resource>(resource),
+                new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)),
+                new PixelSize(8, 8));
+            using var renderer = new Renderer(
+                width: 8,
+                height: 8,
+                renderScale: 1,
+                maxWorkingScale: float.PositiveInfinity,
+                diagnostics: null,
+                surface: new CpuRenderTarget(8, 8))
+            {
+                CacheOptions = RenderCacheOptions.Disabled,
+            };
+
+            renderer.Render(frame);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.GetBoundary(group), Is.EqualTo(new Rect(2, 1, 3, 2)));
+                Assert.That(renderer.RecalculateBoundaries(0), Is.EqualTo(new[] { new Rect(2, 1, 3, 2) }));
+            });
+        });
+    }
+
+    [Test]
+    public void BoundaryCollectionQueries_RequireRenderThreadAccess()
+    {
+        Renderer renderer = RenderThread.Dispatcher.Invoke(() => new Renderer(
+            width: 8,
+            height: 8,
+            renderScale: 1,
+            maxWorkingScale: float.PositiveInfinity,
+            diagnostics: null,
+            surface: new CpuRenderTarget(8, 8)));
+        try
+        {
+            Assert.That(RenderThread.Dispatcher.CheckAccess(), Is.False);
+            Assert.Throws<InvalidOperationException>(() => renderer.GetBoundaries(0));
+            Assert.Throws<InvalidOperationException>(() => renderer.RecalculateBoundaries(0));
+        }
+        finally
+        {
+            RenderThread.Dispatcher.Invoke(renderer.Dispose);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference AbandonRenderer(DisposalThreadState state)
+    {
+        var surface = new DisposalThreadProbeRenderTarget(8, 8, state);
+        GC.SuppressFinalize(surface);
+        var renderer = new Renderer(
+            width: 8,
+            height: 8,
+            renderScale: 1,
+            maxWorkingScale: 1,
+            diagnostics: null,
+            surface: surface);
+        return new WeakReference(renderer, trackResurrection: true);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference AbandonRenderer(Dispatcher dispatcher, DispatcherDisposalState state)
+    {
+        DispatcherDisposalProbeRenderTarget surface = dispatcher.Invoke(
+            () => new DispatcherDisposalProbeRenderTarget(state));
+        GC.SuppressFinalize(surface);
+        var renderer = new Renderer(
+            width: 8,
+            height: 8,
+            renderScale: 1,
+            maxWorkingScale: 1,
+            diagnostics: null,
+            surface: surface,
+            dispatcher: dispatcher);
+        return new WeakReference(renderer, trackResurrection: true);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (Dispatcher Dispatcher, WeakReference Renderer, WeakReference Drawable)
+        AbandonDetachedRendererAfterShutdown()
+    {
+        Dispatcher dispatcher = Dispatcher.Spawn();
+        var state = new CacheMutationThreadState();
+        var root = new CacheMutationHierarchyRoot();
+        var drawable = new CacheMutationThreadProbeDrawable(state);
+        root.Attach(drawable);
+        using var resource = (Drawable.Resource)drawable.ToResource(CompositionContext.Default);
+        var frame = new CompositionFrame(
+            ImmutableArray.Create<EngineObject.Resource>(resource),
+            new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)),
+            new PixelSize(8, 8));
+        var renderer = new Renderer(
+            width: 8,
+            height: 8,
+            renderScale: 1,
+            maxWorkingScale: 1,
+            diagnostics: null,
+            surface: new CpuRenderTarget(8, 8),
+            dispatcher: dispatcher);
+        dispatcher.Invoke(() => renderer.UpdateFrame(frame));
+        dispatcher.Shutdown();
+        if (!dispatcher.Thread.Join(TimeSpan.FromSeconds(5)))
+            throw new TimeoutException("The test dispatcher did not stop.");
+
+        root.Detach(drawable);
+        renderer.Dispose();
+        return (
+            dispatcher,
+            new WeakReference(renderer),
+            new WeakReference(drawable));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference AbandonFinalizerHookProbe(FinalizerHookState state)
+    {
+        var renderer = new FinalizerHookProbeRenderer(state);
+        return new WeakReference(renderer, trackResurrection: true);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void FailRendererConstructionAfterRenderResourcesAreCreated()
+    {
+        var exception = Assert.Throws<AggregateException>(() => new Renderer(
+            width: 8,
+            height: 8,
+            renderScale: 1,
+            maxWorkingScale: 1,
+            diagnostics: null,
+            surface: new CpuRenderTarget(7, 8)));
+        Assert.That(exception!.InnerException, Is.TypeOf<ArgumentException>());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void FailRendererConstructionBeforeFrameRendererIsAssigned()
+    {
+        Assert.Throws<ArgumentException>(() => new Renderer(
+            width: 0,
+            height: 8,
+            renderScale: 1,
+            maxWorkingScale: 1));
+    }
+
+    private sealed class RecordingRootNode(
+        int index,
+        bool[] recorded,
+        RenderNode child) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            recorded[index] = true;
+            context.PublishRange(context.RecordNode(child, []));
+        }
+
+        protected override void OnDispose(bool disposing)
+        {
+            child.Dispose();
+            base.OnDispose(disposing);
+        }
+    }
+
+    private sealed class OrderedSourceNode(
+        int index,
+        bool[] recorded,
+        ICollection<string> executed) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            recorded[index] = true;
+            context.Publish(context.OpaqueSource(CreateDescription(
+                "source",
+                recorded,
+                executed,
+                static (session, output) =>
+                    output.Canvas.Use(canvas => canvas.Clear(new Color(255, 40, 80, 120))))));
+        }
+    }
+
+    private sealed class OrderedTargetCommandNode(
+        int index,
+        bool[] recorded,
+        ICollection<string> executed) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            recorded[index] = true;
+            TargetCommandDescription description = TargetCommandDescription.CreateRequestLocal(
+                session =>
+                {
+                    Assert.That(recorded, Is.All.True);
+                    executed.Add("command");
+                    session.Canvas.Use(canvas => canvas.Clear(new Color(255, 24, 48, 72)));
+                },
+                TargetRegion.Full,
+                Rect.Empty,
+                RenderHitTestContract.None);
+            context.Publish(context.TargetCommand([], description));
+        }
+    }
+
+    private sealed class OrderedCaptureNode(
+        int index,
+        bool[] recorded,
+        ICollection<string> executed) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            recorded[index] = true;
+            Rect bounds = new(0, 0, 8, 8);
+            RenderFragmentHandle capture = context.TargetCapture(TargetCaptureDescription.Create(
+                TargetRegion.Full,
+                bounds,
+                RenderHitTestContract.None,
+                TargetCaptureScaleContract.MaterializeAtWorkingScale));
+            OpaqueRenderDescription replay = OpaqueRenderDescription.CreateRequestLocal(
+                session =>
+                {
+                    Assert.That(recorded, Is.All.True);
+                    executed.Add("capture");
+                    using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                    output.Canvas.Use(session.Inputs.Single().Draw);
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.Map(RenderBoundsContract.Identity),
+                RenderHitTestContract.AnyInput,
+                RenderValueCardinality.Single,
+                RenderScaleContract.PreserveInputSupply);
+            context.Publish(context.ContributeValues(context.OpaqueMap(capture, replay)));
+        }
+    }
+
+    private static OpaqueRenderDescription CreateDescription(
+        string name,
+        bool[] recorded,
+        ICollection<string> executed,
+        Action<OpaqueRenderSession, OpaqueRenderOutput> draw)
+    {
+        return OpaqueRenderDescription.CreateRequestLocal(
+            session =>
+            {
+                Assert.That(recorded, Is.All.True);
+                executed.Add(name);
+                using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                draw(session, output);
+                session.Publish(output);
+            },
+            OpaqueRenderBoundsContract.Source(new Rect(0, 0, 8, 8)),
+            RenderHitTestContract.OutputBounds,
+            RenderValueCardinality.Single,
+            RenderScaleContract.MaterializeAtWorkingScale,
+            structuralKey: (typeof(RendererWideRecordingTests), name));
+    }
+
+    private sealed class DeferredProbeNode(
+        int index,
+        bool[] recorded,
+        List<int> executed) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            recorded[index] = true;
+            var description = OpaqueRenderDescription.CreateRequestLocal(
+                session =>
+                {
+                    Assert.That(recorded, Is.All.True,
+                        "No planner-controlled 2D callback may run until every target root is recorded.");
+                    executed.Add(index);
+                    using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                    output.Canvas.Use(canvas => canvas.Clear(new Color(255, 32, 64, 96)));
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.Source(new Rect(0, 0, 8, 8)),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: (typeof(DeferredProbeNode), index));
+            context.Publish(context.OpaqueSource(description));
+        }
+    }
+
+    private sealed class CpuTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+            => new CpuRenderTarget(allocation.DeviceSize.Width, allocation.DeviceSize.Height);
+    }
+
+    private sealed class CacheMutationHierarchyRoot : Hierarchical, IHierarchicalRoot
+    {
+        public event EventHandler<IHierarchical>? DescendantAttached;
+
+        public event EventHandler<IHierarchical>? DescendantDetached;
+
+        public void Attach(IHierarchical child)
+        {
+            ((IModifiableHierarchical)this).AddChild(child);
+        }
+
+        public void Detach(IHierarchical child)
+        {
+            ((IModifiableHierarchical)this).RemoveChild(child);
+        }
+
+        public void OnDescendantAttached(IHierarchical descendant)
+        {
+            DescendantAttached?.Invoke(this, descendant);
+        }
+
+        public void OnDescendantDetached(IHierarchical descendant)
+        {
+            DescendantDetached?.Invoke(this, descendant);
+        }
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height);
+
+    private sealed class DispatcherDisposalProbeRenderTarget(DispatcherDisposalState state)
+        : RenderTarget(SKSurface.CreateNull(8, 8), 8, 8)
+    {
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !IsDisposed)
+            {
+                state.Record();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class DispatcherDisposalState(Dispatcher dispatcher)
+    {
+        private int _disposeCount;
+        private int _disposedAfterShutdown;
+        private int _disposedOnOwnerThread;
+
+        public int DisposeCount => Volatile.Read(ref _disposeCount);
+
+        public bool DisposedAfterShutdown => Volatile.Read(ref _disposedAfterShutdown) != 0;
+
+        public bool DisposedOnOwnerThread => Volatile.Read(ref _disposedOnOwnerThread) != 0;
+
+        public void Record()
+        {
+            if (dispatcher.HasShutdownFinished)
+                Volatile.Write(ref _disposedAfterShutdown, 1);
+            if (dispatcher.CheckAccess())
+                Volatile.Write(ref _disposedOnOwnerThread, 1);
+            Interlocked.Increment(ref _disposeCount);
+        }
+    }
+
+    private sealed class ConcurrentDisposeProbeRenderer(
+        Dispatcher dispatcher,
+        RenderTarget surface,
+        ConcurrentDisposeState state)
+        : Renderer(
+            width: 8,
+            height: 8,
+            renderScale: 1,
+            maxWorkingScale: 1,
+            diagnostics: null,
+            surface: surface,
+            dispatcher: dispatcher)
+    {
+        protected override void OnDispose(bool disposing)
+        {
+            if (disposing)
+                state.Record();
+            base.OnDispose(disposing);
+        }
+    }
+
+    private sealed class ConcurrentDisposeState
+    {
+        private int _callCount;
+
+        public int CallCount => Volatile.Read(ref _callCount);
+
+        public void Record() => Interlocked.Increment(ref _callCount);
+    }
+
+    private sealed class DisposalThreadProbeRenderTarget(
+        int width,
+        int height,
+        DisposalThreadState? state = null)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height)
+    {
+        private readonly DisposalThreadState _state = state ?? new DisposalThreadState();
+
+        public int DisposeCount => _state.DisposeCount;
+
+        public bool DisposedOnRenderThread => _state.DisposedOnRenderThread;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !IsDisposed)
+            {
+                _state.DisposeCount++;
+                _state.DisposedOnRenderThread = RenderThread.Dispatcher.CheckAccess();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class DisposalThreadState
+    {
+        public int DisposeCount { get; set; }
+
+        public bool DisposedOnRenderThread { get; set; }
+    }
+
+    private sealed class FinalizerHookProbeRenderer(FinalizerHookState state)
+        : Renderer(
+            width: 8,
+            height: 8,
+            renderScale: 1,
+            maxWorkingScale: 1,
+            diagnostics: null,
+            surface: new CpuRenderTarget(8, 8))
+    {
+        protected override void OnDispose(bool disposing)
+        {
+            if (!disposing)
+                state.Record();
+
+            base.OnDispose(disposing);
+        }
+    }
+
+    private sealed class FinalizerHookState
+    {
+        private int _callCount;
+        private int _calledOnRenderThread;
+        private int _completed;
+
+        public int CallCount => Volatile.Read(ref _callCount);
+
+        public bool CalledOnRenderThread => Volatile.Read(ref _calledOnRenderThread) != 0;
+
+        public bool Completed => Volatile.Read(ref _completed) != 0;
+
+        public void Record()
+        {
+            if (RenderThread.Dispatcher.CheckAccess())
+                Volatile.Write(ref _calledOnRenderThread, 1);
+
+            Interlocked.Increment(ref _callCount);
+            Volatile.Write(ref _completed, 1);
+        }
+    }
+}
+
+internal sealed class RendererWideTreeState(int count)
+{
+    public int[] BuildCalls { get; } = new int[count];
+
+    public int[] RecordCalls { get; } = new int[count];
+
+    public int[] FrameRecordCalls { get; } = new int[count];
+
+    public List<int> ExecutionOrder { get; } = [];
+
+    public ProductionTreeProbeNode?[] Nodes { get; } = new ProductionTreeProbeNode[count];
+
+    public bool UseShaderProgram { get; init; }
+}
+
+// Top-level partial because EngineObjectResourceGenerator does not support nested types.
+internal sealed partial class RendererWideProbeDrawable : Drawable
+{
+    private readonly int _index;
+    private readonly RendererWideTreeState _state;
+
+    public RendererWideProbeDrawable(int index, RendererWideTreeState state)
+    {
+        _index = index;
+        _state = state;
+    }
+
+    public override void Render(GraphicsContext2D context, Drawable.Resource resource)
+    {
+        _state.BuildCalls[_index]++;
+        var node = new ProductionTreeProbeNode(_index, _state);
+        node.Cache.ReportRenderCount(RenderNodeCache.Count - 1);
+        _state.Nodes[_index] = node;
+        context.DrawNode(node);
+    }
+
+    protected override Size MeasureCore(Size availableSize, Drawable.Resource resource) => new(8, 8);
+
+    protected override void OnDraw(GraphicsContext2D context, Drawable.Resource resource)
+    {
+    }
+}
+
+internal sealed class ProductionTreeProbeNode(
+    int index,
+    RendererWideTreeState state) : RenderNode
+{
+    public override void Process(RenderNodeContext context)
+    {
+        int completedBuildCount = state.BuildCalls[index];
+        Assert.That(completedBuildCount, Is.GreaterThan(0));
+        Assert.That(state.BuildCalls, Is.All.EqualTo(completedBuildCount),
+            "Every drawable tree must be built before the complete request starts recording.");
+        state.RecordCalls[index]++;
+        if (context.Purpose == RenderRequestPurpose.Frame)
+        {
+            state.FrameRecordCalls[index]++;
+        }
+
+        OpaqueRenderDescription description = OpaqueRenderDescription.CreateRequestLocal(
+            session =>
+            {
+                int completedFrameRecordCount = state.FrameRecordCalls[index];
+                Assert.That(completedFrameRecordCount, Is.GreaterThan(0));
+                Assert.That(state.FrameRecordCalls, Is.All.EqualTo(completedFrameRecordCount),
+                    "Every top-level tree must be recorded before the first execution callback.");
+                state.ExecutionOrder.Add(index);
+                using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                output.Canvas.Use(canvas => canvas.Clear(
+                    index == 0
+                        ? new Color(160, 96, 32, 16)
+                        : new Color(160, 16, 64, 128)));
+                session.Publish(output);
+            },
+            OpaqueRenderBoundsContract.Source(new Rect(0, 0, 8, 8)),
+            RenderHitTestContract.OutputBounds,
+            RenderValueCardinality.Single,
+            RenderScaleContract.MaterializeAtWorkingScale,
+            structuralKey: (typeof(ProductionTreeProbeNode), index));
+        RenderFragmentHandle source = context.OpaqueSource(description);
+        if (state.UseShaderProgram)
+        {
+            ShaderDescription shader = ShaderDescription.CurrentPixel(
+                "half4 apply(half4 color) { return half4(color.b, color.g, color.r, color.a); }");
+            context.Publish(context.Shader(source, shader));
+        }
+        else
+        {
+            context.Publish(source);
+        }
+    }
+}
+
+internal sealed class CacheMutationThreadState
+{
+    public List<bool> DisposedOnRenderThread { get; } = [];
+}
+
+// Top-level partial because EngineObjectResourceGenerator does not support nested types.
+internal sealed partial class CacheMutationThreadProbeDrawable : Drawable
+{
+    private readonly CacheMutationThreadState _state;
+
+    public CacheMutationThreadProbeDrawable(CacheMutationThreadState state)
+    {
+        _state = state;
+    }
+
+    public override void Render(GraphicsContext2D context, Drawable.Resource resource)
+    {
+        context.DrawNode(new CacheMutationThreadProbeNode(_state));
+    }
+
+    protected override Size MeasureCore(Size availableSize, Drawable.Resource resource) => new(8, 8);
+
+    protected override void OnDraw(GraphicsContext2D context, Drawable.Resource resource)
+    {
+    }
+}
+
+internal sealed class CacheMutationThreadProbeNode(
+    CacheMutationThreadState state) : RenderNode
+{
+    public override void Process(RenderNodeContext context)
+    {
+        OpaqueRenderDescription description = OpaqueRenderDescription.CreateRequestLocal(
+            session =>
+            {
+                using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                output.Canvas.Use(canvas => canvas.Clear(new Color(255, 32, 64, 96)));
+                session.Publish(output);
+            },
+            OpaqueRenderBoundsContract.Source(new Rect(0, 0, 8, 8)),
+            RenderHitTestContract.OutputBounds,
+            RenderValueCardinality.Single,
+            RenderScaleContract.MaterializeAtWorkingScale);
+        context.Publish(context.OpaqueSource(description));
+    }
+
+    protected override void OnDispose(bool disposing)
+    {
+        if (disposing)
+            state.DisposedOnRenderThread.Add(RenderThread.Dispatcher.CheckAccess());
+        base.OnDispose(disposing);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/ResourcePlanUseScheduleTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/ResourcePlanUseScheduleTests.cs
@@ -1,0 +1,80 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Planning;
+
+[TestFixture]
+public sealed class ResourcePlanUseScheduleTests
+{
+    [Test]
+    public void SelectedCacheHit_PrunesProducerInputsFromRemainingUseCounts()
+    {
+        var requestId = new RenderRequestId(1);
+        RenderFragmentReference sharedSource = Fragment(RenderFragmentKind.OpaqueSource, []);
+        sharedSource.Id = new RenderFragmentId(requestId, 1);
+        RenderFragmentReference hitProducer = Fragment(RenderFragmentKind.Opacity, [sharedSource]);
+        hitProducer.Id = new RenderFragmentId(requestId, 2);
+
+        ResourcePlanUseSchedule unpruned = ResourcePlanUseSchedule.Create(
+            [hitProducer, sharedSource]);
+        ResourcePlanUseSchedule pruned = ResourcePlanUseSchedule.Create(
+            [hitProducer, sharedSource],
+            new HashSet<RenderFragmentId> { hitProducer.Id.Value });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                unpruned.Lifetimes.Single(item => ReferenceEquals(item.Fragment, sharedSource))
+                    .ConsumerPositions,
+                Has.Length.EqualTo(2));
+            Assert.That(
+                pruned.Lifetimes.Single(item => ReferenceEquals(item.Fragment, sharedSource))
+                    .ConsumerPositions,
+                Has.Length.EqualTo(1),
+                "The remaining authored root use must not be inflated by an input edge below a selected hit.");
+            Assert.That(
+                pruned.BeginExecution().GetRemainingUseCount(sharedSource),
+                Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void SelectedCacheHit_PrunesExclusiveProducerSubtree()
+    {
+        var requestId = new RenderRequestId(1);
+        RenderFragmentReference source = Fragment(RenderFragmentKind.OpaqueSource, []);
+        source.Id = new RenderFragmentId(requestId, 1);
+        RenderFragmentReference hitProducer = Fragment(RenderFragmentKind.Opacity, [source]);
+        hitProducer.Id = new RenderFragmentId(requestId, 2);
+
+        ResourcePlanUseSchedule schedule = ResourcePlanUseSchedule.Create(
+            [hitProducer],
+            new HashSet<RenderFragmentId> { hitProducer.Id.Value });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(schedule.Lifetimes.Select(static item => item.Fragment),
+                Is.EqualTo(new[] { hitProducer }));
+            Assert.That(schedule.BeginExecution().GetRemainingUseCount(hitProducer), Is.EqualTo(1));
+            Assert.That(
+                () => schedule.BeginExecution().GetRemainingUseCount(source),
+                Throws.InvalidOperationException);
+        });
+    }
+
+    private static RenderFragmentReference Fragment(
+        RenderFragmentKind kind,
+        IReadOnlyList<RenderFragmentReference> inputs)
+        => new(
+            kind,
+            new Rect(0, 0, 16, 16),
+            EffectiveScale.Unbounded,
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: false,
+            hasOpaqueExternalWork: false,
+            inputs,
+            payload: null,
+            hitTest: null);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/SymbolicOwningDomainTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/SymbolicOwningDomainTests.cs
@@ -1,0 +1,728 @@
+﻿using System.Reactive;
+using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Planning;
+
+[TestFixture]
+public sealed class SymbolicOwningDomainTests
+{
+    private static readonly Rect s_rootDomain = new(0, 0, 100, 60);
+
+    [Test]
+    public void UnknownLegacy_UnderTranslation_ResolvesLocalDomainBeforeMappingToRoot()
+    {
+        var effect = new SymbolicDomainFilterEffect();
+        using TransformRenderNode root = WrapInTranslation(
+            CreateFilter(effect, new Rect(-5, 10, 10, 10)),
+            10);
+
+        using CompiledRenderRequest compiled = Compile(root, s_rootDomain);
+        RenderFragmentReference legacy = References(compiled.Graph).Values
+            .Single(static reference => reference.Kind == RenderFragmentKind.LegacyFilterEffect);
+        RenderFragmentReference transform = References(compiled.Graph).Values
+            .Single(static reference => reference.Kind == RenderFragmentKind.TargetScope);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(legacy.BoundsRequirement, Is.EqualTo(RenderFragmentBoundsRequirement.OwningTargetDomain));
+            Assert.That(legacy.RecordedBounds, Is.EqualTo(new Rect(-5, 10, 10, 10)));
+            Assert.That(legacy.Bounds, Is.EqualTo(new Rect(-10, 0, 100, 60)));
+            Assert.That(transform.Bounds, Is.EqualTo(s_rootDomain));
+            Assert.That(compiled.Regions.GetMetadata(legacy).Bounds, Is.EqualTo(legacy.Bounds));
+            Assert.That(compiled.Measurement.OutputBounds, Is.EqualTo(s_rootDomain));
+        });
+    }
+
+    [Test]
+    public void UnknownLegacy_LargeResolvedDomain_RecomputesDownstreamScaleClamp()
+    {
+        var domain = new Rect(0, 0, 10_000, 100);
+        var effect = new SymbolicDomainFilterEffect();
+        using TransformRenderNode root = WrapInTranslation(
+            CreateFilter(effect, new Rect(5, 6, 20, 12)),
+            0);
+
+        using CompiledRenderRequest compiled = Compile(root, domain, outputScale: 2);
+        RenderFragmentReference legacy = References(compiled.Graph).Values
+            .Single(static reference => reference.Kind == RenderFragmentKind.LegacyFilterEffect);
+        RenderFragmentReference transform = References(compiled.Graph).Values
+            .Single(static reference => reference.Kind == RenderFragmentKind.TargetScope);
+        float expected = RenderScaleUtilities.ClampWorkingScaleToBufferBudget(domain, 2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(legacy.RecordedEffectiveScale, Is.EqualTo(EffectiveScale.At(2)));
+            Assert.That(legacy.EffectiveScale.Value, Is.EqualTo(expected).Within(1e-6f));
+            Assert.That(transform.EffectiveScale.Value, Is.EqualTo(expected).Within(1e-6f));
+            Assert.That(compiled.Regions.GetMetadata(transform).EffectiveScale,
+                Is.EqualTo(transform.EffectiveScale));
+        });
+    }
+
+    [Test]
+    public void UnknownLegacy_NoOpUnderTranslation_PreservesPixelsFromLocalNegativeCoordinates()
+    {
+        var effect = new SymbolicDomainFilterEffect();
+        using TransformRenderNode root = WrapInTranslation(
+            CreateFilter(effect, new Rect(-5, 10, 10, 10)),
+            10);
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_rootDomain,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+        using var target = new CpuRenderTarget(100, 60);
+        using var canvas = new ImmediateCanvas(target);
+
+        renderer.Render(canvas);
+        using Bitmap bitmap = target.Snapshot();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(effect.CallbackCount, Is.EqualTo(1));
+            Assert.That(AlphaAt(bitmap, 6, 15), Is.GreaterThan(0.9f));
+        });
+    }
+
+    [Test]
+    public void UnknownLegacy_UnderIntersectClip_ResolvesToClippedLocalDomain()
+    {
+        var clip = new Rect(20, 5, 30, 40);
+        var effect = new SymbolicDomainFilterEffect();
+        using var root = new RectClipRenderNode(clip, ClipOperation.Intersect);
+        root.AddChild(CreateFilter(effect, new Rect(25, 10, 5, 5)));
+
+        using CompiledRenderRequest compiled = Compile(root, s_rootDomain);
+        RenderFragmentReference legacy = References(compiled.Graph).Values
+            .Single(static reference => reference.Kind == RenderFragmentKind.LegacyFilterEffect);
+        RenderFragmentReference clipped = References(compiled.Graph).Values
+            .Single(static reference => reference.Kind == RenderFragmentKind.TargetScope);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(legacy.Bounds, Is.EqualTo(clip));
+            Assert.That(clipped.Bounds, Is.EqualTo(clip));
+            Assert.That(compiled.Measurement.OutputBounds, Is.EqualTo(clip));
+        });
+    }
+
+    [Test]
+    public void UnknownLegacy_ExplicitTargetlessDomain_ResolvesDuringMetadata()
+    {
+        var domain = new Rect(-20, -10, 80, 50);
+        var effect = new SymbolicDomainFilterEffect();
+        using FilterEffectRenderNode root = CreateFilter(effect, new Rect(5, 6, 20, 12));
+
+        using CompiledRenderRequest compiled = Compile(root, domain);
+        RenderFragmentReference legacy = References(compiled.Graph).Values
+            .Single(static reference => reference.Kind == RenderFragmentKind.LegacyFilterEffect);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(legacy.Bounds, Is.EqualTo(domain));
+            Assert.That(compiled.Measurement.OutputBounds, Is.EqualTo(domain));
+            Assert.That(effect.CallbackCount, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void UnknownLegacy_RealDestinationSuppliesOwningDomain()
+    {
+        var effect = new SymbolicDomainFilterEffect();
+        using FilterEffectRenderNode root = CreateFilter(effect, new Rect(5, 6, 20, 12));
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+        using var target = new CpuRenderTarget(64, 48);
+        using var canvas = new ImmediateCanvas(target);
+
+        Assert.That(() => renderer.Render(canvas), Throws.Nothing);
+        Assert.That(effect.CallbackCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void UnknownLegacy_WithoutOwningDomain_FailsBeforeRuntimeCallback()
+    {
+        var effect = new SymbolicDomainFilterEffect();
+        using FilterEffectRenderNode root = CreateFilter(effect, new Rect(5, 6, 20, 12));
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+            });
+
+        InvalidOperationException? error = Assert.Throws<RenderTargetDomainRequiredException>(() => renderer.Measure());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(error!.Message, Does.Contain("transformBounds").And.Contain("owning target domain"));
+            Assert.That(effect.CallbackCount, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void UnknownLegacy_InsideFiniteLayer_UsesLayerDomainWithoutRootDomain()
+    {
+        var domain = new Rect(-20, 5, 40, 30);
+        var effect = new SymbolicDomainFilterEffect();
+        using var root = new LayerRenderNode(domain);
+        root.AddChild(CreateFilter(effect, new Rect(-10, 10, 5, 5)));
+
+        using CompiledRenderRequest compiled = Compile(root, targetDomain: null);
+        RenderFragmentReference legacy = References(compiled.Graph).Values
+            .Single(static reference => reference.Kind == RenderFragmentKind.LegacyFilterEffect);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(legacy.Bounds, Is.EqualTo(domain));
+            Assert.That(compiled.Measurement.OutputBounds, Is.EqualTo(domain));
+            Assert.That(effect.CallbackCount, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void FullTargetCommand_FilterUsesOwningDomainLayerAndRecomputesLegacyBounds()
+    {
+        var effect = new FiniteLegacyFilterEffect();
+        using var root = new FilterEffectRenderNode(effect.ToResource(CompositionContext.Default));
+        root.AddChild(new ClearRenderNode(Colors.White));
+
+        using CompiledRenderRequest compiled = Compile(root, s_rootDomain);
+        RenderFragmentReference layer = References(compiled.Graph).Values
+            .Single(static reference => reference.Kind == RenderFragmentKind.Layer);
+        RenderFragmentReference legacy = References(compiled.Graph).Values
+            .Single(static reference => reference.Kind == RenderFragmentKind.LegacyFilterEffect);
+        var layerPayload = (LayerRenderFragmentPayload)layer.Payload!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(effect.ObservedInputBounds.IsInvalid, Is.True,
+                "A full target domain must remain symbolic while the filter records.");
+            Assert.That(layerPayload.Domain, Is.Null,
+                "The internal Layer must resolve from its owning target instead of freezing a root placeholder.");
+            Assert.That(layer.BoundsRequirement,
+                Is.EqualTo(RenderFragmentBoundsRequirement.OwningTargetDomain));
+            Assert.That(layer.Bounds, Is.EqualTo(s_rootDomain));
+            Assert.That(legacy.Bounds, Is.EqualTo(s_rootDomain.Inflate(new Thickness(2))));
+            Assert.That(compiled.Measurement.OutputBounds, Is.EqualTo(s_rootDomain));
+        });
+    }
+
+    [Test]
+    public void UnknownLegacy_FiniteLegacyParentRecomputesBoundsAndHitTestFromResolvedInput()
+    {
+        var unknown = new SymbolicDomainFilterEffect();
+        var finite = new FiniteLegacyFilterEffect();
+        using FilterEffectRenderNode root = CreateFilter(finite, unknown, new Rect(5, 6, 20, 12));
+
+        using CompiledRenderRequest compiled = Compile(root, s_rootDomain);
+        RenderFragmentReference[] legacy = References(compiled.Graph).Values
+            .Where(static reference => reference.Kind == RenderFragmentKind.LegacyFilterEffect)
+            .ToArray();
+        RenderFragmentReference unknownFragment = legacy.Single(static reference =>
+            reference.BoundsRequirement == RenderFragmentBoundsRequirement.OwningTargetDomain);
+        RenderFragmentReference finiteFragment = legacy.Single(static reference =>
+            reference.BoundsRequirement == RenderFragmentBoundsRequirement.Finite);
+        Rect inflatedDomain = s_rootDomain.Inflate(new Thickness(2));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(finite.ObservedInputBounds.IsInvalid, Is.True,
+                "Legacy authoring must not observe provisional finite bounds from a symbolic input.");
+            Assert.That(unknownFragment.Bounds, Is.EqualTo(s_rootDomain));
+            Assert.That(finiteFragment.RecordedBounds, Is.EqualTo(new Rect(3, 4, 24, 16)));
+            Assert.That(finiteFragment.Bounds, Is.EqualTo(inflatedDomain));
+            Assert.That(finiteFragment.HitTest(new Point(-1, 30)), Is.True);
+            Assert.That(compiled.Measurement.OutputBounds, Is.EqualTo(s_rootDomain));
+        });
+    }
+
+    [Test]
+    public void UnknownLegacy_KeepsShaderAndGeometrySuffixInOneOpaqueSegment()
+    {
+        var effect = new SymbolicDomainFilterEffect { AppendTypedSuffix = true };
+        using FilterEffectRenderNode root = CreateFilter(effect, new Rect(5, 6, 20, 12));
+
+        using CompiledRenderRequest compiled = Compile(root, s_rootDomain);
+        RenderFragmentReference[] references = References(compiled.Graph).Values.ToArray();
+        RenderFragmentReference legacy = references
+            .Single(static reference => reference.Kind == RenderFragmentKind.LegacyFilterEffect);
+        var payload = (LegacyFilterEffectRenderFragmentPayload)legacy.Payload!;
+        IFEItem[] items = payload.Context.Registry.Use(
+            payload.Context,
+            static context => context.GetOrderedItems().ToArray());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(references.Any(static reference =>
+                reference.Kind is RenderFragmentKind.Shader or RenderFragmentKind.Geometry), Is.False);
+            Assert.That(items, Has.Length.EqualTo(3));
+            Assert.That(items[0], Is.InstanceOf<IFEItem_Custom>());
+            Assert.That(items[1], Is.InstanceOf<FEItem_Shader>());
+            Assert.That(items[2], Is.InstanceOf<FEItem_Geometry>());
+            Assert.That(legacy.Bounds, Is.EqualTo(s_rootDomain));
+        });
+    }
+
+    [Test]
+    public void BuiltInBackdrop_DerivedShaderGeometryFanOut_UsesProducerDomain()
+    {
+        var producerDomain = new Rect(0, 0, 40, 30);
+        var secondConsumerDomain = new Rect(20, 0, 40, 30);
+        using var root = new BuiltInDerivedFanOutNode(producerDomain, secondConsumerDomain);
+
+        using CompiledRenderRequest compiled = Compile(root, targetDomain: null);
+        RenderFragmentReference[] references = References(compiled.Graph).Values.ToArray();
+        RenderFragmentReference capture = references.Single(static reference =>
+            reference.Kind == RenderFragmentKind.BuiltInBackdropCapture);
+        RenderFragmentReference shader = references.Single(static reference =>
+            reference.Kind == RenderFragmentKind.Shader);
+        RenderFragmentReference geometry = references.Single(static reference =>
+            reference.Kind == RenderFragmentKind.Geometry);
+        RenderFragmentReference[] layers = references
+            .Where(static reference => reference.Kind == RenderFragmentKind.Layer)
+            .ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(capture.Bounds, Is.EqualTo(producerDomain));
+            Assert.That(shader.Bounds, Is.EqualTo(producerDomain));
+            Assert.That(geometry.Bounds, Is.EqualTo(producerDomain));
+            Assert.That(layers.Single(reference =>
+                    ((LayerRenderFragmentPayload)reference.Payload!).Domain == producerDomain).Bounds,
+                Is.EqualTo(producerDomain));
+            Assert.That(layers.Single(reference =>
+                    ((LayerRenderFragmentPayload)reference.Payload!).Domain == secondConsumerDomain).Bounds,
+                Is.EqualTo(producerDomain.Intersect(secondConsumerDomain)));
+        });
+    }
+
+    [Test]
+    public void UnknownLegacy_DerivedFanOutAcrossDifferentDomains_IsRejected()
+    {
+        var effect = new SymbolicDomainFilterEffect();
+        using var root = new UnknownLegacyDerivedFanOutNode(
+            effect,
+            new Rect(0, 0, 40, 30),
+            new Rect(20, 0, 40, 30));
+
+        InvalidOperationException? error = Assert.Throws<InvalidOperationException>(() =>
+        {
+            using CompiledRenderRequest _ = Compile(root, targetDomain: null);
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(error!.Message, Does.Contain("two different owning target domains"));
+            Assert.That(effect.CallbackCount, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void BuiltInBackdrop_InsideFiniteLayer_ResolvesLayerDomainWithoutRootDomain()
+    {
+        var domain = new Rect(12, 8, 40, 30);
+        using var root = new LayerRenderNode(domain);
+        root.AddChild(new SnapshotBackdropRenderNode());
+
+        using CompiledRenderRequest compiled = Compile(root, targetDomain: null);
+        RenderFragmentReference capture = References(compiled.Graph).Values
+            .Single(static reference => reference.Kind == RenderFragmentKind.BuiltInBackdropCapture);
+        TargetDependencyStep captureStep = compiled.TargetDependencies.Steps
+            .Single(static step => step.Kind == TargetDependencyKind.Capture);
+        TargetScopePlan captureScope = compiled.TargetDependencies.Scopes
+            .Single(scope => scope.Id == captureStep.ScopeId);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(capture.BoundsRequirement, Is.EqualTo(RenderFragmentBoundsRequirement.OwningTargetDomain));
+            Assert.That(capture.Bounds, Is.EqualTo(domain));
+            Assert.That(capture.EffectiveScale, Is.EqualTo(EffectiveScale.Unbounded));
+            Assert.That(captureScope.ResolvedDomain, Is.EqualTo(domain));
+        });
+    }
+
+    [Test]
+    public void BuiltInBackdrop_UnderTranslation_UsesCaptureProducerLocalCoordinates()
+    {
+        using TransformRenderNode root = WrapInTranslation(new SnapshotBackdropRenderNode(), 10);
+
+        using CompiledRenderRequest compiled = Compile(root, s_rootDomain);
+        RenderFragmentReference capture = References(compiled.Graph).Values
+            .Single(static reference => reference.Kind == RenderFragmentKind.BuiltInBackdropCapture);
+        TargetDependencyStep captureStep = compiled.TargetDependencies.Steps
+            .Single(static step => step.Kind == TargetDependencyKind.Capture);
+        TargetScopePlan captureScope = compiled.TargetDependencies.Scopes
+            .Single(scope => scope.Id == captureStep.ScopeId);
+        var localDomain = new Rect(-10, 0, 100, 60);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(captureScope.ResolvedDomain, Is.EqualTo(localDomain));
+            Assert.That(capture.Bounds, Is.EqualTo(localDomain));
+            Assert.That(compiled.Regions.GetMetadata(capture).Bounds, Is.EqualTo(localDomain));
+        });
+    }
+
+    [Test]
+    public void BuiltInBackdrop_UnderTranslation_CapturesResolvedExtentAtRuntime()
+    {
+        var probe = new BuiltInCaptureProbeNode();
+        using var root = new ContainerRenderNode();
+        root.AddChild(new RectangleRenderNode(s_rootDomain, Brushes.Resource.White, null));
+        root.AddChild(WrapInTranslation(probe, 10));
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_rootDomain,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+        using var target = new CpuRenderTarget(100, 60);
+        using var canvas = new ImmediateCanvas(target);
+
+        renderer.Render(canvas);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(probe.CaptureCount, Is.EqualTo(1));
+            Assert.That(probe.CapturedDeviceSize, Is.EqualTo(new PixelSize(100, 60)));
+            Assert.That(probe.CapturedDensity, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void BuiltInBackdrop_InsideFiniteLayer_CapturesLayerExtentAtRuntime()
+    {
+        var domain = new Rect(12, 8, 40, 30);
+        var probe = new BuiltInCaptureProbeNode();
+        using var root = new LayerRenderNode(domain);
+        root.AddChild(new RectangleRenderNode(domain, Brushes.Resource.White, null));
+        root.AddChild(probe);
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_rootDomain,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+        using var target = new CpuRenderTarget(100, 60);
+        using var canvas = new ImmediateCanvas(target);
+
+        renderer.Render(canvas);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(probe.CaptureCount, Is.EqualTo(1));
+            Assert.That(probe.CapturedDeviceSize, Is.EqualTo(new PixelSize(40, 30)));
+            Assert.That(probe.CapturedDensity, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void BuiltInBackdrop_ExternalTargetDensityMatchesPlannedDemandAndCapturedBitmap()
+    {
+        var domain = new Rect(0, 0, 8_192, 1);
+        const float density = 2;
+        var probe = new BuiltInCaptureProbeNode();
+        using (CompiledRenderRequest compiled = Compile(probe, domain, outputScale: density))
+        {
+            RenderFragmentReference capture = References(compiled.Graph).Values
+                .Single(static reference =>
+                    reference.Kind == RenderFragmentKind.BuiltInBackdropCapture);
+            Assert.That(
+                compiled.MaterializationDemands[capture],
+                Is.EqualTo(EffectiveScale.At(density)));
+        }
+
+        using var renderer = new RenderNodeRenderer(
+            probe,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = domain,
+                    OutputScale = density,
+                    MaxWorkingScale = 4,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+        PixelSize deviceSize = PixelRect.FromRect(domain, density).Size;
+        using var target = new CpuRenderTarget(deviceSize.Width, deviceSize.Height);
+        using var canvas = new ImmediateCanvas(
+            target,
+            density,
+            maxWorkingScale: 4,
+            domain.Size);
+
+        renderer.Render(canvas);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(deviceSize.Width, Is.EqualTo(RenderScaleUtilities.MaxBufferDimension));
+            Assert.That(probe.CaptureCount, Is.EqualTo(1));
+            Assert.That(probe.CapturedDeviceSize, Is.EqualTo(deviceSize));
+            Assert.That(probe.CapturedDensity, Is.EqualTo(density));
+        });
+    }
+
+    private static FilterEffectRenderNode CreateFilter(
+        SymbolicDomainFilterEffect effect,
+        Rect inputBounds)
+    {
+        var node = new FilterEffectRenderNode(effect.ToResource(CompositionContext.Default));
+        node.AddChild(new EllipseRenderNode(inputBounds, Brushes.Resource.White, null));
+        return node;
+    }
+
+    private static FilterEffectRenderNode CreateFilter(
+        FiniteLegacyFilterEffect outerEffect,
+        SymbolicDomainFilterEffect innerEffect,
+        Rect inputBounds)
+    {
+        var outer = new FilterEffectRenderNode(outerEffect.ToResource(CompositionContext.Default));
+        outer.AddChild(CreateFilter(innerEffect, inputBounds));
+        return outer;
+    }
+
+    private static TransformRenderNode WrapInTranslation(RenderNode child, float x)
+    {
+        var result = new TransformRenderNode(
+            Matrix.CreateTranslation(x, 0),
+            TransformOperator.Prepend);
+        result.AddChild(child);
+        return result;
+    }
+
+    private static CompiledRenderRequest Compile(
+        RenderNode root,
+        Rect? targetDomain,
+        float outputScale = 1)
+    {
+        var request = new RenderRequest(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            targetDomain,
+            outputScale: outputScale,
+            cachePolicy: RenderCacheOptions.Disabled));
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(root);
+        return new RenderRequestCompiler().Compile(request, graph);
+    }
+
+    private static IReadOnlyDictionary<RenderFragmentId, RenderFragmentReference> References(
+        RecordedRenderGraph graph)
+        => graph.Fragments.ToDictionary(
+            static fragment => fragment.Id,
+            static fragment => (RenderFragmentReference)fragment.Payload!);
+
+    private static float AlphaAt(Bitmap bitmap, int x, int y)
+    {
+        Span<ushort> row = bitmap.GetRow<ushort>(y);
+        return (float)BitConverter.UInt16BitsToHalf(row[(x * 4) + 3]);
+    }
+
+    private sealed class CpuTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+            => new CpuRenderTarget(allocation.DeviceSize.Width, allocation.DeviceSize.Height);
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height);
+
+    private sealed class BuiltInCaptureProbeNode : RenderNode, IBuiltInBackdropCaptureSink
+    {
+        public int CaptureCount { get; private set; }
+
+        public PixelSize CapturedDeviceSize { get; private set; }
+
+        public float CapturedDensity { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            context.DisableRenderCache();
+            context.Publish(context.BuiltInBackdropCapture(this));
+        }
+
+        void IBuiltInBackdropCaptureSink.CommitBackdropCapture(Bitmap bitmap, float density)
+        {
+            CaptureCount++;
+            CapturedDeviceSize = new PixelSize(bitmap.Width, bitmap.Height);
+            CapturedDensity = density;
+            bitmap.Dispose();
+        }
+    }
+
+    private sealed class BuiltInDerivedFanOutNode(
+        Rect producerDomain,
+        Rect secondConsumerDomain)
+        : RenderNode, IBuiltInBackdropCaptureSink
+    {
+        private const string IdentityShader = "half4 apply(half4 color) { return color; }";
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle capture = context.BuiltInBackdropCapture(this);
+            RenderFragmentHandle shader = context.Shader(
+                capture,
+                ShaderDescription.CurrentPixel(IdentityShader));
+            RenderFragmentHandle geometry = context.Geometry(
+                shader,
+                GeometryDescription.CreateRequestLocal(
+                    static _ => { },
+                    RenderBoundsContract.Identity,
+                    RenderHitTestContract.AnyInput));
+            RenderFragmentHandle contributing = context.ContributeValues(geometry);
+            context.Publish(context.Layer([contributing], producerDomain));
+            context.Publish(context.Layer([contributing], secondConsumerDomain));
+        }
+
+        void IBuiltInBackdropCaptureSink.CommitBackdropCapture(Bitmap bitmap, float density)
+            => bitmap.Dispose();
+    }
+
+    private sealed class UnknownLegacyDerivedFanOutNode : RenderNode
+    {
+        private const string IdentityShader = "half4 apply(half4 color) { return color; }";
+        private readonly FilterEffectRenderNode _filter;
+        private readonly Rect _firstDomain;
+        private readonly Rect _secondDomain;
+
+        public UnknownLegacyDerivedFanOutNode(
+            SymbolicDomainFilterEffect effect,
+            Rect firstDomain,
+            Rect secondDomain)
+        {
+            _filter = CreateFilter(effect, new Rect(5, 6, 20, 12));
+            _firstDomain = firstDomain;
+            _secondDomain = secondDomain;
+        }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle legacy = context.RecordSubtree(_filter).Single();
+            RenderFragmentHandle derived = context.Shader(
+                legacy,
+                ShaderDescription.CurrentPixel(IdentityShader));
+            context.Publish(context.Layer([derived], _firstDomain));
+            context.Publish(context.Layer([derived], _secondDomain));
+        }
+
+        protected override void OnDispose(bool disposing)
+        {
+            _filter.Dispose();
+            base.OnDispose(disposing);
+        }
+    }
+}
+
+[SuppressResourceClassGeneration]
+internal sealed partial class SymbolicDomainFilterEffect : FilterEffect
+{
+    private const string IdentityShader = "half4 apply(half4 color) { return color; }";
+
+    public int CallbackCount { get; private set; }
+
+    public bool AppendTypedSuffix { get; init; }
+
+    public override void ApplyTo(FilterEffectContext context, FilterEffect.Resource resource)
+    {
+        context.CustomEffect(Unit.Default, (_, _) => CallbackCount++);
+        if (!AppendTypedSuffix)
+            return;
+
+        context.Shader(ShaderDescription.CurrentPixel(IdentityShader));
+        context.Geometry(GeometryDescription.CreateRequestLocal(
+            static _ => { },
+            RenderBoundsContract.Identity,
+            RenderHitTestContract.AnyInput));
+    }
+
+    public override Resource ToResource(CompositionContext context)
+    {
+        var resource = new Resource();
+        bool updateOnly = true;
+        resource.Update(this, context, ref updateOnly);
+        return resource;
+    }
+
+    public new sealed class Resource : FilterEffect.Resource
+    {
+        public Resource()
+        {
+        }
+    }
+}
+
+[SuppressResourceClassGeneration]
+internal sealed partial class FiniteLegacyFilterEffect : FilterEffect
+{
+    public Rect ObservedInputBounds { get; private set; }
+
+    public override void ApplyTo(FilterEffectContext context, FilterEffect.Resource resource)
+    {
+        ObservedInputBounds = context.Bounds;
+        context.CustomEffect(
+            Unit.Default,
+            static (_, _) => { },
+            static (_, bounds) => bounds.Inflate(new Thickness(2)));
+    }
+
+    public override Resource ToResource(CompositionContext context)
+    {
+        var resource = new Resource();
+        bool updateOnly = true;
+        resource.Update(this, context, ref updateOnly);
+        return resource;
+    }
+
+    public new sealed class Resource : FilterEffect.Resource
+    {
+        public Resource()
+        {
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/SymbolicSupplyMappingTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/SymbolicSupplyMappingTests.cs
@@ -1,0 +1,73 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Transformation;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Planning;
+
+[TestFixture]
+public sealed class SymbolicSupplyMappingTests
+{
+    [Test]
+    public void CustomTransform_MapsSupplyAfterSymbolicInputResolution()
+    {
+        var targetDomain = new Rect(0, 0, 10_000, 100);
+        var effect = new SymbolicDomainFilterEffect();
+        var filter = new FilterEffectRenderNode(effect.ToResource(CompositionContext.Default));
+        filter.AddChild(new EllipseRenderNode(
+            new Rect(5, 6, 20, 12),
+            Brushes.Resource.White,
+            null));
+        using Transform.Resource scale = new ScaleTransform(50, 50)
+            .ToResource(CompositionContext.Default);
+        using var root = ScaleRecordingTestHelper.SubtreePipeline(
+            filter,
+            new HalfInputSupplyRenderNode(),
+            new DrawableGroup.CustomTransformRenderNode(
+                scale,
+                default,
+                targetDomain.Size,
+                AlignmentX.Left,
+                AlignmentY.Top,
+                new MemoryNode<Rect>(targetDomain)));
+
+        RenderNodeMeasurement measurement = ScaleRecordingTestHelper.Measure(
+            root,
+            outputScale: 2,
+            targetDomain: targetDomain);
+        Rect inputDomain = targetDomain.TransformToAABB(scale.Matrix.Invert());
+        float expected = RenderScaleUtilities.ClampWorkingScaleToBufferBudget(inputDomain, 2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(expected, Is.LessThan(2), "The setup must resolve the symbolic input below its recorded scale.");
+            Assert.That(measurement.EffectiveScale.IsUnbounded, Is.False);
+            Assert.That(measurement.EffectiveScale.Value, Is.EqualTo(expected).Within(1e-6f));
+        });
+    }
+
+    private sealed class HalfInputSupplyRenderNode : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            foreach (RenderFragmentHandle input in context.Inputs)
+            {
+                OpaqueRenderDescription description = OpaqueRenderDescription.CreateRequestLocal(
+                    execute: static _ => throw new AssertionException(
+                        "Metadata analysis must not execute opaque callbacks."),
+                    bounds: OpaqueRenderBoundsContract.Map(RenderBoundsContract.Identity),
+                    hitTest: RenderHitTestContract.AnyInput,
+                    valueCardinality: RenderValueCardinality.Single,
+                    scale: RenderScaleContract.MapInputSupply(
+                        HalfSupply));
+                context.Publish(context.OpaqueMap(input, description));
+            }
+        }
+
+        private static EffectiveScale HalfSupply(EffectiveScale input)
+            => input.IsUnbounded
+                ? EffectiveScale.Unbounded
+                : EffectiveScale.At(input.Value / 2);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/TargetScopeLoweringTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/TargetScopeLoweringTests.cs
@@ -1,0 +1,1034 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Graphics.Shapes;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Planning;
+
+[TestFixture]
+public sealed class TargetScopeLoweringTests
+{
+    private static readonly Rect s_rootDomain = new(0, 0, 100, 60);
+
+    [Test]
+    public void RootSequence_ThreadsA_Clear_BThroughOneTargetTokenChain()
+    {
+        using var root = new ContainerRenderNode();
+        root.AddChild(new SourceNode(new Rect(0, 0, 20, 20), "root-a"));
+        root.AddChild(new ClearRenderNode(Colors.Transparent));
+        root.AddChild(new SourceNode(new Rect(40, 10, 20, 20), "root-b"));
+
+        using CompiledRenderRequest compiled = Compile(root, s_rootDomain);
+        TargetDependencyStep[] steps = compiled.TargetDependencies.Steps.ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(steps.Select(static step => step.Kind), Is.EqualTo(new[]
+            {
+                TargetDependencyKind.Composite,
+                TargetDependencyKind.Command,
+                TargetDependencyKind.Composite,
+            }));
+            Assert.That(steps.Select(static step => step.ScopeId).Distinct().Count(), Is.EqualTo(1));
+            Assert.That(steps[1].InputToken, Is.EqualTo(steps[0].OutputToken));
+            Assert.That(steps[2].InputToken, Is.EqualTo(steps[1].OutputToken));
+            Assert.That(compiled.Measurement.OutputBounds, Is.EqualTo(s_rootDomain));
+            Assert.That(compiled.Measurement.QueryBounds, Is.EqualTo(new Rect(0, 0, 60, 30)));
+        });
+    }
+
+    [Test]
+    public void FiniteLayer_ThreadsA_Clear_BLocallyThenCompositesExactlyOnce()
+    {
+        var domain = new Rect(10, 20, 50, 30);
+        using var root = new ContainerRenderNode();
+        var layer = new LayerRenderNode(domain);
+        layer.AddChild(new SourceNode(new Rect(12, 22, 5, 4), "layer-a"));
+        layer.AddChild(new ClearRenderNode(Colors.Transparent));
+        layer.AddChild(new SourceNode(new Rect(30, 35, 6, 7), "layer-b"));
+        root.AddChild(layer);
+
+        using CompiledRenderRequest compiled = Compile(root, targetDomain: null);
+        TargetScopePlan local = FindOwnedScope(compiled, RenderFragmentKind.Layer);
+        TargetDependencyStep[] localSteps = compiled.TargetDependencies.Steps
+            .Where(step => step.ScopeId == local.Id)
+            .ToArray();
+        TargetDependencyStep outer = compiled.TargetDependencies.Steps.Single(step =>
+            step.Kind == TargetDependencyKind.ScopeComposite);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(local.ResolvedDomain, Is.EqualTo(domain));
+            Assert.That(local.IsOrderOnly, Is.False);
+            Assert.That(localSteps.Select(static step => step.Kind), Is.EqualTo(new[]
+            {
+                TargetDependencyKind.Composite,
+                TargetDependencyKind.Command,
+                TargetDependencyKind.Composite,
+            }));
+            Assert.That(localSteps[1].InputToken, Is.EqualTo(localSteps[0].OutputToken));
+            Assert.That(localSteps[2].InputToken, Is.EqualTo(localSteps[1].OutputToken));
+            Assert.That(outer.ScopeId, Is.Not.EqualTo(local.Id));
+            Assert.That(compiled.Measurement.OutputBounds, Is.EqualTo(domain));
+            Assert.That(compiled.Measurement.QueryBounds, Is.EqualTo(new Rect(12, 22, 24, 20)));
+        });
+    }
+
+    [Test]
+    public void FiniteLayerFanOutAcrossTargetDomains_ExecutesWithOneResolvedOwningScope()
+    {
+        var layerDomain = new Rect(0, 0, 24, 16);
+        var secondTargetDomain = new Rect(8, 4, 40, 24);
+        using var root = new LayerFanOutNode(layerDomain, secondTargetDomain);
+        using CompiledRenderRequest compiled = Compile(root, s_rootDomain);
+        int owningScopeCount = compiled.TargetDependencies.Scopes.Count(scope =>
+            scope.OwnerFragmentId is { } owner
+            && References(compiled.Graph)[owner].Kind == RenderFragmentKind.Layer);
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_rootDomain,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        using RenderNodeRasterization raster = renderer.Rasterize();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(raster.Bitmap, Is.Not.Null);
+            Assert.That(owningScopeCount, Is.EqualTo(1));
+            Assert.That(root.SourceExecutionCount, Is.EqualTo(1));
+            Assert.That(AlphaAt(raster.Bitmap!, 4, 4), Is.GreaterThan(0.99f));
+        });
+    }
+
+    [Test]
+    public void TransformedFullTargetLayer_ResolvesAgainstMappedCurrentTargetDomain()
+    {
+        using var root = new ContainerRenderNode();
+        var transform = new TransformRenderNode(
+            Matrix.CreateTranslation(10, 0),
+            TransformOperator.Prepend);
+        var isolation = new LayerRenderNode(default);
+        isolation.AddChild(new ClearRenderNode(Colors.White));
+        transform.AddChild(isolation);
+        root.AddChild(transform);
+
+        using CompiledRenderRequest compiled = Compile(root, s_rootDomain);
+        TargetScopePlan transformed = FindOwnedScope(compiled, RenderFragmentKind.TargetScope);
+        TargetScopePlan isolated = FindOwnedScope(compiled, RenderFragmentKind.TargetLayerScope);
+        RenderFragmentReference transformedReference = References(compiled.Graph)[transformed.OwnerFragmentId!.Value];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(transformed.ResolvedDomain, Is.EqualTo(new Rect(-10, 0, 100, 60)));
+            Assert.That(isolated.ResolvedDomain, Is.EqualTo(new Rect(-10, 0, 100, 60)));
+            Assert.That(isolated.ParentId, Is.EqualTo(transformed.Id));
+            Assert.That(compiled.Measurement.OutputBounds, Is.EqualTo(s_rootDomain));
+            Assert.That(compiled.Measurement.QueryBounds, Is.EqualTo(Rect.Empty));
+            Assert.That(compiled.ExecutionTargetBounds, Is.EqualTo(s_rootDomain));
+            Assert.That(
+                compiled.Regions.GetFragmentRequirement(transformedReference).Resolve(s_rootDomain),
+                Is.EqualTo(s_rootDomain));
+        });
+
+        var factory = new CpuTargetFactory();
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_rootDomain,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = factory,
+            });
+        using RenderNodeRasterization raster = renderer.Rasterize();
+        Bitmap bitmap = raster.Bitmap!;
+        Assert.Multiple(() =>
+        {
+            Assert.That(raster.Bounds, Is.EqualTo(s_rootDomain));
+            Assert.That(bitmap, Is.Not.Null);
+            Assert.That(AlphaAt(bitmap, 0, 30), Is.GreaterThan(0.99f),
+                "The inverse-mapped local Full must include the root's left edge.");
+            Assert.That(AlphaAt(bitmap, 99, 30), Is.GreaterThan(0.99f),
+                "The local Full must still include the root's right edge.");
+        });
+    }
+
+    [Test]
+    public void ClippedTransformedFullTargetLayer_ResolvesAgainstTheClippedLocalDomain()
+    {
+        var clipDomain = new Rect(20, 0, 30, 60);
+        using var root = new RectClipRenderNode(clipDomain, ClipOperation.Intersect);
+        var transform = new TransformRenderNode(
+            Matrix.CreateTranslation(10, 0),
+            TransformOperator.Prepend);
+        var isolation = new LayerRenderNode(default);
+        isolation.AddChild(new ClearRenderNode(Colors.White));
+        transform.AddChild(isolation);
+        root.AddChild(transform);
+
+        using CompiledRenderRequest compiled = Compile(root, s_rootDomain);
+        IReadOnlyDictionary<RenderFragmentId, RenderFragmentReference> references = References(compiled.Graph);
+        TargetScopePlan[] mappedScopes = compiled.TargetDependencies.Scopes
+            .Where(scope => scope.OwnerFragmentId is { } owner
+                            && references[owner].Kind == RenderFragmentKind.TargetScope)
+            .ToArray();
+        TargetScopePlan clipped = mappedScopes.Single(scope =>
+            scope.ResolvedDomain == clipDomain);
+        TargetScopePlan transformed = mappedScopes.Single(scope =>
+            scope.ParentId == clipped.Id);
+        TargetScopePlan isolated = FindOwnedScope(compiled, RenderFragmentKind.TargetLayerScope);
+        RenderFragmentReference transformedReference = references[transformed.OwnerFragmentId!.Value];
+        var localDomain = new Rect(10, 0, 30, 60);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(transformed.ResolvedDomain, Is.EqualTo(localDomain));
+            Assert.That(isolated.ResolvedDomain, Is.EqualTo(localDomain));
+            Assert.That(isolated.ParentId, Is.EqualTo(transformed.Id));
+            Assert.That(compiled.Measurement.OutputBounds, Is.EqualTo(clipDomain));
+            Assert.That(compiled.Measurement.QueryBounds, Is.EqualTo(Rect.Empty));
+            Assert.That(compiled.ExecutionTargetBounds, Is.EqualTo(clipDomain));
+            Assert.That(
+                compiled.Regions.GetFragmentRequirement(transformedReference).Resolve(clipDomain),
+                Is.EqualTo(clipDomain));
+        });
+
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_rootDomain,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+        using RenderNodeRasterization raster = renderer.Rasterize();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(raster.Bounds, Is.EqualTo(clipDomain));
+            Assert.That(AlphaAt(raster.Bitmap!, 0, 30), Is.GreaterThan(0.99f));
+            Assert.That(AlphaAt(raster.Bitmap!, 29, 30), Is.GreaterThan(0.99f));
+        });
+    }
+
+    [Test]
+    public void TransformedRootReadback_MapsItsLocalAccessIntoTheRootExecutionTarget()
+    {
+        var localAccess = new Rect(5, 7, 20, 11);
+        using var root = new ContainerRenderNode();
+        root.AddChild(new OrderOnlyCommandNode());
+        var transform = new TransformRenderNode(
+            Matrix.CreateTranslation(10, 0),
+            TransformOperator.Prepend);
+        transform.AddChild(new ReadbackCommandNode(localAccess));
+        root.AddChild(transform);
+
+        using CompiledRenderRequest compiled = Compile(root, s_rootDomain);
+        RenderFragmentReference readback = References(compiled.Graph).Values.Single(reference =>
+            reference.Payload is TargetCommandRenderFragmentPayload payload
+            && payload.Description.Access == TargetAccess.Readback);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(compiled.SelectedOutputBounds, Is.EqualTo(new Rect(15, 7, 20, 11)));
+            Assert.That(
+                compiled.Regions.GetTargetAccessRequirement(readback).Resolve(s_rootDomain),
+                Is.EqualTo(localAccess));
+            Assert.That(
+                compiled.ExecutionTargetBounds,
+                Is.EqualTo(new Rect(15, 7, 20, 11)));
+        });
+    }
+
+    [Test]
+    public void FiniteReadbackRequirement_CrossesAnUnresolvedTargetScope()
+    {
+        var localAccess = new Rect(5, 7, 20, 11);
+        using var root = new ContainerRenderNode();
+        root.AddChild(new OrderOnlyCommandNode());
+        var transform = new TransformRenderNode(
+            Matrix.CreateTranslation(10, 0),
+            TransformOperator.Prepend);
+        transform.AddChild(new ReadbackCommandNode(localAccess));
+        root.AddChild(transform);
+
+        using CompiledRenderRequest compiled = Compile(root, targetDomain: null);
+
+        Assert.That(
+            compiled.ExecutionTargetBounds,
+            Is.EqualTo(new Rect(15, 7, 20, 11)));
+    }
+
+    [TestCase("opacity")]
+    [TestCase("blend")]
+    [TestCase("opacity-mask")]
+    public void TypedTargetStateScope_PreservesTargetOnlyFullWrite(string scopeKind)
+    {
+        using ContainerRenderNode root = scopeKind switch
+        {
+            "opacity" => new OpacityRenderNode(1),
+            "blend" => new BlendModeRenderNode(BlendMode.SrcOver),
+            "opacity-mask" => new OpacityMaskRenderNode(
+                Brushes.Resource.White,
+                s_rootDomain,
+                invert: false),
+            _ => throw new ArgumentOutOfRangeException(nameof(scopeKind)),
+        };
+        root.AddChild(new ClearRenderNode(Colors.White));
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_rootDomain,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        using RenderNodeRasterization raster = renderer.Rasterize();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(raster.Bounds, Is.EqualTo(s_rootDomain));
+            Assert.That(AlphaAt(raster.Bitmap!, 0, 30), Is.GreaterThan(0.99f));
+            Assert.That(AlphaAt(raster.Bitmap!, 99, 30), Is.GreaterThan(0.99f));
+        });
+    }
+
+    [Test]
+    public void DestructiveBlend_LowersAsFullDomainTargetCommand()
+    {
+        var sourceBounds = new Rect(20, 10, 30, 20);
+        using var root = new BlendModeRenderNode(BlendMode.DstIn);
+        root.AddChild(new SourceNode(sourceBounds, "dst-in-source"));
+
+        using CompiledRenderRequest compiled = Compile(root, s_rootDomain);
+        RenderFragmentReference blend = References(compiled.Graph).Values.Single(reference =>
+            reference.Kind == RenderFragmentKind.Blend);
+        TargetDependencyStep step = compiled.TargetDependencies.Steps.Single(item =>
+            item.FragmentId == blend.Id);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(step.Kind, Is.EqualTo(TargetDependencyKind.Command));
+            Assert.That(compiled.Measurement.OutputBounds, Is.EqualTo(s_rootDomain));
+            Assert.That(compiled.Measurement.QueryBounds, Is.EqualTo(sourceBounds));
+            Assert.That(
+                compiled.Regions.GetTargetAccessRequirement(blend).Resolve(s_rootDomain),
+                Is.EqualTo(s_rootDomain));
+            Assert.That(
+                compiled.Regions.GetFragmentRequirement(blend).Resolve(s_rootDomain),
+                Is.EqualTo(s_rootDomain));
+        });
+    }
+
+    [Test]
+    public void NonDestructiveBlend_KeepsChildBoundsComposite()
+    {
+        var sourceBounds = new Rect(20, 10, 30, 20);
+        using var root = new BlendModeRenderNode(BlendMode.Multiply);
+        root.AddChild(new SourceNode(sourceBounds, "multiply-source"));
+
+        using CompiledRenderRequest compiled = Compile(root, s_rootDomain);
+        RenderFragmentReference blend = References(compiled.Graph).Values.Single(reference =>
+            reference.Kind == RenderFragmentKind.Blend);
+        TargetDependencyStep step = compiled.TargetDependencies.Steps.Single(item =>
+            item.FragmentId == blend.Id);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(step.Kind, Is.EqualTo(TargetDependencyKind.Composite));
+            Assert.That(compiled.Measurement.OutputBounds, Is.EqualTo(sourceBounds));
+            Assert.That(compiled.Measurement.QueryBounds, Is.EqualTo(sourceBounds));
+            Assert.That(compiled.Regions.GetTargetAccessRequirement(blend).IsEmpty, Is.True);
+        });
+    }
+
+    [TestCaseSource(nameof(AllBlendModes))]
+    public void BlendMode_FullTargetRegionClassificationMatchesTransparentSourceSemantics(
+        BlendMode blendMode)
+    {
+        bool transparentSourceChangesDestination = TransparentSourceChangesDestination(blendMode);
+
+        Assert.That(
+            BlendModeRenderNode.RequiresFullTargetRegion(blendMode),
+            Is.EqualTo(transparentSourceChangesDestination));
+    }
+
+    private static IEnumerable<BlendMode> AllBlendModes()
+        => Enum.GetValues<BlendMode>();
+
+    private static bool TransparentSourceChangesDestination(BlendMode blendMode)
+    {
+        var destination = new SKColor(53, 107, 181, 199);
+        using var bitmap = new SKBitmap(
+            new SKImageInfo(1, 1, SKColorType.Rgba8888, SKAlphaType.Premul));
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(destination);
+        SKColor before = bitmap.GetPixel(0, 0);
+        using var paint = new SKPaint
+        {
+            Color = SKColors.Transparent,
+            BlendMode = (SKBlendMode)blendMode,
+        };
+
+        canvas.DrawRect(SKRect.Create(1, 1), paint);
+
+        return bitmap.GetPixel(0, 0) != before;
+    }
+
+    [Test]
+    public void OpacityMask_DrawableBrushDependency_RemainsValueOnlyInTargetPlan()
+    {
+        var subjectBounds = new Rect(5, 6, 12, 8);
+        using Brush.Resource mask = CreateRemoteDrawableBrush();
+        using var root = new OpacityMaskRenderNode(mask, s_rootDomain, invert: false);
+        root.AddChild(new SourceNode(subjectBounds, "mask-subject"));
+
+        using CompiledRenderRequest compiled = Compile(root, s_rootDomain);
+        IReadOnlyDictionary<RenderFragmentId, RenderFragmentReference> references = References(compiled.Graph);
+        RenderFragmentReference maskRoot = references[compiled.Graph.PublicationRoots.Single()];
+        RenderFragmentReference maskDependency = maskRoot.Inputs[1];
+        TargetScopePlan dependencyScope = compiled.TargetDependencies.Scopes.Single(scope =>
+            scope.OwnerFragmentId == maskDependency.Id);
+        TargetDependencyStep[] steps = compiled.TargetDependencies.Steps.ToArray();
+        TargetDependencyStep rootComposite = steps.Single(step => step.FragmentId == maskRoot.Id);
+        int rootCompositeIndex = Array.IndexOf(steps, rootComposite);
+        HashSet<TargetScopeId> dependencyScopes = [dependencyScope.Id];
+        bool addedScope;
+        do
+        {
+            addedScope = false;
+            foreach (TargetScopePlan scope in compiled.TargetDependencies.Scopes)
+            {
+                if (scope.ParentId is { } parent
+                    && dependencyScopes.Contains(parent)
+                    && dependencyScopes.Add(scope.Id))
+                {
+                    addedScope = true;
+                }
+            }
+        }
+        while (addedScope);
+        int[] dependencyStepIndices = steps
+            .Select((step, index) => (step, index))
+            .Where(item => dependencyScopes.Contains(item.step.ScopeId))
+            .Select(static item => item.index)
+            .ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(maskRoot.Kind, Is.EqualTo(RenderFragmentKind.OpacityMask));
+            Assert.That(maskDependency.Kind, Is.EqualTo(RenderFragmentKind.Layer));
+            Assert.That(maskDependency.CanBeUsedAsValueInput, Is.True);
+            Assert.That(maskRoot.CanBeUsedAsValueInput, Is.True);
+            Assert.That(maskDependency.Bounds.Intersects(subjectBounds), Is.False,
+                "The test mask dependency must stay remote from the subject bounds.");
+            Assert.That(dependencyStepIndices, Is.Not.Empty,
+                "The DrawableBrush layer must retain its internal materialization steps.");
+            Assert.That(dependencyStepIndices, Is.All.LessThan(rootCompositeIndex));
+            Assert.That(steps, Has.None.Matches<TargetDependencyStep>(step =>
+                step.FragmentId == maskDependency.Id
+                && step.Kind == TargetDependencyKind.ScopeComposite));
+            Assert.That(rootComposite.Kind, Is.EqualTo(TargetDependencyKind.Composite));
+            Assert.That(compiled.Measurement.OutputBounds, Is.EqualTo(subjectBounds));
+            Assert.That(compiled.Measurement.QueryBounds, Is.EqualTo(subjectBounds));
+            Assert.That(compiled.ExecutionTargetBounds, Is.EqualTo(subjectBounds));
+        });
+    }
+
+    [Test]
+    public void NestedOpacityMask_DrawableBrushDependencyScopesRemainInTargetPlan()
+    {
+        var subjectBounds = new Rect(5, 6, 12, 8);
+        using Brush.Resource mask = CreateRemoteDrawableBrush();
+        using var root = new OpacityRenderNode(0.5f);
+        var opacityMask = new OpacityMaskRenderNode(mask, s_rootDomain, invert: false);
+        opacityMask.AddChild(new SourceNode(subjectBounds, "nested-mask-subject"));
+        root.AddChild(opacityMask);
+
+        using CompiledRenderRequest compiled = Compile(root, s_rootDomain);
+        IReadOnlyDictionary<RenderFragmentId, RenderFragmentReference> references = References(compiled.Graph);
+        RenderFragmentReference opacityRoot = references[compiled.Graph.PublicationRoots.Single()];
+        RenderFragmentReference maskRoot = opacityRoot.Inputs.Single();
+        RenderFragmentReference maskDependency = maskRoot.Inputs[1];
+        TargetScopePlan dependencyScope = compiled.TargetDependencies.Scopes.Single(scope =>
+            scope.OwnerFragmentId == maskDependency.Id);
+        TargetDependencyStep[] steps = compiled.TargetDependencies.Steps.ToArray();
+        int maskCompositeIndex = Array.FindIndex(
+            steps,
+            step => step.FragmentId == maskRoot.Id
+                    && step.Kind == TargetDependencyKind.Composite);
+        HashSet<TargetScopeId> dependencyScopes = [dependencyScope.Id];
+        bool addedScope;
+        do
+        {
+            addedScope = false;
+            foreach (TargetScopePlan scope in compiled.TargetDependencies.Scopes)
+            {
+                if (scope.ParentId is { } parent
+                    && dependencyScopes.Contains(parent)
+                    && dependencyScopes.Add(scope.Id))
+                {
+                    addedScope = true;
+                }
+            }
+        }
+        while (addedScope);
+        int[] dependencyStepIndices = steps
+            .Select((step, index) => (step, index))
+            .Where(item => dependencyScopes.Contains(item.step.ScopeId))
+            .Select(static item => item.index)
+            .ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(opacityRoot.Kind, Is.EqualTo(RenderFragmentKind.Opacity));
+            Assert.That(maskRoot.Kind, Is.EqualTo(RenderFragmentKind.OpacityMask));
+            Assert.That(maskDependency.Kind, Is.EqualTo(RenderFragmentKind.Layer));
+            Assert.That(maskRoot.HasTargetEffects, Is.True);
+            Assert.That(opacityRoot.HasTargetEffects, Is.True);
+            Assert.That(dependencyStepIndices, Is.Not.Empty,
+                "The nested DrawableBrush layer must retain its materialization scope.");
+            Assert.That(maskCompositeIndex, Is.GreaterThanOrEqualTo(0));
+            Assert.That(dependencyStepIndices, Is.All.LessThan(maskCompositeIndex));
+            Assert.That(compiled.Measurement.OutputBounds, Is.EqualTo(subjectBounds));
+            Assert.That(compiled.Measurement.QueryBounds, Is.EqualTo(subjectBounds));
+            Assert.That(compiled.ExecutionTargetBounds, Is.EqualTo(subjectBounds));
+        });
+    }
+
+    [Test]
+    public void OpacityMask_NonContributingCommandPrimary_ExcludesDrawableBrushDependencyFromTargetMetadata()
+    {
+        var commandBounds = new Rect(7, 8, 9, 6);
+        using Brush.Resource mask = CreateRemoteDrawableBrush();
+        using var root = new OpacityMaskRenderNode(mask, s_rootDomain, invert: false);
+        root.AddChild(new FiniteCommandNode(commandBounds));
+
+        using CompiledRenderRequest compiled = Compile(root, s_rootDomain);
+        RenderFragmentReference maskRoot = References(compiled.Graph)[compiled.Graph.PublicationRoots.Single()];
+        RenderFragmentReference maskDependency = maskRoot.Inputs[1];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(maskRoot.Kind, Is.EqualTo(RenderFragmentKind.OpacityMask));
+            Assert.That(maskRoot.ContributesValuesToTarget, Is.False);
+            Assert.That(maskRoot.PotentiallyWritesTarget, Is.True);
+            Assert.That(maskDependency.Bounds.Intersects(commandBounds), Is.False,
+                "The test mask dependency must stay remote from the command metadata.");
+            Assert.That(compiled.Measurement.OutputBounds, Is.EqualTo(commandBounds));
+            Assert.That(compiled.Measurement.QueryBounds, Is.EqualTo(commandBounds));
+            Assert.That(compiled.ExecutionTargetBounds, Is.EqualTo(commandBounds));
+        });
+    }
+
+    [Test]
+    public void RootFullTargetLayer_ReplaysAndCompositesItsLocalTarget()
+    {
+        using var root = new EmptyTargetLayerNode(TargetRegion.Full);
+        root.AddChild(new FullCommandNode(Colors.White));
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_rootDomain,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        using RenderNodeRasterization raster = renderer.Rasterize();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(raster.Bounds, Is.EqualTo(s_rootDomain));
+            Assert.That(AlphaAt(raster.Bitmap!, 0, 30), Is.GreaterThan(0.99f));
+            Assert.That(AlphaAt(raster.Bitmap!, 99, 30), Is.GreaterThan(0.99f));
+        });
+    }
+
+    [Test]
+    public void EmptyTargetLayer_RemainsOrderOnlyWithoutAChainOrPixelSteps()
+    {
+        using var root = new ContainerRenderNode();
+        var empty = new EmptyTargetLayerNode();
+        empty.AddChild(new SourceNode(new Rect(0, 0, 20, 20), "empty-source"));
+        empty.AddChild(new ClearRenderNode(Colors.Transparent));
+        root.AddChild(empty);
+        root.AddChild(new SourceNode(new Rect(30, 0, 10, 10), "after-empty"));
+
+        using CompiledRenderRequest compiled = Compile(root, s_rootDomain);
+        TargetScopePlan scope = FindOwnedScope(compiled, RenderFragmentKind.TargetLayerScope);
+        IReadOnlyDictionary<RenderFragmentId, RenderFragmentReference> references = References(compiled.Graph);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(scope.ResolvedDomain, Is.EqualTo(Rect.Empty));
+            Assert.That(scope.IsOrderOnly, Is.True);
+            Assert.That(compiled.TargetDependencies.Steps.Count(step => step.ScopeId == scope.Id), Is.Zero);
+            Assert.That(compiled.TargetDependencies.Steps.Length, Is.EqualTo(1));
+            Assert.That(
+                references[compiled.TargetDependencies.Steps.Single().FragmentId].Kind,
+                Is.EqualTo(RenderFragmentKind.OpaqueSource));
+            Assert.That(compiled.Measurement.OutputBounds, Is.EqualTo(new Rect(30, 0, 10, 10)));
+            Assert.That(compiled.Measurement.QueryBounds, Is.EqualTo(new Rect(30, 0, 10, 10)));
+        });
+    }
+
+    [Test]
+    public void EmptyTargetLayer_SuppressesChildExecutionAndCompletesTheIslandSchedule()
+    {
+        using var root = new ContainerRenderNode();
+        var empty = new EmptyTargetLayerNode();
+        var suppressed = new SourceNode(new Rect(0, 0, 20, 20), "suppressed");
+        var visible = new SourceNode(new Rect(30, 0, 10, 10), "visible", execute: true);
+        empty.AddChild(suppressed);
+        root.AddChild(empty);
+        root.AddChild(visible);
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_rootDomain,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        using RenderNodeRasterization raster = renderer.Rasterize();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(suppressed.ExecuteCount, Is.Zero);
+            Assert.That(visible.ExecuteCount, Is.EqualTo(1));
+            Assert.That(raster.Bounds, Is.EqualTo(new Rect(30, 0, 10, 10)));
+            Assert.That(AlphaAt(raster.Bitmap!, 5, 5), Is.GreaterThan(0.99f));
+        });
+    }
+
+    [Test]
+    public void FullWithoutAnOwningDomain_FailsDuringLowering_NotDuringRecording()
+    {
+        using var fullCommand = new FullCommandNode();
+        using var owner = new RenderRequestOwner();
+        var request = new RenderRequest(Options(targetDomain: null, owner: owner));
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(fullCommand);
+
+        InvalidOperationException? error = Assert.Throws<RenderTargetDomainRequiredException>(
+            () => new RenderRequestCompiler().Compile(request, graph));
+
+        Assert.That(error!.Message, Does.Contain("finite").And.Contain("target domain").IgnoreCase);
+    }
+
+    [Test]
+    public void FullTargetCaptureBoundsOutsideFiniteLayer_AreRejectedDuringLowering()
+    {
+        var layerDomain = new Rect(10, 20, 30, 20);
+        var captureBounds = new Rect(5, 20, 10, 10);
+        using var root = new OutOfDomainCaptureLayerNode(layerDomain, captureBounds);
+
+        InvalidOperationException? error = Assert.Throws<InvalidOperationException>(
+            () =>
+            {
+                using CompiledRenderRequest _ = Compile(root, targetDomain: null);
+            });
+
+        Assert.That(
+            error!.Message,
+            Does.Contain("capture bounds").And.Contain("target domain").IgnoreCase);
+    }
+
+    [Test]
+    public void RequestedRegionDoesNotSupplyMissingTargetDomain_ButFiniteLayerDoes()
+    {
+        using var command = new FullCommandNode();
+        Assert.That(
+            () => Compile(command, targetDomain: null, requestedRegion: new Rect(2, 3, 4, 5)),
+            Throws.TypeOf<RenderTargetDomainRequiredException>());
+
+        using var root = new ContainerRenderNode();
+        var finite = new LayerRenderNode(new Rect(10, 20, 30, 40));
+        var nestedFull = new EmptyTargetLayerNode(TargetRegion.Full);
+        nestedFull.AddChild(new ClearRenderNode(Colors.Transparent));
+        finite.AddChild(nestedFull);
+        root.AddChild(finite);
+
+        using CompiledRenderRequest compiled = Compile(root, targetDomain: null);
+        TargetScopePlan isolated = FindOwnedScope(compiled, RenderFragmentKind.TargetLayerScope);
+        Assert.That(isolated.ResolvedDomain, Is.EqualTo(new Rect(10, 20, 30, 40)));
+    }
+
+    [Test]
+    public void FullClear_UsesOutputDomainButKeepsQueryAndHitTestingEmpty()
+    {
+        var domain = new Rect(10, 20, 40, 30);
+        using var root = new FullCommandNode(Colors.White);
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = domain,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        RenderNodeMeasurement measurement = renderer.Measure();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(measurement.OutputBounds, Is.EqualTo(domain));
+            Assert.That(measurement.QueryBounds, Is.EqualTo(Rect.Empty));
+            Assert.That(renderer.HitTest(new Point(20, 25)), Is.False);
+        });
+
+        using RenderNodeRasterization raster = renderer.Rasterize();
+        Assert.That(AlphaAt(raster.Bitmap!, 20, 15), Is.GreaterThan(0.99f));
+    }
+
+    [Test]
+    public void ReadbackCommandWrites_AreIncludedInOutputPlanning()
+    {
+        using var root = new WritingReadbackCommandNode();
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_rootDomain,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+
+        using RenderNodeRasterization raster = renderer.Rasterize();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(root.ExecutionCount, Is.EqualTo(1));
+            Assert.That(raster.Bounds, Is.EqualTo(s_rootDomain));
+            Assert.That(raster.Bitmap, Is.Not.Null);
+            Assert.That(AlphaAt(raster.Bitmap!, 50, 30), Is.GreaterThan(0.99f));
+        });
+    }
+
+    [Test]
+    public void Rasterize_ReportsTheDeviceCoverOfAShiftedSelection_AndEmptySelectionDoesNotAllocate()
+    {
+        var factory = new CpuTargetFactory();
+        var shifted = new Rect(10.25f, 20.25f, 3.5f, 2.5f);
+        using var root = new SourceNode(shifted, "shifted-raster", execute: true);
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    OutputScale = 2,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = factory,
+            });
+
+        using (RenderNodeRasterization raster = renderer.Rasterize())
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(raster.Bounds, Is.EqualTo(PixelRect.FromRect(shifted, 2).ToRect(2)));
+                Assert.That(raster.Bounds.Contains(shifted), Is.True);
+                Assert.That(raster.Bitmap, Is.Not.Null);
+                Assert.That(raster.OutputScale, Is.EqualTo(2));
+            });
+        }
+
+        int allocationsAfterShifted = factory.AllocationCount;
+        var emptySelection = new Rect(70, 80, 0, 5);
+        using var emptyRenderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    RequestedRegion = emptySelection,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = factory,
+            });
+        using RenderNodeRasterization empty = emptyRenderer.Rasterize();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(empty.Bounds, Is.EqualTo(emptySelection));
+            Assert.That(empty.IsEmpty, Is.True);
+            Assert.That(empty.Bitmap, Is.Null);
+            Assert.That(factory.AllocationCount, Is.EqualTo(allocationsAfterShifted));
+        });
+    }
+
+    private static CompiledRenderRequest Compile(
+        RenderNode root,
+        Rect? targetDomain,
+        Rect? requestedRegion = null)
+    {
+        var request = new RenderRequest(Options(targetDomain, requestedRegion));
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(root);
+        return new RenderRequestCompiler().Compile(request, graph);
+    }
+
+    private static RenderRequestOptions Options(
+        Rect? targetDomain,
+        Rect? requestedRegion = null,
+        RenderRequestOwner? owner = null)
+        => new(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            targetDomain,
+            requestedRegion,
+            cachePolicy: RenderCacheOptions.Disabled,
+            owner: owner);
+
+    private static TargetScopePlan FindOwnedScope(
+        CompiledRenderRequest compiled,
+        RenderFragmentKind kind)
+    {
+        IReadOnlyDictionary<RenderFragmentId, RenderFragmentReference> references = References(compiled.Graph);
+        return compiled.TargetDependencies.Scopes.Single(scope =>
+            scope.OwnerFragmentId is { } owner && references[owner].Kind == kind);
+    }
+
+    private static IReadOnlyDictionary<RenderFragmentId, RenderFragmentReference> References(
+        RecordedRenderGraph graph)
+        => graph.Fragments.ToDictionary(
+            static fragment => fragment.Id,
+            static fragment => (RenderFragmentReference)fragment.Payload!);
+
+    private static float AlphaAt(Bitmap bitmap, int x, int y)
+    {
+        Span<ushort> row = bitmap.GetRow<ushort>(y);
+        return (float)BitConverter.UInt16BitsToHalf(row[(x * 4) + 3]);
+    }
+
+    private static Brush.Resource CreateRemoteDrawableBrush()
+    {
+        var content = new RectShape();
+        content.Width.CurrentValue = 10;
+        content.Height.CurrentValue = 8;
+        content.AlignmentX.CurrentValue = AlignmentX.Right;
+        content.AlignmentY.CurrentValue = AlignmentY.Bottom;
+        content.Fill.CurrentValue = Brushes.White;
+        var brush = new DrawableBrush(content);
+        return (Brush.Resource)brush.ToResource(CompositionContext.Default);
+    }
+
+    private sealed class FullCommandNode(Color? color = null) : RenderNode
+    {
+        private readonly Color _color = color ?? Colors.Transparent;
+
+        public override void Process(RenderNodeContext context)
+        {
+            Color color = _color;
+            context.Publish(context.TargetCommand(
+                [],
+                TargetCommandDescription.CreateRequestLocal(
+                    session => session.Canvas.Use(canvas => canvas.Clear(color)),
+                    TargetRegion.Full,
+                    Rect.Empty,
+                    RenderHitTestContract.None)));
+        }
+    }
+
+    private sealed class ReadbackCommandNode(Rect region) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            context.Publish(context.TargetCommand(
+                [],
+                TargetCommandDescription.CreateRequestLocal(
+                    session => session.UseSnapshot(static _ => { }),
+                    TargetRegion.Region(region),
+                    Rect.Empty,
+                    RenderHitTestContract.None,
+                    TargetAccess.Readback)));
+        }
+    }
+
+    private sealed class WritingReadbackCommandNode : RenderNode
+    {
+        public int ExecutionCount { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            context.Publish(context.TargetCommand(
+                [],
+                TargetCommandDescription.CreateRequestLocal(
+                    session =>
+                    {
+                        ExecutionCount++;
+                        session.UseSnapshot(static _ => { });
+                        session.Canvas.Use(static canvas => canvas.Clear(Colors.White));
+                    },
+                    TargetRegion.Full,
+                    Rect.Empty,
+                    RenderHitTestContract.None,
+                    TargetAccess.Readback)));
+        }
+    }
+
+    private sealed class OrderOnlyCommandNode : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            context.Publish(context.TargetCommand(
+                [],
+                TargetCommandDescription.CreateRequestLocal(
+                    static _ => { },
+                    TargetRegion.Empty,
+                    Rect.Empty,
+                    RenderHitTestContract.None)));
+        }
+    }
+
+    private sealed class FiniteCommandNode(Rect bounds) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            context.Publish(context.TargetCommand(
+                [],
+                TargetCommandDescription.CreateRequestLocal(
+                    static _ => { },
+                    TargetRegion.Region(bounds),
+                    bounds,
+                    RenderHitTestContract.None)));
+        }
+    }
+
+    private sealed class EmptyTargetLayerNode(TargetRegion? region = null) : ContainerRenderNode
+    {
+        private readonly TargetRegion _region = region ?? TargetRegion.Empty;
+
+        public override void Process(RenderNodeContext context)
+            => context.Publish(context.TargetLayerScope(context.Inputs, _region));
+    }
+
+    private sealed class LayerFanOutNode : RenderNode
+    {
+        private readonly Rect _layerDomain;
+        private readonly Rect _secondTargetDomain;
+        private readonly SourceNode _source;
+
+        public LayerFanOutNode(Rect layerDomain, Rect secondTargetDomain)
+        {
+            _layerDomain = layerDomain;
+            _secondTargetDomain = secondTargetDomain;
+            _source = new SourceNode(layerDomain, "layer-fan-out", execute: true);
+        }
+
+        public int SourceExecutionCount => _source.ExecuteCount;
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle source = context.RecordNode(_source, []).Single();
+            RenderFragmentHandle layer = context.Layer([source], _layerDomain);
+            context.Publish(layer);
+            context.Publish(context.TargetLayerScope(
+                [layer],
+                TargetRegion.Region(_secondTargetDomain)));
+        }
+
+        protected override void OnDispose(bool disposing)
+        {
+            _source.Dispose();
+            base.OnDispose(disposing);
+        }
+    }
+
+    private sealed class OutOfDomainCaptureLayerNode(Rect layerDomain, Rect captureBounds) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle capture = context.TargetCapture(TargetCaptureDescription.Create(
+                TargetRegion.Full,
+                captureBounds,
+                RenderHitTestContract.OutputBounds,
+                TargetCaptureScaleContract.MaterializeAtWorkingScale));
+            RenderFragmentHandle contributing = context.ContributeValues(capture);
+            context.Publish(context.Layer([contributing], layerDomain));
+        }
+    }
+
+    private sealed class SourceNode(Rect bounds, string key, bool execute = false) : RenderNode
+    {
+        public int ExecuteCount { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            OpaqueRenderDescription description = OpaqueRenderDescription.CreateRequestLocal(
+                session =>
+                {
+                    ExecuteCount++;
+                    if (!execute)
+                        throw new AssertionException("Metadata and lowering must not execute source callbacks.");
+
+                    using OpaqueRenderOutput output = session.CreateOutput(session.OutputBounds);
+                    output.Canvas.Use(static canvas => canvas.Clear(Colors.White));
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.Source(bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                structuralKey: (typeof(SourceNode), key));
+            context.Publish(context.OpaqueSource(description));
+        }
+    }
+
+    private sealed class CpuTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public int AllocationCount { get; private set; }
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+        {
+            PixelSize deviceSize = allocation.DeviceSize;
+            AllocationCount++;
+            return new CpuRenderTarget(deviceSize.Width, deviceSize.Height);
+        }
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RasterFootprintMetadataTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RasterFootprintMetadataTests.cs
@@ -1,0 +1,607 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+[NonParallelizable]
+[TestFixture]
+public sealed class RasterFootprintMetadataTests
+{
+    [Test]
+    public void ExecutionInput_DrawsTheCompleteRasterFootprintWithoutChangingSemanticBounds()
+    {
+        const float density = 2;
+        var bounds = new Rect(10.25f, 20.25f, 8, 6);
+        PixelRect deviceBounds = PixelRect.FromRect(bounds, density);
+        Rect rasterBounds = deviceBounds.ToRect(density);
+        Rect? drawnBounds = null;
+        var token = new RenderExecutionSessionToken();
+        var input = new RenderExecutionInput(
+            token,
+            bounds,
+            EffectiveScale.At(density),
+            deviceBounds,
+            draw: (_, destination) => drawnBounds = destination,
+            drawDeviceSpace: static (_, _) => { },
+            createShader: null,
+            createSnapshot: null,
+            readbackDeclared: false);
+
+        using RenderTarget target = RenderTarget.CreateNull(deviceBounds.Width, deviceBounds.Height);
+        var canvas = new RenderCallbackCanvas(
+            token,
+            density,
+            bounds,
+            deviceBounds,
+            () => new ImmediateCanvas(target, density, logicalSize: rasterBounds.Size),
+            CallbackCanvasCapability.Draw);
+
+        canvas.Use(input.Draw);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(input.Bounds, Is.EqualTo(bounds));
+            Assert.That(input.DeviceBounds, Is.EqualTo(deviceBounds));
+            Assert.That(input.RasterBounds, Is.EqualTo(rasterBounds));
+            Assert.That(input.LogicalOrigin, Is.EqualTo(rasterBounds.Position));
+            Assert.That(drawnBounds, Is.EqualTo(rasterBounds));
+        });
+
+        token.Complete();
+    }
+
+    [Test]
+    public void CallbackCanvas_UsesAnExplicitPhysicalFootprintForOriginAndClipping()
+    {
+        const float density = 2;
+        var logicalBounds = new Rect(10.25f, 20.25f, 8, 6);
+        PixelRect canonical = PixelRect.FromRect(logicalBounds, density);
+        var deviceBounds = new PixelRect(
+            canonical.X - 1,
+            canonical.Y - 1,
+            canonical.Width + 2,
+            canonical.Height + 2);
+        Rect rasterBounds = deviceBounds.ToRect(density);
+        var token = new RenderExecutionSessionToken();
+        using RenderTarget target = RenderTarget.CreateNull(deviceBounds.Width, deviceBounds.Height);
+        var facade = new RenderCallbackCanvas(
+            token,
+            density,
+            logicalBounds,
+            deviceBounds,
+            () => new ImmediateCanvas(target, density, logicalSize: rasterBounds.Size),
+            CallbackCanvasCapability.Draw);
+
+        facade.Use(canvas =>
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(facade.LogicalBounds, Is.EqualTo(logicalBounds));
+                Assert.That(facade.DeviceBounds, Is.EqualTo(deviceBounds));
+                Assert.That(facade.RasterBounds, Is.EqualTo(rasterBounds));
+                Assert.That(facade.LogicalOrigin, Is.EqualTo(rasterBounds.Position));
+                Assert.That(canvas.Transform.Transform(rasterBounds.Position), Is.EqualTo(default(Point)));
+            });
+        });
+
+        token.Complete();
+    }
+
+    [Test]
+    public void TargetAttachedCallback_DrawDeviceSpaceUsesTheBackingSurfaceOrigin()
+    {
+        var callbackBounds = new Rect(10, 12, 8, 6);
+        var token = new RenderExecutionSessionToken();
+        Point? observedLocalPoint = null;
+        var input = new RenderExecutionInput(
+            token,
+            new Rect(0, 0, 2, 2),
+            EffectiveScale.At(1),
+            draw: static (_, _) => { },
+            drawDeviceSpace: (_, point) => observedLocalPoint = point,
+            createShader: null,
+            createSnapshot: null,
+            readbackDeclared: false);
+        using RenderTarget target = RenderTarget.CreateNull(64, 48);
+        var facade = new RenderCallbackCanvas(
+            token,
+            density: 1,
+            callbackBounds,
+            () => new ImmediateCanvas(target, logicalSize: new Size(64, 48)),
+            CallbackCanvasCapability.TargetCommandRegion,
+            mapLogicalOrigin: false);
+
+        facade.Use(canvas => input.DrawDeviceSpace(canvas, new Point(20, 30)));
+
+        Assert.That(observedLocalPoint, Is.EqualTo(new Point(20, 30)));
+        token.Complete();
+    }
+
+    [Test]
+    public void TargetAttachedCallback_ReportsTheAmbientTranslationDeviceGrid()
+    {
+        var callbackBounds = new Rect(10, 12, 8, 6);
+        var expectedOffset = new Vector(0.25f, 0.75f);
+        var token = new RenderExecutionSessionToken();
+        using RenderTarget target = RenderTarget.CreateNull(64, 48);
+        using var destination = new ImmediateCanvas(target, logicalSize: new Size(64, 48));
+        using (destination.PushTransform(Matrix.CreateTranslation(expectedOffset)))
+        {
+            RenderCallbackCanvas facade = RenderCallbackCanvas.CreateTargetAttached(
+                token,
+                callbackBounds,
+                destination,
+                CallbackCanvasCapability.TargetCommandRegion);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(facade.DeviceGridOffset, Is.EqualTo(expectedOffset));
+                Assert.That(
+                    facade.RasterBounds,
+                    Is.EqualTo(facade.DeviceBounds.ToRect(facade.Density).Translate(-expectedOffset)));
+                Assert.That(facade.RasterBounds.Contains(callbackBounds), Is.True);
+            });
+        }
+
+        token.Complete();
+    }
+
+    [Test]
+    public void TargetAttachedCallback_AcceptsRoundingNoiseAcrossLargeDeviceTranslation()
+    {
+        var callbackBounds = new Rect(
+            -0.025896728f,
+            -3.2809492E-06f,
+            150.05179f,
+            110);
+        var translation = new Vector(49.97410583f, 70);
+        var token = new RenderExecutionSessionToken();
+        using RenderTarget target = RenderTarget.CreateNull(256, 192);
+        using var destination = new ImmediateCanvas(target, logicalSize: new Size(256, 192));
+        using (destination.PushTransform(Matrix.CreateTranslation(translation)))
+        {
+            RenderCallbackCanvas facade = RenderCallbackCanvas.CreateTargetAttached(
+                token,
+                callbackBounds,
+                destination,
+                CallbackCanvasCapability.TargetScope);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(facade.Density, Is.EqualTo(1));
+                Assert.That(facade.DeviceGridOffset, Is.EqualTo(translation));
+                Assert.That(facade.DeviceBounds, Is.EqualTo(new PixelRect(49, 70, 151, 110)));
+                Assert.That(facade.RasterBounds, Is.EqualTo(new Rect(-0.97410583f, 0, 151, 110)));
+            });
+        }
+
+        token.Complete();
+    }
+
+    [TestCase(1.7f)]
+    [TestCase(1.3333333f)]
+    [TestCase(1.06f)]
+    public void CallbackCanvas_AcceptsLargeCanonicalDeviceFootprints(float density)
+    {
+        var logicalBounds = new Rect(0, 0, 1920, 1080);
+        PixelRect deviceBounds = PixelRect.FromRect(logicalBounds, density);
+        Rect rasterBounds = deviceBounds.ToRect(density);
+        var token = new RenderExecutionSessionToken();
+        try
+        {
+            Assert.That(
+                () => new RenderCallbackCanvas(
+                    token,
+                    density,
+                    logicalBounds,
+                    deviceBounds,
+                    static () => throw new InvalidOperationException("The constructor must not open a canvas."),
+                    CallbackCanvasCapability.Draw,
+                    rasterBounds: rasterBounds),
+                Throws.Nothing);
+        }
+        finally
+        {
+            token.Complete();
+        }
+    }
+
+    [Test]
+    public void DeviceBoundsValidation_RejectsOffByOneExtentAboveFloatPrecisionBoundary()
+    {
+        const int deviceExtent = 8_388_610;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                DeviceBoundsValidation.MatchesExtent(deviceExtent, density: 1, deviceExtent),
+                Is.True);
+            Assert.That(
+                DeviceBoundsValidation.MatchesExtent(deviceExtent + 1, density: 1, deviceExtent),
+                Is.False,
+                "An off-by-one backing extent must not be accepted when float ULPs exceed one pixel.");
+        });
+    }
+
+    [TestCase(1.7f)]
+    [TestCase(1.3333333f)]
+    [TestCase(1.06f)]
+    public void ExecutionInput_AcceptsLargeCanonicalDeviceFootprints(float density)
+    {
+        var logicalBounds = new Rect(0, 0, 1920, 1080);
+        PixelRect deviceBounds = PixelRect.FromRect(logicalBounds, density);
+        Rect rasterBounds = deviceBounds.ToRect(density);
+        var token = new RenderExecutionSessionToken();
+        try
+        {
+            Assert.That(
+                () => new RenderExecutionInput(
+                    token,
+                    logicalBounds,
+                    EffectiveScale.At(density),
+                    deviceBounds,
+                    rasterBounds,
+                    draw: static (_, _) => { },
+                    drawDeviceSpace: static (_, _) => { },
+                    createShader: null,
+                    createSnapshot: null,
+                    readbackDeclared: false),
+                Throws.Nothing);
+        }
+        finally
+        {
+            token.Complete();
+        }
+    }
+
+    [Test]
+    public void CallbackCanvas_RejectsAnOffByOneBackingExtent()
+    {
+        const float density = 1.7f;
+        var logicalBounds = new Rect(0, 0, 1920, 1080);
+        PixelRect canonical = PixelRect.FromRect(logicalBounds, density);
+        Rect rasterBounds = canonical.ToRect(density);
+        var mismatched = new PixelRect(
+            canonical.X,
+            canonical.Y,
+            canonical.Width + 1,
+            canonical.Height);
+        var token = new RenderExecutionSessionToken();
+        try
+        {
+            Assert.That(
+                () => new RenderCallbackCanvas(
+                    token,
+                    density,
+                    logicalBounds,
+                    mismatched,
+                    static () => throw new InvalidOperationException("The constructor must not open a canvas."),
+                    CallbackCanvasCapability.Draw,
+                    rasterBounds: rasterBounds),
+                Throws.ArgumentException.With.Message.Contains("backing size"));
+        }
+        finally
+        {
+            token.Complete();
+        }
+    }
+
+    [Test]
+    public void RenderNodeRenderer_TargetScopeRendersAtScaleOnePointSeven()
+    {
+        const float density = 1.7f;
+        var logicalBounds = new Rect(0, 0, 1920, 1080);
+        using var root = new TransformRenderNode(Matrix.Identity, TransformOperator.Prepend);
+        root.AddChild(new RectangleRenderNode(logicalBounds, Brushes.Resource.White, pen: null));
+        using var target = new CpuRenderTarget(
+            (int)Math.Ceiling(logicalBounds.Width * density),
+            (int)Math.Ceiling(logicalBounds.Height * density));
+        using var destination = new ImmediateCanvas(
+            target,
+            density,
+            logicalSize: logicalBounds.Size);
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = logicalBounds,
+                    OutputScale = density,
+                    MaxWorkingScale = density,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+            });
+
+        Assert.That(() => renderer.Render(destination), Throws.Nothing);
+    }
+
+    [Test]
+    public void TargetAttachedTargetScope_ClipsTheRasterApronOnTheAmbientDeviceGrid()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var callbackBounds = new Rect(10, 4, 4, 4);
+            var gridOffset = new Vector(0.25f, 0.75f);
+            var token = new RenderExecutionSessionToken();
+            using RenderTarget target = RenderTarget.Create(32, 16)
+                ?? throw new InvalidOperationException("RenderTarget.Create returned null.");
+            using var destination = new ImmediateCanvas(target, logicalSize: new Size(32, 16));
+            destination.Clear();
+            PixelRect expectedBounds;
+            using (destination.PushTransform(Matrix.CreateTranslation(gridOffset)))
+            {
+                RenderCallbackCanvas facade = RenderCallbackCanvas.CreateTargetAttached(
+                    token,
+                    callbackBounds,
+                    destination,
+                    CallbackCanvasCapability.TargetScope);
+                expectedBounds = RenderScaleUtilities.AddRasterApron(facade.DeviceBounds);
+                using var paint = new SKPaint { Color = SKColors.White };
+                var session = new TargetScopeSession(
+                    token,
+                    callbackBounds,
+                    callbackBounds,
+                    RenderIntent.Preview,
+                    RenderRequestPurpose.Frame,
+                    facade,
+                    [],
+                    canvas => canvas.Canvas.DrawRect(SKRect.Create(32, 16), paint));
+
+                facade.Use(_ => session.ReplayInput());
+                session.ValidateCompletion();
+            }
+
+            token.Complete();
+            using Bitmap bitmap = target.Snapshot();
+
+            Assert.That(MeasureAlphaBounds(bitmap), Is.EqualTo(expectedBounds));
+        });
+    }
+
+    [Test]
+    public void CachedValue_PreservesThePhysicalFootprintIndependentlyOfSemanticBounds()
+    {
+        const float density = 2;
+        var bounds = new Rect(10.25f, 20.25f, 8, 6);
+        PixelRect canonical = PixelRect.FromRect(bounds, density);
+        var deviceBounds = new PixelRect(
+            canonical.Position,
+            new PixelSize(canonical.Width + 1, canonical.Height + 2));
+        using RenderTarget target = RenderTarget.CreateNull(deviceBounds.Width, deviceBounds.Height);
+        var value = new RenderNodeCachedValue(
+            target,
+            bounds,
+            EffectiveScale.At(density),
+            deviceBounds);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(value.Bounds, Is.EqualTo(bounds));
+            Assert.That(value.CompleteBounds, Is.EqualTo(bounds));
+            Assert.That(value.DeviceBounds, Is.EqualTo(deviceBounds));
+            Assert.That(value.RasterBounds, Is.EqualTo(deviceBounds.ToRect(density)));
+        });
+    }
+
+    [Test]
+    public void CachedValue_RejectsAPhysicalFootprintThatDoesNotContainSemanticBounds()
+    {
+        const float density = 2;
+        var bounds = new Rect(10.25f, 20.25f, 8, 6);
+        PixelRect canonical = PixelRect.FromRect(bounds, density);
+        var shifted = new PixelRect(
+            canonical.X + 1,
+            canonical.Y,
+            canonical.Width,
+            canonical.Height);
+        using RenderTarget target = RenderTarget.CreateNull(shifted.Width, shifted.Height);
+
+        Assert.That(
+            () => new RenderNodeCachedValue(target, bounds, EffectiveScale.At(density), shifted),
+            Throws.ArgumentException.With.Property("ParamName").EqualTo("deviceBounds"));
+    }
+
+    [Test]
+    public void EffectTarget_TranslatesRasterBoundsWithoutMutatingItsAllocationFootprint()
+    {
+        const float density = 2;
+        var bounds = new Rect(10.25f, 20.25f, 8, 6);
+        var deviceGridOffset = new Vector(0.25f, -0.125f);
+        PixelRect deviceBounds = PixelRect.FromRect(bounds.Translate(deviceGridOffset), density);
+        using RenderTarget renderTarget = RenderTarget.CreateNull(deviceBounds.Width, deviceBounds.Height);
+        using var target = new EffectTarget(
+            renderTarget,
+            bounds,
+            EffectiveScale.At(density),
+            deviceBounds,
+            deviceGridOffset);
+        Rect initialRasterBounds = deviceBounds.ToRect(density).Translate(-deviceGridOffset);
+        var translation = new Vector(3.25f, -1.5f);
+
+        target.Bounds = target.Bounds.Translate(translation);
+        using EffectTarget clone = target.Clone();
+        using var targets = new EffectTargets { target.Clone() };
+        using EffectTargets clonedTargets = targets.Clone();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(target.DeviceBounds, Is.EqualTo(deviceBounds));
+            Assert.That(target.DeviceGridOffset, Is.EqualTo(deviceGridOffset));
+            Assert.That(target.RasterBounds, Is.EqualTo(initialRasterBounds.Translate(translation)));
+            Assert.That(target.RasterBounds.Size, Is.EqualTo(initialRasterBounds.Size));
+            Assert.That(clone.DeviceBounds, Is.EqualTo(deviceBounds));
+            Assert.That(clone.DeviceGridOffset, Is.EqualTo(deviceGridOffset));
+            Assert.That(clone.Bounds, Is.EqualTo(target.Bounds));
+            Assert.That(clone.RasterBounds, Is.EqualTo(target.RasterBounds));
+            Assert.That(clonedTargets[0].DeviceBounds, Is.EqualTo(deviceBounds));
+            Assert.That(clonedTargets[0].DeviceGridOffset, Is.EqualTo(deviceGridOffset));
+            Assert.That(clonedTargets[0].RasterBounds, Is.EqualTo(target.RasterBounds));
+        });
+    }
+
+    [Test]
+    public void DeviceBufferSize_RemainsIndependentFromCanonicalDeviceOrigin()
+    {
+        const float density = 2;
+        var bounds = new Rect(10.25f, 20.25f, 8, 6);
+
+        PixelRect actual = CustomFilterEffectContext.DeviceBufferBounds(bounds, density);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(actual, Is.EqualTo(PixelRect.FromRect(bounds, density)));
+            Assert.That(actual.Size, Is.EqualTo(new PixelSize(17, 13)));
+            Assert.That(
+                CustomFilterEffectContext.DeviceBufferSize(bounds, density),
+                Is.EqualTo((16, 12)));
+        });
+    }
+
+    [Test]
+    public void ResolveTargetDensity_UsesLegacyLocalDimensions()
+    {
+        var sourceBounds = new Rect(0, 0, 1, 1);
+        var gridOffset = new Vector(0.5f, 0);
+        PixelRect sourceDeviceBounds = PixelRect.FromRect(
+            sourceBounds.Translate(gridOffset),
+            1);
+        using RenderTarget backing = RenderTarget.CreateNull(
+            sourceDeviceBounds.Width,
+            sourceDeviceBounds.Height);
+        using var source = new EffectTarget(
+            backing,
+            sourceBounds,
+            EffectiveScale.At(1),
+            sourceDeviceBounds,
+            gridOffset);
+        using var targets = new EffectTargets { source.Clone() };
+        var context = new CustomFilterEffectContext(
+            targets,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame);
+        var requestedBounds = new Rect(
+            0,
+            0,
+            RenderScaleUtilities.MaxBufferDimension,
+            1);
+
+        float density = context.ResolveTargetDensity(requestedBounds);
+        (int width, int height) = CustomFilterEffectContext.DeviceBufferSize(
+            requestedBounds,
+            density);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(density, Is.EqualTo(1));
+            Assert.That(width, Is.LessThanOrEqualTo(RenderScaleUtilities.MaxBufferDimension));
+            Assert.That(height, Is.LessThanOrEqualTo(RenderScaleUtilities.MaxBufferDimension));
+        });
+    }
+
+    [Test]
+    public void CustomFilterContext_AllowsInputsFromDifferentDeviceGrids()
+    {
+        var bounds = new Rect(0, 0, 8, 6);
+        var firstOffset = new Vector(0.25f, 0);
+        var secondOffset = new Vector(0.75f, 0);
+        var ambientOffset = new Vector(0.5f, 0.5f);
+        PixelRect firstDeviceBounds = PixelRect.FromRect(bounds.Translate(firstOffset), 1);
+        PixelRect secondDeviceBounds = PixelRect.FromRect(bounds.Translate(secondOffset), 1);
+        using RenderTarget firstBacking = RenderTarget.CreateNull(
+            firstDeviceBounds.Width,
+            firstDeviceBounds.Height);
+        using RenderTarget secondBacking = RenderTarget.CreateNull(
+            secondDeviceBounds.Width,
+            secondDeviceBounds.Height);
+        using var targets = new EffectTargets
+        {
+            new EffectTarget(
+                firstBacking,
+                bounds,
+                EffectiveScale.At(1),
+                firstDeviceBounds,
+                firstOffset),
+            new EffectTarget(
+                secondBacking,
+                bounds,
+                EffectiveScale.At(1),
+                secondDeviceBounds,
+                secondOffset),
+        };
+
+        var context = new CustomFilterEffectContext(
+            targets,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            deviceGridOffset: ambientOffset);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(context.DeviceGridOffset, Is.EqualTo(ambientOffset));
+            Assert.That(context.Targets[0].DeviceGridOffset, Is.EqualTo(firstOffset));
+            Assert.That(context.Targets[1].DeviceGridOffset, Is.EqualTo(secondOffset));
+        });
+    }
+
+    [Test]
+    public void MeasureAlphaBounds_IgnoresNonFiniteAndNonPositiveAlpha()
+    {
+        using var bitmap = new Bitmap(
+            6,
+            1,
+            BitmapColorType.RgbaF16,
+            BitmapAlphaType.Premul,
+            BitmapColorSpace.LinearSrgb);
+        Span<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        float[] alphaValues = [float.NegativeInfinity, -1, 0, float.NaN, float.PositiveInfinity, 0.5f];
+        for (int x = 0; x < alphaValues.Length; x++)
+        {
+            pixels[(x * 4) + 3] = BitConverter.HalfToUInt16Bits((Half)alphaValues[x]);
+        }
+
+        Assert.That(MeasureAlphaBounds(bitmap), Is.EqualTo(new PixelRect(5, 0, 1, 1)));
+    }
+
+    private static PixelRect MeasureAlphaBounds(Bitmap bitmap)
+    {
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        int left = bitmap.Width;
+        int top = bitmap.Height;
+        int right = 0;
+        int bottom = 0;
+        for (int y = 0; y < bitmap.Height; y++)
+        {
+            for (int x = 0; x < bitmap.Width; x++)
+            {
+                int offset = ((y * bitmap.Width) + x) * 4;
+                float alpha = (float)BitConverter.UInt16BitsToHalf(pixels[offset + 3]);
+                if (!float.IsFinite(alpha) || alpha <= 0)
+                    continue;
+                left = Math.Min(left, x);
+                top = Math.Min(top, y);
+                right = Math.Max(right, x + 1);
+                bottom = Math.Max(bottom, y + 1);
+            }
+        }
+
+        return new PixelRect(left, top, right - left, bottom - top);
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/AbandonedRecordedSubtreeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/AbandonedRecordedSubtreeTests.cs
@@ -1,0 +1,147 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Particles;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Shapes;
+using Beutl.Graphics.Transformation;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Recording;
+
+// These bail-outs learn there is nothing to draw only after recording a child subtree, so they
+// abandon a subtree that may already have published target-effect fragments of its own.
+[TestFixture]
+public sealed class AbandonedRecordedSubtreeTests
+{
+    private static readonly Rect s_ownerRect = new(0, 0, 32, 24);
+
+    public enum DegenerateBrushContent
+    {
+        NoDrawable,
+        DisabledDrawable,
+        ZeroAreaDrawable,
+    }
+
+    [Test]
+    public void ParticleRenderNode_WithParticlesScaledToZero_RendersNothingWithoutFailing()
+    {
+        var particle = new RectShape();
+        particle.Width.CurrentValue = 20;
+        particle.Height.CurrentValue = 12;
+        particle.Fill.CurrentValue = Brushes.White;
+
+        var emitter = new ParticleEmitter();
+        emitter.ParticleDrawable.CurrentValue = particle;
+        emitter.MaxParticles.CurrentValue = 1;
+        emitter.Speed.CurrentValue = 0;
+        emitter.Gravity.CurrentValue = 0;
+        emitter.ParticleSize.CurrentValue = 0;
+        emitter.SizeRandom.CurrentValue = 0;
+        using var resource = (ParticleEmitter.Resource)emitter.ToResource(
+            new CompositionContext(TimeSpan.FromSeconds(1)));
+
+        Assert.That(resource.GetAliveParticles().Length, Is.GreaterThanOrEqualTo(1),
+            "precondition: the emitter must still hold alive particles, only sized to zero");
+
+        using var node = new ParticleRenderNode(resource);
+        using RenderNodeRasterization rasterization = Rasterize(node);
+
+        Assert.That(rasterization.IsEmpty, Is.True,
+            "a zero-sized particle set draws nothing, and the recorded particle-drawable subtree it "
+            + "abandoned must not fail the recording");
+    }
+
+    [TestCase(DegenerateBrushContent.NoDrawable)]
+    [TestCase(DegenerateBrushContent.DisabledDrawable)]
+    [TestCase(DegenerateBrushContent.ZeroAreaDrawable)]
+    public void DrawableBrush_WithDegenerateContent_DrawsTheOwnerAndFillsNothing(
+        DegenerateBrushContent content)
+    {
+        using Brush.Resource brushResource = CreateDegenerateDrawableBrush(content);
+        var pen = new Pen
+        {
+            Thickness = { CurrentValue = 4 },
+            Brush = { CurrentValue = Brushes.White },
+            StrokeAlignment = { CurrentValue = StrokeAlignment.Inside },
+        };
+        using Pen.Resource penResource = pen.ToResource(CompositionContext.Default);
+        using var node = new RectangleRenderNode(s_ownerRect, brushResource, penResource);
+
+        using RenderNodeRasterization rasterization = Rasterize(node);
+
+        Assert.That(rasterization.IsEmpty, Is.False,
+            "the owner still has a stroke to draw, so degenerate brush content must not erase it");
+        Bitmap bitmap = rasterization.Bitmap
+            ?? throw new AssertionException("A non-empty rasterization must carry a bitmap.");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rasterization.Bounds, Is.EqualTo(s_ownerRect));
+            Assert.That(AlphaAt(bitmap, 2, 2), Is.GreaterThan(0.99f),
+                "the owner's stroke must be drawn");
+            Assert.That(AlphaAt(bitmap, 16, 12), Is.Zero,
+                "content that lowered to nothing must fill nothing, not a fallback colour");
+        });
+    }
+
+    private static Brush.Resource CreateDegenerateDrawableBrush(DegenerateBrushContent content)
+    {
+        if (content == DegenerateBrushContent.NoDrawable)
+            return (Brush.Resource)new DrawableBrush().ToResource(CompositionContext.Default);
+
+        var drawable = new RectShape();
+        drawable.Width.CurrentValue = 18;
+        drawable.Height.CurrentValue = 12;
+        drawable.Fill.CurrentValue = Brushes.White;
+        if (content == DegenerateBrushContent.DisabledDrawable)
+        {
+            drawable.IsEnabled = false;
+        }
+        else
+        {
+            var collapse = new ScaleTransform();
+            collapse.Scale.CurrentValue = 0;
+            drawable.Transform.CurrentValue = collapse;
+        }
+
+        return (Brush.Resource)new DrawableBrush(drawable).ToResource(CompositionContext.Default);
+    }
+
+    private static float AlphaAt(Bitmap bitmap, int x, int y)
+        => (float)BitConverter.UInt16BitsToHalf(bitmap.GetRow<ushort>(y)[(x * 4) + 3]);
+
+    private static RenderNodeRasterization Rasterize(RenderNode node)
+    {
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = new CpuTargetFactory(),
+            });
+        return renderer.Rasterize();
+    }
+
+    private sealed class CpuTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+            => new CpuRenderTarget(allocation.DeviceSize.Width, allocation.DeviceSize.Height);
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/BrushSourceRecordingTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/BrushSourceRecordingTests.cs
@@ -1,0 +1,121 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Shapes;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Recording;
+
+[TestFixture]
+public sealed class BrushSourceRecordingTests
+{
+    [Test]
+    public void RawExternalBrush_RemovesEngineDirectReplay()
+    {
+        var brush = new FallbackBrush();
+        using var brushResource = (Brush.Resource)brush.ToResource(CompositionContext.Default);
+        using var node = new RectangleRenderNode(new Rect(0, 0, 32, 24), brushResource, null);
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        RenderFragmentReference root = GetSingleRoot(graph);
+        var payload = (OpaqueRenderFragmentPayload)root.Payload!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(root.Kind, Is.EqualTo(RenderFragmentKind.OpaqueSource));
+            Assert.That(root.Inputs, Is.Empty);
+            Assert.That(root.HasOpaqueExternalWork, Is.True);
+            Assert.That(payload.Topology, Is.EqualTo(OpaqueRenderTopology.Source));
+            Assert.That(payload.Description.DirectReplay, Is.Null,
+                "An arbitrary Brush implementation must never enter the engine-owned direct replay path.");
+        });
+    }
+
+    [Test]
+    public void DrawableBrush_RecordsMaterializedInputForEngineDirectReplay()
+    {
+        var content = new RectShape();
+        content.Width.CurrentValue = 18;
+        content.Height.CurrentValue = 12;
+        content.Fill.CurrentValue = Brushes.White;
+        var brush = new DrawableBrush(content);
+        brush.Stretch.CurrentValue = Stretch.Fill;
+        using var brushResource = (Brush.Resource)brush.ToResource(CompositionContext.Default);
+        using var node = new RectangleRenderNode(new Rect(0, 0, 32, 24), brushResource, null);
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        RenderFragmentReference root = GetSingleRoot(graph);
+        var payload = (OpaqueRenderFragmentPayload)root.Payload!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(root.Kind, Is.EqualTo(RenderFragmentKind.OpaqueCombine));
+            Assert.That(root.Inputs, Has.Length.EqualTo(1),
+                "DrawableBrush content must remain an explicit materializable graph dependency.");
+            Assert.That(root.Inputs[0].CanBeUsedAsValueInput, Is.True);
+            Assert.That(root.HasOpaqueExternalWork, Is.True);
+            Assert.That(payload.Topology, Is.EqualTo(OpaqueRenderTopology.Combine));
+            Assert.That(payload.Description.DirectReplay, Is.Not.Null,
+                "Engine-owned source replay may consume its explicit materialized brush inputs.");
+        });
+    }
+
+    [Test]
+    public void DirectBrushConstructor_RejectsUnloweredDrawableBrush()
+    {
+        var content = new RectShape();
+        var brush = new DrawableBrush(content);
+        using DrawableBrush.Resource brushResource = brush.ToResource(CompositionContext.Default);
+        var constructor = new BrushConstructor(
+            new Rect(0, 0, 32, 24),
+            brushResource,
+            BlendMode.SrcOver);
+
+        Assert.That(
+            () => constructor.CreateShader(),
+            Throws.TypeOf<InvalidOperationException>()
+                .With.Message.EqualTo(
+                    "DrawableBrush content must be lowered by BrushRecorder before execution; "
+                    + "a direct BrushConstructor cannot resolve nested drawable content."));
+    }
+
+    [Test]
+    public void DirectConstructor_RejectsUnloweredDrawableBrush()
+    {
+        var content = new RectShape();
+        var brush = new DrawableBrush(content);
+        using DrawableBrush.Resource brushResource = brush.ToResource(CompositionContext.Default);
+        var constructor = new BrushConstructor(
+            new Rect(0, 0, 32, 24),
+            brushResource,
+            BlendMode.SrcOver);
+
+        Assert.That(
+            () => constructor.CreateShader(),
+            Throws.TypeOf<InvalidOperationException>()
+                .With.Message.EqualTo(
+                    "DrawableBrush content must be lowered by BrushRecorder before execution; "
+                    + "a direct BrushConstructor cannot resolve nested drawable content."));
+    }
+
+    private static RenderRequest CreateRequest(RenderRequestOwner owner)
+        => new(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            outputScale: 1,
+            maxWorkingScale: 1,
+            owner: owner));
+
+    private static RenderFragmentReference GetSingleRoot(RecordedRenderGraph graph)
+    {
+        RenderFragmentId rootId = graph.PublicationRoots.Single();
+        return (RenderFragmentReference)graph.Fragments
+            .Single(fragment => fragment.Id == rootId)
+            .Payload!;
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/CapturedResourceBorrowTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/CapturedResourceBorrowTests.cs
@@ -1,0 +1,163 @@
+﻿using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Recording;
+
+/// <summary>
+/// Pins what <see cref="RenderNodeContext.Borrow{T}(ValueTuple{T, int})"/> puts into a borrowed resource's
+/// cache identity, against the three-argument form the engine's own nodes used before it.
+/// </summary>
+[TestFixture]
+public sealed class CapturedResourceBorrowTests
+{
+    [Test]
+    public void AnAttachedResource_KeepsTheIdentityTheThreeArgumentFormProduced()
+    {
+        var geometry = new EllipseGeometry();
+        using Geometry.Resource resource = (Geometry.Resource)geometry.ToResource(CompositionContext.Default);
+        (Geometry.Resource Resource, int Version) captured = resource.Capture()!.Value;
+
+        RenderResourceIdentity fromCapture = BorrowIdentity(context => context.Borrow(captured));
+        RenderResourceIdentity fromArguments = BorrowIdentity(context => context.Borrow(
+            captured.Resource,
+            captured.Resource.GetOriginal().Id,
+            captured.Version));
+
+        Assert.That(fromCapture, Is.EqualTo(fromArguments));
+        Assert.That(fromCapture.Key, Is.EqualTo(geometry.Id));
+    }
+
+    [Test]
+    public void ADetachedResource_GetsAStableIdentityWhereTheBackingObjectIdWouldThrow()
+    {
+        using var first = new EngineObject.Resource();
+        using var second = new EngineObject.Resource();
+
+        Assert.That(first.GetOriginal(), Is.Null,
+            "a resource that never went through ToResource has no backing EngineObject");
+
+        RenderResourceIdentity firstIdentity = BorrowIdentity(c => c.Borrow(first.Capture()!.Value));
+        RenderResourceIdentity firstAgain = BorrowIdentity(c => c.Borrow(first.Capture()!.Value));
+        RenderResourceIdentity secondIdentity = BorrowIdentity(c => c.Borrow(second.Capture()!.Value));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.GetOriginal(), Is.Null,
+                "the nullable original contract reports that a detached resource has no backing id");
+            Assert.That(firstIdentity, Is.EqualTo(firstAgain),
+                "a detached resource must coalesce with itself across requests");
+            Assert.That(firstIdentity, Is.Not.EqualTo(secondIdentity),
+                "two detached resources must never share a cache identity");
+        });
+    }
+
+    [Test]
+    public void TheRecordedVersion_IsTheSnapshotsAndNotTheResourcesCurrentOne()
+    {
+        var geometry = new EllipseGeometry();
+        using Geometry.Resource resource = (Geometry.Resource)geometry.ToResource(CompositionContext.Default);
+        (Geometry.Resource Resource, int Version) captured = resource.Capture()!.Value;
+        resource.Version = captured.Version + 7;
+
+        RenderResourceIdentity identity = BorrowIdentity(context => context.Borrow(captured));
+
+        Assert.That(identity.Version, Is.EqualTo(captured.Version),
+            "the cache key must not encode a version the node's Update never compared");
+    }
+
+    [Test]
+    public void ANullResourceInTheSnapshot_IsRejectedByTheOverload()
+    {
+        Assert.That(
+            () => BorrowIdentity(context => context.Borrow<Geometry.Resource>((null!, 0))),
+            Throws.TypeOf<ArgumentNullException>());
+    }
+
+    [Test]
+    public void TheOverload_CostsNoMoreThanTheThreeArgumentFormItReplaces()
+    {
+        var geometry = new EllipseGeometry();
+        using Geometry.Resource resource = (Geometry.Resource)geometry.ToResource(CompositionContext.Default);
+        (Geometry.Resource Resource, int Version) captured = resource.Capture()!.Value;
+
+        long fromCapture = MeasureBytesPerBorrow(context => context.Borrow(captured));
+        long fromArguments = MeasureBytesPerBorrow(context => context.Borrow(
+            captured.Resource,
+            captured.Resource.GetOriginal().Id,
+            captured.Version));
+
+        TestContext.Out.WriteLine($"captured snapshot: {fromCapture} bytes/borrow");
+        TestContext.Out.WriteLine($"explicit arguments: {fromArguments} bytes/borrow");
+        Assert.That(fromCapture, Is.LessThanOrEqualTo(fromArguments),
+            "Process runs per node per frame, so passing the snapshot must not box more than the pair did");
+    }
+
+    /// <remarks>
+    /// The per-borrow cost is a few tens of bytes of boxing on top of a recording scaffold that allocates three
+    /// orders of magnitude more, so a single timed round resolves the difference to roughly one byte and any
+    /// unrelated allocation on this thread — a tiering re-JIT, a lazily grown pool — flips it. Allocation noise
+    /// is one-sided, because nothing an unrelated caller does can lower the counter, so the smallest of several
+    /// rounds is the steady-state cost and the estimate stops depending on which round was quiet.
+    /// </remarks>
+    private static long MeasureBytesPerBorrow(Func<RenderNodeContext, RenderResource> borrow)
+    {
+        const int Iterations = 5000;
+        const int Rounds = 7;
+        for (int index = 0; index < 200; index++)
+            _ = BorrowIdentity(borrow);
+
+        long quietestRound = long.MaxValue;
+        for (int round = 0; round < Rounds; round++)
+        {
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            for (int index = 0; index < Iterations; index++)
+                _ = BorrowIdentity(borrow);
+            long after = GC.GetAllocatedBytesForCurrentThread();
+            quietestRound = Math.Min(quietestRound, after - before);
+        }
+
+        return quietestRound / Iterations;
+    }
+
+    private static RenderResourceIdentity BorrowIdentity(Func<RenderNodeContext, RenderResource> borrow)
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = new RenderRequest(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            outputScale: 1,
+            maxWorkingScale: 1,
+            owner: owner));
+        var host = new BorrowOnlyHost(request);
+        var transaction = new NodeRecordingTransaction(host, new object(), []);
+        RenderResource resource = borrow(new RenderNodeContext(transaction));
+        transaction.Commit();
+        return resource.CacheIdentity;
+    }
+
+    private sealed class BorrowOnlyHost(RenderRequest request) : IRenderRequestRecordingHost
+    {
+        public RenderRequest Request { get; } = request;
+
+        public bool IsRenderCacheEnabled => true;
+
+        public IReadOnlyList<RenderFragmentReference> RecordNode(
+            NodeRecordingTransaction parent,
+            RenderNode node,
+            IReadOnlyList<RenderFragmentReference> inputs,
+            bool subtree)
+            => throw new NotSupportedException();
+
+        public RecordedNestedRenderRequest RecordNestedRequest(RenderNode root, RenderRequestOptions options)
+            => throw new NotSupportedException();
+
+        public void Commit(NodeRecordingCommit commit)
+        {
+            foreach (RenderResource resource in commit.Resources)
+                Request.Options.Owner.ResourceRegistry.Commit(resource);
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/DeclaredResourceOrderTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/DeclaredResourceOrderTests.cs
@@ -1,0 +1,159 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+using Beutl.Media.Source;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Recording;
+
+/// <summary>
+/// Pins the declared resource list of the in-tree sources that borrow a captured engine resource.
+/// </summary>
+/// <remarks>
+/// <c>RenderCacheResolver.AddResources</c> writes the list's count and then each binding name and
+/// <c>CacheIdentity</c> in declaration order into the output-cache key, so the names, contents and order of a <c>resources:</c>
+/// argument are part of every affected fragment's identity. <see cref="OutputIdentityDependsOnResourceOrder"/>
+/// is what makes the pins below load-bearing rather than decorative.
+/// </remarks>
+[TestFixture]
+public sealed class DeclaredResourceOrderTests
+{
+    [Test]
+    public void GeometryRenderNode_DeclaresHitTestThenPrimaryGeometryThenPaint()
+    {
+        var geometry = new EllipseGeometry { Width = { CurrentValue = 40 }, Height = { CurrentValue = 30 } };
+        var fill = new SolidColorBrush(Colors.Red);
+        var pen = new Pen { Brush = { CurrentValue = Brushes.Black }, Thickness = { CurrentValue = 2 } };
+        using Geometry.Resource geometryResource = geometry.ToResource(CompositionContext.Default);
+        using SolidColorBrush.Resource fillResource = fill.ToResource(CompositionContext.Default);
+        using Pen.Resource penResource = pen.ToResource(CompositionContext.Default);
+        using var node = new GeometryRenderNode(geometryResource, fillResource, penResource);
+
+        WithOpaqueRoot(node, payload =>
+        {
+            IReadOnlyList<RenderResourceBinding> declared = payload.Description.Resources;
+            Assert.Multiple(() =>
+            {
+                Assert.That(Keys(declared), Is.EqualTo(new object?[]
+                {
+                    null,
+                    geometry.Id,
+                    fill.Id,
+                    pen.Id,
+                    pen.Brush.CurrentValue!.Id,
+                }));
+                Assert.That(
+                    declared.Select(static binding => binding.Name),
+                    Is.EqualTo(new[] { "hitTest", "__primary", "__paint0", "__paint1", "__paint2" }));
+                Assert.That(declared[1].Resource.CacheIdentity.Version, Is.EqualTo(geometryResource.Version));
+                Assert.That(declared[0].Resource.CacheIdentity.Key, Is.Not.Null,
+                    "the hit-test state carries a composite identity rather than a bare object id");
+            });
+        });
+    }
+
+    [Test]
+    public void ImageSourceRenderNode_DeclaresTheSourceFirst()
+    {
+        var uri = TestMediaHelper.CreateTestImageUri(16, 16, Colors.White);
+        var image = new ImageSource();
+        image.ReadFrom(uri);
+        using ImageSource.Resource imageResource = image.ToResource(CompositionContext.Default);
+        var fill = new SolidColorBrush(Colors.Red);
+        using SolidColorBrush.Resource fillResource = fill.ToResource(CompositionContext.Default);
+        using var node = new ImageSourceRenderNode(imageResource, fillResource, null);
+
+        WithOpaqueRoot(node, payload =>
+        {
+            IReadOnlyList<RenderResourceBinding> declared = payload.Description.Resources;
+            Assert.Multiple(() =>
+            {
+                Assert.That(Keys(declared), Is.EqualTo(new object?[] { image.Id, fill.Id }));
+                Assert.That(declared[0].Resource.CacheIdentity.Version, Is.EqualTo(imageResource.Version));
+            });
+        });
+    }
+
+    [Test]
+    public void OutputIdentityDependsOnResourceOrder()
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+
+        using var forward = new TwoResourceNode(swapped: false);
+        using var reversed = new TwoResourceNode(swapped: true);
+        RenderFragmentOutputIdentity forwardIdentity = OutputIdentity(forward, owner);
+        RenderFragmentOutputIdentity reversedIdentity = OutputIdentity(reversed, owner);
+
+        Assert.That(forwardIdentity, Is.Not.EqualTo(reversedIdentity),
+            "swapping two declared resources must change the fragment's output-cache key");
+    }
+
+    private static object?[] Keys(IReadOnlyList<RenderResourceBinding> resources)
+        => [.. resources.Select(static binding => binding.Resource.CacheIdentity.Key as Guid?)
+            .Select(static id => (object?)id)];
+
+    private static void WithOpaqueRoot(RenderNode node, Action<OpaqueRenderFragmentPayload> assert)
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        assert((OpaqueRenderFragmentPayload)GetSingleRoot(graph).Payload!);
+    }
+
+    private static RenderFragmentOutputIdentity OutputIdentity(RenderNode node, RenderRequestOwner owner)
+    {
+        using var request = CreateRequest(owner);
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        return RenderFragmentOutputIdentity.Create(GetSingleRoot(graph), graph.RequestId);
+    }
+
+    private static RenderRequest CreateRequest(RenderRequestOwner owner)
+        => new(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            outputScale: 1,
+            maxWorkingScale: 1,
+            owner: owner));
+
+    private static RenderFragmentReference GetSingleRoot(RecordedRenderGraph graph)
+    {
+        RenderFragmentId rootId = graph.PublicationRoots.Single();
+        return (RenderFragmentReference)graph.Fragments
+            .Single(fragment => fragment.Id == rootId)
+            .Payload!;
+    }
+
+    private sealed class TwoResourceNode(bool swapped) : RenderNode
+    {
+        private static readonly Rect s_bounds = new(0, 0, 8, 8);
+        private static readonly object s_firstKey = "first";
+        private static readonly object s_secondKey = "second";
+
+        private readonly Payload _first = new();
+        private readonly Payload _second = new();
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<Payload> first = context.Borrow(_first, s_firstKey, version: 1);
+            RenderResource<Payload> second = context.Borrow(_second, s_secondKey, version: 2);
+            OpaqueRenderDescription description = OpaqueRenderDescription.Create(
+                s_bounds,
+                static (session, bounds) =>
+                {
+                    using OpaqueRenderOutput output = session.CreateOutput(bounds);
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.Source(s_bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                resources: swapped
+                    ? [second.Bind("second"), first.Bind("first")]
+                    : [first.Bind("first"), second.Bind("second")]);
+            context.Publish(context.OpaqueSource(description));
+        }
+
+        internal sealed class Payload;
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/FilterEffectRecordingTransactionTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/FilterEffectRecordingTransactionTests.cs
@@ -1,0 +1,331 @@
+﻿using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Recording;
+
+[TestFixture]
+public sealed class FilterEffectRecordingTransactionTests
+{
+    private const string IdentityShader = "half4 apply(half4 color) { return color; }";
+
+    [Test]
+    public void ShaderAndGeometry_UpdateBoundsSynchronouslyInAuthoredOrder()
+    {
+        using var context = new FilterEffectContext(new Rect(10, 20, 30, 40));
+        ShaderDescription currentPixel = ShaderDescription.CurrentPixel(IdentityShader);
+        ShaderDescription wholeSource = ShaderDescription.WholeSource(
+            "uniform shader src; half4 main(float2 coord) { return src.eval(coord); }",
+            RenderBoundsContract.Create(
+                static bounds => bounds.Inflate(new Thickness(2)),
+                static bounds => bounds.Inflate(new Thickness(2)),
+                "inflate-two"));
+        GeometryDescription geometry = GeometryDescription.CreateRequestLocal(
+            static _ => { },
+            RenderBoundsContract.Create(
+                static bounds => bounds.Translate(new Vector(3, 4)),
+                static bounds => bounds.Translate(new Vector(-3, -4)),
+                "translate"),
+            RenderHitTestContract.AnyInput,
+            structuralKey: "geometry");
+
+        context.Shader(currentPixel);
+        Rect afterCurrentPixel = context.Bounds;
+        context.Shader(wholeSource);
+        Rect afterWholeSource = context.Bounds;
+        context.Geometry(geometry);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(afterCurrentPixel, Is.EqualTo(new Rect(10, 20, 30, 40)));
+            Assert.That(afterWholeSource, Is.EqualTo(new Rect(8, 18, 34, 44)));
+            Assert.That(context.Bounds, Is.EqualTo(new Rect(11, 22, 34, 44)));
+            Assert.That(
+                context.GetOrderedItems().Select(static item => item.GetType()),
+                Is.EqualTo(new[]
+                {
+                    typeof(FEItem_Shader),
+                    typeof(FEItem_Shader),
+                    typeof(FEItem_Geometry),
+                }));
+        });
+    }
+
+    [Test]
+    public void InvalidOrThrowingDescriptorAppend_IsAtomic()
+    {
+        using var context = new FilterEffectContext(new Rect(0, 0, 20, 10));
+        context.Saturate(0.5f);
+        int originalCount = context.GetOrderedItems().Count;
+        Rect originalBounds = context.Bounds;
+        ShaderDescription throwing = ShaderDescription.WholeSource(
+            "uniform shader src; half4 main(float2 coord) { return src.eval(coord); }",
+            RenderBoundsContract.Create(
+                static _ => throw new InvalidOperationException("bounds-failure"),
+                static bounds => bounds,
+                "throwing-bounds"));
+        GeometryDescription invalid = GeometryDescription.CreateRequestLocal(
+            static _ => { },
+            RenderBoundsContract.Create(
+                static _ => Rect.Invalid,
+                static bounds => bounds,
+                "invalid-bounds"),
+            RenderHitTestContract.AnyInput,
+            structuralKey: "invalid-geometry");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => context.Shader(throwing), Throws.Exception.Message.EqualTo("bounds-failure"));
+            Assert.That(context.GetOrderedItems(), Has.Count.EqualTo(originalCount));
+            Assert.That(context.Bounds, Is.EqualTo(originalBounds));
+            Assert.That(() => context.Geometry(invalid), Throws.TypeOf<InvalidOperationException>());
+            Assert.That(context.GetOrderedItems(), Has.Count.EqualTo(originalCount));
+            Assert.That(context.Bounds, Is.EqualTo(originalBounds));
+        });
+    }
+
+    [Test]
+    public void ThrowingLegacyTransformAppend_IsAtomic()
+    {
+        using var context = new FilterEffectContext(new Rect(0, 0, 20, 10));
+        context.Saturate(0.5f);
+        int originalCount = context.GetOrderedItems().Count;
+        Rect originalBounds = context.Bounds;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => context.AppendSkiaFilter(
+                    0,
+                    static (_, input, _) => input,
+                    static (_, _) => throw new InvalidOperationException("skia-bounds-failure")),
+                Throws.TypeOf<InvalidOperationException>().With.Message.EqualTo("skia-bounds-failure"));
+            Assert.That(context.GetOrderedItems(), Has.Count.EqualTo(originalCount));
+            Assert.That(context.Bounds, Is.EqualTo(originalBounds));
+            Assert.That(
+                () => context.CustomEffect(
+                    0,
+                    static (_, _) => { },
+                    static (_, _) => throw new InvalidOperationException("custom-bounds-failure")),
+                Throws.TypeOf<InvalidOperationException>().With.Message.EqualTo("custom-bounds-failure"));
+            Assert.That(context.GetOrderedItems(), Has.Count.EqualTo(originalCount));
+            Assert.That(context.Bounds, Is.EqualTo(originalBounds));
+        });
+    }
+
+    [Test]
+    public void NestedApplyTransaction_RollsBackEarlierChildrenWhenLaterChildFails()
+    {
+        using var context = new FilterEffectContext(new Rect(0, 0, 10, 10));
+        FilterEffect.Resource resource = new Blur().ToResource(CompositionContext.Default);
+        var first = new CallbackFilterEffect((recording, _) =>
+            recording.Shader(ShaderDescription.CurrentPixel(IdentityShader)));
+        var second = new CallbackFilterEffect((recording, _) =>
+        {
+            recording.Geometry(GeometryDescription.CreateRequestLocal(
+                static _ => { },
+                RenderBoundsContract.Identity,
+                RenderHitTestContract.AnyInput,
+                structuralKey: "nested-geometry"));
+            throw new InvalidOperationException("nested-failure");
+        });
+        var group = new CallbackFilterEffect((recording, childResource) =>
+        {
+            recording.ApplyTransactional(first, childResource);
+            recording.ApplyTransactional(second, childResource);
+        });
+
+        Assert.That(
+            () => context.ApplyTransactional(group, resource),
+            Throws.TypeOf<InvalidOperationException>().With.Message.EqualTo("nested-failure"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(context.GetOrderedItems(), Is.Empty);
+            Assert.That(context.Bounds, Is.EqualTo(new Rect(0, 0, 10, 10)));
+        });
+    }
+
+    [Test]
+    public void FilterEffectGroup_DirectApplyRollsBackEarlierChildrenWhenLaterChildFails()
+    {
+        using var context = new FilterEffectContext(new Rect(0, 0, 10, 10));
+        var firstResource = new TrackingDisposable();
+        var secondResource = new TrackingDisposable();
+        var first = new CallbackFilterEffect((recording, _) =>
+        {
+            recording.Own(firstResource, "first-owned", 1);
+            recording.Shader(ShaderDescription.CurrentPixel(IdentityShader));
+        });
+        var second = new CallbackFilterEffect((recording, _) =>
+        {
+            recording.Own(secondResource, "second-owned", 1);
+            recording.Geometry(GeometryDescription.CreateRequestLocal(
+                static _ => { },
+                RenderBoundsContract.Identity,
+                RenderHitTestContract.AnyInput,
+                structuralKey: "group-geometry"));
+            throw new InvalidOperationException("group-child-failure");
+        });
+        var group = new FilterEffectGroup { Children = { first, second } };
+        FilterEffect.Resource groupResource = group.ToResource(CompositionContext.Default);
+
+        Assert.That(
+            () => group.ApplyTo(context, groupResource),
+            Throws.TypeOf<InvalidOperationException>().With.Message.EqualTo("group-child-failure"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(context.GetOrderedItems(), Is.Empty);
+            Assert.That(context.Bounds, Is.EqualTo(new Rect(0, 0, 10, 10)));
+            Assert.That(firstResource.DisposeCount, Is.EqualTo(1));
+            Assert.That(secondResource.DisposeCount, Is.EqualTo(1));
+        });
+
+        context.Dispose();
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstResource.DisposeCount, Is.EqualTo(1));
+            Assert.That(secondResource.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void ApplyTransaction_RenderNodeBoundaryContinuesCleanupAndPreservesPrimaryFailure()
+    {
+        using var owner = new RenderRequestOwner();
+        var options = new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            owner: owner);
+        using var request = new RenderRequest(options);
+        var recorder = new RenderRequestRecorder(request);
+        var transaction = new NodeRecordingTransaction(recorder, new object(), []);
+        var renderContext = new RenderNodeContext(transaction);
+        using var context = new FilterEffectContext(new Rect(0, 0, 10, 10), 1, 1, renderContext);
+        var earlier = new TrackingDisposable();
+        var later = new ThrowingDisposable();
+        var primary = new InvalidOperationException("primary-apply-failure");
+        var effect = new CallbackFilterEffect((recording, _) =>
+        {
+            recording.Own(earlier, "earlier", 1);
+            recording.Own(later, "later", 1);
+            recording.Shader(ShaderDescription.CurrentPixel(IdentityShader));
+            throw primary;
+        });
+        FilterEffect.Resource resource = new Blur().ToResource(CompositionContext.Default);
+
+        InvalidOperationException? thrown = Assert.Throws<InvalidOperationException>(
+            () => context.ApplyTransactional(effect, resource));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(thrown, Is.SameAs(primary));
+            Assert.That(context.GetOrderedItems(), Is.Empty);
+            Assert.That(context.Bounds, Is.EqualTo(new Rect(0, 0, 10, 10)));
+            Assert.That(earlier.DisposeCount, Is.EqualTo(1));
+            Assert.That(later.DisposeCount, Is.EqualTo(1));
+            Assert.That(
+                primary.Data["FilterEffectResourceRollbackFailure"],
+                Is.TypeOf<AggregateException>());
+            Assert.That(owner.CleanupFailures, Has.Length.EqualTo(1));
+            Assert.That(owner.CleanupFailures[0].Message, Is.EqualTo("cleanup-failure"));
+        });
+
+        Assert.That(() => transaction.Commit(), Throws.Nothing);
+        owner.Cleanup();
+        Assert.Multiple(() =>
+        {
+            Assert.That(earlier.DisposeCount, Is.EqualTo(1));
+            Assert.That(later.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    // A recorded registration lowers nested drawable content against the authoring frame, so a symbolic frame
+    // cannot silently degrade to an unlowered brush.
+    [Test]
+    public void RecordedContext_RejectsSymbolicBrushAuthoringFrame()
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = new RenderRequest(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            owner: owner));
+        var recorder = new RenderRequestRecorder(request);
+        var transaction = new NodeRecordingTransaction(recorder, new object(), []);
+        var renderContext = new RenderNodeContext(transaction);
+
+        Assert.That(
+            () => new FilterEffectContext(Rect.Invalid, 1, 1, renderContext),
+            Throws.ArgumentException);
+    }
+
+    [Test]
+    public void CloneAndChild_ShareResourceFamilyButKeepDocumentedItemSemantics()
+    {
+        using var context = new FilterEffectContext(new Rect(1, 2, 30, 40));
+        var borrowed = new object();
+        RenderResource<object> token = context.Borrow(borrowed, "shared", 1);
+        context.Shader(ShaderDescription.CurrentPixel(IdentityShader));
+        using FilterEffectContext clone = context.Clone();
+        using FilterEffectContext child = context.CreateChildContext();
+
+        GeometryDescription declared = GeometryDescription.CreateRequestLocal(
+            session => session.UseResource(token, static _ => { }),
+            RenderBoundsContract.Identity,
+            RenderHitTestContract.AnyInput,
+            structuralKey: "shared-resource",
+            resources: [token.Bind("shared")]);
+        clone.Geometry(declared);
+        child.Geometry(declared);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(clone.OriginalBounds, Is.EqualTo(context.OriginalBounds));
+            Assert.That(clone.GetOrderedItems(), Has.Count.EqualTo(2));
+            Assert.That(child.OriginalBounds, Is.EqualTo(context.Bounds));
+            Assert.That(child.GetOrderedItems(), Has.Count.EqualTo(1));
+        });
+    }
+
+    private sealed class TrackingDisposable : IDisposable
+    {
+        public int DisposeCount { get; private set; }
+
+        public void Dispose() => DisposeCount++;
+    }
+
+    private sealed class ThrowingDisposable : IDisposable
+    {
+        public int DisposeCount { get; private set; }
+
+        public void Dispose()
+        {
+            DisposeCount++;
+            throw new InvalidOperationException("cleanup-failure");
+        }
+    }
+}
+
+[SuppressResourceClassGeneration]
+internal sealed partial class CallbackFilterEffect(
+    Action<FilterEffectContext, FilterEffect.Resource> apply) : FilterEffect
+{
+    public override void ApplyTo(FilterEffectContext context, FilterEffect.Resource resource)
+        => apply(context, resource);
+
+    public override Resource ToResource(CompositionContext context)
+    {
+        var resource = new Resource();
+        bool updateOnly = true;
+        resource.Update(this, context, ref updateOnly);
+        return resource;
+    }
+
+    public new sealed class Resource : FilterEffect.Resource
+    {
+        public Resource()
+        {
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/LegacyFilterSegmentBrushScopeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/LegacyFilterSegmentBrushScopeTests.cs
@@ -1,0 +1,197 @@
+﻿using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Shapes;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Recording;
+
+[TestFixture]
+public sealed class LegacyFilterSegmentBrushScopeTests
+{
+    // A brush registered after a segment's last operation cannot be painted by that segment, so the segment must
+    // not inherit its dependency, required region, or target-effect flag.
+    [Test]
+    public void LegacySegment_DoesNotTakeABrushRegisteredAfterItsLastOperation()
+    {
+        using Brush.Resource first = MakeDrawableBrush(10);
+        using Brush.Resource second = MakeDrawableBrush(20);
+        var effect = new TwoSegmentBrushEffect(first, second);
+        LegacyFilterEffectRenderFragmentPayload[] segments = RecordSegments(effect);
+
+        Assert.That(segments, Has.Length.EqualTo(2), "the shader operation must split the legacy run in two");
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                segments[0].Brushes.Select(static binding => binding.Handle),
+                Is.EqualTo(new[] { effect.FirstHandle }));
+            Assert.That(
+                segments[1].Brushes.Select(static binding => binding.Handle),
+                Is.EqualTo(new[] { effect.FirstHandle, effect.SecondHandle }));
+        });
+    }
+
+    // RegisterBrush documents no ordering requirement, so a handle registered before a typed operation must still
+    // reach the later legacy segment that paints with it.
+    [Test]
+    public void LegacySegment_TakesABrushRegisteredBeforeATypedOperation()
+    {
+        using Brush.Resource brush = MakeDrawableBrush(10);
+        var effect = new BrushBeforeTypedOperationEffect(brush);
+        LegacyFilterEffectRenderFragmentPayload[] segments = RecordSegments(effect);
+
+        Assert.That(segments, Has.Length.EqualTo(1), "only the custom effect belongs to a legacy segment");
+        Assert.That(
+            segments[0].Brushes.Select(static binding => binding.Handle),
+            Is.EqualTo(new[] { effect.Handle }));
+    }
+
+    // A handle stays usable from every operation authored after it, so a second use past a typed operation must
+    // reach the second segment too.
+    [Test]
+    public void LegacySegment_TakesABrushReusedAfterATypedOperation()
+    {
+        using Brush.Resource brush = MakeDrawableBrush(10);
+        var effect = new ReusedBrushAcrossTypedOperationEffect(brush);
+        LegacyFilterEffectRenderFragmentPayload[] segments = RecordSegments(effect);
+
+        Assert.That(segments, Has.Length.EqualTo(2), "the shader operation must split the legacy run in two");
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                segments[0].Brushes.Select(static binding => binding.Handle),
+                Is.EqualTo(new[] { effect.Handle }));
+            Assert.That(
+                segments[1].Brushes.Select(static binding => binding.Handle),
+                Is.EqualTo(new[] { effect.Handle }));
+        });
+    }
+
+    private static LegacyFilterEffectRenderFragmentPayload[] RecordSegments(FilterEffect effect)
+    {
+        using var root = new FilterEffectRenderNode(effect.ToResource(CompositionContext.Default));
+        root.AddChild(new RectangleRenderNode(new Rect(0, 0, 40, 30), Brushes.Resource.White, null));
+        using var owner = new RenderRequestOwner();
+        using var request = new RenderRequest(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            outputScale: 1,
+            maxWorkingScale: 1,
+            owner: owner));
+
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(root);
+        return graph.Fragments
+            .Select(static fragment => (RenderFragmentReference)fragment.Payload!)
+            .Where(static reference => reference.Kind == RenderFragmentKind.LegacyFilterEffect)
+            .Select(static reference => (LegacyFilterEffectRenderFragmentPayload)reference.Payload!)
+            .ToArray();
+    }
+
+    private static Brush.Resource MakeDrawableBrush(float size)
+    {
+        var content = new RectShape();
+        content.Width.CurrentValue = size;
+        content.Height.CurrentValue = size;
+        content.Fill.CurrentValue = Brushes.White;
+        var brush = new DrawableBrush(content);
+        brush.Stretch.CurrentValue = Stretch.Fill;
+        return brush.ToResource(CompositionContext.Default);
+    }
+}
+
+[SuppressResourceClassGeneration]
+internal sealed partial class TwoSegmentBrushEffect(Brush.Resource first, Brush.Resource second) : FilterEffect
+{
+    private const string IdentityShader = "half4 apply(half4 color) { return color; }";
+
+    public FilterEffectBrush FirstHandle { get; private set; } = FilterEffectBrush.Empty;
+
+    public FilterEffectBrush SecondHandle { get; private set; } = FilterEffectBrush.Empty;
+
+    public override void ApplyTo(FilterEffectContext context, FilterEffect.Resource resource)
+    {
+        FirstHandle = context.RegisterBrush(first);
+        context.CustomEffect(FirstHandle, static (_, _) => { }, static (_, bounds) => bounds);
+        context.Shader(ShaderDescription.CurrentPixel(IdentityShader));
+        SecondHandle = context.RegisterBrush(second);
+        context.CustomEffect(SecondHandle, static (_, _) => { }, static (_, bounds) => bounds);
+    }
+
+    public override Resource ToResource(CompositionContext context)
+    {
+        var created = new Resource();
+        bool updateOnly = true;
+        created.Update(this, context, ref updateOnly);
+        return created;
+    }
+
+    public new sealed class Resource : FilterEffect.Resource
+    {
+        public Resource()
+        {
+        }
+    }
+}
+
+[SuppressResourceClassGeneration]
+internal sealed partial class BrushBeforeTypedOperationEffect(Brush.Resource brush) : FilterEffect
+{
+    private const string IdentityShader = "half4 apply(half4 color) { return color; }";
+
+    public FilterEffectBrush Handle { get; private set; } = FilterEffectBrush.Empty;
+
+    public override void ApplyTo(FilterEffectContext context, FilterEffect.Resource resource)
+    {
+        Handle = context.RegisterBrush(brush);
+        context.Shader(ShaderDescription.CurrentPixel(IdentityShader));
+        context.CustomEffect(Handle, static (_, _) => { }, static (_, bounds) => bounds);
+    }
+
+    public override Resource ToResource(CompositionContext context)
+    {
+        var created = new Resource();
+        bool updateOnly = true;
+        created.Update(this, context, ref updateOnly);
+        return created;
+    }
+
+    public new sealed class Resource : FilterEffect.Resource
+    {
+        public Resource()
+        {
+        }
+    }
+}
+
+[SuppressResourceClassGeneration]
+internal sealed partial class ReusedBrushAcrossTypedOperationEffect(Brush.Resource brush) : FilterEffect
+{
+    private const string IdentityShader = "half4 apply(half4 color) { return color; }";
+
+    public FilterEffectBrush Handle { get; private set; } = FilterEffectBrush.Empty;
+
+    public override void ApplyTo(FilterEffectContext context, FilterEffect.Resource resource)
+    {
+        Handle = context.RegisterBrush(brush);
+        context.CustomEffect(Handle, static (_, _) => { }, static (_, bounds) => bounds);
+        context.Shader(ShaderDescription.CurrentPixel(IdentityShader));
+        context.CustomEffect(Handle, static (_, _) => { }, static (_, bounds) => bounds);
+    }
+
+    public override Resource ToResource(CompositionContext context)
+    {
+        var created = new Resource();
+        bool updateOnly = true;
+        created.Update(this, context, ref updateOnly);
+        return created;
+    }
+
+    public new sealed class Resource : FilterEffect.Resource
+    {
+        public Resource()
+        {
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/NestedEffectBrushLoweringTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/NestedEffectBrushLoweringTests.cs
@@ -1,0 +1,220 @@
+﻿using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Shapes;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Recording;
+
+[TestFixture]
+[NonParallelizable]
+public sealed class NestedEffectBrushLoweringTests
+{
+    // The probe re-runs the whole child ApplyTo to reach its brush registrations, then throws its operations away.
+    // Anything those operations owned would otherwise be held for the whole request and never executed.
+    [Test]
+    public void NestedBrushLowering_KeepsTheBrushButRollsBackTheProbeOwnedResources()
+    {
+        var owned = new CountingDisposable();
+        using Brush.Resource brush = MakeDrawableBrush();
+        var child = new LegacySuffixCallbackFilterEffect((context, _) =>
+        {
+            context.Own(owned, "nested-probe-owned", 1);
+            FilterEffectBrush handle = context.RegisterBrush(brush);
+            context.CustomEffect(handle, static (_, _) => { }, static (_, bounds) => bounds);
+        });
+
+        // Asserted before the request is torn down, which would release every owned resource anyway.
+        Record(MakeDelayed(child), segments => Assert.Multiple(() =>
+        {
+            Assert.That(segments, Has.Length.EqualTo(1));
+            Assert.That(
+                segments[0].Brushes,
+                Has.Length.EqualTo(1),
+                "the nested brush must still be lowered into the segment");
+            Assert.That(
+                owned.DisposeCount,
+                Is.EqualTo(1),
+                "the probe's owned resource must not survive the discarded probe operations");
+        }));
+    }
+
+    [Test]
+    public void NestedBrushLowering_InsideAnotherProbe_KeepsTheBrushInTheConsumingSegment()
+    {
+        FilterEffect inner = MakeDelayed(new FilterEffectGroup { Children = { MakeDrawableBrushShadow() } });
+
+        Record(MakeDelayed(inner), segments => Assert.Multiple(() =>
+        {
+            Assert.That(segments, Has.Length.EqualTo(1));
+            Assert.That(
+                segments[0].Brushes,
+                Has.Length.EqualTo(1),
+                "the doubly nested brush must still be lowered into the segment");
+        }));
+    }
+
+    // The inner probe's own item index only diverges from the real recording's once the outer probe has authored an
+    // operation of its own, so a preceding sibling in the outer nested group is what exposes the mis-indexing.
+    [Test]
+    public void NestedBrushLowering_AfterAnOperationInTheEnclosingProbe_KeepsTheBrushInTheConsumingSegment()
+    {
+        var precedingSibling = new LegacySuffixCallbackFilterEffect(
+            static (context, _) => context.Blur(new Size(1, 1)));
+        FilterEffect inner = MakeDelayed(new FilterEffectGroup { Children = { MakeDrawableBrushShadow() } });
+
+        Record(
+            MakeDelayed(new FilterEffectGroup { Children = { precedingSibling, inner } }),
+            segments => Assert.Multiple(() =>
+            {
+                Assert.That(segments, Has.Length.EqualTo(1));
+                Assert.That(
+                    segments[0].Brushes,
+                    Has.Length.EqualTo(1),
+                    "the nested brush must be registered in the real recording's item order, not the probe's");
+            }));
+    }
+
+    // A swallowed pre-pass failure otherwise surfaces only as the unlowered-DrawableBrush guard raised much later.
+    [Test]
+    public void FailedNestedBrushLowering_AttachesItsFailureToTheExecutionFailure()
+    {
+        var probeFailure = new InvalidOperationException("nested-probe-boom");
+        var executionFailure = new InvalidOperationException("segment-boom");
+        Rect bounds = new(0, 0, 8, 6);
+        using var authored = new FilterEffectContext(bounds);
+        authored.CustomEffect(
+            0,
+            (_, _) => throw executionFailure,
+            static (_, rect) => rect);
+        using FilterEffectContext segment = FilterEffectContext.CreateLegacySegment(
+            bounds,
+            outputScale: 1,
+            workingScale: 1,
+            authored._items,
+            probeFailure);
+        using EffectTargets targets = CreateSolidTargets(bounds);
+        using var builder = new SKImageFilterBuilder();
+        using var activator = new FilterEffectActivator(
+            targets,
+            builder,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary);
+
+        InvalidOperationException? thrown = Assert.Throws<InvalidOperationException>(() => activator.Apply(segment));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(thrown, Is.SameAs(executionFailure));
+            Assert.That(
+                thrown!.Data[FilterEffectContext.NestedBrushLoweringFailureKey],
+                Is.SameAs(probeFailure));
+        });
+    }
+
+    [Test]
+    public void SucceedingNestedBrushLowering_LeavesTheExecutionFailureUnannotated()
+    {
+        var executionFailure = new InvalidOperationException("segment-boom");
+        Rect bounds = new(0, 0, 8, 6);
+        using var authored = new FilterEffectContext(bounds);
+        authored.CustomEffect(
+            0,
+            (_, _) => throw executionFailure,
+            static (_, rect) => rect);
+        using FilterEffectContext segment = FilterEffectContext.CreateLegacySegment(
+            bounds,
+            outputScale: 1,
+            workingScale: 1,
+            authored._items);
+        using EffectTargets targets = CreateSolidTargets(bounds);
+        using var builder = new SKImageFilterBuilder();
+        using var activator = new FilterEffectActivator(
+            targets,
+            builder,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary);
+
+        InvalidOperationException? thrown = Assert.Throws<InvalidOperationException>(() => activator.Apply(segment));
+
+        Assert.That(
+            thrown!.Data.Contains(FilterEffectContext.NestedBrushLoweringFailureKey),
+            Is.False);
+    }
+
+    private static DelayAnimationEffect MakeDelayed(FilterEffect child)
+    {
+        var delay = new DelayAnimationEffect();
+        delay.Delay.CurrentValue = 0f;
+        delay.Effect.CurrentValue = child;
+        return delay;
+    }
+
+    private static void Record(FilterEffect effect, Action<LegacyFilterEffectRenderFragmentPayload[]> assert)
+    {
+        using var root = new FilterEffectRenderNode(effect.ToResource(CompositionContext.Default));
+        root.AddChild(new RectangleRenderNode(new Rect(0, 0, 40, 30), Brushes.Resource.White, null));
+        using var owner = new RenderRequestOwner();
+        using var request = new RenderRequest(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            outputScale: 1,
+            maxWorkingScale: 1,
+            owner: owner));
+
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(root);
+        assert(graph.Fragments
+            .Select(static fragment => (RenderFragmentReference)fragment.Payload!)
+            .Where(static reference => reference.Kind == RenderFragmentKind.LegacyFilterEffect)
+            .Select(static reference => (LegacyFilterEffectRenderFragmentPayload)reference.Payload!)
+            .ToArray());
+    }
+
+    private static Brush.Resource MakeDrawableBrush()
+        => MakeDrawableBrushSource().ToResource(CompositionContext.Default);
+
+    private static DrawableBrush MakeDrawableBrushSource()
+    {
+        var content = new RectShape();
+        content.Width.CurrentValue = 10;
+        content.Height.CurrentValue = 10;
+        content.Fill.CurrentValue = Brushes.White;
+        var brush = new DrawableBrush(content);
+        brush.Stretch.CurrentValue = Stretch.Fill;
+        return brush;
+    }
+
+    private static FlatShadow MakeDrawableBrushShadow()
+    {
+        var shadow = new FlatShadow();
+        shadow.Length.CurrentValue = 4;
+        shadow.Brush.CurrentValue = MakeDrawableBrushSource();
+        return shadow;
+    }
+
+    private static EffectTargets CreateSolidTargets(Rect bounds)
+    {
+        using RenderTarget renderTarget = RenderTarget.Create((int)bounds.Width, (int)bounds.Height)
+            ?? throw new InvalidOperationException("A CPU render target is required for this test.");
+        using (var canvas = new ImmediateCanvas(
+                   renderTarget,
+                   density: 1,
+                   maxWorkingScale: 1,
+                   logicalSize: bounds.Size))
+        {
+            canvas.Clear(Colors.White);
+        }
+
+        return new EffectTargets { new EffectTarget(renderTarget, bounds, EffectiveScale.At(1)) };
+    }
+
+    private sealed class CountingDisposable : IDisposable
+    {
+        public int DisposeCount { get; private set; }
+
+        public void Dispose() => DisposeCount++;
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/NodeRecordingTransactionTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/NodeRecordingTransactionTests.cs
@@ -1,0 +1,633 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Recording;
+
+[TestFixture]
+public sealed class NodeRecordingTransactionTests
+{
+    [Test]
+    public void Commit_PublishesFragmentsResourcesAndCachePolicyAtomically()
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+        var host = new RecordingHost(request);
+        var transaction = new NodeRecordingTransaction(host, new object(), []);
+        RenderFragmentHandle first = CreateSource(transaction, new Rect(0, 0, 10, 10));
+        RenderFragmentHandle second = CreateSource(transaction, new Rect(10, 0, 10, 10));
+        var resource = new TrackedDisposable("owned");
+        RenderResource<TrackedDisposable> token = transaction.Own(resource, "resource", 1);
+
+        transaction.Publish(first);
+        transaction.Publish(second);
+        transaction.DisableRenderCache();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(host.Commits, Is.Empty, "A checkpoint must not leak partial graph state before commit.");
+            Assert.That(host.IsRenderCacheEnabled, Is.True);
+            Assert.That(token.RegistrationState, Is.EqualTo(RenderResourceRegistrationState.Pending));
+        });
+
+        IReadOnlyList<RenderFragmentReference> publications = transaction.Commit();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(host.Commits, Has.Count.EqualTo(1));
+            Assert.That(host.Commits[0].Fragments, Has.Length.EqualTo(2));
+            Assert.That(host.Commits[0].Publications, Has.Length.EqualTo(2));
+            Assert.That(publications, Is.EqualTo(host.Commits[0].Publications));
+            Assert.That(host.IsRenderCacheEnabled, Is.False);
+            Assert.That(token.RegistrationState, Is.EqualTo(RenderResourceRegistrationState.Committed));
+            Assert.That(resource.DisposeCount, Is.Zero, "A committed owned resource belongs to the request.");
+        });
+
+        owner.Cleanup();
+        Assert.That(resource.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Commit_IgnoresUnpublishedFragmentsDuringFanOutValidation()
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+        var host = new RecordingHost(request);
+        var transaction = new NodeRecordingTransaction(host, new object(), []);
+        var context = new RenderNodeContext(transaction);
+        var publishedBounds = new Rect(0, 0, 10, 10);
+        RenderFragmentHandle published = CreateSource(transaction, publishedBounds);
+        RenderFragmentHandle discarded = context.Blend(published, BlendMode.SrcOver);
+        _ = context.Opacity(discarded, 0.25f);
+        _ = context.Opacity(discarded, 0.75f);
+        transaction.Publish(published);
+
+        Assert.That(() => transaction.Commit(), Throws.Nothing);
+        Assert.Multiple(() =>
+        {
+            Assert.That(host.Commits, Has.Count.EqualTo(1));
+            Assert.That(host.Commits[0].Fragments, Has.Length.EqualTo(4),
+                "Committed but unpublished fragments remain available for skipped-outcome reconciliation.");
+            Assert.That(host.Commits[0].Fragments[0].Reference.Bounds, Is.EqualTo(publishedBounds));
+        });
+    }
+
+    [Test]
+    public void RecordedBrushPlan_ValueEligibilityRequiresEveryDependencyAndNoRawFallback()
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+        var host = new RecordingHost(request);
+        var transaction = new NodeRecordingTransaction(host, new object(), []);
+        var context = new RenderNodeContext(transaction);
+        var bounds = new Rect(0, 0, 10, 10);
+        RenderFragmentHandle source = CreateSource(transaction, bounds);
+        RenderFragmentHandle targetDependent = context.TargetLayerScope(
+            [source],
+            TargetRegion.Region(bounds));
+        var drawable = new RecordedBrush(RecordedBrushKind.Drawable, null, 0);
+        var raw = new RecordedBrush(RecordedBrushKind.RawExternal, null, -1);
+        var eligible = new RecordedBrushPlan(drawable, [source], []);
+        var ineligibleDependency = new RecordedBrushPlan(drawable, [source, targetDependent], []);
+        var rawFallback = new RecordedBrushPlan(raw, [], []);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(eligible.CanBeUsedAsValueInput, Is.True);
+            Assert.That(ineligibleDependency.CanBeUsedAsValueInput, Is.False);
+            Assert.That(rawFallback.CanBeUsedAsValueInput, Is.False);
+        });
+
+        transaction.Drop(targetDependent);
+        transaction.Publish(source);
+        transaction.Commit();
+    }
+
+    // Recording allocates one opacity fragment per drawable per pass. The SkSL text is a compile-time constant,
+    // so a pass must neither re-tokenize it nor mint a description per fragment.
+    [Test]
+    public void Opacity_ReusesOneValidatedFusionDescriptionPerNormalizedValue()
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+        var host = new RecordingHost(request);
+        var transaction = new NodeRecordingTransaction(host, new object(), []);
+        var context = new RenderNodeContext(transaction);
+        var bounds = new Rect(0, 0, 10, 10);
+        RenderFragmentHandle source = CreateSource(transaction, bounds);
+
+        for (int i = 0; i < 8; i++)
+            transaction.Publish(context.Opacity(source, 0.375f));
+
+        transaction.Publish(context.Opacity(source, 0.75f));
+        transaction.Publish(context.Opacity(source, 4f));
+        transaction.Publish(context.Opacity(source, 1f));
+        transaction.Commit();
+
+        ShaderDescription[] descriptions = host.Commits[0].Fragments
+            .Select(static entry => entry.Reference.Payload)
+            .OfType<OpacityRenderFragmentPayload>()
+            .Select(static payload => payload.FusionDescription)
+            .ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(descriptions, Has.Length.EqualTo(11));
+            Assert.That(
+                descriptions,
+                Has.All.Matches<ShaderDescription>(
+                    item => ReferenceEquals(item.Source, descriptions[0].Source)),
+                "The constant fusion source must be normalized and validated once.");
+            Assert.That(
+                descriptions.Take(8),
+                Has.All.SameAs(descriptions[0]),
+                "Fragments sharing one opacity must share one immutable description.");
+            Assert.That(descriptions[8], Is.Not.SameAs(descriptions[0]));
+            Assert.That(
+                descriptions[9],
+                Is.SameAs(descriptions[10]),
+                "An out-of-range opacity clamps onto the description of its normalized value.");
+            Assert.That(
+                descriptions[0],
+                Is.SameAs(OpacityRenderNode.CreateFusionDescription(0.375f)));
+        });
+    }
+
+    [Test]
+    public void Rollback_DiscardsEveryPartialEffectAndRestoresCacheDisablement()
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+        var host = new RecordingHost(request);
+        var transaction = new NodeRecordingTransaction(host, new object(), []);
+        RenderFragmentHandle fragment = CreateSource(transaction, new Rect(0, 0, 10, 10));
+        var resource = new TrackedDisposable("owned");
+        RenderResource<TrackedDisposable> token = transaction.Own(resource, "resource", 1);
+        var primary = new InvalidOperationException("process failed");
+
+        transaction.Publish(fragment);
+        transaction.DisableRenderCache();
+
+        InvalidOperationException? thrown = Assert.Throws<InvalidOperationException>(() => transaction.Rollback(primary));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(thrown, Is.SameAs(primary));
+            Assert.That(transaction.State, Is.EqualTo(NodeRecordingTransactionState.RolledBack));
+            Assert.That(host.Commits, Is.Empty);
+            Assert.That(host.IsRenderCacheEnabled, Is.True,
+                "A rolled-back cache disablement must not escape its checkpoint.");
+            Assert.That(token.RegistrationState, Is.EqualTo(RenderResourceRegistrationState.Released));
+            Assert.That(resource.DisposeCount, Is.EqualTo(1));
+            Assert.That(owner.PrimaryFailure?.SourceException, Is.SameAs(primary));
+        });
+    }
+
+    [Test]
+    public void DisableRenderCache_IsMonotonicAcrossCommittedChildAndParentCheckpoints()
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+        var host = new RecordingHost(request) { ChildAction = static context => context.DisableRenderCache() };
+        var parent = new NodeRecordingTransaction(host, new object(), []);
+        using var childNode = new MemoryNode<int>(0);
+
+        _ = parent.RecordNode(childNode, [], subtree: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(parent.IsRenderCacheEnabled, Is.False,
+                "A committed child disablement must affect its parent result.");
+            Assert.That(host.IsRenderCacheEnabled, Is.True,
+                "The request-wide state changes only when the parent checkpoint commits.");
+        });
+
+        parent.Commit();
+
+        Assert.That(host.IsRenderCacheEnabled, Is.False);
+    }
+
+    [Test]
+    public void NestedRecording_UsesFreshChildAndParentFacadeHandles()
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+        var host = new RecordingHost(request)
+        {
+            ChildAction = static context => context.PassThrough(),
+        };
+        var parent = new NodeRecordingTransaction(host, new object(), []);
+        RenderFragmentHandle parentInput = CreateSource(parent, new Rect(1, 2, 30, 40));
+        using var childNode = new MemoryNode<int>(0);
+
+        IReadOnlyList<RenderFragmentHandle> mapped = parent.RecordNode(
+            childNode,
+            [parentInput],
+            subtree: false);
+
+        RenderFragmentHandle childFacade = host.LastChildInputs.Single();
+        RenderFragmentHandle parentFacade = mapped.Single();
+        Assert.Multiple(() =>
+        {
+            Assert.That(childFacade, Is.Not.SameAs(parentInput));
+            Assert.That(parentFacade, Is.Not.SameAs(parentInput));
+            Assert.That(parentFacade, Is.Not.SameAs(childFacade));
+            Assert.That(parentFacade.TryGetMetadata(out RenderFragmentMetadata parentFacadeMetadata), Is.True);
+            Assert.That(parentInput.TryGetMetadata(out RenderFragmentMetadata parentInputMetadata), Is.True);
+            Assert.That(parentFacadeMetadata, Is.EqualTo(parentInputMetadata));
+            Assert.That(() => childFacade.TryGetMetadata(out _), Throws.TypeOf<InvalidOperationException>(),
+                "Child facades must seal when the child checkpoint ends.");
+            Assert.That(() => parentInput.TryGetMetadata(out _), Throws.Nothing,
+                "The original parent handle remains active.");
+        });
+    }
+
+    [Test]
+    public void NestedRequest_IsStagedUntilCommitAndDisposedOnRollback()
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+        var host = new RecordingHost(request);
+        using var root = new MemoryNode<int>(0);
+        using var committedBinding = new NestedRenderTargetBinding();
+
+        var committedTransaction = new NodeRecordingTransaction(host, new object(), []);
+        RecordedNestedRenderRequest committedNested = committedTransaction.RecordNestedRequest(
+            root,
+            request.Options.CreateNested(committedBinding));
+
+        Assert.That(host.Commits, Is.Empty,
+            "A nested graph must remain checkpoint-local before the parent commits.");
+
+        committedTransaction.Commit();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(host.Commits, Has.Count.EqualTo(1));
+            Assert.That(host.Commits[0].NestedRequests, Has.Length.EqualTo(1));
+            Assert.That(host.Commits[0].NestedRequests[0], Is.SameAs(committedNested));
+            Assert.That(committedNested.Request.State, Is.Not.EqualTo(RenderRequestState.Disposed));
+        });
+        committedNested.Request.Dispose();
+
+        using var rolledBackBinding = new NestedRenderTargetBinding();
+        var rolledBackTransaction = new NodeRecordingTransaction(host, new object(), []);
+        RecordedNestedRenderRequest rolledBackNested = rolledBackTransaction.RecordNestedRequest(
+            root,
+            request.Options.CreateNested(rolledBackBinding));
+        var primary = new InvalidOperationException("rollback nested request");
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => rolledBackTransaction.Rollback(primary));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.SameAs(primary));
+            Assert.That(host.Commits, Has.Count.EqualTo(1),
+                "Rollback must not publish the staged nested graph.");
+            Assert.That(rolledBackNested.Request.State, Is.EqualTo(RenderRequestState.Disposed));
+        });
+    }
+
+    [Test]
+    public void CommitAndRollback_RejectRetainedContextsAndHandles()
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+        var host = new RecordingHost(request);
+
+        var committedTransaction = new NodeRecordingTransaction(host, new object(), []);
+        var committedContext = new RenderNodeContext(committedTransaction);
+        RenderFragmentHandle committedHandle = CreateSource(committedTransaction, new Rect(0, 0, 1, 1));
+        committedTransaction.Publish(committedHandle);
+        committedTransaction.Commit();
+
+        var rolledBackTransaction = new NodeRecordingTransaction(host, new object(), []);
+        var rolledBackContext = new RenderNodeContext(rolledBackTransaction);
+        RenderFragmentHandle rolledBackHandle = CreateSource(rolledBackTransaction, new Rect(0, 0, 1, 1));
+        var primary = new InvalidOperationException("rollback");
+        InvalidOperationException? rollbackFailure = Assert.Throws<InvalidOperationException>(
+            () => rolledBackTransaction.Rollback(primary));
+        Assert.That(rollbackFailure, Is.SameAs(primary));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => committedHandle.TryGetMetadata(out _),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => _ = committedContext.Inputs, Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => _ = committedContext.Intent, Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => _ = committedContext.Purpose, Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => _ = committedContext.OutputScale, Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => _ = committedContext.MaxWorkingScale, Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => _ = committedContext.IsRenderCacheEnabled, Throws.TypeOf<InvalidOperationException>());
+            Assert.That(
+                () => committedContext.TryCalculateInputBounds(out _),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => committedContext.DisableRenderCache(), Throws.TypeOf<InvalidOperationException>());
+            Assert.That(
+                () => rolledBackHandle.TryGetMetadata(out _),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => _ = rolledBackContext.Inputs, Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => rolledBackContext.DisableRenderCache(), Throws.TypeOf<InvalidOperationException>());
+        });
+    }
+
+    [Test]
+    public void Rollback_ReleasesOwnedResourcesInReverseOrderAndPreservesPrimaryFailure()
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+        var host = new RecordingHost(request);
+        var transaction = new NodeRecordingTransaction(host, new object(), []);
+        var disposalOrder = new List<string>();
+        var first = new TrackedDisposable("first", disposalOrder);
+        var secondCleanupFailure = new InvalidOperationException("second cleanup failed");
+        var second = new TrackedDisposable("second", disposalOrder, secondCleanupFailure);
+        var third = new TrackedDisposable("third", disposalOrder);
+        var primary = new InvalidOperationException("recording failed");
+
+        transaction.Own(first, "first", 0);
+        transaction.Own(second, "second", 0);
+        transaction.Own(third, "third", 0);
+
+        InvalidOperationException? rollbackFailure = Assert.Throws<InvalidOperationException>(
+            () => transaction.Rollback(primary));
+        Assert.That(rollbackFailure, Is.SameAs(primary));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(disposalOrder, Is.EqualTo(new[] { "third", "second", "first" }));
+            Assert.That(first.DisposeCount, Is.EqualTo(1));
+            Assert.That(second.DisposeCount, Is.EqualTo(1));
+            Assert.That(third.DisposeCount, Is.EqualTo(1));
+            Assert.That(owner.PrimaryFailure?.SourceException, Is.SameAs(primary));
+            Assert.That(owner.SecondaryFailures, Has.Length.EqualTo(1));
+            Assert.That(owner.SecondaryFailures[0], Is.SameAs(secondCleanupFailure));
+            Assert.That(owner.CleanupFailures, Is.EqualTo(new[] { secondCleanupFailure }));
+        });
+
+        owner.Cleanup();
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.DisposeCount, Is.EqualTo(1));
+            Assert.That(second.DisposeCount, Is.EqualTo(1));
+            Assert.That(third.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void RollbackResources_ContinuesAfterCleanupFailureAndReportsAllFailures()
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+        var transaction = new NodeRecordingTransaction(new RecordingHost(request), new object(), []);
+        var disposalOrder = new List<string>();
+        var first = new TrackedDisposable("first", disposalOrder);
+        var secondFailure = new InvalidOperationException("second failed");
+        var second = new TrackedDisposable("second", disposalOrder, secondFailure);
+        var third = new TrackedDisposable("third", disposalOrder);
+        RenderResource<TrackedDisposable> firstToken = transaction.Own(first, "first", 0);
+        RenderResource<TrackedDisposable> secondToken = transaction.Own(second, "second", 0);
+        RenderResource<TrackedDisposable> thirdToken = transaction.Own(third, "third", 0);
+
+        AggregateException? failure = Assert.Throws<AggregateException>(
+            () => transaction.RollbackResources([firstToken, secondToken, thirdToken]));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(disposalOrder, Is.EqualTo(new[] { "third", "second", "first" }));
+            Assert.That(first.DisposeCount, Is.EqualTo(1));
+            Assert.That(second.DisposeCount, Is.EqualTo(1));
+            Assert.That(third.DisposeCount, Is.EqualTo(1));
+            Assert.That(failure!.InnerExceptions, Is.EqualTo(new[] { secondFailure }));
+            Assert.That(firstToken.RegistrationState, Is.EqualTo(RenderResourceRegistrationState.Released));
+            Assert.That(secondToken.RegistrationState, Is.EqualTo(RenderResourceRegistrationState.Released));
+            Assert.That(thirdToken.RegistrationState, Is.EqualTo(RenderResourceRegistrationState.Released));
+        });
+    }
+
+    [Test]
+    public void Recorder_RejectsDirectAndIndirectSubtreeCyclesWithAPath()
+    {
+        var direct = new ContainerRenderNode();
+        direct.AddChild(direct);
+        try
+        {
+            using var directOwner = new RenderRequestOwner();
+            using var directRequest = CreateRequest(directOwner);
+            var directRecorder = new RenderRequestRecorder(directRequest);
+
+            InvalidOperationException? directFailure = Assert.Throws<InvalidOperationException>(
+                () => directRecorder.Record(direct));
+
+            Assert.That(directFailure!.Message, Does.Contain(nameof(ContainerRenderNode)));
+            Assert.That(directFailure.Message, Does.Contain("->"));
+        }
+        finally
+        {
+            direct.RemoveChild(direct);
+            direct.Dispose();
+        }
+
+        var first = new ContainerRenderNode();
+        var second = new ContainerRenderNode();
+        first.AddChild(second);
+        second.AddChild(first);
+        try
+        {
+            using var indirectOwner = new RenderRequestOwner();
+            using var indirectRequest = CreateRequest(indirectOwner);
+            var indirectRecorder = new RenderRequestRecorder(indirectRequest);
+
+            InvalidOperationException? indirectFailure = Assert.Throws<InvalidOperationException>(
+                () => indirectRecorder.Record(first));
+
+            Assert.That(indirectFailure!.Message, Does.Contain("->"));
+            Assert.That(indirectFailure.Message.Split(nameof(ContainerRenderNode)).Length - 1,
+                Is.GreaterThanOrEqualTo(3));
+        }
+        finally
+        {
+            second.RemoveChild(first);
+            first.RemoveChild(second);
+            first.Dispose();
+            second.Dispose();
+        }
+    }
+
+    [Test]
+    public void Recorder_RejectsDirectAndIndirectRecordNodeCyclesWithAPath()
+    {
+        using var directOwner = new RenderRequestOwner();
+        using var directRequest = CreateRequest(directOwner);
+        using var direct = new MemoryNode<int>(0);
+        var directRecorder = new RenderRequestRecorder(directRequest);
+        var directTransaction = new NodeRecordingTransaction(directRecorder, new object(), []);
+
+        InvalidOperationException? directFailure;
+        using (directOwner.RecordingFamily.Enter(direct))
+        {
+            directFailure = Assert.Throws<InvalidOperationException>(
+                () => directTransaction.RecordNode(direct, [], subtree: false));
+        }
+
+        using var indirectOwner = new RenderRequestOwner();
+        using var indirectRequest = CreateRequest(indirectOwner);
+        using var first = new MemoryNode<int>(1);
+        using var second = new MemoryNode<int>(2);
+        var indirectRecorder = new RenderRequestRecorder(indirectRequest);
+        var indirectTransaction = new NodeRecordingTransaction(indirectRecorder, new object(), []);
+
+        InvalidOperationException? indirectFailure;
+        using (indirectOwner.RecordingFamily.Enter(first))
+        using (indirectOwner.RecordingFamily.Enter(second))
+        {
+            indirectFailure = Assert.Throws<InvalidOperationException>(
+                () => indirectTransaction.RecordNode(first, [], subtree: false));
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(directFailure!.Message, Does.Contain(nameof(MemoryNode<int>)));
+            Assert.That(directFailure.Message, Does.Contain("->"));
+            Assert.That(indirectFailure!.Message, Does.Contain(nameof(MemoryNode<int>)));
+            Assert.That(indirectFailure.Message, Does.Contain("->"));
+        });
+    }
+
+    [Test]
+    public void Recorder_RejectsASeparateTargetCycleUsingTheRequestFamilyGuard()
+    {
+        using var owner = new RenderRequestOwner();
+        RenderRequestOptions options = CreateOptions(owner);
+        using var request = new RenderRequest(options);
+        using var node = new MemoryNode<int>(0);
+        using var binding = new NestedRenderTargetBinding();
+        var recorder = new RenderRequestRecorder(request);
+
+        InvalidOperationException? failure;
+        using (owner.RecordingFamily.Enter(node))
+        {
+            failure = Assert.Throws<InvalidOperationException>(
+                () => recorder.RecordNestedRequest(node, options.CreateNested(binding)));
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Does.Contain(nameof(MemoryNode<int>)));
+            Assert.That(failure.Message, Does.Contain("->"));
+        });
+    }
+
+    [Test]
+    public void Recorder_AllowsSequentialReuseAfterTheActiveScopeEnds()
+    {
+        var root = new ContainerRenderNode();
+        var repeated = new MemoryNode<int>(0);
+        root.AddChild(repeated);
+        root.AddChild(repeated);
+        using var owner = new RenderRequestOwner();
+        using var request = CreateRequest(owner);
+        var recorder = new RenderRequestRecorder(request);
+
+        Assert.That(() => recorder.Record(root), Throws.Nothing);
+
+        root.RemoveChild(repeated);
+        root.RemoveChild(repeated);
+        root.Dispose();
+        repeated.Dispose();
+    }
+
+    private static RenderRequest CreateRequest(RenderRequestOwner owner)
+    {
+        return new RenderRequest(CreateOptions(owner));
+    }
+
+    private static RenderRequestOptions CreateOptions(RenderRequestOwner owner)
+    {
+        return new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            owner: owner);
+    }
+
+    private static RenderFragmentHandle CreateSource(NodeRecordingTransaction transaction, Rect bounds)
+    {
+        return transaction.CreateFragment(
+            RenderFragmentKind.OpaqueSource,
+            bounds,
+            EffectiveScale.Unbounded,
+            RenderValueCardinality.Single,
+            contributesValuesToTarget: true,
+            canBeUsedAsValueInput: true,
+            hasTargetEffects: false,
+            hasOpaqueExternalWork: false,
+            inputs: null,
+            payload: null,
+            hitTest: bounds.Contains);
+    }
+
+    private sealed class RecordingHost(RenderRequest request) : IRenderRequestRecordingHost
+    {
+        public RenderRequest Request { get; } = request;
+
+        public bool IsRenderCacheEnabled { get; private set; } = true;
+
+        public Action<RenderNodeContext>? ChildAction { get; init; }
+
+        public IReadOnlyList<RenderFragmentHandle> LastChildInputs { get; private set; } = [];
+
+        public List<NodeRecordingCommit> Commits { get; } = [];
+
+        public IReadOnlyList<RenderFragmentReference> RecordNode(
+            NodeRecordingTransaction parent,
+            RenderNode node,
+            IReadOnlyList<RenderFragmentReference> inputs,
+            bool subtree)
+        {
+            var child = new NodeRecordingTransaction(this, node, inputs, parent);
+            LastChildInputs = child.Inputs;
+            ChildAction?.Invoke(new RenderNodeContext(child));
+            return child.Commit();
+        }
+
+        public RecordedNestedRenderRequest RecordNestedRequest(
+            RenderNode root,
+            RenderRequestOptions options)
+        {
+            var nestedRequest = new RenderRequest(options, Request);
+            RecordedRenderGraph graph = new RecordedRenderGraphBuilder(nestedRequest.Id).Build();
+            return new RecordedNestedRenderRequest(nestedRequest, graph);
+        }
+
+        public void Commit(NodeRecordingCommit commit)
+        {
+            Commits.Add(commit);
+            foreach (RenderResource resource in commit.Resources)
+            {
+                Request.Options.Owner.ResourceRegistry.Commit(resource);
+            }
+
+            if (commit.CacheDisabled)
+                IsRenderCacheEnabled = false;
+        }
+    }
+
+    private sealed class TrackedDisposable(
+        string name,
+        List<string>? disposalOrder = null,
+        Exception? disposeFailure = null) : IDisposable
+    {
+        public int DisposeCount { get; private set; }
+
+        public void Dispose()
+        {
+            DisposeCount++;
+            disposalOrder?.Add(name);
+            if (disposeFailure is not null)
+                throw disposeFailure;
+        }
+    }
+
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/PrimaryPaintedSourceTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/PrimaryPaintedSourceTests.cs
@@ -1,0 +1,341 @@
+﻿using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Recording;
+
+/// <summary>
+/// Pins what the primary-resource form of <see cref="RenderNodeContext.PaintedSource"/> declares and what it
+/// costs, against the equivalent named-resource form.
+/// </summary>
+[TestFixture]
+public sealed class PrimaryPaintedSourceTests
+{
+    private static readonly Rect s_bounds = new(0, 0, 8, 8);
+
+    [Test]
+    public void ThePrimaryFormDeclaresTheSameResourcesInTheSameOrderAsTheNamedResourceForm()
+    {
+        using var shared = new SharedPaint();
+        using var declared = new PaintedNode(shared, usePrimary: false);
+        using var primary = new PaintedNode(shared, usePrimary: true);
+
+        Assert.That(DeclaredKeys(primary), Is.EqualTo(DeclaredKeys(declared)),
+            "the recorder prepending the primary must reproduce the same ordered identities as the named declaration, "
+            + "because RenderCacheResolver.AddResources writes the count and every identity in order into the "
+            + "output-cache key");
+    }
+
+    /// <remarks>
+    /// The wrapper the recorder builds around the three-argument callback is not the runtime identity — the
+    /// author's state still is — so an unchanged second frame must still reach the first frame's output.
+    /// </remarks>
+    [Test]
+    public void ThePrimaryFormKeepsTheOutputCacheHitTheNamedResourceFormEarned()
+    {
+        using var declaredPaint = new SharedPaint();
+        using var primaryPaint = new SharedPaint();
+        using var declared = new PaintedNode(declaredPaint, usePrimary: false);
+        using var primary = new PaintedNode(primaryPaint, usePrimary: true);
+
+        RasterizeTwice(declared);
+        RasterizeTwice(primary);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(declared.DrawCount, Is.EqualTo(1));
+            Assert.That(primary.DrawCount, Is.EqualTo(1),
+                "the second frame must be served from the cached output without re-invoking the draw callback");
+        });
+    }
+
+    /// <remarks>
+    /// The measurement covers a whole rasterization, so the shared scaffold — targets, the request family, the
+    /// output bitmap — dwarfs the per-form difference. Taking the quietest of several rounds keeps the estimate
+    /// from depending on which round an unrelated allocation landed in; allocation noise only ever adds.
+    /// </remarks>
+    [Test]
+    public void ThePrimaryFormAllocatesNoMorePerRasterizationThanTheNamedResourceForm()
+    {
+        long declared = MeasureBytesPerRasterization(
+            static shared => new PaintedNode(shared, usePrimary: false));
+        long primary = MeasureBytesPerRasterization(
+            static shared => new PaintedNode(shared, usePrimary: true));
+
+        TestContext.Out.WriteLine($"named-resource form: {declared} bytes/rasterization");
+        TestContext.Out.WriteLine($"primary form: {primary} bytes/rasterization");
+        TestContext.Out.WriteLine($"difference: {primary - declared} bytes/rasterization");
+        Assert.That(primary, Is.LessThanOrEqualTo(declared),
+            "the recorder took over the author's name, type argument and nested closure, so it must not have "
+            + "added an allocation to a path that runs per node per frame");
+    }
+
+    /// <summary>
+    /// The same comparison on the shipped <see cref="GeometryRenderNode"/> rather than on a node built for the
+    /// test, against a reconstruction whose <c>Process</c> body differs only in recording the drawing through
+    /// the named-resource overload.
+    /// </summary>
+    /// <remarks>
+    /// Both nodes run in this one process against the same engine resources and the same paint, so the figure
+    /// is a difference between two recordings of one drawing rather than between two builds, and it isolates
+    /// the overload from the rest of the branch. The absolute totals move with the shared rasterization
+    /// scaffold; only the difference is a property of the two overloads.
+    /// </remarks>
+    [Test]
+    public void TheShippedGeometryRenderNodeAllocatesNoMorePerRasterizationThanTheNamedResourceFormOfItsOwnBody()
+    {
+        long declared = MeasureBytesPerRasterization(
+            static shared => new DeclaredGeometryRenderNode(shared));
+        long shipped = MeasureBytesPerRasterization(
+            static shared => new GeometryRenderNode(shared.Geometry, shared.Fill, shared.Pen));
+
+        TestContext.Out.WriteLine($"named-resource body: {declared} bytes/rasterization");
+        TestContext.Out.WriteLine($"shipped node: {shipped} bytes/rasterization");
+        TestContext.Out.WriteLine($"difference: {shipped - declared} bytes/rasterization");
+        Assert.That(shipped, Is.LessThanOrEqualTo(declared));
+    }
+
+    private static object?[] DeclaredKeys(RenderNode node)
+    {
+        using var owner = new RenderRequestOwner();
+        using var request = new RenderRequest(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            outputScale: 1,
+            maxWorkingScale: 1,
+            owner: owner));
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        RenderFragmentId rootId = graph.PublicationRoots.Single();
+        var root = (RenderFragmentReference)graph.Fragments
+            .Single(fragment => fragment.Id == rootId)
+            .Payload!;
+        var payload = (OpaqueRenderFragmentPayload)root.Payload!;
+        return [.. payload.Description.Resources.Select(static binding => binding.Resource.CacheIdentity.Key)];
+    }
+
+    private static void RasterizeTwice(RenderNode node)
+    {
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using RenderNodeRenderer renderer = CreateRenderer(node, RenderCacheOptions.Enabled);
+        using (RenderNodeRasterization first = renderer.Rasterize())
+        {
+            Assert.That(first.IsEmpty, Is.False);
+        }
+
+        using RenderNodeRasterization second = renderer.Rasterize();
+        Assert.That(second.IsEmpty, Is.False);
+    }
+
+    private static long MeasureBytesPerRasterization(Func<SharedPaint, RenderNode> create)
+        => MeasureQuietestRound(iterations => RasterizeRepeatedly(create, iterations));
+
+    private static long MeasureQuietestRound(Action<int> run)
+    {
+        const int Iterations = 200;
+        const int Rounds = 7;
+        run(50);
+
+        long quietestRound = long.MaxValue;
+        for (int round = 0; round < Rounds; round++)
+        {
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            run(Iterations);
+            long after = GC.GetAllocatedBytesForCurrentThread();
+            quietestRound = Math.Min(quietestRound, after - before);
+        }
+
+        return quietestRound / Iterations;
+    }
+
+    private static void RasterizeRepeatedly(Func<SharedPaint, RenderNode> create, int iterations)
+    {
+        using var shared = new SharedPaint();
+        using RenderNode node = create(shared);
+        using RenderNodeRenderer renderer = CreateRenderer(node, RenderCacheOptions.Disabled);
+        for (int index = 0; index < iterations; index++)
+        {
+            using RenderNodeRasterization rasterization = renderer.Rasterize();
+        }
+    }
+
+    private static RenderNodeRenderer CreateRenderer(RenderNode node, RenderCacheOptions cacheOptions)
+        => new(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    TargetDomain = s_bounds,
+                    CacheOptions = cacheOptions,
+                    Purpose = RenderRequestPurpose.Frame,
+                },
+            });
+
+    /// <remarks>
+    /// The engine resources are shared so the two variants declare the same identities, which is the whole
+    /// point of the order comparison: the only difference between them is which overload records the source.
+    /// </remarks>
+    private sealed class SharedPaint : IDisposable
+    {
+        private readonly EllipseGeometry _geometry = new()
+        {
+            Width = { CurrentValue = 8 },
+            Height = { CurrentValue = 8 },
+        };
+
+        private readonly Pen _pen = new()
+        {
+            Brush = { CurrentValue = Brushes.Black },
+            Thickness = { CurrentValue = 2 },
+        };
+
+        public SharedPaint()
+        {
+            Geometry = _geometry.ToResource(CompositionContext.Default);
+            Fill = (SolidColorBrush.Resource)new SolidColorBrush(Colors.Red)
+                .ToResource(CompositionContext.Default);
+            Pen = _pen.ToResource(CompositionContext.Default);
+        }
+
+        public Geometry.Resource Geometry { get; }
+
+        public SolidColorBrush.Resource Fill { get; }
+
+        public Pen.Resource Pen { get; }
+
+        public DrawCounter Counter { get; } = new();
+
+        public void Dispose()
+        {
+            Geometry.Dispose();
+            Fill.Dispose();
+            Pen.Dispose();
+        }
+    }
+
+    /// <remarks>
+    /// A copy of <see cref="GeometryRenderNode"/>'s <c>Process</c> body with one edit: the drawing is recorded
+    /// through the named-resource overload, so the geometry travels in <c>resources</c> under the recorder's
+    /// canonical primary name.
+    /// Its hit-test state is a local equivalent of the node's private one.
+    /// </remarks>
+    private sealed class DeclaredGeometryRenderNode(SharedPaint shared) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            (Geometry.Resource Resource, int Version) geometrySnapshot = shared.Geometry.Capture()!.Value;
+            (Brush.Resource Resource, int Version)? fillSnapshot = shared.Fill.Capture();
+            (Pen.Resource Resource, int Version)? penSnapshot = shared.Pen.Capture();
+            Geometry.Resource geometry = geometrySnapshot.Resource;
+            Brush.Resource? fill = fillSnapshot?.Resource;
+            Pen.Resource? pen = penSnapshot?.Resource;
+            Rect bounds = PenHelper.CalculateBoundsWithStrokeCap(geometry.GetRenderBounds(pen), pen);
+            if (bounds.Width == 0 || bounds.Height == 0)
+                return;
+
+            RenderResource<Geometry.Resource> geometryResource = context.Borrow(geometrySnapshot);
+            var hitTestState = new HitTestState(geometry, fill, pen);
+            var hitTestIdentity = new HitTestIdentity(
+                geometry.GetOriginal().Id,
+                geometrySnapshot.Version,
+                fill?.GetOriginal().Id,
+                fillSnapshot?.Version,
+                pen?.GetOriginal().Id,
+                penSnapshot?.Version);
+            RenderResource<HitTestState> hitTestResource = context.Borrow(hitTestState, hitTestIdentity);
+
+            context.Publish(context.PaintedSource(
+                state: bounds,
+                draw: static (session, _) => session.UseDeclaredResource<Geometry.Resource>(
+                    "__primary",
+                    geometry => session.Canvas.DrawGeometry(geometry, session.Fill, session.Pen)),
+                fill: fillSnapshot,
+                pen: penSnapshot,
+                brushBounds: bounds,
+                outputBounds: bounds,
+                hitTest: RenderHitTestContract.FromResource(
+                    hitTestResource,
+                    static (state, point) => state.HitTest(point),
+                    typeof(HitTestState)),
+                scale: RenderScaleContract.Vector,
+                structuralKey: typeof(GeometryRenderNode),
+                resources: [hitTestResource.Bind("hitTest"), geometryResource.Bind("__primary")]));
+        }
+
+        private sealed class HitTestState(
+            Geometry.Resource geometry,
+            Brush.Resource? fill,
+            Pen.Resource? pen)
+        {
+            public bool HitTest(Point point)
+            {
+                return (fill is not null && geometry.FillContains(point))
+                       || (pen is not null && geometry.StrokeContains(pen, point));
+            }
+        }
+
+        private readonly record struct HitTestIdentity(
+            Guid GeometryId,
+            int GeometryVersion,
+            Guid? FillId,
+            int? FillVersion,
+            Guid? PenId,
+            int? PenVersion);
+    }
+
+    private sealed class PaintedNode(SharedPaint shared, bool usePrimary) : RenderNode
+    {
+        public int DrawCount => shared.Counter.Count;
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<Geometry.Resource> geometry = context.Borrow(shared.Geometry.Capture()!.Value);
+            RenderResource<DrawCounter> counter =
+                context.Borrow(shared.Counter, cacheKey: "counter", version: 1);
+            context.Publish(usePrimary
+                ? context.PaintedSource(
+                    primary: geometry,
+                    state: s_bounds,
+                    draw: static (session, current, _) =>
+                    {
+                        session.UseDeclaredResource<DrawCounter>("counter", static value => value.Record());
+                        session.Canvas.DrawGeometry(current, session.Fill, session.Pen);
+                    },
+                    fill: (shared.Fill, shared.Fill.Version),
+                    pen: null,
+                    brushBounds: s_bounds,
+                    outputBounds: s_bounds,
+                    hitTest: RenderHitTestContract.OutputBounds,
+                    scale: RenderScaleContract.Vector,
+                    structuralKey: typeof(PaintedNode),
+                    resources: [counter.Bind("counter")])
+                : context.PaintedSource(
+                    state: s_bounds,
+                    draw: static (session, _) => session.UseDeclaredResource<Geometry.Resource>(
+                        "__primary",
+                        current =>
+                        {
+                            session.UseDeclaredResource<DrawCounter>("counter", static value => value.Record());
+                            session.Canvas.DrawGeometry(current, session.Fill, session.Pen);
+                        }),
+                    fill: (shared.Fill, shared.Fill.Version),
+                    pen: null,
+                    brushBounds: s_bounds,
+                    outputBounds: s_bounds,
+                    hitTest: RenderHitTestContract.OutputBounds,
+                    scale: RenderScaleContract.Vector,
+                    structuralKey: typeof(PaintedNode),
+                    resources: [counter.Bind("counter"), geometry.Bind("__primary")]));
+        }
+    }
+
+    private sealed class DrawCounter
+    {
+        public int Count { get; private set; }
+
+        public void Record() => Count++;
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RecordingSideEffectTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RecordingSideEffectTests.cs
@@ -1,0 +1,769 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Recording;
+
+[TestFixture]
+public sealed class RecordingSideEffectTests
+{
+    private static readonly MetadataReference[] s_semanticReferences = CreateSemanticReferences();
+
+    private static readonly string[] s_forbiddenEagerInvocations =
+    [
+        "Acquire",
+        "CreateRenderTarget",
+        "CreateSkiaSurface",
+        "Decode",
+        "Flush",
+        "GetFrame",
+        "GetRenderTarget",
+        "Initialize",
+        "Pull",
+        "PullToRoot",
+        "Rasterize",
+        "Read",
+        "ReadAudio",
+        "ReadFrame",
+        "ReadPixels",
+        "ReadVideo",
+        "Render",
+        "RenderDrawableToTarget",
+        "RenderFallbackEllipse",
+        "Resize",
+        "Submit",
+        "Synchronize",
+        "UseSnapshot",
+        "Wait",
+    ];
+
+    private static readonly string[] s_forbiddenEagerConstructions =
+    [
+        "ImmediateCanvas",
+        "Renderer",
+        "Renderer3D",
+        "RenderNodeProcessor",
+        "RenderNodeRenderer",
+        "RenderTarget",
+    ];
+
+    [Test]
+    public void EveryProductionProcessOverride_DefersGpuMediaAndNestedExecution()
+    {
+        string repositoryRoot = FindRepositoryRoot();
+        SourceMethod[] overrides = EnumerateProductionProcessOverrides(repositoryRoot).ToArray();
+        SourceFinding[] findings = overrides
+            .SelectMany(FindEagerExecution)
+            .OrderBy(static finding => finding.RelativePath, StringComparer.Ordinal)
+            .ThenBy(static finding => finding.Line)
+            .ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(overrides, Has.Length.EqualTo(30),
+                "The recording probe must cover the 28 surviving baseline overrides and both new request facades.");
+            Assert.That(findings, Is.Empty,
+                "RenderNode.Process must only capture immutable CPU state and descriptions; execution belongs in "
+                + $"deferred callbacks.{Environment.NewLine}{FormatFindings(findings)}");
+        });
+    }
+
+    [Test]
+    public void RecordingDeferredShapes_LeavesEveryExecutionProbeAtZero()
+    {
+        var tripwire = new SideEffectTripwire();
+        var targetFactory = new CountingTargetFactory();
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var node = new DeferredShapeProbeNode(tripwire);
+        using var renderer = new RenderNodeRenderer(node, new RenderNodeRendererOptions
+        {
+            DefaultRequest = new RenderNodeRenderRequest
+            {
+                TargetDomain = DeferredShapeProbeNode.Bounds,
+                Diagnostics = diagnostics,
+                CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+            },
+            TargetFactory = targetFactory,
+        });
+
+        RenderNodeMeasurement measurement = renderer.Measure();
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        RenderPipelineCounter[] executionCounters =
+        [
+            RenderPipelineCounter.ExecutedGpuPasses,
+            RenderPipelineCounter.IntermediateAcquires,
+            RenderPipelineCounter.IntermediateCreates,
+            RenderPipelineCounter.Synchronizations,
+            RenderPipelineCounter.ProgramCreations,
+            RenderPipelineCounter.OpaqueExternalExecutions,
+        ];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(measurement.HasFragments, Is.True);
+            Assert.That(tripwire.Counts.Values, Is.All.Zero,
+                "Recording and metadata resolution must not execute any deferred callback.");
+            Assert.That(targetFactory.CreateCalls, Is.Zero);
+            foreach (RenderPipelineCounter counter in executionCounters)
+                Assert.That(snapshot[counter], Is.Zero, $"{counter} must remain zero during recording.");
+        });
+    }
+
+    private static IEnumerable<SourceMethod> EnumerateProductionProcessOverrides(string repositoryRoot)
+    {
+        string sourceRoot = Path.Combine(repositoryRoot, "src");
+        foreach (string path in Directory.EnumerateFiles(sourceRoot, "*.cs", SearchOption.AllDirectories))
+        {
+            string relativePath = NormalizePath(Path.GetRelativePath(repositoryRoot, path));
+            if (HasPathSegment(relativePath, "bin") || HasPathSegment(relativePath, "obj"))
+                continue;
+
+            SourceText text = SourceText.From(File.ReadAllText(path));
+            SyntaxTree tree = CSharpSyntaxTree.ParseText(
+                text,
+                CSharpParseOptions.Default.WithDocumentationMode(DocumentationMode.Parse),
+                relativePath);
+            CompilationUnitSyntax root = tree.GetCompilationUnitRoot();
+            SemanticModel semanticModel = CSharpCompilation.Create(
+                    $"RecordingSideEffectProbe_{Path.GetFileNameWithoutExtension(path)}",
+                    [tree],
+                    s_semanticReferences,
+                    new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+                .GetSemanticModel(tree, ignoreAccessibility: true);
+            foreach (MethodDeclarationSyntax method in root.DescendantNodes()
+                         .OfType<MethodDeclarationSyntax>()
+                         .Where(IsRenderNodeProcessOverride))
+            {
+                yield return new SourceMethod(relativePath, text, method, semanticModel);
+            }
+        }
+    }
+
+    private static IEnumerable<SourceFinding> FindEagerExecution(SourceMethod source)
+    {
+        var invocationNames = new HashSet<string>(s_forbiddenEagerInvocations, StringComparer.Ordinal);
+        var constructionNames = new HashSet<string>(s_forbiddenEagerConstructions, StringComparer.Ordinal);
+        SyntaxNode[] eagerNodes = EnumerateSynchronousBodies(source)
+            .SelectMany(EnumerateExecutableNodes)
+            .ToArray();
+
+        foreach (InvocationExpressionSyntax invocation in eagerNodes.OfType<InvocationExpressionSyntax>())
+        {
+            string? name = GetInvokedName(invocation);
+            if (name is not null
+                && invocationNames.Contains(name)
+                && !IsCpuNodeDescriptionRender(invocation, name))
+            {
+                yield return source.ToFinding(
+                    invocation,
+                    $"eager invocation '{name}'");
+            }
+
+            if (name == "Snapshot" && IsNativeSnapshotInvocation(invocation, source.SemanticModel))
+            {
+                yield return source.ToFinding(invocation, "eager surface/target snapshot");
+            }
+
+            if ((name is null || !invocationNames.Contains(name))
+                && IsTargetFactoryInvocation(invocation, source.SemanticModel))
+            {
+                yield return source.ToFinding(invocation, "eager target-factory access");
+            }
+        }
+
+        foreach (ObjectCreationExpressionSyntax creation in eagerNodes.OfType<ObjectCreationExpressionSyntax>())
+        {
+            if (creation.Type is null) continue;
+            string? name = creation.Type.DescendantTokens()
+                .LastOrDefault(static token => token.IsKind(SyntaxKind.IdentifierToken))
+                .ValueText;
+            if (name is not null && constructionNames.Contains(name))
+            {
+                yield return source.ToFinding(creation, $"eager construction '{name}'");
+            }
+        }
+        foreach (ImplicitObjectCreationExpressionSyntax creation in eagerNodes.OfType<ImplicitObjectCreationExpressionSyntax>())
+        {
+            ITypeSymbol? type = source.SemanticModel.GetTypeInfo(creation).Type;
+            string? name = type?.ToDisplayString().Split('.').LastOrDefault();
+            if (name is not null && constructionNames.Contains(name))
+            {
+                yield return source.ToFinding(creation, $"eager construction '{name}'");
+            }
+        }
+
+        foreach (IdentifierNameSyntax identifier in eagerNodes.OfType<IdentifierNameSyntax>())
+        {
+            if (identifier.Identifier.ValueText == "GraphicsContextFactory")
+            {
+                yield return source.ToFinding(identifier, "eager GPU-context access");
+            }
+
+        }
+
+        Dictionary<string, string?> delegateTargets = new(StringComparer.Ordinal);
+        foreach (LocalDeclarationStatementSyntax declaration in eagerNodes.OfType<LocalDeclarationStatementSyntax>())
+        {
+            foreach (VariableDeclaratorSyntax variable in declaration.Declaration.Variables)
+            {
+                if (variable.Initializer?.Value is IdentifierNameSyntax methodGroup
+                    && source.SemanticModel.GetSymbolInfo(methodGroup).Symbol is IMethodSymbol target)
+                {
+                    delegateTargets[variable.Identifier.ValueText] = target.Name;
+                }
+            }
+        }
+        if (delegateTargets.Count > 0)
+        {
+            foreach (InvocationExpressionSyntax invocation in eagerNodes.OfType<InvocationExpressionSyntax>())
+            {
+                if (invocation.Expression is IdentifierNameSyntax identifier
+                    && delegateTargets.TryGetValue(identifier.Identifier.ValueText, out string? targetName)
+                    && targetName is not null
+                    && invocationNames.Contains(targetName)
+                    && !IsCpuNodeDescriptionRender(invocation, targetName))
+                {
+                    yield return source.ToFinding(
+                        invocation,
+                        $"eager delegate invocation '{targetName}'");
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<SyntaxNode> EnumerateSynchronousBodies(SourceMethod source)
+    {
+        var pending = new Queue<SyntaxNode>();
+        var visited = new HashSet<(SyntaxTree Tree, int Start, int Length)>();
+        pending.Enqueue(source.Method);
+        while (pending.TryDequeue(out SyntaxNode? body))
+        {
+            var key = (body.SyntaxTree, body.SpanStart, body.Span.Length);
+            if (!visited.Add(key))
+                continue;
+            yield return body;
+
+            IEnumerable<InvocationExpressionSyntax> invocations = EnumerateExecutableNodes(body)
+                .OfType<InvocationExpressionSyntax>();
+            foreach (InvocationExpressionSyntax invocation in invocations)
+            {
+                SymbolInfo symbolInfo = source.SemanticModel.GetSymbolInfo(invocation);
+                IEnumerable<IMethodSymbol> targets = symbolInfo.Symbol is IMethodSymbol target
+                    ? [target]
+                    : symbolInfo.CandidateSymbols.OfType<IMethodSymbol>();
+                foreach (SyntaxReference reference in targets.SelectMany(
+                             static method => method.DeclaringSyntaxReferences))
+                {
+                    SyntaxNode declaration = reference.GetSyntax();
+                    if (declaration.SyntaxTree != source.Method.SyntaxTree)
+                        continue;
+                    if (declaration is MethodDeclarationSyntax or LocalFunctionStatementSyntax)
+                        pending.Enqueue(declaration);
+                }
+
+                string? invokedName = GetInvokedName(invocation);
+                if (invokedName is null)
+                    continue;
+                MethodDeclarationSyntax? declaringMethod =
+                    invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+                foreach (LocalFunctionStatementSyntax localFunction in (declaringMethod?.DescendantNodes()
+                             .OfType<LocalFunctionStatementSyntax>()
+                             .Where(local => !local.Ancestors()
+                                 .TakeWhile(ancestor => ancestor != declaringMethod)
+                                 .OfType<AnonymousFunctionExpressionSyntax>()
+                                 .Any())
+                         ?? [])
+                             .Where(local => string.Equals(
+                                 local.Identifier.ValueText,
+                                 invokedName,
+                                 StringComparison.Ordinal)))
+                {
+                    pending.Enqueue(localFunction);
+                }
+            }
+
+            IEnumerable<IdentifierNameSyntax> identifiers = EnumerateExecutableNodes(body)
+                .OfType<IdentifierNameSyntax>();
+            foreach (IdentifierNameSyntax identifier in identifiers)
+            {
+                if (source.SemanticModel.GetSymbolInfo(identifier).Symbol is not IPropertySymbol
+                    {
+                        GetMethod: { } getter,
+                    } property)
+                {
+                    continue;
+                }
+
+                foreach (SyntaxReference reference in getter.DeclaringSyntaxReferences
+                             .Concat(property.DeclaringSyntaxReferences))
+                {
+                    SyntaxNode declaration = reference.GetSyntax();
+                    if (declaration.SyntaxTree == source.Method.SyntaxTree
+                        && declaration is AccessorDeclarationSyntax or PropertyDeclarationSyntax)
+                    {
+                        pending.Enqueue(declaration);
+                    }
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<SyntaxNode> EnumerateExecutableNodes(SyntaxNode declaration)
+    {
+        SyntaxNode? root = declaration switch
+        {
+            MethodDeclarationSyntax { Body: { } body } => body,
+            MethodDeclarationSyntax { ExpressionBody.Expression: { } expression } => expression,
+            LocalFunctionStatementSyntax { Body: { } body } => body,
+            LocalFunctionStatementSyntax { ExpressionBody.Expression: { } expression } => expression,
+            AccessorDeclarationSyntax { Body: { } body } => body,
+            AccessorDeclarationSyntax { ExpressionBody.Expression: { } expression } => expression,
+            PropertyDeclarationSyntax { ExpressionBody.Expression: { } expression } => expression,
+            _ => null,
+        };
+        if (root is null)
+            yield break;
+
+        foreach (SyntaxNode node in root.DescendantNodesAndSelf(
+                     descendIntoChildren: static child =>
+                         child is not AnonymousFunctionExpressionSyntax
+                         && child is not LocalFunctionStatementSyntax))
+        {
+            yield return node;
+        }
+    }
+
+    private static bool IsRenderNodeProcessOverride(MethodDeclarationSyntax method)
+    {
+        if (method.Identifier.ValueText != "Process"
+            || !method.Modifiers.Any(SyntaxKind.OverrideKeyword)
+            || method.ParameterList.Parameters.Count != 1)
+        {
+            return false;
+        }
+
+        TypeSyntax? type = method.ParameterList.Parameters[0].Type;
+        return type?.DescendantTokens()
+            .LastOrDefault(static token => token.IsKind(SyntaxKind.IdentifierToken))
+            .ValueText == "RenderNodeContext";
+    }
+
+    private static string? GetInvokedName(InvocationExpressionSyntax invocation)
+    {
+        return invocation.Expression switch
+        {
+            IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
+            GenericNameSyntax generic => generic.Identifier.ValueText,
+            MemberAccessExpressionSyntax member => member.Name.Identifier.ValueText,
+            MemberBindingExpressionSyntax binding => binding.Name.Identifier.ValueText,
+            _ => null,
+        };
+    }
+
+    private static bool IsNativeSnapshotInvocation(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel)
+    {
+        IMethodSymbol? method = semanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol;
+        ITypeSymbol? type = method?.ContainingType;
+        if (type is null && invocation.Expression is MemberAccessExpressionSyntax member)
+            type = semanticModel.GetTypeInfo(member.Expression).Type;
+
+        for (INamedTypeSymbol? current = type as INamedTypeSymbol;
+             current is not null;
+             current = current.BaseType)
+        {
+            string name = current.ToDisplayString();
+            if (name is "Beutl.Graphics.Rendering.RenderTarget"
+                or "Beutl.Graphics.Rendering.Renderer"
+                or "SkiaSharp.SKSurface")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static MetadataReference[] CreateSemanticReferences()
+    {
+        var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") is string trustedPlatformAssemblies)
+        {
+            foreach (string path in trustedPlatformAssemblies.Split(Path.PathSeparator))
+                paths.Add(path);
+        }
+
+        paths.Add(typeof(RenderNode).Assembly.Location);
+        paths.Add(typeof(SKSurface).Assembly.Location);
+        return paths
+            .Where(static path => !string.IsNullOrEmpty(path) && File.Exists(path))
+            .Select(static path => MetadataReference.CreateFromFile(path))
+            .ToArray();
+    }
+
+    [Test]
+    public void TargetFactoryProbe_ResolvesReceiversByType()
+    {
+        const string source = """
+            using Beutl.Graphics.Rendering;
+
+            public sealed class Probe
+            {
+                public void Run(IRenderTargetFactory allocator)
+                {
+                    allocator.Create(default);
+                }
+            }
+            """;
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "TargetFactoryReceiverProbe",
+            [tree],
+            s_semanticReferences,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        SemanticModel semanticModel = compilation.GetSemanticModel(tree);
+        InvocationExpressionSyntax invocation = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Single();
+
+        Assert.That(IsTargetFactoryInvocation(invocation, semanticModel), Is.True,
+            "An IRenderTargetFactory receiver named 'allocator' must remain inside the recording gate.");
+    }
+
+    [Test]
+    public void EagerExecutionCensus_FollowsSynchronousMethodsAndLocalFunctions()
+    {
+        const string sourceText = """
+            public sealed class Probe
+            {
+                public void Process()
+                {
+                    Helper();
+                    Local();
+                    void Local() => ReadFrame();
+                }
+
+                private static void Helper() => Render();
+                private static void Render() { }
+                private static void ReadFrame() { }
+            }
+            """;
+        SourceText text = SourceText.From(sourceText);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(text);
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "SynchronousHelperProbe",
+            [tree],
+            s_semanticReferences,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        SemanticModel semanticModel = compilation.GetSemanticModel(tree);
+        MethodDeclarationSyntax process = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Single(static method => method.Identifier.ValueText == "Process");
+        var source = new SourceMethod("Probe.cs", text, process, semanticModel);
+
+        SourceFinding[] findings = FindEagerExecution(source).ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(findings.Select(static finding => finding.Detail),
+                Has.Some.Contains("'Render'"));
+            Assert.That(findings.Select(static finding => finding.Detail),
+                Has.Some.Contains("'ReadFrame'"));
+        });
+    }
+
+    [Test]
+    public void EagerExecutionCensus_FollowsExpressionBodiedPropertyGetters()
+    {
+        const string sourceText = """
+            public sealed class Probe
+            {
+                public object Process() => Current;
+
+                private static object Current => ReadFrame();
+                private static object ReadFrame() => new();
+            }
+            """;
+        SourceText text = SourceText.From(sourceText);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(text);
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "ExpressionBodiedPropertyProbe",
+            [tree],
+            s_semanticReferences,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        SemanticModel semanticModel = compilation.GetSemanticModel(tree);
+        MethodDeclarationSyntax process = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Single(static method => method.Identifier.ValueText == "Process");
+        var source = new SourceMethod("Probe.cs", text, process, semanticModel);
+
+        SourceFinding[] findings = FindEagerExecution(source).ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                findings.Select(static finding => finding.Detail),
+                Is.EqualTo(["eager invocation 'ReadFrame'"]));
+            Assert.That(
+                findings.Select(static finding => finding.Snippet),
+                Is.EqualTo(["private static object Current => ReadFrame();"]));
+        });
+    }
+
+    private static bool IsTargetFactoryInvocation(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel)
+    {
+        IMethodSymbol? method = semanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol;
+        ITypeSymbol? receiverType = method?.ContainingType;
+        if (receiverType is null && invocation.Expression is MemberAccessExpressionSyntax member)
+            receiverType = semanticModel.GetTypeInfo(member.Expression).Type;
+
+        return receiverType is INamedTypeSymbol named
+               && IsRenderTargetFactoryType(named);
+    }
+
+    private static bool IsRenderTargetFactoryType(INamedTypeSymbol type)
+        => IsRenderTargetFactoryInterface(type)
+           || type.AllInterfaces.Any(IsRenderTargetFactoryInterface);
+
+    private static bool IsRenderTargetFactoryInterface(INamedTypeSymbol type)
+        => type.ToDisplayString() == "Beutl.Graphics.Rendering.IRenderTargetFactory";
+
+    private static bool IsCpuNodeDescriptionRender(
+        InvocationExpressionSyntax invocation,
+        string invokedName)
+    {
+        if (invokedName != "Render"
+            || invocation.Expression is not MemberAccessExpressionSyntax member
+            || member.Expression is not InvocationExpressionSyntax getOriginal
+            || GetInvokedName(getOriginal) is not "GetOriginal"
+            || invocation.ArgumentList.Arguments.Count < 1)
+        {
+            return false;
+        }
+
+        string contextName = invocation.ArgumentList.Arguments[0].Expression.ToString();
+        return invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>()?
+            .DescendantNodes()
+            .OfType<VariableDeclaratorSyntax>()
+            .Any(variable => variable.Identifier.ValueText == contextName
+                && variable.Initializer?.Value is ObjectCreationExpressionSyntax creation
+                && creation.Type.DescendantTokens()
+                    .LastOrDefault(static token => token.IsKind(SyntaxKind.IdentifierToken))
+                    .ValueText == "GraphicsContext2D") == true;
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Beutl.slnx")))
+            directory = directory.Parent;
+
+        return directory?.FullName
+               ?? throw new DirectoryNotFoundException(
+                   $"Could not locate the Beutl repository root above {AppContext.BaseDirectory}.");
+    }
+
+    private static bool HasPathSegment(string path, string segment)
+        => path.Split('/').Contains(segment, StringComparer.Ordinal);
+
+    private static string NormalizePath(string path)
+        => path.Replace(Path.DirectorySeparatorChar, '/');
+
+    private static string FormatFindings(IReadOnlyList<SourceFinding> findings)
+    {
+        return string.Join(Environment.NewLine, findings.Take(30).Select(static finding =>
+            $"  {finding.RelativePath}:{finding.Line}: {finding.Detail}: {finding.Snippet}"));
+    }
+
+    private sealed record SourceMethod(
+        string RelativePath,
+        SourceText Text,
+        MethodDeclarationSyntax Method,
+        SemanticModel SemanticModel)
+    {
+        public SourceFinding ToFinding(SyntaxNode node, string detail)
+        {
+            LinePosition position = Text.Lines.GetLinePosition(node.SpanStart);
+            string snippet = Text.Lines[position.Line].ToString().Trim();
+            return new SourceFinding(RelativePath, position.Line + 1, detail, snippet);
+        }
+    }
+
+    private sealed record SourceFinding(
+        string RelativePath,
+        int Line,
+        string Detail,
+        string Snippet);
+
+    private sealed class DeferredShapeProbeNode(SideEffectTripwire tripwire) : RenderNode
+    {
+        public static Rect Bounds { get; } = new(0, 0, 64, 36);
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderFragmentHandle source = context.OpaqueSource(CreateOpaque(
+                OpaqueRenderBoundsContract.Source(Bounds),
+                RenderValueCardinality.Single,
+                RenderScaleContract.MaterializeAtWorkingScale,
+                "source",
+                inputCount: 0));
+            RenderFragmentHandle mapped = context.OpaqueMap(
+                source,
+                CreateOpaque(
+                    OpaqueRenderBoundsContract.Map(RenderBoundsContract.Identity),
+                    RenderValueCardinality.Single,
+                    RenderScaleContract.PreserveInputSupply,
+                    "map",
+                    inputCount: 1));
+            RenderFragmentHandle combined = context.OpaqueCombine(
+                [source, mapped],
+                CreateOpaque(
+                    OpaqueRenderBoundsContract.Combine(
+                        static inputs => inputs.Aggregate(static (left, right) => left.Union(right)),
+                        static (output, inputs) => inputs.Select(_ => output).ToArray(),
+                        "recording-probe-combine-bounds"),
+                    RenderValueCardinality.Single,
+                    RenderScaleContract.MaterializeAtWorkingScale,
+                    "combine",
+                    inputCount: 2));
+            RenderFragmentHandle expanded = context.OpaqueExpand(
+                [source],
+                CreateOpaque(
+                    OpaqueRenderBoundsContract.FullInputs(
+                        static inputs => inputs.Aggregate(static (left, right) => left.Union(right)),
+                        "recording-probe-expand-bounds"),
+                    RenderValueCardinality.Dynamic,
+                    RenderScaleContract.MaterializeAtWorkingScale,
+                    "expand",
+                    inputCount: 1));
+            RenderFragmentHandle shader = context.Shader(
+                source,
+                ShaderDescription.CurrentPixel(
+                    "half4 apply(half4 color) { return color; }"));
+            RenderFragmentHandle geometry = context.Geometry(
+                source,
+                GeometryDescription.CreateRequestLocal(
+                    _ => tripwire.TouchAll(),
+                    RenderBoundsContract.Identity,
+                    RenderHitTestContract.AnyInput,
+                    structuralKey: "geometry-recording-probe",
+                    requiresReadback: true));
+            RenderFragmentHandle capture = context.TargetCapture(
+                TargetCaptureDescription.Create(
+                    TargetRegion.Full,
+                    Bounds,
+                    RenderHitTestContract.OutputBounds,
+                    TargetCaptureScaleContract.MaterializeAtWorkingScale));
+            RenderFragmentHandle command = context.TargetCommand(
+                [source],
+                TargetCommandDescription.CreateRequestLocal(
+                    _ => tripwire.TouchAll(),
+                    TargetRegion.Full,
+                    Bounds,
+                    RenderHitTestContract.OutputBounds,
+                    TargetAccess.Readback,
+                    inputReadbacks: [RenderInputReadback.All],
+                    structuralKey: "target-command-recording-probe"));
+            RenderFragmentHandle scope = context.TargetScope(
+                source,
+                TargetScopeDescription.CreateRequestLocal(
+                    _ => tripwire.TouchAll(),
+                    RenderBoundsContract.Identity,
+                    RenderHitTestContract.AnyInput,
+                    RenderScaleContract.PreserveInputSupply,
+                    deviceGridSensitivity: RenderDeviceGridSensitivity.PhaseDependent,
+                    structuralKey: "target-scope-recording-probe"));
+            RenderFragmentHandle rawScope = context.RawTargetScope(
+                source,
+                RawTargetScopeDescription.CreateRequestLocal(
+                    _ => tripwire.TouchAll(),
+                    RenderBoundsContract.Identity,
+                    RenderHitTestContract.AnyInput,
+                    RenderScaleContract.PreserveInputSupply,
+                    structuralKey: "raw-target-scope-recording-probe"));
+            RenderFragmentHandle rawCommand = context.RawTargetCommand(
+                RawTargetCommandDescription.CreateRequestLocal(
+                    _ => tripwire.TouchAll(),
+                    Bounds,
+                    RenderHitTestContract.OutputBounds,
+                    structuralKey: "raw-target-command-recording-probe"));
+
+            context.PublishRange(
+                [source, mapped, combined, expanded, shader, geometry, capture, command, scope, rawScope, rawCommand]);
+        }
+
+        private OpaqueRenderDescription CreateOpaque(
+            OpaqueRenderBoundsContract bounds,
+            RenderValueCardinality cardinality,
+            RenderScaleContract scale,
+            string key,
+            int inputCount)
+        {
+            return OpaqueRenderDescription.CreateRequestLocal(
+                _ => tripwire.TouchAll(),
+                bounds,
+                RenderHitTestContract.OutputBounds,
+                cardinality,
+                scale,
+                structuralKey: $"opaque-recording-probe-{key}",
+                inputReadbacks: Enumerable.Repeat(RenderInputReadback.All, inputCount));
+        }
+    }
+
+    private sealed class CountingTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public int CreateCalls { get; private set; }
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+        {
+            PixelSize deviceSize = allocation.DeviceSize;
+            CreateCalls++;
+            throw new AssertionException(
+                $"Recording unexpectedly requested a {deviceSize.Width}x{deviceSize.Height} render target.");
+        }
+    }
+
+    private sealed class SideEffectTripwire
+    {
+        public IReadOnlyDictionary<RecordingSideEffect, int> Counts => _counts;
+
+        private readonly Dictionary<RecordingSideEffect, int> _counts = Enum
+            .GetValues<RecordingSideEffect>()
+            .ToDictionary(static value => value, static _ => 0);
+
+        public void TouchAll()
+        {
+            foreach (RecordingSideEffect sideEffect in Enum.GetValues<RecordingSideEffect>())
+            {
+                _counts[sideEffect]++;
+            }
+        }
+    }
+
+    private enum RecordingSideEffect
+    {
+        GpuContext,
+        TargetFactory,
+        Snapshot,
+        MediaRead,
+        MediaDecode,
+        NestedRenderer,
+        Flush,
+        Synchronization,
+        Readback,
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderContractPrimitiveTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderContractPrimitiveTests.cs
@@ -1,0 +1,238 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Recording;
+
+[TestFixture]
+public sealed class RenderContractPrimitiveTests
+{
+    [Test]
+    public void RenderValueCardinality_ProvidesInitializedCanonicalValues()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(RenderValueCardinality.None.Minimum, Is.Zero);
+            Assert.That(RenderValueCardinality.None.Maximum, Is.Zero);
+            Assert.That(RenderValueCardinality.Single.Minimum, Is.EqualTo(1));
+            Assert.That(RenderValueCardinality.Single.Maximum, Is.EqualTo(1));
+            Assert.That(RenderValueCardinality.ZeroOrOne.Minimum, Is.Zero);
+            Assert.That(RenderValueCardinality.ZeroOrOne.Maximum, Is.EqualTo(1));
+            Assert.That(RenderValueCardinality.Dynamic.Minimum, Is.Zero);
+            Assert.That(RenderValueCardinality.Dynamic.Maximum, Is.Null);
+            Assert.That(RenderValueCardinality.Exactly(3), Is.EqualTo(RenderValueCardinality.Range(3, 3)));
+        });
+    }
+
+    [Test]
+    public void RenderValueCardinality_RejectsInvalidRangesAndDefault()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => RenderValueCardinality.Exactly(-1), Throws.TypeOf<ArgumentOutOfRangeException>());
+            Assert.That(() => RenderValueCardinality.Range(-1, null), Throws.TypeOf<ArgumentOutOfRangeException>());
+            Assert.That(() => RenderValueCardinality.Range(2, 1), Throws.TypeOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => default(RenderValueCardinality).ThrowIfUninitialized("cardinality"),
+                Throws.TypeOf<ArgumentException>().With.Property("ParamName").EqualTo("cardinality"));
+        });
+    }
+
+    [Test]
+    public void TargetRegion_SeparatesFullEmptyAndFiniteRegion()
+    {
+        var region = new Rect(10, 20, 30, 40);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(TargetRegion.Full.Kind, Is.EqualTo(TargetRegionKind.Full));
+            Assert.That(TargetRegion.Empty.Kind, Is.EqualTo(TargetRegionKind.Empty));
+            Assert.That(TargetRegion.Region(region).Kind, Is.EqualTo(TargetRegionKind.Region));
+            Assert.That(TargetRegion.Region(region).Value, Is.EqualTo(region));
+            Assert.That(TargetRegion.Region(new Rect(10, 20, 0, 40)), Is.EqualTo(TargetRegion.Empty));
+            Assert.That(TargetRegion.Region(new Rect(10, 20, 30, 0)), Is.EqualTo(TargetRegion.Empty));
+        });
+    }
+
+    [Test]
+    public void TargetRegion_RejectsInvalidNonFiniteNegativeAndDefault()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => TargetRegion.Region(Rect.Invalid), Throws.TypeOf<ArgumentException>());
+            Assert.That(() => TargetRegion.Region(new Rect(0, 0, float.PositiveInfinity, 1)), Throws.TypeOf<ArgumentException>());
+            Assert.That(() => TargetRegion.Region(new Rect(0, 0, -1, 1)), Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => default(TargetRegion).ThrowIfUninitialized("region"),
+                Throws.TypeOf<ArgumentException>().With.Property("ParamName").EqualTo("region"));
+        });
+    }
+
+    [Test]
+    public void RenderBoundsContract_IdentityAndFullInputHaveDistinctBackwardPolicy()
+    {
+        var bounds = new Rect(1, 2, 30, 40);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(RenderBoundsContract.Identity.TransformBounds(bounds), Is.EqualTo(bounds));
+            Assert.That(RenderBoundsContract.Identity.GetRequiredInputBounds(bounds), Is.EqualTo(bounds));
+            Assert.That(RenderBoundsContract.Identity.RequiresFullInput, Is.False);
+            Assert.That(RenderBoundsContract.FullInput.TransformBounds(bounds), Is.EqualTo(bounds));
+            Assert.That(RenderBoundsContract.FullInput.GetRequiredInputBounds(bounds), Is.EqualTo(bounds));
+            Assert.That(RenderBoundsContract.FullInput.RequiresFullInput, Is.True);
+        });
+    }
+
+    [Test]
+    public void RenderBoundsContract_CustomMapsAreValidated()
+    {
+        RenderBoundsContract contract = RenderBoundsContract.Create(
+            static input => input.Inflate(new Thickness(2, 3)),
+            static output => output.Inflate(new Thickness(4, 5)));
+        var bounds = new Rect(10, 20, 30, 40);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(contract.TransformBounds(bounds), Is.EqualTo(bounds.Inflate(new Thickness(2, 3))));
+            Assert.That(contract.GetRequiredInputBounds(bounds), Is.EqualTo(bounds.Inflate(new Thickness(4, 5))));
+            Assert.That(contract.RequiresFullInput, Is.False);
+            Assert.That(
+                RenderBoundsContract.CreateFullInput(static input => input.Translate(new Vector(3, 4)))
+                    .RequiresFullInput,
+                Is.True);
+            Assert.That(
+                () => RenderBoundsContract.Create(static _ => Rect.Invalid, static value => value)
+                    .TransformBounds(bounds),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(
+                () => RenderBoundsContract.Create(static value => value, static _ => Rect.Invalid)
+                    .GetRequiredInputBounds(bounds),
+                Throws.TypeOf<InvalidOperationException>());
+        });
+    }
+
+    [Test]
+    public void RenderBoundsContract_RejectsNullDelegatesAndDefault()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => RenderBoundsContract.Create(null!, static value => value),
+                Throws.TypeOf<ArgumentNullException>());
+            Assert.That(
+                () => RenderBoundsContract.Create(static value => value, null!),
+                Throws.TypeOf<ArgumentNullException>());
+            Assert.That(
+                () => RenderBoundsContract.CreateFullInput(null!),
+                Throws.TypeOf<ArgumentNullException>());
+            Assert.That(
+                () => default(RenderBoundsContract).TransformBounds(Rect.Empty),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(
+                () => default(RenderBoundsContract).ThrowIfUninitialized("bounds"),
+                Throws.TypeOf<ArgumentException>().With.Property("ParamName").EqualTo("bounds"));
+        });
+    }
+
+    [Test]
+    public void RenderBoundsContract_ExplicitKeyRetainsBoundsPolicyKind()
+    {
+        RenderBoundsContract tight = RenderBoundsContract.Create(
+            static value => value,
+            static value => value,
+            structuralKey: "shared");
+        RenderBoundsContract full = RenderBoundsContract.CreateFullInput(
+            static value => value,
+            structuralKey: "shared");
+        RenderBoundsContract equivalentTight = RenderBoundsContract.Create(
+            static value => value.Translate(new Vector(1, 0)),
+            static value => value.Translate(new Vector(-1, 0)),
+            structuralKey: "shared");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(tight.StructuralIdentity, Is.EqualTo(equivalentTight.StructuralIdentity));
+            Assert.That(tight.StructuralIdentity, Is.Not.EqualTo(full.StructuralIdentity));
+        });
+    }
+
+    [Test]
+    public void RenderBoundsContract_RejectsKeysThatCannotBeRetainedSafely()
+    {
+        int captured = 1;
+        Func<int> closure = () => captured;
+        Func<int> staticMethod = static () => 1;
+        var mutableValues = new List<int> { 1 };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => RenderBoundsContract.Create(
+                    static value => value,
+                    static value => value,
+                    structuralKey: new byte[4]),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => RenderBoundsContract.CreateFullInput(
+                    static value => value,
+                    structuralKey: closure),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => RenderBoundsContract.CreateFullInput(
+                    static value => value,
+                    structuralKey: staticMethod),
+                Throws.Nothing);
+            Assert.That(
+                () => RenderBoundsContract.CreateFullInput(
+                    static value => value,
+                    structuralKey: new DerivedMutableKey { 1 }),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => RenderBoundsContract.CreateFullInput(
+                    static value => value,
+                    structuralKey: mutableValues.AsReadOnly()),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => RenderBoundsContract.CreateFullInput(
+                    static value => value,
+                    structuralKey: new ImmutableIdentity("safe", 1)),
+                Throws.Nothing);
+        });
+    }
+
+    [Test]
+    public void RenderBoundsContract_RejectsMetadataCallbacksThatCaptureLifetimeState()
+    {
+        using var retained = new MemoryStream();
+        Func<Rect, Rect> capturing = value =>
+        {
+            _ = retained.Position;
+            return value;
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => RenderBoundsContract.Create(
+                    capturing,
+                    static value => value,
+                    structuralKey: "capturing-forward"),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => RenderBoundsContract.Create(
+                    static value => value,
+                    capturing,
+                    structuralKey: "capturing-backward"),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => RenderBoundsContract.CreateFullInput(
+                    capturing,
+                    structuralKey: "capturing-full-input"),
+                Throws.TypeOf<ArgumentException>());
+        });
+    }
+
+    private sealed class DerivedMutableKey : List<int>;
+
+    private sealed record ImmutableIdentity(string Name, int Version);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderDescriptionAndExecutionContractTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderDescriptionAndExecutionContractTests.cs
@@ -1,0 +1,707 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Recording;
+
+[TestFixture]
+public sealed class RenderDescriptionAndExecutionContractTests
+{
+    [Test]
+    public void OpaqueDescription_PreservesDeclaredContractsAndRejectsDefaults()
+    {
+        using var registry = new RenderRequestResourceRegistry();
+        var value = new object();
+        RenderResource<object> resource = registry.RegisterBorrowed(value, "resource", 3);
+        Action<OpaqueRenderSession> execute = static _ => { };
+        OpaqueRenderBoundsContract bounds = OpaqueRenderBoundsContract.Source(new Rect(2, 3, 10, 20));
+
+        OpaqueRenderDescription description = OpaqueRenderDescription.Create(
+            ("pixels", 4),
+            static (_, _) => { },
+            bounds,
+            RenderHitTestContract.OutputBounds,
+            RenderValueCardinality.Single,
+            RenderScaleContract.MaterializeAtWorkingScale,
+            structuralKey: "opaque-source",
+            resources: [resource.Bind("resource")]);
+        OpaqueRenderDescription requestLocal = OpaqueRenderDescription.CreateRequestLocal(
+            execute,
+            bounds,
+            RenderHitTestContract.OutputBounds,
+            RenderValueCardinality.Single,
+            RenderScaleContract.MaterializeAtWorkingScale,
+            structuralKey: "opaque-source-request-local");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(description.Bounds, Is.SameAs(bounds));
+            Assert.That(description.HitTest, Is.EqualTo(RenderHitTestContract.OutputBounds));
+            Assert.That(description.ValueCardinality, Is.EqualTo(RenderValueCardinality.Single));
+            Assert.That(description.Scale, Is.EqualTo(RenderScaleContract.MaterializeAtWorkingScale));
+            Assert.That(description.StructuralKey, Is.EqualTo("opaque-source"));
+            Assert.That(description.RuntimeIdentity, Is.Not.Null);
+            Assert.That(requestLocal.RuntimeIdentity, Is.Null,
+                "A request-local description publishes no identity a later request could match.");
+            Assert.That(description.InputReadbacks, Is.Empty);
+            Assert.That(description.Resources, Has.Count.EqualTo(1));
+            Assert.That(description.Resources[0].Name, Is.EqualTo("resource"));
+            Assert.That(description.Resources[0].Resource, Is.SameAs(resource));
+            Assert.That(() => description.ThrowIfIncompatible(OpaqueRenderTopology.Source, "description"),
+                Throws.Nothing);
+            Assert.That(() => description.ThrowIfIncompatible(OpaqueRenderTopology.Map, "description"),
+                Throws.TypeOf<ArgumentException>());
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => OpaqueRenderDescription.CreateRequestLocal(
+                    null!, bounds, RenderHitTestContract.None, RenderValueCardinality.Single, RenderScaleContract.Vector),
+                Throws.TypeOf<ArgumentNullException>());
+            Assert.That(
+                () => OpaqueRenderDescription.CreateRequestLocal(
+                    execute, null!, RenderHitTestContract.None, RenderValueCardinality.Single, RenderScaleContract.Vector),
+                Throws.TypeOf<ArgumentNullException>());
+            Assert.That(
+                () => OpaqueRenderDescription.CreateRequestLocal(
+                    execute, bounds, default, RenderValueCardinality.Single, RenderScaleContract.Vector),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => OpaqueRenderDescription.CreateRequestLocal(
+                    execute, bounds, RenderHitTestContract.None, default, RenderScaleContract.Vector),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => OpaqueRenderDescription.CreateRequestLocal(
+                    execute, bounds, RenderHitTestContract.None, RenderValueCardinality.Single, default),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => OpaqueRenderDescription.CreateRequestLocal(
+                    execute,
+                    bounds,
+                    RenderHitTestContract.None,
+                    RenderValueCardinality.Single,
+                    RenderScaleContract.Vector,
+                    inputReadbacks: [default]),
+                Throws.TypeOf<ArgumentException>().With.Property("ParamName").EqualTo("inputReadbacks"));
+            Assert.That(
+                () => OpaqueRenderDescription.Create(
+                    "state",
+                    (session, _) => execute(session),
+                    bounds,
+                    RenderHitTestContract.None,
+                    RenderValueCardinality.Single,
+                    RenderScaleContract.Vector),
+                Throws.TypeOf<ArgumentException>().With.Property("ParamName").EqualTo("execute"),
+                "a capturing callback could draw with a value the state never carried");
+        });
+    }
+
+    [Test]
+    public void OperationBounds_ValidateTopologyAndMultiInputBackwardMapping()
+    {
+        Rect first = new(0, 0, 10, 20);
+        Rect second = new(30, 5, 10, 10);
+        Rect requested = new(4, 5, 6, 7);
+        OpaqueRenderBoundsContract source = OpaqueRenderBoundsContract.Source(first);
+        OpaqueRenderBoundsContract map = OpaqueRenderBoundsContract.Map(
+            RenderBoundsContract.Create(
+                static value => value.Translate(new Vector(3, 4)),
+                static value => value.Translate(new Vector(-3, -4))));
+        OpaqueRenderBoundsContract combine = OpaqueRenderBoundsContract.Combine(
+            static inputs => inputs.Aggregate(static (left, right) => left.Union(right)),
+            static (output, inputs) => inputs.Select(_ => output).ToArray(),
+            "combine");
+        OpaqueRenderBoundsContract full = OpaqueRenderBoundsContract.FullInputs(
+            static inputs => inputs.Aggregate(static (left, right) => left.Union(right)));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(source.TransformBounds([]), Is.EqualTo(first));
+            Assert.That(map.TransformBounds([first]), Is.EqualTo(first.Translate(new Vector(3, 4))));
+            Assert.That(map.GetRequiredInputBounds(requested, [first]), Is.EqualTo(new[]
+            {
+                requested.Translate(new Vector(-3, -4)),
+            }));
+            Assert.That(combine.TransformBounds([first, second]), Is.EqualTo(first.Union(second)));
+            Assert.That(combine.GetRequiredInputBounds(requested, [first, second]),
+                Is.EqualTo(new[] { requested, requested }));
+            Assert.That(full.GetRequiredInputBounds(requested, [first, second]),
+                Is.EqualTo(new[] { first, second }));
+            Assert.That(
+                () => combine.GetRequiredInputBounds(
+                    requested,
+                    [first]),
+                Throws.Nothing);
+        });
+
+        OpaqueRenderBoundsContract badCount = OpaqueRenderBoundsContract.Combine(
+            static inputs => inputs.Aggregate(static (left, right) => left.Union(right)),
+            static (_, _) => [Rect.Empty]);
+        Assert.That(
+            () => badCount.GetRequiredInputBounds(requested, [first, second]),
+            Throws.TypeOf<InvalidOperationException>());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => source.ThrowIfIncompatible(OpaqueRenderTopology.Source, "bounds"), Throws.Nothing);
+            Assert.That(() => source.ThrowIfIncompatible(OpaqueRenderTopology.Map, "bounds"), Throws.TypeOf<ArgumentException>());
+            Assert.That(() => map.ThrowIfIncompatible(OpaqueRenderTopology.Map, "bounds"), Throws.Nothing);
+            Assert.That(() => combine.ThrowIfIncompatible(OpaqueRenderTopology.Combine, "bounds"), Throws.Nothing);
+            Assert.That(() => full.ThrowIfIncompatible(OpaqueRenderTopology.Expand, "bounds"), Throws.Nothing);
+        });
+    }
+
+    [Test]
+    public void HitTestContracts_EvaluateOnlyDeclaredCpuMetadata()
+    {
+        var output = new Rect(10, 20, 30, 40);
+        RenderHitTestInput[] inputs =
+        [
+            new(new Rect(0, 0, 5, 5), static point => point == new Point(2, 3)),
+            new(new Rect(20, 20, 5, 5), static _ => false),
+        ];
+        RenderHitTestContract custom = RenderHitTestContract.Custom(
+            static (context, point) => context.OutputBounds.Contains(point) && context.Inputs.Count == 2,
+            "custom-hit");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(RenderHitTestContract.None.Evaluate(output, inputs, new Point(12, 24)), Is.False);
+            Assert.That(RenderHitTestContract.OutputBounds.Evaluate(output, inputs, new Point(12, 24)), Is.True);
+            Assert.That(RenderHitTestContract.OutputBounds.Evaluate(output, inputs, new Point(1, 1)), Is.False);
+            Assert.That(RenderHitTestContract.AnyInput.Evaluate(output, inputs, new Point(2, 3)), Is.True);
+            Assert.That(custom.Evaluate(output, inputs, new Point(12, 24)), Is.True);
+            Assert.That(inputs[0].Bounds, Is.EqualTo(new Rect(0, 0, 5, 5)));
+            Assert.That(inputs[0].HitTest(new Point(2, 3)), Is.True);
+            Assert.That(() => default(RenderHitTestContract).Evaluate(output, inputs, default),
+                Throws.TypeOf<InvalidOperationException>());
+        });
+    }
+
+    [Test]
+    public void ScaleContracts_ResolveConcreteSupplyAndRejectInvalidCustomResults()
+    {
+        EffectiveScale[] inputs = [EffectiveScale.At(1.5f), EffectiveScale.At(2.5f)];
+        var bounds = new Rect(0, 0, 100, 100);
+        RenderScaleContract custom = RenderScaleContract.Custom(
+            static context => context.OutputScale * 3,
+            "triple-output");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(RenderScaleContract.Vector.Resolve(inputs, bounds, 2, 4), Is.EqualTo(EffectiveScale.Unbounded));
+            Assert.That(RenderScaleContract.MaterializeAtWorkingScale.Resolve(inputs, bounds, 2, 4),
+                Is.EqualTo(EffectiveScale.At(2.5f)));
+            Assert.That(custom.Resolve(inputs, bounds, 2, 4), Is.EqualTo(EffectiveScale.At(4)));
+            Assert.That(
+                RenderScaleContract.PreserveInputSupply.Resolve([EffectiveScale.At(3)], bounds, 2, 4),
+                Is.EqualTo(EffectiveScale.At(3)));
+            Assert.That(
+                () => RenderScaleContract.PreserveInputSupply.Resolve(inputs, bounds, 2, 4),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(
+                () => RenderScaleContract.Custom(static _ => float.NaN).Resolve(inputs, bounds, 2, 4),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(
+                () => RenderScaleContract.Custom(static _ => float.PositiveInfinity).Resolve(inputs, bounds, 2, 4),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(
+                () => default(RenderScaleContract).Resolve(inputs, bounds, 2, 4),
+                Throws.TypeOf<InvalidOperationException>());
+        });
+    }
+
+    [Test]
+    public void ScaleContracts_ClampTheExactFractionalDeviceFootprint()
+    {
+        var positiveOrigin = new Rect(
+            0.25f,
+            0,
+            RenderScaleUtilities.MaxBufferDimension,
+            1);
+        var exactFitAtNegativeOrigin = new Rect(
+            -0.5f,
+            0,
+            RenderScaleUtilities.MaxBufferDimension - 0.5f,
+            1);
+        EffectiveScale[] resolved =
+        [
+            RenderScaleContract.MaterializeAtWorkingScale.Resolve(
+                [EffectiveScale.At(1)],
+                positiveOrigin,
+                outputScale: 1,
+                maxWorkingScale: 1),
+            RenderScaleContract.Custom(
+                    static _ => 1,
+                    "exact-custom-scale")
+                .Resolve([], positiveOrigin, outputScale: 1, maxWorkingScale: 1),
+            RenderScaleContract.MapInputSupply(
+                    static _ => EffectiveScale.At(1),
+                    "exact-mapped-scale")
+                .Resolve([EffectiveScale.At(1)], positiveOrigin, outputScale: 1, maxWorkingScale: 1),
+        ];
+
+        Assert.Multiple(() =>
+        {
+            foreach (EffectiveScale scale in resolved)
+            {
+                Assert.That(scale.Value, Is.LessThan(1));
+                Assert.That(
+                    PixelRect.FromRect(positiveOrigin, scale.Value).Width,
+                    Is.LessThanOrEqualTo(RenderScaleUtilities.MaxBufferDimension));
+            }
+
+            Assert.That(
+                PixelRect.FromRect(exactFitAtNegativeOrigin, 1).Width,
+                Is.EqualTo(RenderScaleUtilities.MaxBufferDimension));
+            Assert.That(
+                RenderScaleContract.MaterializeAtWorkingScale.Resolve(
+                    [EffectiveScale.At(1)],
+                    exactFitAtNegativeOrigin,
+                    outputScale: 1,
+                    maxWorkingScale: 1),
+                Is.EqualTo(EffectiveScale.At(1)));
+        });
+    }
+
+    [Test]
+    public void MaterializedInput_RequiresConcreteMatchingBackingAndSourceHitTest()
+    {
+        using var registry = new RenderRequestResourceRegistry();
+        var bounds = new Rect(10.25f, 20.25f, 10, 20);
+        var deviceGridOffset = new Vector(0.25f, 0.5f);
+        PixelRect deviceBounds = PixelRect.FromRect(bounds.Translate(deviceGridOffset), 2);
+        using RenderTarget target = RenderTarget.CreateNull(deviceBounds.Width, deviceBounds.Height);
+        using RenderTarget wrongSize = RenderTarget.CreateNull(deviceBounds.Width + 1, deviceBounds.Height);
+        RenderResource<RenderTarget> token = registry.RegisterBorrowed(target, "target", 1);
+
+        MaterializedInputDescription description = MaterializedInputDescription.FromRenderTarget(
+            token,
+            bounds,
+            EffectiveScale.At(2),
+            deviceBounds,
+            deviceGridOffset,
+            RenderHitTestContract.OutputBounds);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(description.Bounds, Is.EqualTo(bounds));
+            Assert.That(description.EffectiveScale, Is.EqualTo(EffectiveScale.At(2)));
+            Assert.That(description.DeviceBounds, Is.EqualTo(deviceBounds));
+            Assert.That(description.DeviceGridOffset, Is.EqualTo(deviceGridOffset));
+            Assert.That(
+                description.RasterBounds,
+                Is.EqualTo(deviceBounds.ToRect(2).Translate(-deviceGridOffset)));
+            Assert.That(description.Target, Is.SameAs(token));
+            Assert.That(description.HitTest, Is.EqualTo(RenderHitTestContract.OutputBounds));
+            Assert.That(
+                () => MaterializedInputDescription.FromRenderTarget(
+                    token,
+                    bounds,
+                    EffectiveScale.Unbounded,
+                    deviceBounds,
+                    deviceGridOffset,
+                    RenderHitTestContract.None),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => description.ValidateTargetDeviceSize(wrongSize),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => MaterializedInputDescription.FromRenderTarget(
+                    token,
+                    bounds,
+                    EffectiveScale.At(2),
+                    deviceBounds,
+                    deviceGridOffset,
+                    RenderHitTestContract.AnyInput),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => MaterializedInputDescription.FromRenderTarget(
+                    token,
+                    bounds,
+                    EffectiveScale.At(2),
+                    new PixelRect(0, 0, deviceBounds.Width, deviceBounds.Height),
+                    deviceGridOffset,
+                    RenderHitTestContract.None),
+                Throws.TypeOf<ArgumentException>());
+        });
+    }
+
+    [Test]
+    public void CaptureAndTargetDescriptions_ValidateRegionsReadbackAndIdentities()
+    {
+        var bounds = new Rect(1, 2, 30, 40);
+        TargetCaptureDescription capture = TargetCaptureDescription.Create(
+            TargetRegion.Region(bounds),
+            bounds,
+            RenderHitTestContract.OutputBounds,
+            TargetCaptureScaleContract.MaterializeAtWorkingScale);
+        TargetCommandDescription command = TargetCommandDescription.Create(
+            ("command", 2),
+            static (_, _) => { },
+            TargetRegion.Region(bounds),
+            bounds,
+            RenderHitTestContract.OutputBounds,
+            TargetAccess.Readback,
+            inputReadbacks: [RenderInputReadback.Values([0])],
+            structuralKey: "read-command");
+        TargetScopeDescription scope = TargetScopeDescription.CreateRequestLocal(
+            static _ => { },
+            RenderBoundsContract.Identity,
+            RenderHitTestContract.AnyInput,
+            RenderScaleContract.PreserveInputSupply,
+            deviceGridSensitivity: RenderDeviceGridSensitivity.PhaseDependent,
+            structuralKey: "scope");
+        RawTargetScopeDescription rawScope = RawTargetScopeDescription.CreateRequestLocal(
+            static _ => { },
+            RenderBoundsContract.FullInput,
+            RenderHitTestContract.AnyInput,
+            RenderScaleContract.PreserveInputSupply,
+            "raw-scope");
+        RawTargetCommandDescription rawCommand = RawTargetCommandDescription.CreateRequestLocal(
+            static _ => { },
+            bounds,
+            RenderHitTestContract.OutputBounds,
+            "raw-command");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(capture.SourceRegion.Kind, Is.EqualTo(TargetRegionKind.Region));
+            Assert.That(capture.Bounds, Is.EqualTo(bounds));
+            Assert.That(command.Access, Is.EqualTo(TargetAccess.Readback));
+            Assert.That(command.InputReadbacks, Is.EqualTo(new[] { RenderInputReadback.Values([0]) }));
+            Assert.That(RenderInputReadback.Values([1, 0]), Is.EqualTo(RenderInputReadback.Values([0, 1])));
+            Assert.That(command.QueryBounds, Is.EqualTo(bounds));
+            Assert.That(scope.Bounds, Is.EqualTo(RenderBoundsContract.Identity));
+            Assert.That(rawScope.Scale, Is.EqualTo(RenderScaleContract.PreserveInputSupply));
+            Assert.That(rawCommand.QueryBounds, Is.EqualTo(bounds));
+            Assert.That(
+                () => RenderInputReadback.Values([-1]),
+                Throws.TypeOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => RenderInputReadback.Values([0, 0]),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => TargetCommandDescription.CreateRequestLocal(
+                    static _ => { },
+                    TargetRegion.Region(bounds),
+                    bounds,
+                    RenderHitTestContract.None,
+                    inputReadbacks: [default]),
+                Throws.TypeOf<ArgumentException>().With.Property("ParamName").EqualTo("inputReadbacks"));
+        });
+
+        ArgumentException emptyReadback = Assert.Throws<ArgumentException>(
+            () => TargetCommandDescription.CreateRequestLocal(
+                static _ => { },
+                TargetRegion.Empty,
+                Rect.Empty,
+                RenderHitTestContract.None,
+                TargetAccess.Readback))!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(emptyReadback.ParamName, Is.EqualTo("affectedRegion"));
+            Assert.That(
+                () => TargetCaptureDescription.Create(
+                    TargetRegion.Empty, bounds, RenderHitTestContract.None, TargetCaptureScaleContract.MaterializeAtWorkingScale),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => TargetCaptureDescription.Create(
+                    TargetRegion.Full, bounds, RenderHitTestContract.AnyInput, TargetCaptureScaleContract.MaterializeAtWorkingScale),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => TargetCaptureDescription.Create(
+                    TargetRegion.Full, bounds, RenderHitTestContract.None, default),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => TargetCaptureDescription.Create(
+                    TargetRegion.Region(new Rect(0, 0, 10, 10)),
+                    bounds,
+                    RenderHitTestContract.None,
+                    TargetCaptureScaleContract.MaterializeAtWorkingScale),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => TargetCommandDescription.CreateRequestLocal(
+                    static _ => { },
+                    default,
+                    Rect.Empty,
+                    RenderHitTestContract.None),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => TargetScopeDescription.CreateRequestLocal(
+                    static _ => { },
+                    default,
+                    RenderHitTestContract.None,
+                    RenderScaleContract.Vector,
+                    deviceGridSensitivity: RenderDeviceGridSensitivity.PhaseDependent),
+                Throws.TypeOf<ArgumentException>());
+        });
+    }
+
+    [Test]
+    public void EveryDescriptionFactory_RejectsAnUndefinedDeclaredPlannerTrait()
+    {
+        const RenderDeviceGridSensitivity undefinedSensitivity = (RenderDeviceGridSensitivity)7;
+        const RenderDeviceGridMapping undefinedMapping = (RenderDeviceGridMapping)7;
+        OpaqueRenderBoundsContract opaqueBounds = OpaqueRenderBoundsContract.Source(new Rect(0, 0, 8, 8));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => OpaqueRenderDescription.CreateRequestLocal(
+                    static _ => { },
+                    opaqueBounds,
+                    RenderHitTestContract.OutputBounds,
+                    RenderValueCardinality.Single,
+                    RenderScaleContract.Vector,
+                    undefinedSensitivity,
+                    structuralKey: "undefined-sensitivity"),
+                Throws.TypeOf<ArgumentOutOfRangeException>()
+                    .With.Property(nameof(ArgumentOutOfRangeException.ParamName))
+                    .EqualTo("deviceGridSensitivity"));
+            Assert.That(
+                () => OpaqueRenderDescription.CreateEngineSource(
+                    static _ => { },
+                    static _ => { },
+                    opaqueBounds,
+                    RenderHitTestContract.OutputBounds,
+                    RenderScaleContract.Vector,
+                    undefinedSensitivity,
+                    structuralKey: "undefined-sensitivity",
+                    runtimeIdentity: null),
+                Throws.TypeOf<ArgumentOutOfRangeException>()
+                    .With.Property(nameof(ArgumentOutOfRangeException.ParamName))
+                    .EqualTo("deviceGridSensitivity"));
+            Assert.That(
+                () => OpaqueRenderDescription.CreateBackendBoundary(
+                    RenderBackendBoundary.Graphics3D,
+                    static _ => { },
+                    opaqueBounds,
+                    RenderHitTestContract.OutputBounds,
+                    RenderValueCardinality.Single,
+                    RenderScaleContract.Vector,
+                    undefinedSensitivity,
+                    structuralKey: "undefined-sensitivity",
+                    runtimeIdentity: new RenderRuntimeIdentity("undefined-sensitivity")),
+                Throws.TypeOf<ArgumentOutOfRangeException>()
+                    .With.Property(nameof(ArgumentOutOfRangeException.ParamName))
+                    .EqualTo("deviceGridSensitivity"));
+            Assert.That(
+                () => TargetScopeDescription.CreateRequestLocal(
+                    static session => session.Canvas.Use(_ => session.ReplayInput()),
+                    RenderBoundsContract.Identity,
+                    RenderHitTestContract.AnyInput,
+                    RenderScaleContract.PreserveInputSupply,
+                    deviceGridSensitivity: RenderDeviceGridSensitivity.Insensitive,
+                    deviceGridMapping: undefinedMapping,
+                    structuralKey: "undefined-mapping"),
+                Throws.TypeOf<ArgumentOutOfRangeException>()
+                    .With.Property(nameof(ArgumentOutOfRangeException.ParamName))
+                    .EqualTo("deviceGridMapping"));
+            Assert.That(
+                () => TargetScopeDescription.CreateValueReplayMap(
+                    static session => session.Canvas.Use(_ => session.ReplayInput()),
+                    RenderBoundsContract.Identity,
+                    RenderHitTestContract.AnyInput,
+                    RenderScaleContract.PreserveInputSupply,
+                    deviceGridSensitivity: RenderDeviceGridSensitivity.Insensitive,
+                    deviceGridMapping: undefinedMapping,
+                    structuralKey: "undefined-mapping"),
+                Throws.TypeOf<ArgumentOutOfRangeException>()
+                    .With.Property(nameof(ArgumentOutOfRangeException.ParamName))
+                    .EqualTo("deviceGridMapping"));
+        });
+    }
+
+    [Test]
+    public void CallbackCanvas_MapsCompositionGlobalOriginAndEnforcesOneShotCapabilities()
+    {
+        var token = new RenderExecutionSessionToken();
+        var logicalBounds = new Rect(10.25f, 20.25f, 8, 8);
+        PixelRect deviceBounds = PixelRect.FromRect(logicalBounds, 2);
+        using RenderTarget target = RenderTarget.CreateNull(deviceBounds.Width, deviceBounds.Height);
+        var facade = new RenderCallbackCanvas(
+            token,
+            density: 2,
+            logicalBounds,
+            () => new ImmediateCanvas(target, 2, logicalSize: deviceBounds.Size.ToSize(2)),
+            CallbackCanvasCapability.Draw);
+        ImmediateCanvas? retainedCanvas = null;
+
+        facade.Use(canvas =>
+        {
+            retainedCanvas = canvas;
+            Assert.Multiple(() =>
+            {
+                Assert.That(facade.DeviceBounds, Is.EqualTo(deviceBounds));
+                Assert.That(facade.RasterBounds, Is.EqualTo(deviceBounds.ToRect(2)));
+                Assert.That(facade.LogicalOrigin,
+                    Is.EqualTo(new Point(deviceBounds.X / 2f, deviceBounds.Y / 2f)));
+                Assert.That(canvas.Transform.Transform(facade.LogicalOrigin), Is.EqualTo(default(Point)));
+                Assert.That(() => canvas.Clear(Colors.Red), Throws.Nothing);
+                canvas.Pop(0);
+                Assert.That(canvas.Transform.Transform(facade.LogicalOrigin), Is.EqualTo(default(Point)));
+                Assert.That(() => canvas.PushLayer(), Throws.TypeOf<InvalidOperationException>());
+                Assert.That(() => canvas.DrawNode(null!), Throws.TypeOf<InvalidOperationException>());
+                Assert.That(() => RenderTarget.GetRenderTarget(canvas), Throws.TypeOf<InvalidOperationException>());
+                Assert.That(() => canvas.Dispose(), Throws.TypeOf<InvalidOperationException>());
+            });
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(retainedCanvas, Is.Not.Null);
+            Assert.That(retainedCanvas!.IsDisposed, Is.True);
+            Assert.That(() => retainedCanvas.Clear(), Throws.TypeOf<ObjectDisposedException>());
+            Assert.That(() => facade.Use(static _ => { }), Throws.TypeOf<InvalidOperationException>());
+        });
+
+        token.Complete();
+        Assert.That(() => _ = facade.Density, Throws.TypeOf<InvalidOperationException>());
+    }
+
+    [Test]
+    public void ExecutionInput_RequiresActiveSameSessionCanvasAndUsesShiftedDevicePlacement()
+    {
+        var token = new RenderExecutionSessionToken();
+        var inputBounds = new Rect(4, 6, 10, 12);
+        Rect? logicalPlacement = null;
+        Point? devicePlacement = null;
+        var input = new RenderExecutionInput(
+            token,
+            inputBounds,
+            EffectiveScale.At(2),
+            draw: (_, destination) => logicalPlacement = destination,
+            drawDeviceSpace: (_, point) => devicePlacement = point,
+            createShader: null,
+            createSnapshot: null,
+            readbackDeclared: false);
+        var callbackBounds = new Rect(10.25f, 20.25f, 8, 8);
+        PixelRect callbackDeviceBounds = PixelRect.FromRect(callbackBounds, 2);
+        using RenderTarget callbackTarget = RenderTarget.CreateNull(
+            callbackDeviceBounds.Width,
+            callbackDeviceBounds.Height);
+        var facade = new RenderCallbackCanvas(
+            token,
+            2,
+            callbackBounds,
+            () => new ImmediateCanvas(callbackTarget, 2, logicalSize: callbackDeviceBounds.Size.ToSize(2)),
+            CallbackCanvasCapability.Draw);
+        using RenderTarget externalTarget = RenderTarget.CreateNull(8, 8);
+        using var externalCanvas = new ImmediateCanvas(externalTarget);
+
+        Assert.That(() => input.Draw(externalCanvas), Throws.TypeOf<InvalidOperationException>());
+
+        facade.Use(canvas =>
+        {
+            input.Draw(canvas);
+            input.DrawDeviceSpace(
+                canvas,
+                new Point(callbackDeviceBounds.X + 3, callbackDeviceBounds.Y + 5));
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(logicalPlacement, Is.EqualTo(input.DeviceBounds.ToRect(2)));
+            Assert.That(devicePlacement, Is.EqualTo(new Point(3, 5)));
+            Assert.That(input.DeviceBounds, Is.EqualTo(PixelRect.FromRect(inputBounds, 2)));
+            Assert.That(input.DeviceSize, Is.EqualTo(input.DeviceBounds.Size));
+            Assert.That(input.RasterBounds, Is.EqualTo(input.DeviceBounds.ToRect(2)));
+            Assert.That(input.LogicalOrigin,
+                Is.EqualTo(new Point(input.DeviceBounds.X / 2f, input.DeviceBounds.Y / 2f)));
+        });
+
+        token.Complete();
+        Assert.That(() => _ = input.Bounds, Throws.TypeOf<InvalidOperationException>());
+    }
+
+    [Test]
+    public void ExecutionInput_ReadbackIsDeclaredOneShotAndDisposesOnCallbackFailure()
+    {
+        var token = new RenderExecutionSessionToken();
+        Bitmap? supplied = null;
+        var input = new RenderExecutionInput(
+            token,
+            new Rect(0, 0, 2, 2),
+            EffectiveScale.At(1),
+            draw: static (_, _) => { },
+            drawDeviceSpace: static (_, _) => { },
+            createShader: null,
+            createSnapshot: () => supplied = new Bitmap(2, 2),
+            readbackDeclared: true);
+        var expected = new InvalidOperationException("callback failed");
+
+        InvalidOperationException? actual = Assert.Throws<InvalidOperationException>(
+            () => input.UseSnapshot(bitmap =>
+            {
+                Assert.That(bitmap, Is.SameAs(supplied));
+                throw expected;
+            }));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(actual, Is.SameAs(expected));
+            Assert.That(supplied, Is.Not.Null);
+            Assert.That(supplied!.IsDisposed, Is.True);
+            Assert.That(() => input.UseSnapshot(static _ => { }), Throws.TypeOf<InvalidOperationException>());
+        });
+
+        token.Complete();
+    }
+
+    [Test]
+    public void TargetScopeCanvas_AllowsOnlyStateAroundExactlyOneReplay()
+    {
+        var token = new RenderExecutionSessionToken();
+        var bounds = new Rect(5, 7, 10, 12);
+        PixelRect deviceBounds = PixelRect.FromRect(bounds, 1);
+        using RenderTarget target = RenderTarget.CreateNull(deviceBounds.Width, deviceBounds.Height);
+        var facade = new RenderCallbackCanvas(
+            token,
+            1,
+            bounds,
+            () => new ImmediateCanvas(target, logicalSize: deviceBounds.Size.ToSize(1)),
+            CallbackCanvasCapability.TargetScope);
+        int replayCount = 0;
+        var session = new TargetScopeSession(
+            token,
+            bounds,
+            bounds,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            facade,
+            [],
+            canvas =>
+            {
+                replayCount++;
+                using (canvas.PushLayer())
+                {
+                    canvas.Clear(Colors.Blue);
+                }
+            });
+
+        Assert.That(() => session.ReplayInput(), Throws.TypeOf<InvalidOperationException>());
+        facade.Use(canvas =>
+        {
+            Assert.That(() => canvas.Clear(), Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => canvas.PushLayer(), Throws.TypeOf<InvalidOperationException>());
+            using (canvas.PushTransform(Matrix.CreateTranslation(2, 3)))
+            {
+                session.ReplayInput();
+            }
+
+            Assert.That(() => session.ReplayInput(), Throws.TypeOf<InvalidOperationException>());
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(replayCount, Is.EqualTo(1));
+            Assert.That(() => session.ValidateCompletion(), Throws.Nothing);
+        });
+
+        token.Complete();
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
@@ -1,0 +1,764 @@
+﻿using System.Text.RegularExpressions;
+
+using Beutl.UnitTests.Engine.Graphics.Rendering.Baseline;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Recording;
+
+[TestFixture]
+public sealed class RenderPipelineMigrationCensusTests
+{
+    private const string HistoricalEvidencePatch =
+        "docs/specs/004-gpu-pass-fusion/evidence/target-baseline-generator.patch";
+
+    private static readonly Lazy<SourceCorpus> s_corpus = new(SourceCorpus.Discover);
+
+    private static readonly IReadOnlyDictionary<string, int> s_productionOverrideBaseline =
+        new Dictionary<string, int>(StringComparer.Ordinal)
+        {
+            ["src/Beutl.Engine/Graphics/AudioVisualizers/AudioVisualizerRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/DrawableGroup.cs"] = 2,
+            ["src/Beutl.Engine/Graphics/Particles/ParticleRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/BlendModeRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/ClearRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/ContainerRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/DrawBackdropRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/EllipseRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/FilterEffectRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/GeometryClipRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/GeometryRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/ImageSourceRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/LayerRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/MemoryNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/OpacityMaskRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/OpacityRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/PushRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/RectClipRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/RectangleRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/ReferencesChildRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/Renderer.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/SnapshotBackdropRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/TextRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/TransformRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics/Rendering/VideoSourceRenderNode.cs"] = 1,
+            ["src/Beutl.Engine/Graphics3D/Scene3DRenderNode.cs"] = 1,
+            ["src/Beutl.NodeGraph/NodeGraphFilterEffectRenderNode.cs"] = 1,
+            ["src/Beutl.NodeGraph/Nodes/FilterEffectInputNode.cs"] = 1,
+            ["src/Beutl.ProjectSystem/ProjectSystem/SceneDrawable.cs"] = 1,
+        };
+
+    // The starting-SHA baseline is a historical fact about 83e63689d; overrides that first
+    // appeared during the migration are excluded from the derivation.
+    private static readonly IReadOnlyDictionary<string, int> s_startingProductionOverrideBaseline =
+        s_productionOverrideBaseline
+            .Where(static item =>
+                item.Key != "src/Beutl.Engine/Graphics/Rendering/Renderer.cs"
+                && item.Key != "src/Beutl.NodeGraph/Nodes/FilterEffectInputNode.cs")
+            .Append(new KeyValuePair<string, int>(
+                "src/Beutl.Engine/Graphics/Rendering/OperationWrapperRenderNode.cs",
+                1))
+            .ToDictionary(static item => item.Key, static item => item.Value, StringComparer.Ordinal);
+
+    private static readonly IReadOnlyDictionary<string, int> s_testOverrideBaseline =
+        new Dictionary<string, int>(StringComparer.Ordinal)
+        {
+            ["tests/Beutl.Benchmarks/Rendering/RenderPipelineBenchmarks.cs"] = 6,
+            ["tests/Beutl.Graphics3DTests/GpuPassFusion3DBoundaryTests.cs"] = 1,
+            ["tests/Beutl.HeadlessUITests/PlayerSelectedDrawableTargetDomainTests.cs"] = 1,
+            ["tests/Beutl.PublicApiContractTests/CapturedResourceBorrowContractTests.cs"] = 1,
+            ["tests/Beutl.PublicApiContractTests/DeclaredPlannerTraitContractTests.cs"] = 6,
+            ["tests/Beutl.PublicApiContractTests/DeclaredResourceAddressingContractTests.cs"] = 5,
+            ["tests/Beutl.PublicApiContractTests/EngineResourceIdentityContractTests.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/EngineResourceIdentityRoutingTests.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/EngineResourceIdentityStabilityTests.cs"] = 2,
+            ["tests/Beutl.PublicApiContractTests/FilterEffectCompatibilityContractTests.cs"] = 5,
+            ["tests/Beutl.PublicApiContractTests/GeometryAuthoringContractTests.cs"] = 2,
+            ["tests/Beutl.PublicApiContractTests/LoweredBrushAuthoringContractTests.cs"] = 3,
+            ["tests/Beutl.PublicApiContractTests/LoweredPaintSafetyContractTests.cs"] = 6,
+            ["tests/Beutl.PublicApiContractTests/LoweredVideoSourceAuthoringContractTests.cs"] = 1,
+            ["tests/Beutl.PublicApiContractTests/OrphanedTargetEffectContractTests.cs"] = 2,
+            ["tests/Beutl.PublicApiContractTests/PrimaryPaintedSourceContractTests.cs"] = 5,
+            ["tests/Beutl.PublicApiContractTests/RenderNodeAuthoringContractTests.cs"] = 2,
+            ["tests/Beutl.PublicApiContractTests/RenderNodeRendererContractTests.cs"] = 1,
+            ["tests/Beutl.PublicApiContractTests/RenderScaleMappingContractTests.cs"] = 1,
+            ["tests/Beutl.PublicApiContractTests/ShaderAuthoringContractTests.cs"] = 5,
+            ["tests/Beutl.PublicApiContractTests/TargetAuthoringContractTests.cs"] = 2,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/AllocationPreflightTests.cs"] = 4,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/BrushIntermediateAllocationIntentTests.cs"] = 3,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/ContributeValuesCacheHitExecutionTests.cs"] = 4,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/RenderCacheIdentityChannelTests.cs"] = 5,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/RenderCacheResolutionTests.cs"] = 2,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/RenderCacheVerificationTests.cs"] = 9,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/StructuralAndProgramCacheTests.cs"] = 6,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/ContainerRenderNodeTest.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/DeclaredResourceAddressingTests.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/DeferredCallbackFailureTests.cs"] = 7,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/NestedTargetAndCleanupFailureTests.cs"] = 16,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/RecordingAndPlanningFailureTests.cs"] = 5,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/RenderNodeRendererLifetimeTests.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Failure/ShaderAndAllocationFailureTests.cs"] = 4,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Fusion/CrossNodeShaderFusionTests.cs"] = 5,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Fusion/ExecutionIslandAuthorityTests.cs"] = 3,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Fusion/FusionBoundaryExecutionTestSupport.cs"] = 6,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Fusion/ShaderFallbackTests.cs"] = 2,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/GpuPassFusionFeature003RegressionTests.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/GpuPassFusionScaleRegionTests.cs"] = 6,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/LosslessCompositeCoverageTests.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/ShaderMatrixUniformTests.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/TargetCaptureValueWrapperTests.cs"] = 2,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/GraphicsContext2DTests.cs"] = 2,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/ImageSourceRenderNodeTest.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/LegacyFilterTypedSuffixExecutionTests.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/NodeCacheScaleTests.cs"] = 3,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/BackdropOrderingTests.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/MaterializedInputCompositeTests.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/ProductionResourceLifetimeTests.cs"] = 2,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/RawScopeNestingAndCaptureOffsetTests.cs"] = 3,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/RenderPipelineReconciliationTests.cs"] = 14,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/RendererWideRecordingTests.cs"] = 7,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/SymbolicOwningDomainTests.cs"] = 3,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/SymbolicSupplyMappingTests.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Planning/TargetScopeLoweringTests.cs"] = 9,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/DeclaredResourceOrderTests.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/PrimaryPaintedSourceTests.cs"] = 2,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RecordingSideEffectTests.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/ValueReplaySafetyTests.cs"] = 2,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeRendererDeviceBoundsTests.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeRendererExceptionSafetyTests.cs"] = 2,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeRendererSnapshotFastPathTests.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/RendererExceptionSafetyTests.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/ResolutionScaleTests.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/SourceEffectiveScaleFlowTests.cs"] = 13,
+            ["tests/Beutl.UnitTests/NodeGraph/NodeGraphFilterEffectRenderNodeTests.cs"] = 6,
+            ["tests/Beutl.UnitTests/ProjectSystem/SceneDrawableScaleTests.cs"] = 1,
+        };
+
+    private static readonly IReadOnlyDictionary<string, int> s_startingTestOverrideBaseline =
+        new Dictionary<string, int>(StringComparer.Ordinal)
+        {
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/NodeCacheScaleTests.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/RendererExceptionSafetyTests.cs"] = 1,
+            ["tests/Beutl.UnitTests/Engine/Graphics/Rendering/SourceEffectiveScaleFlowTests.cs"] = 3,
+            ["tests/Beutl.UnitTests/NodeGraph/NodeGraphFilterEffectRenderNodeTests.cs"] = 1,
+        };
+
+    [Test]
+    public void SourceScope_IsOnlyCheckedInCSharpAndExcludesHistoricalEvidence()
+    {
+        SourceCorpus corpus = s_corpus.Value;
+        string[] outsideScope = corpus.Documents
+            .Where(document =>
+                !document.RelativePath.StartsWith("src/", StringComparison.Ordinal)
+                && !document.RelativePath.StartsWith("tests/", StringComparison.Ordinal))
+            .Select(document => document.RelativePath)
+            .ToArray();
+        string[] buildOutputs = corpus.Documents
+            .Where(document => HasPathSegment(document.RelativePath, "bin")
+                || HasPathSegment(document.RelativePath, "obj"))
+            .Select(document => document.RelativePath)
+            .ToArray();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(corpus.Documents, Is.Not.Empty);
+            Assert.That(outsideScope, Is.Empty);
+            Assert.That(buildOutputs, Is.Empty);
+            Assert.That(corpus.Documents.Select(document => document.RelativePath),
+                Does.Not.Contain(HistoricalEvidencePatch));
+        }
+    }
+
+    [Test]
+    public void HistoricalEvidencePatch_ExistsOutsideCompiledSourceCorpus()
+    {
+        GpuPassFusionEvidenceStackSliceGate.RequireStack4EvidenceSlice();
+        SourceCorpus corpus = s_corpus.Value;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(corpus.Documents.Select(document => document.RelativePath),
+                Does.Not.Contain(HistoricalEvidencePatch));
+            Assert.That(File.Exists(Path.Combine(corpus.RepositoryRoot, HistoricalEvidencePatch)), Is.True,
+                "The historical patch should exist but remain outside the compiled-source corpus.");
+        });
+    }
+
+    [Test]
+    public void ProcessOverrideInventory_PinsStartingBaselineAndMigratedOverrides()
+    {
+        IReadOnlyList<SourceMethod> overrides = s_corpus.Value.FindRenderNodeProcessOverrides();
+
+        using (Assert.EnterMultipleScope())
+        {
+            AssertDeclaredBaseline("production", 29, s_startingProductionOverrideBaseline);
+            AssertDeclaredBaseline("test", 7, s_startingTestOverrideBaseline);
+            AssertAllOverridesAreMapped(overrides);
+            AssertBaselineInventory("production", 30, s_productionOverrideBaseline, overrides);
+            AssertBaselineInventory("test", 234, s_testOverrideBaseline, overrides);
+        }
+    }
+
+    [Test]
+    public void ProcessOverrides_UseTheVoidRecordingContract()
+    {
+        IEnumerable<SourceFinding> findings = s_corpus.Value.FindRenderNodeProcessOverrides()
+            .Where(sourceMethod => !ReturnsVoid(sourceMethod.Method))
+            .Select(sourceMethod => sourceMethod.ToFinding(
+                $"returns '{sourceMethod.Method.ReturnType}'"));
+
+        AssertNoFindings("Every render-node Process override must return void.", findings);
+    }
+
+    [Test]
+    public void ExecutableOperationTypeAndFactories_AreRemoved()
+    {
+        string operationType = BuildName("Render", "Node", "Operation");
+        string[] factoryNames =
+        [
+            BuildName("Create", "Lambda"),
+            BuildName("Create", "Decorator"),
+            BuildName("Create", "From", "Render", "Target"),
+            BuildName("Create", "From", "Surface"),
+        ];
+
+        using (Assert.EnterMultipleScope())
+        {
+            AssertNoFindings($"The executable type '{operationType}' must be absent.",
+                s_corpus.Value.FindWord(operationType));
+            AssertNoFindings("Executable operation factories must be absent.",
+                factoryNames.SelectMany(s_corpus.Value.FindWord));
+        }
+    }
+
+    [Test]
+    public void ProcessorPullApis_AreRemoved()
+    {
+        string[] pullNames =
+        [
+            BuildName("Pu", "ll"),
+            BuildName("Pu", "ll", "To", "Root"),
+        ];
+
+        AssertNoFindings("Processor pull APIs must be absent.",
+            pullNames.SelectMany(s_corpus.Value.FindWord));
+    }
+
+    [Test]
+    public void ListRasterizationCompatibility_IsRemoved()
+    {
+        string[] compatibilityNames =
+        [
+            BuildName("Rasterize", "To", "Render", "Targets"),
+            BuildName("Rasterize", "And", "Concat"),
+        ];
+        IEnumerable<SourceFinding> findings = s_corpus.Value.FindLegacyRasterizers()
+            .Concat(compatibilityNames.SelectMany(s_corpus.Value.FindWord));
+
+        AssertNoFindings("Rasterization must return one owned RenderNodeRasterization, not a list or compatibility result.",
+            findings);
+    }
+
+    [Test]
+    public void OperationRetentionAndBackedEffectTargets_AreRemoved()
+    {
+        string setterName = BuildName("Set", "Operations");
+        string operationPropertyName = BuildName("Node", "Operation");
+        string operationType = BuildName("Render", "Node", "Operation");
+
+        using (Assert.EnterMultipleScope())
+        {
+            AssertNoFindings("Operation wrappers must not retain executable results.",
+                s_corpus.Value.FindWord(setterName));
+            AssertNoFindings("Effect targets must not expose an operation-backed property.",
+                s_corpus.Value.FindWord(operationPropertyName));
+            AssertNoFindings("Effect targets must have only materialized-target construction paths.",
+                s_corpus.Value.FindOperationBackedEffectTargets(operationType));
+        }
+    }
+
+    [Test]
+    public void ProcessMethods_DoNotCreateIsolatedNestedRenderers()
+    {
+        string[] rendererTypes =
+        [
+            BuildName("Render", "Node", "Processor"),
+            BuildName("Render", "Node", "Renderer"),
+        ];
+
+        AssertNoFindings("Nested nodes must record through the current context instead of creating an isolated renderer.",
+            s_corpus.Value.FindNamedTokensInsideRenderNodeProcess(rendererTypes));
+    }
+
+    [Test]
+    public void CacheGeneration_DoesNotStartAnIndependentPullOrRasterization()
+    {
+        string[] forbiddenNames =
+        [
+            BuildName("Render", "Node", "Processor"),
+            BuildName("Render", "Node", "Renderer"),
+            BuildName("Pu", "ll"),
+            BuildName("Pu", "ll", "To", "Root"),
+            BuildName("Rasterize"),
+            BuildName("Rasterize", "To", "Render", "Targets"),
+            BuildName("Rasterize", "And", "Concat"),
+        ];
+
+        AssertNoFindings("Cache generation must be resolved inside the current request.",
+            s_corpus.Value.FindForbiddenCacheExecution(forbiddenNames));
+    }
+
+    [Test]
+    public void RawCanvasCallbacks_AreExplicitlyClassified()
+    {
+        string[] callbackFactoryNames =
+        [
+            BuildName("Create", "Lambda"),
+            BuildName("Create", "Decorator"),
+        ];
+
+        AssertNoFindings(
+            "Raw callbacks must use a typed, guarded opaque, or explicitly raw description.",
+            s_corpus.Value.FindInvocations(callbackFactoryNames));
+    }
+
+    [Test]
+    public void ContextScaleHelpers_AreMovedWithoutForwardingMembers()
+    {
+        string contextType = BuildName("Render", "Node", "Context");
+        string[] helperNames =
+        [
+            BuildName("Max", "Buffer", "Dimension"),
+            BuildName("Sanitize", "Max", "Working", "Scale"),
+            BuildName("Resolve", "Working", "Scale"),
+            BuildName("Clamp", "Working", "Scale", "To", "Buffer", "Budget"),
+        ];
+        IEnumerable<SourceFinding> findings = s_corpus.Value.FindQualifiedReferences(contextType, helperNames)
+            .Concat(s_corpus.Value.FindMembersDeclaredByType(contextType, helperNames));
+
+        AssertNoFindings("Scale helpers must be owned only by RenderScaleUtilities.", findings);
+    }
+
+    private static void AssertBaselineInventory(
+        string label,
+        int expectedCount,
+        IReadOnlyDictionary<string, int> expected,
+        IReadOnlyList<SourceMethod> allOverrides)
+    {
+        SourceMethod[] baselineOverrides = allOverrides
+            .Where(sourceMethod => expected.ContainsKey(sourceMethod.Document.RelativePath))
+            .ToArray();
+        string[] expectedInventory = FormatInventory(expected);
+        string[] actualInventory = FormatInventory(baselineOverrides
+            .GroupBy(sourceMethod => sourceMethod.Document.RelativePath, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.Ordinal));
+
+        Assert.That(expected.Values.Sum(), Is.EqualTo(expectedCount),
+            $"The checked-in {label} baseline declaration is inconsistent.");
+        Assert.That(baselineOverrides, Has.Length.EqualTo(expectedCount),
+            $"The {label} Process override baseline changed.{Environment.NewLine}{FormatMethods(baselineOverrides)}");
+        Assert.That(actualInventory, Is.EqualTo(expectedInventory),
+            $"The {label} Process override inventory changed.");
+    }
+
+    private static void AssertAllOverridesAreMapped(IReadOnlyList<SourceMethod> allOverrides)
+    {
+        var mappedPaths = new HashSet<string>(s_productionOverrideBaseline.Keys, StringComparer.Ordinal);
+        mappedPaths.UnionWith(s_testOverrideBaseline.Keys);
+        SourceMethod[] unmapped = allOverrides
+            .Where(sourceMethod => !mappedPaths.Contains(sourceMethod.Document.RelativePath))
+            .ToArray();
+
+        Assert.That(unmapped, Is.Empty,
+            $"Every RenderNode.Process override must appear in the production or test inventory."
+            + $"{Environment.NewLine}{FormatMethods(unmapped)}");
+    }
+
+    private static void AssertDeclaredBaseline(
+        string label,
+        int expectedCount,
+        IReadOnlyDictionary<string, int> expected)
+    {
+        Assert.That(expected.Values.Sum(), Is.EqualTo(expectedCount),
+            $"The checked-in starting-SHA {label} baseline declaration is inconsistent.");
+    }
+
+    private static string[] FormatInventory(IReadOnlyDictionary<string, int> inventory)
+    {
+        return inventory
+            .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+            .Select(pair => $"{pair.Key}#{pair.Value}")
+            .ToArray();
+    }
+
+    private static string FormatMethods(IEnumerable<SourceMethod> methods)
+    {
+        return string.Join(Environment.NewLine, methods
+            .OrderBy(sourceMethod => sourceMethod.Document.RelativePath, StringComparer.Ordinal)
+            .ThenBy(sourceMethod => sourceMethod.Line)
+            .Select(sourceMethod => $"  {sourceMethod.Document.RelativePath}:{sourceMethod.Line}"));
+    }
+
+    private static void AssertNoFindings(string requirement, IEnumerable<SourceFinding> findings)
+    {
+        SourceFinding[] materialized = findings
+            .Distinct()
+            .OrderBy(finding => finding.RelativePath, StringComparer.Ordinal)
+            .ThenBy(finding => finding.Line)
+            .ThenBy(finding => finding.Detail, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.That(materialized, Is.Empty, $"{requirement}{Environment.NewLine}{FormatFindings(materialized)}");
+    }
+
+    private static string FormatFindings(IReadOnlyList<SourceFinding> findings)
+    {
+        const int maximumReportedFindings = 30;
+        IEnumerable<string> lines = findings.Take(maximumReportedFindings)
+            .Select(finding =>
+                $"  {finding.RelativePath}:{finding.Line}: {finding.Detail}: {finding.Snippet}");
+        string result = string.Join(Environment.NewLine, lines);
+        if (findings.Count > maximumReportedFindings)
+        {
+            result += Environment.NewLine
+                + $"  ... {findings.Count - maximumReportedFindings} more finding(s)";
+        }
+
+        return result;
+    }
+
+    private static bool ReturnsVoid(MethodDeclarationSyntax method)
+    {
+        return method.ReturnType is PredefinedTypeSyntax predefined
+            && predefined.Keyword.IsKind(SyntaxKind.VoidKeyword);
+    }
+
+    private static bool IsNamedType(TypeSyntax? type, string expectedName)
+    {
+        return type?.DescendantTokens()
+            .LastOrDefault(token => token.IsKind(SyntaxKind.IdentifierToken))
+            .ValueText == expectedName;
+    }
+
+    private static bool IsRenderNodeProcess(MethodDeclarationSyntax method)
+    {
+        return method.Identifier.ValueText == "Process"
+            && method.ParameterList.Parameters.Count == 1
+            && IsNamedType(method.ParameterList.Parameters[0].Type, "RenderNodeContext");
+    }
+
+    private static string BuildName(params string[] parts)
+    {
+        return string.Concat(parts);
+    }
+
+    private static bool HasPathSegment(string path, string segment)
+    {
+        return path.Split('/').Contains(segment, StringComparer.Ordinal);
+    }
+
+    private sealed class SourceCorpus
+    {
+        private SourceCorpus(string repositoryRoot, IReadOnlyList<SourceDocument> documents)
+        {
+            RepositoryRoot = repositoryRoot;
+            Documents = documents;
+        }
+
+        public string RepositoryRoot { get; }
+
+        public IReadOnlyList<SourceDocument> Documents { get; }
+
+        public static SourceCorpus Discover()
+        {
+            DirectoryInfo? directory = new(AppContext.BaseDirectory);
+            while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Beutl.slnx")))
+                directory = directory.Parent;
+
+            if (directory is null)
+            {
+                throw new DirectoryNotFoundException(
+                    $"Could not locate the Beutl repository root above {AppContext.BaseDirectory}.");
+            }
+
+            string repositoryRoot = directory.FullName;
+            var documents = new List<SourceDocument>();
+            foreach (string sourceRootName in new[] { "src", "tests" })
+            {
+                string sourceRoot = Path.Combine(repositoryRoot, sourceRootName);
+                foreach (string path in Directory.EnumerateFiles(sourceRoot, "*.cs", SearchOption.AllDirectories))
+                {
+                    string relativePath = NormalizePath(Path.GetRelativePath(repositoryRoot, path));
+                    if (HasPathSegment(relativePath, "bin") || HasPathSegment(relativePath, "obj"))
+                        continue;
+
+                    SourceText text = SourceText.From(File.ReadAllText(path));
+                    var tree = CSharpSyntaxTree.ParseText(
+                        text,
+                        CSharpParseOptions.Default.WithDocumentationMode(DocumentationMode.Parse),
+                        relativePath);
+                    documents.Add(new SourceDocument(
+                        relativePath,
+                        text,
+                        tree.GetCompilationUnitRoot()));
+                }
+            }
+
+            documents.Sort((left, right) =>
+                StringComparer.Ordinal.Compare(left.RelativePath, right.RelativePath));
+            return new SourceCorpus(repositoryRoot, documents);
+        }
+
+        public IReadOnlyList<SourceMethod> FindRenderNodeProcessOverrides()
+        {
+            return Documents.SelectMany(document => document.Root.DescendantNodes()
+                    .OfType<MethodDeclarationSyntax>()
+                    .Where(method => method.Modifiers.Any(SyntaxKind.OverrideKeyword) && IsRenderNodeProcess(method))
+                    .Select(method => new SourceMethod(document, method)))
+                .ToArray();
+        }
+
+        public IEnumerable<SourceFinding> FindWord(string value)
+        {
+            foreach (SourceDocument document in Documents)
+            {
+                foreach (SyntaxToken token in document.Root.DescendantTokens()
+                             .Where(token => token.IsKind(SyntaxKind.IdentifierToken)
+                                 && token.ValueText == value))
+                {
+                    yield return document.ToFinding(token, $"reference to '{value}'");
+                }
+            }
+        }
+
+        public IEnumerable<SourceFinding> FindQualifiedReferences(
+            string containingType,
+            IReadOnlyList<string> memberNames)
+        {
+            string alternatives = string.Join("|", memberNames.Select(Regex.Escape));
+            var pattern = new Regex(
+                $@"(?<![\p{{L}}\p{{N}}_]){Regex.Escape(containingType)}\s*\.\s*(?:{alternatives})(?![\p{{L}}\p{{N}}_])",
+                RegexOptions.CultureInvariant);
+            return FindText(pattern, $"reference through '{containingType}'");
+        }
+
+        public IEnumerable<SourceFinding> FindInvocations(IReadOnlyCollection<string> names)
+        {
+            var nameSet = new HashSet<string>(names, StringComparer.Ordinal);
+            foreach (SourceDocument document in Documents)
+            {
+                foreach (InvocationExpressionSyntax invocation in document.Root.DescendantNodes()
+                             .OfType<InvocationExpressionSyntax>())
+                {
+                    string? name = GetInvokedName(invocation);
+                    if (name is not null && nameSet.Contains(name))
+                        yield return document.ToFinding(invocation, $"invocation of '{name}'");
+                }
+            }
+        }
+
+        public IEnumerable<SourceFinding> FindLegacyRasterizers()
+        {
+            foreach (SourceDocument document in Documents)
+            {
+                foreach (MethodDeclarationSyntax method in document.Root.DescendantNodes()
+                             .OfType<MethodDeclarationSyntax>()
+                             .Where(method => method.Identifier.ValueText == "Rasterize"
+                                 && !IsNamedType(method.ReturnType, "RenderNodeRasterization")))
+                {
+                    yield return document.ToFinding(method,
+                        $"Rasterize returns '{method.ReturnType}'");
+                }
+            }
+        }
+
+        public IEnumerable<SourceFinding> FindOperationBackedEffectTargets(string operationType)
+        {
+            foreach (SourceDocument document in Documents)
+            {
+                foreach (ConstructorDeclarationSyntax constructor in document.Root.DescendantNodes()
+                             .OfType<ConstructorDeclarationSyntax>()
+                             .Where(constructor => constructor.Identifier.ValueText == "EffectTarget"
+                                 && constructor.ParameterList.Parameters.Count == 1
+                                 && IsNamedType(constructor.ParameterList.Parameters[0].Type, operationType)))
+                {
+                    yield return document.ToFinding(constructor,
+                        "operation-backed EffectTarget constructor");
+                }
+
+                foreach (ObjectCreationExpressionSyntax creation in document.Root.DescendantNodes()
+                             .OfType<ObjectCreationExpressionSyntax>()
+                             .Where(creation => IsNamedType(creation.Type, "EffectTarget")
+                                 && creation.ArgumentList?.Arguments.Count == 1))
+                {
+                    yield return document.ToFinding(creation,
+                        "one-argument EffectTarget construction");
+                }
+            }
+        }
+
+        public IEnumerable<SourceFinding> FindNamedTokensInsideRenderNodeProcess(
+            IReadOnlyCollection<string> names)
+        {
+            var nameSet = new HashSet<string>(names, StringComparer.Ordinal);
+            foreach (SourceDocument document in Documents)
+            {
+                foreach (MethodDeclarationSyntax method in document.Root.DescendantNodes()
+                             .OfType<MethodDeclarationSyntax>()
+                             .Where(IsRenderNodeProcess))
+                {
+                    foreach (SyntaxToken token in method.DescendantTokens()
+                                 .Where(token => token.IsKind(SyntaxKind.IdentifierToken)
+                                     && nameSet.Contains(token.ValueText)))
+                    {
+                        yield return document.ToFinding(token,
+                            $"isolated renderer '{token.ValueText}' inside Process");
+                    }
+                }
+            }
+        }
+
+        public IEnumerable<SourceFinding> FindForbiddenCacheExecution(IReadOnlyCollection<string> names)
+        {
+            var nameSet = new HashSet<string>(names, StringComparer.Ordinal);
+            string cacheHelperType = BuildName("Render", "Node", "Cache", "Helper");
+            string[] cacheMethodNames =
+            [
+                BuildName("Make", "Cache"),
+                BuildName("Create", "Default", "Cache"),
+            ];
+
+            foreach (SourceDocument document in Documents)
+            {
+                IEnumerable<SyntaxNode> roots = document.Root.DescendantNodes()
+                    .OfType<TypeDeclarationSyntax>()
+                    .Where(type => type.Identifier.ValueText == cacheHelperType)
+                    .Cast<SyntaxNode>()
+                    .Concat(document.Root.DescendantNodes()
+                        .OfType<MethodDeclarationSyntax>()
+                        .Where(method => cacheMethodNames.Contains(method.Identifier.ValueText, StringComparer.Ordinal)));
+
+                foreach (SyntaxNode root in roots)
+                {
+                    foreach (SyntaxToken token in root.DescendantTokens()
+                                 .Where(token => token.IsKind(SyntaxKind.IdentifierToken)
+                                     && nameSet.Contains(token.ValueText)))
+                    {
+                        yield return document.ToFinding(token,
+                            $"independent cache execution '{token.ValueText}'");
+                    }
+                }
+            }
+        }
+
+        public IEnumerable<SourceFinding> FindMembersDeclaredByType(
+            string typeName,
+            IReadOnlyCollection<string> memberNames)
+        {
+            var memberNameSet = new HashSet<string>(memberNames, StringComparer.Ordinal);
+            foreach (SourceDocument document in Documents)
+            {
+                foreach (TypeDeclarationSyntax type in document.Root.DescendantNodes()
+                             .OfType<TypeDeclarationSyntax>()
+                             .Where(type => type.Identifier.ValueText == typeName))
+                {
+                    foreach (MemberDeclarationSyntax member in type.Members)
+                    {
+                        foreach (SyntaxToken identifier in GetDeclaredIdentifiers(member)
+                                     .Where(token => memberNameSet.Contains(token.ValueText)))
+                        {
+                            yield return document.ToFinding(identifier,
+                                $"forwarding member '{identifier.ValueText}' on '{typeName}'");
+                        }
+                    }
+                }
+            }
+        }
+
+        private IEnumerable<SourceFinding> FindText(Regex pattern, string detail)
+        {
+            foreach (SourceDocument document in Documents)
+            {
+                foreach (Match match in pattern.Matches(document.Text.ToString()))
+                    yield return document.ToFinding(match.Index, detail);
+            }
+        }
+
+        private static string? GetInvokedName(InvocationExpressionSyntax invocation)
+        {
+            return invocation.Expression switch
+            {
+                IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
+                GenericNameSyntax generic => generic.Identifier.ValueText,
+                MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.ValueText,
+                MemberBindingExpressionSyntax memberBinding => memberBinding.Name.Identifier.ValueText,
+                _ => null,
+            };
+        }
+
+        private static IEnumerable<SyntaxToken> GetDeclaredIdentifiers(MemberDeclarationSyntax member)
+        {
+            return member switch
+            {
+                MethodDeclarationSyntax method => [method.Identifier],
+                PropertyDeclarationSyntax property => [property.Identifier],
+                EventDeclarationSyntax eventDeclaration => [eventDeclaration.Identifier],
+                FieldDeclarationSyntax field => field.Declaration.Variables.Select(variable => variable.Identifier),
+                EventFieldDeclarationSyntax eventField =>
+                    eventField.Declaration.Variables.Select(variable => variable.Identifier),
+                _ => [],
+            };
+        }
+
+        private static string NormalizePath(string path)
+        {
+            return path.Replace(Path.DirectorySeparatorChar, '/');
+        }
+    }
+
+    private sealed record SourceDocument(
+        string RelativePath,
+        SourceText Text,
+        CompilationUnitSyntax Root)
+    {
+        public SourceFinding ToFinding(SyntaxNode node, string detail)
+        {
+            return ToFinding(node.SpanStart, detail);
+        }
+
+        public SourceFinding ToFinding(SyntaxToken token, string detail)
+        {
+            return ToFinding(token.SpanStart, detail);
+        }
+
+        public SourceFinding ToFinding(int position, string detail)
+        {
+            LinePosition linePosition = Text.Lines.GetLinePosition(position);
+            string snippet = Text.Lines[linePosition.Line].ToString().Trim();
+            if (snippet.Length > 180)
+                snippet = snippet[..177] + "...";
+
+            return new SourceFinding(RelativePath, linePosition.Line + 1, detail, snippet);
+        }
+    }
+
+    private sealed record SourceMethod(SourceDocument Document, MethodDeclarationSyntax Method)
+    {
+        public int Line => Method.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+
+        public SourceFinding ToFinding(string detail)
+        {
+            return Document.ToFinding(Method, detail);
+        }
+    }
+
+    private sealed record SourceFinding(
+        string RelativePath,
+        int Line,
+        string Detail,
+        string Snippet);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderScaleContractTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderScaleContractTests.cs
@@ -1,0 +1,94 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Recording;
+
+[TestFixture]
+public sealed class RenderScaleContractTests
+{
+    private static readonly Rect s_bounds = new(0, 0, 100, 80);
+
+    [Test]
+    public void MapInputSupply_MapsConcreteSupplyAndPreservesUnbounded()
+    {
+        RenderScaleContract contract = RenderScaleContract.MapInputSupply(
+            DoubleSupply,
+            structuralKey: "double-supply");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                contract.Resolve([EffectiveScale.At(1.5f)], s_bounds, outputScale: 1, maxWorkingScale: 10),
+                Is.EqualTo(EffectiveScale.At(3)));
+            Assert.That(
+                contract.Resolve([EffectiveScale.Unbounded], s_bounds, outputScale: 1, maxWorkingScale: 10),
+                Is.EqualTo(EffectiveScale.Unbounded));
+            Assert.That(
+                contract.Resolve([EffectiveScale.At(3)], s_bounds, outputScale: 1, maxWorkingScale: 4),
+                Is.EqualTo(EffectiveScale.At(4)));
+        });
+    }
+
+    [Test]
+    public void MapInputSupply_RequiresAnElementWiseSingleInputTopology()
+    {
+        RenderScaleContract contract = RenderScaleContract.MapInputSupply(
+            static input => input,
+            structuralKey: "identity-supply");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => contract.Resolve([], s_bounds, outputScale: 1, maxWorkingScale: 4),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(
+                () => contract.Resolve(
+                    [EffectiveScale.At(1), EffectiveScale.At(2)],
+                    s_bounds,
+                    outputScale: 1,
+                    maxWorkingScale: 4),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(
+                () => contract.ThrowIfIncompatible(OpaqueRenderTopology.Map, "scale"),
+                Throws.Nothing);
+            Assert.That(
+                () => contract.ThrowIfIncompatible(OpaqueRenderTopology.Source, "scale"),
+                Throws.TypeOf<ArgumentException>());
+        });
+    }
+
+    [Test]
+    public void MapInputSupply_HasStableKindSpecificStructuralIdentity()
+    {
+        const string sharedKey = "shared-scale-key";
+        RenderScaleContract first = RenderScaleContract.MapInputSupply(DoubleSupply, sharedKey);
+        RenderScaleContract second = RenderScaleContract.MapInputSupply(DoubleSupply, sharedKey);
+        RenderScaleContract custom = RenderScaleContract.Custom(
+            static _ => 2,
+            structuralKey: sharedKey);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.StructuralIdentity, Is.EqualTo(second.StructuralIdentity));
+            Assert.That(first.StructuralIdentity, Is.Not.EqualTo(custom.StructuralIdentity));
+        });
+    }
+
+    [Test]
+    public void MapInputSupply_RejectsMutableCallbackCapture()
+    {
+        var mutable = new List<float> { 2 };
+
+        Assert.That(
+            () => RenderScaleContract.MapInputSupply(
+                input => input.IsUnbounded
+                    ? EffectiveScale.Unbounded
+                    : EffectiveScale.At(input.Value * mutable[0])),
+            Throws.TypeOf<ArgumentException>());
+    }
+
+    private static EffectiveScale DoubleSupply(EffectiveScale input)
+        => input.IsUnbounded
+            ? EffectiveScale.Unbounded
+            : EffectiveScale.At(input.Value * 2);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderStateValidationDepthTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderStateValidationDepthTests.cs
@@ -1,0 +1,162 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Recording;
+
+/// <summary>
+/// Pins that a description's <c>state</c> is validated through tuple elements and custom aggregate fields to
+/// every nesting depth.
+/// </summary>
+[TestFixture]
+public sealed class RenderStateValidationDepthTests
+{
+    private static readonly Rect s_bounds = new(0, 0, 8, 8);
+
+    [Test]
+    public void ARootCapturingCallbackIsStillRejected()
+    {
+        var color = Colors.Red;
+        Func<Color> capturing = () => color;
+
+        Assert.That(
+            () => Create(capturing),
+            Throws.TypeOf<ArgumentException>().With.Property("ParamName").EqualTo("state"));
+    }
+
+    [Test]
+    public void ACapturingDelegateInsideTheStateTupleIsRejected()
+    {
+        var color = Colors.Red;
+        Func<Color> capturing = () => color;
+
+        ArgumentException? rejection = Assert.Throws<ArgumentException>(() => Create((1, capturing)));
+
+        TestContext.Out.WriteLine(rejection!.Message);
+        Assert.Multiple(() =>
+        {
+            Assert.That(rejection.ParamName, Is.EqualTo("state"));
+            Assert.That(rejection.Message, Does.Contain("deeply immutable"));
+        });
+    }
+
+    [Test]
+    public void ANonCapturingDelegateInsideTheStateTupleIsRejected()
+    {
+        Assert.That(
+            () => Create((1, (Func<Color>)(static () => Colors.Red))),
+            Throws.TypeOf<ArgumentException>().With.Property("ParamName").EqualTo("state"));
+    }
+
+    [Test]
+    public void AMutableCollectionInsideTheStateTupleIsRejected()
+    {
+        ArgumentException? rejection = Assert.Throws<ArgumentException>(() => Create((1, new List<int>())));
+
+        TestContext.Out.WriteLine(rejection!.Message);
+        Assert.That(rejection.ParamName, Is.EqualTo("state"));
+    }
+
+    [Test]
+    public void ADisposableInsideTheStateTupleIsRejected()
+    {
+        using var disposable = new DisposablePayload();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => Create((1, disposable)),
+                Throws.TypeOf<ArgumentException>().With.Property("ParamName").EqualTo("state"),
+                "a concretely typed disposable element is decided from the element type");
+            Assert.That(
+                () => Create((1, (IDisposable)disposable)),
+                Throws.TypeOf<ArgumentException>().With.Property("ParamName").EqualTo("state"),
+                "an interface-typed element is decided from the value it holds");
+        });
+    }
+
+    [Test]
+    public void AnExecutionFacadeInsideTheStateTupleIsRejected()
+    {
+        ArgumentException? rejection = Assert.Throws<ArgumentException>(
+            () => Create((1, (OpaqueRenderSession?)null, 2)));
+
+        TestContext.Out.WriteLine(rejection!.Message);
+        Assert.Multiple(() =>
+        {
+            Assert.That(rejection.ParamName, Is.EqualTo("state"));
+            Assert.That(rejection.Message, Does.Contain("deeply immutable"));
+        });
+    }
+
+    [Test]
+    public void RejectionReachesEveryNestingLevel()
+    {
+        using var disposable = new DisposablePayload();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => Create((1, (2, new List<int>()))),
+                Throws.TypeOf<ArgumentException>().With.Property("ParamName").EqualTo("state"));
+            Assert.That(
+                () => Create((1, (2, (3, disposable)))),
+                Throws.TypeOf<ArgumentException>().With.Property("ParamName").EqualTo("state"));
+            Assert.That(
+                () => Create((1, 2, 3, 4, 5, 6, 7, new List<int>())),
+                Throws.TypeOf<ArgumentException>().With.Property("ParamName").EqualTo("state"),
+                "an eight-element tuple carries its eighth element in a flattened rest chain");
+        });
+    }
+
+    [Test]
+    public void AHolderObjectIsValidatedThroughItsFieldsAndRejected()
+    {
+        var color = Colors.Red;
+        var holder = new DelegateHolder(() => color);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => Create(holder),
+                Throws.TypeOf<ArgumentException>().With.Property("ParamName").EqualTo("state"));
+            Assert.That(
+                () => Create((1, holder)),
+                Throws.TypeOf<ArgumentException>().With.Property("ParamName").EqualTo("state"));
+        });
+    }
+
+    [Test]
+    public void TheProductionStateShapesStayAccepted()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => Create((s_bounds, ClipOperation.Intersect)), Throws.Nothing);
+            Assert.That(() => Create((Guid.NewGuid(), 3, ClipOperation.Difference)), Throws.Nothing);
+            Assert.That(() => Create(("pixels", 4)), Throws.Nothing);
+            Assert.That(() => Create(typeof(RenderStateValidationDepthTests)), Throws.Nothing);
+        });
+    }
+
+    private static OpaqueRenderDescription Create<TState>(TState state)
+        where TState : notnull
+        => OpaqueRenderDescription.Create(
+            state,
+            static (_, _) => { },
+            OpaqueRenderBoundsContract.Source(s_bounds),
+            RenderHitTestContract.OutputBounds,
+            RenderValueCardinality.Single,
+            RenderScaleContract.MaterializeAtWorkingScale);
+
+    private sealed class DisposablePayload : IDisposable
+    {
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class DelegateHolder(Func<Color> read)
+    {
+        public Color Read() => read();
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/ValueReplaySafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/ValueReplaySafetyTests.cs
@@ -1,0 +1,153 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Recording;
+
+[TestFixture]
+public sealed class ValueReplaySafetyTests
+{
+    [TestCase(TransformOperator.Prepend, true)]
+    [TestCase(TransformOperator.Append, false)]
+    [TestCase(TransformOperator.Set, false)]
+    public void Transform_OnlyPrependPublishesAValueReplayMap(
+        TransformOperator transformOperator,
+        bool expectedValueReplay)
+    {
+        using var transform = new TransformRenderNode(
+            Matrix.CreateTranslation(3.25f, 4.5f),
+            transformOperator);
+        transform.AddChild(new RectangleRenderNode(
+            new Rect(2, 3, 12, 8),
+            Brushes.Resource.White,
+            null));
+        using var request = CreateRequest(cacheEnabled: false);
+
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(transform);
+        RenderFragmentReference root = GetSingleRoot(graph);
+        var payload = (TargetScopeRenderFragmentPayload)root.Payload!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(payload.Description.IsValueReplayMap, Is.EqualTo(expectedValueReplay));
+            Assert.That(root.CanBeUsedAsValueInput, Is.EqualTo(expectedValueReplay));
+        });
+    }
+
+    [Test]
+    public void ValueReplayMap_RejectsContributingTargetCapture()
+    {
+        using var node = new TargetCaptureReplayNode();
+        using var request = CreateRequest(cacheEnabled: false);
+
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        RenderFragmentReference root = GetSingleRoot(graph);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(root.ContributesValuesToTarget, Is.True);
+            Assert.That(root.ValueCardinality, Is.EqualTo(RenderValueCardinality.Single));
+            Assert.That(root.CanBeUsedAsValueInput, Is.False,
+                "A target capture must not be replayed against a fresh transparent value target.");
+            Assert.That(RenderFragmentTargetDependency.HasExternalTargetDependency(root), Is.True);
+        });
+    }
+
+    [Test]
+    public void ValueReplayMap_AllowsSelfContainedFiniteLayerCacheCandidate()
+    {
+        using var node = new FiniteLayerReplayNode();
+        node.Cache.ReportRenderCount(RenderNodeCache.Count);
+        using var request = CreateRequest(cacheEnabled: true, RenderRequestPurpose.Frame);
+
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        RenderFragmentReference root = GetSingleRoot(graph);
+        var cacheContext = new RenderCacheResolutionContext(
+            RenderCacheFormatIdentity.LinearPremultipliedRgba16Float,
+            new RenderCacheDeviceContextIdentity("device", "context"));
+        using CompiledRenderRequest compiled = new RenderRequestCompiler(
+            renderCacheContext: cacheContext).Compile(request, graph);
+        RenderCacheDecision decision = compiled.CacheResolution.Decisions.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(root.HasTargetEffects, Is.True,
+                "A finite Layer still owns target-scoped execution metadata.");
+            Assert.That(RenderFragmentTargetDependency.HasExternalTargetDependency(root), Is.False);
+            Assert.That(root.CanBeUsedAsValueInput, Is.True);
+            Assert.That(graph.CacheCandidates, Has.Length.EqualTo(1));
+            Assert.That(decision.Kind, Is.EqualTo(RenderCacheResolutionKind.MissCapture));
+        });
+    }
+
+    private static RenderRequest CreateRequest(
+        bool cacheEnabled,
+        RenderRequestPurpose purpose = RenderRequestPurpose.Auxiliary)
+        => new(new RenderRequestOptions(
+            RenderIntent.Preview,
+            purpose,
+            targetDomain: new Rect(0, 0, 64, 64),
+            outputScale: 1,
+            maxWorkingScale: 1,
+            cachePolicy: cacheEnabled ? RenderCacheOptions.Enabled : RenderCacheOptions.Disabled));
+
+    private static RenderFragmentReference GetSingleRoot(RecordedRenderGraph graph)
+    {
+        RenderFragmentId rootId = graph.PublicationRoots.Single();
+        return (RenderFragmentReference)graph.Fragments
+            .Single(fragment => fragment.Id == rootId)
+            .Payload!;
+    }
+
+    private static TargetScopeDescription CreateIdentityValueReplayDescription(string key)
+        => TargetScopeDescription.CreateValueReplayMap(
+            session => session.Canvas.Use(_ => session.ReplayInput()),
+            RenderBoundsContract.Identity,
+            RenderHitTestContract.AnyInput,
+            RenderScaleContract.PreserveInputSupply,
+            deviceGridSensitivity: RenderDeviceGridSensitivity.Insensitive,
+            deviceGridMapping: RenderDeviceGridMapping.Preserved,
+            structuralKey: key);
+
+    private sealed class TargetCaptureReplayNode : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            var bounds = new Rect(0, 0, 24, 16);
+            RenderFragmentHandle capture = context.TargetCapture(TargetCaptureDescription.Create(
+                TargetRegion.Region(bounds),
+                bounds,
+                RenderHitTestContract.OutputBounds,
+                TargetCaptureScaleContract.MaterializeAtWorkingScale));
+            RenderFragmentHandle contributing = context.ContributeValues(capture);
+            context.Publish(context.TargetScope(
+                contributing,
+                CreateIdentityValueReplayDescription(nameof(TargetCaptureReplayNode))));
+        }
+    }
+
+    private sealed class FiniteLayerReplayNode : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            var bounds = new Rect(0, 0, 24, 16);
+            RenderFragmentHandle source = context.OpaqueSource(OpaqueRenderDescription.CreateRequestLocal(
+                session =>
+                {
+                    using OpaqueRenderOutput output = session.CreateOutput(bounds);
+                    output.Canvas.Use(canvas => canvas.Clear(Colors.White));
+                    session.Publish(output);
+                },
+                OpaqueRenderBoundsContract.Source(bounds),
+                RenderHitTestContract.OutputBounds,
+                RenderValueCardinality.Single,
+                RenderScaleContract.Vector,
+                structuralKey: nameof(FiniteLayerReplayNode)));
+            RenderFragmentHandle layer = context.Layer([source], bounds);
+            context.Publish(context.TargetScope(
+                layer,
+                CreateIdentityValueReplayDescription(nameof(FiniteLayerReplayNode))));
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/ReferencedChildRevalidationTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/ReferencedChildRevalidationTests.cs
@@ -1,0 +1,254 @@
+﻿using System.Collections.Immutable;
+using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+[NonParallelizable]
+[TestFixture]
+public class ReferencedChildRevalidationTests
+{
+    [Test]
+    public void Frame_ClearsMarksOnANodeBehindAReference()
+    {
+        RenderThread.Dispatcher.Invoke(() =>
+        {
+            using var child = new ContainerRenderNode();
+            var grandchild = new RectangleRenderNode(new Rect(0, 0, 4, 4), Brushes.Resource.White, null);
+            child.AddChild(grandchild);
+            using Renderer renderer = CreateRenderer();
+            CompositionFrame frame = CreateFrame(new ReferencingDrawable(child));
+
+            renderer.UpdateFrame(frame);
+            child.HasChanges = true;
+            grandchild.HasChanges = true;
+            renderer.UpdateFrame(frame);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(child.HasChanges, Is.False, "the referenced child kept its mark");
+                Assert.That(grandchild.HasChanges, Is.False, "a node under the referenced child kept its mark");
+            });
+        });
+    }
+
+    [Test]
+    public void Frame_KeepsASharedMarkVisibleToEveryEntryThatReferencesIt()
+    {
+        RenderThread.Dispatcher.Invoke(() =>
+        {
+            using var child = new ContainerRenderNode();
+            var first = new ReferencingDrawable(child);
+            var second = new ReferencingDrawable(child);
+            using Renderer renderer = CreateRenderer();
+
+            renderer.UpdateFrame(CreateFrame(first, second));
+            child.HasChanges = true;
+            renderer.UpdateFrame(CreateFrame(first, second));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(first.LastRecordingObservedChange, Is.True,
+                    "the first entry never saw the shared mark");
+                Assert.That(second.LastRecordingObservedChange, Is.True,
+                    "the first entry's revalidation cleared the shared mark before the second entry recorded");
+                Assert.That(child.HasChanges, Is.False, "the shared mark outlived the frame");
+            });
+        });
+    }
+
+    [Test]
+    public void Frame_ResetsCacheAdmissionOfEveryReferenceToAChangedSharedChild()
+    {
+        RenderThread.Dispatcher.Invoke(() =>
+        {
+            using var child = new ContainerRenderNode();
+            var first = new ReferencingDrawable(child);
+            var second = new ReferencingDrawable(child);
+            using Renderer renderer = CreateRenderer();
+
+            renderer.UpdateFrame(CreateFrame(first, second));
+            ReferencesChildRenderNode secondReference = FindReference(renderer, second);
+            secondReference.Cache.ReportRenderCount(RenderNodeCache.Count - 1);
+            child.HasChanges = true;
+
+            renderer.UpdateFrame(CreateFrame(first, second));
+
+            Assert.That(secondReference.Cache.CanCache(), Is.False,
+                "the second reference reached the cache-admission threshold although the node it references changed");
+        });
+    }
+
+    [Test]
+    public void FaultedFrame_KeepsASharedMarkVisibleToAnEntryTheFaultSkipped()
+    {
+        RenderThread.Dispatcher.Invoke(() =>
+        {
+            using var child = new ContainerRenderNode();
+            var first = new ReferencingDrawable(child);
+            var faulting = new SwitchableFaultingDrawable();
+            var last = new ReferencingDrawable(child);
+            using Renderer renderer = CreateRenderer();
+
+            renderer.UpdateFrame(CreateFrame(first, faulting, last));
+
+            child.HasChanges = true;
+            faulting.ShouldFault = true;
+            Assert.That(
+                () => renderer.UpdateFrame(CreateFrame(first, faulting, last)),
+                Throws.TypeOf<InvalidOperationException>().With.Message.EqualTo("recording failed"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(first.LastRecordingObservedChange, Is.True,
+                    "the entry recorded before the fault never saw the shared mark");
+                Assert.That(child.HasChanges, Is.True,
+                    "the faulted frame consumed the shared mark although the last entry never recorded");
+            });
+
+            faulting.ShouldFault = false;
+            renderer.UpdateFrame(CreateFrame(first, faulting, last));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(last.LastRecordingObservedChange, Is.True,
+                    "the entry the fault skipped never saw the shared mark");
+                Assert.That(child.HasChanges, Is.False, "the shared mark outlived the recovered frame");
+            });
+        });
+    }
+
+    [Test]
+    public void StableFrames_CountAChildReachedByTwoReferencesOncePerFrame()
+    {
+        RenderThread.Dispatcher.Invoke(() =>
+        {
+            using var child = new ContainerRenderNode();
+            using Renderer renderer = CreateRenderer();
+            CompositionFrame frame = CreateFrame(
+                new ReferencingDrawable(child),
+                new ReferencingDrawable(child));
+
+            child.Cache.ReportRenderCount(RenderNodeCache.Count - 2);
+            renderer.UpdateFrame(frame);
+            bool afterOneFrame = child.Cache.CanCache();
+            renderer.UpdateFrame(frame);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(afterOneFrame, Is.False, "the shared child advanced twice in one frame");
+                Assert.That(child.Cache.CanCache(), Is.True, "the referenced child's render count never advanced");
+            });
+        });
+    }
+
+    [Test]
+    public void Frame_SkipsADisposedReferencedChild()
+    {
+        RenderThread.Dispatcher.Invoke(() =>
+        {
+            var disposedChild = new ContainerRenderNode();
+            disposedChild.Cache.ReportRenderCount(RenderNodeCache.Count);
+            disposedChild.HasChanges = true;
+            disposedChild.Dispose();
+
+            using var liveChild = new ContainerRenderNode();
+            liveChild.HasChanges = true;
+            using Renderer renderer = CreateRenderer();
+            CompositionFrame frame = CreateFrame(
+                new ReferencingDrawable(disposedChild),
+                new ReferencingDrawable(liveChild));
+
+            renderer.UpdateFrame(frame);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(disposedChild.Cache.CanCache(), Is.True, "a disposed referenced child was revalidated");
+                Assert.That(liveChild.HasChanges, Is.False, "the live referenced child kept its mark");
+            });
+        });
+    }
+
+    private static ReferencesChildRenderNode FindReference(Renderer renderer, Drawable drawable)
+    {
+        DrawableRenderNode node = renderer.FindRenderNode(drawable)
+            ?? throw new InvalidOperationException("The drawable was never recorded.");
+        return node.Children.OfType<ReferencesChildRenderNode>().Single();
+    }
+
+    private static Renderer CreateRenderer()
+        => new(
+            width: 16,
+            height: 16,
+            renderScale: 1,
+            maxWorkingScale: float.PositiveInfinity,
+            diagnostics: null,
+            surface: new CpuRenderTarget(16, 16));
+
+    private static CompositionFrame CreateFrame(params Drawable[] drawables)
+        => new(
+            [.. drawables.Select(static drawable =>
+                (EngineObject.Resource)drawable.ToResource(CompositionContext.Default))],
+            new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)),
+            new PixelSize(16, 16));
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height);
+}
+
+// Top-level partial because EngineObjectResourceGenerator does not support nested types.
+internal sealed partial class ReferencingDrawable : Drawable
+{
+    private readonly RenderNode _child;
+
+    public ReferencingDrawable(RenderNode child)
+    {
+        _child = child;
+    }
+
+    public bool LastRecordingObservedChange { get; private set; }
+
+    public override void Render(GraphicsContext2D context, Drawable.Resource resource)
+        => context.DrawNode(
+            _child,
+            static node => new ReferencesChildRenderNode(node),
+            (reference, node) => LastRecordingObservedChange = reference.Update(node));
+
+    protected override Size MeasureCore(Size availableSize, Drawable.Resource resource) => new(4, 4);
+
+    protected override void OnDraw(GraphicsContext2D context, Drawable.Resource resource)
+    {
+    }
+}
+
+internal sealed partial class SwitchableFaultingDrawable : Drawable
+{
+    public bool ShouldFault { get; set; }
+
+    public override void Render(GraphicsContext2D context, Drawable.Resource resource)
+    {
+        context.DrawRectangle(new Rect(0, 0, 4, 4), Brushes.Resource.White, null);
+        if (ShouldFault)
+        {
+            throw new InvalidOperationException("recording failed");
+        }
+    }
+
+    protected override Size MeasureCore(Size availableSize, Drawable.Resource resource) => new(4, 4);
+
+    protected override void OnDraw(GraphicsContext2D context, Drawable.Resource resource)
+    {
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderDescriptionAllocationTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderDescriptionAllocationTests.cs
@@ -1,0 +1,357 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Graphics.Shapes;
+using Beutl.Graphics.Transformation;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+[TestFixture]
+public sealed class RenderDescriptionAllocationTests
+{
+    private const int Iterations = 20000;
+    private const int SceneFrames = 40;
+    private const int SceneWarmupFrames = 8;
+
+    // Measured steady state is ~255,300 bytes/frame; observed runs span 254,968-255,336, a 0.14% spread. The
+    // headroom is for the platform-dependent part of the scene - font fallback for its TextBlock - rather than
+    // for measurement noise, so a whole-frame regression above roughly a fifth fails here while per-call
+    // regressions are caught by the comparative tests in this fixture.
+    private const long SceneBytesPerFrameCeiling = 300_000;
+
+    // The same scene with the render cache warm allocates about 289,400-289,500 bytes/frame. Each machine
+    // reports one deterministic value, but not the same one: two machines measured 105 bytes apart, so the
+    // figure is platform-specific rather than a property of the scene. The ceiling keeps the same
+    // proportional headroom as the cache-disabled budget above, for the same platform-dependent font
+    // fallback.
+    private const long WarmCacheSceneBytesPerFrameCeiling = 345_000;
+
+    private static readonly object s_explicitKey = new();
+    private static readonly PixelSize s_frameSize = new(240, 160);
+
+    [Test]
+    public void DefaultStructuralKey_AllocatesNoMoreThanAnExplicitOne()
+    {
+        Warm();
+
+        long withDefaultKey = MeasureBytesPerCall(structuralKey: null);
+        long withExplicitKey = MeasureBytesPerCall(s_explicitKey);
+
+        TestContext.Out.WriteLine($"default key: {withDefaultKey} bytes/call");
+        TestContext.Out.WriteLine($"explicit key: {withExplicitKey} bytes/call");
+        Assert.That(
+            withDefaultKey,
+            Is.LessThanOrEqualTo(withExplicitKey),
+            "resolving the default structural key runs once per node per frame and must not allocate");
+    }
+
+    [Test]
+    public void StatePassing_AllocatesNoMoreThanTheCapturingRequestLocalOptOut()
+    {
+        WarmState();
+
+        long statePassing = MeasureBytesPerCall(static () => CreateWithState(new Rect(0, 0, 4, 4)));
+        long requestLocal = MeasureBytesPerCall(static () => CreateRequestLocalCapturing(new Rect(0, 0, 4, 4)));
+
+        TestContext.Out.WriteLine($"state-passing: {statePassing} bytes/call");
+        TestContext.Out.WriteLine($"capturing request-local: {requestLocal} bytes/call");
+        Assert.That(
+            statePassing,
+            Is.LessThanOrEqualTo(requestLocal),
+            "a static callback plus a state binding must not cost more than the closure it replaced");
+    }
+
+    [Test]
+    public void TypedValueTupleState_StaysBoundedWhileTheBoxedChannelIsRejected()
+    {
+        WarmState();
+
+        long tupleState = MeasureBytesPerCall(
+            static () => TargetCommandDescription.Create(
+                (1, 2L, 3f, 4d),
+                static (_, _) => { },
+                TargetRegion.Full,
+                Rect.Empty,
+                RenderHitTestContract.None));
+        TestContext.Out.WriteLine($"value-tuple state: {tupleState} bytes/call");
+        Assert.Multiple(() =>
+        {
+            Assert.That(tupleState, Is.LessThanOrEqualTo(1024));
+            Assert.That(
+                static () => TargetCommandDescription.Create(
+                    (object)(1, 2L, 3f, 4d),
+                    static (_, _) => { },
+                    TargetRegion.Full,
+                    Rect.Empty,
+                    RenderHitTestContract.None),
+                Throws.TypeOf<ArgumentException>().With.Property("ParamName").EqualTo("state"));
+        });
+    }
+
+    [Test]
+    public void NestedTupleState_CostsNoMoreThanTheFlatTupleItValidatesAs()
+    {
+        WarmState();
+
+        long flat = MeasureBytesPerCall(
+            static () => TargetCommandDescription.Create(
+                (1, 2, 3, 4),
+                static (_, _) => { },
+                TargetRegion.Full,
+                Rect.Empty,
+                RenderHitTestContract.None));
+        long nested = MeasureBytesPerCall(
+            static () => TargetCommandDescription.Create(
+                ((1, 2), (3, 4)),
+                static (_, _) => { },
+                TargetRegion.Full,
+                Rect.Empty,
+                RenderHitTestContract.None));
+
+        TestContext.Out.WriteLine($"flat tuple state: {flat} bytes/call");
+        TestContext.Out.WriteLine($"nested tuple state: {nested} bytes/call");
+        Assert.That(
+            nested,
+            Is.LessThanOrEqualTo(flat),
+            "descending through tuple element types happens once per closed state type, not per call");
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void RepresentativeScene_AllocatesWithinItsPerFrameBudget_WithTheCacheDisabled()
+    {
+        long bytesPerFrame = RenderThread.Dispatcher.Invoke(
+            static () => MeasureSceneBytesPerFrame(warmCache: false));
+
+        TestContext.Out.WriteLine($"representative scene, cache disabled: {bytesPerFrame} bytes/frame");
+        Assert.That(
+            bytesPerFrame,
+            Is.LessThan(SceneBytesPerFrameCeiling),
+            "recording one frame of the representative scene must stay within its allocation budget");
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void RepresentativeScene_AllocatesWithinItsPerFrameBudget_WithTheCacheActive()
+    {
+        long bytesPerFrame = RenderThread.Dispatcher.Invoke(
+            static () => MeasureSceneBytesPerFrame(warmCache: true));
+
+        TestContext.Out.WriteLine($"representative scene, cache active: {bytesPerFrame} bytes/frame");
+        Assert.That(
+            bytesPerFrame,
+            Is.LessThan(WarmCacheSceneBytesPerFrameCeiling),
+            "recording one frame with cache candidates recorded must stay within its allocation budget");
+    }
+
+    private static long MeasureSceneBytesPerFrame(bool warmCache)
+    {
+        Drawable.Resource[] resources = CreateSceneResources();
+        try
+        {
+            using var root = new DrawableRenderNode(resources[0]);
+            using (var context = new GraphicsContext2D(root, s_frameSize.ToSize(1)))
+            {
+                context.Clear();
+                foreach (Drawable.Resource resource in resources)
+                    context.DrawDrawable(resource);
+            }
+
+            using var renderer = new RenderNodeRenderer(
+                root,
+                new RenderNodeRendererOptions
+                {
+                    DefaultRequest = new RenderNodeRenderRequest
+                    {
+                        TargetDomain = new Rect(default, s_frameSize.ToSize(1)),
+                        CacheOptions = warmCache
+                            ? RenderCacheOptions.Enabled
+                            : RenderCacheOptions.Disabled,
+                        Purpose = RenderRequestPurpose.Frame,
+                    },
+                    TargetFactory = new CpuTargetFactory(),
+                });
+
+            var revalidated = new HashSet<RenderNode>(ReferenceEqualityComparer.Instance);
+            for (int frame = 0; frame < SceneWarmupFrames; frame++)
+            {
+                if (warmCache)
+                    IncrementRenderCounts(root, revalidated);
+                renderer.Rasterize().Dispose();
+            }
+
+            if (warmCache && !root.Cache.CanCache())
+            {
+                throw new InvalidOperationException(
+                    "The warm-cache budget must measure a frame whose nodes are cache candidates.");
+            }
+
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            for (int frame = 0; frame < SceneFrames; frame++)
+            {
+                if (warmCache)
+                    IncrementRenderCounts(root, revalidated);
+                renderer.Rasterize().Dispose();
+            }
+
+            long after = GC.GetAllocatedBytesForCurrentThread();
+            return (after - before) / SceneFrames;
+        }
+        finally
+        {
+            foreach (Drawable.Resource resource in resources)
+                resource.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Mirrors the per-frame walk in <c>Renderer.RevalidateAll</c>. Without it
+    /// <see cref="RenderNodeCache.CanCache"/> never reaches <see cref="RenderNodeCache.Count"/>, so no
+    /// cache candidate is recorded and the whole cache-resolution path stays out of the measurement.
+    /// </summary>
+    private static void IncrementRenderCounts(RenderNode root, HashSet<RenderNode> revalidated)
+    {
+        revalidated.Clear();
+        Visit(root);
+        return;
+
+        void Visit(RenderNode current)
+        {
+            if (current.IsDisposed || !revalidated.Add(current))
+                return;
+
+            ReadOnlySpan<RenderNode> children = current.ChildNodes;
+            for (int index = 0; index < children.Length; index++)
+                Visit(children[index]);
+
+            current.Cache.IncrementRenderCount();
+            current.HasChanges = false;
+        }
+    }
+
+    private static Drawable.Resource[] CreateSceneResources()
+    {
+        var background = new RectShape
+        {
+            Width = { CurrentValue = s_frameSize.Width },
+            Height = { CurrentValue = s_frameSize.Height },
+            Fill = { CurrentValue = Brushes.CornflowerBlue },
+        };
+
+        var accent = new EllipseShape
+        {
+            Width = { CurrentValue = 76 },
+            Height = { CurrentValue = 76 },
+            Fill = { CurrentValue = Brushes.OrangeRed },
+            FilterEffect = { CurrentValue = new Brightness { Amount = { CurrentValue = 78 } } },
+            Transform = { CurrentValue = new TranslateTransform(44, -18) },
+        };
+
+        var label = new TextBlock
+        {
+            FontFamily = { CurrentValue = FontFamily.Default },
+            Size = { CurrentValue = 28 },
+            Fill = { CurrentValue = Brushes.White },
+            Text = { CurrentValue = "CACHE" },
+            Transform = { CurrentValue = new TranslateTransform(-28, 30) },
+        };
+
+        CompositionContext context = CompositionContext.Default;
+        return
+        [
+            background.ToResource(context),
+            accent.ToResource(context),
+            label.ToResource(context),
+        ];
+    }
+
+    private static void Warm()
+    {
+        for (int index = 0; index < 200; index++)
+        {
+            _ = Create(null);
+            _ = Create(s_explicitKey);
+        }
+    }
+
+    private static void WarmState()
+    {
+        for (int index = 0; index < 200; index++)
+        {
+            _ = CreateWithState(new Rect(0, 0, 4, 4));
+            _ = CreateRequestLocalCapturing(new Rect(0, 0, 4, 4));
+        }
+    }
+
+    private static TargetCommandDescription CreateWithState(Rect bounds)
+        => TargetCommandDescription.Create(
+            bounds,
+            static (session, state) => session.Canvas.Use(canvas => canvas.ReplaceAffectedRegion(default)),
+            TargetRegion.Region(bounds),
+            Rect.Empty,
+            RenderHitTestContract.None);
+
+    private static TargetCommandDescription CreateRequestLocalCapturing(Rect bounds)
+        => TargetCommandDescription.CreateRequestLocal(
+            session => session.Canvas.Use(canvas => canvas.ReplaceAffectedRegion(
+                bounds.Width > 0 ? Colors.White : Colors.Black)),
+            TargetRegion.Region(bounds),
+            Rect.Empty,
+            RenderHitTestContract.None);
+
+    private static long MeasureBytesPerCall(object? structuralKey)
+    {
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int index = 0; index < Iterations; index++)
+            _ = Create(structuralKey);
+        long after = GC.GetAllocatedBytesForCurrentThread();
+        return (after - before) / Iterations;
+    }
+
+    private static long MeasureBytesPerCall(Func<object> create)
+    {
+        for (int index = 0; index < 200; index++)
+            _ = create();
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int index = 0; index < Iterations; index++)
+            _ = create();
+        long after = GC.GetAllocatedBytesForCurrentThread();
+        return (after - before) / Iterations;
+    }
+
+    private static TargetCommandDescription Create(object? structuralKey)
+        => TargetCommandDescription.CreateRequestLocal(
+            Execute,
+            TargetRegion.Full,
+            Rect.Empty,
+            RenderHitTestContract.None,
+            structuralKey: structuralKey);
+
+    private static void Execute(TargetCommandSession session)
+    {
+    }
+
+    private sealed class CpuTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+            => new CpuRenderTarget(allocation.DeviceSize.Width, allocation.DeviceSize.Height);
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeHasChangesTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeHasChangesTests.cs
@@ -1,0 +1,124 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Shapes;
+using Beutl.Graphics3D;
+using Beutl.Media;
+using Beutl.Media.Source;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+[TestFixture]
+public class RenderNodeHasChangesTests
+{
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        TestMediaHelper.RegisterTestDecoder();
+    }
+
+    public static IEnumerable<TestCaseData> NoOpUpdateCases()
+    {
+        yield return new TestCaseData((Func<NoOpUpdateCase>)EllipseCase).SetName("EllipseRenderNode");
+        yield return new TestCaseData((Func<NoOpUpdateCase>)RectangleCase).SetName("RectangleRenderNode");
+        yield return new TestCaseData((Func<NoOpUpdateCase>)GeometryCase).SetName("GeometryRenderNode");
+        yield return new TestCaseData((Func<NoOpUpdateCase>)TransformCase).SetName("TransformRenderNode");
+        yield return new TestCaseData((Func<NoOpUpdateCase>)CustomTransformCase).SetName("CustomTransformRenderNode");
+        yield return new TestCaseData((Func<NoOpUpdateCase>)ImageSourceCase).SetName("ImageSourceRenderNode");
+        yield return new TestCaseData((Func<NoOpUpdateCase>)VideoSourceCase).SetName("VideoSourceRenderNode");
+        yield return new TestCaseData((Func<NoOpUpdateCase>)Scene3DCase).SetName("Scene3DRenderNode");
+    }
+
+    [TestCaseSource(nameof(NoOpUpdateCases))]
+    public void Update_ShouldNotClearAMarkLeftByAnotherWriter(Func<NoOpUpdateCase> factory)
+    {
+        NoOpUpdateCase testCase = factory();
+        using RenderNode node = testCase.Node;
+        node.HasChanges = true;
+
+        bool changed = testCase.NoOpUpdate();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.False, "the update was supposed to be a no-op");
+            Assert.That(node.HasChanges, Is.True);
+        });
+    }
+
+    private static NoOpUpdateCase EllipseCase()
+    {
+        var rect = new Rect(0, 0, 100, 100);
+        var fill = Brushes.Resource.White;
+        var node = new EllipseRenderNode(rect, fill, null);
+        return new NoOpUpdateCase(node, () => node.Update(rect, fill, null));
+    }
+
+    private static NoOpUpdateCase RectangleCase()
+    {
+        var rect = new Rect(0, 0, 100, 100);
+        var fill = Brushes.Resource.White;
+        var node = new RectangleRenderNode(rect, fill, null);
+        return new NoOpUpdateCase(node, () => node.Update(rect, fill, null));
+    }
+
+    private static NoOpUpdateCase GeometryCase()
+    {
+        var geometry = new EllipseGeometry();
+        geometry.Width.CurrentValue = 100;
+        geometry.Height.CurrentValue = 100;
+        var resource = (Geometry.Resource)geometry.ToResource(CompositionContext.Default);
+        var fill = Brushes.Resource.White;
+        var node = new GeometryRenderNode(resource, fill, null);
+        return new NoOpUpdateCase(node, () => node.Update(resource, fill, null));
+    }
+
+    private static NoOpUpdateCase TransformCase()
+    {
+        Matrix matrix = Matrix.CreateRotation(45);
+        var node = new TransformRenderNode(matrix, TransformOperator.Prepend);
+        return new NoOpUpdateCase(node, () => node.Update(matrix, TransformOperator.Prepend));
+    }
+
+    private static NoOpUpdateCase CustomTransformCase()
+    {
+        var bounds = new MemoryNode<Rect>(new Rect(0, 0, 100, 100));
+        var screenSize = new Size(1920, 1080);
+        var node = new DrawableGroup.CustomTransformRenderNode(
+            null, RelativePoint.Center, screenSize, AlignmentX.Center, AlignmentY.Center, bounds);
+        return new NoOpUpdateCase(
+            node,
+            () => node.Update(null, RelativePoint.Center, screenSize, AlignmentX.Center, AlignmentY.Center, bounds));
+    }
+
+    private static NoOpUpdateCase ImageSourceCase()
+    {
+        var imageSource = new ImageSource();
+        imageSource.ReadFrom(TestMediaHelper.CreateTestImageUri(100, 100, Colors.White));
+        var resource = (ImageSource.Resource)imageSource.ToResource(CompositionContext.Default);
+        var fill = Brushes.Resource.White;
+        var node = new ImageSourceRenderNode(resource, fill, null);
+        return new NoOpUpdateCase(node, () => node.Update(resource, fill, null));
+    }
+
+    private static NoOpUpdateCase VideoSourceCase()
+    {
+        var videoSource = new VideoSource();
+        videoSource.ReadFrom(new Uri(TestMediaHelper.CreateTestVideoFile(100, 100, new Rational(30), 300)));
+        var resource = (VideoSource.Resource)videoSource.ToResource(CompositionContext.Default);
+        var fill = Brushes.Resource.White;
+        var node = new VideoSourceRenderNode(resource, 0, fill, null);
+        return new NoOpUpdateCase(node, () => node.Update(resource, 0, fill, null));
+    }
+
+    private static NoOpUpdateCase Scene3DCase()
+    {
+        var scene = new Scene3D();
+        scene.RenderWidth.CurrentValue = 32;
+        scene.RenderHeight.CurrentValue = 32;
+        var resource = (Scene3D.Resource)scene.ToResource(CompositionContext.Default);
+        var node = new Scene3DRenderNode(resource);
+        return new NoOpUpdateCase(node, () => node.Update(resource));
+    }
+
+    public sealed record NoOpUpdateCase(RenderNode Node, Func<bool> NoOpUpdate);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeRendererAllocationFailureTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeRendererAllocationFailureTests.cs
@@ -1,0 +1,318 @@
+﻿using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+[TestFixture]
+public sealed class RenderNodeRendererAllocationFailureTests
+{
+    private static readonly Rect s_domain = new(0, 0, 100, 100);
+
+    [Test]
+    public void PreviewMaterializationAllocationFailure_DropsContributionAndRecordsDiagnostics()
+    {
+        using FilterEffect.Resource resource = CreateStrokeEffectResource();
+        using FilterEffectRenderNode node = CreateScene(resource);
+        var factory = new FailSecondTargetFactory();
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var renderer = CreateRenderer(node, RenderIntent.Preview, factory, diagnostics);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Bitmap bitmap = rasterization.Bitmap
+            ?? throw new AssertionException("The preview allocation-drop request produced no bitmap.");
+        PixelSize expectedDeviceSize = PixelRect.FromRect(s_domain, rasterization.OutputScale).Size;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rasterization.IsEmpty, Is.False);
+            Assert.That(rasterization.Bounds, Is.EqualTo(s_domain));
+            Assert.That(rasterization.OutputScale, Is.EqualTo(1));
+            Assert.That(new PixelSize(bitmap.Width, bitmap.Height), Is.EqualTo(expectedDeviceSize));
+            Assert.That(bitmap.GetPixelSpan<ushort>().ToArray(), Is.All.Zero,
+                "a dropped preview contribution must leave the cleared destination transparent");
+            Assert.That(factory.FailureConsumed, Is.True);
+            Assert.That(factory.CreateCalls, Is.EqualTo(2));
+            Assert.That(factory.FailedDeviceSize, Is.EqualTo(new PixelSize(102, 102)));
+            Assert.That(snapshot.Succeeded, Is.True);
+            Assert.That(snapshot.FailurePhase, Is.Null);
+            Assert.That(snapshot[RenderPipelineCounter.PreviewAllocationDrops], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.Failures], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.CleanupFailures], Is.Zero);
+        });
+    }
+
+    [Test]
+    public void DeliveryMaterializationAllocationFailure_Throws()
+    {
+        using FilterEffect.Resource resource = CreateStrokeEffectResource();
+        using FilterEffectRenderNode node = CreateScene(resource);
+        var factory = new FailSecondTargetFactory();
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var renderer = CreateRenderer(node, RenderIntent.Delivery, factory, diagnostics);
+
+        InvalidOperationException? exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            using RenderNodeRasterization unexpected = renderer.Rasterize();
+        });
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                exception!.Message,
+                Is.EqualTo("The render-target factory could not allocate 102x102 pixels."));
+            Assert.That(factory.FailureConsumed, Is.True);
+            Assert.That(factory.CreateCalls, Is.EqualTo(2));
+            Assert.That(factory.FailedDeviceSize, Is.EqualTo(new PixelSize(102, 102)));
+            Assert.That(snapshot.Succeeded, Is.False);
+            Assert.That(snapshot.FailurePhase, Is.EqualTo(RenderPipelineFailurePhase.Allocation));
+            Assert.That(snapshot[RenderPipelineCounter.PreviewAllocationDrops], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.Failures], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.CleanupFailures], Is.Zero);
+        });
+    }
+
+    [Test]
+    public void PreviewGeometryCropAllocationFailure_DropsContributionAndRecordsDiagnostics()
+    {
+        using FilterEffect.Resource resource = new ShrinkingGeometryEffect()
+            .ToResource(CompositionContext.Default);
+        using FilterEffectRenderNode node = CreateScene(resource);
+        var factory = new FailSpecificSizeTargetFactory(new PixelSize(98, 98));
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var renderer = CreateRenderer(node, RenderIntent.Preview, factory, diagnostics);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Bitmap bitmap = rasterization.Bitmap
+            ?? throw new AssertionException("The preview Geometry crop allocation-drop request produced no bitmap.");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(bitmap.GetPixelSpan<ushort>().ToArray(), Is.All.Zero,
+                "a dropped Geometry crop must leave the cleared destination transparent");
+            Assert.That(factory.FailureConsumed, Is.True);
+            Assert.That(factory.FailedDeviceSize, Is.EqualTo(new PixelSize(98, 98)));
+            Assert.That(snapshot.Succeeded, Is.True);
+            Assert.That(snapshot.FailurePhase, Is.Null);
+            Assert.That(snapshot[RenderPipelineCounter.PreviewAllocationDrops], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.Failures], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.CleanupFailures], Is.Zero);
+        });
+    }
+
+    [Test]
+    public void DeliveryGeometryCropAllocationFailure_Throws()
+    {
+        using FilterEffect.Resource resource = new ShrinkingGeometryEffect()
+            .ToResource(CompositionContext.Default);
+        using FilterEffectRenderNode node = CreateScene(resource);
+        var factory = new FailSpecificSizeTargetFactory(new PixelSize(98, 98));
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var renderer = CreateRenderer(node, RenderIntent.Delivery, factory, diagnostics);
+
+        InvalidOperationException? exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            using RenderNodeRasterization unexpected = renderer.Rasterize();
+        });
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                exception!.Message,
+                Is.EqualTo("The render-target factory could not allocate 98x98 pixels."));
+            Assert.That(factory.FailureConsumed, Is.True);
+            Assert.That(factory.FailedDeviceSize, Is.EqualTo(new PixelSize(98, 98)));
+            Assert.That(snapshot.Succeeded, Is.False);
+            Assert.That(snapshot.FailurePhase, Is.EqualTo(RenderPipelineFailurePhase.Allocation));
+            Assert.That(snapshot[RenderPipelineCounter.PreviewAllocationDrops], Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.Failures], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.CleanupFailures], Is.Zero);
+        });
+    }
+
+    [Test]
+    public void ZeroAreaOutput_DoesNotRecordPreviewAllocationDrop()
+    {
+        using FilterEffect.Resource resource = CreateStrokeEffectResource();
+        using FilterEffectRenderNode node = CreateScene(resource);
+        var factory = new CpuTargetFactory();
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        using var renderer = CreateRenderer(
+            node,
+            RenderIntent.Preview,
+            factory,
+            diagnostics,
+            requestedRegion: new Rect(20, 30, 0, 10));
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rasterization.IsEmpty, Is.True);
+            Assert.That(diagnostics.Latest.Succeeded, Is.True);
+            Assert.That(
+                diagnostics.Latest[RenderPipelineCounter.PreviewAllocationDrops],
+                Is.Zero);
+        });
+    }
+
+    private static FilterEffect.Resource CreateStrokeEffectResource()
+    {
+        var pen = new Pen
+        {
+            Thickness = { CurrentValue = 9 },
+            Brush = { CurrentValue = Brushes.OrangeRed },
+        };
+        var effect = new StrokeEffect
+        {
+            Pen = { CurrentValue = pen },
+        };
+        return effect.ToResource(CompositionContext.Default);
+    }
+
+    [SuppressResourceClassGeneration]
+    private sealed partial class ShrinkingGeometryEffect : FilterEffect
+    {
+        private static readonly GeometryDescription s_geometry = GeometryDescription.Create(
+            state: true,
+            static (session, _) =>
+            {
+                session.Canvas.Use(session.Input.Draw);
+                session.SetOutputBounds(session.OutputBounds.Inflate(new Thickness(-1)));
+            },
+            RenderBoundsContract.Identity,
+            RenderHitTestContract.AnyInput,
+            structuralKey: "allocation-failure-shrinking-geometry");
+
+        public override void ApplyTo(FilterEffectContext context, FilterEffect.Resource resource)
+            => context.Geometry(s_geometry);
+
+        public override Resource ToResource(CompositionContext context)
+        {
+            var resource = new Resource();
+            bool updateOnly = false;
+            resource.Update(this, context, ref updateOnly);
+            return resource;
+        }
+
+        public new sealed class Resource : FilterEffect.Resource
+        {
+            public Resource()
+            {
+            }
+        }
+    }
+
+    private static FilterEffectRenderNode CreateScene(FilterEffect.Resource resource)
+    {
+        var node = new FilterEffectRenderNode(resource);
+        node.AddChild(new EllipseRenderNode(s_domain, Brushes.Resource.White, null));
+        return node;
+    }
+
+    private static RenderNodeRenderer CreateRenderer(
+        RenderNode node,
+        RenderIntent intent,
+        IRenderTargetFactory factory,
+        RenderPipelineDiagnosticsState diagnostics,
+        Rect? requestedRegion = null)
+        => new(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    Intent = intent,
+                    TargetDomain = s_domain,
+                    RequestedRegion = requestedRegion,
+                    OutputScale = 1,
+                    MaxWorkingScale = intent == RenderIntent.Delivery
+                    ? float.PositiveInfinity
+                    : 2,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                    Purpose = RenderRequestPurpose.Frame,
+                    Diagnostics = diagnostics,
+                },
+                TargetFactory = factory,
+            });
+
+    private sealed class FailSecondTargetFactory : CpuTargetFactory
+    {
+        public bool FailureConsumed { get; private set; }
+
+        public PixelSize? FailedDeviceSize { get; private set; }
+
+        public override RenderTarget? Create(RenderTargetAllocationDescriptor allocation)
+        {
+            PixelSize deviceSize = allocation.DeviceSize;
+            int index = CreateCalls++;
+            if (index == 1)
+            {
+                FailureConsumed = true;
+                FailedDeviceSize = deviceSize;
+                return null;
+            }
+
+            return CreateTarget(deviceSize);
+        }
+    }
+
+    private sealed class FailSpecificSizeTargetFactory(PixelSize failureSize) : CpuTargetFactory
+    {
+        public bool FailureConsumed { get; private set; }
+
+        public PixelSize? FailedDeviceSize { get; private set; }
+
+        public override RenderTarget? Create(RenderTargetAllocationDescriptor allocation)
+        {
+            PixelSize deviceSize = allocation.DeviceSize;
+            CreateCalls++;
+            if (!FailureConsumed && deviceSize == failureSize)
+            {
+                FailureConsumed = true;
+                FailedDeviceSize = deviceSize;
+                return null;
+            }
+
+            return CreateTarget(deviceSize);
+        }
+    }
+
+    private class CpuTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public int CreateCalls { get; protected set; }
+
+        public virtual RenderTarget? Create(RenderTargetAllocationDescriptor allocation)
+        {
+            PixelSize deviceSize = allocation.DeviceSize;
+            CreateCalls++;
+            return CreateTarget(deviceSize);
+        }
+
+        protected static RenderTarget CreateTarget(PixelSize deviceSize)
+        {
+            SKSurface surface = SKSurface.Create(new SKImageInfo(
+                    deviceSize.Width,
+                    deviceSize.Height,
+                    SKColorType.RgbaF16,
+                    SKAlphaType.Premul,
+                    SKColorSpace.CreateSrgbLinear()))
+                ?? throw new InvalidOperationException("Could not create the CPU allocation-failure test surface.");
+            return new CpuRenderTarget(surface, deviceSize);
+        }
+    }
+
+    private sealed class CpuRenderTarget(SKSurface surface, PixelSize size)
+        : RenderTarget(surface, size.Width, size.Height);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeRendererDeviceBoundsTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeRendererDeviceBoundsTests.cs
@@ -1,0 +1,152 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+[TestFixture]
+public sealed class RenderNodeRendererDeviceBoundsTests
+{
+    [Test]
+    public void Rasterize_FractionalOriginReportsTheBoundsTheBitmapActuallyOccupies()
+    {
+        var bounds = new Rect(10.25f, 20.25f, 3.5f, 2.5f);
+        const float outputScale = 2;
+        using RenderNode root = ScaleRecordingTestHelper.Source(EffectiveScale.At(1), bounds);
+        var factory = new CpuTargetFactory();
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    OutputScale = outputScale,
+                    MaxWorkingScale = 2,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = factory,
+            });
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        Bitmap bitmap = rasterization.Bitmap
+            ?? throw new AssertionException("The fractional-origin fixture must produce a bitmap.");
+        PixelRect reportedDeviceBounds = PixelRect.FromRect(rasterization.Bounds, outputScale);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rasterization.Bounds.X * outputScale, Is.EqualTo((float)reportedDeviceBounds.X),
+                "The reported origin must land on a device pixel.");
+            Assert.That(rasterization.Bounds.Y * outputScale, Is.EqualTo((float)reportedDeviceBounds.Y),
+                "The reported origin must land on a device pixel.");
+            Assert.That(rasterization.Bounds.Width * outputScale, Is.EqualTo((float)bitmap.Width),
+                "The reported width must be the width of the returned pixels.");
+            Assert.That(rasterization.Bounds.Height * outputScale, Is.EqualTo((float)bitmap.Height),
+                "The reported height must be the height of the returned pixels.");
+            Assert.That(rasterization.Bounds.Contains(bounds), Is.True,
+                "The reported bounds must cover the selected logical output.");
+        });
+    }
+
+    [Test]
+    public void Rasterize_SelectionWhoseScaledEdgesCollapseStillProducesItsDevicePixel()
+    {
+        // 2^24 is the float magnitude at which adding 0.5 no longer changes the value, so the selection's
+        // right edge is indistinguishable from its left edge.
+        const float origin = 16777216f;
+        var bounds = new Rect(origin, 0, 0.5f, 4);
+        Assert.That(bounds.Right, Is.EqualTo(bounds.X), "the fixture requires a float-collapsed right edge");
+
+        using RenderNode root = ScaleRecordingTestHelper.Source(EffectiveScale.At(1), bounds);
+        var factory = new CpuTargetFactory();
+        using var renderer = new RenderNodeRenderer(
+            root,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    OutputScale = 1,
+                    MaxWorkingScale = 1,
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+                TargetFactory = factory,
+            });
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        Bitmap bitmap = rasterization.Bitmap
+            ?? throw new AssertionException("A selection with positive area must produce a bitmap.");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rasterization.IsEmpty, Is.False);
+            Assert.That(bitmap.Width, Is.EqualTo(1));
+            Assert.That(bitmap.Height, Is.EqualTo(4));
+            Assert.That(rasterization.Bounds, Is.EqualTo(new Rect(origin, 0, 1, 4)));
+        });
+    }
+
+    [Test]
+    public void RenderInDeviceSpace_ResolvesFullTargetAgainstPhysicalViewport()
+    {
+        var deviceSize = new PixelSize(384, 216);
+        var logicalSize = new Size(192, 108);
+        Rect? observedDomain = null;
+        using var root = new DomainProbeNode(context => observedDomain = context.TargetDomain);
+        using var target = new DeviceBoundsRenderTarget(deviceSize);
+        using var canvas = new ImmediateCanvas(target, density: 2, logicalSize: logicalSize);
+        using var renderer = new RenderNodeRenderer(root);
+
+        using (canvas.PushDeviceSpace())
+            renderer.Render(canvas);
+
+        Assert.That(observedDomain, Is.EqualTo(new Rect(0, 0, 384, 216)));
+    }
+
+    private sealed class CpuTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+        {
+            PixelSize deviceSize = allocation.DeviceSize;
+            SKSurface surface = SKSurface.Create(new SKImageInfo(
+                                   deviceSize.Width,
+                                   deviceSize.Height,
+                                   SKColorType.RgbaF16,
+                                   SKAlphaType.Premul,
+                                   SKColorSpace.CreateSrgbLinear()))
+                               ?? throw new InvalidOperationException(
+                                   "Could not create the CPU device-bounds test surface.");
+            return new CpuRenderTarget(surface, deviceSize);
+        }
+
+        private sealed class CpuRenderTarget(SKSurface surface, PixelSize size)
+            : RenderTarget(surface, size.Width, size.Height);
+    }
+
+    private sealed class DeviceBoundsRenderTarget(PixelSize size)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                size.Width,
+                size.Height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            size.Width,
+            size.Height);
+
+    private sealed class DomainProbeNode(Action<RenderNodeContext> observe) : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+            observe(context);
+            context.Publish(context.TargetCommand(
+                [],
+                TargetCommandDescription.CreateRequestLocal(
+                    static _ => { },
+                    TargetRegion.Full,
+                    Rect.Empty,
+                    RenderHitTestContract.None)));
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeRendererExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeRendererExceptionSafetyTests.cs
@@ -1,0 +1,632 @@
+﻿using System.Runtime.ExceptionServices;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Rendering.Failure;
+
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+[TestFixture]
+public class RenderNodeRendererExceptionSafetyTests
+{
+    public enum EntryPoint
+    {
+        Rasterize,
+        Render,
+    }
+
+    [TestCase(EntryPoint.Rasterize)]
+    [TestCase(EntryPoint.Render)]
+    public void DischargesFaultingAndUnexecutedResources_WhenExecutionThrows(EntryPoint entryPoint)
+    {
+        var discharged = new List<string>();
+        using var node = CreateNode(
+            discharged,
+            new RecordedOperationSpec("first"),
+            new RecordedOperationSpec("fault", ThrowOnExecute: true),
+            new RecordedOperationSpec("remaining"));
+        using var renderer = CreateRenderer(node);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Execute(entryPoint, renderer));
+
+        Assert.That(ex!.Message, Is.EqualTo("fault"));
+        Assert.That(discharged, Is.EqualTo(new[] { "remaining", "fault", "first" }));
+    }
+
+    [Test]
+    public void CleanupOnlyFailure_DischargesEveryResourceExactlyOnceAndSurfacesFailure()
+    {
+        var discharged = new List<string>();
+        using var node = CreateNode(
+            discharged,
+            new RecordedOperationSpec("first"),
+            new RecordedOperationSpec("fault", ThrowOnDispose: true),
+            new RecordedOperationSpec("remaining"));
+        using var target = CreateCpuTarget(4, 4);
+        using var canvas = new ImmediateCanvas(target);
+
+        var ex = Assert.Throws<AggregateException>(() => ExecuteRequestAndSurfaceOwnerFailure(node, canvas));
+
+        Assert.That(ex!.InnerExceptions.Single().Message, Is.EqualTo("fault"));
+        Assert.That(discharged, Is.EqualTo(new[] { "remaining", "fault", "first" }));
+    }
+
+    [Test]
+    public void ExpandedTargetCleanup_PreservesPrimaryAndAttemptsEveryResource()
+    {
+        var primaryFailure = new InvalidOperationException("expanded-primary");
+        var firstFailure = new InvalidOperationException("expanded-first-cleanup");
+        var secondFailure = new InvalidOperationException("expanded-second-cleanup");
+        var thirdFailure = new InvalidOperationException("expanded-third-cleanup");
+        var first = new FailureTestDisposable(firstFailure);
+        var second = new FailureTestDisposable(secondFailure);
+        var third = new FailureTestDisposable(thirdFailure);
+        using var owner = new RenderRequestOwner();
+        ExceptionDispatchInfo? primary = ExceptionDispatchInfo.Capture(primaryFailure);
+
+        RenderNodeRenderer.DisposeExecutionResourcesAndCapture(
+            owner,
+            ref primary,
+            first,
+            second,
+            third);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(primary?.SourceException, Is.SameAs(primaryFailure));
+            Assert.That(owner.PrimaryFailure?.SourceException, Is.SameAs(primaryFailure));
+            Assert.That(owner.CleanupFailures, Is.EqualTo(new[] { firstFailure, secondFailure, thirdFailure }));
+            Assert.That(first.DisposeCalls, Is.EqualTo(1));
+            Assert.That(second.DisposeCalls, Is.EqualTo(1));
+            Assert.That(third.DisposeCalls, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void Measure_CleanupOnlyFailure_DischargesEveryResourceExactlyOnceAndSurfacesFailure()
+    {
+        var discharged = new List<string>();
+        using var node = CreateNode(
+            discharged,
+            new RecordedOperationSpec("first", TrackMetadataDischarge: true),
+            new RecordedOperationSpec("fault", ThrowOnDispose: true, TrackMetadataDischarge: true),
+            new RecordedOperationSpec("remaining", TrackMetadataDischarge: true));
+        using var renderer = CreateRenderer(node);
+
+        var ex = Assert.Throws<AggregateException>(() => renderer.Measure());
+
+        Assert.That(ex!.Flatten().InnerExceptions.Single().Message, Is.EqualTo("fault"));
+        Assert.That(discharged, Is.EqualTo(new[] { "remaining", "fault", "first" }));
+    }
+
+    [TestCase(EntryPoint.Rasterize)]
+    [TestCase(EntryPoint.Render)]
+    public void PooledTargetDisposeFailure_SurfacesAtRendererDisposalAfterSuccessfulRequest(EntryPoint entryPoint)
+    {
+        var discharged = new List<string>();
+        using var node = CreateNode(
+            discharged,
+            new RecordedOperationSpec("first"),
+            new RecordedOperationSpec("second"));
+        int throwingTarget = entryPoint == EntryPoint.Rasterize ? 1 : 0;
+        var factory = new TrackingTargetFactory(index => index == throwingTarget);
+        var renderer = CreateRenderer(node, factory);
+
+        Assert.DoesNotThrow(() => Execute(entryPoint, renderer));
+        Assert.That(factory.CreatedTargets, Has.All.Property(nameof(FakeRenderTarget.DisposeWasCalled)).False);
+        var ex = Assert.Throws<InvalidOperationException>(renderer.Dispose);
+
+        Assert.That(ex!.Message, Is.EqualTo("rt-dispose-fault"));
+        Assert.That(factory.CreatedTargets, Has.Count.EqualTo(entryPoint == EntryPoint.Rasterize ? 2 : 1));
+        Assert.That(factory.CreatedTargets, Has.All.Property(nameof(FakeRenderTarget.DisposeWasCalled)).True);
+        Assert.That(discharged, Is.EqualTo(new[] { "second", "first" }));
+    }
+
+    [TestCase(EntryPoint.Rasterize)]
+    [TestCase(EntryPoint.Render)]
+    public void ContinuesCleanupAndPreservesOriginalException_WhenRemainingResourcesThrow(EntryPoint entryPoint)
+    {
+        var discharged = new List<string>();
+        using var node = CreateNode(
+            discharged,
+            new RecordedOperationSpec("first"),
+            new RecordedOperationSpec("render-fault", ThrowOnExecute: true),
+            new RecordedOperationSpec("throwing-remaining-1", ThrowOnDispose: true),
+            new RecordedOperationSpec("throwing-remaining-2", ThrowOnDispose: true),
+            new RecordedOperationSpec("remaining"));
+        using var renderer = CreateRenderer(node);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Execute(entryPoint, renderer));
+
+        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
+        Assert.That(discharged, Is.EqualTo(new[]
+        {
+            "remaining",
+            "throwing-remaining-2",
+            "throwing-remaining-1",
+            "render-fault",
+            "first",
+        }));
+    }
+
+    [TestCase(EntryPoint.Rasterize)]
+    [TestCase(EntryPoint.Render)]
+    public void PreservesExecutionException_WhenFaultingResourceAlsoThrowsOnDispose(EntryPoint entryPoint)
+    {
+        var discharged = new List<string>();
+        using var node = CreateNode(
+            discharged,
+            new RecordedOperationSpec("first"),
+            new RecordedOperationSpec(
+                "render-fault",
+                ThrowOnExecute: true,
+                ThrowOnDispose: true,
+                DisposeFaultMessage: "dispose-fault"),
+            new RecordedOperationSpec("remaining"));
+        using var renderer = CreateRenderer(node);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Execute(entryPoint, renderer));
+
+        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
+        Assert.That(discharged, Is.EqualTo(new[] { "remaining", "render-fault", "first" }));
+    }
+
+    [TestCase(EntryPoint.Rasterize)]
+    [TestCase(EntryPoint.Render)]
+    public void PreservesExecutionException_WhilePooledTargetFailureWaitsForRendererDisposal(EntryPoint entryPoint)
+    {
+        var discharged = new List<string>();
+        using var node = CreateNode(
+            discharged,
+            new RecordedOperationSpec("render-fault", ThrowOnExecute: true, AllocateBeforeThrow: true));
+        int throwingTarget = entryPoint == EntryPoint.Rasterize ? 1 : 0;
+        var factory = new TrackingTargetFactory(index => index == throwingTarget);
+        var renderer = CreateRenderer(node, factory);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Execute(entryPoint, renderer));
+
+        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
+        Assert.That(factory.CreatedTargets, Has.Count.EqualTo(entryPoint == EntryPoint.Rasterize ? 2 : 1));
+        Assert.That(factory.CreatedTargets, Has.All.Property(nameof(FakeRenderTarget.DisposeWasCalled)).False);
+        Assert.That(discharged, Is.EqualTo(new[] { "render-fault" }));
+        var cleanup = Assert.Throws<InvalidOperationException>(renderer.Dispose);
+        Assert.That(cleanup!.Message, Is.EqualTo("rt-dispose-fault"));
+        Assert.That(factory.CreatedTargets, Has.All.Property(nameof(FakeRenderTarget.DisposeWasCalled)).True);
+    }
+
+    [TestCase(EntryPoint.Rasterize)]
+    [TestCase(EntryPoint.Render)]
+    public void DischargesRecordedResources_WhenTargetFactoryThrows(EntryPoint entryPoint)
+    {
+        var discharged = new List<string>();
+        using var node = CreateNode(
+            discharged,
+            new RecordedOperationSpec("first"),
+            new RecordedOperationSpec("second"));
+        var factory = new TrackingTargetFactory(_ => false, throwOnCreate: true);
+        using var renderer = CreateRenderer(node, factory);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Execute(entryPoint, renderer));
+
+        Assert.That(ex!.Message, Is.EqualTo("rt-create-fault"));
+        Assert.That(discharged, Is.EqualTo(new[] { "second", "first" }));
+    }
+
+    [TestCase(EntryPoint.Rasterize)]
+    [TestCase(EntryPoint.Render)]
+    public void DischargesRecordedResources_WhenTargetFactoryReturnsNull(EntryPoint entryPoint)
+    {
+        var discharged = new List<string>();
+        using var node = CreateNode(
+            discharged,
+            new RecordedOperationSpec("first"),
+            new RecordedOperationSpec("second"));
+        var factory = new TrackingTargetFactory(_ => false, returnNullOnCreate: true);
+        using var renderer = CreateRenderer(node, factory);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Execute(entryPoint, renderer));
+
+        Assert.That(
+            ex!.Message,
+            Does.StartWith("The render-target factory could not allocate 4x4 pixels"));
+        Assert.That(discharged, Is.EqualTo(new[] { "second", "first" }));
+    }
+
+    [TestCase(EntryPoint.Rasterize)]
+    [TestCase(EntryPoint.Render)]
+    public void PreExecutionAllocationFailureRecordsTheFamilyOwnerWithoutDiagnostics(
+        EntryPoint entryPoint)
+    {
+        using var node = new ExpandedCaptureNode(
+            publishRasterOutput: entryPoint == EntryPoint.Rasterize);
+        var factory = new TrackingTargetFactory(_ => false, throwOnCreate: true);
+        using var renderer = CreateRenderer(node, factory);
+
+        InvalidOperationException? failure = Assert.Throws<InvalidOperationException>(
+            () => Execute(entryPoint, renderer));
+        RenderRequestOwner owner = node.NestedRequest!.Request.Options.Owner;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Is.EqualTo("rt-create-fault"));
+            Assert.That(owner.PrimaryFailure?.SourceException, Is.SameAs(failure));
+            Assert.That(owner.SecondaryFailures, Is.Empty);
+            Assert.That(node.NestedRequest.Request.State, Is.EqualTo(RenderRequestState.Disposed));
+        });
+    }
+
+    [Test]
+    public void PreExecutionFailureWithoutDiagnostics_MarksRootAndNestedBeforeDisposal()
+    {
+        using var node = new ExpandedCaptureNode();
+        using var request = new RenderRequest(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Frame,
+            targetDomain: new Rect(0, 0, 4, 4),
+            cachePolicy: RenderCacheOptions.Disabled,
+            diagnostics: null));
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+        using CompiledRenderRequest compiled = new RenderRequestCompiler().Compile(request, graph);
+        var failure = new InvalidOperationException("pre-execution-fault");
+
+        bool completeDiagnostics = RenderNodeRenderer.FailRequestFamilyBeforeExecution(
+            compiled,
+            failure,
+            RenderPipelineFailurePhase.Allocation);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(completeDiagnostics, Is.False);
+            Assert.That(compiled.Request.State, Is.EqualTo(RenderRequestState.Failed));
+            Assert.That(node.NestedRequest!.Request.State, Is.EqualTo(RenderRequestState.Failed));
+            Assert.That(request.Options.Owner.PrimaryFailure?.SourceException, Is.SameAs(failure));
+            Assert.That(request.Options.Owner.SecondaryFailures, Is.Empty);
+        });
+    }
+
+    [TestCase(EntryPoint.Rasterize)]
+    [TestCase(EntryPoint.Render)]
+    public void PreservesAllocationFailure_WhenResourceCleanupAlsoThrows(EntryPoint entryPoint)
+    {
+        var discharged = new List<string>();
+        using var node = CreateNode(
+            discharged,
+            new RecordedOperationSpec("first", ThrowOnDispose: true),
+            new RecordedOperationSpec("second"));
+        var factory = new TrackingTargetFactory(_ => false, returnNullOnCreate: true);
+        using var renderer = CreateRenderer(node, factory);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Execute(entryPoint, renderer));
+
+        Assert.That(
+            ex!.Message,
+            Does.StartWith("The render-target factory could not allocate 4x4 pixels"));
+        Assert.That(discharged, Is.EqualTo(new[] { "second", "first" }));
+    }
+
+    [Test]
+    public void RequestOwner_CleanupContinuesAfterFaultAndPreservesStrictLifo()
+    {
+        var discharged = new List<string>();
+        using var owner = new RenderRequestOwner();
+        Register(owner, new RecordedOperation(new RecordedOperationSpec("first"), discharged, true));
+        Register(owner, new RecordedOperation(
+            new RecordedOperationSpec("throws", ThrowOnDispose: true),
+            discharged,
+            true));
+        Register(owner, new RecordedOperation(new RecordedOperationSpec("remaining"), discharged, true));
+
+        owner.Cleanup();
+
+        Assert.That(discharged, Is.EqualTo(new[] { "remaining", "throws", "first" }));
+        Assert.That(owner.CleanupFailures.Length, Is.EqualTo(1));
+        Assert.That(owner.PrimaryFailure!.SourceException, Is.TypeOf<AggregateException>());
+    }
+
+    [Test]
+    public void Diagnostics_ClassifyResourceDisposeFaultAsCleanup()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        RenderPipelineDiagnosticRecorder recorder = RenderPipelineDiagnosticRecorder.Start(
+            diagnostics,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            nameof(RenderNodeRenderer))!;
+        long[] subjects = recorder.RecordFragments(2, RenderPipelineOutcome.Executed);
+        var discharged = new List<string>();
+        using var owner = new RenderRequestOwner();
+        Register(owner, new RecordedOperation(new RecordedOperationSpec("remaining"), discharged, true));
+        Register(owner, new RecordedOperation(
+            new RecordedOperationSpec("fault", ThrowOnDispose: true),
+            discharged,
+            true));
+
+        owner.Cleanup();
+        recorder.RecordCleanupFailure(subjects[0]);
+        recorder.Complete();
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot.FailurePhase, Is.EqualTo(RenderPipelineFailurePhase.Cleanup));
+            Assert.That(snapshot[RenderPipelineCounter.CleanupFailures], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.FailedOutcomes], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.SkippedOutcomes], Is.EqualTo(1));
+            Assert.That(
+                snapshot.Events.Single(item => item.Kind == RenderPipelineDiagnosticEventKind.Failure).SubjectId,
+                Is.EqualTo(subjects[0]));
+        });
+    }
+
+    [Test]
+    public void Rasterize_ReturnsBuiltTargetsToPoolAndPreservesExecutionFailure()
+    {
+        var discharged = new List<string>();
+        using var node = CreateNode(
+            discharged,
+            new RecordedOperationSpec("first"),
+            new RecordedOperationSpec("second"),
+            new RecordedOperationSpec("render-fault", ThrowOnExecute: true, AllocateBeforeThrow: true));
+        var factory = new TrackingTargetFactory(index => index == 1);
+        var renderer = CreateRenderer(node, factory);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => renderer.Rasterize());
+
+        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
+        Assert.That(factory.CreatedTargets, Has.Count.EqualTo(2));
+        Assert.That(factory.CreatedTargets, Has.All.Property(nameof(FakeRenderTarget.DisposeWasCalled)).False);
+        Assert.That(discharged, Is.EqualTo(new[] { "render-fault", "second", "first" }));
+        var cleanup = Assert.Throws<InvalidOperationException>(renderer.Dispose);
+        Assert.That(cleanup!.Message, Is.EqualTo("rt-dispose-fault"));
+        Assert.That(factory.CreatedTargets, Has.All.Property(nameof(FakeRenderTarget.DisposeWasCalled)).True);
+    }
+
+    [Test]
+    public void Rasterize_SurfacesPooledRootTargetDisposeFailureAtRendererDisposal()
+    {
+        var discharged = new List<string>();
+        using var node = CreateNode(discharged, new RecordedOperationSpec("ok"));
+        var factory = new TrackingTargetFactory(index => index == 0);
+        var renderer = CreateRenderer(node, factory);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        Assert.That(factory.CreatedTargets, Has.All.Property(nameof(FakeRenderTarget.DisposeWasCalled)).False);
+        var ex = Assert.Throws<InvalidOperationException>(renderer.Dispose);
+
+        Assert.That(ex!.Message, Is.EqualTo("rt-dispose-fault"));
+        Assert.That(factory.CreatedTargets, Has.Count.EqualTo(2));
+        Assert.That(factory.CreatedTargets[0].DisposeWasCalled, Is.True);
+        Assert.That(factory.CreatedTargets[1].DisposeWasCalled, Is.True);
+        Assert.That(discharged, Is.EqualTo(new[] { "ok" }));
+    }
+
+    [Test]
+    public void Diagnostics_ReconcileCleanupFaultAndIntermediateDischarge()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        RenderPipelineDiagnosticRecorder recorder = RenderPipelineDiagnosticRecorder.Start(
+            diagnostics,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            nameof(RenderNodeRenderer))!;
+        long subject = recorder.RecordFragments(1, RenderPipelineOutcome.Executed).Single();
+
+        recorder.RecordIntermediateCreated();
+        recorder.RecordOutcome(subject, RenderPipelineOutcome.Executed);
+        recorder.RecordIntermediateDischarged();
+        recorder.RecordCleanupFailure();
+        recorder.Complete();
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot.Succeeded, Is.False);
+            Assert.That(snapshot.FailurePhase, Is.EqualTo(RenderPipelineFailurePhase.Cleanup));
+            Assert.That(snapshot[RenderPipelineCounter.CleanupFailures], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.IntermediateAcquires], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.IntermediateDischarges], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedOutcomes], Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void Diagnostics_AttributeRequestLevelOutputFailureWithoutReplacingExecutedOutcome()
+    {
+        var diagnostics = new RenderPipelineDiagnosticsState();
+        RenderPipelineDiagnosticRecorder recorder = RenderPipelineDiagnosticRecorder.Start(
+            diagnostics,
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            nameof(RenderNodeRenderer))!;
+        long subject = recorder.RecordFragments(1, RenderPipelineOutcome.Executed).Single();
+
+        recorder.RecordOutcome(subject, RenderPipelineOutcome.Executed);
+        recorder.RecordFailure(RenderPipelineFailurePhase.Execution);
+        recorder.Complete();
+
+        RenderPipelineDiagnosticSnapshot snapshot = diagnostics.Latest;
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot.Succeeded, Is.False);
+            Assert.That(snapshot.FailurePhase, Is.EqualTo(RenderPipelineFailurePhase.Execution));
+            Assert.That(
+                snapshot.Events.Single(item => item.Kind == RenderPipelineDiagnosticEventKind.Failure).SubjectId,
+                Is.Zero);
+            Assert.That(snapshot[RenderPipelineCounter.ExecutedOutcomes], Is.EqualTo(1));
+            Assert.That(snapshot[RenderPipelineCounter.FailedOutcomes], Is.Zero);
+        });
+    }
+
+    private static FixedOpsNode CreateNode(
+        ICollection<string> discharged,
+        params RecordedOperationSpec[] operations)
+        => new(operations, discharged);
+
+    private static RenderNodeRenderer CreateRenderer(
+        RenderNode node,
+        IRenderTargetFactory? targetFactory = null)
+        => new(node, new RenderNodeRendererOptions
+        {
+            DefaultRequest = new RenderNodeRenderRequest
+            {
+                OutputScale = 1,
+                MaxWorkingScale = float.PositiveInfinity,
+                CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+            },
+            TargetFactory = targetFactory,
+        });
+
+    private static void Execute(EntryPoint entryPoint, RenderNodeRenderer renderer)
+    {
+        if (entryPoint == EntryPoint.Rasterize)
+        {
+            using RenderNodeRasterization rasterization = renderer.Rasterize();
+            return;
+        }
+
+        using RenderTarget target = CreateCpuTarget(4, 4);
+        using var canvas = new ImmediateCanvas(target);
+        renderer.Render(canvas);
+    }
+
+    private static void ExecuteRequestAndSurfaceOwnerFailure(RenderNode node, ImmediateCanvas destination)
+    {
+        var request = new RenderRequest(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            outputScale: destination.Density,
+            maxWorkingScale: destination.MaxWorkingScale,
+            cachePolicy: Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled));
+        RenderRequestOwner owner = request.Options.Owner;
+        CompiledRenderRequest? compiled = null;
+        Exception? executionFailure = null;
+        using var targetRegistry = new RenderTargetLeaseRegistry(factory: null);
+        using RenderTargetLeaseSession targets = targetRegistry.BeginSession(
+            RenderIntent.Preview,
+            RenderAllocationBudget.Default,
+            destination._renderTarget);
+        try
+        {
+            RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+            compiled = new RenderRequestCompiler().Compile(request, graph);
+            new RenderRequestExecutor(targets).Execute(compiled, destination);
+        }
+        catch (Exception ex)
+        {
+            executionFailure = ex;
+        }
+        finally
+        {
+            if (compiled is not null)
+                compiled.Dispose();
+            else
+                request.Dispose();
+            targets.Dispose();
+        }
+
+        owner.ThrowIfFailed();
+        targets.ThrowIfCleanupFailed();
+        if (executionFailure is not null)
+            throw executionFailure;
+    }
+
+    private static void Register(RenderRequestOwner owner, RecordedOperation operation)
+    {
+        RenderResource<RecordedOperation> resource = owner.ResourceRegistry.RegisterOwned(operation);
+        owner.ResourceRegistry.Commit(resource);
+    }
+
+    private static RenderTarget CreateCpuTarget(int width, int height)
+        => new FakeRenderTarget(width, height, throwOnDispose: false);
+
+    private sealed class TrackingTargetFactory(
+        Func<int, bool> shouldThrowOnDispose,
+        bool throwOnCreate = false,
+        bool returnNullOnCreate = false) : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public List<FakeRenderTarget> CreatedTargets { get; } = [];
+
+        public RenderTarget? Create(RenderTargetAllocationDescriptor allocation)
+        {
+            PixelSize deviceSize = allocation.DeviceSize;
+            if (throwOnCreate)
+                throw new InvalidOperationException("rt-create-fault");
+            if (returnNullOnCreate)
+                return null;
+
+            var target = new FakeRenderTarget(
+                deviceSize.Width,
+                deviceSize.Height,
+                shouldThrowOnDispose(CreatedTargets.Count));
+            CreatedTargets.Add(target);
+            return target;
+        }
+    }
+
+    private sealed class ExpandedCaptureNode(bool publishRasterOutput = false) : RenderNode
+    {
+        private static readonly Rect s_domain = new(0, 0, 4, 4);
+        private readonly EmptyNode _nested = new();
+
+        public RecordedNestedRenderTarget? NestedRequest { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            NestedRequest = context.RecordNestedTarget(_nested, s_domain);
+            context.Publish(context.TargetCapture(TargetCaptureDescription.Create(
+                TargetRegion.Region(s_domain),
+                s_domain,
+                RenderHitTestContract.None,
+                TargetCaptureScaleContract.MaterializeAtWorkingScale)));
+            if (publishRasterOutput)
+            {
+                context.Publish(context.OpaqueSource(
+                    FailureTestSupport.SourceDescription(
+                        structuralKey: "expanded-readback-raster-output")));
+            }
+        }
+
+        protected override void OnDispose(bool disposing)
+        {
+            if (disposing)
+                _nested.Dispose();
+        }
+    }
+
+    private sealed class EmptyNode : RenderNode
+    {
+        public override void Process(RenderNodeContext context)
+        {
+        }
+    }
+
+    private sealed class FakeRenderTarget(int width, int height, bool throwOnDispose)
+        : RenderTarget(CreateReadbackSurface(width, height), width, height)
+    {
+        public bool DisposeWasCalled { get; private set; }
+
+        private static SKSurface CreateReadbackSurface(int width, int height)
+            => SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear()));
+
+        protected override void Dispose(bool disposing)
+        {
+            bool shouldThrow = disposing && throwOnDispose;
+            if (disposing)
+                DisposeWasCalled = true;
+
+            base.Dispose(disposing);
+            if (shouldThrow)
+                throw new InvalidOperationException("rt-dispose-fault");
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeRendererSnapshotFastPathTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeRendererSnapshotFastPathTests.cs
@@ -1,0 +1,313 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+[TestFixture]
+public sealed class RenderNodeRendererSnapshotFastPathTests
+{
+    [Test]
+    public void TakeRasterizationBitmap_FullExtentTransfersOriginalSnapshot()
+    {
+        Bitmap complete = CreateTokenBitmap(4, 2);
+
+        Bitmap selected = RenderNodeRenderer.TakeRasterizationBitmap(
+            complete,
+            new PixelRect(0, 0, 4, 2));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(selected, Is.SameAs(complete));
+            Assert.That(complete.IsDisposed, Is.False);
+            AssertToken(selected, 3, 1, 7);
+        });
+
+        selected.Dispose();
+        selected.Dispose();
+        Assert.That(complete.IsDisposed, Is.True);
+    }
+
+    [Test]
+    public void TakeRasterizationBitmap_PartialExtentCopiesPixelsAndDisposesOriginal()
+    {
+        Bitmap complete = CreateTokenBitmap(4, 3);
+
+        using Bitmap selected = RenderNodeRenderer.TakeRasterizationBitmap(
+            complete,
+            new PixelRect(1, 1, 2, 2));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(selected, Is.Not.SameAs(complete));
+            Assert.That(complete.IsDisposed, Is.True);
+            Assert.That(selected.Width, Is.EqualTo(2));
+            Assert.That(selected.Height, Is.EqualTo(2));
+            AssertToken(selected, 0, 0, 5);
+            AssertToken(selected, 1, 0, 6);
+            AssertToken(selected, 0, 1, 9);
+            AssertToken(selected, 1, 1, 10);
+        });
+    }
+
+    [Test]
+    public void TakeRasterizationBitmap_CropFailureDisposesOriginal()
+    {
+        Bitmap complete = CreateTokenBitmap(4, 2);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            RenderNodeRenderer.TakeRasterizationBitmap(
+                complete,
+                new PixelRect(3, 0, 2, 2)));
+
+        Assert.That(complete.IsDisposed, Is.True);
+    }
+
+    [Test]
+    public void Rasterize_FullOutputPreservesPixelsAndOwnsBitmapIndependently()
+    {
+        var bounds = new Rect(0, 0, 4, 2);
+        using var source = new CpuRenderTarget(4, 2);
+        DrawColumnPattern(source);
+        using var node = new MaterializedSourceNode(source, bounds, requireFullReadback: false);
+        var factory = new TrackingTargetFactory();
+        var renderer = CreateRenderer(node, bounds, requestedRegion: null, factory);
+        RenderNodeRasterization? rasterization = null;
+
+        try
+        {
+            rasterization = renderer.Rasterize();
+            Bitmap bitmap = rasterization.Bitmap
+                ?? throw new AssertionException("The full-output fixture must produce a bitmap.");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(rasterization.Bounds, Is.EqualTo(bounds));
+                Assert.That(bitmap.Width, Is.EqualTo(4));
+                Assert.That(bitmap.Height, Is.EqualTo(2));
+                AssertDominant(bitmap, 0, 0, red: true, green: false, blue: false);
+                AssertDominant(bitmap, 3, 1, red: true, green: true, blue: true);
+            });
+
+            renderer.Dispose();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(bitmap.IsDisposed, Is.False);
+                AssertDominant(bitmap, 2, 0, red: false, green: false, blue: true);
+                Assert.That(factory.Targets, Is.Not.Empty);
+                Assert.That(factory.Targets, Has.All.Matches<TrackingRenderTarget>(
+                    target => target.IsDisposed && target.DisposeCalls == 1));
+                Assert.That(source.IsDisposed, Is.False);
+            });
+
+            rasterization.Dispose();
+            rasterization.Dispose();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(rasterization.IsDisposed, Is.True);
+                Assert.That(bitmap.IsDisposed, Is.True);
+                Assert.Throws<ObjectDisposedException>(() => _ = rasterization.Bitmap);
+            });
+        }
+        finally
+        {
+            rasterization?.Dispose();
+            renderer.Dispose();
+        }
+    }
+
+    [Test]
+    public void Rasterize_PartialOutputCropsExpandedSnapshot()
+    {
+        var bounds = new Rect(0, 0, 4, 2);
+        var requestedRegion = new Rect(1, 0, 2, 2);
+        using var source = new CpuRenderTarget(4, 2);
+        DrawColumnPattern(source);
+        using var node = new MaterializedSourceNode(source, bounds, requireFullReadback: true);
+        var factory = new TrackingTargetFactory();
+        using var renderer = CreateRenderer(node, bounds, requestedRegion, factory);
+
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        Bitmap bitmap = rasterization.Bitmap
+            ?? throw new AssertionException("The partial-output fixture must produce a bitmap.");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.ReadbackSize, Is.EqualTo(new PixelSize(4, 2)),
+                "The target readback must keep the execution snapshot larger than the selected subset.");
+            Assert.That(rasterization.Bounds, Is.EqualTo(requestedRegion));
+            Assert.That(bitmap.Width, Is.EqualTo(2));
+            Assert.That(bitmap.Height, Is.EqualTo(2));
+            AssertDominant(bitmap, 0, 0, red: false, green: true, blue: false);
+            AssertDominant(bitmap, 1, 1, red: false, green: false, blue: true);
+        });
+    }
+
+    private static RenderNodeRenderer CreateRenderer(
+        RenderNode node,
+        Rect targetDomain,
+        Rect? requestedRegion,
+        IRenderTargetFactory targetFactory)
+        => new(node, new RenderNodeRendererOptions
+        {
+            DefaultRequest = new RenderNodeRenderRequest
+            {
+                TargetDomain = targetDomain,
+                RequestedRegion = requestedRegion,
+                OutputScale = 1,
+                MaxWorkingScale = 1,
+                CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+            },
+            TargetFactory = targetFactory,
+        });
+
+    private static Bitmap CreateTokenBitmap(int width, int height)
+    {
+        var bitmap = new Bitmap(
+            width,
+            height,
+            BitmapColorType.Rgba8888,
+            BitmapAlphaType.Unpremul);
+        for (int y = 0; y < height; y++)
+        {
+            Span<byte> row = bitmap.GetRow(y);
+            for (int x = 0; x < width; x++)
+            {
+                byte token = checked((byte)((y * width) + x));
+                int offset = x * bitmap.BytesPerPixel;
+                row[offset] = token;
+                row[offset + 1] = (byte)(token + 1);
+                row[offset + 2] = (byte)(token + 2);
+                row[offset + 3] = byte.MaxValue;
+            }
+        }
+
+        return bitmap;
+    }
+
+    private static void AssertToken(Bitmap bitmap, int x, int y, byte expected)
+    {
+        Span<byte> row = bitmap.GetRow(y);
+        int offset = x * bitmap.BytesPerPixel;
+        Assert.That(row[offset], Is.EqualTo(expected));
+    }
+
+    private static void DrawColumnPattern(RenderTarget target)
+    {
+        SKCanvas canvas = target.Value.Canvas;
+        canvas.Clear(SKColors.Transparent);
+        SKColor[] colors = [SKColors.Red, SKColors.Lime, SKColors.Blue, SKColors.White];
+        using var paint = new SKPaint();
+        for (int x = 0; x < colors.Length; x++)
+        {
+            paint.Color = colors[x];
+            canvas.DrawRect(x, 0, 1, target.Height, paint);
+        }
+
+        canvas.Flush();
+    }
+
+    private static void AssertDominant(
+        Bitmap bitmap,
+        int x,
+        int y,
+        bool red,
+        bool green,
+        bool blue)
+    {
+        Span<ushort> row = bitmap.GetRow<ushort>(y);
+        int offset = x * 4;
+        float actualRed = (float)BitConverter.UInt16BitsToHalf(row[offset]);
+        float actualGreen = (float)BitConverter.UInt16BitsToHalf(row[offset + 1]);
+        float actualBlue = (float)BitConverter.UInt16BitsToHalf(row[offset + 2]);
+        const float threshold = 0.75f;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(actualRed, red ? Is.GreaterThan(threshold) : Is.LessThan(0.25f));
+            Assert.That(actualGreen, green ? Is.GreaterThan(threshold) : Is.LessThan(0.25f));
+            Assert.That(actualBlue, blue ? Is.GreaterThan(threshold) : Is.LessThan(0.25f));
+        });
+    }
+
+    private sealed class MaterializedSourceNode(
+        RenderTarget source,
+        Rect bounds,
+        bool requireFullReadback) : RenderNode
+    {
+        public PixelSize? ReadbackSize { get; private set; }
+
+        public override void Process(RenderNodeContext context)
+        {
+            RenderResource<RenderTarget> target = context.Borrow(
+                source,
+                "snapshot-fast-path-source",
+                version: 1);
+            context.Publish(context.MaterializedInput(
+                MaterializedInputDescription.FromRenderTarget(
+                    target,
+                    bounds,
+                    EffectiveScale.At(1),
+                    PixelRect.FromRect(bounds, 1),
+                    default,
+                    RenderHitTestContract.OutputBounds)));
+
+            if (!requireFullReadback)
+                return;
+
+            context.Publish(context.TargetCommand(
+                [],
+                TargetCommandDescription.CreateRequestLocal(
+                    session => session.UseSnapshot(
+                        bitmap => ReadbackSize = new PixelSize(bitmap.Width, bitmap.Height)),
+                    TargetRegion.Region(bounds),
+                    Rect.Empty,
+                    RenderHitTestContract.None,
+                    TargetAccess.Readback)));
+        }
+    }
+
+    private sealed class TrackingTargetFactory : IRenderTargetFactory
+    {
+        public int GetMaximumDimension(RenderTargetAllocationDescriptor allocation) => RenderScaleUtilities.MaxBufferDimension;
+
+        public List<TrackingRenderTarget> Targets { get; } = [];
+
+        public RenderTarget Create(RenderTargetAllocationDescriptor allocation)
+        {
+            PixelSize deviceSize = allocation.DeviceSize;
+            var target = new TrackingRenderTarget(deviceSize.Width, deviceSize.Height);
+            Targets.Add(target);
+            return target;
+        }
+    }
+
+    private sealed class TrackingRenderTarget(int width, int height)
+        : RenderTarget(CreateSurface(width, height), width, height)
+    {
+        public int DisposeCalls { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !IsDisposed)
+                DisposeCalls++;
+
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(CreateSurface(width, height), width, height);
+
+    private static SKSurface CreateSurface(int width, int height)
+        => SKSurface.Create(new SKImageInfo(
+               width,
+               height,
+               SKColorType.RgbaF16,
+               SKAlphaType.Premul,
+               SKColorSpace.CreateSrgbLinear()))
+           ?? throw new InvalidOperationException("Could not create a CPU render target.");
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderScaleFootprintBudgetTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderScaleFootprintBudgetTests.cs
@@ -1,0 +1,141 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+// Every clamp must bound the footprint PixelRect.FromRect actually allocates, not a logical-extent estimate.
+[TestFixture]
+public class RenderScaleFootprintBudgetTests
+{
+    private static readonly float[] s_origins =
+        [-40000.5f, -16384.5f, -1.5f, -0.75f, -0.5f, 0f, 0.1f, 0.5f, 0.75f, 1.5f, 1000.3f];
+
+    private static readonly float[] s_extents =
+        [0f, 0.25f, 1f, 16383.5f, 16384f, 16384.5f, 20000.7f, 40000f, 100000f];
+
+    private static readonly float[] s_scales = [0.5f, 1f, 1.7f, 4f, 8f];
+
+    [Test]
+    public void ExactBufferBudget_DegenerateAxisWithFractionalOrigin_KeepsFootprintWithinBudget()
+    {
+        var bounds = new Rect(0.5f, 0.5f, 0f, RenderScaleUtilities.MaxBufferDimension);
+
+        float clamped = RenderScaleUtilities.ClampWorkingScaleToExactBufferBudget(bounds, 1f);
+
+        Assert.That(
+            PixelRect.FromRect(bounds, 1f).Height,
+            Is.GreaterThan(RenderScaleUtilities.MaxBufferDimension),
+            "the fixture must actually overflow at the requested scale");
+        Assert.That(
+            PixelRect.FromRect(bounds, clamped).Height,
+            Is.LessThanOrEqualTo(RenderScaleUtilities.MaxBufferDimension));
+        Assert.That(clamped, Is.GreaterThan(0f).And.LessThanOrEqualTo(1f));
+    }
+
+    [Test]
+    public void RasterApronBudget_DegenerateAxisWithFractionalOrigin_KeepsAproneFootprintWithinBudget()
+    {
+        var bounds = new Rect(0.5f, 0.5f, 0f, RenderScaleUtilities.MaxBufferDimension - 2f);
+
+        float clamped = RenderScaleUtilities.ClampWorkingScaleToRasterApronBudget(bounds, 1f);
+
+        Assert.That(
+            RenderScaleUtilities.AddRasterApron(PixelRect.FromRect(bounds, 1f)).Height,
+            Is.GreaterThan(RenderScaleUtilities.MaxBufferDimension),
+            "the fixture must actually overflow at the requested scale");
+        Assert.That(
+            RenderScaleUtilities.AddRasterApron(PixelRect.FromRect(bounds, clamped)).Height,
+            Is.LessThanOrEqualTo(RenderScaleUtilities.MaxBufferDimension));
+        Assert.That(clamped, Is.GreaterThan(0f).And.LessThanOrEqualTo(1f));
+    }
+
+    [Test]
+    public void BufferBudget_FractionalOrigin_KeepsFootprintWithinBudget()
+    {
+        var bounds = new Rect(0.5f, 0f, RenderScaleUtilities.MaxBufferDimension - 0.4f, 1f);
+
+        float clamped = RenderScaleUtilities.ClampWorkingScaleToBufferBudget(bounds, 1f);
+
+        Assert.That(
+            PixelRect.FromRect(bounds, 1f).Width,
+            Is.GreaterThan(RenderScaleUtilities.MaxBufferDimension),
+            "the fixture must actually overflow at the requested scale");
+        Assert.That(
+            PixelRect.FromRect(bounds, clamped).Width,
+            Is.LessThanOrEqualTo(RenderScaleUtilities.MaxBufferDimension));
+        Assert.That(clamped, Is.GreaterThan(0f).And.LessThanOrEqualTo(1f));
+    }
+
+    [Test]
+    public void BufferBudget_NonPositiveMaxDimension_IsRejected()
+    {
+        Assert.That(
+            () => RenderScaleUtilities.ClampWorkingScaleToBufferBudget(new Rect(0, 0, 100, 100), 2, 0),
+            Throws.TypeOf<ArgumentOutOfRangeException>());
+        Assert.That(
+            () => RenderScaleUtilities.ClampWorkingScaleToBufferBudget(new Rect(0, 0, 100, 100), 2, -1),
+            Throws.TypeOf<ArgumentOutOfRangeException>());
+    }
+
+    [Test]
+    public void AllClamps_SweepOfOriginsExtentsAndScales_NeverExceedTheBudget()
+    {
+        foreach (Rect bounds in EnumerateBounds())
+        {
+            foreach (float requested in s_scales)
+            {
+                AssertWithinBudget(
+                    "coarse",
+                    bounds,
+                    requested,
+                    RenderScaleUtilities.ClampWorkingScaleToBufferBudget(bounds, requested),
+                    apronPixels: 0);
+                AssertWithinBudget(
+                    "exact",
+                    bounds,
+                    requested,
+                    RenderScaleUtilities.ClampWorkingScaleToExactBufferBudget(bounds, requested),
+                    apronPixels: 0);
+                AssertWithinBudget(
+                    "apron",
+                    bounds,
+                    requested,
+                    RenderScaleUtilities.ClampWorkingScaleToRasterApronBudget(bounds, requested),
+                    apronPixels: 2);
+            }
+        }
+
+        static void AssertWithinBudget(
+            string clamp, Rect bounds, float requested, float clamped, int apronPixels)
+        {
+            string context = $"{clamp}: bounds={bounds}, requested={requested}, clamped={clamped}";
+            Assert.That(clamped, Is.GreaterThan(0f), context);
+            Assert.That(clamped, Is.LessThanOrEqualTo(requested), context);
+
+            PixelRect footprint = PixelRect.FromRect(bounds, clamped);
+            Assert.That(
+                footprint.Width + apronPixels,
+                Is.LessThanOrEqualTo(RenderScaleUtilities.MaxBufferDimension),
+                context);
+            Assert.That(
+                footprint.Height + apronPixels,
+                Is.LessThanOrEqualTo(RenderScaleUtilities.MaxBufferDimension),
+                context);
+        }
+    }
+
+    private static IEnumerable<Rect> EnumerateBounds()
+    {
+        foreach (float x in s_origins)
+        {
+            foreach (float width in s_extents)
+            {
+                foreach (float height in s_extents)
+                {
+                    yield return new Rect(x, -x, width, height);
+                }
+            }
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
@@ -2,6 +2,7 @@
 using Beutl.Graphics;
 using Beutl.Graphics.Rendering;
 using Beutl.Media;
+using Beutl.Threading;
 using SkiaSharp;
 
 namespace Beutl.UnitTests.Engine.Graphics.Rendering;
@@ -102,6 +103,52 @@ public class RenderTargetThreadAffinityTests
 
         Assert.That(WaitUntilReleased(surface), Is.True,
             "the queued release should still run once the render thread drains it");
+    }
+
+    [Test]
+    public void A_timed_out_release_completes_when_the_busy_dispatcher_shuts_down()
+    {
+        Dispatcher dispatcher = Dispatcher.Spawn();
+        using var occupied = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+        int executions = 0;
+        Task? caller = null;
+        bool dispatcherJoined;
+
+        try
+        {
+            dispatcher.Dispatch(() =>
+            {
+                occupied.Set();
+                release.Wait(TimeSpan.FromSeconds(30));
+            });
+            Assert.That(occupied.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+            caller = Task.Run(() => GpuResourceRelease.Run(
+                dispatcher,
+                () => Interlocked.Increment(ref executions)));
+            Assert.That(
+                SpinWait.SpinUntil(() => caller.IsCompleted, TimeSpan.FromSeconds(10)),
+                Is.True,
+                "Run did not return after its bounded wait");
+            Assert.That(executions, Is.Zero);
+
+            dispatcher.Shutdown();
+        }
+        finally
+        {
+            release.Set();
+            if (!dispatcher.HasShutdownStarted)
+                dispatcher.Shutdown();
+            dispatcherJoined = dispatcher.Thread.Join(TimeSpan.FromSeconds(5));
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(caller!.IsCompletedSuccessfully, Is.True);
+            Assert.That(dispatcherJoined, Is.True);
+            Assert.That(executions, Is.EqualTo(1));
+        });
     }
 
     // Giving up leaves the cleanup queued with IsDisposed still false, so the second Dispose has to
@@ -266,6 +313,108 @@ public class RenderTargetThreadAffinityTests
 
         Assert.That(RenderThread.Dispatcher.InvokeAsync(static () => { }).Wait(TimeSpan.FromSeconds(30)), Is.True,
             "the render thread must keep draining after a queued release faulted");
+    }
+
+    [Test]
+    public void A_required_operation_queued_before_shutdown_is_rejected_once()
+    {
+        Dispatcher dispatcher = Dispatcher.Spawn();
+        using var occupied = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+        using var callerEntered = new ManualResetEventSlim(false);
+        Exception? failure = null;
+        int executions = 0;
+        var caller = new Thread(() =>
+        {
+            callerEntered.Set();
+            try
+            {
+                GpuResourceRelease.RunRequired(dispatcher, () => Interlocked.Increment(ref executions));
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+        })
+        { IsBackground = true };
+
+        try
+        {
+            dispatcher.Dispatch(() =>
+            {
+                occupied.Set();
+                release.Wait(TimeSpan.FromSeconds(30));
+            });
+            Assert.That(occupied.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            caller.Start();
+            Assert.That(callerEntered.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            Assert.That(WaitUntilBlocked(caller), Is.True);
+
+            dispatcher.Shutdown();
+            Assert.That(caller.Join(TimeSpan.FromSeconds(5)), Is.True);
+        }
+        finally
+        {
+            release.Set();
+            if (!dispatcher.HasShutdownStarted)
+                dispatcher.Shutdown();
+            dispatcher.Thread.Join(TimeSpan.FromSeconds(5));
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.TypeOf<InvalidOperationException>());
+            Assert.That(executions, Is.Zero);
+        });
+    }
+
+    [Test]
+    public async Task A_required_operation_that_started_before_shutdown_completes_once()
+    {
+        Dispatcher dispatcher = Dispatcher.Spawn();
+        using var started = new ManualResetEventSlim(false);
+        using var finish = new ManualResetEventSlim(false);
+        int executions = 0;
+        Task<int> caller = Task.Run(() => GpuResourceRelease.RunRequired(dispatcher, () =>
+        {
+            started.Set();
+            finish.Wait(TimeSpan.FromSeconds(30));
+            return Interlocked.Increment(ref executions);
+        }));
+        int result;
+        bool dispatcherJoined;
+
+        try
+        {
+            Assert.That(started.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            dispatcher.Shutdown();
+            Assert.That(caller.IsCompleted, Is.False);
+            finish.Set();
+            result = await caller.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            finish.Set();
+            if (!dispatcher.HasShutdownStarted)
+                dispatcher.Shutdown();
+            dispatcherJoined = dispatcher.Thread.Join(TimeSpan.FromSeconds(5));
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(1));
+            Assert.That(dispatcherJoined, Is.True);
+            Assert.That(executions, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void A_required_operation_preserves_its_exception_type()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            GpuResourceRelease.RunRequired(
+                RenderThread.Dispatcher,
+                static () => throw new InvalidOperationException("required operation failed")));
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RendererIntentTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RendererIntentTests.cs
@@ -1,0 +1,142 @@
+﻿using System.Collections.Immutable;
+using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+using Beutl.Threading;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+[TestFixture]
+public sealed class RendererIntentTests
+{
+    [TestCase(RenderIntent.Preview)]
+    [TestCase(RenderIntent.Delivery)]
+    public void TheExecutedFrameRequestCarriesTheRendererIntent(RenderIntent intent)
+    {
+        RenderThread.Dispatcher.Invoke(() =>
+        {
+            var diagnostics = new RenderPipelineDiagnosticsState();
+            using Renderer renderer = CreateRenderer(intent, diagnostics);
+
+            renderer.Render(CreateEmptyFrame());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(diagnostics.LatestFrame.Succeeded, Is.True);
+                Assert.That(diagnostics.LatestFrame.Intent, Is.EqualTo(intent));
+            });
+        });
+    }
+
+    [Test]
+    public void TheExecutedFrameRequestKeepsTheIntentWhenCacheOptionsRebuildTheFrameRenderer()
+    {
+        RenderThread.Dispatcher.Invoke(() =>
+        {
+            var diagnostics = new RenderPipelineDiagnosticsState();
+            using Renderer renderer = CreateRenderer(RenderIntent.Delivery, diagnostics);
+
+            renderer.CacheOptions = RenderCacheOptions.Disabled;
+            renderer.ClearAllCaches();
+            renderer.Render(CreateEmptyFrame());
+
+            Assert.That(diagnostics.LatestFrame.Intent, Is.EqualTo(RenderIntent.Delivery));
+        });
+    }
+
+    // The canvas is the switch every brush-owned intermediate reads to choose degrade vs fail;
+    // BrushIntermediateAllocationIntentTests covers the outcome itself.
+    [TestCase(RenderIntent.Preview)]
+    [TestCase(RenderIntent.Delivery)]
+    public void ThePaintingCanvasCarriesTheRendererIntent(RenderIntent intent)
+    {
+        RenderThread.Dispatcher.Invoke(() =>
+        {
+            using Renderer renderer = CreateRenderer(intent, diagnostics: null);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.Intent, Is.EqualTo(intent));
+                Assert.That(Renderer.GetInternalCanvas(renderer).Intent, Is.EqualTo(intent));
+            });
+        });
+    }
+
+    [Test]
+    public void PreviewIsTheDefaultEvenWithoutAWorkingScaleCeiling()
+    {
+        RenderThread.Dispatcher.Invoke(() =>
+        {
+            using var renderer = new Renderer(
+                width: 8,
+                height: 8,
+                renderScale: 1,
+                maxWorkingScale: float.PositiveInfinity,
+                diagnostics: null,
+                surface: new CpuRenderTarget(8, 8));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderer.Intent, Is.EqualTo(RenderIntent.Preview));
+                Assert.That(Renderer.GetInternalCanvas(renderer).Intent, Is.EqualTo(RenderIntent.Preview),
+                    "An unbounded working scale must not promote a preview renderer to delivery fail-fast.");
+            });
+        });
+    }
+
+    [Test]
+    public void UndefinedIntent_IsRejectedBeforeAnySurfaceIsCreated()
+    {
+        ArgumentOutOfRangeException? failure = Assert.Throws<ArgumentOutOfRangeException>(
+            () => new Renderer(8, 8, intent: (RenderIntent)12345));
+
+        Assert.That(failure!.ParamName, Is.EqualTo("intent"));
+    }
+
+    [Test]
+    public void UndefinedIntent_DisposesTheCallerSuppliedSurface()
+    {
+        var surface = new CpuRenderTarget(8, 8);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Renderer(
+            width: 8,
+            height: 8,
+            renderScale: 1,
+            maxWorkingScale: 1,
+            diagnostics: null,
+            surface: surface,
+            intent: (RenderIntent)12345));
+
+        Assert.That(surface.IsDisposed, Is.True);
+    }
+
+    private static Renderer CreateRenderer(RenderIntent intent, IRenderPipelineDiagnosticsState? diagnostics)
+        => new(
+            width: 8,
+            height: 8,
+            renderScale: 1,
+            maxWorkingScale: 1,
+            diagnostics: diagnostics,
+            surface: new CpuRenderTarget(8, 8),
+            intent: intent);
+
+    private static CompositionFrame CreateEmptyFrame() => new(
+        ImmutableArray<EngineObject.Resource>.Empty,
+        new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)),
+        new PixelSize(8, 8));
+
+    private sealed class CpuRenderTarget(int width, int height)
+        : RenderTarget(
+            SKSurface.Create(new SKImageInfo(
+                width,
+                height,
+                SKColorType.RgbaF16,
+                SKAlphaType.Premul,
+                SKColorSpace.CreateSrgbLinear())),
+            width,
+            height);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/TextRenderNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/TextRenderNodeTests.cs
@@ -1,0 +1,118 @@
+﻿using System.Reflection;
+using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+using Beutl.Media.TextFormatting;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+[TestFixture]
+public class TextRenderNodeTests
+{
+    [Test]
+    public void Measure_UsesRasterBoundsForTheEmptinessGate()
+    {
+        using var text = new FormattedText
+        {
+            Font = TypefaceProvider.Typeface().FontFamily,
+            Size = 48f,
+            Text = "Raster footprint",
+        };
+        Rect rasterBounds = text.RasterBounds;
+
+        // Current public font backends did not expose a glyph with a degenerate outline but a non-empty
+        // hinted mask. Inject that valid measured-state relationship to isolate which published bound the
+        // render node gates on; the source allocation still comes from the real measured RasterBounds.
+        FieldInfo actualBoundsField = typeof(FormattedText).GetField(
+            "_actualBounds",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        actualBoundsField.SetValue(
+            text,
+            new Rect(rasterBounds.X, rasterBounds.Y, 0, rasterBounds.Height));
+
+        using var node = new TextRenderNode(text, Brushes.Resource.White, null);
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+            });
+        RenderNodeMeasurement measurement = renderer.Measure();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(measurement.HasFragments, Is.True);
+            Assert.That(measurement.HasContributingValues, Is.True);
+            Assert.That(measurement.OutputBounds, Is.EqualTo(rasterBounds));
+        });
+    }
+
+    [Test]
+    public void DrawableBrush_RecordsNestedContentAgainstSemanticBounds()
+    {
+        using var text = new FormattedText
+        {
+            Font = TypefaceProvider.Typeface().FontFamily,
+            Size = 48f,
+            Text = "A    ",
+        };
+        Rect semanticBounds = text.Bounds;
+        _ = text.RasterBounds;
+        var injectedActualBounds = new Rect(
+            semanticBounds.X,
+            semanticBounds.Y,
+            semanticBounds.Width / 2,
+            semanticBounds.Height / 2);
+        FieldInfo actualBoundsField = typeof(FormattedText).GetField(
+            "_actualBounds",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        actualBoundsField.SetValue(text, injectedActualBounds);
+        var observedSizes = new List<Size>();
+        var content = new TextBrushBoundsProbeDrawable(observedSizes);
+        var brush = new DrawableBrush(content);
+        using DrawableBrush.Resource brushResource = brush.ToResource(CompositionContext.Default);
+        using var node = new TextRenderNode(text, brushResource, null);
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest
+                {
+                    CacheOptions = Beutl.Graphics.Rendering.Cache.RenderCacheOptions.Disabled,
+                },
+            });
+
+        _ = renderer.Measure();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(text.ActualBounds.Size, Is.Not.EqualTo(semanticBounds.Size));
+            Assert.That(observedSizes, Is.EqualTo(new[] { semanticBounds.Size }));
+        });
+    }
+}
+
+internal sealed partial class TextBrushBoundsProbeDrawable : Drawable
+{
+    private readonly ICollection<Size> _observedSizes;
+
+    public TextBrushBoundsProbeDrawable(ICollection<Size> observedSizes)
+    {
+        _observedSizes = observedSizes;
+    }
+
+    protected override Size MeasureCore(Size availableSize, Drawable.Resource resource)
+    {
+        _observedSizes.Add(availableSize);
+        return new Size(1, 1);
+    }
+
+    protected override void OnDraw(GraphicsContext2D context, Drawable.Resource resource)
+    {
+        context.DrawRectangle(new Rect(0, 0, 1, 1), Brushes.Resource.White, null);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/SourceVideoThumbnailTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/SourceVideoThumbnailTests.cs
@@ -1,5 +1,7 @@
 ﻿using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
 using Beutl.Media;
+using Beutl.Threading;
 
 namespace Beutl.UnitTests.Engine.Graphics;
 
@@ -48,5 +50,136 @@ public class SourceVideoThumbnailTests
     {
         // duration.TotalSeconds / count when count == 0 yields +Infinity.
         Assert.Throws<OverflowException>(() => TimeSpan.FromSeconds(double.PositiveInfinity * 0.5));
+    }
+
+    [Test]
+    [NonParallelizable]
+    public async Task ThumbnailRenderResources_AreDisposedOnRenderThread()
+    {
+        var resources = new[]
+        {
+            new DisposalThreadProbe(),
+            new DisposalThreadProbe(),
+            new DisposalThreadProbe(),
+        };
+
+        Assert.That(RenderThread.Dispatcher.CheckAccess(), Is.False,
+            "the fixture must begin on the thumbnail consumer's non-render thread");
+        await SourceVideo.DisposeThumbnailRenderResourcesAsync(resources);
+
+        Assert.That(resources, Has.All.Matches<DisposalThreadProbe>(static item =>
+            item.DisposeCount == 1 && item.DisposedOnRenderThread));
+    }
+
+    [Test]
+    public async Task ThumbnailRenderResources_StopWaitingWhenDispatcherShutsDownBeforeQueuedCleanupRuns()
+    {
+        Dispatcher dispatcher = Dispatcher.Spawn();
+        using var blockerEntered = new ManualResetEventSlim();
+        using var releaseBlocker = new ManualResetEventSlim();
+        var resource = new DisposalThreadProbe();
+        try
+        {
+            await dispatcher.InvokeAsync(static () => { });
+            dispatcher.Dispatch(() =>
+            {
+                blockerEntered.Set();
+                releaseBlocker.Wait();
+            }, DispatchPriority.High);
+            Assert.That(blockerEntered.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "The dispatcher fixture did not enter its blocking operation.");
+
+            Task cleanup = SourceVideo.DisposeThumbnailRenderResourcesAsync(dispatcher, resource);
+            dispatcher.Shutdown();
+
+            await cleanup.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.That(resource.DisposeCount, Is.Zero,
+                "Thread-affine resources must not be disposed from the thumbnail consumer after shutdown.");
+        }
+        finally
+        {
+            releaseBlocker.Set();
+            if (!dispatcher.HasShutdownStarted)
+                dispatcher.Shutdown();
+            Assert.That(dispatcher.Thread.Join(TimeSpan.FromSeconds(5)), Is.True,
+                "The local dispatcher did not finish after its blocker was released.");
+        }
+    }
+
+    [Test]
+    public async Task ThumbnailRenderResources_CopiedShutdownHandlerIsSafeAfterCleanupUnsubscribes()
+    {
+        Dispatcher dispatcher = Dispatcher.Spawn();
+        using var cleanupEntered = new ManualResetEventSlim();
+        using var releaseCleanup = new ManualResetEventSlim();
+        using var shutdownHandlerEntered = new ManualResetEventSlim();
+        using var releaseShutdownHandler = new ManualResetEventSlim();
+        var resource = new BlockingDisposalProbe(cleanupEntered, releaseCleanup);
+        EventHandler blockingShutdownHandler = (_, _) =>
+        {
+            shutdownHandlerEntered.Set();
+            releaseShutdownHandler.Wait();
+        };
+        dispatcher.ShutdownStarted += blockingShutdownHandler;
+        Task? shutdown = null;
+        try
+        {
+            await dispatcher.InvokeAsync(static () => { });
+            Task cleanup = SourceVideo.DisposeThumbnailRenderResourcesAsync(dispatcher, resource);
+            Assert.That(cleanupEntered.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "The cleanup fixture did not enter resource disposal.");
+
+            shutdown = Task.Run(dispatcher.Shutdown);
+            Assert.That(shutdownHandlerEntered.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "Shutdown did not snapshot and enter the blocking handler.");
+
+            releaseCleanup.Set();
+            await cleanup.WaitAsync(TimeSpan.FromSeconds(5));
+            releaseShutdownHandler.Set();
+            await shutdown.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.That(resource.DisposeCount, Is.EqualTo(1));
+        }
+        finally
+        {
+            releaseCleanup.Set();
+            releaseShutdownHandler.Set();
+            dispatcher.ShutdownStarted -= blockingShutdownHandler;
+            if (!dispatcher.HasShutdownStarted)
+                dispatcher.Shutdown();
+            if (shutdown is not null)
+                await shutdown.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(dispatcher.Thread.Join(TimeSpan.FromSeconds(5)), Is.True,
+                "The local dispatcher did not finish after the shutdown race fixture was released.");
+        }
+    }
+
+    private sealed class DisposalThreadProbe : IDisposable
+    {
+        public int DisposeCount { get; private set; }
+
+        public bool DisposedOnRenderThread { get; private set; }
+
+        public void Dispose()
+        {
+            DisposeCount++;
+            DisposedOnRenderThread = RenderThread.Dispatcher.CheckAccess();
+        }
+    }
+
+    private sealed class BlockingDisposalProbe(
+        ManualResetEventSlim entered,
+        ManualResetEventSlim release) : IDisposable
+    {
+        private int _disposeCount;
+
+        public int DisposeCount => Volatile.Read(ref _disposeCount);
+
+        public void Dispose()
+        {
+            Interlocked.Increment(ref _disposeCount);
+            entered.Set();
+            release.Wait();
+        }
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Graphics3D/DetachedMeshResourceTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics3D/DetachedMeshResourceTests.cs
@@ -1,0 +1,92 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics3D;
+using Beutl.Graphics3D.Meshes;
+using Beutl.Graphics3D.Models;
+
+namespace Beutl.UnitTests.Engine.Graphics3D;
+
+/// <summary>
+/// <c>Mesh</c> had the same shape as <c>Geometry</c>: <c>EnsureCached</c> dispatched through the backing
+/// engine object, so a publicly constructed resource threw. Generation now dispatches on the resource.
+/// </summary>
+[TestFixture]
+public sealed class DetachedMeshResourceTests
+{
+    [Test]
+    public void ADetachedCube_GeneratesTheSameMeshAsItsAttachedCounterpart()
+    {
+        using var detached = new CubeMesh.Resource { Width = 2, Height = 3, Depth = 4 };
+        using Mesh.Resource attached = new CubeMesh
+        {
+            Width = { CurrentValue = 2 },
+            Height = { CurrentValue = 3 },
+            Depth = { CurrentValue = 4 },
+        }.ToResource(CompositionContext.Default);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(detached.GetVertices().ToArray(), Is.EqualTo(attached.GetVertices().ToArray()).AsCollection);
+            Assert.That(detached.GetIndices().ToArray(), Is.EqualTo(attached.GetIndices().ToArray()).AsCollection);
+            Assert.That(detached.GetBoundingBox().Min, Is.EqualTo(attached.GetBoundingBox().Min));
+            Assert.That(detached.GetBoundingBox().Max, Is.EqualTo(attached.GetBoundingBox().Max));
+        }
+    }
+
+    [Test]
+    public void EveryDetachedBuiltInMesh_ReportsItsCounts()
+    {
+        using var cube = new CubeMesh.Resource { Width = 1, Height = 1, Depth = 1 };
+        using var plane = new PlaneMesh.Resource { Width = 2, Height = 2, WidthSegments = 2, HeightSegments = 3 };
+        using var sphere = new SphereMesh.Resource { Radius = 1, Segments = 8, Rings = 4 };
+        using var model = new ModelMesh.Resource
+        {
+            Vertices = [.. new CubeMesh.Resource { Width = 1, Height = 1, Depth = 1 }.GetVertices()],
+            Indices = [.. new CubeMesh.Resource { Width = 1, Height = 1, Depth = 1 }.GetIndices()],
+        };
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(cube.VertexCount, Is.EqualTo(24));
+            Assert.That(plane.VertexCount, Is.EqualTo(12));
+            Assert.That(sphere.VertexCount, Is.EqualTo(45));
+            Assert.That(model.VertexCount, Is.EqualTo(24));
+            Assert.That(model.IndexCount, Is.EqualTo(cube.IndexCount));
+        }
+    }
+
+    /// <summary>
+    /// <c>MeshBufferUploadHelper</c> and <c>TransparentPass</c> clear <c>BuffersDirty</c> once they have
+    /// uploaded the current vertices, so a regenerated mesh that leaves it clear keeps the GPU on the old
+    /// buffers.
+    /// </summary>
+    [Test]
+    public void RegeneratingAMesh_MarksItsGpuBuffersDirtyAgain()
+    {
+        using var mesh = new CubeMesh.Resource { Width = 1, Height = 1, Depth = 1 };
+        _ = mesh.GetVertices();
+        mesh.BuffersDirty = false;
+
+        mesh.Width = 4;
+        mesh.Version++;
+        ReadOnlySpan<Vertex3D> regenerated = mesh.GetVertices();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(mesh.GetBoundingBox().Max.X, Is.EqualTo(2));
+            Assert.That(regenerated.Length, Is.EqualTo(24));
+            Assert.That(mesh.BuffersDirty, Is.True);
+        }
+    }
+
+    [Test]
+    public void AMeshServedFromItsCache_LeavesTheGpuBufferFlagAlone()
+    {
+        using var mesh = new CubeMesh.Resource { Width = 1, Height = 1, Depth = 1 };
+        _ = mesh.GetVertices();
+        mesh.BuffersDirty = false;
+
+        _ = mesh.GetVertices();
+
+        Assert.That(mesh.BuffersDirty, Is.False);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Media/Geometry/DetachedGeometryResourceTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Media/Geometry/DetachedGeometryResourceTests.cs
@@ -1,0 +1,179 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Rendering.Cache;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Media.Geometry;
+
+using Geometry = Beutl.Media.Geometry;
+
+/// <summary>
+/// A "detached" resource is one built through its public parameterless constructor rather than through
+/// <see cref="Beutl.Engine.EngineObject.ToResource"/>, so its backing engine object is null. At 989856e8d the
+/// four public members a detached geometry resource needs — <c>Bounds</c>, <c>GetRenderBounds</c>,
+/// <c>FillContains</c>, <c>StrokeContains</c> — were all non-virtual, so an out-of-tree author who built one
+/// could not override the <see cref="NullReferenceException"/> away.
+/// </summary>
+/// <remarks>
+/// Path construction now dispatches on the resource's own type, so a detached resource produces the same path
+/// its attached counterpart does.
+/// </remarks>
+[TestFixture]
+public sealed class DetachedGeometryResourceTests
+{
+    [Test]
+    public void ADetachedEllipse_ProducesTheSameBoundsAsItsAttachedCounterpart()
+    {
+        using var detached = new EllipseGeometry.Resource { Width = 100, Height = 50 };
+        using Geometry.Resource attached = new EllipseGeometry
+        {
+            Width = { CurrentValue = 100 },
+            Height = { CurrentValue = 50 },
+        }.ToResource(CompositionContext.Default);
+
+        Assert.That(detached.Bounds, Is.EqualTo(attached.Bounds));
+    }
+
+    [Test]
+    public void ADetachedRect_ProducesTheSameBoundsAsItsAttachedCounterpart()
+    {
+        using var detached = new RectGeometry.Resource { Width = 30, Height = 40 };
+        using Geometry.Resource attached = new RectGeometry
+        {
+            Width = { CurrentValue = 30 },
+            Height = { CurrentValue = 40 },
+        }.ToResource(CompositionContext.Default);
+
+        Assert.That(detached.Bounds, Is.EqualTo(attached.Bounds));
+    }
+
+    [Test]
+    public void EveryPublicEntryPointOfADetachedEllipse_Answers()
+    {
+        using var pen = new Pen
+        {
+            Brush = { CurrentValue = Brushes.Black },
+            Thickness = { CurrentValue = 4 },
+        }.ToResource(CompositionContext.Default);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(Fresh().Bounds, Is.EqualTo(new Rect(0, 0, 100, 50)));
+            Assert.That(Fresh().GetRenderBounds(null), Is.EqualTo(new Rect(0, 0, 100, 50)));
+            Assert.That(Fresh().GetRenderBounds(pen), Is.EqualTo(new Rect(-2, -2, 104, 54)));
+            Assert.That(Fresh().FillContains(new Point(50, 25)), Is.True);
+            Assert.That(Fresh().StrokeContains(null, new Point(0, 25)), Is.False);
+            Assert.That(Fresh().StrokeContains(pen, new Point(0, 25)), Is.True);
+        }
+
+        static EllipseGeometry.Resource Fresh() => new() { Width = 100, Height = 50 };
+    }
+
+    [Test]
+    public void ADetachedPathGeometryWithDetachedFiguresAndSegments_BuildsThatPath()
+    {
+        using var detached = new PathGeometry.Resource
+        {
+            Figures =
+            {
+                new PathFigure.Resource
+                {
+                    StartPoint = new Point(0, 0),
+                    IsClosed = true,
+                    Segments =
+                    {
+                        new LineSegment.Resource { Point = new Point(60, 0) },
+                        new LineSegment.Resource { Point = new Point(60, 20) },
+                    },
+                },
+            },
+        };
+
+        Assert.That(detached.Bounds, Is.EqualTo(new Rect(0, 0, 60, 20)));
+    }
+
+    [Test]
+    public void AnAttachedPathGeometryHoldingADetachedFigure_BuildsThatFigure()
+    {
+        var geometry = new PathGeometry();
+        geometry.Figures.Add(new PathFigure
+        {
+            StartPoint = { CurrentValue = new Point(0, 0) },
+            Segments = { new LineSegment(new Point(10, 0)) },
+        });
+        using PathGeometry.Resource resource =
+            (PathGeometry.Resource)geometry.ToResource(CompositionContext.Default);
+        resource.Figures.Add(new PathFigure.Resource
+        {
+            StartPoint = new Point(0, 0),
+            Segments = { new LineSegment.Resource { Point = new Point(80, 40) } },
+        });
+        resource.InvalidateCachedPaths();
+
+        Assert.That(resource.Bounds, Is.EqualTo(new Rect(0, 0, 80, 40)));
+    }
+
+    [Test]
+    public void GeometryRenderNode_WithADetachedGeometry_RecordsAndRasterizes()
+    {
+        using var detached = new EllipseGeometry.Resource { Width = 40, Height = 30 };
+        using var node = new GeometryRenderNode(detached, Brushes.Resource.White, null);
+
+        using var owner = new RenderRequestOwner();
+        using var request = new RenderRequest(new RenderRequestOptions(
+            RenderIntent.Preview,
+            RenderRequestPurpose.Auxiliary,
+            outputScale: 1,
+            maxWorkingScale: 1,
+            targetDomain: new Rect(0, 0, 64, 64),
+            cachePolicy: RenderCacheOptions.Disabled,
+            owner: owner));
+        RecordedRenderGraph graph = new RenderRequestRecorder(request).Record(node);
+
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest { CacheOptions = RenderCacheOptions.Disabled },
+            });
+        using RenderNodeRasterization rasterization = renderer.Rasterize();
+        Bitmap bitmap = rasterization.Bitmap
+            ?? throw new AssertionException("Detached geometry rasterization returned no bitmap.");
+        ReadOnlySpan<ushort> pixels = bitmap.GetPixelSpan<ushort>();
+        int center = ((bitmap.Height / 2 * bitmap.Width) + (bitmap.Width / 2)) * 4;
+        float red = (float)BitConverter.UInt16BitsToHalf(pixels[center]);
+        float green = (float)BitConverter.UInt16BitsToHalf(pixels[center + 1]);
+        float blue = (float)BitConverter.UInt16BitsToHalf(pixels[center + 2]);
+        float alpha = (float)BitConverter.UInt16BitsToHalf(pixels[center + 3]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(graph.PublicationRoots.Count(), Is.EqualTo(1));
+            Assert.That(rasterization.Bounds, Is.EqualTo(new Rect(0, 0, 40, 30)));
+            Assert.That(rasterization.Bitmap, Is.Not.Null);
+            Assert.That(alpha, Is.GreaterThan(0.9f), "the detached ellipse center must be opaque");
+            Assert.That(red, Is.GreaterThan(0.9f), "the detached ellipse center must retain its white fill");
+            Assert.That(green, Is.GreaterThan(0.9f), "the detached ellipse center must retain its white fill");
+            Assert.That(blue, Is.GreaterThan(0.9f), "the detached ellipse center must retain its white fill");
+        }
+    }
+
+    [Test]
+    public void GeometryClipRenderNode_WithADetachedGeometry_Measures()
+    {
+        using var detached = new RectGeometry.Resource { Width = 30, Height = 40 };
+        using var node = new GeometryClipRenderNode(detached, ClipOperation.Intersect);
+        node.AddChild(new RectangleRenderNode(new Rect(0, 0, 100, 100), Brushes.Resource.White, null));
+        using var renderer = new RenderNodeRenderer(
+            node,
+            new RenderNodeRendererOptions
+            {
+                DefaultRequest = new RenderNodeRenderRequest { CacheOptions = RenderCacheOptions.Disabled },
+            });
+
+        RenderNodeMeasurement measurement = renderer.Measure();
+
+        Assert.That(measurement.OutputBounds, Is.EqualTo(new Rect(0, 0, 30, 40)));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Media/Geometry/GeometryPathAllocationTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Media/Geometry/GeometryPathAllocationTests.cs
@@ -1,0 +1,96 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Media.Geometry;
+
+using Geometry = Beutl.Media.Geometry;
+
+/// <summary>
+/// <c>GetCachedPath</c> is on the render path, so a cache hit has to stay allocation-free and a rebuild must
+/// not cost more than the pre-change construction transcribed in <see cref="PreChangeGeometryPath"/>.
+/// </summary>
+[TestFixture]
+public sealed class GeometryPathAllocationTests
+{
+    private const int Iterations = 20000;
+    private const int Rounds = 5;
+
+    [Test]
+    public void ACacheHit_DoesNotAllocate()
+    {
+        using Geometry.Resource resource = CreateGeometry().ToResource(CompositionContext.Default);
+        _ = resource.GetCachedPath();
+
+        Assert.That(Measure(() => resource.GetCachedPath(), Iterations), Is.Zero);
+    }
+
+    [Test]
+    public void ADetachedCacheHit_DoesNotAllocate()
+    {
+        using var resource = new EllipseGeometry.Resource { Width = 100, Height = 50 };
+        _ = resource.GetCachedPath();
+
+        Assert.That(Measure(() => resource.GetCachedPath(), Iterations), Is.Zero);
+    }
+
+    [Test]
+    public void ARebuild_DoesNotCostMoreThanThePreChangeConstruction()
+    {
+        using Geometry.Resource shipped = CreateGeometry().ToResource(CompositionContext.Default);
+        using Geometry.Resource reference = CreateGeometry().ToResource(CompositionContext.Default);
+
+        const int rebuildIterations = 2000;
+        long before = Measure(
+            () =>
+            {
+                using GeometryContext context = PreChangeGeometryPath.Build(reference);
+                _ = context.NativeObject;
+            },
+            rebuildIterations);
+        long after = Measure(
+            () =>
+            {
+                shipped.InvalidateCachedPaths();
+                _ = shipped.GetCachedPath();
+            },
+            rebuildIterations);
+
+        Assert.That(after, Is.LessThanOrEqualTo(before),
+            $"rebuild allocated {after} bytes against the pre-change {before}");
+    }
+
+    private static PathGeometry CreateGeometry()
+    {
+        var geometry = new PathGeometry();
+        geometry.Figures.Add(new PathFigure
+        {
+            StartPoint = { CurrentValue = new Point(5, 5) },
+            IsClosed = { CurrentValue = true },
+            Segments =
+            {
+                new LineSegment(new Point(50, 5)),
+                new QuadraticBezierSegment(new Point(70, 15), new Point(50, 35)),
+                new CubicBezierSegment(new Point(40, 55), new Point(20, 55), new Point(10, 40)),
+            },
+        });
+        return geometry;
+    }
+
+    private static long Measure(Action action, int iterations)
+    {
+        for (int index = 0; index < 200; index++)
+            action();
+
+        long best = long.MaxValue;
+        for (int round = 0; round < Rounds; round++)
+        {
+            long start = GC.GetAllocatedBytesForCurrentThread();
+            for (int index = 0; index < iterations; index++)
+                action();
+            best = Math.Min(best, GC.GetAllocatedBytesForCurrentThread() - start);
+        }
+
+        return best;
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Media/Geometry/GeometryPathCacheFailureTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Media/Geometry/GeometryPathCacheFailureTests.cs
@@ -1,0 +1,167 @@
+﻿using Beutl.Graphics;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Media.Geometry;
+
+using Geometry = Beutl.Media.Geometry;
+
+/// <summary>
+/// A failing <c>ApplyTo</c> must not be able to install a half-built path behind the version guard.
+/// </summary>
+/// <remarks>
+/// <see cref="PreChangeOrdering"/> reproduces the field-write order this cache used at 989856e8d, so the
+/// difference is measured in one process rather than read off the diff.
+/// </remarks>
+[TestFixture]
+public sealed class GeometryPathCacheFailureTests
+{
+    [Test]
+    public void PreChangeOrdering_ServedWhateverWasBuiltBeforeTheThrow()
+    {
+        using var partial = new PreChangeOrdering();
+        using var immediate = new PreChangeOrdering();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.Throws<InvalidOperationException>(() => partial.GetCachedPath(ThrowingApplyTo));
+            Assert.That(partial.GetCachedPath(ThrowingApplyTo).TightBounds.ToGraphicsRect(),
+                Is.EqualTo(new Rect(0, 0, 20, 10)),
+                "the guard passes on the next call and hands back the two segments recorded before the throw");
+            Assert.That(partial.GetCachedPath(ThrowingApplyTo).TightBounds.ToGraphicsRect(),
+                Is.EqualTo(new Rect(0, 0, 20, 10)));
+
+            Assert.Throws<InvalidOperationException>(
+                () => immediate.GetCachedPath(static _ => throw new InvalidOperationException("author failure")));
+            Assert.That(
+                immediate.GetCachedPath(static _ => throw new InvalidOperationException("author failure"))
+                    .TightBounds.ToGraphicsRect(),
+                Is.EqualTo(default(Rect)),
+                "an author that throws before recording anything degrades to an empty path instead");
+        }
+    }
+
+    [Test]
+    public void ShippedOrdering_KeepsThrowingInsteadOfServingAnEmptyPath()
+    {
+        using var resource = new ThrowingGeometryResource();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.Throws<InvalidOperationException>(() => _ = resource.Bounds);
+            Assert.Throws<InvalidOperationException>(() => _ = resource.Bounds);
+            Assert.Throws<InvalidOperationException>(() => _ = resource.FillContains(new Point(1, 1)));
+            Assert.Throws<InvalidOperationException>(() => _ = resource.GetRenderBounds(null));
+            Assert.That(resource.Calls, Is.EqualTo(4), "each entry point must retry the build, not serve a stale one");
+        }
+    }
+
+    [Test]
+    public void ARebuildThatSucceedsAfterAFailure_ProducesTheCompletePath()
+    {
+        using var resource = new ThrowingGeometryResource();
+
+        Assert.Throws<InvalidOperationException>(() => _ = resource.Bounds);
+        resource.Throw = false;
+
+        Assert.That(resource.Bounds, Is.EqualTo(new Rect(0, 0, 20, 10)));
+    }
+
+    [Test]
+    public void AFailedRebuild_DoesNotReleaseThePathAPreviousBuildProduced()
+    {
+        using var resource = new ThrowingGeometryResource { Throw = false };
+        SKPath first = resource.GetCachedPath();
+
+        resource.Throw = true;
+        resource.InvalidateCachedPaths();
+        Assert.Throws<InvalidOperationException>(() => _ = resource.Bounds);
+
+        // SKPath.Handle is zero once the owning GeometryContext has disposed it. This must stop the test
+        // rather than collect into a multiple scope: reading TightBounds off a released path crashes the host.
+        Assert.That(first.Handle, Is.Not.EqualTo(IntPtr.Zero),
+            "the failed rebuild released the path the previous successful build produced");
+        Assert.That(first.TightBounds.ToGraphicsRect(), Is.EqualTo(new Rect(0, 0, 20, 10)));
+
+        resource.Throw = false;
+        resource.InvalidateCachedPaths();
+        Assert.That(resource.Bounds, Is.EqualTo(new Rect(0, 0, 20, 10)));
+    }
+
+    [Test]
+    public void AFallbackSegment_MakesTheEnclosingGeometryKeepThrowing()
+    {
+        using var resource = new PathGeometry.Resource
+        {
+            Figures =
+            {
+                new PathFigure.Resource
+                {
+                    StartPoint = new Point(0, 0),
+                    Segments = { new FallbackPathSegment.Resource() },
+                },
+            },
+        };
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.Throws<InvalidOperationException>(() => _ = resource.Bounds);
+            Assert.Throws<InvalidOperationException>(() => _ = resource.Bounds);
+        }
+    }
+
+    private static void ThrowingApplyTo(IGeometryContext context)
+    {
+        context.MoveTo(new Point(0, 0));
+        context.LineTo(new Point(20, 10));
+        throw new InvalidOperationException("author failure");
+    }
+
+    private sealed class ThrowingGeometryResource : Geometry.Resource
+    {
+        public ThrowingGeometryResource()
+        {
+        }
+
+        public bool Throw { get; set; } = true;
+
+        public int Calls { get; private set; }
+
+        public override void ApplyTo(IGeometryContext context)
+        {
+            Calls++;
+            context.MoveTo(new Point(0, 0));
+            context.LineTo(new Point(20, 10));
+            if (Throw)
+                throw new InvalidOperationException("author failure");
+        }
+    }
+
+    /// <summary>
+    /// The cache orchestration <c>Geometry.Resource.GetCachedPath</c> used at 989856e8d, transcribed so its
+    /// behaviour on a throwing build can be observed alongside the shipped one.
+    /// </summary>
+    private sealed class PreChangeOrdering : IDisposable
+    {
+        private int? _capturedVersion;
+        private GeometryContext? _cachedPath;
+
+        public int Version { get; set; }
+
+        public SKPath GetCachedPath(Action<IGeometryContext> applyTo)
+        {
+            if (_capturedVersion != Version || _cachedPath == null)
+            {
+                _capturedVersion = Version;
+                _cachedPath?.Dispose();
+
+                _cachedPath = new GeometryContext();
+                applyTo(_cachedPath);
+            }
+
+            return _cachedPath.NativeObject;
+        }
+
+        public void Dispose() => _cachedPath?.Dispose();
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Media/Geometry/GeometryPathParityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Media/Geometry/GeometryPathParityTests.cs
@@ -1,0 +1,265 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Transformation;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Media.Geometry;
+
+using Geometry = Beutl.Media.Geometry;
+
+/// <summary>
+/// Compares the shipped path against <see cref="PreChangeGeometryPath"/>, a transcription of the same
+/// construction as it stood at 989856e8d, in one process and element by element.
+/// </summary>
+[TestFixture]
+public sealed class GeometryPathParityTests
+{
+    private static IEnumerable<TestCaseData> Cases()
+    {
+        yield return new TestCaseData((Func<Geometry>)(() => new EllipseGeometry
+        {
+            Width = { CurrentValue = 100 },
+            Height = { CurrentValue = 50 },
+        })).SetName("Ellipse");
+
+        yield return new TestCaseData((Func<Geometry>)(() => new EllipseGeometry
+        {
+            Width = { CurrentValue = float.PositiveInfinity },
+            Height = { CurrentValue = 50 },
+        })).SetName("EllipseWithInfiniteWidth");
+
+        yield return new TestCaseData((Func<Geometry>)(() => new RectGeometry
+        {
+            Width = { CurrentValue = 30 },
+            Height = { CurrentValue = 40 },
+        })).SetName("Rect");
+
+        yield return new TestCaseData((Func<Geometry>)(() =>
+        {
+            var geometry = new RectGeometry
+            {
+                Width = { CurrentValue = 30 },
+                Height = { CurrentValue = 40 },
+            };
+            geometry.FillType.CurrentValue = PathFillType.EvenOdd;
+            geometry.Transform.CurrentValue = new RotationTransform { Rotation = { CurrentValue = 30 } };
+            return geometry;
+        })).SetName("RectWithTransformAndFillType");
+
+        yield return new TestCaseData((Func<Geometry>)(() => new RoundedRectGeometry
+        {
+            Width = { CurrentValue = 120 },
+            Height = { CurrentValue = 80 },
+            CornerRadius = { CurrentValue = new CornerRadius(12, 4, 30, 0) },
+            Smoothing = { CurrentValue = 60 },
+        })).SetName("RoundedRectSmoothed");
+
+        yield return new TestCaseData((Func<Geometry>)(() => new RoundedRectGeometry
+        {
+            Width = { CurrentValue = 120 },
+            Height = { CurrentValue = 80 },
+            CornerRadius = { CurrentValue = new CornerRadius(0) },
+            Smoothing = { CurrentValue = 0 },
+        })).SetName("RoundedRectSquare");
+
+        yield return new TestCaseData((Func<Geometry>)(() =>
+            PathGeometry.Parse("M 10 10 L 60 10 Q 80 30 60 50 C 40 60 20 60 10 50 Z")))
+            .SetName("PathGeometryParsed");
+
+        yield return new TestCaseData((Func<Geometry>)AllSegmentKinds).SetName("PathGeometryAllSegmentKinds");
+
+        yield return new TestCaseData((Func<Geometry>)(() =>
+        {
+            PathGeometry geometry = AllSegmentKinds();
+            geometry.Figures[0].StartPoint.CurrentValue = new Point(float.NaN, float.NaN);
+            return geometry;
+        })).SetName("PathGeometryWithoutStartPoint");
+
+        yield return new TestCaseData((Func<Geometry>)(() =>
+        {
+            PathGeometry geometry = AllSegmentKinds();
+            geometry.Figures[0].StartPoint.CurrentValue = new Point(float.NaN, float.NaN);
+            geometry.Figures[0].IsClosed.CurrentValue = true;
+            return geometry;
+        })).SetName("PathGeometryClosedWithoutStartPoint");
+
+        yield return new TestCaseData((Func<Geometry>)(() =>
+        {
+            PathGeometry geometry = AllSegmentKinds();
+            geometry.Figures.Add(new PathFigure
+            {
+                StartPoint = { CurrentValue = new Point(200, 200) },
+                Segments = { new LineSegment(new Point(260, 240)) },
+            });
+            return geometry;
+        })).SetName("PathGeometryMultipleFigures");
+    }
+
+    private static PathGeometry AllSegmentKinds()
+    {
+        var geometry = new PathGeometry();
+        geometry.Figures.Add(new PathFigure
+        {
+            StartPoint = { CurrentValue = new Point(5, 5) },
+            Segments =
+            {
+                new LineSegment(new Point(50, 5)),
+                new QuadraticBezierSegment(new Point(70, 15), new Point(50, 35)),
+                new CubicBezierSegment(new Point(40, 55), new Point(20, 55), new Point(10, 40)),
+                new ConicSegment(new Point(0, 25), new Point(5, 5), 0.7f),
+                new ArcSegment
+                {
+                    Radius = { CurrentValue = new Size(20, 12) },
+                    RotationAngle = { CurrentValue = 15 },
+                    IsLargeArc = { CurrentValue = true },
+                    SweepClockwise = { CurrentValue = false },
+                    Point = { CurrentValue = new Point(40, 20) },
+                },
+            },
+        });
+        return geometry;
+    }
+
+    [TestCaseSource(nameof(Cases))]
+    public void ShippedPath_MatchesThePreChangePathElementByElement(Func<Geometry> create)
+    {
+        Geometry geometry = create();
+        using Geometry.Resource resource = geometry.ToResource(CompositionContext.Default);
+        using GeometryContext expected = PreChangeGeometryPath.Build(resource);
+
+        IReadOnlyList<string> before = PreChangeGeometryPath.Describe(expected.NativeObject);
+        IReadOnlyList<string> after = PreChangeGeometryPath.Describe(resource.GetCachedPath());
+
+        Assert.That(after, Is.EqualTo(before).AsCollection);
+    }
+
+    [TestCaseSource(nameof(Cases))]
+    public void DetachedResource_ProducesTheSamePathAsItsAttachedCounterpart(Func<Geometry> create)
+    {
+        Geometry geometry = create();
+        using Geometry.Resource attached = geometry.ToResource(CompositionContext.Default);
+        IReadOnlyList<string> expected = PreChangeGeometryPath.Describe(attached.GetCachedPath());
+        Geometry.Resource detached = Detach(attached);
+        try
+        {
+            IReadOnlyList<string> actual = PreChangeGeometryPath.Describe(detached.GetCachedPath());
+
+            Assert.That(actual, Is.EqualTo(expected).AsCollection);
+        }
+        finally
+        {
+            detached.Dispose();
+        }
+    }
+
+    [TestCaseSource(nameof(Cases))]
+    public void StrokeAndHitTestResults_MatchThePreChangePath(Func<Geometry> create)
+    {
+        Geometry geometry = create();
+        using Geometry.Resource resource = geometry.ToResource(CompositionContext.Default);
+        using Pen.Resource pen = new Pen
+        {
+            Brush = { CurrentValue = Brushes.Black },
+            Thickness = { CurrentValue = 6 },
+        }.ToResource(CompositionContext.Default);
+        using GeometryContext expected = PreChangeGeometryPath.Build(resource);
+        Rect expectedBounds = expected.NativeObject.TightBounds.ToGraphicsRect();
+        using SKPath expectedStroke = PenHelper.CreateStrokePath(expected.NativeObject, pen, expectedBounds);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(resource.Bounds, Is.EqualTo(expectedBounds));
+            Assert.That(
+                PreChangeGeometryPath.Describe(resource.GetCachedStrokePath(pen)),
+                Is.EqualTo(PreChangeGeometryPath.Describe(expectedStroke)).AsCollection);
+            Assert.That(
+                resource.GetRenderBounds(pen),
+                Is.EqualTo(expectedStroke.TightBounds.ToGraphicsRect()));
+            Assert.That(
+                resource.FillContains(expectedBounds.Center),
+                Is.EqualTo(expected.NativeObject.Contains(expectedBounds.Center.X, expectedBounds.Center.Y)));
+        }
+    }
+
+    /// <summary>
+    /// Rebuilds <paramref name="attached"/>'s value graph into resources that never went through
+    /// <c>ToResource</c>, which is the shape a plugin author constructs by hand.
+    /// </summary>
+    private static Geometry.Resource Detach(Geometry.Resource attached)
+    {
+        Geometry.Resource copy = attached switch
+        {
+            EllipseGeometry.Resource r => new EllipseGeometry.Resource { Width = r.Width, Height = r.Height },
+            RectGeometry.Resource r => new RectGeometry.Resource { Width = r.Width, Height = r.Height },
+            RoundedRectGeometry.Resource r => new RoundedRectGeometry.Resource
+            {
+                Width = r.Width,
+                Height = r.Height,
+                CornerRadius = r.CornerRadius,
+                Smoothing = r.Smoothing,
+            },
+            PathGeometry.Resource r => DetachPath(r),
+            _ => throw new NotSupportedException(attached.GetType().ToString()),
+        };
+
+        if (attached.Transform is { } transform)
+        {
+            copy.Transform = new Transform.Resource { Matrix = transform.Matrix };
+        }
+
+        copy.FillType = attached.FillType;
+        return copy;
+    }
+
+    private static PathGeometry.Resource DetachPath(PathGeometry.Resource source)
+    {
+        var copy = new PathGeometry.Resource();
+        foreach (PathFigure.Resource figure in source.Figures)
+        {
+            var figureCopy = new PathFigure.Resource
+            {
+                StartPoint = figure.StartPoint,
+                IsClosed = figure.IsClosed,
+            };
+            foreach (PathSegment.Resource segment in figure.Segments)
+            {
+                figureCopy.Segments.Add(segment switch
+                {
+                    LineSegment.Resource s => new LineSegment.Resource { Point = s.Point },
+                    QuadraticBezierSegment.Resource s => new QuadraticBezierSegment.Resource
+                    {
+                        ControlPoint = s.ControlPoint,
+                        EndPoint = s.EndPoint,
+                    },
+                    CubicBezierSegment.Resource s => new CubicBezierSegment.Resource
+                    {
+                        ControlPoint1 = s.ControlPoint1,
+                        ControlPoint2 = s.ControlPoint2,
+                        EndPoint = s.EndPoint,
+                    },
+                    ConicSegment.Resource s => new ConicSegment.Resource
+                    {
+                        ControlPoint = s.ControlPoint,
+                        EndPoint = s.EndPoint,
+                        Weight = s.Weight,
+                    },
+                    ArcSegment.Resource s => new ArcSegment.Resource
+                    {
+                        Radius = s.Radius,
+                        RotationAngle = s.RotationAngle,
+                        IsLargeArc = s.IsLargeArc,
+                        SweepClockwise = s.SweepClockwise,
+                        Point = s.Point,
+                    },
+                    _ => throw new NotSupportedException(segment.GetType().ToString()),
+                });
+            }
+
+            copy.Figures.Add(figureCopy);
+        }
+
+        return copy;
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Media/Geometry/GeometryStrokePathCacheTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Media/Geometry/GeometryStrokePathCacheTests.cs
@@ -1,0 +1,126 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Media.Geometry;
+
+using Geometry = Beutl.Media.Geometry;
+
+/// <summary>
+/// <c>Geometry.Resource</c>'s stroke-path cache keys on the pen. Both halves of that key are exercised here:
+/// which pen the cached stroke belongs to, and whether the fill path it was derived from is still current.
+/// </summary>
+[TestFixture]
+public sealed class GeometryStrokePathCacheTests
+{
+    [Test]
+    public void TwoDetachedPens_DoNotShareOneCachedStroke()
+    {
+        using Geometry.Resource geometry = CreateAttachedEllipse();
+        using var thin = CreateDetachedPen(thickness: 4);
+        using var thick = CreateDetachedPen(thickness: 20);
+
+        Rect first = geometry.GetRenderBounds(thin);
+        Rect second = geometry.GetRenderBounds(thick);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(first, Is.EqualTo(new Rect(-2, -2, 104, 54)));
+            Assert.That(second, Is.EqualTo(new Rect(-10, -10, 120, 70)),
+                "keying the cache on GetOriginal() reads null for both detached pens and serves the thin stroke");
+        }
+    }
+
+    [Test]
+    public void TwoAttachedPens_DoNotShareOneCachedStroke()
+    {
+        using Geometry.Resource geometry = CreateAttachedEllipse();
+        using Pen.Resource thin = CreateAttachedPen(thickness: 4);
+        using Pen.Resource thick = CreateAttachedPen(thickness: 20);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(geometry.GetRenderBounds(thin), Is.EqualTo(new Rect(-2, -2, 104, 54)));
+            Assert.That(geometry.GetRenderBounds(thick), Is.EqualTo(new Rect(-10, -10, 120, 70)));
+        }
+    }
+
+    [Test]
+    public void OneDetachedPenReused_StillHitsTheCache()
+    {
+        using Geometry.Resource geometry = CreateAttachedEllipse();
+        using var pen = CreateDetachedPen(thickness: 4);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(geometry.GetRenderBounds(pen), Is.EqualTo(new Rect(-2, -2, 104, 54)));
+            Assert.That(geometry.GetRenderBounds(pen), Is.EqualTo(new Rect(-2, -2, 104, 54)));
+        }
+    }
+
+    [Test]
+    public void ADetachedPenWhoseVersionMoved_RebuildsTheStroke()
+    {
+        using Geometry.Resource geometry = CreateAttachedEllipse();
+        using var pen = CreateDetachedPen(thickness: 4);
+        Rect before = geometry.GetRenderBounds(pen);
+
+        pen.Thickness = 20;
+        pen.Version++;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(before, Is.EqualTo(new Rect(-2, -2, 104, 54)));
+            Assert.That(geometry.GetRenderBounds(pen), Is.EqualTo(new Rect(-10, -10, 120, 70)));
+        }
+    }
+
+    [Test]
+    public void RebuildingTheFillPath_DropsTheStrokeBuiltFromTheOldOne()
+    {
+        using var geometry = new RectGeometry.Resource { Width = 100, Height = 50 };
+        using Pen.Resource pen = CreateAttachedPen(thickness: 4);
+        Rect before = geometry.GetRenderBounds(pen);
+
+        geometry.Width = 200;
+        geometry.InvalidateCachedPaths();
+        // Rebuilding the fill path first is what leaves a stale stroke reachable: GetCachedStrokePath then
+        // sees a matching version, a live fill path, a live stroke path, and the same pen.
+        _ = geometry.Bounds;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(before, Is.EqualTo(new Rect(-2, -2, 104, 54)));
+            Assert.That(geometry.GetRenderBounds(pen), Is.EqualTo(new Rect(-2, -2, 204, 54)));
+        }
+    }
+
+    private static Geometry.Resource CreateAttachedEllipse()
+    {
+        return new EllipseGeometry
+        {
+            Width = { CurrentValue = 100 },
+            Height = { CurrentValue = 50 },
+        }.ToResource(CompositionContext.Default);
+    }
+
+    private static Pen.Resource CreateAttachedPen(float thickness)
+    {
+        return new Pen
+        {
+            Brush = { CurrentValue = Brushes.Black },
+            Thickness = { CurrentValue = thickness },
+        }.ToResource(CompositionContext.Default);
+    }
+
+    private static Pen.Resource CreateDetachedPen(float thickness)
+    {
+        return new Pen.Resource
+        {
+            Brush = Colors.Black.ToBrushResource(),
+            Thickness = thickness,
+            MiterLimit = 10,
+            TrimEnd = 100,
+        };
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Media/Geometry/PreChangeGeometryPath.cs
+++ b/tests/Beutl.UnitTests/Engine/Media/Geometry/PreChangeGeometryPath.cs
@@ -1,0 +1,395 @@
+﻿using Beutl.Graphics;
+using Beutl.Media;
+using Beutl.Utilities;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Media.Geometry;
+
+using Geometry = Beutl.Media.Geometry;
+
+/// <summary>
+/// A verbatim copy of the geometry path construction as it stood at 989856e8d, when
+/// <c>Geometry.Resource.GetCachedPath</c> dispatched through <c>GetOriginal().ApplyTo(context, this)</c>.
+/// </summary>
+/// <remarks>
+/// The copy is the comparison baseline for <see cref="GeometryPathParityTests"/>: dispatch moved onto the
+/// resource, and every value the old engine-object overrides read already came from the resource, so the two
+/// must agree element for element. Edit this only to correct a transcription error — it is not a second
+/// implementation to keep in step with the shipped one.
+/// </remarks>
+internal static class PreChangeGeometryPath
+{
+    public static GeometryContext Build(Geometry.Resource resource)
+    {
+        var context = new GeometryContext { FillType = resource.FillType };
+        ApplyGeometry(context, resource);
+        if (resource.Transform != null)
+        {
+            context.Transform(resource.Transform.Matrix);
+        }
+
+        return context;
+    }
+
+    private static void ApplyGeometry(IGeometryContext context, Geometry.Resource resource)
+    {
+        switch (resource)
+        {
+            case EllipseGeometry.Resource r:
+                ApplyEllipse(context, r);
+                break;
+            case RectGeometry.Resource r:
+                ApplyRect(context, r);
+                break;
+            case RoundedRectGeometry.Resource r:
+                ApplyRoundedRect(context, r);
+                break;
+            case PathGeometry.Resource r:
+                ApplyPathGeometry(context, r);
+                break;
+            default:
+                throw new NotSupportedException($"{resource.GetType()} has no transcribed pre-change path.");
+        }
+    }
+
+    private static void ApplyEllipse(IGeometryContext context, EllipseGeometry.Resource r)
+    {
+        float width = r.Width;
+        float height = r.Height;
+        if (float.IsInfinity(width))
+            width = 0;
+
+        if (float.IsInfinity(height))
+            height = 0;
+
+        float radiusX = width / 2;
+        float radiusY = height / 2;
+        var radius = new Size(radiusX, radiusY);
+
+        context.MoveTo(new Point(radiusX, 0));
+        context.ArcTo(radius, 0, true, false, new Point(radiusX, height));
+        context.ArcTo(radius, 0, true, false, new Point(radiusX, 0));
+        context.Close();
+    }
+
+    private static void ApplyRect(IGeometryContext context, RectGeometry.Resource r)
+    {
+        float width = r.Width;
+        float height = r.Height;
+        if (float.IsInfinity(width))
+            width = 0;
+
+        if (float.IsInfinity(height))
+            height = 0;
+
+        context.MoveTo(new Point(0, 0));
+        context.LineTo(new Point(width, 0));
+        context.LineTo(new Point(width, height));
+        context.LineTo(new Point(0, height));
+        context.LineTo(new Point(0, 0));
+        context.Close();
+    }
+
+    private static void ApplyPathGeometry(IGeometryContext context, PathGeometry.Resource r)
+    {
+        foreach (PathFigure.Resource item in r.Figures)
+        {
+            ApplyFigure(context, item);
+        }
+    }
+
+    private static void ApplyFigure(IGeometryContext context, PathFigure.Resource resource)
+    {
+        bool skipFirst = false;
+        if (!resource.StartPoint.IsInvalid)
+        {
+            context.MoveTo(resource.StartPoint);
+        }
+        else if (resource.Segments.Count > 0)
+        {
+            if (resource.IsClosed)
+            {
+                var endPoint = resource.Segments[^1].GetEndPoint();
+                if (endPoint.HasValue)
+                {
+                    context.MoveTo(endPoint.Value);
+                }
+            }
+            else
+            {
+                var endPoint = resource.Segments[0].GetEndPoint();
+                if (endPoint.HasValue)
+                {
+                    context.MoveTo(endPoint.Value);
+                    skipFirst = true;
+                }
+            }
+        }
+
+        foreach (PathSegment.Resource item in resource.Segments)
+        {
+            if (skipFirst)
+            {
+                skipFirst = false;
+                continue;
+            }
+
+            ApplySegment(context, item);
+        }
+
+        if (resource.IsClosed)
+            context.Close();
+    }
+
+    private static void ApplySegment(IGeometryContext context, PathSegment.Resource resource)
+    {
+        switch (resource)
+        {
+            case LineSegment.Resource r:
+                context.LineTo(r.Point);
+                break;
+            case QuadraticBezierSegment.Resource r:
+                context.QuadraticTo(r.ControlPoint, r.EndPoint);
+                break;
+            case CubicBezierSegment.Resource r:
+                context.CubicTo(r.ControlPoint1, r.ControlPoint2, r.EndPoint);
+                break;
+            case ConicSegment.Resource r:
+                context.ConicTo(r.ControlPoint, r.EndPoint, r.Weight);
+                break;
+            case ArcSegment.Resource r:
+                context.ArcTo(r.Radius, r.RotationAngle, r.IsLargeArc, r.SweepClockwise, r.Point);
+                break;
+            default:
+                throw new NotSupportedException($"{resource.GetType()} has no transcribed pre-change path.");
+        }
+    }
+
+    private static void ApplyRoundedRect(IGeometryContext context, RoundedRectGeometry.Resource r)
+    {
+        float width = r.Width;
+        float height = r.Height;
+        if (float.IsInfinity(width))
+            width = 0;
+
+        if (float.IsInfinity(height))
+            height = 0;
+
+        (float radiusX, float radiusY) = (width / 2, height / 2);
+        float maxRadius = Math.Max(radiusX, radiusY);
+        CornerRadius cornerRadius = r.CornerRadius;
+        float topLeft = Math.Clamp(cornerRadius.TopLeft, 0, maxRadius);
+        float topRight = Math.Clamp(cornerRadius.TopRight, 0, maxRadius);
+        float bottomRight = Math.Clamp(cornerRadius.BottomRight, 0, maxRadius);
+        float bottomLeft = Math.Clamp(cornerRadius.BottomLeft, 0, maxRadius);
+        float smoothing = r.Smoothing / 100;
+
+        ApplyTopRightCorner(width, height, topRight, smoothing, context);
+        ApplyBottomRightCorner(width, height, bottomRight, smoothing, context);
+        ApplyBottomLeftCorner(width, height, bottomLeft, smoothing, context);
+        ApplyTopLeftCorner(width, height, topLeft, smoothing, context);
+    }
+
+    // https://github.com/yjb94/react-native-squircle-skia
+    private static void GetPathParams(
+        float width, float height, float cornerRadius, float smoothing,
+        out float a, out float b, out float c, out float d, out float p, out float circularSectionLength)
+    {
+        float maxRadius = MathF.Min(width, height) / 2;
+        cornerRadius = MathF.Min(cornerRadius, maxRadius);
+
+        p = MathF.Min((1 + smoothing) * cornerRadius, maxRadius);
+
+        float angleAlpha;
+        float angleBeta;
+
+        if (cornerRadius <= maxRadius / 2)
+        {
+            angleBeta = 90 * (1 - smoothing);
+            angleAlpha = 45 * smoothing;
+        }
+        else
+        {
+            float diffRatio = (cornerRadius - maxRadius / 2) / (maxRadius / 2);
+
+            angleBeta = 90 * (1 - smoothing * (1 - diffRatio));
+            angleAlpha = 45 * smoothing * (1 - diffRatio);
+        }
+
+        float angleTheta = (90 - angleBeta) / 2;
+        float p3ToP4Distance = cornerRadius * MathF.Tan(MathUtilities.Deg2Rad(angleTheta / 2));
+
+        circularSectionLength = MathF.Sin(MathUtilities.Deg2Rad(angleBeta / 2)) * cornerRadius * MathF.Sqrt(2);
+
+        c = p3ToP4Distance * MathF.Cos(MathUtilities.Deg2Rad(angleAlpha));
+        d = c * MathF.Tan(MathUtilities.Deg2Rad(angleAlpha));
+        b = (p - circularSectionLength - c - d) / 3;
+        a = 2 * b;
+    }
+
+    private static void ApplyTopRightCorner(float width, float height,
+        float cornerRadius, float smoothing, IGeometryContext context)
+    {
+        if (cornerRadius != 0)
+        {
+            GetPathParams(
+                width, height, cornerRadius, smoothing,
+                out float a, out float b, out float c, out float d, out float p, out float circularSectionLength);
+
+            context.MoveTo(new Point(MathF.Max(width / 2, width - p), 0));
+            context.CubicTo(
+                new Point(width - (p - a), 0),
+                new Point(width - (p - a - b), 0),
+                new Point(width - (p - a - b - c), d));
+            context.ArcTo(
+                new Size(cornerRadius, cornerRadius),
+                0,
+                false,
+                true,
+                new Point(circularSectionLength, circularSectionLength) + context.LastPoint);
+            context.CubicTo(
+                new Point(width, p - a - b),
+                new Point(width, p - a),
+                new Point(width, MathF.Min(height / 2, p)));
+        }
+        else
+        {
+            context.MoveTo(new Point(width / 2, 0));
+            context.LineTo(new Point(width, 0));
+            context.LineTo(new Point(width, height / 2));
+        }
+    }
+
+    private static void ApplyBottomRightCorner(float width, float height,
+        float cornerRadius, float smoothing, IGeometryContext context)
+    {
+        if (cornerRadius != 0)
+        {
+            GetPathParams(
+                width, height, cornerRadius, smoothing,
+                out float a, out float b, out float c, out float d, out float p, out float circularSectionLength);
+
+            context.LineTo(new Point(width, MathF.Max(height / 2, height - p)));
+            context.CubicTo(
+                new Point(width, height - (p - a)),
+                new Point(width, height - (p - a - b)),
+                new Point(width - d, height - (p - a - b - c)));
+            context.ArcTo(
+                new Size(cornerRadius, cornerRadius),
+                0,
+                false,
+                true,
+                new Point(-circularSectionLength, circularSectionLength) + context.LastPoint);
+            context.CubicTo(
+                new Point(width - (p - a - b), height),
+                new Point(width - (p - a), height),
+                new Point(MathF.Max(width / 2, width - p), height));
+        }
+        else
+        {
+            context.LineTo(new Point(width, height));
+            context.LineTo(new Point(width / 2, height));
+        }
+    }
+
+    private static void ApplyBottomLeftCorner(float width, float height,
+        float cornerRadius, float smoothing, IGeometryContext context)
+    {
+        if (cornerRadius != 0)
+        {
+            GetPathParams(
+                width, height, cornerRadius, smoothing,
+                out float a, out float b, out float c, out float d, out float p, out float circularSectionLength);
+
+            context.LineTo(new Point(MathF.Min(width / 2, p), height));
+            context.CubicTo(
+                new Point(p - a, height),
+                new Point(p - a - b, height),
+                new Point(p - a - b - c, height - d));
+            context.ArcTo(
+                new Size(cornerRadius, cornerRadius),
+                0,
+                false,
+                true,
+                new Point(-circularSectionLength, -circularSectionLength) + context.LastPoint);
+            context.CubicTo(
+                new Point(0, height - (p - a - b)),
+                new Point(0, height - (p - a)),
+                new Point(0, MathF.Max(height / 2, height - p)));
+        }
+        else
+        {
+            context.LineTo(new Point(0, height));
+            context.LineTo(new Point(0, height / 2));
+        }
+    }
+
+    private static void ApplyTopLeftCorner(float width, float height,
+        float cornerRadius, float smoothing, IGeometryContext context)
+    {
+        if (cornerRadius != 0)
+        {
+            GetPathParams(
+                width, height, cornerRadius, smoothing,
+                out float a, out float b, out float c, out float d, out float p, out float circularSectionLength);
+
+            context.LineTo(new Point(0, MathF.Min(height / 2, p)));
+            context.CubicTo(
+                new Point(0, p - a),
+                new Point(0, p - a - b),
+                new Point(d, p - a - b - c));
+            context.ArcTo(
+                new Size(cornerRadius, cornerRadius),
+                0,
+                false,
+                true,
+                new Point(circularSectionLength, -circularSectionLength) + context.LastPoint);
+            context.CubicTo(
+                new Point(p - a - b, 0),
+                new Point(p - a, 0),
+                new Point(MathF.Min(width / 2, p), 0));
+        }
+        else
+        {
+            context.LineTo(new Point(0, 0));
+        }
+
+        context.Close();
+    }
+
+    public static IReadOnlyList<string> Describe(SKPath path)
+    {
+        var elements = new List<string>
+        {
+            $"fillType={path.FillType}",
+            $"points={path.PointCount}",
+            $"verbs={path.VerbCount}",
+            $"tightBounds={path.TightBounds}",
+            $"bounds={path.Bounds}",
+            $"svg={path.ToSvgPathData()}",
+        };
+
+        using SKPath.RawIterator iterator = path.CreateRawIterator();
+        Span<SKPoint> points = stackalloc SKPoint[4];
+        SKPathVerb verb;
+        int index = 0;
+        do
+        {
+            verb = iterator.Next(points);
+            elements.Add(verb switch
+            {
+                SKPathVerb.Move => $"[{index}] Move {points[0]}",
+                SKPathVerb.Line => $"[{index}] Line {points[0]} {points[1]}",
+                SKPathVerb.Quad => $"[{index}] Quad {points[0]} {points[1]} {points[2]}",
+                SKPathVerb.Conic =>
+                    $"[{index}] Conic {points[0]} {points[1]} {points[2]} w={iterator.ConicWeight()}",
+                SKPathVerb.Cubic => $"[{index}] Cubic {points[0]} {points[1]} {points[2]} {points[3]}",
+                SKPathVerb.Close => $"[{index}] Close",
+                _ => $"[{index}] Done",
+            });
+            index++;
+        } while (verb != SKPathVerb.Done);
+
+        return elements;
+    }
+}

--- a/tests/Beutl.UnitTests/NodeGraph/GraphSnapshotTests.cs
+++ b/tests/Beutl.UnitTests/NodeGraph/GraphSnapshotTests.cs
@@ -1,4 +1,5 @@
 ﻿using Beutl.Composition;
+using Beutl.Graphics;
 using Beutl.Media.Proxy;
 using Beutl.NodeGraph;
 using Beutl.NodeGraph.Composition;
@@ -20,12 +21,14 @@ public sealed class GraphSnapshotTests
             DisableResourceShare = false,
             PreferProxy = true,
             PreferredProxyPreset = ProxyPreset.Half,
+            TargetDomain = new Rect(0, 0, 1920, 1080),
         };
         var secondContext = new CompositionContext(TimeSpan.FromSeconds(1))
         {
             DisableResourceShare = true,
             PreferProxy = false,
             PreferredProxyPreset = ProxyPreset.Eighth,
+            TargetDomain = new Rect(0, 0, 1280, 720),
         };
 
         snapshot.Build(model, firstContext);
@@ -40,6 +43,8 @@ public sealed class GraphSnapshotTests
             Assert.That(node.CapturedContexts[1].DisableResourceShare, Is.True);
             Assert.That(node.CapturedContexts[1].PreferProxy, Is.False);
             Assert.That(node.CapturedContexts[1].PreferredProxyPreset, Is.EqualTo(ProxyPreset.Eighth));
+            Assert.That(node.CapturedContexts[0].TargetDomain, Is.EqualTo(firstContext.TargetDomain));
+            Assert.That(node.CapturedContexts[1].TargetDomain, Is.EqualTo(secondContext.TargetDomain));
         });
     }
 }
@@ -56,7 +61,8 @@ internal sealed partial class ContextCaptureNode : GraphNode
             node.CapturedContexts.Add(new CapturedGraphContext(
                 context.DisableResourceShare,
                 context.PreferProxy,
-                context.PreferredProxyPreset));
+                context.PreferredProxyPreset,
+                context.TargetDomain));
         }
     }
 }
@@ -64,4 +70,5 @@ internal sealed partial class ContextCaptureNode : GraphNode
 internal readonly record struct CapturedGraphContext(
     bool DisableResourceShare,
     bool PreferProxy,
-    ProxyPreset PreferredProxyPreset);
+    ProxyPreset PreferredProxyPreset,
+    Rect? TargetDomain);

--- a/tests/SourceGeneratorTest/EngineObject.cs
+++ b/tests/SourceGeneratorTest/EngineObject.cs
@@ -57,6 +57,22 @@ public class EngineObject
         {
         }
 
+        protected TResource? ExchangeOwnedResource<TResource>(
+            ref TResource? location,
+            TResource? value)
+            where TResource : Resource
+        {
+            lock (_resourceOwnershipGate)
+            {
+                if (System.Threading.Volatile.Read(ref _disposeState) != 0)
+                {
+                    throw new ObjectDisposedException(GetType().FullName);
+                }
+
+                return System.Threading.Interlocked.Exchange(ref location, value);
+            }
+        }
+
         protected void SetOwnedResource<TResource>(
             ref TResource? location,
             TResource? value)
@@ -75,6 +91,29 @@ public class EngineObject
 
                 current?.Dispose();
                 System.Threading.Interlocked.Exchange(ref location, value);
+            }
+        }
+
+        protected TResource ReplaceOwnedResource<TResource>(
+            ref TResource? location,
+            TResource replacement)
+            where TResource : Resource
+        {
+            lock (_resourceOwnershipGate)
+            {
+                if (System.Threading.Volatile.Read(ref _disposeState) != 0)
+                {
+                    throw new ObjectDisposedException(GetType().FullName);
+                }
+
+                ArgumentNullException.ThrowIfNull(replacement);
+                TResource current = location ?? throw new InvalidOperationException();
+                if (ReferenceEquals(current, replacement))
+                {
+                    throw new ArgumentException(null, nameof(replacement));
+                }
+
+                return System.Threading.Interlocked.Exchange(ref location, replacement)!;
             }
         }
 


### PR DESCRIPTION
## Description

Stacked-PR slice **3/5** of `speckit/004-gpu-pass-fusion` (tests and benchmark harness coverage).

This slice adds renderer-wide recording, planning, fusion, resource-lifetime, failure-matrix, cache, ROI, nested-target, diagnostics, benchmark-contract, and GPU golden suites. It deliberately excludes the built-in Shader migration tests, which land with their production changes in slice 5, and the immutable evidence corpus, which begins in slice 4.

The review follow-up hardens the evidence producer and analyzer before the corpus is introduced: output archives and feature-harness provenance are mandatory, setup and measured RGBA16F blobs are authenticated independently, logical geometry is compared for every case, and baseline and feature revisions must be distinct. The affected S3 fixtures were also migrated to the final S2 named-resource, deep-state, allocation-budget, and phase-dependent cache contracts.

## Stack

1. `speckit/004-s1-spec` — specification and contracts
2. `speckit/004-s2-engine` — record-then-plan engine and consumer migration
3. **This PR** — pipeline, benchmark-contract, and rendering test suites
4. `speckit/004-s4-evidence` — benchmarks, paired evidence, and acceptance
5. `speckit/004-s5-shader-migration` — built-in Shader migration, excluding Blur and DropShadow

## Affected areas

- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [x] Build / CI / docs only

## Breaking changes

None in this slice.

## Review follow-up (2026-08-09)

- Required baseline, baseline-repeat, and feature output archives plus both harness source trees.
- Upgraded counters to schema 3 with separately authenticated setup and measured RGBA16F blobs, including length, SHA-256, checksum, dimensions, logical bounds, and cross-pipeline checks.
- Rejected identical baseline and feature revisions and recorded tracked feature-harness hashes in the manifest.
- Eliminated the extra setup render, added a real Blur stage to `MixedSpatialColor`, and strengthened effect and primary-stage non-vacuity controls without lowering tolerances.
- Made artifact writes root-confined, bound manifest parsing and hashing to one byte snapshot, and derived the feature revision from assembly provenance instead of the caller working directory.
- Extended the synchronous recording census through helpers and local functions, recognized parenthesized null-forgiving original access, and required visible detached-geometry pixels.
- Preserved the Stack 3 evidence boundary: corpus-backed tests skip before reading files only while slice 4 is absent, and become strict from slice 4 onward.
- Propagated the final reviewed S2 contract through an ordinary signed merge; no branch was rebased or force-pushed.

All 17 unresolved inline review threads were answered and resolved. The two review-summary findings about deterministic non-finite output and blank SKSL output were also addressed and answered.

## Test plan

- Fresh `Beutl.UnitTests`: 6,319 passed, 16 expected skips, 0 failed.
- Focused renderer and evidence-contract tests: 185 passed, 1 expected Stack 4 evidence skip, 0 failed.
- `Beutl.HeadlessUITests`: 250/250 passed.
- `Beutl.PublicApiContractTests`: 194/194 passed.
- `SourceGeneratorTest`: 30/30 passed.
- GPU `Beutl.Graphics3DTests`: 14/14 passed on Apple M3 / MoltenVK.
- Solution-wide `dotnet format --verify-no-changes` and `git diff --check`: passed.

## Fixed issues / References

- Feature 004: renderer-wide GPU pass fusion


## Review follow-up (2026-08-10)

- Followed expression-bodied property getters in the recording side-effect census and added a red-first Roslyn regression.
- Replaced the unstable rotated InnerShadow parity fixture with the already-proven finite axis-aligned survey fixture without weakening non-finite, SSIM, or non-vacuity gates.
- Propagated final S1/S2 contracts through an ordinary signed merge, migrated 31 render-target factories and 14 target-scope call sites, and removed one generated-resource ownership alias.
- Replied to and resolved the newly raised review thread.

Validation: fresh solution build 0 warnings / 0 errors; focused contracts 60/60; Geometry ownership 33/33; recording/census 16 passed / 1 expected evidence skip; Apple M3/MoltenVK parity 30/30; PublicApiContractTests 212/212; SourceGeneratorTest 30/30; full UnitTests 6,325 passed / 16 expected skips / 0 failed; format and diff checks passed. The InnerShadow fixture also passed Linux arm64 SwiftShader; Linux x64 SwiftShader remains delegated to PR CI.
