### PR TITLE
fix: prevent crash when importing video without audio track

### DIFF
--- a/src/Beutl.Engine/Audio/Sound.cs
+++ b/src/Beutl.Engine/Audio/Sound.cs
@@ -48,7 +48,9 @@ public abstract partial class Sound : EngineObject
         }
 
         var soundSource = resource.GetSoundSource();
-        if (soundSource == null)
+        // SampleRate <= 0 marks an unreadable source (e.g. a video-only file, #2183); composing a
+        // ResampleNode at zero rate would throw, so emit silence instead.
+        if (soundSource == null || soundSource.SampleRate <= 0)
         {
             context.Clear();
             return;

--- a/src/Beutl.Engine/Audio/SourceSound.cs
+++ b/src/Beutl.Engine/Audio/SourceSound.cs
@@ -25,7 +25,7 @@ public sealed partial class SourceSound : Sound, IOriginalDurationProvider, ISpl
     public bool TryGetOriginalDuration(out TimeSpan timeSpan)
     {
         using var resource = Source.CurrentValue?.ToResource(CompositionContext.Default);
-        if (resource != null)
+        if (resource != null && resource.Duration > TimeSpan.Zero)
         {
             timeSpan = resource.Duration;
             return true;

--- a/src/Beutl.Engine/Media/Source/SoundSource.cs
+++ b/src/Beutl.Engine/Media/Source/SoundSource.cs
@@ -134,13 +134,6 @@ public sealed class SoundSource : MediaSource
                     {
                         var reader = MediaReader.Open(soundSource.Uri.LocalPath, new(MediaMode.Audio));
                         _counter = new Counter<MediaReader>(reader, null);
-                        // DisableResourceShare 時は WeakReference を書き換えない。
-                        // 他 Renderer（プレビュー側）の共有カウンタを
-                        // エンコード専用カウンタで汚染してしまうため。
-                        if (!context.DisableResourceShare)
-                        {
-                            Volatile.Write(ref soundSource._mediaReaderRef, new WeakReference<Counter<MediaReader>>(_counter));
-                        }
                     }
                     catch
                     {
@@ -148,6 +141,30 @@ public sealed class SoundSource : MediaSource
                         _loadedUri = soundSource.Uri;
                         return;
                     }
+                }
+
+                // A media without an audio stream (e.g. a video-only file) cannot expose AudioInfo
+                // without throwing, so treat it as an unreadable source (#2183): release the reader
+                // and zero the metadata so callers safely see "no audio". Never publish such a
+                // counter to the shared cache, which would poison other resources with a silent
+                // source.
+                if (!_counter.Value.HasAudio)
+                {
+                    _counter.Release();
+                    _counter = null;
+                    Duration = TimeSpan.Zero;
+                    SampleRate = 0;
+                    NumChannels = 0;
+                    _loadedUri = soundSource.Uri;
+                    return;
+                }
+
+                if (!context.DisableResourceShare && shared is null)
+                {
+                    // When DisableResourceShare is set, do not rewrite the WeakReference: it would
+                    // contaminate other renderers' (preview-side) shared counter with an
+                    // encode-only counter.
+                    Volatile.Write(ref soundSource._mediaReaderRef, new WeakReference<Counter<MediaReader>>(_counter));
                 }
 
                 Duration = TimeSpan.FromSeconds(_counter.Value.AudioInfo.Duration.ToDouble());

--- a/src/Beutl/ViewModels/EditContext/ElementAdderImpl.cs
+++ b/src/Beutl/ViewModels/EditContext/ElementAdderImpl.cs
@@ -336,17 +336,20 @@ internal sealed class ElementAdderImpl(EditViewModel context) : IElementAdder
             .Distinct());
     }
 
-    private static bool HasAudioTrack(string filePath)
+    private bool HasAudioTrack(string filePath)
     {
         try
         {
             using var reader = MediaReader.Open(filePath, new MediaOptions(MediaMode.Audio));
             return reader.HasAudio;
         }
-        catch
+        catch (Exception ex)
         {
-            // Treat an unopenable audio stream (no audio track, or no usable decoder) as
-            // audio-less; the video import itself still proceeds.
+            // A failed audio open means either the file genuinely has no audio track, or the audio
+            // decoder is unavailable (e.g. missing FFmpeg natives, unsupported codec). Treat both as
+            // audio-less so the video import proceeds, but log the reason so a silently dropped
+            // audio companion stays diagnosable.
+            _logger.LogWarning(ex, "Failed to open the audio stream of '{File}' for track detection; importing as video-only.", filePath);
             return false;
         }
     }

--- a/src/Beutl/ViewModels/EditContext/ElementAdderImpl.cs
+++ b/src/Beutl/ViewModels/EditContext/ElementAdderImpl.cs
@@ -124,17 +124,18 @@ internal sealed class ElementAdderImpl(EditViewModel context) : IElementAdder
             else if (MatchFileVideoOnly(desc.FileName))
             {
                 _logger.LogDebug("File is a video.");
-                // The audio companion goes to desc.Layer + 1; refuse the whole
-                // import rather than adding the video without its sound.
-                if (scene.IsLayerLocked(desc.Layer + 1))
+                // Probe the audio track so a video-only file (e.g. an .mkv without sound) does not
+                // get a SourceSound element that would crash on AudioInfo access (#2183).
+                bool hasAudio = HasAudioTrack(desc.FileName);
+                // The audio companion goes to desc.Layer + 1; refuse the whole import when that
+                // layer is locked and an audio companion is actually going to be created.
+                if (hasAudio && scene.IsLayerLocked(desc.Layer + 1))
                 {
                     NotificationService.ShowWarning(Strings.Lock, Strings.LayerIsLocked);
                     return;
                 }
 
                 Element element1 = CreateElementFor<SourceVideo>(out var t1);
-                Element element2 = CreateElementFor<SourceSound>(out var t2);
-                element2.ZIndex++;
                 var video = VideoSource.Open(desc.FileName);
                 t1.Source.CurrentValue = video;
                 var videoResource = TrySetDuration(
@@ -142,12 +143,19 @@ internal sealed class ElementAdderImpl(EditViewModel context) : IElementAdder
                     () => video.ToResource(CompositionContext.Default),
                     v => v.Duration);
 
-                var sound = SoundSource.Open(desc.FileName);
-                t2.Source.CurrentValue = sound;
-                var soundResource = TrySetDuration(
-                    element2,
-                    () => sound.ToResource(CompositionContext.Default),
-                    v => v.Duration);
+                Element? element2 = null;
+                SoundSource.Resource? soundResource = null;
+                if (hasAudio)
+                {
+                    element2 = CreateElementFor<SourceSound>(out var t2);
+                    element2.ZIndex++;
+                    var sound = SoundSource.Open(desc.FileName);
+                    t2.Source.CurrentValue = sound;
+                    soundResource = TrySetDuration(
+                        element2,
+                        () => sound.ToResource(CompositionContext.Default),
+                        v => v.Duration);
+                }
                 // VideoSource.Resource, SoundSource.ResourceのMediaReaderは参照カウンターで管理され、Resource間で共有される
                 // すぐに解放してしまうとこのDuration設定時とレンダリング時の2回MediaReaderが生成されてしまう
                 // 作成 -> 参照カウントを引く -> 解放 -> レンダラ側で作成 のようになってしまう
@@ -160,11 +168,14 @@ internal sealed class ElementAdderImpl(EditViewModel context) : IElementAdder
                 }, DispatchPriority.Low)));
 
                 CoreSerializer.StoreToUri(element1, element1.Uri!);
-                CoreSerializer.StoreToUri(element2, element2.Uri!);
                 scene.AddChild(element1);
-                scene.AddChild(element2);
-                // グループ化
-                scene.Groups.Add([element1.Id, element2.Id]);
+                if (element2 != null)
+                {
+                    CoreSerializer.StoreToUri(element2, element2.Uri!);
+                    scene.AddChild(element2);
+                    // グループ化
+                    scene.Groups.Add([element1.Id, element2.Id]);
+                }
                 scrollPos = (element1.Range, element1.ZIndex);
             }
             else if (MatchFileAudioOnly(desc.FileName))
@@ -323,6 +334,21 @@ internal sealed class ElementAdderImpl(EditViewModel context) : IElementAdder
         return MatchFileExtensions(filePath, DecoderRegistry.EnumerateDecoder()
             .SelectMany(x => x.VideoExtensions())
             .Distinct());
+    }
+
+    private static bool HasAudioTrack(string filePath)
+    {
+        try
+        {
+            using var reader = MediaReader.Open(filePath, new MediaOptions(MediaMode.Audio));
+            return reader.HasAudio;
+        }
+        catch
+        {
+            // Treat an unopenable audio stream (no audio track, or no usable decoder) as
+            // audio-less; the video import itself still proceeds.
+            return false;
+        }
     }
 
     private static bool MatchFileImage(string filePath)

--- a/tests/Beutl.HeadlessUITests/VideoFileImportTests.cs
+++ b/tests/Beutl.HeadlessUITests/VideoFileImportTests.cs
@@ -1,0 +1,191 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Avalonia.Headless.NUnit;
+using Beutl.Audio;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Graphics;
+using Beutl.Media;
+using Beutl.Media.Decoding;
+using Beutl.Media.Music;
+using Beutl.Media.Source;
+using Beutl.ProjectSystem;
+using Beutl.Services;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+
+namespace Beutl.HeadlessUITests;
+
+// Regression tests for #2183: dropping a video without an audio track onto the timeline must not
+// add a SourceSound element (which crashed when its resource dereferenced AudioInfo).
+[TestFixture]
+public class VideoFileImportTests
+{
+    private static readonly object s_registerLock = new();
+    private static bool s_registered;
+
+    private static Task ResetProjectAsync() => TestReset.ResetShellAsync();
+
+    private static string NewWorkspace(string name)
+    {
+        string location = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(location);
+        return location;
+    }
+
+    private static async Task<EditViewModel> OpenEditorForNewScene(string name)
+    {
+        Project project = (await TestShell.Project.CreateProject(
+            640, 480, 30, 44100, name, NewWorkspace(name)))!;
+        HeadlessTestHelpers.Settle();
+        Scene scene = project.Items.OfType<Scene>().First();
+
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+
+        EditorTabItem tab = TestShell.Editor.SelectedTabItem.Value!;
+        return (EditViewModel)tab.Context.Value;
+    }
+
+    [AvaloniaTest]
+    public async Task ImportVideoWithoutAudioTrack_AddsOnlyVideoElement()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("videoonly");
+        RegisterImportDecoder();
+        string path = CreateImportFile("sample", withAudio: false);
+
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        adder.AddElement(new ElementDescription(
+            Start: TimeSpan.Zero,
+            Length: TimeSpan.FromSeconds(5),
+            Layer: 0,
+            FileName: path));
+        HeadlessTestHelpers.Settle();
+
+        Assert.That(editor.Scene.Children, Has.Count.EqualTo(1),
+            "音声トラックのない動画はビデオ要素のみ追加する (#2183)");
+        Element element = editor.Scene.Children[0];
+        Assert.Multiple(() =>
+        {
+            Assert.That(element.Objects.OfType<SourceVideo>().Any(), Is.True);
+            Assert.That(element.Objects.OfType<SourceSound>().Any(), Is.False,
+                "音声トラックのない動画に音声要素を追加してはならない (#2183)");
+        });
+        Assert.That(editor.Scene.Groups, Is.Empty,
+            "音声要素がないのでグループ化も発生しない (#2183)");
+    }
+
+    [AvaloniaTest]
+    public async Task ImportVideoWithAudioTrack_AddsVideoAndSoundElementsAsGroup()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("videoaudio");
+        RegisterImportDecoder();
+        string path = CreateImportFile("sample", withAudio: true);
+
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        adder.AddElement(new ElementDescription(
+            Start: TimeSpan.Zero,
+            Length: TimeSpan.FromSeconds(5),
+            Layer: 0,
+            FileName: path));
+        HeadlessTestHelpers.Settle();
+
+        Assert.That(editor.Scene.Children, Has.Count.EqualTo(2),
+            "音声トラックのある動画はビデオ要素と音声要素の両方を追加する");
+        Assert.That(editor.Scene.Children.Count(c => c.Objects.OfType<SourceVideo>().Any()), Is.EqualTo(1));
+        Assert.That(editor.Scene.Children.Count(c => c.Objects.OfType<SourceSound>().Any()), Is.EqualTo(1));
+        Assert.That(editor.Scene.Groups, Has.Count.EqualTo(1),
+            "音声要素がある場合は従来どおりグループ化する");
+    }
+
+    private static void RegisterImportDecoder()
+    {
+        lock (s_registerLock)
+        {
+            if (s_registered) return;
+            DecoderRegistry.Register(new ImportTestDecoderInfo());
+            s_registered = true;
+        }
+    }
+
+    private static string CreateImportFile(string stem, bool withAudio)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "beutl-import-tests");
+        Directory.CreateDirectory(dir);
+        string ext = withAudio ? ".vaudio" : ".vonly";
+        string path = Path.Combine(dir, $"{stem}-{Guid.NewGuid():N}{ext}");
+        File.WriteAllBytes(path, []);
+        return path;
+    }
+
+    private sealed class ImportTestDecoderInfo : IDecoderInfo
+    {
+        public string Name => "Import Test Decoder";
+
+        public MediaReader? Open(string file, MediaOptions options)
+        {
+            string ext = Path.GetExtension(file);
+            return ext switch
+            {
+                ".vonly" => new ImportTestReader(hasVideo: true, hasAudio: false),
+                ".vaudio" => new ImportTestReader(hasVideo: true, hasAudio: true),
+                _ => null,
+            };
+        }
+
+        public IEnumerable<string> VideoExtensions() => [".vonly", ".vaudio"];
+
+        public IEnumerable<string> AudioExtensions() => [];
+    }
+
+    // Mirrors the real backends: AudioInfo/VideoInfo throw "The stream does not exist." when the
+    // reader was not created with the corresponding stream, exactly like FFmpegReaderProxy.
+    private sealed class ImportTestReader : MediaReader
+    {
+        private readonly VideoStreamInfo? _videoInfo;
+        private readonly AudioStreamInfo? _audioInfo;
+
+        public ImportTestReader(bool hasVideo, bool hasAudio)
+        {
+            HasVideo = hasVideo;
+            HasAudio = hasAudio;
+            if (hasVideo)
+            {
+                _videoInfo = new VideoStreamInfo(
+                    "test",
+                    numFrames: 60,
+                    new PixelSize(80, 80),
+                    new Rational(30, 1));
+            }
+            if (hasAudio)
+            {
+                _audioInfo = new AudioStreamInfo(
+                    "test",
+                    new Rational(2, 1),
+                    44100,
+                    2);
+            }
+        }
+
+        public override VideoStreamInfo VideoInfo => _videoInfo ?? throw new Exception("The stream does not exist.");
+
+        public override AudioStreamInfo AudioInfo => _audioInfo ?? throw new Exception("The stream does not exist.");
+
+        public override bool HasVideo { get; }
+
+        public override bool HasAudio { get; }
+
+        public override bool ReadVideo(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
+        {
+            image = null;
+            return false;
+        }
+
+        public override bool ReadAudio(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
+        {
+            sound = null;
+            return false;
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/VideoFileImportTests.cs
+++ b/tests/Beutl.HeadlessUITests/VideoFileImportTests.cs
@@ -22,6 +22,21 @@ public class VideoFileImportTests
 {
     private static readonly object s_registerLock = new();
     private static bool s_registered;
+    private static string? s_tempDir;
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        try
+        {
+            if (s_tempDir != null && Directory.Exists(s_tempDir))
+                Directory.Delete(s_tempDir, recursive: true);
+        }
+        catch (Exception)
+        {
+            // Best-effort cleanup of the temp fixture; a leftover directory must not fail the run.
+        }
+    }
 
     private static Task ResetProjectAsync() => TestReset.ResetShellAsync();
 
@@ -111,10 +126,10 @@ public class VideoFileImportTests
 
     private static string CreateImportFile(string stem, bool withAudio)
     {
-        string dir = Path.Combine(Path.GetTempPath(), "beutl-import-tests");
-        Directory.CreateDirectory(dir);
+        s_tempDir ??= Path.Combine(Path.GetTempPath(), $"beutl-import-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(s_tempDir);
         string ext = withAudio ? ".vaudio" : ".vonly";
-        string path = Path.Combine(dir, $"{stem}-{Guid.NewGuid():N}{ext}");
+        string path = Path.Combine(s_tempDir, $"{stem}-{Guid.NewGuid():N}{ext}");
         File.WriteAllBytes(path, []);
         return path;
     }

--- a/tests/Beutl.UnitTests/Engine/Audio/ComposerTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/ComposerTests.cs
@@ -5,6 +5,8 @@ using Beutl.Audio.Graph;
 using Beutl.Composition;
 using Beutl.Engine;
 using Beutl.Media;
+using Beutl.Media.Source;
+using Beutl.UnitTests.Engine.Graphics.Rendering;
 
 namespace Beutl.UnitTests.Engine.Audio;
 
@@ -47,5 +49,44 @@ public class ComposerTests
         // ヘルパー経由で取得した値とそのまま比較し、Composer の silence fallback がヘルパーと
         // 乖離した場合 (整数秒入力でも) に検出できるようにする。
         Assert.That(buffer!.SampleCount, Is.EqualTo(AudioProcessContext.GetSampleCount(range, sampleRate)));
+    }
+
+    // Regression for #2183: a SourceSound whose media has no audio track (video-only file) loads as an
+    // unreadable source (SampleRate == 0). Sound.Compose must emit silence instead of throwing from
+    // CreateResampleNode(0) / AudioProcessContext.
+    [Test]
+    public void Compose_SourceSoundWithNoAudioTrack_ReturnsSilenceInsteadOfThrowing()
+    {
+        TestMediaHelper.RegisterTestDecoder();
+        string videoPath = TestMediaHelper.CreateTestVideoFile(80, 80, new Rational(30, 1), 60);
+        var source = new SoundSource();
+        source.ReadFrom(new Uri(videoPath));
+        var sound = new SourceSound();
+        sound.Source.CurrentValue = source;
+
+        using var resource = (SourceSound.Resource)sound.ToResource(CompositionContext.Default);
+        var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+        var frame = new CompositionFrame(
+            ImmutableArray.Create((EngineObject.Resource)resource), range, default);
+
+        const int sampleRate = 44100;
+        using var composer = new Composer { SampleRate = sampleRate };
+
+        AudioBuffer? buffer = null;
+        Assert.DoesNotThrow(() => buffer = composer.Compose(range, frame));
+
+        using (buffer)
+        {
+            Assert.That(buffer, Is.Not.Null);
+            Assert.That(buffer!.SampleRate, Is.EqualTo(sampleRate));
+            Assert.That(buffer.ChannelCount, Is.EqualTo(2));
+            Assert.That(buffer.SampleCount, Is.EqualTo(AudioProcessContext.GetSampleCount(range, sampleRate)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(buffer.GetChannelData(0).ToArray(), Is.All.EqualTo(0f),
+                    "音声トラックのないソースは無音を出力する (#2183)");
+                Assert.That(buffer.GetChannelData(1).ToArray(), Is.All.EqualTo(0f));
+            });
+        }
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs
@@ -160,6 +160,27 @@ public class SourceSoundThumbnailTests
             Is.EqualTo(totalSamples));
     }
 
+    // Regression for #2183: a video-only source (no audio track) loads as an unreadable resource
+    // (Duration == 0). TryGetOriginalDuration must return false instead of reporting a zero duration,
+    // so timeline resize/trim code does not act on it (or crash dereferencing AudioInfo).
+    [Test]
+    public void TryGetOriginalDuration_VideoOnlySource_ReturnsFalse()
+    {
+        string path = TestMediaHelper.CreateTestVideoFile(80, 80, new Rational(30, 1), 60);
+        var soundSource = new SoundSource();
+        soundSource.ReadFrom(new Uri(path));
+        var sound = new SourceSound
+        {
+            Source = { CurrentValue = soundSource }
+        };
+
+        bool result = sound.TryGetOriginalDuration(out TimeSpan duration);
+
+        Assert.That(result, Is.False,
+            "音声トラックのないソースは元の長さを持たない (#2183)");
+        Assert.That(duration, Is.EqualTo(TimeSpan.Zero));
+    }
+
     private static async Task<List<WaveformChunk>> CollectAsync(
         SourceSound sound, int chunkCount, int samplesPerChunk, IThumbnailCacheService cache)
     {

--- a/tests/Beutl.UnitTests/Engine/Graphics/MediaSourceResourceShareTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/MediaSourceResourceShareTest.cs
@@ -69,9 +69,9 @@ public class MediaSourceResourceShareTest
     [Test]
     public void SoundSource_SharedByDefault_ReusesMediaReader()
     {
-        var videoPath = TestMediaHelper.CreateTestVideoFile(80, 80, new Rational(30, 1), 60);
+        var audioPath = TestMediaHelper.CreateTestAudioFile(durationSeconds: 2.0);
         var soundSource = new SoundSource();
-        soundSource.ReadFrom(new Uri(videoPath));
+        soundSource.ReadFrom(new Uri(audioPath));
 
         using var a = soundSource.ToResource(CompositionContext.Default);
         using var b = soundSource.ToResource(CompositionContext.Default);
@@ -85,9 +85,9 @@ public class MediaSourceResourceShareTest
     [Test]
     public void SoundSource_DisableResourceShare_YieldsIndependentMediaReader()
     {
-        var videoPath = TestMediaHelper.CreateTestVideoFile(80, 80, new Rational(30, 1), 60);
+        var audioPath = TestMediaHelper.CreateTestAudioFile(durationSeconds: 2.0);
         var soundSource = new SoundSource();
-        soundSource.ReadFrom(new Uri(videoPath));
+        soundSource.ReadFrom(new Uri(audioPath));
 
         using var preview = soundSource.ToResource(CompositionContext.Default);
         using var encode = soundSource.ToResource(
@@ -152,9 +152,9 @@ public class MediaSourceResourceShareTest
     [Test]
     public void SoundSource_DisableResourceShare_DoesNotContaminateSharedCache()
     {
-        var videoPath = TestMediaHelper.CreateTestVideoFile(80, 80, new Rational(30, 1), 60);
+        var audioPath = TestMediaHelper.CreateTestAudioFile(durationSeconds: 2.0);
         var soundSource = new SoundSource();
-        soundSource.ReadFrom(new Uri(videoPath));
+        soundSource.ReadFrom(new Uri(audioPath));
 
         // エンコード側が先に Resource を生成しても、プレビュー側 (共有モード) は
         // エンコード専用 MediaReader を掴まない
@@ -215,8 +215,8 @@ public class MediaSourceResourceShareTest
     [Test]
     public void SoundSource_ReadFromDifferentUri_DoesNotShareStaleCounter()
     {
-        var pathOld = TestMediaHelper.CreateTestVideoFile(80, 80, new Rational(30, 1), 60);
-        var pathNew = TestMediaHelper.CreateTestVideoFile(120, 120, new Rational(30, 1), 60);
+        var pathOld = TestMediaHelper.CreateTestAudioFile(sampleRate: 44100, durationSeconds: 2.0);
+        var pathNew = TestMediaHelper.CreateTestAudioFile(sampleRate: 48000, durationSeconds: 3.0);
 
         var soundSource = new SoundSource();
         soundSource.ReadFrom(new Uri(pathOld));
@@ -230,5 +230,40 @@ public class MediaSourceResourceShareTest
         Assert.That(newResource.MediaReader, Is.Not.Null);
         Assert.That(newResource.MediaReader, Is.Not.SameAs(oldResource.MediaReader),
             "URI 切替後の Resource が旧 URI の MediaReader を共有してはならない");
+    }
+
+    // Regression for #2183: a video-only file (no audio track) must not crash SoundSource.Resource.
+    // The test decoder's TestMediaReader reports HasAudio == false for .testvideo files, mirroring the
+    // FFmpegReaderProxy behavior that threw "The stream does not exist." when AudioInfo was dereferenced.
+    [Test]
+    public void SoundSource_VideoOnlyFile_DoesNotThrowAndYieldsUnloadedResource()
+    {
+        var videoPath = TestMediaHelper.CreateTestVideoFile(80, 80, new Rational(30, 1), 60);
+        var soundSource = new SoundSource();
+        soundSource.ReadFrom(new Uri(videoPath));
+
+        using var resource = soundSource.ToResource(CompositionContext.Default);
+
+        Assert.That(resource.MediaReader, Is.Null,
+            "音声トラックのないメディアは MediaReader を保持してはならない (#2183)");
+        Assert.That(resource.Duration, Is.EqualTo(TimeSpan.Zero));
+        Assert.That(resource.SampleRate, Is.Zero);
+        Assert.That(resource.NumChannels, Is.Zero);
+    }
+
+    [Test]
+    public void SoundSource_VideoOnlyFile_RepeatedResource_DoesNotThrow()
+    {
+        var videoPath = TestMediaHelper.CreateTestVideoFile(80, 80, new Rational(30, 1), 60);
+        var soundSource = new SoundSource();
+        soundSource.ReadFrom(new Uri(videoPath));
+
+        using var a = soundSource.ToResource(CompositionContext.Default);
+        using var b = soundSource.ToResource(CompositionContext.Default);
+
+        // The unloaded result must be stable: opening the same video-only source again must not throw
+        // or resurrect a stale counter.
+        Assert.That(a.MediaReader, Is.Null);
+        Assert.That(b.MediaReader, Is.Null);
     }
 }


### PR DESCRIPTION
## Description
- Dropping a video file without an audio track (e.g. a video-only `.mkv`) onto the timeline always created a `SourceSound` element, which crashed when its resource dereferenced `AudioInfo` ("The stream does not exist.")
- The importer now probes the file for an audio track and skips the sound element when there is none; the video element is still added as before
- `SoundSource` and the audio graph now treat audio-less media as an unreadable source instead of throwing, so existing projects with such elements no longer crash on resize, render, or waveform generation

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None

## Test plan
- `tests/Beutl.HeadlessUITests/VideoFileImportTests.cs`: importing a video-only file adds only the video element (no `SourceSound`, no group); a file with audio still adds both elements as a group
- `tests/Beutl.UnitTests/Engine/Graphics/MediaSourceResourceShareTest.cs`: `SoundSource` over a video-only file yields an unloaded resource without throwing; repeated opens stay stable
- `tests/Beutl.UnitTests/Engine/Audio/ComposerTests.cs`: composing a `SourceSound` without an audio track emits silence instead of throwing
- `tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs`: `TryGetOriginalDuration` returns false for a video-only source
- Full `Beutl.UnitTests`: 4,959 passed / 3 skipped / 0 failed; `Beutl.HeadlessUITests`: 195 passed

## Fixed issues / References
- Closes #2183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of video-only media during import.
  - Video files without audio now create only a video element, avoiding unnecessary sound elements.
  - Audio resources without valid tracks no longer cause errors or invalid duration data.
  - Audio composition now safely produces silence when no readable audio source is available.
  - Preserved grouping behavior for videos that include audio tracks.

- **Tests**
  - Added regression coverage for importing video-only and audiovisual files.
  - Added validation for safe audio composition and resource handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->