### PR TITLE
feat: Use portrait-specific default dock layout for scenes

### DIFF
--- a/src/Beutl/ViewModels/Dock/BeutlDockFactory.cs
+++ b/src/Beutl/ViewModels/Dock/BeutlDockFactory.cs
@@ -29,6 +29,19 @@ public class BeutlDockFactory(EditViewModel editViewModel) : Factory
 
     public override IRootDock CreateLayout()
     {
+        return IsPortraitScene()
+            ? CreatePortraitLayout()
+            : CreateLandscapeLayout();
+    }
+
+    private bool IsPortraitScene()
+    {
+        var frameSize = editViewModel.Scene.FrameSize;
+        return frameSize.Height > frameSize.Width;
+    }
+
+    private IRootDock CreateLandscapeLayout()
+    {
         var leftDock = CreateAnchoredDock(DockAnchor.Left);
 
         var playerDockable = new PlayerToolDockable(editViewModel.Player, Strings.Preview);
@@ -59,6 +72,60 @@ public class BeutlDockFactory(EditViewModel editViewModel) : Factory
             topDock,
             CreateProportionalDockSplitter(),
             bottomDock);
+
+        var rootDock = CreateRootDock();
+        rootDock.Id = DockIds.Root;
+        rootDock.Title = "Editor";
+        rootDock.IsCollapsable = false;
+        rootDock.VisibleDockables = CreateList<IDockable>(root);
+        rootDock.ActiveDockable = root;
+        rootDock.DefaultDockable = root;
+
+        _rootDock = rootDock;
+        _anchorCacheDirty = true;
+        return rootDock;
+    }
+
+    private IRootDock CreatePortraitLayout()
+    {
+        var playerDockable = new PlayerToolDockable(editViewModel.Player, Strings.Preview);
+        var playerDock = CreateAnchoredDock(DockAnchor.Player);
+        playerDock.VisibleDockables = CreateList<IDockable>(playerDockable);
+        playerDock.ActiveDockable = playerDockable;
+
+        var leftDock = CreateAnchoredDock(DockAnchor.Left);
+        var rightDock = CreateAnchoredDock(DockAnchor.Right);
+
+        // Library / file browser | properties
+        var toolsRow = CreateProportionalDock();
+        toolsRow.Id = DockIds.ToolsRow;
+        toolsRow.Orientation = Orientation.Horizontal;
+        toolsRow.VisibleDockables = CreateList<IDockable>(
+            leftDock,
+            CreateProportionalDockSplitter(),
+            rightDock);
+
+        var bottomDock = CreateAnchoredDock(DockAnchor.Bottom);
+
+        var rightColumn = CreateProportionalDock();
+        rightColumn.Id = DockIds.RightColumn;
+        rightColumn.Orientation = Orientation.Vertical;
+        // Preview : tools column = 1 : 2 (the dock panel normalizes proportions).
+        playerDock.Proportion = 0.5;
+        rightColumn.Proportion = 1.0;
+        rightColumn.VisibleDockables = CreateList<IDockable>(
+            toolsRow,
+            CreateProportionalDockSplitter(),
+            bottomDock);
+
+        var root = CreateProportionalDock();
+        root.Id = DockIds.RootSplit;
+        root.Orientation = Orientation.Horizontal;
+        root.IsCollapsable = false;
+        root.VisibleDockables = CreateList<IDockable>(
+            playerDock,
+            CreateProportionalDockSplitter(),
+            rightColumn);
 
         var rootDock = CreateRootDock();
         rootDock.Id = DockIds.Root;

--- a/src/Beutl/ViewModels/Dock/DockIds.cs
+++ b/src/Beutl/ViewModels/Dock/DockIds.cs
@@ -5,6 +5,8 @@ internal static class DockIds
     public const string Root = "Root";
     public const string RootSplit = "Dock.Root";
     public const string TopSplit = "Dock.TopSplit";
+    public const string RightColumn = "Dock.RightColumn";
+    public const string ToolsRow = "Dock.ToolsRow";
     public const string Left = "Dock.Left";
     public const string Right = "Dock.Right";
     public const string Bottom = "Dock.Bottom";

--- a/tests/Beutl.HeadlessUITests/DefaultLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/DefaultLayoutTests.cs
@@ -1,12 +1,12 @@
-using Avalonia.Headless.NUnit;
+﻿using Avalonia.Headless.NUnit;
 using Beutl.Editor.Components.ElementPropertyTab;
 using Beutl.Editor.Components.FileBrowserTab;
 using Beutl.Editor.Components.LibraryTab;
 using Beutl.ProjectSystem;
+using Beutl.Services.PrimitiveImpls;
 using Beutl.Testing.Headless;
 using Beutl.ViewModels;
 using Beutl.ViewModels.Dock;
-using Beutl.Services.PrimitiveImpls;
 using Dock.Model.Controls;
 using Dock.Model.Core;
 

--- a/tests/Beutl.HeadlessUITests/DefaultLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/DefaultLayoutTests.cs
@@ -1,0 +1,113 @@
+using Avalonia.Headless.NUnit;
+using Beutl.Editor.Components.ElementPropertyTab;
+using Beutl.Editor.Components.FileBrowserTab;
+using Beutl.Editor.Components.LibraryTab;
+using Beutl.ProjectSystem;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.ViewModels.Dock;
+using Beutl.Services.PrimitiveImpls;
+using Dock.Model.Controls;
+using Dock.Model.Core;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class DefaultLayoutTests
+{
+    private static Task ResetProjectAsync() => TestReset.ResetShellAsync();
+
+    private static string NewWorkspace(string name)
+    {
+        string location = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(location);
+        return location;
+    }
+
+    private static async Task<EditViewModel> OpenEditorForNewScene(int width, int height, string name)
+    {
+        Project project = (await TestShell.Project.CreateProject(
+            width, height, 30, 44100, name, NewWorkspace(name)))!;
+        HeadlessTestHelpers.Settle();
+        Scene scene = project.Items.OfType<Scene>().First();
+
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+    }
+
+    [AvaloniaTest]
+    public async Task Landscape_scene_uses_landscape_default_layout()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene(1920, 1080, "layout-landscape");
+
+        IRootDock root = editor.DockHost.Layout.Value;
+        var docks = BeutlDockFactory.Traverse(root).OfType<IDock>().ToList();
+
+        var rootSplit = docks.Single(d => d.Id == DockIds.RootSplit);
+        Assert.That(((IProportionalDock)rootSplit).Orientation, Is.EqualTo(Orientation.Vertical));
+
+        // Landscape: tools | preview | properties on top, timeline below.
+        Assert.That(docks.Any(d => d.Id == DockIds.TopSplit), Is.True);
+        Assert.That(docks.Any(d => d.Id == DockIds.RightColumn), Is.False);
+        Assert.That(docks.Any(d => d.Id == DockIds.ToolsRow), Is.False);
+
+        Assert.That(GetToolDockIds(editor, typeof(LibraryTabExtension)), Does.Contain(DockIds.Left));
+        Assert.That(GetToolDockIds(editor, typeof(FileBrowserTabExtension)), Does.Contain(DockIds.Left));
+        Assert.That(GetToolDockIds(editor, typeof(ElementPropertyTabExtension)), Does.Contain(DockIds.Right));
+        Assert.That(GetToolDockIds(editor, typeof(TimelineTabExtension)), Does.Contain(DockIds.Bottom));
+    }
+
+    [AvaloniaTest]
+    public async Task Portrait_scene_uses_portrait_default_layout()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene(1080, 1920, "layout-portrait");
+
+        IRootDock root = editor.DockHost.Layout.Value;
+        var docks = BeutlDockFactory.Traverse(root).OfType<IDock>().ToList();
+
+        var rootSplit = docks.Single(d => d.Id == DockIds.RootSplit);
+        Assert.That(((IProportionalDock)rootSplit).Orientation, Is.EqualTo(Orientation.Horizontal));
+
+        // Portrait: preview on the left, tools | properties on top right, timeline below.
+        var rightColumn = docks.Single(d => d.Id == DockIds.RightColumn);
+        Assert.That(((IProportionalDock)rightColumn).Orientation, Is.EqualTo(Orientation.Vertical));
+
+        var toolsRow = docks.Single(d => d.Id == DockIds.ToolsRow);
+        Assert.That(((IProportionalDock)toolsRow).Orientation, Is.EqualTo(Orientation.Horizontal));
+        Assert.That(docks.Any(d => d.Id == DockIds.TopSplit), Is.False);
+
+        // Preview : tools column = 1 : 2 (proportions are normalized by the dock panel).
+        var playerDock = docks.OfType<IToolDock>().Single(d => d.Id == DockIds.Player);
+        Assert.That(playerDock.Proportion, Is.EqualTo(0.5));
+        Assert.That(rightColumn.Proportion, Is.EqualTo(1.0));
+
+        Assert.That(GetToolDockIds(editor, typeof(LibraryTabExtension)), Does.Contain(DockIds.Left));
+        Assert.That(GetToolDockIds(editor, typeof(FileBrowserTabExtension)), Does.Contain(DockIds.Left));
+        Assert.That(GetToolDockIds(editor, typeof(ElementPropertyTabExtension)), Does.Contain(DockIds.Right));
+        Assert.That(GetToolDockIds(editor, typeof(TimelineTabExtension)), Does.Contain(DockIds.Bottom));
+    }
+
+    private static string[] GetToolDockIds(EditViewModel editor, Type extensionType)
+    {
+        IRootDock root = editor.DockHost.Layout.Value;
+        return BeutlDockFactory.Traverse(root)
+            .OfType<BeutlToolDockable>()
+            .Where(tool => tool.ToolContext.Extension.GetType() == extensionType)
+            .Select(tool => FindToolDockId(root, tool))
+            .OfType<string>()
+            .ToArray();
+    }
+
+    private static string? FindToolDockId(IDockable root, BeutlToolDockable tool)
+    {
+        foreach (var dock in BeutlDockFactory.Traverse(root).OfType<IToolDock>())
+        {
+            if (dock.VisibleDockables?.Contains(tool) == true)
+                return dock.Id;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Description
- The default dock layout now adapts to the scene frame's aspect ratio. Landscape scenes keep the existing layout (tools | preview | properties on top, timeline below), while portrait scenes get a dedicated layout: preview on the left, library/file browser | properties on the top right, and the timeline underneath.
- In the portrait layout the preview and the tools column share width at a 1:2 ratio.
- The existing `DockAnchor` definitions are reused, so default tabs (library, properties, timeline) are placed without any extension changes.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None

## Test plan
- Added `tests/Beutl.HeadlessUITests/DefaultLayoutTests.cs` verifying the dock tree structure and default tab placement for landscape (1920x1080) and portrait (1080x1920) scenes, including the 1:2 preview/tools-column ratio.
- `dotnet build src/Beutl/Beutl.csproj` passes; the HeadlessUITests full suite (195 tests) passes.

## Fixed issues / References
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic workspace layouts tailored to portrait and landscape scenes.
  * Portrait scenes now place the player above the tools and bottom panel, with tool panels arranged side by side.
  * Landscape scenes retain the existing workspace arrangement.

* **Tests**
  * Added automated coverage to verify default layouts, panel placement, orientation, and proportions for both scene formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->