### PR TITLE
test: stabilize flaky preview render error ordering test

### DIFF
--- a/tests/Beutl.HeadlessUITests/PreviewRenderErrorTests.cs
+++ b/tests/Beutl.HeadlessUITests/PreviewRenderErrorTests.cs
@@ -61,7 +61,10 @@ public class PreviewRenderErrorTests
     private static void DrainPendingPreviewRender()
     {
         HeadlessTestHelpers.Settle();
-        RenderThread.Dispatcher.Invoke(static () => { });
+        // The barrier is a blocking call; bound it so a render-thread deadlock or regression
+        // fails the test with a stack trace instead of hanging the whole headless run.
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        RenderThread.Dispatcher.Invoke(static () => { }, ct: timeout.Token);
         HeadlessTestHelpers.Settle();
     }
 

--- a/tests/Beutl.HeadlessUITests/PreviewRenderErrorTests.cs
+++ b/tests/Beutl.HeadlessUITests/PreviewRenderErrorTests.cs
@@ -45,7 +45,24 @@ public class PreviewRenderErrorTests
 
         TestShell.Editor.ActivateTabItem(scene);
         HeadlessTestHelpers.Settle();
-        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+        EditViewModel editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+
+        // Opening a scene queues a preview render that is dispatched asynchronously to the
+        // render thread; when it succeeds it posts a clear of PreviewRenderError. Drain it
+        // (and the queued clear) so tests start from a settled state and a manual error set
+        // cannot be clobbered by the scene-open render's completion.
+        DrainPendingPreviewRender();
+        return editor;
+    }
+
+    // The scene-open preview render is dispatched asynchronously to the render thread;
+    // when it succeeds it queues a clear of PreviewRenderError. Drain it (and the queued
+    // clear) so a manual error set below is guaranteed to be the latest update.
+    private static void DrainPendingPreviewRender()
+    {
+        HeadlessTestHelpers.Settle();
+        RenderThread.Dispatcher.Invoke(static () => { });
+        HeadlessTestHelpers.Settle();
     }
 
     private static void AddFaultingDrawable(EditViewModel editor)


### PR DESCRIPTION
## Description
- The `PreviewRenderError_LatestQueuedUpdateWins` headless UI test intermittently failed on CI (re-running passed) because opening a scene dispatches a preview render asynchronously to the render thread, and the render's success path posts a clear of `PreviewRenderError` that can land after the manual error sets in the test, resetting the value to null and failing the assertion.
- `OpenEditorForNewScene` now drains the pending render-thread work (and the queued clear) before returning, so every test in this fixture starts from a settled state and a manual `SetPreviewRenderError` is guaranteed to be the latest update.

## Affected areas
- Test-only change (no production module touched).

## Breaking changes
None

## Test plan
- `tests/Beutl.HeadlessUITests/PreviewRenderErrorTests.cs`: `OpenEditorForNewScene` drains the scene-open preview render (and its queued success-path clear) before returning, removing the race where the clear clobbered a manual error set.
- Full `Beutl.HeadlessUITests` suite: 195 passed / 0 failed.
- The previously flaky `PreviewRenderError_LatestQueuedUpdateWins` passed 12 consecutive local runs.

## Fixed issues / References
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview rendering stability when opening a new scene.
  * Ensured pending preview updates are completed before the editor becomes available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->