### PR TITLE
test: stop the headless dispatcher flake with per-assembly isolation

### DIFF
--- a/tests/Beutl.HeadlessUITests/DarkBorderThemeColorTests.cs
+++ b/tests/Beutl.HeadlessUITests/DarkBorderThemeColorTests.cs
@@ -24,7 +24,7 @@ public class DarkBorderThemeColorTests
     [AvaloniaTest]
     public void Selected_color_type_tab_paints_the_indeterminate_fill_under_the_border_theme()
     {
-        Application.Current!.RequestedThemeVariant = ThemeVariant.Dark;
+        using ThemeVariantScope themeScope = ThemeVariantScope.Use(ThemeVariant.Dark);
 
         var toggle = new ToggleButton { IsChecked = true, Content = new TextBlock { Text = "Solid" } };
         var window = new Window
@@ -65,7 +65,7 @@ public class DarkBorderThemeColorTests
     [AvaloniaTest]
     public void Indeterminate_toggle_fill_is_visible_under_the_border_theme()
     {
-        Application.Current!.RequestedThemeVariant = ThemeVariant.Dark;
+        using ThemeVariantScope themeScope = ThemeVariantScope.Use(ThemeVariant.Dark);
 
         var probe = new ToggleButton();
         var window = new Window { Content = probe, Width = 200, Height = 120 };
@@ -91,7 +91,7 @@ public class DarkBorderThemeColorTests
     [AvaloniaTest]
     public void Indeterminate_toggle_fill_mirrors_the_list_and_tree_selected_surface()
     {
-        Application.Current!.RequestedThemeVariant = ThemeVariant.Dark;
+        using ThemeVariantScope themeScope = ThemeVariantScope.Use(ThemeVariant.Dark);
 
         var probe = new ToggleButton();
         var window = new Window { Content = probe, Width = 200, Height = 120 };
@@ -124,8 +124,8 @@ public class DarkBorderThemeColorTests
     [AvaloniaTest]
     public void Custom_accent_retints_the_accent_fill_and_selected_surfaces()
     {
-        Application.Current!.RequestedThemeVariant = ThemeVariant.Dark;
-        FluentAvaloniaTheme faTheme = Application.Current.Styles.OfType<FluentAvaloniaTheme>().Single();
+        using ThemeVariantScope themeScope = ThemeVariantScope.Use(ThemeVariant.Dark);
+        FluentAvaloniaTheme faTheme = Application.Current!.Styles.OfType<FluentAvaloniaTheme>().Single();
 
         var probe = new Border();
         var window = new Window { Content = probe, Width = 200, Height = 120 };
@@ -172,7 +172,7 @@ public class DarkBorderThemeColorTests
     [AvaloniaTest]
     public void Disabled_text_input_matches_disabled_combobox_under_dark_theme()
     {
-        Application.Current!.RequestedThemeVariant = ThemeVariant.Dark;
+        using ThemeVariantScope themeScope = ThemeVariantScope.Use(ThemeVariant.Dark);
 
         var textBox = new TextBox { Text = "1920", Width = 160, IsEnabled = false };
         var comboBox = new ComboBox { ItemsSource = new[] { "Spectrum" }, SelectedIndex = 0, Width = 160, IsEnabled = false };
@@ -229,7 +229,7 @@ public class DarkBorderThemeColorTests
     [AvaloniaTest]
     public void Title_bar_bottom_border_matches_the_dock_splitter_under_the_border_theme()
     {
-        Application.Current!.RequestedThemeVariant = ThemeVariant.Dark;
+        using ThemeVariantScope themeScope = ThemeVariantScope.Use(ThemeVariant.Dark);
 
         var probe = new Border();
         var window = new Window { Content = probe, Width = 200, Height = 120 };
@@ -276,8 +276,8 @@ public class DarkBorderThemeColorTests
 
     private static void AssertMarkerGlyphContrasts(Color accent, Color expectedGlyph)
     {
-        Application.Current!.RequestedThemeVariant = ThemeVariant.Dark;
-        FluentAvaloniaTheme faTheme = Application.Current.Styles.OfType<FluentAvaloniaTheme>().Single();
+        using ThemeVariantScope themeScope = ThemeVariantScope.Use(ThemeVariant.Dark);
+        FluentAvaloniaTheme faTheme = Application.Current!.Styles.OfType<FluentAvaloniaTheme>().Single();
 
         var probe = new Border();
         var window = new Window { Content = probe, Width = 200, Height = 120 };

--- a/tests/Beutl.HeadlessUITests/DarkBorderThemeExtensionTests.cs
+++ b/tests/Beutl.HeadlessUITests/DarkBorderThemeExtensionTests.cs
@@ -99,6 +99,7 @@ public class DarkBorderThemeExtensionTests
         ClearRegistry();
         FluentAvaloniaTheme theme = Application.Current!.Styles.OfType<FluentAvaloniaTheme>().Single();
         IResourceProvider[] mergedOnEntry = [.. Application.Current.Resources.MergedDictionaries];
+        ThemeVariant? variantOnEntry = Application.Current.RequestedThemeVariant;
         var config = new ViewConfig();
         var service = new ThemeService(theme, config);
         try
@@ -137,7 +138,7 @@ public class DarkBorderThemeExtensionTests
 
             theme.CustomAccentColor = null;
             AccentResolution.ApplyTextOnAccent(Application.Current.Resources, null);
-            Application.Current.RequestedThemeVariant = ThemeVariant.Dark;
+            Application.Current.RequestedThemeVariant = variantOnEntry;
         }
     }
 
@@ -146,6 +147,7 @@ public class DarkBorderThemeExtensionTests
     {
         ClearRegistry();
         FluentAvaloniaTheme theme = Application.Current!.Styles.OfType<FluentAvaloniaTheme>().Single();
+        ThemeVariant? variantOnEntry = Application.Current.RequestedThemeVariant;
         var config = new ViewConfig { Theme = BuiltinThemeIds.Light };
         var service = new ThemeService(theme, config);
         var extension = new DarkBorderThemeExtension();
@@ -178,7 +180,7 @@ public class DarkBorderThemeExtensionTests
             extension.Unload();
             ClearRegistry();
             Dispatcher.UIThread.RunJobs();
-            Application.Current!.RequestedThemeVariant = ThemeVariant.Dark;
+            Application.Current!.RequestedThemeVariant = variantOnEntry;
         }
     }
 

--- a/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
@@ -58,7 +58,6 @@ public class ElementViewLayoutTests
     private static async Task<(Window Window, ElementView Element)> InflateFirstElementView(string name)
     {
         await TestReset.ResetShellAsync();
-        Application.Current!.RequestedThemeVariant = ThemeVariant.Dark;
         EditViewModel editor = await OpenEditorForNewScene(name);
         AddRectangle(editor);
 
@@ -74,6 +73,7 @@ public class ElementViewLayoutTests
     [AvaloniaTest]
     public async Task Label_is_inset_clear_of_the_rounded_corner()
     {
+        using ThemeVariantScope themeScope = ThemeVariantScope.Use(ThemeVariant.Dark);
         (Window window, ElementView element) = await InflateFirstElementView("elementview-inset");
         try
         {
@@ -96,6 +96,7 @@ public class ElementViewLayoutTests
     [AvaloniaTest]
     public async Task Locked_clip_keeps_the_label_clear_of_the_lock_glyph()
     {
+        using ThemeVariantScope themeScope = ThemeVariantScope.Use(ThemeVariant.Dark);
         (Window window, ElementView element) = await InflateFirstElementView("elementview-locked");
         try
         {
@@ -126,6 +127,7 @@ public class ElementViewLayoutTests
     [AvaloniaTest]
     public async Task Rename_textbox_text_starts_where_the_label_does()
     {
+        using ThemeVariantScope themeScope = ThemeVariantScope.Use(ThemeVariant.Dark);
         (Window window, ElementView element) = await InflateFirstElementView("elementview-rename");
         try
         {
@@ -162,6 +164,7 @@ public class ElementViewLayoutTests
     [AvaloniaTest]
     public async Task Renaming_does_not_paint_into_the_rounded_corner()
     {
+        using ThemeVariantScope themeScope = ThemeVariantScope.Use(ThemeVariant.Dark);
         (Window window, ElementView element) = await InflateFirstElementView("elementview-corner");
         try
         {
@@ -248,6 +251,7 @@ public class ElementViewLayoutTests
     [AvaloniaTest]
     public async Task Media_host_rounds_and_clips_the_thumbnail_and_waveform()
     {
+        using ThemeVariantScope themeScope = ThemeVariantScope.Use(ThemeVariant.Dark);
         (Window window, ElementView element) = await InflateFirstElementView("elementview-rounded");
         try
         {

--- a/tests/Beutl.HeadlessUITests/HeadlessSessionIsolationTests.cs
+++ b/tests/Beutl.HeadlessUITests/HeadlessSessionIsolationTests.cs
@@ -1,0 +1,28 @@
+﻿using System.Reflection;
+using Avalonia.Headless;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class HeadlessSessionIsolationTests
+{
+    [Test]
+    public void Assembly_opts_out_of_per_test_isolation()
+    {
+        AvaloniaTestIsolationAttribute? isolation = typeof(TestAppBuilder).Assembly
+            .GetCustomAttribute<AvaloniaTestIsolationAttribute>();
+
+        Assert.That(isolation, Is.Not.Null);
+        Assert.That(isolation!.IsolationLevel, Is.EqualTo(AvaloniaTestIsolationLevel.PerAssembly));
+    }
+
+    // The precondition Dispatcher.PushFrame checks; HeadlessUnitTestSession calls it for every test
+    // whose body does not complete synchronously, so losing it makes async tests fail at random.
+    [AvaloniaTest]
+    public void UI_dispatcher_supports_run_loops()
+    {
+        Assert.That(Dispatcher.UIThread.SupportsRunLoops, Is.True);
+    }
+}

--- a/tests/Beutl.HeadlessUITests/TestAppBuilder.cs
+++ b/tests/Beutl.HeadlessUITests/TestAppBuilder.cs
@@ -4,6 +4,12 @@ using Beutl.HeadlessUITests;
 
 [assembly: AvaloniaTestApplication(typeof(TestAppBuilder))]
 
+// Required, not a preference. The default PerTest isolation nulls the static Dispatcher.UIThread
+// after every test with no IDispatcherImpl registered, and this suite deliberately keeps editor
+// state alive across tests (see TestReset), so a service left running from the previous test pins
+// the singleton to the run-loop-less NullDispatcherImpl and the next test dies in PushFrame.
+[assembly: AvaloniaTestIsolation(AvaloniaTestIsolationLevel.PerAssembly)]
+
 namespace Beutl.HeadlessUITests;
 
 public static class TestAppBuilder

--- a/tests/Beutl.HeadlessUITests/TextBoxFocusBorderTests.cs
+++ b/tests/Beutl.HeadlessUITests/TextBoxFocusBorderTests.cs
@@ -17,7 +17,7 @@ public class TextBoxFocusBorderTests
     [AvaloniaTest]
     public void Focused_textbox_border_is_uniform_one_pixel()
     {
-        Application.Current!.RequestedThemeVariant = ThemeVariant.Dark;
+        using ThemeVariantScope themeScope = ThemeVariantScope.Use(ThemeVariant.Dark);
 
         Assert.That(Application.Current!.TryGetResource("TextControlBorderThemeThicknessFocused", ThemeVariant.Dark, out object? focused), Is.True,
             "the focused border-thickness token should resolve");

--- a/tests/Beutl.HeadlessUITests/ThemeServiceTests.cs
+++ b/tests/Beutl.HeadlessUITests/ThemeServiceTests.cs
@@ -518,6 +518,7 @@ public class ThemeServiceTests
     private sealed class ThemeScope : IDisposable
     {
         private readonly IResourceProvider[] _mergedOnEntry;
+        private readonly ThemeVariant? _variantOnEntry;
 
         public ThemeScope()
         {
@@ -526,10 +527,10 @@ public class ThemeServiceTests
             // Reset before the snapshot rather than trusting the previous scope's Dispose — a test
             // that fails mid-body never reaches it, and the snapshot would then adopt the leak as
             // this scope's baseline. Only the accent and its derived tokens need it: the merged
-            // dictionaries are restored by diffing against this snapshot, and the theme variant is
-            // overwritten by every apply.
+            // dictionaries and the theme variant are restored from the snapshots below.
             ResetAccentState(Theme);
             _mergedOnEntry = [.. Application.Current.Resources.MergedDictionaries];
+            _variantOnEntry = Application.Current.RequestedThemeVariant;
             Config = new ViewConfig();
             Service = new ThemeService(Theme, Config);
         }
@@ -552,6 +553,7 @@ public class ThemeServiceTests
                 merged.Remove(applied);
             }
 
+            Application.Current.RequestedThemeVariant = _variantOnEntry;
             ClearRegistry();
         }
 

--- a/tests/Beutl.HeadlessUITests/ThemeVariantScope.cs
+++ b/tests/Beutl.HeadlessUITests/ThemeVariantScope.cs
@@ -1,0 +1,22 @@
+﻿using Avalonia;
+using Avalonia.Styling;
+
+namespace Beutl.HeadlessUITests;
+
+// PerAssembly isolation (see TestAppBuilder) shares one Application across the whole run, so a test
+// that leaves RequestedThemeVariant flipped picks the theme for every test after it.
+internal sealed class ThemeVariantScope : IDisposable
+{
+    private readonly ThemeVariant? _previous;
+
+    private ThemeVariantScope(ThemeVariant? previous) => _previous = previous;
+
+    public static ThemeVariantScope Use(ThemeVariant variant)
+    {
+        var scope = new ThemeVariantScope(Application.Current!.RequestedThemeVariant);
+        Application.Current.RequestedThemeVariant = variant;
+        return scope;
+    }
+
+    public void Dispose() => Application.Current!.RequestedThemeVariant = _previous;
+}


### PR DESCRIPTION
## Description

- `Beutl.HeadlessUITests` inherited Avalonia's default `PerTest` isolation, which tears the `Application` down after every test and leaves the static `Dispatcher.UIThread` null with no `IDispatcherImpl` registered. This suite keeps editor state alive across tests on purpose (see `TestReset`), so a service still running from the previous test could re-create that singleton as the run-loop-less `NullDispatcherImpl`. The next test whose body did not complete synchronously then died inside `HeadlessUnitTestSession` at `Dispatcher.PushFrame` with `PlatformNotSupportedException`, and the test after it reset the field again — hence exactly one rotating victim per run, with an identical stack every time. Three of the last four `.NET` CI failures on `main` were this.
- `PerAssembly` isolation never nulls the dispatcher, so the window disappears. Sharing one `Application` for the whole run then exposes tests that flip `RequestedThemeVariant` and never restore it, so those now restore it — otherwise the first theme test decides the theme for every test after it (`DockTabAddButtonTests` failed deterministically on that).
- Two of the restorations were cleanup blocks in `DarkBorderThemeExtensionTests` that pinned the variant to `Dark` in the name of cleanup; they now restore the value captured on entry. `ThemeServiceTests`' existing `ThemeScope` already restored merged dictionaries and the accent, and now restores the variant too.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [x] Build / CI / docs only

Test-infrastructure only — every changed file is under `tests/Beutl.HeadlessUITests/`. No production code is touched.

## Breaking changes

None.

## Test plan

- **Root cause confirmed, not inferred.** A temporary NUnit `ITestAction` reflected Avalonia's private `Dispatcher.s_uiThread` before each test (reflection rather than the `Dispatcher.UIThread` property, which would have created the singleton and caused the very bug). Every captured failure showed `SupportsRunLoops=False` on the failing test and `True` on the test before it. The diagnostic is not part of this PR.
- **Flake reproduction, macOS host:** looping `--filter FullyQualifiedName~EditorProjectSessionGatewayTests` failed **2 of 4** runs before the change and **0 of 40** after.
- **Full assembly:** 199/199 green across repeated runs; `dotnet build` 0 warnings / 0 errors; `dotnet format --verify-no-changes` clean.
- **Regression guard:** `HeadlessSessionIsolationTests` asserts the assembly declares `PerAssembly` isolation (deterministic — fails immediately if the attribute is dropped) and that `Dispatcher.UIThread.SupportsRunLoops` holds, which is the precondition `PushFrame` checks.
- Not reproducible in the arm64 SwiftShader container (60 iterations, 0 hits); use a macOS host to reproduce.

## Fixed issues / References

- CI runs with the signature fixed here: 30438903976, 30600715402.
- https://github.com/b-editor/beutl/actions/runs/31229274598 was killed by a separate native test-host crash (`Reason: Test host process crashed`, no managed stack), which this PR reduces but does not eliminate. That one is a distinct defect and is being tracked separately with the maintainer, not fixed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved headless UI test isolation and dispatcher run-loop coverage.
  * Added safer theme handling so tests restore the previously active theme after execution.
  * Updated dark-theme UI tests to apply themes only within their individual test scopes.
  * Preserved application and editor state consistently across related test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->