### PR TITLE
fix(engine): release GPU resources on the thread that owns them

### DIFF
--- a/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
+++ b/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
@@ -68,7 +68,7 @@ public partial class ImmediateCanvas : IDisposable, IPopable
         // GC path swallows; explicit Dispose() still surfaces errors.
         try
         {
-            Dispose();
+            Dispose(disposing: false);
         }
         catch
         {
@@ -143,7 +143,9 @@ public partial class ImmediateCanvas : IDisposable, IPopable
         Canvas.ClipPath(geometry.GetCachedPath(), operation.ToSKClipOperation(), true);
     }
 
-    public void Dispose()
+    public void Dispose() => Dispose(disposing: true);
+
+    private void Dispose(bool disposing)
     {
         void DisposeCore()
         {
@@ -174,10 +176,20 @@ public partial class ImmediateCanvas : IDisposable, IPopable
         // Claimed before queuing, not inside DisposeCore: GpuResourceRelease.Run can return with the
         // work still queued, and a second Dispose would then pass an IsDisposed that is still false
         // and queue a rival cleanup that disposes the shared paints again.
-        if (Interlocked.Exchange(ref _disposeClaimed, 1) == 0)
+        if (Interlocked.Exchange(ref _disposeClaimed, 1) != 0)
         {
-            GpuResourceRelease.Run(_dispatcher, DisposeCore);
+            return;
         }
+
+        // A finalizer must not block on another thread, so it hands the cleanup over instead of
+        // taking the bounded wait below.
+        if (!disposing && _dispatcher is { HasShutdownFinished: false } dispatcher && !dispatcher.CheckAccess())
+        {
+            dispatcher.Dispatch(DisposeCore);
+            return;
+        }
+
+        GpuResourceRelease.Run(_dispatcher, DisposeCore);
     }
 
     public void DrawSurface(SKSurface surface, Point point)

--- a/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
+++ b/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
@@ -15,6 +15,7 @@ public partial class ImmediateCanvas : IDisposable, IPopable
     private readonly SKPaint _sharedFillPaint = new();
     private readonly SKPaint _sharedStrokePaint = new();
     private readonly Stack<CanvasPushedState> _states = new();
+    private int _disposeClaimed;
     private Matrix _currentTransform;
     // Base CTM = CreateScale(SurfaceDensity); identity when density == 1.
     private readonly Matrix _baseTransform;
@@ -170,7 +171,10 @@ public partial class ImmediateCanvas : IDisposable, IPopable
             _sharedStrokePaint.Dispose();
         }
 
-        if (!IsDisposed)
+        // Claimed before queuing, not inside DisposeCore: GpuResourceRelease.Run can return with the
+        // work still queued, and a second Dispose would then pass an IsDisposed that is still false
+        // and queue a rival cleanup that disposes the shared paints again.
+        if (Interlocked.Exchange(ref _disposeClaimed, 1) == 0)
         {
             GpuResourceRelease.Run(_dispatcher, DisposeCore);
         }

--- a/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
+++ b/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
@@ -172,14 +172,7 @@ public partial class ImmediateCanvas : IDisposable, IPopable
 
         if (!IsDisposed)
         {
-            if (_dispatcher == null)
-            {
-                DisposeCore();
-            }
-            else
-            {
-                _dispatcher?.Invoke(DisposeCore);
-            }
+            GpuResourceRelease.Run(_dispatcher, DisposeCore);
         }
     }
 

--- a/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
+++ b/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
@@ -173,16 +173,14 @@ public partial class ImmediateCanvas : IDisposable, IPopable
             _sharedStrokePaint.Dispose();
         }
 
-        // Claimed before queuing, not inside DisposeCore: GpuResourceRelease.Run can return with the
-        // work still queued, and a second Dispose would then pass an IsDisposed that is still false
-        // and queue a rival cleanup that disposes the shared paints again.
+        // Claimed here, not inside DisposeCore: Run can return with the cleanup still queued, so a
+        // second Dispose would see IsDisposed false and queue a rival one, double-disposing the paints.
         if (Interlocked.Exchange(ref _disposeClaimed, 1) != 0)
         {
             return;
         }
 
-        // A finalizer must not block on another thread, so it hands the cleanup over instead of
-        // taking the bounded wait below.
+        // A finalizer must not block on another thread, so it cannot take the bounded wait below.
         if (!disposing && _dispatcher is { HasShutdownFinished: false } dispatcher && !dispatcher.CheckAccess())
         {
             dispatcher.Dispatch(DisposeCore);

--- a/src/Beutl.Engine/Graphics/Rendering/GpuResourceRelease.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/GpuResourceRelease.cs
@@ -65,5 +65,14 @@ internal static class GpuResourceRelease
         s_logger.LogDebug(
             "GPU resource release is still queued after {Deadline}; leaving it to the render thread.",
             s_deadline);
+
+        // InvokeAsync runs the action inside a Task, so a failure lands there rather than in the
+        // dispatcher's exception handler. With the caller gone nothing would observe it, and a
+        // half-finished cleanup would look like a success.
+        _ = queued.ContinueWith(
+            static t => s_logger.LogWarning(t.Exception, "A GPU resource release failed after its caller stopped waiting"),
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 }

--- a/src/Beutl.Engine/Graphics/Rendering/GpuResourceRelease.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/GpuResourceRelease.cs
@@ -1,0 +1,50 @@
+﻿using Beutl.Threading;
+
+namespace Beutl.Graphics.Rendering;
+
+internal static class GpuResourceRelease
+{
+    // A caller that waits forever is worse than a GPU resource released on the wrong thread: the
+    // dispatcher can stop between the shutdown check and the enqueue, and a wedged render thread
+    // would otherwise hang Dispose (or the whole finalizer queue). Bounded, then release in place.
+    private static readonly TimeSpan s_timeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Runs <paramref name="release"/> on <paramref name="dispatcher"/>, falling back to the calling
+    /// thread if that dispatcher is gone or does not pick the work up in time. Runs exactly once even
+    /// when a timed-out operation is later drained by the dispatcher after all.
+    /// </summary>
+    public static void Run(Dispatcher? dispatcher, Action release)
+    {
+        if (dispatcher is null || dispatcher.CheckAccess())
+        {
+            release();
+            return;
+        }
+
+        int claimed = 0;
+        void Once()
+        {
+            if (Interlocked.Exchange(ref claimed, 1) == 0)
+            {
+                release();
+            }
+        }
+
+        if (dispatcher.HasShutdownStarted)
+        {
+            Once();
+            return;
+        }
+
+        try
+        {
+            using var cts = new CancellationTokenSource(s_timeout);
+            dispatcher.Invoke(Once, ct: cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            Once();
+        }
+    }
+}

--- a/src/Beutl.Engine/Graphics/Rendering/GpuResourceRelease.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/GpuResourceRelease.cs
@@ -52,17 +52,16 @@ internal static class GpuResourceRelease
         for (TimeSpan waited = TimeSpan.Zero; waited < s_deadline; waited += s_slice)
         {
             // Waited through the handle, not Task.Wait: that wraps a failed release in an
-            // AggregateException, and callers of the formerly inline API catch the release's own
-            // exception type. GetResult rethrows the original.
+            // AggregateException, but callers catch the release's own exception type. GetResult
+            // rethrows the original.
             if (((IAsyncResult)queued).AsyncWaitHandle.WaitOne(s_slice))
             {
                 queued.GetAwaiter().GetResult();
                 return;
             }
 
-            // Already running on the owner thread: the deadline guards against work that never
-            // starts, not against a release that is simply slow, and returning here would tell the
-            // caller the resources are free while they are still being torn down.
+            // Already running on the owner thread: the deadline guards work that never starts, not
+            // a slow release, and returning would report resources free that are still being torn down.
             if (Volatile.Read(ref started) == 1)
             {
                 queued.GetAwaiter().GetResult();

--- a/src/Beutl.Engine/Graphics/Rendering/GpuResourceRelease.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/GpuResourceRelease.cs
@@ -51,8 +51,12 @@ internal static class GpuResourceRelease
         Task queued = dispatcher.InvokeAsync(Once);
         for (TimeSpan waited = TimeSpan.Zero; waited < s_deadline; waited += s_slice)
         {
-            if (queued.Wait(s_slice))
+            // Waited through the handle, not Task.Wait: that wraps a failed release in an
+            // AggregateException, and callers of the formerly inline API catch the release's own
+            // exception type. GetResult rethrows the original.
+            if (((IAsyncResult)queued).AsyncWaitHandle.WaitOne(s_slice))
             {
+                queued.GetAwaiter().GetResult();
                 return;
             }
 

--- a/src/Beutl.Engine/Graphics/Rendering/GpuResourceRelease.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/GpuResourceRelease.cs
@@ -32,8 +32,10 @@ internal static class GpuResourceRelease
         }
 
         int claimed = 0;
+        int started = 0;
         void Once()
         {
+            Volatile.Write(ref started, 1);
             if (Interlocked.Exchange(ref claimed, 1) == 0)
             {
                 release();
@@ -51,6 +53,15 @@ internal static class GpuResourceRelease
         {
             if (queued.Wait(s_slice))
             {
+                return;
+            }
+
+            // Already running on the owner thread: the deadline guards against work that never
+            // starts, not against a release that is simply slow, and returning here would tell the
+            // caller the resources are free while they are still being torn down.
+            if (Volatile.Read(ref started) == 1)
+            {
+                queued.GetAwaiter().GetResult();
                 return;
             }
 

--- a/src/Beutl.Engine/Graphics/Rendering/GpuResourceRelease.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/GpuResourceRelease.cs
@@ -73,6 +73,14 @@ internal static class GpuResourceRelease
             }
         }
 
+        // The dispatcher may have picked the operation up during the last slice, after the check
+        // inside the loop; returning here would abandon a release that is already running.
+        if (Volatile.Read(ref started) == 1)
+        {
+            queued.GetAwaiter().GetResult();
+            return;
+        }
+
         s_logger.LogDebug(
             "GPU resource release is still queued after {Deadline}; leaving it to the render thread.",
             s_deadline);

--- a/src/Beutl.Engine/Graphics/Rendering/GpuResourceRelease.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/GpuResourceRelease.cs
@@ -1,19 +1,26 @@
-﻿using Beutl.Threading;
+﻿using Beutl.Logging;
+using Beutl.Threading;
+using Microsoft.Extensions.Logging;
 
 namespace Beutl.Graphics.Rendering;
 
 internal static class GpuResourceRelease
 {
-    // A caller that waits forever is worse than a GPU resource released on the wrong thread: the
-    // dispatcher can stop between the shutdown check and the enqueue, and a wedged render thread
-    // would otherwise hang Dispose (or the whole finalizer queue). Bounded, then release in place.
-    private static readonly TimeSpan s_timeout = TimeSpan.FromSeconds(5);
+    private static readonly ILogger s_logger = Log.CreateLogger(typeof(GpuResourceRelease));
+    private static readonly TimeSpan s_slice = TimeSpan.FromMilliseconds(50);
+    private static readonly TimeSpan s_deadline = TimeSpan.FromSeconds(5);
 
     /// <summary>
-    /// Runs <paramref name="release"/> on <paramref name="dispatcher"/>, falling back to the calling
-    /// thread if that dispatcher is gone or does not pick the work up in time. Runs exactly once even
-    /// when a timed-out operation is later drained by the dispatcher after all.
+    /// Runs <paramref name="release"/> on <paramref name="dispatcher"/>, the thread that owns the
+    /// GPU resources it frees.
     /// </summary>
+    /// <remarks>
+    /// Slow and stopped are not the same thing. A live dispatcher that has not got to the operation
+    /// yet may be mid-frame and still using what <paramref name="release"/> would tear down, so the
+    /// caller stops waiting rather than releasing off-thread — the queued operation still runs when
+    /// the dispatcher drains it. Only an observed shutdown, where nothing will ever drain, licenses
+    /// releasing here. Runs exactly once across both paths.
+    /// </remarks>
     public static void Run(Dispatcher? dispatcher, Action release)
     {
         if (dispatcher is null || dispatcher.CheckAccess())
@@ -37,14 +44,24 @@ internal static class GpuResourceRelease
             return;
         }
 
-        try
+        Task queued = dispatcher.InvokeAsync(Once);
+        for (TimeSpan waited = TimeSpan.Zero; waited < s_deadline; waited += s_slice)
         {
-            using var cts = new CancellationTokenSource(s_timeout);
-            dispatcher.Invoke(Once, ct: cts.Token);
+            if (queued.Wait(s_slice))
+            {
+                return;
+            }
+
+            // Re-checked every slice, so a shutdown starting after the check above is still caught.
+            if (dispatcher.HasShutdownStarted)
+            {
+                Once();
+                return;
+            }
         }
-        catch (OperationCanceledException)
-        {
-            Once();
-        }
+
+        s_logger.LogDebug(
+            "GPU resource release is still queued after {Deadline}; leaving it to the render thread.",
+            s_deadline);
     }
 }

--- a/src/Beutl.Engine/Graphics/Rendering/GpuResourceRelease.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/GpuResourceRelease.cs
@@ -18,8 +18,10 @@ internal static class GpuResourceRelease
     /// Slow and stopped are not the same thing. A live dispatcher that has not got to the operation
     /// yet may be mid-frame and still using what <paramref name="release"/> would tear down, so the
     /// caller stops waiting rather than releasing off-thread — the queued operation still runs when
-    /// the dispatcher drains it. Only an observed shutdown, where nothing will ever drain, licenses
-    /// releasing here. Runs exactly once across both paths.
+    /// the dispatcher drains it. Only <see cref="Dispatcher.HasShutdownFinished"/> licenses releasing
+    /// here: <c>HasShutdownStarted</c> is set the moment <c>Shutdown()</c> is called and does not wait
+    /// for the operation already running, so it would still overlap a live frame. Runs exactly once
+    /// across both paths.
     /// </remarks>
     public static void Run(Dispatcher? dispatcher, Action release)
     {
@@ -38,7 +40,7 @@ internal static class GpuResourceRelease
             }
         }
 
-        if (dispatcher.HasShutdownStarted)
+        if (dispatcher.HasShutdownFinished)
         {
             Once();
             return;
@@ -52,8 +54,8 @@ internal static class GpuResourceRelease
                 return;
             }
 
-            // Re-checked every slice, so a shutdown starting after the check above is still caught.
-            if (dispatcher.HasShutdownStarted)
+            // Re-checked every slice, so a shutdown finishing after the check above is still caught.
+            if (dispatcher.HasShutdownFinished)
             {
                 Once();
                 return;

--- a/src/Beutl.Engine/Graphics/Rendering/RenderTarget.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderTarget.cs
@@ -190,13 +190,40 @@ public class RenderTarget : IDisposable
         if (IsDisposed) return;
 
         IsDisposed = true;
+
+        // Skia's GPU context is thread-affine, so the surface and its shared texture have to be
+        // released on the dispatcher that allocated them — releasing from another thread corrupts
+        // the context and faults the render thread later. ImmediateCanvas.Dispose hops the same way.
+        // Once that dispatcher is shutting down nothing can run there, so release in place instead.
+        if (_dispatcher is { HasShutdownStarted: false } dispatcher && !dispatcher.CheckAccess())
+        {
+            SKSurfaceCounter<SKSurface> surface = _surface;
+            SKSurfaceCounter<ITexture2D>? texture = _texture;
+            if (disposing)
+            {
+                dispatcher.Invoke(() => Release(surface, texture));
+            }
+            else
+            {
+                // A finalizer must not block on another thread.
+                dispatcher.Dispatch(() => Release(surface, texture));
+            }
+
+            return;
+        }
+
+        Release(_surface, _texture);
+    }
+
+    private static void Release(SKSurfaceCounter<SKSurface> surface, SKSurfaceCounter<ITexture2D>? texture)
+    {
         try
         {
-            _surface.Release();
+            surface.Release();
         }
         finally
         {
-            _texture?.Release();
+            texture?.Release();
         }
     }
 

--- a/src/Beutl.Engine/Graphics/Rendering/RenderTarget.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderTarget.cs
@@ -275,9 +275,11 @@ public class RenderTarget : IDisposable
                         Value = null;
                         if (value != null)
                         {
-                            // Dispatch would queue onto a loop that no longer drains, leaving the
-                            // native resource alive for the rest of the process.
-                            if (_dispatcher is { HasShutdownStarted: false } dispatcher
+                            // Finished, not Started: between the two the owner thread is still
+                            // running an operation, so disposing here could free a surface in use.
+                            // Past Finished, dispatching would queue onto a loop that no longer
+                            // drains and the native resource would outlive the process instead.
+                            if (_dispatcher is { HasShutdownFinished: false } dispatcher
                                 && !dispatcher.CheckAccess())
                             {
                                 dispatcher.Dispatch(value.Dispose);

--- a/src/Beutl.Engine/Graphics/Rendering/RenderTarget.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderTarget.cs
@@ -197,7 +197,7 @@ public class RenderTarget : IDisposable
         SKSurfaceCounter<SKSurface> surface = _surface;
         SKSurfaceCounter<ITexture2D>? texture = _texture;
 
-        if (!disposing && _dispatcher is { HasShutdownStarted: false } dispatcher && !dispatcher.CheckAccess())
+        if (!disposing && _dispatcher is { HasShutdownFinished: false } dispatcher && !dispatcher.CheckAccess())
         {
             // A finalizer must not block on another thread, so it cannot use the bounded wait below.
             dispatcher.Dispatch(() => Release(surface, texture));

--- a/src/Beutl.Engine/Graphics/Rendering/RenderTarget.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderTarget.cs
@@ -194,25 +194,17 @@ public class RenderTarget : IDisposable
         // Skia's GPU context is thread-affine, so the surface and its shared texture have to be
         // released on the dispatcher that allocated them — releasing from another thread corrupts
         // the context and faults the render thread later. ImmediateCanvas.Dispose hops the same way.
-        // Once that dispatcher is shutting down nothing can run there, so release in place instead.
-        if (_dispatcher is { HasShutdownStarted: false } dispatcher && !dispatcher.CheckAccess())
-        {
-            SKSurfaceCounter<SKSurface> surface = _surface;
-            SKSurfaceCounter<ITexture2D>? texture = _texture;
-            if (disposing)
-            {
-                dispatcher.Invoke(() => Release(surface, texture));
-            }
-            else
-            {
-                // A finalizer must not block on another thread.
-                dispatcher.Dispatch(() => Release(surface, texture));
-            }
+        SKSurfaceCounter<SKSurface> surface = _surface;
+        SKSurfaceCounter<ITexture2D>? texture = _texture;
 
+        if (!disposing && _dispatcher is { HasShutdownStarted: false } dispatcher && !dispatcher.CheckAccess())
+        {
+            // A finalizer must not block on another thread, so it cannot use the bounded wait below.
+            dispatcher.Dispatch(() => Release(surface, texture));
             return;
         }
 
-        Release(_surface, _texture);
+        GpuResourceRelease.Run(_dispatcher, () => Release(surface, texture));
     }
 
     private static void Release(SKSurfaceCounter<SKSurface> surface, SKSurfaceCounter<ITexture2D>? texture)
@@ -283,16 +275,12 @@ public class RenderTarget : IDisposable
                         Value = null;
                         if (value != null)
                         {
-                            if (_dispatcher != null)
+                            // Dispatch would queue onto a loop that no longer drains, leaving the
+                            // native resource alive for the rest of the process.
+                            if (_dispatcher is { HasShutdownStarted: false } dispatcher
+                                && !dispatcher.CheckAccess())
                             {
-                                if (_dispatcher.CheckAccess())
-                                {
-                                    value.Dispose();
-                                }
-                                else
-                                {
-                                    _dispatcher.Dispatch(value.Dispose);
-                                }
+                                dispatcher.Dispatch(value.Dispose);
                             }
                             else
                             {

--- a/src/Beutl.Engine/Graphics/Rendering/RenderTarget.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderTarget.cs
@@ -193,7 +193,7 @@ public class RenderTarget : IDisposable
 
         // Skia's GPU context is thread-affine, so the surface and its shared texture have to be
         // released on the dispatcher that allocated them — releasing from another thread corrupts
-        // the context and faults the render thread later. ImmediateCanvas.Dispose hops the same way.
+        // the context and faults the render thread later.
         SKSurfaceCounter<SKSurface> surface = _surface;
         SKSurfaceCounter<ITexture2D>? texture = _texture;
 

--- a/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
@@ -276,21 +276,29 @@ public class Renderer : IRenderer
                     return;
                 }
 
+                // Independently guarded: a failed cache clear must not skip the entry's own
+                // disposal, which is the only thing that releases its node.
                 try
                 {
                     RenderNodeCacheHelper.ClearCache(entry.Node);
+                }
+                catch (Exception ex)
+                {
+                    s_logger.LogWarning(ex, "Failed to clear the render cache of a detached drawable");
+                }
+
+                try
+                {
                     entry.Dispose();
                 }
                 catch (Exception ex)
                 {
-                    s_logger.LogWarning(ex, "Failed to release the render cache of a detached drawable");
+                    s_logger.LogWarning(ex, "Failed to dispose the render entry of a detached drawable");
                 }
-                finally
-                {
-                    // The handler is already unsubscribed, so an entry left behind by a failed
-                    // cleanup would be reused by a reattached drawable and never retried.
-                    renderer._nodeCache.Remove(senderDrawable);
-                }
+
+                // The handler is already unsubscribed, so an entry left behind would be reused by a
+                // reattached drawable and never retried.
+                renderer._nodeCache.Remove(senderDrawable);
             });
         }
 

--- a/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
@@ -86,7 +86,9 @@ public class Renderer : IRenderer
         {
             SafeStep(nameof(_immediateCanvas), () => _immediateCanvas?.Dispose());
             SafeStep(nameof(_surface), () => _surface?.Dispose());
-            SafeStep(nameof(ClearAllCaches), ClearAllCaches);
+            // Core, not the public wrapper: this already runs on the render thread, or in place
+            // because it is gone — either way the wrapper's bounded wait must not re-enter here.
+            SafeStep(nameof(ClearAllCachesCore), ClearAllCachesCore);
             SafeStep(nameof(DisposeAllEntries), DisposeAllEntries);
         }
 
@@ -146,11 +148,11 @@ public class Renderer : IRenderer
             OnDispose(true);
             // The canvas, the surface and every cached node hold GPU resources owned by the render
             // thread, so tear them down there — the constructor allocates them the same way.
-            RenderThread.Dispatcher.Invoke(() =>
+            GpuResourceRelease.Run(RenderThread.Dispatcher, () =>
             {
                 _immediateCanvas.Dispose();
                 _surface.Dispose();
-                ClearAllCaches();
+                ClearAllCachesCore();
                 DisposeAllEntries();
             });
             GC.SuppressFinalize(this);
@@ -497,16 +499,18 @@ public class Renderer : IRenderer
     // cached nodes hold GPU resources the render thread owns.
     public void ClearAllCaches()
     {
-        RenderThread.Dispatcher.Invoke(() =>
+        GpuResourceRelease.Run(RenderThread.Dispatcher, ClearAllCachesCore);
+    }
+
+    private void ClearAllCachesCore()
+    {
+        var entries = _nodeCache.ToArray();
+        _nodeCache.Clear();
+        foreach (var item in entries)
         {
-            var entries = _nodeCache.ToArray();
-            _nodeCache.Clear();
-            foreach (var item in entries)
-            {
-                RenderNodeCacheHelper.ClearCache(item.Value.Node);
-                item.Value.Dispose();
-            }
-        });
+            RenderNodeCacheHelper.ClearCache(item.Value.Node);
+            item.Value.Dispose();
+        }
     }
 
     private void DisposeAllEntries()

--- a/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
@@ -270,19 +270,26 @@ public class Renderer : IRenderer
                 // Nothing awaits this, and the dispatcher has no UnhandledException handler, so an
                 // escaping exception would rethrow out of its loop and kill the render thread for
                 // the rest of the process.
+                if (!weakRef.TryGetTarget(out Renderer? renderer)
+                    || !renderer._nodeCache.TryGetValue(senderDrawable, out Entry? entry))
+                {
+                    return;
+                }
+
                 try
                 {
-                    if (weakRef.TryGetTarget(out Renderer? renderer)
-                        && renderer._nodeCache.TryGetValue(senderDrawable, out Entry? entry))
-                    {
-                        RenderNodeCacheHelper.ClearCache(entry.Node);
-                        entry.Dispose();
-                        renderer._nodeCache.Remove(senderDrawable);
-                    }
+                    RenderNodeCacheHelper.ClearCache(entry.Node);
+                    entry.Dispose();
                 }
                 catch (Exception ex)
                 {
                     s_logger.LogWarning(ex, "Failed to release the render cache of a detached drawable");
+                }
+                finally
+                {
+                    // The handler is already unsubscribed, so an entry left behind by a failed
+                    // cleanup would be reused by a reattached drawable and never retried.
+                    renderer._nodeCache.Remove(senderDrawable);
                 }
             });
         }

--- a/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
@@ -148,7 +148,7 @@ public class Renderer : IRenderer
             _isDisposed = true;
             OnDispose(true);
             // The canvas, the surface and every cached node hold GPU resources owned by the render
-            // thread, so tear them down there — the constructor allocates them the same way.
+            // thread, so tear them down there.
             GpuResourceRelease.Run(RenderThread.Dispatcher, () =>
             {
                 _immediateCanvas.Dispose();
@@ -267,9 +267,8 @@ public class Renderer : IRenderer
             // render thread. Queued rather than awaited so an edit never blocks behind a frame.
             RenderThread.Dispatcher.Dispatch(() =>
             {
-                // Nothing awaits this, and the dispatcher has no UnhandledException handler, so an
-                // escaping exception would rethrow out of its loop and kill the render thread for
-                // the rest of the process.
+                // Nothing awaits this and the dispatcher has no UnhandledException handler, so an
+                // escaping exception would rethrow out of its loop and kill the render thread.
                 if (!weakRef.TryGetTarget(out Renderer? renderer)
                     || !renderer._nodeCache.TryGetValue(senderDrawable, out Entry? entry))
                 {

--- a/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
@@ -96,8 +96,9 @@ public class Renderer : IRenderer
         SafeStep(nameof(OnDispose), () => OnDispose(false));
 
         // The finalizer thread does not own these GPU resources and must not block waiting for the
-        // thread that does, so hand the release over unless that thread is already gone.
-        if (RenderThread.Dispatcher.HasShutdownStarted)
+        // thread that does, so hand the release over unless that thread is already gone. Finished,
+        // not Started: the latter is set before the operation already running has returned.
+        if (RenderThread.Dispatcher.HasShutdownFinished)
         {
             ReleaseGpuResources();
         }
@@ -266,12 +267,22 @@ public class Renderer : IRenderer
             // render thread. Queued rather than awaited so an edit never blocks behind a frame.
             RenderThread.Dispatcher.Dispatch(() =>
             {
-                if (weakRef.TryGetTarget(out Renderer? renderer)
-                    && renderer._nodeCache.TryGetValue(senderDrawable, out Entry? entry))
+                // Nothing awaits this, and the dispatcher has no UnhandledException handler, so an
+                // escaping exception would rethrow out of its loop and kill the render thread for
+                // the rest of the process.
+                try
                 {
-                    RenderNodeCacheHelper.ClearCache(entry.Node);
-                    entry.Dispose();
-                    renderer._nodeCache.Remove(senderDrawable);
+                    if (weakRef.TryGetTarget(out Renderer? renderer)
+                        && renderer._nodeCache.TryGetValue(senderDrawable, out Entry? entry))
+                    {
+                        RenderNodeCacheHelper.ClearCache(entry.Node);
+                        entry.Dispose();
+                        renderer._nodeCache.Remove(senderDrawable);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    s_logger.LogWarning(ex, "Failed to release the render cache of a detached drawable");
                 }
             });
         }

--- a/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
@@ -82,12 +82,27 @@ public class Renderer : IRenderer
             }
         }
 
+        void ReleaseGpuResources()
+        {
+            SafeStep(nameof(_immediateCanvas), () => _immediateCanvas?.Dispose());
+            SafeStep(nameof(_surface), () => _surface?.Dispose());
+            SafeStep(nameof(ClearAllCaches), ClearAllCaches);
+            SafeStep(nameof(DisposeAllEntries), DisposeAllEntries);
+        }
+
         _isDisposed = true;
         SafeStep(nameof(OnDispose), () => OnDispose(false));
-        SafeStep(nameof(_immediateCanvas), () => _immediateCanvas?.Dispose());
-        SafeStep(nameof(_surface), () => _surface?.Dispose());
-        SafeStep(nameof(ClearAllCaches), ClearAllCaches);
-        SafeStep(nameof(DisposeAllEntries), DisposeAllEntries);
+
+        // The finalizer thread does not own these GPU resources and must not block waiting for the
+        // thread that does, so hand the release over unless that thread is already gone.
+        if (RenderThread.Dispatcher.HasShutdownStarted)
+        {
+            ReleaseGpuResources();
+        }
+        else
+        {
+            SafeStep(nameof(ReleaseGpuResources), () => RenderThread.Dispatcher.Dispatch(ReleaseGpuResources));
+        }
     }
 
     private volatile bool _isDisposed;
@@ -129,10 +144,15 @@ public class Renderer : IRenderer
         {
             _isDisposed = true;
             OnDispose(true);
-            _immediateCanvas.Dispose();
-            _surface.Dispose();
-            ClearAllCaches();
-            DisposeAllEntries();
+            // The canvas, the surface and every cached node hold GPU resources owned by the render
+            // thread, so tear them down there — the constructor allocates them the same way.
+            RenderThread.Dispatcher.Invoke(() =>
+            {
+                _immediateCanvas.Dispose();
+                _surface.Dispose();
+                ClearAllCaches();
+                DisposeAllEntries();
+            });
             GC.SuppressFinalize(this);
         }
     }
@@ -238,15 +258,20 @@ public class Renderer : IRenderer
         {
             if (sender is not Drawable senderDrawable) return;
 
-            if (weakRef.TryGetTarget(out Renderer? renderer)
-                && renderer._nodeCache.TryGetValue(senderDrawable, out Entry? entry))
-            {
-                RenderNodeCacheHelper.ClearCache(entry.Node);
-                entry.Dispose();
-                renderer._nodeCache.Remove(senderDrawable);
-            }
-
             senderDrawable.DetachedFromHierarchy -= Handler;
+
+            // Detaching happens on the edit thread, but the entry's cache is GPU state owned by the
+            // render thread. Queued rather than awaited so an edit never blocks behind a frame.
+            RenderThread.Dispatcher.Dispatch(() =>
+            {
+                if (weakRef.TryGetTarget(out Renderer? renderer)
+                    && renderer._nodeCache.TryGetValue(senderDrawable, out Entry? entry))
+                {
+                    RenderNodeCacheHelper.ClearCache(entry.Node);
+                    entry.Dispose();
+                    renderer._nodeCache.Remove(senderDrawable);
+                }
+            });
         }
 
         drawable.DetachedFromHierarchy += Handler;
@@ -468,15 +493,20 @@ public class Renderer : IRenderer
     /// </summary>
     public Bitmap CreateSnapshotBitmap() => _surface.CreateSnapshotBitmap();
 
+    // Callers reach this from the UI thread (a cache-option change, an export teardown), but the
+    // cached nodes hold GPU resources the render thread owns.
     public void ClearAllCaches()
     {
-        var entries = _nodeCache.ToArray();
-        _nodeCache.Clear();
-        foreach (var item in entries)
+        RenderThread.Dispatcher.Invoke(() =>
         {
-            RenderNodeCacheHelper.ClearCache(item.Value.Node);
-            item.Value.Dispose();
-        }
+            var entries = _nodeCache.ToArray();
+            _nodeCache.Clear();
+            foreach (var item in entries)
+            {
+                RenderNodeCacheHelper.ClearCache(item.Value.Node);
+                item.Value.Dispose();
+            }
+        });
     }
 
     private void DisposeAllEntries()

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
@@ -144,16 +144,22 @@ public class RenderTargetThreadAffinityTests
     public void A_release_slower_than_the_deadline_is_waited_out_once_it_has_started()
     {
         using var finish = new ManualResetEventSlim(false);
+        using var started = new ManualResetEventSlim(false);
         var completed = false;
 
         Task caller = Task.Run(() => GpuResourceRelease.Run(RenderThread.Dispatcher, () =>
         {
+            started.Set();
             finish.Wait(TimeSpan.FromSeconds(60));
             completed = true;
         }));
 
         try
         {
+            // A caller the pool never scheduled satisfies the assertion below just as well.
+            Assert.That(started.Wait(TimeSpan.FromSeconds(30)), Is.True,
+                "the render thread never started the release");
+
             // From a finally: the failure this asserts is Run returning early, which would leave the
             // shared render dispatcher blocked in the callback and take out every later test.
             Assert.That(caller.Wait(TimeSpan.FromSeconds(8)), Is.False,

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
@@ -138,6 +138,28 @@ public class RenderTargetThreadAffinityTests
         Assert.That(canvas.IsDisposed, Is.True);
     }
 
+    // The deadline exists for a release that never starts. Once it is running on the owner thread,
+    // returning early would report free resources that are still being torn down.
+    [Test]
+    public void A_release_slower_than_the_deadline_is_waited_out_once_it_has_started()
+    {
+        using var finish = new ManualResetEventSlim(false);
+        var completed = false;
+
+        Task caller = Task.Run(() => GpuResourceRelease.Run(RenderThread.Dispatcher, () =>
+        {
+            finish.Wait(TimeSpan.FromSeconds(60));
+            completed = true;
+        }));
+
+        Assert.That(caller.Wait(TimeSpan.FromSeconds(8)), Is.False,
+            "Run returned while the release it started was still executing");
+
+        finish.Set();
+        Assert.That(caller.Wait(TimeSpan.FromSeconds(30)), Is.True);
+        Assert.That(completed, Is.True);
+    }
+
     [Test]
     public void A_release_that_throws_after_the_wait_was_given_up_leaves_the_dispatcher_usable()
     {

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
@@ -124,8 +124,7 @@ public class RenderTargetThreadAffinityTests
             Assert.That(Task.Run(canvas.Dispose).Wait(TimeSpan.FromSeconds(30)), Is.True);
             Assert.That(canvas.IsDisposed, Is.False, "precondition: the first Dispose left the cleanup queued");
 
-            // Only a claim taken before queuing can turn the second call away without waiting; a
-            // guard on IsDisposed alone would queue a rival cleanup and block for the full deadline.
+            // A guard on IsDisposed alone would queue a rival cleanup and block for the full deadline.
             Assert.That(Task.Run(canvas.Dispose).Wait(TimeSpan.FromSeconds(1)), Is.True,
                 "a second Dispose must be turned away immediately, not queue another cleanup");
         }
@@ -160,8 +159,8 @@ public class RenderTargetThreadAffinityTests
             Assert.That(started.Wait(TimeSpan.FromSeconds(30)), Is.True,
                 "the render thread never started the release");
 
-            // From a finally: the failure this asserts is Run returning early, which would leave the
-            // shared render dispatcher blocked in the callback and take out every later test.
+            // Under the finally: a failure would otherwise leave the shared render dispatcher
+            // blocked in the callback and take out every later test.
             Assert.That(caller.Wait(TimeSpan.FromSeconds(8)), Is.False,
                 "Run returned while the release it started was still executing");
         }

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
@@ -1,0 +1,46 @@
+﻿using Beutl.Graphics.Rendering;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+// Skia's GPU context is thread-affine: releasing a surface off the thread that allocated it
+// corrupts the context and faults the render thread later (SIGSEGV inside libSkiaSharp with no
+// managed stack). These lock the hop that keeps the release on the owning thread.
+public class RenderTargetThreadAffinityTests
+{
+    [Test]
+    public void Dispose_from_another_thread_releases_on_the_owning_thread()
+    {
+        RenderTarget target = RenderThread.Dispatcher.Invoke(() => RenderTarget.CreateNull(4, 4));
+        using var occupied = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+
+        RenderThread.Dispatcher.Dispatch(() =>
+        {
+            occupied.Set();
+            release.Wait(TimeSpan.FromSeconds(30));
+        });
+        Assert.That(occupied.Wait(TimeSpan.FromSeconds(30)), Is.True, "the render thread never picked up the blocker");
+
+        Task dispose = Task.Run(target.Dispose);
+
+        Assert.That(dispose.Wait(TimeSpan.FromMilliseconds(500)), Is.False,
+            "Dispose returned while the render thread was busy, so it released the surface on the calling thread.");
+
+        release.Set();
+        Assert.That(dispose.Wait(TimeSpan.FromSeconds(30)), Is.True);
+        Assert.That(target.IsDisposed, Is.True);
+    }
+
+    [Test]
+    public void Dispose_on_the_owning_thread_releases_inline()
+    {
+        RenderThread.Dispatcher.Invoke(() =>
+        {
+            RenderTarget target = RenderTarget.CreateNull(4, 4);
+
+            target.Dispose();
+
+            Assert.That(target.IsDisposed, Is.True);
+        });
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
@@ -66,6 +66,41 @@ public class RenderTargetThreadAffinityTests
         Assert.That(target.IsDisposed, Is.True);
     }
 
+    // Slow is not stopped: a dispatcher that has not drained the release yet may be mid-frame and
+    // still using what the release would tear down, so waiting must time out into leaving the work
+    // queued, never into releasing here.
+    [Test]
+    public void Dispose_gives_up_waiting_rather_than_releasing_off_a_busy_owning_thread()
+    {
+        ProbeRenderTarget target = CreateOnRenderThread(out SKSurface surface);
+        using var occupied = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+
+        try
+        {
+            RenderThread.Dispatcher.Dispatch(() =>
+            {
+                occupied.Set();
+                release.Wait(TimeSpan.FromSeconds(60));
+            });
+            Assert.That(occupied.Wait(TimeSpan.FromSeconds(30)), Is.True, "the render thread never took the blocker");
+
+            Task dispose = Task.Run(target.Dispose);
+
+            Assert.That(dispose.Wait(TimeSpan.FromSeconds(30)), Is.True,
+                "Dispose must stop waiting on a busy dispatcher instead of blocking its caller indefinitely");
+            Assert.That(surface.Handle, Is.Not.EqualTo(IntPtr.Zero),
+                "giving up must leave the release queued, not run it on the calling thread while the render thread is live");
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        Assert.That(WaitUntilReleased(surface), Is.True,
+            "the queued release should still run once the render thread drains it");
+    }
+
     [Test]
     public void Dispose_on_the_owning_thread_releases_inline()
     {
@@ -80,6 +115,21 @@ public class RenderTargetThreadAffinityTests
                 "disposal on the owning thread must release the surface before it returns, not queue it");
             Assert.That(target.IsDisposed, Is.True);
         });
+    }
+
+    private static bool WaitUntilReleased(SKSurface surface)
+    {
+        for (int i = 0; i < 300; i++)
+        {
+            if (surface.Handle == IntPtr.Zero)
+            {
+                return true;
+            }
+
+            Thread.Sleep(10);
+        }
+
+        return false;
     }
 
     private static bool WaitUntilBlocked(Thread thread)

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
@@ -139,6 +139,34 @@ public class RenderTargetThreadAffinityTests
     }
 
     [Test]
+    public void A_release_that_throws_after_the_wait_was_given_up_leaves_the_dispatcher_usable()
+    {
+        using var occupied = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+
+        try
+        {
+            RenderThread.Dispatcher.Dispatch(() =>
+            {
+                occupied.Set();
+                release.Wait(TimeSpan.FromSeconds(60));
+            });
+            Assert.That(occupied.Wait(TimeSpan.FromSeconds(30)), Is.True, "the render thread never took the blocker");
+
+            Assert.DoesNotThrow(() => GpuResourceRelease.Run(
+                RenderThread.Dispatcher,
+                static () => throw new InvalidOperationException("release failed after the caller gave up")));
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        Assert.That(RenderThread.Dispatcher.InvokeAsync(static () => { }).Wait(TimeSpan.FromSeconds(30)), Is.True,
+            "the render thread must keep draining after a queued release faulted");
+    }
+
+    [Test]
     public void Dispose_on_the_owning_thread_releases_inline()
     {
         RenderThread.Dispatcher.Invoke(() =>

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.Graphics.Rendering;
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
 using SkiaSharp;
 
 namespace Beutl.UnitTests.Engine.Graphics.Rendering;
@@ -99,6 +100,42 @@ public class RenderTargetThreadAffinityTests
 
         Assert.That(WaitUntilReleased(surface), Is.True,
             "the queued release should still run once the render thread drains it");
+    }
+
+    // Giving up leaves the cleanup queued with IsDisposed still false, so the second Dispose has to
+    // be turned away by something claimed before the queue, or the shared paints get disposed twice.
+    [Test]
+    public void Repeated_canvas_dispose_behind_a_busy_owning_thread_queues_one_cleanup()
+    {
+        ImmediateCanvas canvas = RenderThread.Dispatcher.Invoke(() =>
+            new ImmediateCanvas(RenderTarget.CreateNull(4, 4), 1f, 1f, new Size(4, 4)));
+        using var occupied = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+
+        try
+        {
+            RenderThread.Dispatcher.Dispatch(() =>
+            {
+                occupied.Set();
+                release.Wait(TimeSpan.FromSeconds(60));
+            });
+            Assert.That(occupied.Wait(TimeSpan.FromSeconds(30)), Is.True, "the render thread never took the blocker");
+
+            Assert.That(Task.Run(canvas.Dispose).Wait(TimeSpan.FromSeconds(30)), Is.True);
+            Assert.That(canvas.IsDisposed, Is.False, "precondition: the first Dispose left the cleanup queued");
+
+            // Only a claim taken before queuing can turn the second call away without waiting; a
+            // guard on IsDisposed alone would queue a rival cleanup and block for the full deadline.
+            Assert.That(Task.Run(canvas.Dispose).Wait(TimeSpan.FromSeconds(1)), Is.True,
+                "a second Dispose must be turned away immediately, not queue another cleanup");
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        RenderThread.Dispatcher.Invoke(() => { });
+        Assert.That(canvas.IsDisposed, Is.True);
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
@@ -152,10 +152,18 @@ public class RenderTargetThreadAffinityTests
             completed = true;
         }));
 
-        Assert.That(caller.Wait(TimeSpan.FromSeconds(8)), Is.False,
-            "Run returned while the release it started was still executing");
+        try
+        {
+            // From a finally: the failure this asserts is Run returning early, which would leave the
+            // shared render dispatcher blocked in the callback and take out every later test.
+            Assert.That(caller.Wait(TimeSpan.FromSeconds(8)), Is.False,
+                "Run returned while the release it started was still executing");
+        }
+        finally
+        {
+            finish.Set();
+        }
 
-        finish.Set();
         Assert.That(caller.Wait(TimeSpan.FromSeconds(30)), Is.True);
         Assert.That(completed, Is.True);
     }

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
@@ -1,33 +1,67 @@
 ﻿using Beutl.Graphics.Rendering;
+using SkiaSharp;
 
 namespace Beutl.UnitTests.Engine.Graphics.Rendering;
 
 // Skia's GPU context is thread-affine: releasing a surface off the thread that allocated it
 // corrupts the context and faults the render thread later (SIGSEGV inside libSkiaSharp with no
-// managed stack). These lock the hop that keeps the release on the owning thread.
+// managed stack). These assert on the backing SKSurface rather than on IsDisposed, which Dispose
+// sets before the release runs and so cannot distinguish an inline release from a queued one.
 public class RenderTargetThreadAffinityTests
 {
-    [Test]
-    public void Dispose_from_another_thread_releases_on_the_owning_thread()
+    private sealed class ProbeRenderTarget(SKSurface surface) : RenderTarget(surface, 4, 4);
+
+    private static ProbeRenderTarget CreateOnRenderThread(out SKSurface surface)
     {
-        RenderTarget target = RenderThread.Dispatcher.Invoke(() => RenderTarget.CreateNull(4, 4));
+        SKSurface? created = null;
+        ProbeRenderTarget target = RenderThread.Dispatcher.Invoke(() =>
+        {
+            created = SKSurface.CreateNull(4, 4);
+            return new ProbeRenderTarget(created);
+        });
+        surface = created!;
+        return target;
+    }
+
+    [Test]
+    public void Dispose_from_another_thread_defers_the_release_to_the_owning_thread()
+    {
+        ProbeRenderTarget target = CreateOnRenderThread(out SKSurface surface);
         using var occupied = new ManualResetEventSlim(false);
         using var release = new ManualResetEventSlim(false);
-
-        RenderThread.Dispatcher.Dispatch(() =>
+        using var entered = new ManualResetEventSlim(false);
+        var disposer = new Thread(() =>
         {
-            occupied.Set();
-            release.Wait(TimeSpan.FromSeconds(30));
-        });
-        Assert.That(occupied.Wait(TimeSpan.FromSeconds(30)), Is.True, "the render thread never picked up the blocker");
+            entered.Set();
+            target.Dispose();
+        })
+        { IsBackground = true, Name = "dispose-probe" };
 
-        Task dispose = Task.Run(target.Dispose);
+        try
+        {
+            RenderThread.Dispatcher.Dispatch(() =>
+            {
+                occupied.Set();
+                release.Wait(TimeSpan.FromSeconds(30));
+            });
+            Assert.That(occupied.Wait(TimeSpan.FromSeconds(30)), Is.True, "the render thread never took the blocker");
 
-        Assert.That(dispose.Wait(TimeSpan.FromMilliseconds(500)), Is.False,
-            "Dispose returned while the render thread was busy, so it released the surface on the calling thread.");
+            // A dedicated thread rather than the pool: a starved pool could delay Dispose past the
+            // observation below and let an inline release pass unnoticed.
+            disposer.Start();
+            Assert.That(entered.Wait(TimeSpan.FromSeconds(30)), Is.True);
+            WaitUntilBlocked(disposer);
 
-        release.Set();
-        Assert.That(dispose.Wait(TimeSpan.FromSeconds(30)), Is.True);
+            Assert.That(surface.Handle, Is.Not.EqualTo(IntPtr.Zero),
+                "the surface was released while the render thread was blocked, so Dispose released it on the calling thread");
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        Assert.That(disposer.Join(TimeSpan.FromSeconds(30)), Is.True);
+        Assert.That(surface.Handle, Is.EqualTo(IntPtr.Zero), "the surface should be released once the render thread is free");
         Assert.That(target.IsDisposed, Is.True);
     }
 
@@ -36,11 +70,22 @@ public class RenderTargetThreadAffinityTests
     {
         RenderThread.Dispatcher.Invoke(() =>
         {
-            RenderTarget target = RenderTarget.CreateNull(4, 4);
+            SKSurface surface = SKSurface.CreateNull(4, 4);
+            var target = new ProbeRenderTarget(surface);
 
             target.Dispose();
 
+            Assert.That(surface.Handle, Is.EqualTo(IntPtr.Zero),
+                "disposal on the owning thread must release the surface before it returns, not queue it");
             Assert.That(target.IsDisposed, Is.True);
         });
+    }
+
+    private static void WaitUntilBlocked(Thread thread)
+    {
+        for (int i = 0; i < 300 && (thread.ThreadState & ThreadState.WaitSleepJoin) == 0; i++)
+        {
+            Thread.Sleep(10);
+        }
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs
@@ -50,7 +50,8 @@ public class RenderTargetThreadAffinityTests
             // observation below and let an inline release pass unnoticed.
             disposer.Start();
             Assert.That(entered.Wait(TimeSpan.FromSeconds(30)), Is.True);
-            WaitUntilBlocked(disposer);
+            Assert.That(WaitUntilBlocked(disposer), Is.True,
+                "Dispose never blocked while the owning render thread was occupied");
 
             Assert.That(surface.Handle, Is.Not.EqualTo(IntPtr.Zero),
                 "the surface was released while the render thread was blocked, so Dispose released it on the calling thread");
@@ -81,11 +82,18 @@ public class RenderTargetThreadAffinityTests
         });
     }
 
-    private static void WaitUntilBlocked(Thread thread)
+    private static bool WaitUntilBlocked(Thread thread)
     {
-        for (int i = 0; i < 300 && (thread.ThreadState & ThreadState.WaitSleepJoin) == 0; i++)
+        for (int i = 0; i < 300; i++)
         {
+            if ((thread.ThreadState & ThreadState.WaitSleepJoin) != 0)
+            {
+                return true;
+            }
+
             Thread.Sleep(10);
         }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Description

- `RenderTarget` captures the allocating dispatcher in `_dispatcher` and enforces it through `VerifyAccess()` for every draw operation — but `Dispose` ignored it. A render target allocated on the render thread could therefore be torn down from the UI thread, a thread-pool thread, or the GC finalizer thread. Skia's GPU context is thread-affine, so that is not a safe place to release a GPU-backed `SKSurface`.
- Four call paths reach that disposal from off the render thread: `Renderer.Dispose` (via `EditViewModel.DisposeAsync`, which resumes on a thread-pool thread after its `RenderThread.Dispatcher.InvokeAsync` barrier), `Renderer.ClearAllCaches` (a `CacheOptions` change or an export teardown, on the UI thread), the `Drawable.DetachedFromHierarchy` handler (the edit thread), and the `Renderer` finalizer (the GC thread). Instrumenting a single `Beutl.HeadlessUITests` run showed **9 of 10** `RenderTarget` disposals happening on a thread-pool thread rather than the render thread.
- `ImmediateCanvas.Dispose` already hops back to its own dispatcher for exactly this reason (its comment notes that `Canvas.Handle` can be zeroed during `GrContext` teardown). This makes the rest of the teardown consistent with it, and with `Renderer`'s constructor, which allocates through `RenderThread.Dispatcher.Invoke`.
- The finalizer paths dispatch rather than invoke, since a finalizer must not block on another thread, and every path falls back to releasing in place once the owning dispatcher has started shutting down — leaking is worse than never releasing at all.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes

None. No public signature changes. `RenderTarget.Dispose`, `Renderer.Dispose` and `Renderer.ClearAllCaches` now block while the owning dispatcher runs the release when called from another thread (they already ran inline when called on the render thread, and `Dispatcher.Invoke` still short-circuits in that case). Callers that disposed a render target from a background thread and relied on `Dispose` returning before the native release completed will now wait for it.

## Test plan

- New `tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderTargetThreadAffinityTests.cs`:
  - `Dispose_from_another_thread_releases_on_the_owning_thread` occupies the render thread, disposes from a thread-pool thread, and asserts `Dispose` cannot complete until the render thread is free — which is only true if the release was marshalled. **Characterized: with the production change stashed this test fails** with `Dispose returned while the render thread was busy, so it released the surface on the calling thread.`, and passes with it.
  - `Dispose_on_the_owning_thread_releases_inline` pins the no-hop path so the fix cannot regress into dispatching from the render thread onto itself.
- `dotnet build Beutl.slnx`: 0 warnings, 0 errors. `dotnet test tests/Beutl.UnitTests -f net10.0`: 4961 passed, 3 skipped, 0 failed. `dotnet format --verify-no-changes`: clean.

## Fixed issues / References

None — no issue is filed for this.

### Scope note: this is not a crash fix

`Beutl.HeadlessUITests` has an intermittent native test-host crash (`Reason: Test host process crashed`, faulting thread `Beutl.RenderThread` inside `libSkiaSharp`). This change was written while investigating it and does **not** fix it: over full-assembly runs on macOS, unmodified `main` crashed 7/26 and this branch 6/30 (Fisher exact two-tailed p = 0.75). The reason it does not help is worth recording — `SKSurfaceCounter.Release` already dispatches the final native `Dispose` to the owning dispatcher, so the off-thread `Dispose` calls this PR corrects were not themselves reaching Skia off-thread.

The change still stands on its own: `RenderTarget` declared a thread affinity it did not enforce on teardown, and the regression test now holds it to it. That crash is separately mitigated by #2187 (per-assembly Avalonia test isolation), which took it from 26.9% to 0 failures in 12 consecutive CI re-runs and 0/104 local concurrent runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU resource cleanup across render threads.
  * Prevented rendering resources from being released on the wrong thread.
  * Ensured disposal remains reliable during shutdown and finalization.
  * Prevented duplicate cleanup when canvases are disposed repeatedly.
  * Improved cleanup of detached drawing resources and rendering caches.

* **Tests**
  * Added coverage for disposal on owning and non-owning threads, busy render threads, repeated disposal, delayed releases, failed releases, and shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->