### PR TITLE
fix: keep frame cache entries consistent with the options that made them

### DIFF
--- a/src/Beutl.Editor/Models/PreviewFrameCacheSizing.cs
+++ b/src/Beutl.Editor/Models/PreviewFrameCacheSizing.cs
@@ -13,9 +13,8 @@ public static class PreviewFrameCacheSizing
     /// the panel is at least as large as the frame, or the reduction rounds down to 1.
     /// </summary>
     /// <remarks>
-    /// The reduction is rounded down so an entry is never coarser than what the panel shows. A
-    /// coarser entry would make a cached frame visibly softer than a freshly rendered one, and the
-    /// preview alternates between the two as it crosses cache boundaries.
+    /// Rounded down, so an entry is never coarser than the panel: a coarser one looks softer than a
+    /// freshly rendered frame, and the preview alternates between the two across cache boundaries.
     /// </remarks>
     public static PixelSize? DeriveCacheSize(Size maxFrameSize, PixelSize frameSize)
     {

--- a/src/Beutl.Editor/Models/PreviewFrameCacheSizing.cs
+++ b/src/Beutl.Editor/Models/PreviewFrameCacheSizing.cs
@@ -11,6 +11,11 @@ public static class PreviewFrameCacheSizing
     /// <summary>
     /// Returns the cache entry size, or null if the panel is at least as large as the frame.
     /// </summary>
+    /// <remarks>
+    /// The reduction is rounded down so an entry is never coarser than what the panel shows. A
+    /// coarser entry would make a cached frame visibly softer than a freshly rendered one, and the
+    /// preview alternates between the two as it crosses cache boundaries.
+    /// </remarks>
     public static PixelSize? DeriveCacheSize(Size maxFrameSize, PixelSize frameSize)
     {
         Size frame = frameSize.ToSize(1);
@@ -23,11 +28,12 @@ public static class PreviewFrameCacheSizing
         }
 
         int den = (int)(1f / scale);
-        if (den % 2 == 1)
+        if (den <= 1)
         {
-            den++;
+            return null;
         }
 
-        return PixelSize.FromSize(frame, 1f / den);
+        PixelSize reduced = PixelSize.FromSize(frame, 1f / den);
+        return new PixelSize(Math.Max(1, reduced.Width), Math.Max(1, reduced.Height));
     }
 }

--- a/src/Beutl.Editor/Models/PreviewFrameCacheSizing.cs
+++ b/src/Beutl.Editor/Models/PreviewFrameCacheSizing.cs
@@ -9,7 +9,8 @@ namespace Beutl.Models;
 public static class PreviewFrameCacheSizing
 {
     /// <summary>
-    /// Returns the cache entry size, or null if the panel is at least as large as the frame.
+    /// Returns the reduced cache entry size, or null when there is nothing to gain from reducing:
+    /// the panel is at least as large as the frame, or the reduction rounds down to 1.
     /// </summary>
     /// <remarks>
     /// The reduction is rounded down so an entry is never coarser than what the panel shows. A

--- a/src/Beutl/Models/FrameCacheManager.CacheEntry.cs
+++ b/src/Beutl/Models/FrameCacheManager.CacheEntry.cs
@@ -59,9 +59,13 @@ public partial class FrameCacheManager
             try
             {
                 // Resize if needed
+                // Alpha type is part of the stored representation: the branch below draws into a
+                // Premul surface and ToBitmap describes entries that way, so unpremultiplied input
+                // that skipped it would have its translucent colors read as premultiplied.
                 if (newSize.Width < size.Width ||
                     newSize.Height < size.Height ||
                     bitmap.ColorType != BitmapColorType.Bgra8888 ||
+                    bitmap.AlphaType != BitmapAlphaType.Premul ||
                     bitmap.ColorSpace != BitmapColorSpace.Srgb)
                 {
                     var newWidth = Math.Min(size.Width, newSize.Width);

--- a/src/Beutl/Models/FrameCacheManager.CacheEntry.cs
+++ b/src/Beutl/Models/FrameCacheManager.CacheEntry.cs
@@ -144,7 +144,10 @@ public partial class FrameCacheManager
         {
             if (!_isYuv)
             {
-                var bitmap = new Bitmap(_width, _height);
+                // ToCacheData draws into a Premul surface, so the entry has to describe itself that
+                // way; labelling premultiplied pixels Unpremul makes the preview premultiply them a
+                // second time and darkens every translucent area.
+                var bitmap = new Bitmap(_width, _height, BitmapColorType.Bgra8888, BitmapAlphaType.Premul);
                 int srcStride = _width * 4;
                 int dstStride = bitmap.RowBytes;
 
@@ -171,7 +174,7 @@ public partial class FrameCacheManager
             }
             else
             {
-                var bitmap = new Bitmap(_width, _height);
+                var bitmap = new Bitmap(_width, _height, BitmapColorType.Bgra8888, BitmapAlphaType.Premul);
                 fixed (byte* yuvPtr = _data)
                 {
                     YuvConversion.I420ToBgra(yuvPtr, (byte*)bitmap.Data, bitmap.RowBytes, _width, _height);

--- a/src/Beutl/Models/FrameCacheManager.CacheEntry.cs
+++ b/src/Beutl/Models/FrameCacheManager.CacheEntry.cs
@@ -60,8 +60,7 @@ public partial class FrameCacheManager
             {
                 // Resize if needed
                 // Alpha type is part of the stored representation: the branch below draws into a
-                // Premul surface and ToBitmap describes entries that way, so unpremultiplied input
-                // that skipped it would have its translucent colors read as premultiplied.
+                // Premul surface, so unpremultiplied input that skipped it would be read as premultiplied.
                 if (newSize.Width < size.Width ||
                     newSize.Height < size.Height ||
                     bitmap.ColorType != BitmapColorType.Bgra8888 ||
@@ -148,9 +147,8 @@ public partial class FrameCacheManager
         {
             if (!_isYuv)
             {
-                // ToCacheData draws into a Premul surface, so the entry has to describe itself that
-                // way; labelling premultiplied pixels Unpremul makes the preview premultiply them a
-                // second time and darkens every translucent area.
+                // ToCacheData draws into a Premul surface; labelling those pixels Unpremul makes the
+                // preview premultiply them a second time and darkens every translucent area.
                 var bitmap = new Bitmap(_width, _height, BitmapColorType.Bgra8888, BitmapAlphaType.Premul);
                 int srcStride = _width * 4;
                 int dstStride = bitmap.RowBytes;

--- a/src/Beutl/Models/FrameCacheManager.cs
+++ b/src/Beutl/Models/FrameCacheManager.cs
@@ -46,7 +46,7 @@ public sealed partial class FrameCacheManager : IDisposable
                 FrameCacheOptions old = _options;
                 _options = value;
 
-                if (!old.ProducesSameCacheData(value, FrameSize))
+                if (!old.ProducesSameCacheData(value))
                 {
                     Clear();
                 }

--- a/src/Beutl/Models/FrameCacheManager.cs
+++ b/src/Beutl/Models/FrameCacheManager.cs
@@ -29,18 +29,16 @@ public sealed partial class FrameCacheManager : IDisposable
     public ImmutableArray<CacheBlock> Blocks { get; private set; } = [];
 
     /// <summary>
-    /// Cache-entry format. Assigning options that change the stored representation drops every entry:
-    /// the existing ones were encoded under the previous options, and mixing the two makes playback
-    /// alternate between resolutions.
+    /// Cache-entry format. Assigning options that change the stored representation drops every entry;
+    /// mixing the two makes playback alternate between resolutions.
     /// </summary>
     public FrameCacheOptions Options
     {
         get => _options;
         set
         {
-            // Under one lock: releasing it between the assignment and the invalidation lets a
-            // concurrent TryGet return an entry encoded with the old options after the new ones are
-            // published, and a concurrent Add create a correctly encoded entry that Clear then drops.
+            // One lock: releasing it between the assignment and the invalidation lets a concurrent
+            // TryGet return an entry encoded with the options it just replaced.
             lock (_lock)
             {
                 FrameCacheOptions old = _options;
@@ -72,8 +70,7 @@ public sealed partial class FrameCacheManager : IDisposable
                 if (old.IsLocked)
                 {
                     // Locked pins an entry against eviction and deletion; it does not freeze the
-                    // picture. Locked entries are excluded from _size (see Lock), so refreshing one
-                    // leaves the accounting alone.
+                    // picture. Locked entries are excluded from _size (see Lock).
                     old.SetBitmap(bitmap, Options);
                 }
                 else

--- a/src/Beutl/Models/FrameCacheManager.cs
+++ b/src/Beutl/Models/FrameCacheManager.cs
@@ -38,16 +38,18 @@ public sealed partial class FrameCacheManager : IDisposable
         get => _options;
         set
         {
-            FrameCacheOptions old;
+            // Under one lock: releasing it between the assignment and the invalidation lets a
+            // concurrent TryGet return an entry encoded with the old options after the new ones are
+            // published, and a concurrent Add create a correctly encoded entry that Clear then drops.
             lock (_lock)
             {
-                old = _options;
+                FrameCacheOptions old = _options;
                 _options = value;
-            }
 
-            if (!old.ProducesSameCacheData(value, FrameSize))
-            {
-                Clear();
+                if (!old.ProducesSameCacheData(value, FrameSize))
+                {
+                    Clear();
+                }
             }
         }
     }
@@ -67,8 +69,14 @@ public sealed partial class FrameCacheManager : IDisposable
         {
             if (_entries.TryGetValue(frame, out CacheEntry? old))
             {
-                // Locked entries are excluded from _size (see Lock), so only this branch adjusts it.
-                if (!old.IsLocked)
+                if (old.IsLocked)
+                {
+                    // Locked pins an entry against eviction and deletion; it does not freeze the
+                    // picture. Locked entries are excluded from _size (see Lock), so refreshing one
+                    // leaves the accounting alone.
+                    old.SetBitmap(bitmap, Options);
+                }
+                else
                 {
                     _size -= old.ByteCount;
                     old.SetBitmap(bitmap, Options);
@@ -83,7 +91,7 @@ public sealed partial class FrameCacheManager : IDisposable
             }
         }
 
-        if (_size >= _maxSize.Value)
+        if (_size > _maxSize.Value)
         {
             Task.Run(AutoDelete);
         }
@@ -243,7 +251,7 @@ public sealed partial class FrameCacheManager : IDisposable
         {
             foreach (KeyValuePair<int, CacheEntry> item in items)
             {
-                if (_size < _maxSize.Value)
+                if (_size <= _maxSize.Value)
                     break;
 
                 _size -= item.Value.ByteCount;
@@ -267,7 +275,7 @@ public sealed partial class FrameCacheManager : IDisposable
                 }
 
                 DeleteRange(item.Start, item.Start + item.Length);
-                if (_size < _maxSize.Value)
+                if (_size <= _maxSize.Value)
                     return;
             }
 
@@ -285,13 +293,13 @@ public sealed partial class FrameCacheManager : IDisposable
                 int loop = 5;
                 FrameCacheDeletionStrategy strategy = Options.DeletionStrategy;
 
-                while (_size >= _maxSize.Value && loop >= 0)
+                while (_size > _maxSize.Value && loop >= 0)
                 {
                     if (strategy == FrameCacheDeletionStrategy.BackwardBlock)
                     {
                         DeleteBackwardBlock();
                         strategy = FrameCacheDeletionStrategy.Far;
-                        if (_size < _maxSize.Value)
+                        if (_size <= _maxSize.Value)
                         {
                             return;
                         }

--- a/src/Beutl/Models/FrameCacheManager.cs
+++ b/src/Beutl/Models/FrameCacheManager.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using Beutl.Configuration;
-using Beutl.Editor.Models;
 using Beutl.Media;
 using Beutl.Media.Source;
 using Reactive.Bindings;
@@ -14,22 +12,45 @@ public sealed partial class FrameCacheManager : IDisposable
     private readonly object _lock = new();
     private readonly ReadOnlyReactivePropertySlim<long> _maxSize;
     private long _size;
+    private FrameCacheOptions _options;
 
     public event Action<ImmutableArray<CacheBlock>>? BlocksUpdated;
 
-    public FrameCacheManager(PixelSize frameSize, FrameCacheOptions options)
+    /// <summary>Creates a frame cache for frames of <paramref name="frameSize"/>.</summary>
+    /// <param name="maxSize">Cache budget in bytes. Must publish a value on subscribe.</param>
+    public FrameCacheManager(PixelSize frameSize, FrameCacheOptions options, IObservable<long> maxSize)
     {
+        ArgumentNullException.ThrowIfNull(maxSize);
         FrameSize = frameSize;
-        Options = options;
-
-        _maxSize = GlobalConfiguration.Instance.EditorConfig.GetObservable(EditorConfig.FrameCacheMaxSizeProperty)
-            .Select(v => (long)(v * 1024 * 1024))
-            .ToReadOnlyReactivePropertySlim();
+        _options = options;
+        _maxSize = maxSize.ToReadOnlyReactivePropertySlim();
     }
 
-    public ImmutableArray<CacheBlock> Blocks { get; private set; }
+    public ImmutableArray<CacheBlock> Blocks { get; private set; } = [];
 
-    public FrameCacheOptions Options { get; set; }
+    /// <summary>
+    /// Cache-entry format. Assigning options that change the stored representation drops every entry:
+    /// the existing ones were encoded under the previous options, and mixing the two makes playback
+    /// alternate between resolutions.
+    /// </summary>
+    public FrameCacheOptions Options
+    {
+        get => _options;
+        set
+        {
+            FrameCacheOptions old;
+            lock (_lock)
+            {
+                old = _options;
+                _options = value;
+            }
+
+            if (!old.ProducesSameCacheData(value, FrameSize))
+            {
+                Clear();
+            }
+        }
+    }
 
     // 再生中のフレーム
     public int CurrentFrame { get; set; }
@@ -46,8 +67,13 @@ public sealed partial class FrameCacheManager : IDisposable
         {
             if (_entries.TryGetValue(frame, out CacheEntry? old))
             {
+                // Locked entries are excluded from _size (see Lock), so only this branch adjusts it.
                 if (!old.IsLocked)
+                {
+                    _size -= old.ByteCount;
                     old.SetBitmap(bitmap, Options);
+                    _size += old.ByteCount;
+                }
             }
             else
             {
@@ -184,12 +210,16 @@ public sealed partial class FrameCacheManager : IDisposable
 
             _size = 0;
             _entries.Clear();
-            BlocksUpdated?.Invoke([]);
+            Blocks = [];
+            BlocksUpdated?.Invoke(Blocks);
         }
     }
 
     private void AutoDelete()
     {
+        // Queued by Add via Task.Run, so it can still be scheduled after Dispose released _maxSize.
+        if (_isDisposed) return;
+
         int currentFrame = CurrentFrame;
         KeyValuePair<int, CacheEntry>[] GetOldCaches(long targetCount)
         {
@@ -249,31 +279,47 @@ public sealed partial class FrameCacheManager : IDisposable
 
         lock (_lock)
         {
-            int loop = 5;
-            FrameCacheDeletionStrategy strategy = Options.DeletionStrategy;
-
-            while (_size >= _maxSize.Value && loop >= 0)
+            int countBefore = _entries.Count;
+            try
             {
-                if (strategy == FrameCacheDeletionStrategy.BackwardBlock)
+                int loop = 5;
+                FrameCacheDeletionStrategy strategy = Options.DeletionStrategy;
+
+                while (_size >= _maxSize.Value && loop >= 0)
                 {
-                    DeleteBackwardBlock();
-                    strategy = FrameCacheDeletionStrategy.Far;
-                    if (_size < _maxSize.Value)
+                    if (strategy == FrameCacheDeletionStrategy.BackwardBlock)
                     {
-                        return;
+                        DeleteBackwardBlock();
+                        strategy = FrameCacheDeletionStrategy.Far;
+                        if (_size < _maxSize.Value)
+                        {
+                            return;
+                        }
                     }
+
+                    long excess = _size - _maxSize.Value;
+                    int sizePerCache = Math.Max(1, CalculateBitmapByteSize(
+                        Options.GetSize(FrameSize), Options.ColorType == FrameCacheColorType.YUV));
+                    // At least one, so an excess smaller than a single entry still makes progress
+                    // instead of spinning the loop out with an empty deletion set.
+                    long targetCount = Math.Max(1, excess / sizePerCache);
+
+                    KeyValuePair<int, CacheEntry>[] items = strategy == FrameCacheDeletionStrategy.Old
+                        ? GetOldCaches(targetCount)
+                        : GetFarCaches(targetCount);
+                    DeleteItems(items);
+
+                    loop--;
                 }
-
-                long excess = _size - _maxSize.Value;
-                int sizePerCache = CalculateBitmapByteSize(Options.GetSize(FrameSize), Options.ColorType == FrameCacheColorType.YUV);
-                long targetCount = excess / sizePerCache;
-
-                var items = Options.DeletionStrategy == FrameCacheDeletionStrategy.Old
-                    ? GetOldCaches(targetCount)
-                    : GetFarCaches(targetCount);
-                DeleteItems(items);
-
-                loop--;
+            }
+            finally
+            {
+                // Eviction is the only removal path that does not go through DeleteAndUpdateBlocks,
+                // so without this the timeline keeps painting evicted ranges as cached.
+                if (_entries.Count != countBefore)
+                {
+                    UpdateBlocks();
+                }
             }
         }
     }

--- a/src/Beutl/Models/FrameCacheOptions.cs
+++ b/src/Beutl/Models/FrameCacheOptions.cs
@@ -20,8 +20,19 @@ public record FrameCacheOptions(
         };
     }
 
-    internal bool ProducesSameCacheData(FrameCacheOptions other, PixelSize frameSize)
+    /// <summary>
+    /// Whether entries encoded under these options can be read back under <paramref name="other"/>.
+    /// </summary>
+    /// <remarks>
+    /// Compared by scale mode rather than by the size the modes resolve to: an entry is encoded from
+    /// the rendered snapshot, whose size is the device size, while the size these modes resolve
+    /// against is the logical frame. Two modes that agree on the logical frame can therefore still
+    /// produce entries of different sizes whenever the output scale is not 1.
+    /// </remarks>
+    internal bool ProducesSameCacheData(FrameCacheOptions other)
     {
-        return ColorType == other.ColorType && GetSize(frameSize) == other.GetSize(frameSize);
+        return ColorType == other.ColorType
+            && Scale == other.Scale
+            && (Scale != FrameCacheScale.Manual || Size == other.Size);
     }
 }

--- a/src/Beutl/Models/FrameCacheOptions.cs
+++ b/src/Beutl/Models/FrameCacheOptions.cs
@@ -19,4 +19,9 @@ public record FrameCacheOptions(
             _ => PixelSize.FromSize(original.ToSize(0.5f), 0.5f)
         };
     }
+
+    internal bool ProducesSameCacheData(FrameCacheOptions other, PixelSize frameSize)
+    {
+        return ColorType == other.ColorType && GetSize(frameSize) == other.GetSize(frameSize);
+    }
 }

--- a/src/Beutl/Models/FrameCacheOptions.cs
+++ b/src/Beutl/Models/FrameCacheOptions.cs
@@ -24,10 +24,9 @@ public record FrameCacheOptions(
     /// Whether entries encoded under these options can be read back under <paramref name="other"/>.
     /// </summary>
     /// <remarks>
-    /// Compared by scale mode rather than by the size the modes resolve to: an entry is encoded from
-    /// the rendered snapshot, whose size is the device size, while the size these modes resolve
-    /// against is the logical frame. Two modes that agree on the logical frame can therefore still
-    /// produce entries of different sizes whenever the output scale is not 1.
+    /// By scale mode, not by the size the modes resolve to: an entry is encoded from the rendered
+    /// snapshot, whose size is the device size, while the modes resolve against the logical frame. Two
+    /// modes agreeing on the logical frame still differ whenever the output scale is not 1.
     /// </remarks>
     internal bool ProducesSameCacheData(FrameCacheOptions other)
     {

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -112,7 +112,10 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
 
         // Derived from Renderer so the swap is ordered: cache subscribers see the new Renderer.
         FrameCacheManager = Renderer
-            .Select(r => new FrameCacheManager(r.FrameSize, CreateFrameCacheOptions()) { IsEnabled = config.IsFrameCacheEnabled })
+            .Select(r => new FrameCacheManager(r.FrameSize, CreateFrameCacheOptions(), CreateFrameCacheMaxSize())
+            {
+                IsEnabled = config.IsFrameCacheEnabled
+            })
             .DisposePreviousValue()
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables)!;
@@ -180,6 +183,13 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
         RestoreState();
 
         _logger.LogInformation("Initialized EditViewModel for Scene ({SceneId}).", SceneId);
+    }
+
+    private static IObservable<long> CreateFrameCacheMaxSize()
+    {
+        return GlobalConfiguration.Instance.EditorConfig
+            .GetObservable(EditorConfig.FrameCacheMaxSizeProperty)
+            .Select(v => (long)(v * 1024 * 1024));
     }
 
     private static FrameCacheOptions CreateFrameCacheOptions()

--- a/tests/Beutl.HeadlessUITests/FrameCacheDitherTests.cs
+++ b/tests/Beutl.HeadlessUITests/FrameCacheDitherTests.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.Media;
+﻿using System.Reactive.Linq;
+using Beutl.Media;
 using Beutl.Media.Source;
 using Beutl.Models;
 
@@ -59,7 +60,8 @@ public class FrameCacheDitherTests
     {
         using var manager = new FrameCacheManager(
             new PixelSize(Width, Height),
-            new FrameCacheOptions(FrameCacheScale.Original, FrameCacheColorType.BGRA))
+            new FrameCacheOptions(FrameCacheScale.Original, FrameCacheColorType.BGRA),
+            Observable.Return(long.MaxValue))
         {
             IsEnabled = true
         };
@@ -108,7 +110,8 @@ public class FrameCacheDitherTests
             new FrameCacheOptions(FrameCacheScale.Manual, FrameCacheColorType.BGRA)
             {
                 Size = new PixelSize(Width / 4, Width / 4)
-            })
+            },
+            Observable.Return(long.MaxValue))
         { IsEnabled = true };
 
         using (Ref<Bitmap> source = Ref<Bitmap>.Create(CreateCheckerboard()))

--- a/tests/Beutl.HeadlessUITests/FrameCacheManagerTests.cs
+++ b/tests/Beutl.HeadlessUITests/FrameCacheManagerTests.cs
@@ -10,8 +10,8 @@ using SkiaSharp;
 namespace Beutl.HeadlessUITests;
 
 /// <summary>
-/// The timeline paints cache blocks purely from <see cref="FrameCacheManager.BlocksUpdated"/>, and the
-/// preview shows whatever an entry holds, so eviction and option changes both have to be observable.
+/// The timeline paints cache blocks purely from <see cref="FrameCacheManager.BlocksUpdated"/>, so
+/// eviction and option changes both have to be observable.
 /// </summary>
 [TestFixture]
 public class FrameCacheManagerTests
@@ -139,9 +139,8 @@ public class FrameCacheManagerTests
     }
 
     /// <summary>
-    /// A rendered frame is premultiplied; the preview draws the cache entry through the same code
-    /// path as a fresh snapshot, so the entry has to describe its own pixels the same way or
-    /// translucent areas change appearance the moment a frame comes from the cache.
+    /// The preview draws a cache entry through the same path as a fresh snapshot, so the entry has to
+    /// describe its pixels the same way or translucent areas change the moment a frame is cached.
     /// </summary>
     [Test]
     public void RoundTrip_TranslucentFrame_PreservesTheRenderedColors()

--- a/tests/Beutl.HeadlessUITests/FrameCacheManagerTests.cs
+++ b/tests/Beutl.HeadlessUITests/FrameCacheManagerTests.cs
@@ -188,6 +188,78 @@ public class FrameCacheManagerTests
     }
 
     [Test]
+    public void RoundTrip_UnpremultipliedNativeFrame_PreservesTheRenderedColors()
+    {
+        // Already BGRA/sRGB, so nothing but the alpha type can send this through the conversion path.
+        using var source = new Bitmap(Side, Side, BitmapColorType.Bgra8888, BitmapAlphaType.Unpremul);
+        var translucent = new Bgra8888(40, 80, 200, 128);
+        source.GetPixelSpan<Bgra8888>().Fill(translucent);
+
+        using Bitmap expected = source.Convert(
+            BitmapColorType.Bgra8888, BitmapAlphaType.Premul, BitmapColorSpace.Srgb);
+
+        using FrameCacheManager manager = NewManager(
+            new FrameCacheOptions(FrameCacheScale.Original, FrameCacheColorType.BGRA));
+
+        using (Ref<Bitmap> reference = Ref<Bitmap>.Create(source.Clone()))
+        {
+            manager.Add(0, reference);
+        }
+
+        Assert.That(manager.TryGet(0, out Ref<Bitmap>? cached), Is.True);
+        using (cached)
+        {
+            Bgra8888 e = expected.GetPixelSpan<Bgra8888>()[Side / 2 * Side + Side / 2];
+            Bgra8888 a = cached!.Value.GetPixelSpan<Bgra8888>()[Side / 2 * Side + Side / 2];
+
+            Assert.Multiple(() =>
+            {
+                Assert.That((int)a.A, Is.EqualTo((int)e.A).Within(2), "alpha");
+                Assert.That((int)a.R, Is.EqualTo((int)e.R).Within(2), "red");
+                Assert.That((int)a.G, Is.EqualTo((int)e.G).Within(2), "green");
+                Assert.That((int)a.B, Is.EqualTo((int)e.B).Within(2), "blue");
+            });
+        }
+    }
+
+    [Test]
+    public void AnEntryThatExactlyFitsTheBudget_IsKept()
+    {
+        using FrameCacheManager manager = NewManager(
+            new FrameCacheOptions(FrameCacheScale.Original, FrameCacheColorType.BGRA), EntryBytes);
+
+        Add(manager, 0);
+        Thread.Sleep(200);
+
+        Assert.That(Contains(manager, 0), Is.True);
+    }
+
+    [Test]
+    public void ReRenderingALockedFrame_RefreshesThePicture()
+    {
+        using FrameCacheManager manager = NewManager(
+            new FrameCacheOptions(FrameCacheScale.Original, FrameCacheColorType.BGRA));
+
+        Add(manager, 0);
+        manager.Lock(0, 1);
+
+        using (var replacement = new Bitmap(Side, Side, BitmapColorType.Bgra8888, BitmapAlphaType.Premul))
+        {
+            replacement.GetPixelSpan<Bgra8888>().Fill(new Bgra8888(200, 20, 30, 255));
+            using Ref<Bitmap> reference = Ref<Bitmap>.Create(replacement.Clone());
+            manager.Add(0, reference);
+        }
+
+        Assert.That(manager.TryGet(0, out Ref<Bitmap>? cached), Is.True);
+        using (cached)
+        {
+            Bgra8888 pixel = cached!.Value.GetPixelSpan<Bgra8888>()[Side / 2 * Side + Side / 2];
+            Assert.That((int)pixel.R, Is.EqualTo(200).Within(2),
+                "a locked entry is pinned against deletion, not frozen");
+        }
+    }
+
+    [Test]
     public void ReassigningEquivalentOptions_KeepsTheEntries()
     {
         using FrameCacheManager manager = NewManager(new FrameCacheOptions(FrameCacheScale.Original, FrameCacheColorType.BGRA));

--- a/tests/Beutl.HeadlessUITests/FrameCacheManagerTests.cs
+++ b/tests/Beutl.HeadlessUITests/FrameCacheManagerTests.cs
@@ -1,0 +1,202 @@
+﻿using System.Collections.Immutable;
+using System.Reactive.Linq;
+using Beutl.Media;
+using Beutl.Media.Pixel;
+using Beutl.Media.Source;
+using Beutl.Models;
+
+using SkiaSharp;
+
+namespace Beutl.HeadlessUITests;
+
+/// <summary>
+/// The timeline paints cache blocks purely from <see cref="FrameCacheManager.BlocksUpdated"/>, and the
+/// preview shows whatever an entry holds, so eviction and option changes both have to be observable.
+/// </summary>
+[TestFixture]
+public class FrameCacheManagerTests
+{
+    private const int Side = 64;
+    private static readonly PixelSize FrameSize = new(Side, Side);
+    private const long EntryBytes = Side * Side * 4;
+
+    private static FrameCacheManager NewManager(
+        FrameCacheOptions options, long maxSizeBytes = long.MaxValue)
+    {
+        return new FrameCacheManager(FrameSize, options, Observable.Return(maxSizeBytes))
+        {
+            IsEnabled = true
+        };
+    }
+
+    private static Bitmap CreateFrame()
+    {
+        var info = new SKImageInfo(Side, Side, SKColorType.RgbaF16, SKAlphaType.Premul,
+            SKColorSpace.CreateSrgbLinear());
+        var skBitmap = new SKBitmap(info);
+        using (var canvas = new SKCanvas(skBitmap))
+        {
+            canvas.Clear(SKColors.Gray);
+        }
+
+        return new Bitmap(skBitmap);
+    }
+
+    private static void Add(FrameCacheManager manager, int frame)
+    {
+        using Ref<Bitmap> source = Ref<Bitmap>.Create(CreateFrame());
+        manager.Add(frame, source);
+    }
+
+    private static bool Contains(FrameCacheManager manager, int frame)
+    {
+        if (!manager.TryGet(frame, out Ref<Bitmap>? cached))
+        {
+            return false;
+        }
+
+        cached.Dispose();
+        return true;
+    }
+
+    private static int TotalCachedFrames(ImmutableArray<FrameCacheManager.CacheBlock> blocks)
+    {
+        return blocks.Sum(b => b.Length);
+    }
+
+    [Test]
+    public void Eviction_ReportsTheReducedBlocksToTheTimeline()
+    {
+        using FrameCacheManager manager = NewManager(
+            new FrameCacheOptions(FrameCacheScale.Original, FrameCacheColorType.BGRA),
+            maxSizeBytes: EntryBytes * 4);
+
+        const int AddedFrames = 24;
+        using var evicted = new ManualResetEventSlim();
+        ImmutableArray<FrameCacheManager.CacheBlock> reported = [];
+        manager.BlocksUpdated += blocks =>
+        {
+            // Raised under the manager's lock, so handlers never overlap; keep the first payload
+            // to pair with the Set/Wait barrier below.
+            if (evicted.IsSet) return;
+
+            reported = blocks;
+            evicted.Set();
+        };
+
+        for (int i = 0; i < AddedFrames; i++)
+        {
+            Add(manager, i);
+        }
+
+        Assert.That(evicted.Wait(TimeSpan.FromSeconds(10)), Is.True,
+            "eviction must report the surviving blocks; the timeline has no other source for them.");
+        Assert.That(TotalCachedFrames(reported), Is.LessThan(AddedFrames));
+    }
+
+    [Test]
+    public void ChangingOnlyTheDeletionStrategy_KeepsTheEntries()
+    {
+        using FrameCacheManager manager = NewManager(new FrameCacheOptions(FrameCacheScale.Original, FrameCacheColorType.BGRA));
+
+        Add(manager, 0);
+
+        // Playback flips this on every start/stop; dropping the cache there would defeat the feature.
+        manager.Options = manager.Options with { DeletionStrategy = FrameCacheDeletionStrategy.BackwardBlock };
+
+        Assert.That(Contains(manager, 0), Is.True);
+    }
+
+    [TestCase(FrameCacheScale.Half, null)]
+    [TestCase(FrameCacheScale.Manual, Side / 2)]
+    public void ChangingTheStoredResolution_DropsTheEntries(FrameCacheScale scale, int? manualSide)
+    {
+        using FrameCacheManager manager = NewManager(new FrameCacheOptions(FrameCacheScale.Original, FrameCacheColorType.BGRA));
+
+        Add(manager, 0);
+        Assert.That(Contains(manager, 0), Is.True);
+
+        manager.Options = manager.Options with
+        {
+            Scale = scale,
+            Size = manualSide is { } side ? new PixelSize(side, side) : null
+        };
+
+        Assert.That(Contains(manager, 0), Is.False,
+            "entries encoded at the previous resolution must not be mixed with new ones.");
+    }
+
+    [Test]
+    public void ChangingTheColorType_DropsTheEntries()
+    {
+        using FrameCacheManager manager = NewManager(new FrameCacheOptions(FrameCacheScale.Original, FrameCacheColorType.BGRA));
+
+        Add(manager, 0);
+
+        manager.Options = manager.Options with { ColorType = FrameCacheColorType.YUV };
+
+        Assert.That(Contains(manager, 0), Is.False);
+    }
+
+    /// <summary>
+    /// A rendered frame is premultiplied; the preview draws the cache entry through the same code
+    /// path as a fresh snapshot, so the entry has to describe its own pixels the same way or
+    /// translucent areas change appearance the moment a frame comes from the cache.
+    /// </summary>
+    [Test]
+    public void RoundTrip_TranslucentFrame_PreservesTheRenderedColors()
+    {
+        var info = new SKImageInfo(Side, Side, SKColorType.RgbaF16, SKAlphaType.Premul,
+            SKColorSpace.CreateSrgbLinear());
+        var skBitmap = new SKBitmap(info);
+        using (var canvas = new SKCanvas(skBitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            canvas.DrawRect(new SKRect(0, 0, Side, Side),
+                new SKPaint { Color = new SKColor(255, 255, 255, 128), BlendMode = SKBlendMode.Src });
+        }
+
+        using var source = new Bitmap(skBitmap);
+        using Bitmap expected = source.Convert(BitmapColorType.Bgra8888, colorSpace: BitmapColorSpace.Srgb);
+
+        using FrameCacheManager manager = NewManager(new FrameCacheOptions(FrameCacheScale.Original, FrameCacheColorType.BGRA));
+
+        using (Ref<Bitmap> reference = Ref<Bitmap>.Create(source.Clone()))
+        {
+            manager.Add(0, reference);
+        }
+
+        Assert.That(manager.TryGet(0, out Ref<Bitmap>? cached), Is.True);
+        using (cached)
+        {
+            Bitmap actual = cached!.Value;
+            Assert.That(actual.AlphaType, Is.EqualTo(expected.AlphaType));
+
+            ReadOnlySpan<Bgra8888> expectedPixels = expected.GetPixelSpan<Bgra8888>();
+            ReadOnlySpan<Bgra8888> actualPixels = actual.GetPixelSpan<Bgra8888>();
+            Bgra8888 e = expectedPixels[Side / 2 * Side + Side / 2];
+            Bgra8888 a = actualPixels[Side / 2 * Side + Side / 2];
+
+            Assert.Multiple(() =>
+            {
+                Assert.That((int)a.A, Is.EqualTo((int)e.A).Within(2), "alpha");
+                Assert.That((int)a.R, Is.EqualTo((int)e.R).Within(2), "red");
+                Assert.That((int)a.G, Is.EqualTo((int)e.G).Within(2), "green");
+                Assert.That((int)a.B, Is.EqualTo((int)e.B).Within(2), "blue");
+            });
+        }
+    }
+
+    [Test]
+    public void ReassigningEquivalentOptions_KeepsTheEntries()
+    {
+        using FrameCacheManager manager = NewManager(new FrameCacheOptions(FrameCacheScale.Original, FrameCacheColorType.BGRA));
+
+        Add(manager, 0);
+
+        // Manual with the frame's own size stores exactly what Original does.
+        manager.Options = manager.Options with { Scale = FrameCacheScale.Manual, Size = FrameSize };
+
+        Assert.That(Contains(manager, 0), Is.True);
+    }
+}

--- a/tests/Beutl.HeadlessUITests/FrameCacheManagerTests.cs
+++ b/tests/Beutl.HeadlessUITests/FrameCacheManagerTests.cs
@@ -260,15 +260,28 @@ public class FrameCacheManagerTests
     }
 
     [Test]
-    public void ReassigningEquivalentOptions_KeepsTheEntries()
+    public void ReassigningTheSameOptions_KeepsTheEntries()
     {
         using FrameCacheManager manager = NewManager(new FrameCacheOptions(FrameCacheScale.Original, FrameCacheColorType.BGRA));
 
         Add(manager, 0);
 
-        // Manual with the frame's own size stores exactly what Original does.
-        manager.Options = manager.Options with { Scale = FrameCacheScale.Manual, Size = FrameSize };
+        manager.Options = manager.Options with { };
 
         Assert.That(Contains(manager, 0), Is.True);
+    }
+
+    [Test]
+    public void SwitchingScaleMode_DropsTheEntries_EvenWhenTheLogicalSizesAgree()
+    {
+        using FrameCacheManager manager = NewManager(new FrameCacheOptions(FrameCacheScale.Original, FrameCacheColorType.BGRA));
+
+        Add(manager, 0);
+
+        // Manual with the frame's own size resolves to the same logical size as Original, but an
+        // entry is encoded from the rendered snapshot, whose size is the device size.
+        manager.Options = manager.Options with { Scale = FrameCacheScale.Manual, Size = FrameSize };
+
+        Assert.That(Contains(manager, 0), Is.False);
     }
 }

--- a/tests/Beutl.UnitTests/Editor/PreviewFrameCacheSizingTests.cs
+++ b/tests/Beutl.UnitTests/Editor/PreviewFrameCacheSizingTests.cs
@@ -20,20 +20,33 @@ public class PreviewFrameCacheSizingTests
     }
 
     [Test]
-    public void DeriveCacheSize_OddDenominator_IsBumpedToEven()
+    public void DeriveCacheSize_OddDenominator_KeepsTheOddReduction()
     {
-        // scale = 1/3 -> den = 3 -> bumped to 4 -> 480x270.
+        // scale = 1/3 -> den = 3 -> 640x360, matching the panel exactly. Rounding the denominator
+        // up to 4 would store 480x270 and show a softer picture than a freshly rendered frame.
         PixelSize? size = PreviewFrameCacheSizing.DeriveCacheSize(new Size(640, 360), Frame);
-        Assert.That(size, Is.EqualTo(new PixelSize(480, 270)));
+        Assert.That(size, Is.EqualTo(new PixelSize(640, 360)));
     }
 
     [Test]
-    public void DeriveCacheSize_PanelJustBelowFrameSize_StillCachesAtHalf()
+    public void DeriveCacheSize_PanelJustBelowFrameSize_DoesNotReduce()
     {
-        // scale 0.9 -> den = (int)(1 / 0.9) = 1 -> bumped to 2: any panel smaller than the frame
-        // caches at most at half size (matches the historical MaxFrameSize setter).
-        PixelSize? size = PreviewFrameCacheSizing.DeriveCacheSize(new Size(1728, 972), Frame);
-        Assert.That(size, Is.EqualTo(new PixelSize(960, 540)));
+        // scale 0.9 -> den = 1: halving here would show 960x540 on a 1728x972 panel.
+        Assert.That(PreviewFrameCacheSizing.DeriveCacheSize(new Size(1728, 972), Frame), Is.Null);
+    }
+
+    [Test]
+    public void DeriveCacheSize_NeverStoresLessThanThePanelShows()
+    {
+        for (int panelWidth = 16; panelWidth <= 1920; panelWidth += 7)
+        {
+            var panel = new Size(panelWidth, panelWidth * 1080f / 1920f);
+            PixelSize? size = PreviewFrameCacheSizing.DeriveCacheSize(panel, Frame);
+            if (size is not { } cache) continue;
+
+            Assert.That(cache.Width, Is.GreaterThanOrEqualTo((int)panel.Width),
+                $"panel {panelWidth}px would be upscaled from a {cache.Width}px entry");
+        }
     }
 
     [Test]


### PR DESCRIPTION
## Problem

A frame cache entry is an encoded — and possibly reduced — copy of a snapshot, so anything that changes what an entry holds has to invalidate or account for it. Several paths did not:

- Assigning `Options` that change the stored representation kept the existing entries, which were encoded under the previous options, so playback alternated between resolutions.
- `CacheEntry.ToBitmap` labelled premultiplied pixels `Unpremul`, so the preview premultiplied them a second time and every translucent area came back darker.
- Eviction (`AutoDelete`) removed entries without raising `BlocksUpdated`, so the timeline kept painting evicted ranges as cached.
- Replacing an existing entry did not adjust the accounted size, so the budget drifted.
- `PreviewFrameCacheSizing` rounded the reduction denominator up, which can make an entry coarser than the panel it is shown in.

`FrameCacheManager` also reached into `GlobalConfiguration` for its budget, which made the type untestable without process-wide state.

## Change

Drop every entry when assigned options change the stored representation (`FrameCacheOptions.ProducesSameCacheData` decides), describe entries as `Premul`, raise `BlocksUpdated` from the eviction path, adjust the size on replace, and round the sizing denominator down. The budget is injected as `IObservable<long>`.

## Tests

`FrameCacheManagerTests` covers the options swap, the eviction notification and the size accounting; `PreviewFrameCacheSizingTests` covers the rounding; `FrameCacheDitherTests` moves to the injected budget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved preview frame caching to use available cache limits more effectively.
  - Added safer cache eviction behavior to prevent unnecessary memory growth.
  - Ensured reduced preview caches remain large enough for the displayed panel.

- **Bug Fixes**
  - Fixed translucent frame rendering to preserve correct colors and alpha blending.
  - Improved cache updates when preview resolution or color settings change.
  - Prevented cache operations from continuing after shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## BREAKING CHANGE

`FrameCacheManager`'s public constructor now takes the cache budget as a third parameter, `IObservable<long> maxSize`, which must publish a value on subscribe. The two-argument form is gone.

Migration: pass the budget explicitly — `new FrameCacheManager(frameSize, options, Observable.Return(bytes))` for a fixed budget, or an observable over the setting for a live one, as `EditViewModel.CreateFrameCacheMaxSize` does.

The type lives in the `Beutl` application project rather than in a library plugin authors consume, so no extensibility contract changes.