### PR TITLE
fix: show the cached rendition of a frame on the pass that renders it

### DIFF
--- a/src/Beutl/Beutl.csproj
+++ b/src/Beutl/Beutl.csproj
@@ -55,6 +55,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The shell E2E suite is the one test project that references this app; it drives the
+         playback producer directly rather than through the wall-clock timer. -->
+    <InternalsVisibleTo Include="Beutl.HeadlessUITests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AsyncImageLoader.Avalonia" />
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Controls.ItemsRepeater" />

--- a/src/Beutl/Models/BufferedPlayer.cs
+++ b/src/Beutl/Models/BufferedPlayer.cs
@@ -138,9 +138,8 @@ internal sealed class BufferedPlayer : IPlayer
 
                             activeCacheManager.Add(frame, bitmap);
 
-                            // Queue the stored entry rather than the snapshot it was made from: an
-                            // entry is a converted (and possibly reduced) copy, so a frame must not
-                            // look one way on the pass that renders it and another on replay.
+                            // An entry is a converted, possibly reduced copy of the snapshot, so a
+                            // frame must not look one way here and another on replay.
                             if (activeCacheManager.TryGet(frame, out Ref<Bitmap>? stored))
                             {
                                 _queue.Enqueue(new(stored, frame));

--- a/src/Beutl/Models/BufferedPlayer.cs
+++ b/src/Beutl/Models/BufferedPlayer.cs
@@ -136,8 +136,19 @@ internal sealed class BufferedPlayer : IPlayer
                             if (_isDisposed || _playbackToken.IsCancellationRequested)
                                 break;
 
-                            _queue.Enqueue(new(bitmap.Clone(), frame));
                             activeCacheManager.Add(frame, bitmap);
+
+                            // Queue the stored entry rather than the snapshot it was made from: an
+                            // entry is a converted (and possibly reduced) copy, so a frame must not
+                            // look one way on the pass that renders it and another on replay.
+                            if (activeCacheManager.TryGet(frame, out Ref<Bitmap>? stored))
+                            {
+                                _queue.Enqueue(new(stored, frame));
+                            }
+                            else
+                            {
+                                _queue.Enqueue(new(bitmap.Clone(), frame));
+                            }
                         }
                     }
 

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -1913,11 +1913,21 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                         {
                             cacheManager.Add(frame, bitmapRef);
                             cacheManager.UpdateBlocks();
+
+                            // An entry is a converted (and possibly reduced) copy of the snapshot,
+                            // so showing the snapshot here would make the same frame look one way
+                            // before it is cached and another way afterwards.
+                            if (cacheManager.TryGet(frame, out Ref<Bitmap>? stored))
+                            {
+                                bitmapRef.Dispose();
+                                bitmapRef = stored;
+                            }
                         }
 
-                        using (var canvas = new SKCanvas(bitmap.SKBitmap))
+                        using (var canvas = new SKCanvas(bitmapRef.Value.SKBitmap))
                         {
-                            DrawBoundaries(renderer, canvas, new(bitmap.Width, bitmap.Height), true);
+                            DrawBoundaries(renderer, canvas,
+                                new(bitmapRef.Value.Width, bitmapRef.Value.Height), true);
                         }
                     }
 

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -1914,9 +1914,8 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                             cacheManager.Add(frame, bitmapRef);
                             cacheManager.UpdateBlocks();
 
-                            // An entry is a converted (and possibly reduced) copy of the snapshot,
-                            // so showing the snapshot here would make the same frame look one way
-                            // before it is cached and another way afterwards.
+                            // An entry is a converted, possibly reduced copy of the snapshot, so a
+                            // frame must not look one way here and another once it is cached.
                             if (cacheManager.TryGet(frame, out Ref<Bitmap>? stored))
                             {
                                 bitmapRef.Dispose();

--- a/tests/Beutl.HeadlessUITests/PreviewShowsRequestedFrameTests.cs
+++ b/tests/Beutl.HeadlessUITests/PreviewShowsRequestedFrameTests.cs
@@ -10,9 +10,11 @@ using Beutl.Graphics.Shapes;
 using Beutl.Media;
 using Beutl.Media.Pixel;
 using Beutl.Media.Source;
+using Beutl.Models;
 using Beutl.ProjectSystem;
 using Beutl.Testing.Headless;
 using Beutl.ViewModels;
+using Reactive.Bindings;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Beutl.HeadlessUITests;
@@ -332,13 +334,17 @@ public class PreviewShowsRequestedFrameTests
     }
 
     /// <summary>
-    /// Playback renders through <c>BufferedPlayer</c>, a different producer from the scrub path, and
+    /// Playback produces through <c>BufferedPlayer</c>, a different producer from the scrub path, and
     /// it stores every frame it renders. What it hands to the preview has to be that stored entry —
     /// the snapshot it was made from is a different rendition (RgbaF16/linear at full size), so
     /// queueing it would make a frame change appearance the moment it came back from the cache.
     /// </summary>
+    /// <remarks>
+    /// The producer is driven directly instead of through <c>Player.Play()</c>: playback advances on
+    /// a wall-clock timer, which a loaded CI runner on software rendering cannot be relied on to turn.
+    /// </remarks>
     [AvaloniaTest]
-    public async Task Playing_publishes_the_rendition_it_stores_in_the_cache()
+    public async Task The_playback_producer_queues_the_rendition_it_stores_in_the_cache()
     {
         await TestReset.ResetShellAsync();
         GpuTestGate.EnsureAvailable();
@@ -348,33 +354,41 @@ public class PreviewShowsRequestedFrameTests
         config.IsFrameCacheEnabled = true;
         try
         {
-            EditViewModel editor = await NewSegmentedEditor(nameof(Playing_publishes_the_rendition_it_stores_in_the_cache));
+            EditViewModel editor = await NewSegmentedEditor(
+                nameof(The_playback_producer_queues_the_rendition_it_stores_in_the_cache));
             SeekTo(editor, 0);
             DrainRenders();
 
-            var published = new List<BitmapColorType>();
-            using (editor.Player.PreviewImage.Subscribe(frame =>
-                   {
-                       if (editor.Player.IsPlaying.Value && frame?.Value is { IsDisposed: false } bitmap)
-                       {
-                           published.Add(bitmap.ColorType);
-                       }
-                   }))
+            var isPlaying = new ReactivePropertySlim<bool>(true);
+            using var cts = new CancellationTokenSource();
+            using var player = new BufferedPlayer(editor, editor.Scene, isPlaying, Rate, cts.Token);
+            player.Start();
+
+            var produced = new List<BitmapColorType>();
+            var stopwatch = Stopwatch.StartNew();
+            while (produced.Count == 0 && stopwatch.Elapsed < TimeSpan.FromSeconds(30))
             {
-                editor.Player.Play();
-                // One published frame already settles which rendition the producer queues, and a CI
-                // runner on software rendering needs room to produce even that.
-                await WaitUntilAsync(() => published.Count >= 1, TimeSpan.FromSeconds(30));
-                await editor.Player.Pause();
+                while (player.TryDequeue(out IPlayer.Frame frame))
+                {
+                    using (frame.Bitmap)
+                    {
+                        produced.Add(frame.Bitmap.Value.ColorType);
+                    }
+                }
+
+                if (produced.Count == 0 && player.ProducerStopped) break;
+                HeadlessTestHelpers.Settle();
+                await Task.Delay(10);
             }
 
-            DrainRenders();
+            isPlaying.Value = false;
+            cts.Cancel();
 
-            Assert.That(published, Is.Not.Empty, "playback published no frame");
-            Assert.That(published, Is.All.EqualTo(BitmapColorType.Bgra8888),
-                "playback published the raw snapshot instead of the entry it stored");
+            Assert.That(produced, Is.Not.Empty, "the producer queued no frame");
+            Assert.That(produced, Is.All.EqualTo(BitmapColorType.Bgra8888),
+                "the producer queued the raw snapshot instead of the entry it stored");
             Assert.That(editor.FrameCacheManager.Value.TryGet(0, out Ref<Bitmap>? stored), Is.True,
-                "playback stored nothing for frame 0");
+                "the producer stored nothing for frame 0");
             stored!.Dispose();
         }
         finally

--- a/tests/Beutl.HeadlessUITests/PreviewShowsRequestedFrameTests.cs
+++ b/tests/Beutl.HeadlessUITests/PreviewShowsRequestedFrameTests.cs
@@ -21,8 +21,8 @@ namespace Beutl.HeadlessUITests;
 
 /// <summary>
 /// Whatever the preview shows has to be the picture of the frame the playhead is on. The frame cache
-/// keys entries on the frame number alone, so a mistake anywhere in the store / lookup / present path
-/// shows up as a picture belonging to some other frame.
+/// keys entries on the frame number alone, so a mistake in the store / lookup / present path shows up
+/// as a picture belonging to some other frame.
 /// </summary>
 [TestFixture]
 public class PreviewShowsRequestedFrameTests
@@ -98,8 +98,7 @@ public class PreviewShowsRequestedFrameTests
                     Width = { CurrentValue = 160 },
                     Height = { CurrentValue = 120 },
                     // A gradient, not a flat fill: a flat colour survives the cache's 8-bit
-                    // conversion untouched, so it cannot show whether the entry and the render
-                    // agree.
+                    // conversion untouched and could not show a mismatch.
                     Fill = { CurrentValue = NewGradient(color) }
                 }));
             HeadlessTestHelpers.Settle();
@@ -211,9 +210,8 @@ public class PreviewShowsRequestedFrameTests
     }
 
     /// <summary>
-    /// A drag moves the playhead faster than a frame can be rendered, so requests pile up and only
-    /// the last one matters. Once the playhead settles, the preview has to end up on that frame and
-    /// not on whichever superseded render happened to publish last.
+    /// A drag outruns rendering, so requests pile up. Once the playhead settles the preview has to end
+    /// up on that frame, not on whichever superseded render published last.
     /// </summary>
     [AvaloniaTest]
     public async Task A_burst_of_seeks_settles_on_the_last_requested_frame()
@@ -281,10 +279,9 @@ public class PreviewShowsRequestedFrameTests
     }
 
     /// <summary>
-    /// A cache entry is a converted, possibly reduced copy of the render, so a frame that is served
-    /// from the cache must be the same picture the preview showed when it was rendered. Otherwise
-    /// scrubbing across the edge of a cached range alternates between two renditions of neighbouring
-    /// frames.
+    /// A cache entry is a converted, possibly reduced copy of the render, so a frame served from the
+    /// cache must be the picture the preview showed when it was rendered — otherwise scrubbing across
+    /// the edge of a cached range alternates between two renditions.
     /// </summary>
     [AvaloniaTest]
     public async Task A_frame_looks_the_same_freshly_rendered_and_replayed_from_the_cache()
@@ -334,14 +331,13 @@ public class PreviewShowsRequestedFrameTests
     }
 
     /// <summary>
-    /// Playback produces through <c>BufferedPlayer</c>, a different producer from the scrub path, and
-    /// it stores every frame it renders. What it hands to the preview has to be that stored entry —
-    /// the snapshot it was made from is a different rendition (RgbaF16/linear at full size), so
-    /// queueing it would make a frame change appearance the moment it came back from the cache.
+    /// <c>BufferedPlayer</c> is a different producer from the scrub path, and it stores every frame it
+    /// renders. What it hands to the preview has to be that stored entry: the snapshot it was made from
+    /// is a different rendition (RgbaF16/linear at full size).
     /// </summary>
     /// <remarks>
-    /// The producer is driven directly instead of through <c>Player.Play()</c>: playback advances on
-    /// a wall-clock timer, which a loaded CI runner on software rendering cannot be relied on to turn.
+    /// Driven directly rather than through <c>Player.Play()</c>, which advances on a wall-clock timer a
+    /// loaded CI runner on software rendering cannot be relied on to turn.
     /// </remarks>
     [AvaloniaTest]
     public async Task The_playback_producer_queues_the_rendition_it_stores_in_the_cache()
@@ -358,8 +354,8 @@ public class PreviewShowsRequestedFrameTests
                 nameof(The_playback_producer_queues_the_rendition_it_stores_in_the_cache));
             SeekTo(editor, 0);
             DrainRenders();
-            // Building the editor and settling the seek already render frame 0 into the cache, and
-            // the producer would then take its cache-hit branch and never reach the one under test.
+            // Building the editor already renders frame 0 into the cache, and the producer would then
+            // take its cache-hit branch and never reach the one under test.
             editor.FrameCacheManager.Value.Clear();
 
             var isPlaying = new ReactivePropertySlim<bool>(true);

--- a/tests/Beutl.HeadlessUITests/PreviewShowsRequestedFrameTests.cs
+++ b/tests/Beutl.HeadlessUITests/PreviewShowsRequestedFrameTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Reactive.Disposables;
+﻿using System.Diagnostics;
+using System.Reactive.Disposables;
 using Avalonia.Headless.NUnit;
 using Beutl.Configuration;
 using Beutl.Editor.Models;
@@ -87,8 +88,8 @@ public class PreviewShowsRequestedFrameTests
             (bool r, bool g, bool b) = s_segmentChannels[i];
             var color = new Color(255, r ? (byte)255 : (byte)0, g ? (byte)255 : (byte)0, b ? (byte)255 : (byte)0);
             adder.AddElement(new ElementDescription(
-                Start: TimeSpan.FromSeconds(i * SegmentFrames / (double)Rate),
-                Length: TimeSpan.FromSeconds(SegmentFrames / (double)Rate),
+                Start: FrameTime(i * SegmentFrames),
+                Length: FrameTime(SegmentFrames),
                 Layer: 0,
                 EngineObjectFactory: () => new RectShape
                 {
@@ -105,9 +106,30 @@ public class PreviewShowsRequestedFrameTests
         return editor;
     }
 
+    // Ticks, not seconds: a frame boundary computed in double can land just off the grid, which
+    // makes two segments overlap or leave a gap.
+    private static TimeSpan FrameTime(int frame) =>
+        TimeSpan.FromTicks(frame * TimeSpan.TicksPerSecond / Rate);
+
     private static void SeekTo(EditViewModel editor, int frame)
     {
-        editor.Player.CurrentFrame.Value = TimeSpan.FromSeconds(frame / (double)Rate);
+        editor.Player.CurrentFrame.Value = FrameTime(frame);
+    }
+
+    // Playback advances on a timer, so pumping the dispatcher is not enough to make frames appear.
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (!condition())
+        {
+            if (stopwatch.Elapsed >= timeout)
+            {
+                Assert.Fail($"Condition was not met within {timeout}.");
+            }
+
+            HeadlessTestHelpers.Settle();
+            await Task.Delay(10);
+        }
     }
 
     private static void DrainRenders()
@@ -146,8 +168,8 @@ public class PreviewShowsRequestedFrameTests
     [AvaloniaTest]
     public async Task Scrubbing_over_cached_frames_always_shows_the_frame_under_the_playhead()
     {
-        GpuTestGate.EnsureAvailable();
         await TestReset.ResetShellAsync();
+        GpuTestGate.EnsureAvailable();
         using IDisposable autoSave = SuspendAutoSave();
 
         try
@@ -194,8 +216,8 @@ public class PreviewShowsRequestedFrameTests
     [AvaloniaTest]
     public async Task A_burst_of_seeks_settles_on_the_last_requested_frame()
     {
-        GpuTestGate.EnsureAvailable();
         await TestReset.ResetShellAsync();
+        GpuTestGate.EnsureAvailable();
         using IDisposable autoSave = SuspendAutoSave();
 
         try
@@ -265,8 +287,8 @@ public class PreviewShowsRequestedFrameTests
     [AvaloniaTest]
     public async Task A_frame_looks_the_same_freshly_rendered_and_replayed_from_the_cache()
     {
-        GpuTestGate.EnsureAvailable();
         await TestReset.ResetShellAsync();
+        GpuTestGate.EnsureAvailable();
         using IDisposable autoSave = SuspendAutoSave();
 
         try
@@ -305,6 +327,57 @@ public class PreviewShowsRequestedFrameTests
         }
         finally
         {
+            await TestReset.ResetShellAsync();
+        }
+    }
+
+    /// <summary>
+    /// Playback renders through <c>BufferedPlayer</c>, a different producer from the scrub path, and
+    /// it stores every frame it renders. What it hands to the preview has to be that stored entry —
+    /// the snapshot it was made from is a different rendition (RgbaF16/linear at full size), so
+    /// queueing it would make a frame change appearance the moment it came back from the cache.
+    /// </summary>
+    [AvaloniaTest]
+    public async Task Playing_publishes_the_rendition_it_stores_in_the_cache()
+    {
+        await TestReset.ResetShellAsync();
+        GpuTestGate.EnsureAvailable();
+        using IDisposable autoSave = SuspendAutoSave();
+        EditorConfig config = GlobalConfiguration.Instance.EditorConfig;
+        bool cacheWasEnabled = config.IsFrameCacheEnabled;
+        config.IsFrameCacheEnabled = true;
+        try
+        {
+            EditViewModel editor = await NewSegmentedEditor(nameof(Playing_publishes_the_rendition_it_stores_in_the_cache));
+            SeekTo(editor, 0);
+            DrainRenders();
+
+            var published = new List<BitmapColorType>();
+            using (editor.Player.PreviewImage.Subscribe(frame =>
+                   {
+                       if (editor.Player.IsPlaying.Value && frame?.Value is { IsDisposed: false } bitmap)
+                       {
+                           published.Add(bitmap.ColorType);
+                       }
+                   }))
+            {
+                editor.Player.Play();
+                await WaitUntilAsync(() => published.Count >= 3, TimeSpan.FromSeconds(10));
+                await editor.Player.Pause();
+            }
+
+            DrainRenders();
+
+            Assert.That(published, Is.Not.Empty, "playback published no frame");
+            Assert.That(published, Is.All.EqualTo(BitmapColorType.Bgra8888),
+                "playback published the raw snapshot instead of the entry it stored");
+            Assert.That(editor.FrameCacheManager.Value.TryGet(0, out Ref<Bitmap>? stored), Is.True,
+                "playback stored nothing for frame 0");
+            stored!.Dispose();
+        }
+        finally
+        {
+            config.IsFrameCacheEnabled = cacheWasEnabled;
             await TestReset.ResetShellAsync();
         }
     }

--- a/tests/Beutl.HeadlessUITests/PreviewShowsRequestedFrameTests.cs
+++ b/tests/Beutl.HeadlessUITests/PreviewShowsRequestedFrameTests.cs
@@ -358,6 +358,9 @@ public class PreviewShowsRequestedFrameTests
                 nameof(The_playback_producer_queues_the_rendition_it_stores_in_the_cache));
             SeekTo(editor, 0);
             DrainRenders();
+            // Building the editor and settling the seek already render frame 0 into the cache, and
+            // the producer would then take its cache-hit branch and never reach the one under test.
+            editor.FrameCacheManager.Value.Clear();
 
             var isPlaying = new ReactivePropertySlim<bool>(true);
             using var cts = new CancellationTokenSource();

--- a/tests/Beutl.HeadlessUITests/PreviewShowsRequestedFrameTests.cs
+++ b/tests/Beutl.HeadlessUITests/PreviewShowsRequestedFrameTests.cs
@@ -1,0 +1,311 @@
+﻿using System.Reactive.Disposables;
+using Avalonia.Headless.NUnit;
+using Beutl.Configuration;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Shapes;
+using Beutl.Media;
+using Beutl.Media.Pixel;
+using Beutl.Media.Source;
+using Beutl.ProjectSystem;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Beutl.HeadlessUITests;
+
+/// <summary>
+/// Whatever the preview shows has to be the picture of the frame the playhead is on. The frame cache
+/// keys entries on the frame number alone, so a mistake anywhere in the store / lookup / present path
+/// shows up as a picture belonging to some other frame.
+/// </summary>
+[TestFixture]
+public class PreviewShowsRequestedFrameTests
+{
+    private const int Rate = 30;
+    private const int SegmentFrames = 5;
+    private const int SegmentCount = 6;
+    private const int TotalFrames = SegmentFrames * SegmentCount;
+
+    // Each segment lights a distinct combination of channels, so a sampled pixel identifies its
+    // segment regardless of whether the frame reached the screen as linear F16 or 8-bit sRGB.
+    private static readonly (bool R, bool G, bool B)[] s_segmentChannels =
+    [
+        (true, false, false),
+        (false, true, false),
+        (false, false, true),
+        (true, true, false),
+        (true, false, true),
+        (false, true, true),
+    ];
+
+    private static int ExpectedSegment(int frame) => frame / SegmentFrames;
+
+    private static string NewWorkspace(string name)
+    {
+        string location = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(location);
+        return location;
+    }
+
+    private static IDisposable SuspendAutoSave()
+    {
+        EditorConfig config = GlobalConfiguration.Instance.EditorConfig;
+        bool prior = config.IsAutoSaveEnabled;
+        config.IsAutoSaveEnabled = false;
+        return Disposable.Create(() => config.IsAutoSaveEnabled = prior);
+    }
+
+    private static LinearGradientBrush NewGradient(Color color)
+    {
+        var brush = new LinearGradientBrush();
+        brush.GradientStops.Add(new GradientStop { Offset = { CurrentValue = 0f }, Color = { CurrentValue = color } });
+        brush.GradientStops.Add(new GradientStop
+        {
+            Offset = { CurrentValue = 1f },
+            Color = { CurrentValue = new Color(255, (byte)(color.R / 3), (byte)(color.G / 3), (byte)(color.B / 3)) }
+        });
+        return brush;
+    }
+
+    private static async Task<EditViewModel> NewSegmentedEditor(string name)
+    {
+        Project project = (await TestShell.Project.CreateProject(
+            160, 120, Rate, 44100, name, NewWorkspace(name)))!;
+        HeadlessTestHelpers.Settle();
+        Scene scene = project.Items.OfType<Scene>().First();
+
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+        var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+        var adder = (IElementAdder)editor.GetRequiredService<IElementAdder>();
+
+        for (int i = 0; i < SegmentCount; i++)
+        {
+            (bool r, bool g, bool b) = s_segmentChannels[i];
+            var color = new Color(255, r ? (byte)255 : (byte)0, g ? (byte)255 : (byte)0, b ? (byte)255 : (byte)0);
+            adder.AddElement(new ElementDescription(
+                Start: TimeSpan.FromSeconds(i * SegmentFrames / (double)Rate),
+                Length: TimeSpan.FromSeconds(SegmentFrames / (double)Rate),
+                Layer: 0,
+                EngineObjectFactory: () => new RectShape
+                {
+                    Width = { CurrentValue = 160 },
+                    Height = { CurrentValue = 120 },
+                    // A gradient, not a flat fill: a flat colour survives the cache's 8-bit
+                    // conversion untouched, so it cannot show whether the entry and the render
+                    // agree.
+                    Fill = { CurrentValue = NewGradient(color) }
+                }));
+            HeadlessTestHelpers.Settle();
+        }
+
+        return editor;
+    }
+
+    private static void SeekTo(EditViewModel editor, int frame)
+    {
+        editor.Player.CurrentFrame.Value = TimeSpan.FromSeconds(frame / (double)Rate);
+    }
+
+    private static void DrainRenders()
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            HeadlessTestHelpers.Settle();
+            RenderThread.Dispatcher.Invoke(static () => { });
+        }
+
+        HeadlessTestHelpers.Settle();
+    }
+
+    private static byte[] CurrentPixels(EditViewModel editor)
+    {
+        Ref<Bitmap>? preview = editor.Player.PreviewImage.Value;
+        Assert.That(preview, Is.Not.Null, "no preview frame was published");
+
+        using Bitmap bgra = preview!.Value.Convert(BitmapColorType.Bgra8888);
+        return bgra.GetPixelSpan().ToArray();
+    }
+
+    private static int CurrentSegment(EditViewModel editor)
+    {
+        Ref<Bitmap>? preview = editor.Player.PreviewImage.Value;
+        Assert.That(preview, Is.Not.Null, "no preview frame was published");
+
+        using Bitmap bgra = preview!.Value.Convert(BitmapColorType.Bgra8888);
+        ReadOnlySpan<Bgra8888> pixels = bgra.GetPixelSpan<Bgra8888>();
+        Bgra8888 p = pixels[bgra.Height / 2 * bgra.Width + bgra.Width / 2];
+
+        (bool R, bool G, bool B) lit = (p.R > 64, p.G > 64, p.B > 64);
+        return Array.IndexOf(s_segmentChannels, lit);
+    }
+
+    [AvaloniaTest]
+    public async Task Scrubbing_over_cached_frames_always_shows_the_frame_under_the_playhead()
+    {
+        GpuTestGate.EnsureAvailable();
+        await TestReset.ResetShellAsync();
+        using IDisposable autoSave = SuspendAutoSave();
+
+        try
+        {
+            EditViewModel editor = await NewSegmentedEditor("previewrequestedframe");
+            editor.FrameCacheManager.Value.IsEnabled = true;
+            editor.FrameCacheManager.Value.Clear();
+
+            var mismatches = new List<string>();
+
+            void Scrub(string pass, IEnumerable<int> frames)
+            {
+                foreach (int frame in frames)
+                {
+                    SeekTo(editor, frame);
+                    DrainRenders();
+                    int actual = CurrentSegment(editor);
+                    if (actual != ExpectedSegment(frame))
+                    {
+                        mismatches.Add($"{pass}: frame {frame} showed segment {actual}, expected {ExpectedSegment(frame)}");
+                    }
+                }
+            }
+
+            Scrub("cold", Enumerable.Range(0, TotalFrames));
+            Scrub("cached-forward", Enumerable.Range(0, TotalFrames));
+            Scrub("cached-backward", Enumerable.Range(0, TotalFrames).Reverse());
+            // Jumping across segment boundaries is what a real scrub does.
+            Scrub("cached-jumpy", Enumerable.Range(0, TotalFrames).Select(i => i * 7 % TotalFrames));
+
+            Assert.That(mismatches, Is.Empty, string.Join(Environment.NewLine, mismatches));
+        }
+        finally
+        {
+            await TestReset.ResetShellAsync();
+        }
+    }
+
+    /// <summary>
+    /// A drag moves the playhead faster than a frame can be rendered, so requests pile up and only
+    /// the last one matters. Once the playhead settles, the preview has to end up on that frame and
+    /// not on whichever superseded render happened to publish last.
+    /// </summary>
+    [AvaloniaTest]
+    public async Task A_burst_of_seeks_settles_on_the_last_requested_frame()
+    {
+        GpuTestGate.EnsureAvailable();
+        await TestReset.ResetShellAsync();
+        using IDisposable autoSave = SuspendAutoSave();
+
+        try
+        {
+            EditViewModel editor = await NewSegmentedEditor("previewseekburst");
+            editor.FrameCacheManager.Value.IsEnabled = true;
+            editor.FrameCacheManager.Value.Clear();
+
+            // Warm every frame so the burst below runs entirely out of the cache.
+            for (int frame = 0; frame < TotalFrames; frame++)
+            {
+                SeekTo(editor, frame);
+                DrainRenders();
+            }
+
+            var mismatches = new List<string>();
+
+            void Burst(string pass, int[] frames, bool pumpUiBetweenSeeks)
+            {
+                foreach (int frame in frames)
+                {
+                    SeekTo(editor, frame);
+                    if (pumpUiBetweenSeeks)
+                    {
+                        HeadlessTestHelpers.Settle();
+                    }
+                }
+
+                DrainRenders();
+                int settled = frames[^1];
+                int actual = CurrentSegment(editor);
+                if (actual != ExpectedSegment(settled))
+                {
+                    mismatches.Add(
+                        $"{pass}: settled on frame {settled} but showed segment {actual}, expected {ExpectedSegment(settled)}");
+                }
+            }
+
+            int[][] bursts =
+            [
+                [0, 6, 12, 18, 24, 29],
+                [29, 22, 15, 8, 1],
+                [3, 27, 5, 25, 7, 23],
+                [10, 11, 12, 13, 14],
+            ];
+
+            foreach (int[] burst in bursts)
+            {
+                Burst("no-pump", burst, pumpUiBetweenSeeks: false);
+                Burst("pump", burst, pumpUiBetweenSeeks: true);
+            }
+
+            Assert.That(mismatches, Is.Empty, string.Join(Environment.NewLine, mismatches));
+        }
+        finally
+        {
+            await TestReset.ResetShellAsync();
+        }
+    }
+
+    /// <summary>
+    /// A cache entry is a converted, possibly reduced copy of the render, so a frame that is served
+    /// from the cache must be the same picture the preview showed when it was rendered. Otherwise
+    /// scrubbing across the edge of a cached range alternates between two renditions of neighbouring
+    /// frames.
+    /// </summary>
+    [AvaloniaTest]
+    public async Task A_frame_looks_the_same_freshly_rendered_and_replayed_from_the_cache()
+    {
+        GpuTestGate.EnsureAvailable();
+        await TestReset.ResetShellAsync();
+        using IDisposable autoSave = SuspendAutoSave();
+
+        try
+        {
+            EditViewModel editor = await NewSegmentedEditor("previewcacheparity");
+            editor.FrameCacheManager.Value.IsEnabled = true;
+            editor.FrameCacheManager.Value.Clear();
+
+            var mismatches = new List<int>();
+            for (int frame = 0; frame < TotalFrames; frame += 3)
+            {
+                // Always arrive from somewhere else: seeking to the frame the playhead already sits
+                // on renders nothing and would sample a stale preview.
+                int elsewhere = frame == 0 ? TotalFrames - 1 : 0;
+
+                SeekTo(editor, elsewhere);
+                DrainRenders();
+                SeekTo(editor, frame);
+                DrainRenders();
+                byte[] rendered = CurrentPixels(editor);
+
+                SeekTo(editor, elsewhere);
+                DrainRenders();
+                SeekTo(editor, frame);
+                DrainRenders();
+                byte[] cached = CurrentPixels(editor);
+
+                if (!rendered.AsSpan().SequenceEqual(cached))
+                {
+                    mismatches.Add(frame);
+                }
+            }
+
+            Assert.That(mismatches, Is.Empty,
+                $"frames served from the cache differ from the same frames when rendered: {string.Join(", ", mismatches)}");
+        }
+        finally
+        {
+            await TestReset.ResetShellAsync();
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/PreviewShowsRequestedFrameTests.cs
+++ b/tests/Beutl.HeadlessUITests/PreviewShowsRequestedFrameTests.cs
@@ -14,8 +14,8 @@ using Beutl.Models;
 using Beutl.ProjectSystem;
 using Beutl.Testing.Headless;
 using Beutl.ViewModels;
-using Reactive.Bindings;
 using Microsoft.Extensions.DependencyInjection;
+using Reactive.Bindings;
 
 namespace Beutl.HeadlessUITests;
 

--- a/tests/Beutl.HeadlessUITests/PreviewShowsRequestedFrameTests.cs
+++ b/tests/Beutl.HeadlessUITests/PreviewShowsRequestedFrameTests.cs
@@ -362,7 +362,9 @@ public class PreviewShowsRequestedFrameTests
                    }))
             {
                 editor.Player.Play();
-                await WaitUntilAsync(() => published.Count >= 3, TimeSpan.FromSeconds(10));
+                // One published frame already settles which rendition the producer queues, and a CI
+                // runner on software rendering needs room to produce even that.
+                await WaitUntilAsync(() => published.Count >= 1, TimeSpan.FromSeconds(30));
                 await editor.Player.Pause();
             }
 


### PR DESCRIPTION
## Problem

A frame cache entry is a converted, and possibly reduced, copy of the snapshot it was made from. Both the scrub path (`PlayerViewModel.QueueRender`) and the playback producer (`BufferedPlayer`) presented the snapshot itself while storing the entry, so a frame looked one way the first time it was drawn and another way once it came back from the cache — a visible change on an otherwise idle preview.

## Change

After storing, read the entry back and present that, on both paths.

## Tests

`PreviewShowsRequestedFrameTests` seeks over a scene whose content differs on every frame and asserts that the picture shown for a frame is the same whether it was just rendered or served from the cache. The scene uses gradients rather than flat fills, because flat colours survive the 8-bit conversion and would hide the difference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved preview accuracy when scrubbing through cached frames.
  - Fixed issues where backward, forward, or jumpy seeking could display the wrong frame.
  - Rapid consecutive seeks now settle reliably on the final requested frame.
  - Ensured cached playback matches the appearance of freshly rendered frames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->