### PR TITLE
fix: stop playback from skipping past the frame it was asked for

### DIFF
--- a/src/Beutl.Editor/Beutl.Editor.csproj
+++ b/src/Beutl.Editor/Beutl.Editor.csproj
@@ -6,6 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="Beutl" />
         <InternalsVisibleTo Include="Beutl.UnitTests" />
     </ItemGroup>
 

--- a/src/Beutl.Editor/Models/PlaybackFrameSkip.cs
+++ b/src/Beutl.Editor/Models/PlaybackFrameSkip.cs
@@ -1,6 +1,6 @@
 ﻿namespace Beutl.Models;
 
-public static class PlaybackFrameSkip
+internal static class PlaybackFrameSkip
 {
     /// <summary>
     /// Returns the frame the playback producer renders next after finishing

--- a/src/Beutl.Editor/Models/PlaybackFrameSkip.cs
+++ b/src/Beutl.Editor/Models/PlaybackFrameSkip.cs
@@ -8,9 +8,8 @@ internal static class PlaybackFrameSkip
     /// consumer has moved past it.
     /// </summary>
     /// <remarks>
-    /// The result never overshoots <paramref name="requestedFrame"/>. The consumer displays whatever
-    /// the producer hands it, so a later frame would put a future frame on screen and then freeze the
-    /// preview until the playback clock caught up with it.
+    /// Never overshoots <paramref name="requestedFrame"/>: the consumer displays whatever it is handed,
+    /// so a later frame puts a future picture on screen and freezes there until the clock catches up.
     /// </remarks>
     public static int ResolveNextFrame(int producedFrame, int? requestedFrame)
     {

--- a/src/Beutl.Editor/Models/PlaybackFrameSkip.cs
+++ b/src/Beutl.Editor/Models/PlaybackFrameSkip.cs
@@ -1,0 +1,20 @@
+﻿namespace Beutl.Models;
+
+public static class PlaybackFrameSkip
+{
+    /// <summary>
+    /// Returns the frame the playback producer renders next after finishing
+    /// <paramref name="producedFrame"/>, catching up to <paramref name="requestedFrame"/> when the
+    /// consumer has moved past it.
+    /// </summary>
+    /// <remarks>
+    /// The result never overshoots <paramref name="requestedFrame"/>. The consumer displays whatever
+    /// the producer hands it, so a later frame would put a future frame on screen and then freeze the
+    /// preview until the playback clock caught up with it.
+    /// </remarks>
+    public static int ResolveNextFrame(int producedFrame, int? requestedFrame)
+    {
+        int next = producedFrame + 1;
+        return requestedFrame is { } requested && requested > next ? requested : next;
+    }
+}

--- a/src/Beutl/Models/BufferedPlayer.cs
+++ b/src/Beutl/Models/BufferedPlayer.cs
@@ -28,7 +28,9 @@ internal sealed class BufferedPlayer : IPlayer
 
     // Written by the playback consumer thread, read by the producer. Plain int rather than int? so
     // both sides see a whole value: Nullable<int> is two fields and can tear across threads.
-    private const int NoRequestedFrame = -1;
+    // int.MinValue rather than -1: a frame number comes from the clock and can legitimately be
+    // negative, and a request for that frame must not read as "no request".
+    private const int NoRequestedFrame = int.MinValue;
     private int _requestedFrame = NoRequestedFrame;
     private RenderFailure? _renderFailure;
     private volatile bool _isDisposed;

--- a/src/Beutl/Models/BufferedPlayer.cs
+++ b/src/Beutl/Models/BufferedPlayer.cs
@@ -25,7 +25,11 @@ internal sealed class BufferedPlayer : IPlayer
     private readonly BufferedPlayerWaitGate _waitRenderGate;
     private readonly BufferedPlayerWaitGate _waitTimerGate;
     private readonly IDisposable _disposable;
-    private int? _requestedFrame;
+
+    // Written by the playback consumer thread, read by the producer. Plain int rather than int? so
+    // both sides see a whole value: Nullable<int> is two fields and can tear across threads.
+    private const int NoRequestedFrame = -1;
+    private int _requestedFrame = NoRequestedFrame;
     private RenderFailure? _renderFailure;
     private volatile bool _isDisposed;
 
@@ -81,7 +85,7 @@ internal sealed class BufferedPlayer : IPlayer
                 _logger.LogInformation("Start rendering from frame {StartFrame} to {DurationFrame}", startFrame,
                     durationFrame);
                 int endFrame = (int)_scene.Start.ToFrameNumber(_rate) + durationFrame;
-                for (; frame < endFrame; frame++)
+                while (frame < endFrame)
                 {
                     if (_isDisposed || _playbackToken.IsCancellationRequested || !_isPlaying.Value)
                     {
@@ -145,15 +149,18 @@ internal sealed class BufferedPlayer : IPlayer
                     if (!_isDisposed && !_playbackToken.IsCancellationRequested && _isPlaying.Value)
                         _editViewModel.BufferStatus.EndTime.Value = time;
 
-                    int? requestedFrame = _requestedFrame;
-                    if (requestedFrame > frame)
+                    int requestedFrame = Volatile.Read(ref _requestedFrame);
+                    int nextFrame = PlaybackFrameSkip.ResolveNextFrame(
+                        frame, requestedFrame == NoRequestedFrame ? null : requestedFrame);
+                    if (nextFrame > frame + 1)
                     {
                         _logger.LogDebug(
-                            "Frame delay detected. Requested frame {RequestedFrame} is greater than current frame {Frame}",
-                            requestedFrame, frame);
-                        frame = requestedFrame.Value + (requestedFrame.Value - frame) * 2;
-                        _requestedFrame = null;
+                            "Frame delay detected. Skipping from frame {Frame} to requested frame {NextFrame}",
+                            frame, nextFrame);
+                        Interlocked.CompareExchange(ref _requestedFrame, NoRequestedFrame, requestedFrame);
                     }
+
+                    frame = nextFrame;
                 }
 
                 _logger.LogInformation("Rendering completed.");
@@ -234,7 +241,7 @@ internal sealed class BufferedPlayer : IPlayer
 
     public void Skipped(int requestedFrame)
     {
-        _requestedFrame = requestedFrame;
+        Volatile.Write(ref _requestedFrame, requestedFrame);
     }
 
     public void Dispose()

--- a/tests/Beutl.UnitTests/Editor/PlaybackFrameSkipTests.cs
+++ b/tests/Beutl.UnitTests/Editor/PlaybackFrameSkipTests.cs
@@ -1,0 +1,45 @@
+﻿using Beutl.Models;
+
+namespace Beutl.UnitTests.Editor;
+
+// Tests for PlaybackFrameSkip.ResolveNextFrame. BufferedPlayer's producer loop uses it to catch up
+// with the playback consumer, which displays every frame it dequeues — so a result past the consumer's
+// request is a future frame on screen followed by a freeze until the clock reaches it.
+[TestFixture]
+public class PlaybackFrameSkipTests
+{
+    [Test]
+    public void ResolveNextFrame_NoRequest_AdvancesOneFrame()
+    {
+        Assert.That(PlaybackFrameSkip.ResolveNextFrame(100, null), Is.EqualTo(101));
+    }
+
+    [TestCase(50, Description = "consumer far behind the producer")]
+    [TestCase(100, Description = "consumer at the produced frame")]
+    [TestCase(101, Description = "consumer at the next frame")]
+    public void ResolveNextFrame_RequestNotAhead_AdvancesOneFrame(int requestedFrame)
+    {
+        Assert.That(PlaybackFrameSkip.ResolveNextFrame(100, requestedFrame), Is.EqualTo(101));
+    }
+
+    [TestCase(102)]
+    [TestCase(160)]
+    public void ResolveNextFrame_RequestAhead_LandsExactlyOnTheRequest(int requestedFrame)
+    {
+        Assert.That(PlaybackFrameSkip.ResolveNextFrame(100, requestedFrame), Is.EqualTo(requestedFrame));
+    }
+
+    [Test]
+    public void ResolveNextFrame_RequestAhead_NeverOvershoots()
+    {
+        for (int produced = 0; produced < 200; produced++)
+        {
+            for (int requested = produced - 5; requested < produced + 90; requested++)
+            {
+                int next = PlaybackFrameSkip.ResolveNextFrame(produced, requested);
+                Assert.That(next, Is.LessThanOrEqualTo(Math.Max(requested, produced + 1)));
+                Assert.That(next, Is.GreaterThan(produced));
+            }
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/PlaybackFrameSkipTests.cs
+++ b/tests/Beutl.UnitTests/Editor/PlaybackFrameSkipTests.cs
@@ -2,9 +2,8 @@
 
 namespace Beutl.UnitTests.Editor;
 
-// Tests for PlaybackFrameSkip.ResolveNextFrame. BufferedPlayer's producer loop uses it to catch up
-// with the playback consumer, which displays every frame it dequeues — so a result past the consumer's
-// request is a future frame on screen followed by a freeze until the clock reaches it.
+// The playback consumer displays every frame it dequeues, so a result past its request is a future
+// picture on screen followed by a freeze until the clock reaches it.
 [TestFixture]
 public class PlaybackFrameSkipTests
 {

--- a/tests/Beutl.UnitTests/Editor/PlaybackFrameSkipTests.cs
+++ b/tests/Beutl.UnitTests/Editor/PlaybackFrameSkipTests.cs
@@ -42,4 +42,11 @@ public class PlaybackFrameSkipTests
             }
         }
     }
+
+    [Test]
+    public void ARequestForANegativeFrameIsStillARequest()
+    {
+        Assert.That(PlaybackFrameSkip.ResolveNextFrame(producedFrame: -10, requestedFrame: -3),
+            Is.EqualTo(-3));
+    }
 }


### PR DESCRIPTION
## Problem

When the playback consumer fell behind, the producer jumped to `requested + (requested - current) * 2` — well past the frame the consumer actually asked for. Every frame in between was left uncached, and the picture on screen belonged to a later time than the playhead.

The request was also read and written across threads as an `int?`, which is two fields and can be observed half-updated.

## Change

Resolve the next frame through `PlaybackFrameSkip.ResolveNextFrame`, which advances by one when there is no pending request and otherwise moves to exactly the requested frame — never beyond it. The request is carried in a plain `int` with a `NoRequestedFrame` sentinel, read with `Volatile.Read` and cleared with `Interlocked.CompareExchange` so a request that arrives during the skip is not lost.

## Tests

`PlaybackFrameSkipTests` covers no-request, a request ahead, a request behind (already passed) and the boundary where the request equals the produced frame.