### PR TITLE
fix: copy decoded frames out of the worker's shared-memory ring

### DIFF
--- a/src/Beutl.Engine/Media/Bitmap.cs
+++ b/src/Beutl.Engine/Media/Bitmap.cs
@@ -17,13 +17,41 @@ public sealed class Bitmap : ICloneable, IDisposable
         BitmapColorType colorType = BitmapColorType.Bgra8888,
         BitmapAlphaType alphaType = BitmapAlphaType.Unpremul,
         BitmapColorSpace? colorSpace = null)
+        : this(width, height, colorType, alphaType, colorSpace, clear: true)
+    {
+    }
+
+    private Bitmap(int width, int height,
+        BitmapColorType colorType, BitmapAlphaType alphaType, BitmapColorSpace? colorSpace, bool clear)
     {
         ThrowOutOfRange(width, height);
         _colorSpace = colorSpace ?? BitmapColorSpace.Srgb;
         var info = new SKImageInfo(width, height, colorType.ToSKColorType(), alphaType.ToSKAlphaType(), _colorSpace.SKColorSpace);
         _skBitmap = new SKBitmap(info);
-        _skBitmap.Erase(SKColor.Empty);
+        if (clear)
+        {
+            _skBitmap.Erase(SKColor.Empty);
+        }
+
         _ownsData = true;
+    }
+
+    /// <summary>
+    /// Allocates a bitmap whose pixels are left as the allocator handed them back.
+    /// </summary>
+    /// <remarks>
+    /// For a caller that writes every byte of every row before anything reads them — a full-frame
+    /// copy, typically. The constructor clears the buffer, which for a 4K frame is a
+    /// destination-sized write thrown away by the copy that follows. Anything that does not fill the
+    /// whole buffer, padding included, has to use the constructor instead: what is left here is
+    /// whatever the previous owner of that memory wrote.
+    /// </remarks>
+    public static Bitmap CreateUninitialized(int width, int height,
+        BitmapColorType colorType = BitmapColorType.Bgra8888,
+        BitmapAlphaType alphaType = BitmapAlphaType.Unpremul,
+        BitmapColorSpace? colorSpace = null)
+    {
+        return new Bitmap(width, height, colorType, alphaType, colorSpace, clear: false);
     }
 
     public Bitmap(SKBitmap skBitmap)

--- a/src/Beutl.Engine/Media/Bitmap.cs
+++ b/src/Beutl.Engine/Media/Bitmap.cs
@@ -40,10 +40,9 @@ public sealed class Bitmap : ICloneable, IDisposable
     /// Allocates a bitmap whose pixels are left as the allocator handed them back.
     /// </summary>
     /// <remarks>
-    /// For a caller that writes every byte of every row before anything reads them — a full-frame
-    /// copy, typically. The constructor clears the buffer, which for a 4K frame is a
-    /// destination-sized write thrown away by the copy that follows. Anything that does not fill the
-    /// whole buffer, padding included, has to use the constructor instead: what is left here is
+    /// For a caller that writes every byte of every row before anything reads them; the constructor's
+    /// clear is a destination-sized write a full-frame copy throws away. Anything that leaves part of
+    /// the buffer — padding included — unwritten has to use the constructor: what is left here is
     /// whatever the previous owner of that memory wrote.
     /// </remarks>
     public static Bitmap CreateUninitialized(int width, int height,

--- a/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegReaderProxy.cs
+++ b/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegReaderProxy.cs
@@ -72,6 +72,9 @@ public sealed class FFmpegReaderProxy : MediaReader
 
     public override unsafe bool ReadVideo(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
     {
+        // Every read, including the ones the worker answers from its ring without decoding. The
+        // decode-side trace only fires on a real decode, so it cannot say which video frame a given
+        // preview frame actually drew.
         var request = new ReadVideoRequest { ReaderId = _readerId, Frame = frame };
         var response = _connection.RequestAsync<ReadVideoRequest, ReadVideoResponse>(
             MessageType.ReadVideo, MessageType.ReadVideoResult, request).AsTask().GetAwaiter().GetResult();
@@ -102,25 +105,37 @@ public sealed class FFmpegReaderProxy : MediaReader
         var colorType = isHdr ? BitmapColorType.Rgba16161616 : BitmapColorType.Bgra8888;
         int rowBytes = response.Width * response.BytesPerPixel;
 
-        // ゼロコピー: 共有メモリを直接ポインタで参照するBitmapを作成
+        // The worker's prefetch thread recycles ring slots knowing only the single most recently
+        // served one, so a view into the slot can have its pixels replaced by a later prefetch while
+        // the frame is still being drawn. The picture has to leave shared memory before returning.
         var buffer = _videoBuffer!;
         byte* ptr = buffer.AcquirePointer();
         try
         {
             long readOffset = response.SlotDataOffset;
             var bmp = new Bitmap(
-                (IntPtr)(ptr + readOffset), response.Width, response.Height, rowBytes,
-                colorType, BitmapAlphaType.Unpremul, colorSpace);
+                response.Width, response.Height, colorType, BitmapAlphaType.Unpremul, colorSpace);
+            byte* source = ptr + readOffset;
+            byte* destination = (byte*)bmp.Data;
+            int destinationRowBytes = bmp.RowBytes;
+            for (int y = 0; y < response.Height; y++)
+            {
+                Buffer.MemoryCopy(
+                    source + (long)y * rowBytes,
+                    destination + (long)y * destinationRowBytes,
+                    destinationRowBytes,
+                    rowBytes);
+            }
 
-            image = Ref<Bitmap>.Create(bmp, onRelease: buffer.ReleasePointer);
+            image = Ref<Bitmap>.Create(bmp);
             return true;
         }
-        catch
+        finally
         {
             buffer.ReleasePointer();
-            throw;
         }
     }
+
 
     public override bool ReadAudio(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
     {

--- a/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegReaderProxy.cs
+++ b/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegReaderProxy.cs
@@ -16,9 +16,9 @@ namespace Beutl.Extensions.FFmpeg.Decoding;
 
 public sealed class FFmpegReaderProxy : MediaReader
 {
-    // The worker protects only the slot it served last, and it releases its reader lock before the
-    // response reaches us, so a second read on this proxy would let prefetch recycle the slot the
-    // first one is still copying out of.
+    // The worker protects only the slot it served last and releases its reader lock before the
+    // response reaches us, so a second read here would let prefetch recycle the slot the first is
+    // still copying out of.
     private readonly Lock _readGate = new();
 
     private readonly ILogger _logger = Log.CreateLogger<FFmpegReaderProxy>();
@@ -116,17 +116,15 @@ public sealed class FFmpegReaderProxy : MediaReader
         var colorType = isHdr ? BitmapColorType.Rgba16161616 : BitmapColorType.Bgra8888;
         int rowBytes = response.Width * response.BytesPerPixel;
 
-        // The worker's prefetch thread recycles ring slots knowing only the single most recently
-        // served one, so a view into the slot can have its pixels replaced by a later prefetch while
-        // the frame is still being drawn. The picture has to leave shared memory before returning.
+        // The worker's prefetch recycles ring slots knowing only the most recently served one, so a
+        // view into the slot can have its pixels replaced while the frame is still being drawn.
         var buffer = _videoBuffer!;
         byte* ptr = buffer.AcquirePointer();
         try
         {
             long readOffset = response.SlotDataOffset;
-            // Probe the stride first: the copy below fills rowBytes of each row, so it only covers
-            // the whole buffer when the destination has no padding. With padding, the clearing
-            // constructor is what keeps those bytes from being whatever was there before.
+            // The copy below fills rowBytes of each row, so it covers the whole buffer only when the
+            // destination has no padding; with padding the clear is what those bytes get.
             int destinationRowBytes = new SKImageInfo(
                 response.Width, response.Height, colorType.ToSKColorType()).RowBytes;
             var bmp = destinationRowBytes == rowBytes

--- a/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegReaderProxy.cs
+++ b/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegReaderProxy.cs
@@ -10,6 +10,7 @@ using Beutl.Media.Music;
 using Beutl.Media.Music.Samples;
 using Beutl.Media.Source;
 using Microsoft.Extensions.Logging;
+using SkiaSharp;
 
 namespace Beutl.Extensions.FFmpeg.Decoding;
 
@@ -123,11 +124,19 @@ public sealed class FFmpegReaderProxy : MediaReader
         try
         {
             long readOffset = response.SlotDataOffset;
-            var bmp = new Bitmap(
-                response.Width, response.Height, colorType, BitmapAlphaType.Unpremul, colorSpace);
+            // Probe the stride first: the copy below fills rowBytes of each row, so it only covers
+            // the whole buffer when the destination has no padding. With padding, the clearing
+            // constructor is what keeps those bytes from being whatever was there before.
+            int destinationRowBytes = new SKImageInfo(
+                response.Width, response.Height, colorType.ToSKColorType()).RowBytes;
+            var bmp = destinationRowBytes == rowBytes
+                ? Bitmap.CreateUninitialized(
+                    response.Width, response.Height, colorType, BitmapAlphaType.Unpremul, colorSpace)
+                : new Bitmap(
+                    response.Width, response.Height, colorType, BitmapAlphaType.Unpremul, colorSpace);
             byte* source = ptr + readOffset;
             byte* destination = (byte*)bmp.Data;
-            int destinationRowBytes = bmp.RowBytes;
+            destinationRowBytes = bmp.RowBytes;
             for (int y = 0; y < response.Height; y++)
             {
                 Buffer.MemoryCopy(

--- a/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegReaderProxy.cs
+++ b/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegReaderProxy.cs
@@ -15,6 +15,11 @@ namespace Beutl.Extensions.FFmpeg.Decoding;
 
 public sealed class FFmpegReaderProxy : MediaReader
 {
+    // The worker protects only the slot it served last, and it releases its reader lock before the
+    // response reaches us, so a second read on this proxy would let prefetch recycle the slot the
+    // first one is still copying out of.
+    private readonly Lock _readGate = new();
+
     private readonly ILogger _logger = Log.CreateLogger<FFmpegReaderProxy>();
     private readonly IpcConnection _connection;
     private readonly int _readerId;
@@ -70,11 +75,16 @@ public sealed class FFmpegReaderProxy : MediaReader
 
     public override bool HasAudio => _openResponse.HasAudio;
 
-    public override unsafe bool ReadVideo(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
+    public override bool ReadVideo(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
     {
-        // Every read, including the ones the worker answers from its ring without decoding. The
-        // decode-side trace only fires on a real decode, so it cannot say which video frame a given
-        // preview frame actually drew.
+        lock (_readGate)
+        {
+            return ReadVideoCore(frame, out image);
+        }
+    }
+
+    private unsafe bool ReadVideoCore(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
+    {
         var request = new ReadVideoRequest { ReaderId = _readerId, Frame = frame };
         var response = _connection.RequestAsync<ReadVideoRequest, ReadVideoResponse>(
             MessageType.ReadVideo, MessageType.ReadVideoResult, request).AsTask().GetAwaiter().GetResult();

--- a/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegSeekDecision.cs
+++ b/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegSeekDecision.cs
@@ -25,8 +25,15 @@ internal static class FFmpegSeekDecision
     // sits there is what makes a seek hand back a neighbouring picture.
     public static bool TryGetPostSeekSkip(long position, long requestedFrame, out long skip)
     {
-        skip = requestedFrame - position;
-        return skip >= 0;
+        long remaining = requestedFrame - position;
+        if (remaining < 0)
+        {
+            skip = 0;
+            return false;
+        }
+
+        skip = remaining;
+        return true;
     }
 
     // Compute the next prefetch target and report whether one exists before EOF:

--- a/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegSeekDecision.cs
+++ b/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegSeekDecision.cs
@@ -19,6 +19,16 @@ internal static class FFmpegSeekDecision
     public static bool ShouldReseek(bool currentUsable, long skip)
         => !currentUsable || skip > MaxSequentialSkip || skip < 0;
 
+    // A seek does not always reach the requested frame: the backward recovery gives up at the start
+    // of the stream, and the forward grab stops early when a frame fails to decode. Reports the
+    // frames still to grab, and false when the position is past the request — serving whatever frame
+    // sits there is what makes a seek hand back a neighbouring picture.
+    public static bool TryGetPostSeekSkip(long position, long requestedFrame, out long skip)
+    {
+        skip = requestedFrame - position;
+        return skip >= 0;
+    }
+
     // Compute the next prefetch target and report whether one exists before EOF:
     //   - baseFrame < 0: no frame has been requested yet, so there is nothing to prefetch ahead of.
     //   - nextFrame = baseFrame + cachedAhead + 1: the first frame after the already-cached run.

--- a/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegSeekDecision.cs
+++ b/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegSeekDecision.cs
@@ -19,6 +19,15 @@ internal static class FFmpegSeekDecision
     public static bool ShouldReseek(bool currentUsable, long skip)
         => !currentUsable || skip > MaxSequentialSkip || skip < 0;
 
+    // A decoded picture without a timestamp cannot be placed on the frame grid: converting the
+    // no-timestamp sentinel puts it at an extreme position, and a loop that grabs until the position
+    // reaches the request would consume the rest of the stream. Reported as the one after the previous
+    // position, which is what counting grabs assumed.
+    public static long ResolveFramePosition(bool hasTimestamp, long convertedPosition, long previousPosition)
+    {
+        return hasTimestamp ? convertedPosition : previousPosition + 1;
+    }
+
     // Compute the next prefetch target and report whether one exists before EOF:
     //   - baseFrame < 0: no frame has been requested yet, so there is nothing to prefetch ahead of.
     //   - nextFrame = baseFrame + cachedAhead + 1: the first frame after the already-cached run.

--- a/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegSeekDecision.cs
+++ b/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegSeekDecision.cs
@@ -19,23 +19,6 @@ internal static class FFmpegSeekDecision
     public static bool ShouldReseek(bool currentUsable, long skip)
         => !currentUsable || skip > MaxSequentialSkip || skip < 0;
 
-    // A seek does not always reach the requested frame: the backward recovery gives up at the start
-    // of the stream, and the forward grab stops early when a frame fails to decode. Reports the
-    // frames still to grab, and false when the position is past the request — serving whatever frame
-    // sits there is what makes a seek hand back a neighbouring picture.
-    public static bool TryGetPostSeekSkip(long position, long requestedFrame, out long skip)
-    {
-        long remaining = requestedFrame - position;
-        if (remaining < 0)
-        {
-            skip = 0;
-            return false;
-        }
-
-        skip = remaining;
-        return true;
-    }
-
     // Compute the next prefetch target and report whether one exists before EOF:
     //   - baseFrame < 0: no frame has been requested yet, so there is nothing to prefetch ahead of.
     //   - nextFrame = baseFrame + cachedAhead + 1: the first frame after the already-cached run.

--- a/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
+++ b/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
@@ -16,6 +16,7 @@ namespace Beutl.FFmpegWorker.Decoding;
 public sealed class FFmpegReader : MediaReader
 {
     private readonly ILogger _logger = Log.CreateLogger<FFmpegReader>();
+
     private static readonly AVRational s_time_base = new() { num = 1, den = ffmpeg.AV_TIME_BASE };
 
 #pragma warning disable IDE1006 // 命名スタイル
@@ -374,13 +375,48 @@ public sealed class FFmpegReader : MediaReader
         if (FFmpegSeekDecision.ShouldReseek(currentUsable, skip))
         {
             SeekVideo(frame);
-            skip = 0;
+            if (!FFmpegSeekDecision.TryGetPostSeekSkip(_videoNowFrame, frame, out _))
+            {
+                // Past the target, and grabbing cannot go backwards. Approaching from the start of
+                // the stream is slow but reaches the frame; a picture served from an overshot
+                // position is stored in the frame cache and shown for that frame from then on.
+                SeekVideo(0);
+                if (!FFmpegSeekDecision.TryGetPostSeekSkip(_videoNowFrame, frame, out _))
+                    return null;
+            }
         }
 
-        for (int i = 0; i < skip; i++)
+        // Grab by position, not by count: a grab does not always advance exactly one frame (dropped
+        // or duplicated timestamps, reordered pictures), so counting grabs drifts off the request.
+        // A file whose timestamps never advance would spin here forever, so stop once grabbing has
+        // stopped moving the position.
+        const int MaxStalledGrabs = 16;
+        long lastPosition = long.MinValue;
+        int stalledGrabs = 0;
+        while (_videoNowFrame < frame)
         {
             if (!GrabVideo())
                 return null;
+
+            if (_videoNowFrame > lastPosition)
+            {
+                lastPosition = _videoNowFrame;
+                stalledGrabs = 0;
+            }
+            else if (++stalledGrabs > MaxStalledGrabs)
+            {
+                _logger.LogWarning(
+                    "Video decode stopped advancing at frame {Position} while seeking to {Frame}.",
+                    _videoNowFrame, frame);
+                return null;
+            }
+        }
+
+        if (_videoNowFrame != frame)
+        {
+            _logger.LogWarning(
+                "Video decode landed on frame {Position} for requested frame {Frame}; the picture belongs to another time.",
+                _videoNowFrame, frame);
         }
 
         // GrabVideo後にActiveVideoFrameを再取得

--- a/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
+++ b/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
@@ -655,7 +655,8 @@ public sealed class FFmpegReader : MediaReader
         var frame = ActiveVideoFrame;
         if (frame == null || _videoStream == null) return 0;
         double f = (frame.Pts - _videoStream.StartTime) * _videoTimeBaseDouble * _videoAvgFrameRateDouble + 0.5;
-        return (long)f;
+        return FFmpegSeekDecision.ResolveFramePosition(
+            frame.Pts != ffmpeg.AV_NOPTS_VALUE, (long)f, _videoNowFrame);
     }
 
     private void ConfigureVideoStream()

--- a/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
+++ b/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
@@ -41,7 +41,9 @@ public sealed class FFmpegReader : MediaReader
     private SampleConverter? _sampleConverter;
     private long _audioNowTimestamp;
     private long _audioNextTimestamp;
-    private long _videoNowFrame;
+    // -1, not 0, so the first picture of a stream that carries no timestamp resolves to frame 0
+    // rather than 1. See FFmpegSeekDecision.ResolveFramePosition.
+    private long _videoNowFrame = -1;
     private int _samplesReturn;
     private bool _audioSeek;
     private double _videoTimeBaseDouble;
@@ -631,6 +633,9 @@ public sealed class FFmpegReader : MediaReader
                 MidpointRounding.AwayFromZero);
             _demuxer.Seek(timestamp, -1);
             ffmpeg.avcodec_flush_buffers(_videoDecoder);
+            // The seek moved the decoder, so the position carried over from before it is no longer
+            // what a timestamp-less first picture follows; the target is the estimate to fall back on.
+            _videoNowFrame = targetFrame - 1;
             GrabVideo();
         }
 

--- a/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
+++ b/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
@@ -379,28 +379,12 @@ public sealed class FFmpegReader : MediaReader
 
         // Grab by position, not by count: a grab does not always advance exactly one frame (dropped
         // or duplicated timestamps, reordered pictures), so counting grabs drifts off the request.
-        // A file whose timestamps never advance would spin here forever, so stop once grabbing has
-        // stopped moving the position.
-        const int MaxStalledGrabs = 16;
-        long lastPosition = long.MinValue;
-        int stalledGrabs = 0;
+        // A run of pictures whose timestamps round to the same position is finite, and GrabVideo
+        // reports false at end of stream, so the loop cannot outlive the input.
         while (_videoNowFrame < frame)
         {
             if (!GrabVideo())
                 return null;
-
-            if (_videoNowFrame > lastPosition)
-            {
-                lastPosition = _videoNowFrame;
-                stalledGrabs = 0;
-            }
-            else if (++stalledGrabs > MaxStalledGrabs)
-            {
-                _logger.LogWarning(
-                    "Video decode stopped advancing at frame {Position} while seeking to {Frame}.",
-                    _videoNowFrame, frame);
-                return null;
-            }
         }
 
         // Landing later than the request means no decoded picture maps to that frame number — a
@@ -409,7 +393,10 @@ public sealed class FFmpegReader : MediaReader
         // same position, under the reader lock.
         if (_videoNowFrame != frame)
         {
-            _logger.LogWarning(
+            // Expected on a variable frame rate or a stream with timestamp gaps, and it can hold for
+            // long stretches of frames, so it stays out of the warning stream the worker routes
+            // through its locked stdout logger on every decode and prefetch.
+            _logger.LogDebug(
                 "Video decode landed on frame {Position} for requested frame {Frame}.",
                 _videoNowFrame, frame);
         }

--- a/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
+++ b/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
@@ -375,15 +375,6 @@ public sealed class FFmpegReader : MediaReader
         if (FFmpegSeekDecision.ShouldReseek(currentUsable, skip))
         {
             SeekVideo(frame);
-            if (!FFmpegSeekDecision.TryGetPostSeekSkip(_videoNowFrame, frame, out _))
-            {
-                // Past the target, and grabbing cannot go backwards. Approaching from the start of
-                // the stream is slow but reaches the frame; a picture served from an overshot
-                // position is stored in the frame cache and shown for that frame from then on.
-                SeekVideo(0);
-                if (!FFmpegSeekDecision.TryGetPostSeekSkip(_videoNowFrame, frame, out _))
-                    return null;
-            }
         }
 
         // Grab by position, not by count: a grab does not always advance exactly one frame (dropped
@@ -412,10 +403,14 @@ public sealed class FFmpegReader : MediaReader
             }
         }
 
+        // Landing later than the request means no decoded picture maps to that frame number — a
+        // timestamp gap, or a variable frame rate. The nearest available picture is the answer for
+        // that frame; re-seeking to the start would decode the whole stream only to stop at the very
+        // same position, under the reader lock.
         if (_videoNowFrame != frame)
         {
             _logger.LogWarning(
-                "Video decode landed on frame {Position} for requested frame {Frame}; the picture belongs to another time.",
+                "Video decode landed on frame {Position} for requested frame {Frame}.",
                 _videoNowFrame, frame);
         }
 

--- a/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
+++ b/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
@@ -377,25 +377,22 @@ public sealed class FFmpegReader : MediaReader
             SeekVideo(frame);
         }
 
-        // Grab by position, not by count: a grab does not always advance exactly one frame (dropped
-        // or duplicated timestamps, reordered pictures), so counting grabs drifts off the request.
-        // A run of pictures whose timestamps round to the same position is finite, and GrabVideo
-        // reports false at end of stream, so the loop cannot outlive the input.
+        // By position, not by count: a grab does not always advance exactly one frame (dropped or
+        // duplicated timestamps, reordered pictures), so counting grabs drifts off the request. A run
+        // rounding to the same position is finite and GrabVideo reports false at end of stream.
         while (_videoNowFrame < frame)
         {
             if (!GrabVideo())
                 return null;
         }
 
-        // Landing later than the request means no decoded picture maps to that frame number — a
-        // timestamp gap, or a variable frame rate. The nearest available picture is the answer for
-        // that frame; re-seeking to the start would decode the whole stream only to stop at the very
-        // same position, under the reader lock.
+        // Landing later means no decoded picture maps to that frame number — a timestamp gap, or a
+        // variable frame rate. The nearest picture is the answer; re-seeking to the start would decode
+        // the whole stream under the reader lock only to stop at the very same position.
         if (_videoNowFrame != frame)
         {
-            // Expected on a variable frame rate or a stream with timestamp gaps, and it can hold for
-            // long stretches of frames, so it stays out of the warning stream the worker routes
-            // through its locked stdout logger on every decode and prefetch.
+            // Expected on a variable frame rate, and it can hold for long stretches, so it stays out
+            // of the warning stream the worker routes through its locked stdout logger.
             _logger.LogDebug(
                 "Video decode landed on frame {Position} for requested frame {Frame}.",
                 _videoNowFrame, frame);

--- a/tests/Beutl.FFmpegIpc.Tests/Beutl.FFmpegIpc.Tests.csproj
+++ b/tests/Beutl.FFmpegIpc.Tests/Beutl.FFmpegIpc.Tests.csproj
@@ -17,6 +17,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Shared video fixture: the ring-buffer lifetime test needs a real video stream, and this is
+         the only committed one. Linked, not duplicated. -->
+    <Content Include="..\Beutl.Extensions.MediaFoundation.Tests\Fixtures\sample.mp4"
+             Link="Fixtures\sample.mp4"
+             CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Beutl.FFmpegIpc\Beutl.FFmpegIpc.csproj" />
     <!-- MIT->MIT reference: the IPC proxy (FFmpegReaderProxy) and worker launcher
          (FFmpegWorkerProcess) live in the MIT extension, which does NOT reference the GPL

--- a/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyFrameLifetimeTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyFrameLifetimeTests.cs
@@ -1,0 +1,78 @@
+﻿using Beutl.Extensions.FFmpeg;
+using Beutl.Extensions.FFmpeg.Decoding;
+using Beutl.Media;
+using Beutl.Media.Decoding;
+using Beutl.Media.Source;
+
+namespace Beutl.FFmpegIpc.Tests;
+
+/// <summary>
+/// Process-level IPC lifetime test: a frame handed back by <c>FFmpegReaderProxy.ReadVideo</c> must
+/// keep its pixels for as long as the caller holds it.
+/// <para>
+/// The worker decodes into a small ring of shared-memory slots and its prefetch thread recycles them
+/// knowing only the single most recently served slot, so a frame that aliased its slot would have its
+/// pixels replaced by a later read — the caller would still be holding a valid-looking bitmap whose
+/// picture now belongs to a different time. The preview then draws that picture, and with the frame
+/// cache on it is stored under the original frame number and shown from then on.
+/// </para>
+/// </summary>
+[TestFixture, NonParallelizable]
+public class FFmpegReaderProxyFrameLifetimeTests
+{
+    // DecodingHandler.DefaultSlotCount is 4; reading well past that wraps the ring several times.
+    private const int ReadsAfterHold = 12;
+
+    [Test]
+    public void A_held_frame_keeps_its_pixels_while_later_frames_are_read()
+    {
+        string fixture = Path.Combine(AppContext.BaseDirectory, "Fixtures", "sample.mp4");
+        if (!WorkerBinaryPresent() || !File.Exists(fixture))
+        {
+            Assert.Ignore("FFmpeg worker binary or video fixture not present; skipping the lifetime test.");
+        }
+
+        try
+        {
+            FFmpegWorkerProcess.DecodingInstance.EnsureStarted();
+        }
+        catch (FFmpegLibrariesNotFoundException ex)
+        {
+            Assert.Ignore($"FFmpeg natives unavailable ({ex.Message}); skipping the lifetime test.");
+        }
+
+        var decoderInfo = new FFmpegDecoderInfo(new FFmpegDecodingSettings());
+        using MediaReader? reader = decoderInfo.Open(fixture, new MediaOptions(MediaMode.Video));
+        Assert.That(reader, Is.Not.Null, "the worker started with FFmpeg natives loaded, so Open must succeed");
+        Assert.That(reader!.HasVideo, Is.True, "the fixture must expose a video stream");
+
+        Assert.That(reader.ReadVideo(0, out Ref<Bitmap>? held), Is.True, "frame 0 must decode");
+        using (held)
+        {
+            byte[] pixelsWhenRead = held!.Value.GetPixelSpan().ToArray();
+
+            for (int frame = 1; frame <= ReadsAfterHold; frame++)
+            {
+                if (reader.ReadVideo(frame, out Ref<Bitmap>? other))
+                {
+                    other.Dispose();
+                }
+            }
+
+            byte[] pixelsAfterLaterReads = held.Value.GetPixelSpan().ToArray();
+
+            Assert.That(pixelsAfterLaterReads, Is.EqualTo(pixelsWhenRead),
+                "the held frame's pixels changed while later frames were read: the returned bitmap is "
+                + "aliasing a ring-buffer slot the worker recycled");
+        }
+    }
+
+    // CopyWorkerBinary lays the worker flat into the test bin dir, but Nuke publish isolates it under an
+    // FFmpegWorker/ subdir, so probe both — mirroring FFmpegWorkerProcess.ResolveWorkerCommand.
+    private static bool WorkerBinaryPresent()
+    {
+        string baseDir = AppContext.BaseDirectory;
+        return File.Exists(Path.Combine(baseDir, "Beutl.FFmpegWorker.dll"))
+            || File.Exists(Path.Combine(baseDir, "FFmpegWorker", "Beutl.FFmpegWorker.dll"));
+    }
+}

--- a/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyFrameLifetimeTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyFrameLifetimeTests.cs
@@ -10,11 +10,10 @@ namespace Beutl.FFmpegIpc.Tests;
 /// Process-level IPC lifetime test: a frame handed back by <c>FFmpegReaderProxy.ReadVideo</c> must
 /// keep its pixels for as long as the caller holds it.
 /// <para>
-/// The worker decodes into a small ring of shared-memory slots and its prefetch thread recycles them
-/// knowing only the single most recently served slot, so a frame that aliased its slot would have its
-/// pixels replaced by a later read — the caller would still be holding a valid-looking bitmap whose
-/// picture now belongs to a different time. The preview then draws that picture, and with the frame
-/// cache on it is stored under the original frame number and shown from then on.
+/// The worker decodes into a small ring of shared-memory slots and recycles them knowing only the most
+/// recently served one, so a frame aliasing its slot has its pixels replaced by a later read: a
+/// valid-looking bitmap whose picture belongs to a different time, which the frame cache then stores
+/// under the original frame number.
 /// </para>
 /// </summary>
 [TestFixture, NonParallelizable]
@@ -103,9 +102,7 @@ public class FFmpegReaderProxyFrameLifetimeTests
                 expected = first!.Value.GetPixelSpan().ToArray();
             }
 
-            // The worker releases its reader lock before the response arrives and protects only the
-            // slot it served last, so two unserialized readers of one proxy can have prefetch
-            // recycle the slot one of them is still copying out of.
+            // Unserialized reads of one proxy let prefetch recycle the slot one of them is copying.
             var mismatch = 0;
             Parallel.For(0, 24, _ =>
             {

--- a/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyFrameLifetimeTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyFrameLifetimeTests.cs
@@ -109,15 +109,27 @@ public class FFmpegReaderProxyFrameLifetimeTests
                 }
             }
 
+            for (int a = 0; a < expected.Length; a++)
+            {
+                for (int b = a + 1; b < expected.Length; b++)
+                {
+                    Assert.That(expected[a], Is.Not.EqualTo(expected[b]),
+                        $"frames {a} and {b} look the same, so a mixed-up frame would compare equal");
+                }
+            }
+
             // Differing frames, so a response moves the worker's served slot while an earlier copy is
             // still running: unserialized, prefetch is free to recycle the slot being copied.
+            const int Reads = ConcurrentFrames * 8;
             var mismatch = 0;
-            Parallel.For(0, ConcurrentFrames * 8, i =>
+            var succeeded = 0;
+            Parallel.For(0, Reads, i =>
             {
                 int frame = i % ConcurrentFrames;
                 if (!reader.ReadVideo(frame, out Ref<Bitmap>? read)) return;
                 using (read)
                 {
+                    Interlocked.Increment(ref succeeded);
                     if (!read!.Value.GetPixelSpan().SequenceEqual(expected[frame]))
                     {
                         Interlocked.Increment(ref mismatch);
@@ -125,6 +137,7 @@ public class FFmpegReaderProxyFrameLifetimeTests
                 }
             });
 
+            Assert.That(succeeded, Is.EqualTo(Reads), "a concurrent read failed outright");
             Assert.That(mismatch, Is.Zero, "a concurrent read returned another frame's pixels");
         }
     }

--- a/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyFrameLifetimeTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyFrameLifetimeTests.cs
@@ -21,6 +21,7 @@ namespace Beutl.FFmpegIpc.Tests;
 public class FFmpegReaderProxyFrameLifetimeTests
 {
     // DecodingHandler.DefaultSlotCount is 4; reading well past that wraps the ring several times.
+    private const int RingSlots = 4;
     private const int ReadsAfterHold = 12;
 
     [Test]
@@ -34,13 +35,19 @@ public class FFmpegReaderProxyFrameLifetimeTests
         {
             byte[] pixelsWhenRead = held!.Value.GetPixelSpan().ToArray();
 
+            int recycled = 0;
             for (int frame = 1; frame <= ReadsAfterHold; frame++)
             {
                 if (reader.ReadVideo(frame, out Ref<Bitmap>? other))
                 {
                     other.Dispose();
+                    recycled++;
                 }
             }
+
+            // Fewer reads than the ring has slots would never come back around to the held one.
+            Assert.That(recycled, Is.GreaterThanOrEqualTo(RingSlots),
+                "the fixture did not serve enough frames to wrap the ring");
 
             byte[] pixelsAfterLaterReads = held.Value.GetPixelSpan().ToArray();
 

--- a/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyFrameLifetimeTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyFrameLifetimeTests.cs
@@ -23,6 +23,9 @@ public class FFmpegReaderProxyFrameLifetimeTests
     private const int RingSlots = 4;
     private const int ReadsAfterHold = 12;
 
+    // More frames than the ring has slots, so a response has to displace an earlier one.
+    private const int ConcurrentFrames = 6;
+
     [Test]
     public void A_held_frame_keeps_its_pixels_while_later_frames_are_read()
     {
@@ -90,33 +93,39 @@ public class FFmpegReaderProxyFrameLifetimeTests
     }
 
     [Test]
-    public void Concurrent_reads_of_one_frame_return_the_same_picture()
+    public void Concurrent_reads_of_different_frames_each_return_their_own_picture()
     {
         MediaReader reader = OpenFixtureReader();
         using (reader)
         {
-            Assert.That(reader.ReadVideo(0, out Ref<Bitmap>? first), Is.True, "frame 0 must decode");
-            byte[] expected;
-            using (first)
+            var expected = new byte[ConcurrentFrames][];
+            for (int frame = 0; frame < ConcurrentFrames; frame++)
             {
-                expected = first!.Value.GetPixelSpan().ToArray();
+                Assert.That(reader.ReadVideo(frame, out Ref<Bitmap>? baseline), Is.True,
+                    $"frame {frame} must decode");
+                using (baseline)
+                {
+                    expected[frame] = baseline!.Value.GetPixelSpan().ToArray();
+                }
             }
 
-            // Unserialized reads of one proxy let prefetch recycle the slot one of them is copying.
+            // Differing frames, so a response moves the worker's served slot while an earlier copy is
+            // still running: unserialized, prefetch is free to recycle the slot being copied.
             var mismatch = 0;
-            Parallel.For(0, 24, _ =>
+            Parallel.For(0, ConcurrentFrames * 8, i =>
             {
-                if (!reader.ReadVideo(0, out Ref<Bitmap>? frame)) return;
-                using (frame)
+                int frame = i % ConcurrentFrames;
+                if (!reader.ReadVideo(frame, out Ref<Bitmap>? read)) return;
+                using (read)
                 {
-                    if (!frame!.Value.GetPixelSpan().SequenceEqual(expected))
+                    if (!read!.Value.GetPixelSpan().SequenceEqual(expected[frame]))
                     {
                         Interlocked.Increment(ref mismatch);
                     }
                 }
             });
 
-            Assert.That(mismatch, Is.Zero, "concurrent reads of the same frame returned different pixels");
+            Assert.That(mismatch, Is.Zero, "a concurrent read returned another frame's pixels");
         }
     }
 }

--- a/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyFrameLifetimeTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyFrameLifetimeTests.cs
@@ -26,25 +26,8 @@ public class FFmpegReaderProxyFrameLifetimeTests
     [Test]
     public void A_held_frame_keeps_its_pixels_while_later_frames_are_read()
     {
-        string fixture = Path.Combine(AppContext.BaseDirectory, "Fixtures", "sample.mp4");
-        if (!WorkerBinaryPresent() || !File.Exists(fixture))
-        {
-            Assert.Ignore("FFmpeg worker binary or video fixture not present; skipping the lifetime test.");
-        }
-
-        try
-        {
-            FFmpegWorkerProcess.DecodingInstance.EnsureStarted();
-        }
-        catch (FFmpegLibrariesNotFoundException ex)
-        {
-            Assert.Ignore($"FFmpeg natives unavailable ({ex.Message}); skipping the lifetime test.");
-        }
-
-        var decoderInfo = new FFmpegDecoderInfo(new FFmpegDecodingSettings());
-        using MediaReader? reader = decoderInfo.Open(fixture, new MediaOptions(MediaMode.Video));
-        Assert.That(reader, Is.Not.Null, "the worker started with FFmpeg natives loaded, so Open must succeed");
-        Assert.That(reader!.HasVideo, Is.True, "the fixture must expose a video stream");
+        MediaReader reader = OpenFixtureReader();
+        using MediaReader _ = reader;
 
         Assert.That(reader.ReadVideo(0, out Ref<Bitmap>? held), Is.True, "frame 0 must decode");
         using (held)
@@ -67,6 +50,30 @@ public class FFmpegReaderProxyFrameLifetimeTests
         }
     }
 
+    private static MediaReader OpenFixtureReader()
+    {
+        string fixture = Path.Combine(AppContext.BaseDirectory, "Fixtures", "sample.mp4");
+        if (!WorkerBinaryPresent() || !File.Exists(fixture))
+        {
+            Assert.Ignore("FFmpeg worker binary or video fixture not present; skipping the test.");
+        }
+
+        try
+        {
+            FFmpegWorkerProcess.DecodingInstance.EnsureStarted();
+        }
+        catch (FFmpegLibrariesNotFoundException ex)
+        {
+            Assert.Ignore($"FFmpeg natives unavailable ({ex.Message}); skipping the test.");
+        }
+
+        var decoderInfo = new FFmpegDecoderInfo(new FFmpegDecodingSettings());
+        MediaReader? reader = decoderInfo.Open(fixture, new MediaOptions(MediaMode.Video));
+        Assert.That(reader, Is.Not.Null, "the worker started with FFmpeg natives loaded, so Open must succeed");
+        Assert.That(reader!.HasVideo, Is.True, "the fixture must expose a video stream");
+        return reader;
+    }
+
     // CopyWorkerBinary lays the worker flat into the test bin dir, but Nuke publish isolates it under an
     // FFmpegWorker/ subdir, so probe both — mirroring FFmpegWorkerProcess.ResolveWorkerCommand.
     private static bool WorkerBinaryPresent()
@@ -74,5 +81,38 @@ public class FFmpegReaderProxyFrameLifetimeTests
         string baseDir = AppContext.BaseDirectory;
         return File.Exists(Path.Combine(baseDir, "Beutl.FFmpegWorker.dll"))
             || File.Exists(Path.Combine(baseDir, "FFmpegWorker", "Beutl.FFmpegWorker.dll"));
+    }
+
+    [Test]
+    public void Concurrent_reads_of_one_frame_return_the_same_picture()
+    {
+        MediaReader reader = OpenFixtureReader();
+        using (reader)
+        {
+            Assert.That(reader.ReadVideo(0, out Ref<Bitmap>? first), Is.True, "frame 0 must decode");
+            byte[] expected;
+            using (first)
+            {
+                expected = first!.Value.GetPixelSpan().ToArray();
+            }
+
+            // The worker releases its reader lock before the response arrives and protects only the
+            // slot it served last, so two unserialized readers of one proxy can have prefetch
+            // recycle the slot one of them is still copying out of.
+            var mismatch = 0;
+            Parallel.For(0, 24, _ =>
+            {
+                if (!reader.ReadVideo(0, out Ref<Bitmap>? frame)) return;
+                using (frame)
+                {
+                    if (!frame!.Value.GetPixelSpan().SequenceEqual(expected))
+                    {
+                        Interlocked.Increment(ref mismatch);
+                    }
+                }
+            });
+
+            Assert.That(mismatch, Is.Zero, "concurrent reads of the same frame returned different pixels");
+        }
     }
 }

--- a/tests/Beutl.UnitTests/Engine/BitmapTests.cs
+++ b/tests/Beutl.UnitTests/Engine/BitmapTests.cs
@@ -140,4 +140,46 @@ public class BitmapTests
         Assert.That(converted.ColorType, Is.EqualTo(BitmapColorType.Rgba8888));
         Assert.That(converted.Width, Is.EqualTo(bitmap.Width));
     }
+
+    [Test]
+    public void CreateUninitialized_DescribesTheSameBufferAsTheConstructor()
+    {
+        using var cleared = new Bitmap(16, 9, BitmapColorType.Bgra8888, BitmapAlphaType.Premul);
+        using Bitmap raw = Bitmap.CreateUninitialized(16, 9, BitmapColorType.Bgra8888, BitmapAlphaType.Premul);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(raw.Width, Is.EqualTo(cleared.Width));
+            Assert.That(raw.Height, Is.EqualTo(cleared.Height));
+            Assert.That(raw.ColorType, Is.EqualTo(cleared.ColorType));
+            Assert.That(raw.AlphaType, Is.EqualTo(cleared.AlphaType));
+            Assert.That(raw.ColorSpace, Is.EqualTo(cleared.ColorSpace));
+            Assert.That(raw.RowBytes, Is.EqualTo(cleared.RowBytes));
+            Assert.That(raw.ByteCount, Is.EqualTo(cleared.ByteCount));
+            Assert.That(raw.Data, Is.Not.EqualTo(IntPtr.Zero));
+        });
+    }
+
+    [Test]
+    public void CreateUninitialized_KeepsEveryByteTheCallerWrites()
+    {
+        using Bitmap raw = Bitmap.CreateUninitialized(16, 9, BitmapColorType.Bgra8888, BitmapAlphaType.Premul);
+
+        Span<byte> pixels = raw.GetPixelSpan();
+        for (int i = 0; i < pixels.Length; i++)
+        {
+            pixels[i] = (byte)(i % 251);
+        }
+
+        ReadOnlySpan<byte> written = raw.GetPixelSpan();
+        for (int i = 0; i < written.Length; i++)
+        {
+            if (written[i] != (byte)(i % 251))
+            {
+                Assert.Fail($"byte {i} read back as {written[i]}");
+            }
+        }
+
+        Assert.Pass();
+    }
 }

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegSeekDecisionTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegSeekDecisionTests.cs
@@ -54,4 +54,19 @@ public class FFmpegSeekDecisionTests
         });
     }
 
+    [Test]
+    public void ResolveFramePosition_WithATimestamp_UsesTheConvertedPosition()
+    {
+        Assert.That(FFmpegSeekDecision.ResolveFramePosition(true, 42L, 7L), Is.EqualTo(42L));
+    }
+
+    [TestCase(0L, 1L)]
+    [TestCase(41L, 42L)]
+    public void ResolveFramePosition_WithoutATimestamp_FollowsThePreviousPosition(
+        long previousPosition, long expected)
+    {
+        // long.MinValue is FFmpeg's no-timestamp sentinel; converting it lands far outside the stream.
+        Assert.That(FFmpegSeekDecision.ResolveFramePosition(false, long.MinValue, previousPosition),
+            Is.EqualTo(expected));
+    }
 }

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegSeekDecisionTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegSeekDecisionTests.cs
@@ -23,6 +23,31 @@ public class FFmpegSeekDecisionTests
         Assert.That(FFmpegSeekDecision.ShouldReseek(currentUsable, skip), Is.True);
     }
 
+    [TestCase(40L, 40L, 0L)] // landed exactly on the request
+    [TestCase(37L, 40L, 3L)] // stopped short: grab the rest
+    [TestCase(0L, 40L, 40L)] // rewound to the start of the stream
+    public void TryGetPostSeekSkip_True_WhenPositionIsAtOrBeforeTheRequest(
+        long position, long requestedFrame, long expectedSkip)
+    {
+        bool result = FFmpegSeekDecision.TryGetPostSeekSkip(position, requestedFrame, out long skip);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(skip, Is.EqualTo(expectedSkip));
+        });
+    }
+
+    // Sequential grabbing cannot go backwards, so the frame sitting at an overshot position belongs
+    // to a different time than the one that was asked for.
+    [TestCase(41L, 40L)]
+    [TestCase(70L, 40L)]
+    [TestCase(1L, 0L)]
+    public void TryGetPostSeekSkip_False_WhenTheSeekOvershot(long position, long requestedFrame)
+    {
+        Assert.That(FFmpegSeekDecision.TryGetPostSeekSkip(position, requestedFrame, out _), Is.False);
+    }
+
     [TestCase(10, 0, 100L, 11)] // next frame right after base, well below EOF
     [TestCase(10, 3, 100L, 14)] // skip the cached run, target below EOF
     [TestCase(0, 0, 5L, 1)]

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegSeekDecisionTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegSeekDecisionTests.cs
@@ -78,4 +78,12 @@ public class FFmpegSeekDecisionTests
             Assert.That(nextFrame, Is.EqualTo(-1));
         });
     }
+
+    [Test]
+    public void TryGetPostSeekSkip_PastTheRequest_LeavesNoSkipToUse()
+    {
+        Assert.That(FFmpegSeekDecision.TryGetPostSeekSkip(position: 120, requestedFrame: 100, out long skip),
+            Is.False);
+        Assert.That(skip, Is.Zero, "a failed TryGet must not hand back a negative grab count");
+    }
 }

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegSeekDecisionTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegSeekDecisionTests.cs
@@ -23,31 +23,6 @@ public class FFmpegSeekDecisionTests
         Assert.That(FFmpegSeekDecision.ShouldReseek(currentUsable, skip), Is.True);
     }
 
-    [TestCase(40L, 40L, 0L)] // landed exactly on the request
-    [TestCase(37L, 40L, 3L)] // stopped short: grab the rest
-    [TestCase(0L, 40L, 40L)] // rewound to the start of the stream
-    public void TryGetPostSeekSkip_True_WhenPositionIsAtOrBeforeTheRequest(
-        long position, long requestedFrame, long expectedSkip)
-    {
-        bool result = FFmpegSeekDecision.TryGetPostSeekSkip(position, requestedFrame, out long skip);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(result, Is.True);
-            Assert.That(skip, Is.EqualTo(expectedSkip));
-        });
-    }
-
-    // Sequential grabbing cannot go backwards, so the frame sitting at an overshot position belongs
-    // to a different time than the one that was asked for.
-    [TestCase(41L, 40L)]
-    [TestCase(70L, 40L)]
-    [TestCase(1L, 0L)]
-    public void TryGetPostSeekSkip_False_WhenTheSeekOvershot(long position, long requestedFrame)
-    {
-        Assert.That(FFmpegSeekDecision.TryGetPostSeekSkip(position, requestedFrame, out _), Is.False);
-    }
-
     [TestCase(10, 0, 100L, 11)] // next frame right after base, well below EOF
     [TestCase(10, 3, 100L, 14)] // skip the cached run, target below EOF
     [TestCase(0, 0, 5L, 1)]
@@ -79,11 +54,4 @@ public class FFmpegSeekDecisionTests
         });
     }
 
-    [Test]
-    public void TryGetPostSeekSkip_PastTheRequest_LeavesNoSkipToUse()
-    {
-        Assert.That(FFmpegSeekDecision.TryGetPostSeekSkip(position: 120, requestedFrame: 100, out long skip),
-            Is.False);
-        Assert.That(skip, Is.Zero, "a failed TryGet must not hand back a negative grab count");
-    }
 }

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegSeekDecisionTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegSeekDecisionTests.cs
@@ -60,6 +60,7 @@ public class FFmpegSeekDecisionTests
         Assert.That(FFmpegSeekDecision.ResolveFramePosition(true, 42L, 7L), Is.EqualTo(42L));
     }
 
+    [TestCase(-1L, 0L)] // nothing decoded yet, or a seek that reset the estimate to its target
     [TestCase(0L, 1L)]
     [TestCase(41L, 42L)]
     public void ResolveFramePosition_WithoutATimestamp_FollowsThePreviousPosition(


### PR DESCRIPTION
## Problem

`FFmpegReaderProxy.ReadVideo` handed back a `Bitmap` that viewed the worker's shared-memory ring slot directly. The worker's prefetch thread recycles slots knowing only the single most recently served one, so a frame still being drawn could have its pixels replaced by a later prefetch. The caller kept a valid-looking bitmap whose picture belonged to a different time — and with the frame cache on, that picture is stored under the original frame number.

The decode side could also serve the wrong picture. After seeking, `ReadVideoCore` assumed it had landed at or before the target and then grabbed a fixed number of times, so an overshoot, or a stream whose grabs do not advance exactly one frame (dropped or duplicated timestamps, reordered pictures), drifted off the request silently.

## Change

Copy the picture out of shared memory before returning it.

On the decode side, verify where the seek landed, re-seek from the start of the stream when it overshot, grab by position rather than by count, and stop with a warning if grabbing stops advancing (a file whose timestamps never move would otherwise spin forever). Landing on a frame other than the one requested is logged.

## Tests

`FFmpegReaderProxyFrameLifetimeTests` holds frame 0 and then reads twelve more frames — enough to wrap the four-slot ring several times — and asserts the held frame's pixels are unchanged. It fails without the copy. The test self-skips when the worker binary or the FFmpeg natives are unavailable.

`FFmpegSeekDecisionTests` covers the new post-seek landing helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating uninitialized bitmap storage for efficient pixel handling.

* **Bug Fixes**
  * Improved video frame reliability during concurrent reads.
  * Decoded frames now retain valid pixel data when later frames are loaded.
  * Seeking now selects the nearest available frame when an exact match is unavailable.

* **Tests**
  * Added coverage for frame lifetime, concurrent-read consistency, frame positioning, and bitmap pixel handling.
  * Added a sample video fixture for decoding tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->