### PR TITLE
feat: save and apply named dock layouts

### DIFF
--- a/src/Beutl.Language/MessageStrings.ja.resx
+++ b/src/Beutl.Language/MessageStrings.ja.resx
@@ -24,6 +24,12 @@
   <data name="OperationCompletedSuccessfully" xml:space="preserve">
     <value>操作が正常に完了しました。</value>
   </data>
+  <data name="NoDockLayoutPresets" xml:space="preserve">
+    <value>保存されたドックレイアウトはありません。</value>
+  </data>
+  <data name="DockLayoutSaved" xml:space="preserve">
+    <value>ドックレイアウト「{0}」を保存しました。</value>
+  </data>
   <data name="ExportProjectPartialFailure" xml:space="preserve">
     <value>エクスポートは完了しましたが、{0}件のリソースのコピーに失敗しました。書き出されたパッケージが不完全な可能性があります。</value>
   </data>

--- a/src/Beutl.Language/MessageStrings.resx
+++ b/src/Beutl.Language/MessageStrings.resx
@@ -29,6 +29,12 @@
   <data name="OperationCompletedSuccessfully" xml:space="preserve">
     <value>The operation completed successfully.</value>
   </data>
+  <data name="NoDockLayoutPresets" xml:space="preserve">
+    <value>No dock layouts have been saved yet.</value>
+  </data>
+  <data name="DockLayoutSaved" xml:space="preserve">
+    <value>Saved the dock layout '{0}'.</value>
+  </data>
   <data name="ExportProjectPartialFailure" xml:space="preserve">
     <value>Export completed, but {0} resources failed to copy. The exported package may be incomplete.</value>
   </data>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -216,6 +216,21 @@
   <data name="ResetDockLayout" xml:space="preserve">
     <value>ドックレイアウトをリセット</value>
   </data>
+  <data name="DockLayout" xml:space="preserve">
+    <value>ドックレイアウト</value>
+  </data>
+  <data name="ApplyDockLayout" xml:space="preserve">
+    <value>ドックレイアウトを適用</value>
+  </data>
+  <data name="ManageDockLayouts" xml:space="preserve">
+    <value>ドックレイアウトを管理</value>
+  </data>
+  <data name="SaveCurrentDockLayout" xml:space="preserve">
+    <value>現在のレイアウトを保存</value>
+  </data>
+  <data name="SavedDockLayouts" xml:space="preserve">
+    <value>保存済みレイアウト</value>
+  </data>
   <data name="Others" xml:space="preserve">
     <value>その他</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -278,6 +278,21 @@
   <data name="ResetDockLayout" xml:space="preserve">
     <value>Reset dock layout</value>
   </data>
+  <data name="DockLayout" xml:space="preserve">
+    <value>Dock layout</value>
+  </data>
+  <data name="ApplyDockLayout" xml:space="preserve">
+    <value>Apply dock layout</value>
+  </data>
+  <data name="ManageDockLayouts" xml:space="preserve">
+    <value>Manage dock layouts</value>
+  </data>
+  <data name="SaveCurrentDockLayout" xml:space="preserve">
+    <value>Save the current layout</value>
+  </data>
+  <data name="SavedDockLayouts" xml:space="preserve">
+    <value>Saved layouts</value>
+  </data>
   <data name="EditAnimation" xml:space="preserve">
     <value>Edit animation</value>
   </data>

--- a/src/Beutl/Services/DockLayoutPresetService.cs
+++ b/src/Beutl/Services/DockLayoutPresetService.cs
@@ -206,6 +206,10 @@ public sealed class DockLayoutPresetService
     public void RestoreItems()
     {
         string filePath = FilePath;
+        // A reload that fails must re-arm the guard: otherwise a transient read error would leave
+        // the previous success standing and let a later save overwrite the file from a stale
+        // snapshot — the exact case SaveItems refuses to do on a first-load failure.
+        _isRestored = false;
         try
         {
             if (!File.Exists(filePath))

--- a/src/Beutl/Services/DockLayoutPresetService.cs
+++ b/src/Beutl/Services/DockLayoutPresetService.cs
@@ -1,0 +1,215 @@
+﻿using System.Text.Json.Nodes;
+using Beutl.Logging;
+using Microsoft.Extensions.Logging;
+using Reactive.Bindings;
+
+namespace Beutl.Services;
+
+/// <summary>
+/// A named dock layout that the user saved from an editor and can re-apply later.
+/// </summary>
+public sealed class DockLayoutPresetItem(string name, JsonObject layout)
+{
+    /// <summary>Gets the display name, unique within <see cref="DockLayoutPresetService"/>.</summary>
+    public ReactiveProperty<string> Name { get; } = new(name);
+
+    /// <summary>Gets the serialized layout, in <c>DockHostViewModel</c>'s view-state shape.</summary>
+    public JsonObject Layout { get; } = layout;
+
+    public static JsonNode ToJson(DockLayoutPresetItem item)
+    {
+        return new JsonObject
+        {
+            [nameof(Name)] = item.Name.Value,
+            [nameof(Layout)] = item.Layout.DeepClone(),
+        };
+    }
+
+    public static DockLayoutPresetItem? FromJson(JsonNode json, ILogger logger)
+    {
+        try
+        {
+            if (json[nameof(Name)] is not JsonValue nameValue
+                || !nameValue.TryGetValue(out string? name)
+                || string.IsNullOrWhiteSpace(name))
+            {
+                logger.LogWarning("Dock layout preset has no name.");
+                return null;
+            }
+
+            if (json[nameof(Layout)] is not JsonObject layout)
+            {
+                logger.LogWarning("Dock layout preset '{Name}' has no layout.", name);
+                return null;
+            }
+
+            return new DockLayoutPresetItem(name, (JsonObject)layout.DeepClone());
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An exception has occurred while creating DockLayoutPresetItem from JSON.");
+            return null;
+        }
+    }
+}
+
+/// <summary>
+/// Stores named dock layouts in <c>$BEUTL_HOME/dock-layout-presets.json</c> so they can be
+/// applied to any scene, in any project.
+/// </summary>
+public sealed class DockLayoutPresetService
+{
+    public static readonly DockLayoutPresetService Instance = new();
+
+    private readonly CoreList<DockLayoutPresetItem> _items = [];
+    private readonly ILogger _logger = Log.CreateLogger<DockLayoutPresetService>();
+    private readonly string? _filePathOverride;
+    private bool _isRestored;
+
+    private DockLayoutPresetService()
+    {
+        RestoreItems();
+    }
+
+    // Test seam: points the store at a scratch file instead of the ambient BEUTL_HOME.
+    internal DockLayoutPresetService(string filePath)
+    {
+        _filePathOverride = filePath;
+        RestoreItems();
+    }
+
+    public ICoreList<DockLayoutPresetItem> Items => _items;
+
+    private string FilePath => _filePathOverride
+                               ?? Path.Combine(BeutlEnvironment.GetHomeDirectoryPath(), "dock-layout-presets.json");
+
+    /// <summary>Adds a preset, or overwrites the one already using <paramref name="name"/>.</summary>
+    /// <returns>The added or updated item, or null when <paramref name="name"/> is blank.</returns>
+    public DockLayoutPresetItem? Save(string name, JsonObject layout)
+    {
+        name = name.Trim();
+        if (name.Length == 0)
+        {
+            _logger.LogWarning("Refused to save a dock layout preset with a blank name.");
+            return null;
+        }
+
+        var clone = (JsonObject)layout.DeepClone();
+        DockLayoutPresetItem? existing = Find(name);
+        if (existing is not null)
+        {
+            int index = _items.IndexOf(existing);
+            var replacement = new DockLayoutPresetItem(existing.Name.Value, clone);
+            _items[index] = replacement;
+            SaveItems();
+            _logger.LogInformation("Overwrote dock layout preset '{Name}'.", name);
+            return replacement;
+        }
+
+        var item = new DockLayoutPresetItem(name, clone);
+        _items.Add(item);
+        SaveItems();
+        _logger.LogInformation("Added dock layout preset '{Name}'.", name);
+        return item;
+    }
+
+    public bool Remove(DockLayoutPresetItem item)
+    {
+        if (!_items.Remove(item)) return false;
+        SaveItems();
+        _logger.LogInformation("Removed dock layout preset '{Name}'.", item.Name.Value);
+        return true;
+    }
+
+    public bool Rename(DockLayoutPresetItem item, string newName)
+    {
+        newName = newName.Trim();
+        if (newName.Length == 0) return false;
+        if (!_items.Contains(item)) return false;
+        if (string.Equals(item.Name.Value, newName, StringComparison.OrdinalIgnoreCase))
+        {
+            // Same preset, possibly a case-only change — allow it.
+            item.Name.Value = newName;
+            SaveItems();
+            return true;
+        }
+
+        if (Find(newName) is not null) return false;
+
+        item.Name.Value = newName;
+        SaveItems();
+        return true;
+    }
+
+    public DockLayoutPresetItem? Find(string name)
+    {
+        return _items.FirstOrDefault(
+            i => string.Equals(i.Name.Value, name.Trim(), StringComparison.OrdinalIgnoreCase));
+    }
+
+    public bool Exists(string name) => Find(name) is not null;
+
+    public void SaveItems()
+    {
+        // Never overwrite a file we failed to read; a transient IO error would wipe every preset.
+        if (!_isRestored) return;
+
+        try
+        {
+            var array = new JsonArray();
+            foreach (DockLayoutPresetItem item in _items)
+            {
+                array.Add(DockLayoutPresetItem.ToJson(item));
+            }
+
+            array.JsonSave(FilePath);
+            _logger.LogInformation(
+                "Saved {Count} dock layout presets to file: {FilePath}", _items.Count, FilePath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An exception has occurred while saving dock layout presets.");
+        }
+    }
+
+    public void RestoreItems()
+    {
+        string filePath = FilePath;
+        try
+        {
+            if (!File.Exists(filePath))
+            {
+                _isRestored = true;
+                return;
+            }
+
+            using FileStream stream = File.Open(filePath, FileMode.Open);
+            JsonNode? jsonNode = JsonNode.Parse(stream);
+            if (jsonNode is not JsonArray jsonArray)
+            {
+                _logger.LogWarning("Invalid JSON format in dock layout preset file: {FilePath}", filePath);
+                return;
+            }
+
+            _items.Clear();
+            _items.EnsureCapacity(jsonArray.Count);
+            foreach (JsonNode? jsonItem in jsonArray)
+            {
+                if (jsonItem is null) continue;
+                DockLayoutPresetItem? item = DockLayoutPresetItem.FromJson(jsonItem, _logger);
+                if (item is not null && !Exists(item.Name.Value))
+                {
+                    _items.Add(item);
+                }
+            }
+
+            _isRestored = true;
+            _logger.LogInformation(
+                "Restored {Count} dock layout presets from file: {FilePath}", _items.Count, filePath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An exception has occurred while restoring dock layout presets.");
+        }
+    }
+}

--- a/src/Beutl/Services/DockLayoutPresetService.cs
+++ b/src/Beutl/Services/DockLayoutPresetService.cs
@@ -84,7 +84,9 @@ public sealed class DockLayoutPresetService
                                ?? Path.Combine(BeutlEnvironment.GetHomeDirectoryPath(), "dock-layout-presets.json");
 
     /// <summary>Adds a preset, or overwrites the one already using <paramref name="name"/>.</summary>
-    /// <returns>The added or updated item, or null when <paramref name="name"/> is blank.</returns>
+    /// <returns>
+    /// The added or updated item, or null when <paramref name="name"/> is blank or the write failed.
+    /// </returns>
     public DockLayoutPresetItem? Save(string name, JsonObject layout)
     {
         name = name.Trim();
@@ -101,22 +103,40 @@ public sealed class DockLayoutPresetService
             int index = _items.IndexOf(existing);
             var replacement = new DockLayoutPresetItem(existing.Name.Value, clone);
             _items[index] = replacement;
-            SaveItems();
+            if (!SaveItems())
+            {
+                _items[index] = existing;
+                return null;
+            }
+
             _logger.LogInformation("Overwrote dock layout preset '{Name}'.", name);
             return replacement;
         }
 
         var item = new DockLayoutPresetItem(name, clone);
         _items.Add(item);
-        SaveItems();
+        if (!SaveItems())
+        {
+            _items.Remove(item);
+            return null;
+        }
+
         _logger.LogInformation("Added dock layout preset '{Name}'.", name);
         return item;
     }
 
     public bool Remove(DockLayoutPresetItem item)
     {
-        if (!_items.Remove(item)) return false;
-        SaveItems();
+        int index = _items.IndexOf(item);
+        if (index < 0) return false;
+
+        _items.RemoveAt(index);
+        if (!SaveItems())
+        {
+            _items.Insert(index, item);
+            return false;
+        }
+
         _logger.LogInformation("Removed dock layout preset '{Name}'.", item.Name.Value);
         return true;
     }
@@ -126,19 +146,25 @@ public sealed class DockLayoutPresetService
         newName = newName.Trim();
         if (newName.Length == 0) return false;
         if (!_items.Contains(item)) return false;
+
+        string previousName = item.Name.Value;
         if (string.Equals(item.Name.Value, newName, StringComparison.OrdinalIgnoreCase))
         {
             // Same preset, possibly a case-only change — allow it.
             item.Name.Value = newName;
-            SaveItems();
-            return true;
+            if (SaveItems()) return true;
+
+            item.Name.Value = previousName;
+            return false;
         }
 
         if (Find(newName) is not null) return false;
 
         item.Name.Value = newName;
-        SaveItems();
-        return true;
+        if (SaveItems()) return true;
+
+        item.Name.Value = previousName;
+        return false;
     }
 
     public DockLayoutPresetItem? Find(string name)
@@ -149,10 +175,12 @@ public sealed class DockLayoutPresetService
 
     public bool Exists(string name) => Find(name) is not null;
 
-    public void SaveItems()
+    /// <summary>Writes the presets to disk.</summary>
+    /// <returns><c>true</c> when the store was written.</returns>
+    public bool SaveItems()
     {
         // Never overwrite a file we failed to read; a transient IO error would wipe every preset.
-        if (!_isRestored) return;
+        if (!_isRestored) return false;
 
         try
         {
@@ -165,10 +193,12 @@ public sealed class DockLayoutPresetService
             array.JsonSave(FilePath);
             _logger.LogInformation(
                 "Saved {Count} dock layout presets to file: {FilePath}", _items.Count, FilePath);
+            return true;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "An exception has occurred while saving dock layout presets.");
+            return false;
         }
     }
 
@@ -188,6 +218,10 @@ public sealed class DockLayoutPresetService
             if (jsonNode is not JsonArray jsonArray)
             {
                 _logger.LogWarning("Invalid JSON format in dock layout preset file: {FilePath}", filePath);
+                // An unreadable file is not worth preserving: leaving _isRestored false would make
+                // every later save a silent no-op.
+                _items.Clear();
+                _isRestored = true;
                 return;
             }
 

--- a/src/Beutl/Services/DockLayoutPresetService.cs
+++ b/src/Beutl/Services/DockLayoutPresetService.cs
@@ -214,7 +214,9 @@ public sealed class DockLayoutPresetService
                 return;
             }
 
-            using FileStream stream = File.Open(filePath, FileMode.Open);
+            // Read-only: applying a layout needs no write access, so a read-only preset file must
+            // still load rather than throwing before it is parsed.
+            using FileStream stream = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
             JsonNode? jsonNode = JsonNode.Parse(stream);
             if (jsonNode is not JsonArray jsonArray)
             {

--- a/src/Beutl/Services/DockLayoutPresetService.cs
+++ b/src/Beutl/Services/DockLayoutPresetService.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Nodes;
+﻿using System.Text.Json;
+using System.Text.Json.Nodes;
 using Beutl.Logging;
 using Microsoft.Extensions.Logging;
 using Reactive.Bindings;
@@ -218,10 +219,7 @@ public sealed class DockLayoutPresetService
             if (jsonNode is not JsonArray jsonArray)
             {
                 _logger.LogWarning("Invalid JSON format in dock layout preset file: {FilePath}", filePath);
-                // An unreadable file is not worth preserving: leaving _isRestored false would make
-                // every later save a silent no-op.
-                _items.Clear();
-                _isRestored = true;
+                MarkUnusableFileRestored();
                 return;
             }
 
@@ -244,6 +242,20 @@ public sealed class DockLayoutPresetService
         catch (Exception ex)
         {
             _logger.LogError(ex, "An exception has occurred while restoring dock layout presets.");
+            if (ex is JsonException)
+            {
+                // Unparsable content, not a transient IO fault — the same dead end as a non-array
+                // root, so recover the same way instead of wedging every later save.
+                MarkUnusableFileRestored();
+            }
         }
+    }
+
+    // A file we can read but never use is not worth protecting: leaving _isRestored false would
+    // make every later save a silent no-op.
+    private void MarkUnusableFileRestored()
+    {
+        _items.Clear();
+        _isRestored = true;
     }
 }

--- a/src/Beutl/Services/PrimitiveImpls/DockLayoutTabExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/DockLayoutTabExtension.cs
@@ -1,0 +1,51 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Avalonia.Controls;
+using Beutl.ViewModels;
+using Beutl.ViewModels.Tools;
+using Beutl.Views.Tools;
+
+namespace Beutl.Services.PrimitiveImpls;
+
+[PrimitiveImpl]
+public sealed class DockLayoutTabExtension : ToolTabExtension
+{
+    public static readonly DockLayoutTabExtension Instance = new();
+
+    public override string Name => "Dock layout";
+
+    public override string DisplayName => Strings.DockLayout;
+
+    public override string? Header => Strings.DockLayout;
+
+    public override bool CanMultiple => false;
+
+    public override DockAnchor DefaultAnchor => DockAnchor.Right;
+
+    public override bool OpenByDefault => false;
+
+    public override int DefaultOrder => 110;
+
+    public override bool TryCreateContent(IEditorContext editorContext, [NotNullWhen(true)] out Control? control)
+    {
+        if (editorContext is EditViewModel)
+        {
+            control = new DockLayoutView();
+            return true;
+        }
+
+        control = null;
+        return false;
+    }
+
+    public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)
+    {
+        if (editorContext is EditViewModel editViewModel)
+        {
+            context = new DockLayoutViewModel(editViewModel);
+            return true;
+        }
+
+        context = null;
+        return false;
+    }
+}

--- a/src/Beutl/Services/StartupTasks/LoadPrimitiveExtensionTask.cs
+++ b/src/Beutl/Services/StartupTasks/LoadPrimitiveExtensionTask.cs
@@ -58,6 +58,7 @@ public sealed class LoadPrimitiveExtensionTask : StartupTask
         ScriptEditorExtension.Instance,
         FileBrowserTabExtension.Instance,
         HistoryTabExtension.Instance,
+        DockLayoutTabExtension.Instance,
         TerminalTabExtension.Instance,
         DarkBorderThemeExtension.Instance
     ];

--- a/src/Beutl/ViewModels/Dock/BeutlDockFactory.cs
+++ b/src/Beutl/ViewModels/Dock/BeutlDockFactory.cs
@@ -295,6 +295,18 @@ public class BeutlDockFactory(EditViewModel editViewModel) : Factory
             if (root.HiddenDockables is { } hidden)
                 foreach (var c in hidden)
                     foreach (var g in Traverse(c)) yield return g;
+            // Pinned (auto-hidden) tools live outside VisibleDockables but are still owned by the
+            // layout — they are serialized and restored, so enumeration must see them too.
+            foreach (var pinned in new[]
+                     {
+                         root.LeftPinnedDockables, root.RightPinnedDockables,
+                         root.TopPinnedDockables, root.BottomPinnedDockables
+                     })
+            {
+                if (pinned is null) continue;
+                foreach (var c in pinned)
+                    foreach (var g in Traverse(c)) yield return g;
+            }
             if (root.Windows is { } windows)
                 foreach (var w in windows)
                     if (w.Layout is not null)

--- a/src/Beutl/ViewModels/DockHostViewModel.cs
+++ b/src/Beutl/ViewModels/DockHostViewModel.cs
@@ -17,6 +17,10 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
     private readonly ILogger _logger = Log.CreateLogger<DockHostViewModel>();
     private bool _layoutInitialized;
 
+    // Set only while ApplyLayout is walking a restore, so a failure mid-walk can dispose the tools
+    // built so far. Null at every other time.
+    private List<BeutlToolDockable>? _restoredTools;
+
     public DockHostViewModel(string sceneId, EditViewModel editViewModel)
     {
         _sceneId = sceneId;
@@ -266,7 +270,9 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
 
         // Restore first: a malformed preset must not leave the editor without a layout.
         IRootDock restored;
-        IDockable? partial = null;
+        // Collects every tool built during the walk, so a mid-walk failure can dispose them.
+        var built = new List<BeutlToolDockable>();
+        _restoredTools = built;
         try
         {
             if (!IsCurrentVersion(layout))
@@ -283,11 +289,10 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
                 return false;
             }
 
-            partial = RestoreNode(layoutObj);
-            if (partial is not IRootDock rootDock)
+            if (RestoreNode(layoutObj) is not IRootDock rootDock)
             {
                 _logger.LogWarning("Saved dock layout did not restore to an IRootDock ({SceneId})", _sceneId);
-                DisposeRestored(partial);
+                DisposeAll(built, "partially restored");
                 return false;
             }
 
@@ -296,10 +301,12 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to restore a saved dock layout ({SceneId})", _sceneId);
-            // Restoration builds tool contexts as it walks the tree; the ones it managed to create
-            // before failing are unreachable now and would leak their subscriptions.
-            DisposeRestored(partial);
+            DisposeAll(built, "partially restored");
             return false;
+        }
+        finally
+        {
+            _restoredTools = null;
         }
 
         // Dispose after the swap, and directly — CloseDockable would walk the old tree.
@@ -310,17 +317,7 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         Layout.Value = restored;
         _layoutInitialized = true;
 
-        foreach (BeutlToolDockable tool in previousTools)
-        {
-            try
-            {
-                tool.Dispose();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to dispose a replaced tool tab ({SceneId})", _sceneId);
-            }
-        }
+        DisposeAll(previousTools, "replaced");
 
         if (!Factory.EnumerateTools().Any())
         {
@@ -330,11 +327,9 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         return true;
     }
 
-    private void DisposeRestored(IDockable? root)
+    private void DisposeAll(IEnumerable<BeutlToolDockable> tools, string what)
     {
-        if (root is null) return;
-
-        foreach (BeutlToolDockable tool in BeutlDockFactory.Traverse(root).OfType<BeutlToolDockable>())
+        foreach (BeutlToolDockable tool in tools)
         {
             try
             {
@@ -342,7 +337,7 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to dispose a partially restored tool tab ({SceneId})", _sceneId);
+                _logger.LogWarning(ex, "Failed to dispose a {What} tool tab ({SceneId})", what, _sceneId);
             }
         }
     }
@@ -701,6 +696,10 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         var dockable = new BeutlToolDockable(ctx, _editViewModel);
         if (obj["id"]?.GetValue<string>() is { Length: > 0 } savedId)
             dockable.Id = savedId;
+
+        // Registered as soon as it exists so a failure deeper in the walk can still dispose it;
+        // waiting for RestoreNode to return would lose everything built before the throw.
+        _restoredTools?.Add(dockable);
         return dockable;
     }
 

--- a/src/Beutl/ViewModels/DockHostViewModel.cs
+++ b/src/Beutl/ViewModels/DockHostViewModel.cs
@@ -191,11 +191,7 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
     {
         _logger.LogInformation("Reading DockHostViewModel from JSON ({SceneId})", _sceneId);
 
-        var hasVersion = json.TryGetPropertyValue("_dockVersion", out var vNode) &&
-            vNode is JsonValue vVal && vVal.TryGetValue(out int version) &&
-            version == DockVersion;
-
-        if (hasVersion &&
+        if (IsCurrentVersion(json) &&
             json.TryGetPropertyValue("DockLayout", out var layoutNode) &&
             layoutNode is JsonObject layoutObj)
         {
@@ -237,6 +233,139 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
     {
         ResetToDefaultLayout("user requested");
         OpenDefaultTabs();
+    }
+
+    /// <summary>
+    /// Captures the current layout in the same shape <see cref="WriteToJson"/> writes, for
+    /// <see cref="ApplyLayout"/> to restore later.
+    /// </summary>
+    /// <remarks>
+    /// Per-tool state (selected element ids, search text, ...) is dropped; it belongs to the scene
+    /// it was captured from.
+    /// </remarks>
+    public JsonObject CaptureLayout()
+    {
+        EnsureDefaultLayout();
+        var json = new JsonObject();
+        WriteToJson(json);
+        if (json["DockLayout"] is JsonObject layout)
+        {
+            StripToolState(layout);
+        }
+
+        return json;
+    }
+
+    // Keeps only what identifies a tab: its type and dockable id.
+    private static void StripToolState(JsonObject node)
+    {
+        if (node.TryGetPropertyValueAsJsonValue("$type", out string? type) && type == "tool")
+        {
+            foreach (string key in node.Select(p => p.Key)
+                         .Where(k => k is not ("$type" or "id" or "extension"))
+                         .ToArray())
+            {
+                node.Remove(key);
+            }
+
+            return;
+        }
+
+        foreach ((string _, JsonNode? child) in node.ToArray())
+        {
+            switch (child)
+            {
+                case JsonObject childObj:
+                    StripToolState(childObj);
+                    break;
+                case JsonArray childArray:
+                    foreach (JsonNode? item in childArray)
+                    {
+                        if (item is JsonObject itemObj) StripToolState(itemObj);
+                    }
+
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Replaces the current layout with a previously captured one.
+    /// </summary>
+    /// <remarks>
+    /// The outgoing tool contexts are disposed and the incoming layout builds fresh ones against
+    /// this editor, so a layout captured elsewhere restores the arrangement only.
+    /// </remarks>
+    public bool ApplyLayout(JsonObject layout)
+    {
+        _logger.LogInformation("Applying a saved dock layout ({SceneId})", _sceneId);
+
+        // Restore first: a malformed preset must not leave the editor without a layout.
+        IRootDock restored;
+        try
+        {
+            if (!IsCurrentVersion(layout))
+            {
+                _logger.LogWarning(
+                    "Saved dock layout was written by an incompatible version ({SceneId})", _sceneId);
+                return false;
+            }
+
+            if (!layout.TryGetPropertyValue("DockLayout", out JsonNode? layoutNode)
+                || layoutNode is not JsonObject layoutObj)
+            {
+                _logger.LogWarning("Saved dock layout has no DockLayout node ({SceneId})", _sceneId);
+                return false;
+            }
+
+            if (RestoreNode(layoutObj) is not IRootDock rootDock)
+            {
+                _logger.LogWarning("Saved dock layout did not restore to an IRootDock ({SceneId})", _sceneId);
+                return false;
+            }
+
+            restored = rootDock;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to restore a saved dock layout ({SceneId})", _sceneId);
+            return false;
+        }
+
+        // Dispose after the swap, and directly — CloseDockable would walk the old tree.
+        var previousTools = Factory.EnumerateTools().ToList();
+
+        Factory.SetRootDock(restored);
+        Factory.InitLayout(restored);
+        Layout.Value = restored;
+        _layoutInitialized = true;
+
+        foreach (BeutlToolDockable tool in previousTools)
+        {
+            try
+            {
+                tool.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to dispose a replaced tool tab ({SceneId})", _sceneId);
+            }
+        }
+
+        if (!Factory.EnumerateTools().Any())
+        {
+            OpenDefaultTabs();
+        }
+
+        return true;
+    }
+
+    private static bool IsCurrentVersion(JsonObject json)
+    {
+        return json.TryGetPropertyValue("_dockVersion", out JsonNode? node)
+               && node is JsonValue value
+               && value.TryGetValue(out int version)
+               && version == DockVersion;
     }
 
     private void ResetToDefaultLayout(string reason)

--- a/src/Beutl/ViewModels/DockHostViewModel.cs
+++ b/src/Beutl/ViewModels/DockHostViewModel.cs
@@ -246,47 +246,11 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
     public JsonObject CaptureLayout()
     {
         EnsureDefaultLayout();
-        var json = new JsonObject();
-        WriteToJson(json);
-        if (json["DockLayout"] is JsonObject layout)
+        return new JsonObject
         {
-            StripToolState(layout);
-        }
-
-        return json;
-    }
-
-    // Keeps only what identifies a tab: its type and dockable id.
-    private static void StripToolState(JsonObject node)
-    {
-        if (node.TryGetPropertyValueAsJsonValue("$type", out string? type) && type == "tool")
-        {
-            foreach (string key in node.Select(p => p.Key)
-                         .Where(k => k is not ("$type" or "id" or "extension"))
-                         .ToArray())
-            {
-                node.Remove(key);
-            }
-
-            return;
-        }
-
-        foreach ((string _, JsonNode? child) in node.ToArray())
-        {
-            switch (child)
-            {
-                case JsonObject childObj:
-                    StripToolState(childObj);
-                    break;
-                case JsonArray childArray:
-                    foreach (JsonNode? item in childArray)
-                    {
-                        if (item is JsonObject itemObj) StripToolState(itemObj);
-                    }
-
-                    break;
-            }
-        }
+            ["_dockVersion"] = DockVersion,
+            ["DockLayout"] = SaveNode(Layout.Value, includeToolState: false),
+        };
     }
 
     /// <summary>
@@ -302,6 +266,7 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
 
         // Restore first: a malformed preset must not leave the editor without a layout.
         IRootDock restored;
+        IDockable? partial = null;
         try
         {
             if (!IsCurrentVersion(layout))
@@ -318,9 +283,11 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
                 return false;
             }
 
-            if (RestoreNode(layoutObj) is not IRootDock rootDock)
+            partial = RestoreNode(layoutObj);
+            if (partial is not IRootDock rootDock)
             {
                 _logger.LogWarning("Saved dock layout did not restore to an IRootDock ({SceneId})", _sceneId);
+                DisposeRestored(partial);
                 return false;
             }
 
@@ -329,6 +296,9 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to restore a saved dock layout ({SceneId})", _sceneId);
+            // Restoration builds tool contexts as it walks the tree; the ones it managed to create
+            // before failing are unreachable now and would leak their subscriptions.
+            DisposeRestored(partial);
             return false;
         }
 
@@ -360,6 +330,23 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         return true;
     }
 
+    private void DisposeRestored(IDockable? root)
+    {
+        if (root is null) return;
+
+        foreach (BeutlToolDockable tool in BeutlDockFactory.Traverse(root).OfType<BeutlToolDockable>())
+        {
+            try
+            {
+                tool.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to dispose a partially restored tool tab ({SceneId})", _sceneId);
+            }
+        }
+    }
+
     private static bool IsCurrentVersion(JsonObject json)
     {
         return json.TryGetPropertyValue("_dockVersion", out JsonNode? node)
@@ -386,21 +373,21 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         EnsureDefaultLayout();
     }
 
-    private JsonObject SaveNode(IDockable node)
+    private JsonObject SaveNode(IDockable node, bool includeToolState = true)
     {
         return node switch
         {
-            IRootDock root => SaveRootDock(root),
+            IRootDock root => SaveRootDock(root, includeToolState),
             IProportionalDockSplitter => new JsonObject { ["$type"] = "splitter" },
-            IProportionalDock prop => SaveProportionalDock(prop),
-            IToolDock toolDock => SaveToolDock(toolDock),
-            BeutlToolDockable tool => SaveBeutlTool(tool),
+            IProportionalDock prop => SaveProportionalDock(prop, includeToolState),
+            IToolDock toolDock => SaveToolDock(toolDock, includeToolState),
+            BeutlToolDockable tool => SaveBeutlTool(tool, includeToolState),
             PlayerToolDockable => new JsonObject { ["$type"] = "player" },
             _ => new JsonObject { ["$type"] = "unknown" },
         };
     }
 
-    private JsonObject SaveRootDock(IRootDock root)
+    private JsonObject SaveRootDock(IRootDock root, bool includeToolState)
     {
         var obj = new JsonObject
         {
@@ -412,15 +399,15 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         {
             var children = new JsonArray();
             foreach (var child in visible)
-                children.Add(SaveNode(child));
+                children.Add(SaveNode(child, includeToolState));
             obj["children"] = children;
         }
 
-        SaveDockableList(obj, "hidden", root.HiddenDockables);
-        SaveDockableList(obj, "leftPinned", root.LeftPinnedDockables);
-        SaveDockableList(obj, "rightPinned", root.RightPinnedDockables);
-        SaveDockableList(obj, "topPinned", root.TopPinnedDockables);
-        SaveDockableList(obj, "bottomPinned", root.BottomPinnedDockables);
+        SaveDockableList(obj, "hidden", root.HiddenDockables, includeToolState);
+        SaveDockableList(obj, "leftPinned", root.LeftPinnedDockables, includeToolState);
+        SaveDockableList(obj, "rightPinned", root.RightPinnedDockables, includeToolState);
+        SaveDockableList(obj, "topPinned", root.TopPinnedDockables, includeToolState);
+        SaveDockableList(obj, "bottomPinned", root.BottomPinnedDockables, includeToolState);
 
         if (root.Windows is { Count: > 0 } windows)
         {
@@ -430,7 +417,7 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
                 if (w.Layout is null) continue;
                 var wObj = new JsonObject
                 {
-                    ["layout"] = SaveNode(w.Layout),
+                    ["layout"] = SaveNode(w.Layout, includeToolState),
                     ["x"] = w.X,
                     ["y"] = w.Y,
                     ["width"] = w.Width,
@@ -448,16 +435,16 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         return obj;
     }
 
-    private void SaveDockableList(JsonObject parent, string key, IList<IDockable>? list)
+    private void SaveDockableList(JsonObject parent, string key, IList<IDockable>? list, bool includeToolState)
     {
         if (list is not { Count: > 0 }) return;
         var array = new JsonArray();
         foreach (var item in list)
-            array.Add(SaveNode(item));
+            array.Add(SaveNode(item, includeToolState));
         parent[key] = array;
     }
 
-    private JsonObject SaveProportionalDock(IProportionalDock prop)
+    private JsonObject SaveProportionalDock(IProportionalDock prop, bool includeToolState)
     {
         var obj = new JsonObject
         {
@@ -472,14 +459,14 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         {
             var children = new JsonArray();
             foreach (var child in visible)
-                children.Add(SaveNode(child));
+                children.Add(SaveNode(child, includeToolState));
             obj["children"] = children;
         }
 
         return obj;
     }
 
-    private JsonObject SaveToolDock(IToolDock toolDock)
+    private JsonObject SaveToolDock(IToolDock toolDock, bool includeToolState)
     {
         var obj = new JsonObject
         {
@@ -499,7 +486,7 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
             for (int i = 0; i < visible.Count; i++)
             {
                 var child = visible[i];
-                tools.Add(SaveNode(child));
+                tools.Add(SaveNode(child, includeToolState));
                 if (child == toolDock.ActiveDockable)
                     activeDockableIndex = i;
             }
@@ -512,7 +499,7 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         return obj;
     }
 
-    private static JsonObject SaveBeutlTool(BeutlToolDockable dockable)
+    private static JsonObject SaveBeutlTool(BeutlToolDockable dockable, bool includeToolState)
     {
         var ctx = dockable.ToolContext;
         var obj = new JsonObject
@@ -523,7 +510,14 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         var extObj = new JsonObject();
         extObj.WriteDiscriminator(ctx.Extension.GetType());
         obj["extension"] = extObj;
-        ctx.WriteToJson(obj);
+
+        // A tool's serializer can have side effects (some write their own per-scene state file), so
+        // a preset capture must not invoke it just to discard the result.
+        if (includeToolState)
+        {
+            ctx.WriteToJson(obj);
+        }
+
         return obj;
     }
 

--- a/src/Beutl/ViewModels/DockHostViewModel.cs
+++ b/src/Beutl/ViewModels/DockHostViewModel.cs
@@ -21,6 +21,11 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
     // built so far. Null at every other time.
     private List<BeutlToolDockable>? _restoredTools;
 
+    // Set while restoring an arrangement-only payload (a saved layout). Such a payload deliberately
+    // omits tool state, so handing it to IToolContext.ReadFromJson would feed every reader a
+    // document missing the fields its writer produces.
+    private bool _restoringArrangementOnly;
+
     public DockHostViewModel(string sceneId, EditViewModel editViewModel)
     {
         _sceneId = sceneId;
@@ -273,6 +278,8 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         // Collects every tool built during the walk, so a mid-walk failure can dispose them.
         var built = new List<BeutlToolDockable>();
         _restoredTools = built;
+        // A saved layout carries no tool state (see CaptureLayout), so the readers must be skipped.
+        _restoringArrangementOnly = true;
         try
         {
             if (!IsCurrentVersion(layout))
@@ -307,6 +314,7 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         finally
         {
             _restoredTools = null;
+            _restoringArrangementOnly = false;
         }
 
         // Dispose after the swap, and directly — CloseDockable would walk the old tree.
@@ -680,26 +688,34 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
 
         if (!extension.TryCreateContext(_editViewModel, out IToolContext? ctx)) return null;
 
-        try
+        if (!_restoringArrangementOnly)
         {
-            ctx.ReadFromJson(obj);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Failed to restore tool state for '{ToolType}' ({SceneId})",
-                extType.FullName,
-                _sceneId);
+            try
+            {
+                ctx.ReadFromJson(obj);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Failed to restore tool state for '{ToolType}' ({SceneId})",
+                    extType.FullName,
+                    _sceneId);
+            }
         }
 
         var dockable = new BeutlToolDockable(ctx, _editViewModel);
-        if (obj["id"]?.GetValue<string>() is { Length: > 0 } savedId)
-            dockable.Id = savedId;
-
-        // Registered as soon as it exists so a failure deeper in the walk can still dispose it;
-        // waiting for RestoreNode to return would lose everything built before the throw.
+        // Registered before anything that can throw — including the id parse just below — so a
+        // failure anywhere after construction can still dispose it.
         _restoredTools?.Add(dockable);
+
+        if (obj["id"] is JsonValue idValue
+            && idValue.TryGetValue(out string? savedId)
+            && savedId.Length > 0)
+        {
+            dockable.Id = savedId;
+        }
+
         return dockable;
     }
 

--- a/src/Beutl/ViewModels/MenuBarViewModel.View.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.View.cs
@@ -1,26 +1,77 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using Beutl.Services;
+using Beutl.Services.PrimitiveImpls;
+using Microsoft.Extensions.Logging;
 using Reactive.Bindings;
 
 namespace Beutl.ViewModels;
 
 public partial class MenuBarViewModel
 {
-    [MemberNotNull(nameof(ResetDockLayout))]
+    [MemberNotNull(nameof(ResetDockLayout), nameof(ApplyDockLayout), nameof(OpenDockLayoutTab))]
     private void InitializeViewCommands(IObservable<bool> isSceneOpened)
     {
         ResetDockLayout = new ReactiveCommandSlim(isSceneOpened)
             .WithSubscribe(OnResetDockLayout);
+
+        ApplyDockLayout = new ReactiveCommandSlim<DockLayoutPresetItem>()
+            .WithSubscribe(OnApplyDockLayout);
+
+        // Saving, renaming and deleting live in the dock layout tool tab.
+        OpenDockLayoutTab = new ReactiveCommandSlim(isSceneOpened)
+            .WithSubscribe(OnOpenDockLayoutTab);
     }
 
     // View
     //    Reset dock layout
+    //    Apply a saved dock layout
+    //    Open the dock layout tool tab
     public ReactiveCommandSlim ResetDockLayout { get; private set; }
+
+    public ReactiveCommandSlim<DockLayoutPresetItem> ApplyDockLayout { get; private set; }
+
+    public ReactiveCommandSlim OpenDockLayoutTab { get; private set; }
+
+    public ICoreList<DockLayoutPresetItem> DockLayoutPresets => DockLayoutPresetService.Instance.Items;
 
     private void OnResetDockLayout()
     {
         if (TryGetSelectedEditViewModel(out EditViewModel? viewModel))
         {
             viewModel.DockHost.ResetLayout();
+        }
+    }
+
+    private void OnOpenDockLayoutTab()
+    {
+        if (!TryGetSelectedEditViewModel(out EditViewModel? viewModel)) return;
+
+        if (viewModel.DockHost.FindToolContext(typeof(DockLayoutTabExtension)) is { } existing)
+        {
+            existing.IsSelected.Value = true;
+            return;
+        }
+
+        if (DockLayoutTabExtension.Instance.TryCreateContext(viewModel, out IToolContext? context)
+            && !viewModel.OpenToolTab(context))
+        {
+            context.Dispose();
+        }
+    }
+
+    private void OnApplyDockLayout(DockLayoutPresetItem? preset)
+    {
+        if (preset is null) return;
+        if (!TryGetSelectedEditViewModel(out EditViewModel? viewModel)) return;
+
+        if (viewModel.DockHost.ApplyLayout(preset.Layout))
+        {
+            _logger.LogInformation("Applied dock layout preset '{Name}'.", preset.Name.Value);
+        }
+        else
+        {
+            _logger.LogWarning("Failed to apply dock layout preset '{Name}'.", preset.Name.Value);
+            NotificationService.ShowError(Strings.DockLayout, MessageStrings.OperationFailed);
         }
     }
 }

--- a/src/Beutl/ViewModels/MenuBarViewModel.View.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.View.cs
@@ -14,7 +14,7 @@ public partial class MenuBarViewModel
         ResetDockLayout = new ReactiveCommandSlim(isSceneOpened)
             .WithSubscribe(OnResetDockLayout);
 
-        ApplyDockLayout = new ReactiveCommandSlim<DockLayoutPresetItem>()
+        ApplyDockLayout = new ReactiveCommandSlim<DockLayoutPresetItem>(isSceneOpened)
             .WithSubscribe(OnApplyDockLayout);
 
         // Saving, renaming and deleting live in the dock layout tool tab.

--- a/src/Beutl/ViewModels/Tools/DockLayoutViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/DockLayoutViewModel.cs
@@ -1,0 +1,150 @@
+﻿using System.Reactive.Disposables;
+using System.Text.Json.Nodes;
+using Beutl.Logging;
+using Beutl.Services;
+using Beutl.Services.PrimitiveImpls;
+using Microsoft.Extensions.Logging;
+using Reactive.Bindings;
+using Reactive.Bindings.Extensions;
+
+namespace Beutl.ViewModels.Tools;
+
+/// <summary>
+/// Drives the dock layout tool tab. Names are collected by the view through a flyout, so the
+/// operations take the target and the name as arguments instead of exposing text-box state.
+/// </summary>
+public sealed class DockLayoutViewModel : IToolContext
+{
+    private readonly ILogger _logger = Log.CreateLogger<DockLayoutViewModel>();
+    private readonly CompositeDisposable _disposables = [];
+    private readonly EditViewModel _editViewModel;
+    private readonly DockLayoutPresetService _service;
+
+    public DockLayoutViewModel(EditViewModel editViewModel)
+        : this(editViewModel, DockLayoutPresetService.Instance)
+    {
+    }
+
+    internal DockLayoutViewModel(EditViewModel editViewModel, DockLayoutPresetService service)
+    {
+        _editViewModel = editViewModel;
+        _service = service;
+
+        SelectedItem = new ReactiveProperty<DockLayoutPresetItem?>().AddTo(_disposables);
+
+        HasSelection = SelectedItem.Select(i => i is not null)
+            .ToReadOnlyReactivePropertySlim()
+            .AddTo(_disposables);
+    }
+
+    public ToolTabExtension Extension => DockLayoutTabExtension.Instance;
+
+    public IReactiveProperty<bool> IsSelected { get; } = new ReactiveProperty<bool>();
+
+    public string Header => Strings.DockLayout;
+
+    public ICoreList<DockLayoutPresetItem> Items => _service.Items;
+
+    public ReactiveProperty<DockLayoutPresetItem?> SelectedItem { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> HasSelection { get; }
+
+    public string SuggestName()
+    {
+        string baseName = Strings.DockLayout;
+        if (!_service.Exists(baseName)) return baseName;
+
+        for (int i = 2; i < int.MaxValue; i++)
+        {
+            string candidate = $"{baseName} {i}";
+            if (!_service.Exists(candidate)) return candidate;
+        }
+
+        return baseName;
+    }
+
+    public DockLayoutPresetItem? Save(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return null;
+
+        DockLayoutPresetItem? saved = _service.Save(name, _editViewModel.DockHost.CaptureLayout());
+        if (saved is null)
+        {
+            NotificationService.ShowError(Strings.DockLayout, MessageStrings.OperationFailed);
+            return null;
+        }
+
+        SelectedItem.Value = saved;
+        NotificationService.ShowSuccess(
+            Strings.DockLayout,
+            string.Format(MessageStrings.DockLayoutSaved, saved.Name.Value));
+        return saved;
+    }
+
+    /// <summary>Applies <paramref name="item"/>, or the selected layout when null.</summary>
+    public bool Apply(DockLayoutPresetItem? item = null)
+    {
+        DockLayoutPresetItem? target = item ?? SelectedItem.Value;
+        if (target is null) return false;
+
+        if (_editViewModel.DockHost.ApplyLayout(target.Layout))
+        {
+            _logger.LogInformation("Applied dock layout '{Name}'.", target.Name.Value);
+            return true;
+        }
+
+        _logger.LogWarning("Failed to apply dock layout '{Name}'.", target.Name.Value);
+        NotificationService.ShowError(Strings.DockLayout, MessageStrings.OperationFailed);
+        return false;
+    }
+
+    public void Remove(DockLayoutPresetItem? item = null)
+    {
+        DockLayoutPresetItem? target = item ?? SelectedItem.Value;
+        if (target is null) return;
+
+        _service.Remove(target);
+        if (ReferenceEquals(SelectedItem.Value, target))
+        {
+            SelectedItem.Value = null;
+        }
+    }
+
+    public bool Rename(DockLayoutPresetItem? item, string? newName)
+    {
+        DockLayoutPresetItem? target = item ?? SelectedItem.Value;
+        if (target is null || string.IsNullOrWhiteSpace(newName)) return false;
+
+        // Dismissing the flyout unedited must not report an error.
+        if (string.Equals(target.Name.Value, newName.Trim(), StringComparison.Ordinal)) return true;
+
+        if (_service.Rename(target, newName)) return true;
+
+        NotificationService.ShowError(Strings.DockLayout, MessageStrings.OperationFailed);
+        return false;
+    }
+
+    public void ResetLayout()
+    {
+        _editViewModel.DockHost.ResetLayout();
+    }
+
+    public void Dispose()
+    {
+        _disposables.Dispose();
+    }
+
+    public object? GetService(Type serviceType)
+    {
+        return _editViewModel.GetService(serviceType);
+    }
+
+    public void ReadFromJson(JsonObject json)
+    {
+        // Saved layouts live in BEUTL_HOME, not in the per-scene view state.
+    }
+
+    public void WriteToJson(JsonObject json)
+    {
+    }
+}

--- a/src/Beutl/ViewModels/Tools/DockLayoutViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/DockLayoutViewModel.cs
@@ -103,7 +103,12 @@ public sealed class DockLayoutViewModel : IToolContext
         DockLayoutPresetItem? target = item ?? SelectedItem.Value;
         if (target is null) return;
 
-        _service.Remove(target);
+        if (!_service.Remove(target))
+        {
+            NotificationService.ShowError(Strings.DockLayout, MessageStrings.OperationFailed);
+            return;
+        }
+
         if (ReferenceEquals(SelectedItem.Value, target))
         {
             SelectedItem.Value = null;

--- a/src/Beutl/Views/MacWindow.axaml
+++ b/src/Beutl/Views/MacWindow.axaml
@@ -125,6 +125,11 @@
                     <NativeMenuItemSeparator />
                     <NativeMenuItem Command="{CompiledBinding MenuBar.ResetDockLayout}"
                                     Header="{x:Static lang:Strings.ResetDockLayout}" />
+                    <NativeMenuItem Header="{x:Static lang:Strings.ApplyDockLayout}">
+                        <NativeMenu />
+                    </NativeMenuItem>
+                    <NativeMenuItem Command="{CompiledBinding MenuBar.OpenDockLayoutTab}"
+                                    Header="{x:Static lang:Strings.ManageDockLayouts}" />
                 </NativeMenu>
             </NativeMenuItem>
             <NativeMenuItem Header="{x:Static lang:Strings.Tools}">

--- a/src/Beutl/Views/MacWindow.axaml.cs
+++ b/src/Beutl/Views/MacWindow.axaml.cs
@@ -134,6 +134,7 @@ public sealed partial class MacWindow : Window
         NativeMenu? editorTabMenu = null;
         NativeMenu? toolTabMenu = null;
         NativeMenu? toolWindowMenu = null;
+        NativeMenu? dockLayoutPresetMenu = null;
         try
         {
             var rootMenu = NativeMenu.GetMenu(this)!;
@@ -141,12 +142,19 @@ public sealed partial class MacWindow : Window
             editorTabMenu = ((NativeMenuItem)viewMenuItem.Menu!.Items[0]).Menu;
             toolTabMenu = ((NativeMenuItem)viewMenuItem.Menu!.Items[1]).Menu;
             toolWindowMenu = ((NativeMenuItem)rootMenu.Items[3]).Menu;
+            // View > ... > "Apply dock layout" (see MacWindow.axaml).
+            dockLayoutPresetMenu = ((NativeMenuItem)viewMenuItem.Menu!.Items[^2]).Menu;
         }
         catch
         {
         }
 
         if (viewMenuItem == null || editorTabMenu == null || toolTabMenu == null || toolWindowMenu == null) return;
+
+        if (dockLayoutPresetMenu != null)
+        {
+            InitDockLayoutPresetMenu(viewModel, dockLayoutPresetMenu);
+        }
 
         // ToolTabExtensionをメニューに表示する
         NativeMenuItem CreateToolTabMenuItem(ToolTabExtension item)
@@ -285,6 +293,25 @@ public sealed partial class MacWindow : Window
             toolWindowMenu.Items.Insert,
             (i, _) => toolWindowMenu.Items.RemoveAt(i),
             toolWindowMenu.Items.Clear);
+    }
+
+    private static void InitDockLayoutPresetMenu(MainViewModel viewModel, NativeMenu menu)
+    {
+        void AddItem(int index, DockLayoutPresetItem item)
+        {
+            menu.Items.Insert(index, new NativeMenuItem
+            {
+                // NativeMenuItem headers are static; a rename rebuilds the list instead.
+                Header = item.Name.Value,
+                Command = viewModel.MenuBar.ApplyDockLayout,
+                CommandParameter = item
+            });
+        }
+
+        viewModel.MenuBar.DockLayoutPresets.ForEachItem(
+            AddItem,
+            (i, _) => menu.Items.RemoveAt(i),
+            menu.Items.Clear);
     }
 
     private async Task OpenToolWindowAsync(ToolWindowExtension extension)

--- a/src/Beutl/Views/MacWindow.axaml.cs
+++ b/src/Beutl/Views/MacWindow.axaml.cs
@@ -297,21 +297,50 @@ public sealed partial class MacWindow : Window
 
     private static void InitDockLayoutPresetMenu(MainViewModel viewModel, NativeMenu menu)
     {
+        // Renaming mutates Name.Value in place without a collection change, so each item's header
+        // follows its name observable. The subscriptions are keyed by menu item so removal and
+        // clear can dispose them.
+        var nameSubscriptions = new Dictionary<NativeMenuItem, IDisposable>();
+
         void AddItem(int index, DockLayoutPresetItem item)
         {
-            menu.Items.Insert(index, new NativeMenuItem
+            var menuItem = new NativeMenuItem
             {
-                // NativeMenuItem headers are static; a rename rebuilds the list instead.
                 Header = item.Name.Value,
                 Command = viewModel.MenuBar.ApplyDockLayout,
                 CommandParameter = item
-            });
+            };
+
+            nameSubscriptions[menuItem] = item.Name.Subscribe(name => menuItem.Header = name);
+            menu.Items.Insert(index, menuItem);
+        }
+
+        void RemoveAt(int index)
+        {
+            if (menu.Items[index] is NativeMenuItem menuItem
+                && nameSubscriptions.Remove(menuItem, out IDisposable? subscription))
+            {
+                subscription.Dispose();
+            }
+
+            menu.Items.RemoveAt(index);
+        }
+
+        void Clear()
+        {
+            foreach (IDisposable subscription in nameSubscriptions.Values)
+            {
+                subscription.Dispose();
+            }
+
+            nameSubscriptions.Clear();
+            menu.Items.Clear();
         }
 
         viewModel.MenuBar.DockLayoutPresets.ForEachItem(
             AddItem,
-            (i, _) => menu.Items.RemoveAt(i),
-            menu.Items.Clear);
+            (i, _) => RemoveAt(i),
+            Clear);
     }
 
     private async Task OpenToolWindowAsync(ToolWindowExtension extension)

--- a/src/Beutl/Views/MainView.axaml
+++ b/src/Beutl/Views/MainView.axaml
@@ -175,6 +175,9 @@
                     <Separator />
                     <MenuItem Command="{CompiledBinding MenuBar.ResetDockLayout}"
                               Header="{x:Static lang:Strings.ResetDockLayout}" />
+                    <MenuItem x:Name="dockLayoutPresetMenuItem" Header="{x:Static lang:Strings.ApplyDockLayout}" />
+                    <MenuItem Command="{CompiledBinding MenuBar.OpenDockLayoutTab}"
+                              Header="{x:Static lang:Strings.ManageDockLayouts}" />
                 </MenuItem>
                 <MenuItem x:Name="toolWindowMenuItem" Header="{x:Static lang:Strings.Tools}" />
                 <!--  シーン  -->

--- a/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
+++ b/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
@@ -70,6 +70,11 @@ public partial class MainView
 
     private void InitializeDockLayoutPresetMenu(MainViewModel viewModel)
     {
+        // Keyed by menu item so a removed preset's header subscription goes away with it; leaving
+        // it in _disposables would pin the MenuItem — and through it the preset's layout JSON —
+        // for the rest of the session.
+        var headerSubscriptions = new Dictionary<MenuItem, IDisposable>();
+
         MenuItem CreateDockLayoutMenuItem(DockLayoutPresetItem item)
         {
             var menuItem = new MenuItem
@@ -82,17 +87,33 @@ public partial class MainView
             // A typed subscription rather than a string-path Binding: the surrounding XAML uses
             // compiled bindings, and a reflection path would silently blank the header if the
             // property were ever renamed.
-            item.Name.Subscribe(name => menuItem.Header = name).DisposeWith(_disposables);
+            headerSubscriptions[menuItem] = item.Name.Subscribe(name => menuItem.Header = name);
             return menuItem;
+        }
+
+        void DisposeMenuItem(MenuItem menuItem)
+        {
+            if (headerSubscriptions.Remove(menuItem, out IDisposable? subscription))
+            {
+                subscription.Dispose();
+            }
         }
 
         viewModel.MenuBar.DockLayoutPresets
             .ToObservableChangeSet<ICoreReadOnlyList<DockLayoutPresetItem>, DockLayoutPresetItem>()
             .ObserveOnUIDispatcher()
-            .Cast(CreateDockLayoutMenuItem)
+            .Transform(CreateDockLayoutMenuItem)
+            .OnItemRemoved(DisposeMenuItem)
             .Bind(out ReadOnlyObservableCollection<MenuItem>? presetMenuItems)
             .Subscribe()
             .DisposeWith(_disposables);
+
+        // The change set only fires OnItemRemoved while the view lives; drop the rest on teardown.
+        Disposable.Create(headerSubscriptions, subs =>
+        {
+            foreach (IDisposable subscription in subs.Values) subscription.Dispose();
+            subs.Clear();
+        }).DisposeWith(_disposables);
 
         dockLayoutPresetMenuItem.ItemsSource = presetMenuItems;
 

--- a/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
+++ b/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
@@ -1,9 +1,12 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Windows.Input;
 using Avalonia;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
 using Avalonia.Platform.Storage;
 using Beutl.Api.Services;
 using Beutl.Configuration;
@@ -15,6 +18,8 @@ using Beutl.Services;
 using Beutl.ViewModels;
 using Beutl.ViewModels.Dialogs;
 using Beutl.Views.Dialogs;
+using DynamicData;
+using DynamicData.Binding;
 using FluentAvalonia.UI.Controls;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -61,6 +66,40 @@ public partial class MainView
 
         viewModel.MenuBar.ExportProject.Subscribe(OnExportProject).AddTo(_disposables);
         viewModel.MenuBar.ImportProject.Subscribe(OnImportProject).AddTo(_disposables);
+
+        InitializeDockLayoutPresetMenu(viewModel);
+    }
+
+    private void InitializeDockLayoutPresetMenu(MainViewModel viewModel)
+    {
+        MenuItem CreateDockLayoutMenuItem(DockLayoutPresetItem item)
+        {
+            var menuItem = new MenuItem
+            {
+                DataContext = item,
+                Command = viewModel.MenuBar.ApplyDockLayout,
+                CommandParameter = item
+            };
+            menuItem.Bind(HeaderedSelectingItemsControl.HeaderProperty, new Binding(
+                $"{nameof(DockLayoutPresetItem.Name)}.{nameof(item.Name.Value)}"));
+            return menuItem;
+        }
+
+        viewModel.MenuBar.DockLayoutPresets
+            .ToObservableChangeSet<ICoreReadOnlyList<DockLayoutPresetItem>, DockLayoutPresetItem>()
+            .ObserveOnUIDispatcher()
+            .Cast(CreateDockLayoutMenuItem)
+            .Bind(out ReadOnlyObservableCollection<MenuItem>? presetMenuItems)
+            .Subscribe()
+            .DisposeWith(_disposables);
+
+        dockLayoutPresetMenuItem.ItemsSource = presetMenuItems;
+
+        // An empty submenu would render as a dead-end, so hide the entry until presets exist.
+        viewModel.MenuBar.DockLayoutPresets.ObserveProperty(x => x.Count)
+            .ObserveOnUIDispatcher()
+            .Subscribe(count => dockLayoutPresetMenuItem.IsVisible = count > 0)
+            .DisposeWith(_disposables);
     }
 
     private void InitializeRecentItems(MainViewModel viewModel)

--- a/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
+++ b/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
@@ -5,8 +5,6 @@ using Avalonia;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Controls.Primitives;
-using Avalonia.Data;
 using Avalonia.Platform.Storage;
 using Beutl.Api.Services;
 using Beutl.Configuration;
@@ -80,8 +78,11 @@ public partial class MainView
                 Command = viewModel.MenuBar.ApplyDockLayout,
                 CommandParameter = item
             };
-            menuItem.Bind(HeaderedSelectingItemsControl.HeaderProperty, new Binding(
-                $"{nameof(DockLayoutPresetItem.Name)}.{nameof(item.Name.Value)}"));
+
+            // A typed subscription rather than a string-path Binding: the surrounding XAML uses
+            // compiled bindings, and a reflection path would silently blank the header if the
+            // property were ever renamed.
+            item.Name.Subscribe(name => menuItem.Header = name).DisposeWith(_disposables);
             return menuItem;
         }
 

--- a/src/Beutl/Views/Tools/DockLayoutView.axaml
+++ b/src/Beutl/Views/Tools/DockLayoutView.axaml
@@ -1,0 +1,127 @@
+<UserControl x:Class="Beutl.Views.Tools.DockLayoutView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
+             xmlns:lang="using:Beutl.Language"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:services="using:Beutl.Services"
+             xmlns:viewModels="using:Beutl.ViewModels.Tools"
+             Name="Root"
+             d:DesignHeight="450"
+             d:DesignWidth="280"
+             x:CompileBindings="True"
+             x:DataType="viewModels:DockLayoutViewModel"
+             mc:Ignorable="d">
+    <UserControl.Styles>
+        <!--  Opacity rather than IsVisible: the row must not change height when actions appear.  -->
+        <Style Selector="ListBoxItem Button.row-action">
+            <Setter Property="Opacity" Value="0" />
+            <Setter Property="IsHitTestVisible" Value="False" />
+        </Style>
+        <Style Selector="ListBoxItem:pointerover Button.row-action">
+            <Setter Property="Opacity" Value="1" />
+            <Setter Property="IsHitTestVisible" Value="True" />
+        </Style>
+        <Style Selector="ListBoxItem:selected Button.row-action">
+            <Setter Property="Opacity" Value="1" />
+            <Setter Property="IsHitTestVisible" Value="True" />
+        </Style>
+    </UserControl.Styles>
+
+    <Grid RowDefinitions="Auto,*">
+        <Border Grid.Row="0"
+                Padding="4"
+                BorderBrush="{DynamicResource DividerStrokeColorDefaultBrush}"
+                BorderThickness="0,0,0,1">
+            <Grid ColumnDefinitions="*,Auto">
+                <TextBlock Grid.Column="0"
+                           Margin="8,0"
+                           VerticalAlignment="Center"
+                           FontWeight="DemiBold"
+                           Text="{x:Static lang:Strings.SavedDockLayouts}" />
+
+                <StackPanel Grid.Column="1"
+                            Orientation="Horizontal"
+                            Spacing="2">
+                    <Button Padding="6"
+                            Click="OnSaveClick"
+                            Theme="{StaticResource TransparentButton}"
+                            ToolTip.Tip="{x:Static lang:Strings.SaveCurrentDockLayout}">
+                        <icons:FluentIcon FontSize="16" Icon="Add" />
+                    </Button>
+                    <Button Padding="6"
+                            Click="OnResetClick"
+                            Theme="{StaticResource TransparentButton}"
+                            ToolTip.Tip="{x:Static lang:Strings.ResetDockLayout}">
+                        <icons:FluentIcon FontSize="16" Icon="ArrowReset" />
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <Panel Grid.Row="1">
+            <StackPanel Margin="16,24"
+                        VerticalAlignment="Top"
+                        IsVisible="{CompiledBinding !Items.Count}"
+                        Spacing="8">
+                <icons:FluentIcon HorizontalAlignment="Center"
+                                  FontSize="32"
+                                  Foreground="{DynamicResource TextFillColorTertiaryBrush}"
+                                  Icon="LayoutColumnThree" />
+                <TextBlock HorizontalAlignment="Center"
+                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                           Text="{x:Static lang:MessageStrings.NoDockLayoutPresets}"
+                           TextAlignment="Center"
+                           TextWrapping="Wrap" />
+            </StackPanel>
+
+            <ListBox x:Name="LayoutList"
+                     Background="Transparent"
+                     DoubleTapped="OnItemDoubleTapped"
+                     IsVisible="{CompiledBinding Items.Count}"
+                     ItemsSource="{CompiledBinding Items}"
+                     SelectedItem="{CompiledBinding SelectedItem.Value}"
+                     SelectionMode="Single">
+                <ListBox.ItemTemplate>
+                    <DataTemplate x:DataType="services:DockLayoutPresetItem">
+                        <Grid ColumnDefinitions="*,Auto">
+                            <TextBlock Grid.Column="0"
+                                       VerticalAlignment="Center"
+                                       Text="{CompiledBinding Name.Value}"
+                                       TextTrimming="CharacterEllipsis"
+                                       ToolTip.Tip="{CompiledBinding Name.Value}" />
+
+                            <StackPanel Grid.Column="1"
+                                        VerticalAlignment="Center"
+                                        Orientation="Horizontal"
+                                        Spacing="2">
+                                <Button Padding="6"
+                                        Classes="row-action"
+                                        Click="OnApplyClick"
+                                        Theme="{StaticResource TransparentButton}"
+                                        ToolTip.Tip="{x:Static lang:Strings.ApplyDockLayout}">
+                                    <icons:FluentIcon FontSize="16" Icon="Checkmark" />
+                                </Button>
+                                <Button Padding="6"
+                                        Classes="row-action"
+                                        Click="OnRenameClick"
+                                        Theme="{StaticResource TransparentButton}"
+                                        ToolTip.Tip="{x:Static lang:Strings.Rename}">
+                                    <icons:FluentIcon FontSize="16" Icon="Rename" />
+                                </Button>
+                                <Button Padding="6"
+                                        Classes="row-action"
+                                        Click="OnRemoveClick"
+                                        Theme="{StaticResource TransparentButton}"
+                                        ToolTip.Tip="{x:Static lang:Strings.Remove}">
+                                    <icons:FluentIcon FontSize="16" Icon="Delete" />
+                                </Button>
+                            </StackPanel>
+                        </Grid>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </Panel>
+    </Grid>
+</UserControl>

--- a/src/Beutl/Views/Tools/DockLayoutView.axaml.cs
+++ b/src/Beutl/Views/Tools/DockLayoutView.axaml.cs
@@ -1,0 +1,79 @@
+﻿using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.LogicalTree;
+using Beutl.Controls;
+using Beutl.Services;
+using Beutl.ViewModels.Tools;
+
+namespace Beutl.Views.Tools;
+
+public partial class DockLayoutView : UserControl
+{
+    public DockLayoutView()
+    {
+        InitializeComponent();
+    }
+
+    private DockLayoutViewModel? ViewModel => DataContext as DockLayoutViewModel;
+
+    private void OnSaveClick(object? sender, RoutedEventArgs e)
+    {
+        if (ViewModel is not { } viewModel || sender is not Control anchor) return;
+
+        var flyout = new RenameFlyout { Text = viewModel.SuggestName() };
+        flyout.Confirmed += (_, name) => viewModel.Save(name);
+        flyout.ShowAt(anchor);
+    }
+
+    private void OnItemDoubleTapped(object? sender, TappedEventArgs e)
+    {
+        if (ViewModel is not { } viewModel) return;
+        if (ItemFrom(e.Source) is not { } item) return;
+
+        viewModel.Apply(item);
+        e.Handled = true;
+    }
+
+    private void OnApplyClick(object? sender, RoutedEventArgs e)
+    {
+        if (ViewModel is { } viewModel && ItemFrom(sender) is { } item)
+        {
+            viewModel.Apply(item);
+        }
+    }
+
+    private void OnRenameClick(object? sender, RoutedEventArgs e)
+    {
+        if (ViewModel is not { } viewModel) return;
+        if (sender is not Control anchor || ItemFrom(sender) is not { } item) return;
+
+        var flyout = new RenameFlyout { Text = item.Name.Value };
+        flyout.Confirmed += (_, name) => viewModel.Rename(item, name);
+        flyout.ShowAt(anchor);
+    }
+
+    private void OnRemoveClick(object? sender, RoutedEventArgs e)
+    {
+        if (ViewModel is { } viewModel && ItemFrom(sender) is { } item)
+        {
+            viewModel.Remove(item);
+        }
+    }
+
+    private void OnResetClick(object? sender, RoutedEventArgs e)
+    {
+        ViewModel?.ResetLayout();
+    }
+
+    // The acted-on layout comes from the row's DataContext, not the list selection.
+    private static DockLayoutPresetItem? ItemFrom(object? source)
+    {
+        return (source as Control)?.DataContext as DockLayoutPresetItem
+               ?? (source as ILogical)?.GetLogicalAncestors()
+               .OfType<Control>()
+               .Select(c => c.DataContext)
+               .OfType<DockLayoutPresetItem>()
+               .FirstOrDefault();
+    }
+}

--- a/src/Beutl/Views/Tools/DockLayoutView.axaml.cs
+++ b/src/Beutl/Views/Tools/DockLayoutView.axaml.cs
@@ -29,6 +29,15 @@ public partial class DockLayoutView : UserControl
     private void OnItemDoubleTapped(object? sender, TappedEventArgs e)
     {
         if (ViewModel is not { } viewModel) return;
+
+        // DoubleTapped is attached to the ListBox, so a double click on a row action bubbles here
+        // too. Applying on top of the action the user actually pressed would be a surprise.
+        if (e.Source is ILogical source
+            && source.GetSelfAndLogicalAncestors().OfType<Button>().Any())
+        {
+            return;
+        }
+
         if (ItemFrom(e.Source) is not { } item) return;
 
         viewModel.Apply(item);

--- a/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
@@ -141,6 +141,42 @@ public class DockLayoutPresetTests
     }
 
     [AvaloniaTest]
+    public async Task A_failed_restore_disposes_the_tools_it_already_built()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("preset-partial-restore");
+
+        JsonObject captured = editor.DockHost.CaptureLayout();
+
+        // Corrupt the root so restoration walks the tree, builds tool contexts, and only then
+        // fails to produce an IRootDock.
+        var broken = (JsonObject)captured.DeepClone();
+        ((JsonObject)broken["DockLayout"]!)["$type"] = "proportional";
+
+        IRootDock layoutBefore = editor.DockHost.Layout.Value;
+        BeutlToolDockable[] liveBefore = editor.DockHost.Factory.EnumerateTools().ToArray();
+
+        // Each live tool tracks its selection through its context, so a disposed context stops
+        // mirroring. Record the current state to prove the survivors were left alone.
+        bool[] selectedBefore = liveBefore.Select(t => t.ToolContext.IsSelected.Value).ToArray();
+
+        Assert.That(editor.DockHost.ApplyLayout(broken), Is.False);
+        Assert.That(editor.DockHost.Layout.Value, Is.SameAs(layoutBefore), "the live layout must survive");
+        Assert.That(editor.DockHost.Factory.EnumerateTools(), Is.EquivalentTo(liveBefore));
+
+        // A disposed BeutlToolDockable stops mirroring IsSelected onto its context, so flipping it
+        // here proves the surviving tools were not caught up in the cleanup.
+        for (int i = 0; i < liveBefore.Length; i++)
+        {
+            liveBefore[i].IsSelected = !selectedBefore[i];
+            Assert.That(
+                liveBefore[i].ToolContext.IsSelected.Value, Is.EqualTo(!selectedBefore[i]),
+                "a surviving tool must still be wired to its context");
+            liveBefore[i].IsSelected = selectedBefore[i];
+        }
+    }
+
+    [AvaloniaTest]
     public async Task A_layout_from_an_incompatible_version_is_refused()
     {
         await ResetProjectAsync();

--- a/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
@@ -271,13 +271,37 @@ public class DockLayoutPresetTests
         string path = Path.Combine(Path.GetTempPath(), $"beutl-dock-presets-{Guid.NewGuid():N}.json");
         try
         {
-            File.WriteAllText(path, "{ \"not\": \"an array\" }");
+            // Syntactically invalid, so this exercises the JsonNode.Parse failure path.
+            File.WriteAllText(path, "{ this is not json");
 
             var service = new DockLayoutPresetService(path);
             Assert.That(service.Items, Is.Empty);
 
             var layout = new JsonObject { ["DockLayout"] = new JsonObject { ["$type"] = "root" } };
             Assert.That(service.Save("Editing", layout), Is.Not.Null, "a bad file must not wedge the store");
+            Assert.That(new DockLayoutPresetService(path).Items.Select(i => i.Name.Value),
+                Is.EqualTo(new[] { "Editing" }));
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Test]
+    public void A_store_file_that_is_not_an_array_still_accepts_later_saves()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"beutl-dock-presets-{Guid.NewGuid():N}.json");
+        try
+        {
+            // Parses, but the root is not the expected array.
+            File.WriteAllText(path, "{ \"not\": \"an array\" }");
+
+            var service = new DockLayoutPresetService(path);
+            Assert.That(service.Items, Is.Empty);
+
+            var layout = new JsonObject { ["DockLayout"] = new JsonObject { ["$type"] = "root" } };
+            Assert.That(service.Save("Editing", layout), Is.Not.Null);
             Assert.That(new DockLayoutPresetService(path).Items.Select(i => i.Name.Value),
                 Is.EqualTo(new[] { "Editing" }));
         }

--- a/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
@@ -335,6 +335,32 @@ public class DockLayoutPresetTests
     }
 
     [Test]
+    public void A_read_only_store_file_still_loads()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"beutl-dock-presets-{Guid.NewGuid():N}.json");
+        try
+        {
+            new DockLayoutPresetService(path)
+                .Save("Editing", new JsonObject { ["DockLayout"] = new JsonObject { ["$type"] = "root" } });
+
+            // Applying a layout needs read access only, so a read-only file must still load.
+            File.SetAttributes(path, FileAttributes.ReadOnly);
+
+            Assert.That(
+                new DockLayoutPresetService(path).Items.Select(i => i.Name.Value),
+                Is.EqualTo(new[] { "Editing" }));
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.SetAttributes(path, FileAttributes.Normal);
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Test]
     public void A_store_file_that_is_not_an_array_still_accepts_later_saves()
     {
         string path = Path.Combine(Path.GetTempPath(), $"beutl-dock-presets-{Guid.NewGuid():N}.json");

--- a/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
@@ -11,6 +11,7 @@ using Beutl.ViewModels.Dock;
 using Beutl.ViewModels.Tools;
 using Beutl.Views.Tools;
 using Dock.Model.Controls;
+using Dock.Model.Core;
 
 namespace Beutl.HeadlessUITests;
 
@@ -191,4 +192,98 @@ public class DockLayoutPresetTests
         }
     }
 
+    [AvaloniaTest]
+    public async Task Pinned_tools_are_enumerated_when_replacing_a_layout()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("preset-pinned");
+
+        IRootDock root = editor.DockHost.Layout.Value;
+        BeutlToolDockable pinned = editor.DockHost.Factory.EnumerateTools()
+            .First(t => t.ToolContext.Extension is LibraryTabExtension);
+
+        // Pin the tool the way the dock does: out of VisibleDockables, into a pinned collection.
+        (pinned.Owner as IDock)?.VisibleDockables?.Remove(pinned);
+        root.LeftPinnedDockables ??= editor.DockHost.Factory.CreateList<IDockable>();
+        root.LeftPinnedDockables.Add(pinned);
+        HeadlessTestHelpers.Settle();
+
+        // A pinned tool is still owned by the layout, so enumeration must find it — otherwise its
+        // context leaks on replace and an all-pinned layout looks empty.
+        Assert.That(editor.DockHost.Factory.EnumerateTools(), Does.Contain(pinned));
+        Assert.That(
+            ToolExtensionNames(editor), Does.Contain(typeof(LibraryTabExtension).FullName));
+    }
+
+    [Test]
+    public void A_failed_write_rolls_back_the_in_memory_change()
+    {
+        // Pointing the store at a directory makes every write throw, standing in for an unwritable
+        // BEUTL_HOME. Reporting success there would lose the preset at the next restart.
+        string directoryAsFile = Path.Combine(Path.GetTempPath(), $"beutl-dock-presets-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directoryAsFile);
+        try
+        {
+            var service = new DockLayoutPresetService(directoryAsFile);
+            var layout = new JsonObject { ["DockLayout"] = new JsonObject { ["$type"] = "root" } };
+
+            Assert.That(service.Save("Editing", layout), Is.Null, "an unwritable store must report failure");
+            Assert.That(service.Items, Is.Empty, "the failed save must not linger in memory");
+        }
+        finally
+        {
+            Directory.Delete(directoryAsFile, recursive: true);
+        }
+    }
+
+    [Test]
+    public void Rename_and_remove_roll_back_when_the_write_fails()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"beutl-dock-presets-{Guid.NewGuid():N}.json");
+        try
+        {
+            var service = new DockLayoutPresetService(path);
+            var layout = new JsonObject { ["DockLayout"] = new JsonObject { ["$type"] = "root" } };
+            service.Save("Editing", layout);
+            service.Save("Grading", layout);
+
+            // Replacing the file with a directory makes the next write throw.
+            File.Delete(path);
+            Directory.CreateDirectory(path);
+
+            DockLayoutPresetItem editing = service.Items[0];
+            Assert.That(service.Rename(editing, "Rough cut"), Is.False);
+            Assert.That(editing.Name.Value, Is.EqualTo("Editing"), "a failed rename must not stick");
+
+            Assert.That(service.Remove(editing), Is.False);
+            Assert.That(service.Items.Select(i => i.Name.Value), Is.EqualTo(new[] { "Editing", "Grading" }));
+        }
+        finally
+        {
+            if (Directory.Exists(path)) Directory.Delete(path, recursive: true);
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Test]
+    public void An_unparsable_store_file_still_accepts_later_saves()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"beutl-dock-presets-{Guid.NewGuid():N}.json");
+        try
+        {
+            File.WriteAllText(path, "{ \"not\": \"an array\" }");
+
+            var service = new DockLayoutPresetService(path);
+            Assert.That(service.Items, Is.Empty);
+
+            var layout = new JsonObject { ["DockLayout"] = new JsonObject { ["$type"] = "root" } };
+            Assert.That(service.Save("Editing", layout), Is.Not.Null, "a bad file must not wedge the store");
+            Assert.That(new DockLayoutPresetService(path).Items.Select(i => i.Name.Value),
+                Is.EqualTo(new[] { "Editing" }));
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
 }

--- a/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
@@ -1,0 +1,194 @@
+﻿using System.Text.Json.Nodes;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Beutl.Editor.Components.LibraryTab;
+using Beutl.ProjectSystem;
+using Beutl.Services;
+using Beutl.Services.PrimitiveImpls;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.ViewModels.Dock;
+using Beutl.ViewModels.Tools;
+using Beutl.Views.Tools;
+using Dock.Model.Controls;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class DockLayoutPresetTests
+{
+    private static Task ResetProjectAsync() => TestReset.ResetShellAsync();
+
+    private static string NewWorkspace(string name)
+    {
+        string location = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(location);
+        return location;
+    }
+
+    private static async Task<EditViewModel> OpenEditorForNewScene(string name, int width = 1920, int height = 1080)
+    {
+        Project project = (await TestShell.Project.CreateProject(
+            width, height, 30, 44100, name, NewWorkspace(name)))!;
+        HeadlessTestHelpers.Settle();
+        Scene scene = project.Items.OfType<Scene>().First();
+
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+    }
+
+    private static DockLayoutPresetService NewService()
+    {
+        string path = Path.Combine(
+            BeutlHomeIsolation.CurrentHome!, $"dock-layout-presets-{Guid.NewGuid():N}.json");
+        return new DockLayoutPresetService(path);
+    }
+
+    private static string[] ToolExtensionNames(EditViewModel editor)
+    {
+        return editor.DockHost.Factory.EnumerateTools()
+            .Select(t => t.ToolContext.Extension.GetType().FullName!)
+            .OrderBy(n => n)
+            .ToArray();
+    }
+
+    [AvaloniaTest]
+    public async Task Saved_layout_can_be_applied_to_another_scene()
+    {
+        await ResetProjectAsync();
+        EditViewModel source = await OpenEditorForNewScene("preset-source");
+
+        // Make the layout distinguishable from the default: close the library tab.
+        BeutlToolDockable library = source.DockHost.Factory.EnumerateTools()
+            .First(t => t.ToolContext.Extension is LibraryTabExtension);
+        source.DockHost.CloseToolTab(library.ToolContext);
+        HeadlessTestHelpers.Settle();
+
+        string[] expected = ToolExtensionNames(source);
+        Assert.That(expected, Does.Not.Contain(typeof(LibraryTabExtension).FullName));
+
+        DockLayoutPresetService service = NewService();
+        DockLayoutPresetItem? preset = service.Save("No library", source.DockHost.CaptureLayout());
+        Assert.That(preset, Is.Not.Null);
+
+        EditViewModel target = await OpenEditorForNewScene("preset-target");
+        Assert.That(ToolExtensionNames(target), Does.Contain(typeof(LibraryTabExtension).FullName));
+
+        Assert.That(target.DockHost.ApplyLayout(preset!.Layout), Is.True);
+        HeadlessTestHelpers.Settle();
+
+        Assert.That(ToolExtensionNames(target), Is.EqualTo(expected));
+        Assert.That(target.DockHost.Layout.Value.Id, Is.EqualTo(DockIds.Root));
+    }
+
+    [AvaloniaTest]
+    public async Task Captured_layout_does_not_carry_per_tool_state()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("preset-strip-state");
+
+        JsonObject captured = editor.DockHost.CaptureLayout();
+
+        var toolNodes = new List<JsonObject>();
+        Collect(captured, toolNodes);
+        Assert.That(toolNodes, Is.Not.Empty);
+
+        foreach (JsonObject tool in toolNodes)
+        {
+            Assert.That(
+                tool.Select(p => p.Key),
+                Is.SubsetOf(new[] { "$type", "id", "extension" }),
+                "A preset must only carry what identifies a tab.");
+        }
+
+        static void Collect(JsonNode? node, List<JsonObject> result)
+        {
+            switch (node)
+            {
+                case JsonObject obj:
+                    if (obj["$type"]?.GetValue<string>() == "tool") result.Add(obj);
+                    foreach ((string _, JsonNode? child) in obj) Collect(child, result);
+                    break;
+                case JsonArray array:
+                    foreach (JsonNode? item in array) Collect(item, result);
+                    break;
+            }
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Applying_a_malformed_layout_keeps_the_current_one()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("preset-malformed");
+
+        string[] before = ToolExtensionNames(editor);
+        IRootDock layoutBefore = editor.DockHost.Layout.Value;
+
+        Assert.That(editor.DockHost.ApplyLayout(new JsonObject()), Is.False);
+        Assert.That(
+            editor.DockHost.ApplyLayout(new JsonObject { ["DockLayout"] = new JsonObject { ["$type"] = "tool" } }),
+            Is.False);
+
+        Assert.That(editor.DockHost.Layout.Value, Is.SameAs(layoutBefore));
+        Assert.That(ToolExtensionNames(editor), Is.EqualTo(before));
+    }
+
+    [AvaloniaTest]
+    public async Task A_layout_from_an_incompatible_version_is_refused()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("preset-version");
+
+        JsonObject captured = editor.DockHost.CaptureLayout();
+        Assert.That(editor.DockHost.ApplyLayout(captured), Is.True, "the captured layout should apply as-is");
+
+        IRootDock layoutBefore = editor.DockHost.Layout.Value;
+        var stale = (JsonObject)captured.DeepClone();
+        stale["_dockVersion"] = 1;
+
+        Assert.That(editor.DockHost.ApplyLayout(stale), Is.False);
+        Assert.That(editor.DockHost.Layout.Value, Is.SameAs(layoutBefore));
+    }
+
+    [Test]
+    public void Presets_round_trip_through_the_store()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"beutl-dock-presets-{Guid.NewGuid():N}.json");
+        try
+        {
+            var service = new DockLayoutPresetService(path);
+            var layout = new JsonObject { ["DockLayout"] = new JsonObject { ["$type"] = "root" } };
+
+            Assert.That(service.Save("Editing", layout), Is.Not.Null);
+            Assert.That(service.Items, Has.Count.EqualTo(1));
+
+            // Same name overwrites instead of adding a duplicate.
+            var other = new JsonObject
+            {
+                ["DockLayout"] = new JsonObject { ["$type"] = "root", ["id"] = "Root" }
+            };
+            Assert.That(service.Save("editing", other), Is.Not.Null);
+            Assert.That(service.Items, Has.Count.EqualTo(1));
+            Assert.That(service.Items[0].Layout["DockLayout"]!["id"]!.GetValue<string>(), Is.EqualTo("Root"));
+
+            Assert.That(service.Save("  ", layout), Is.Null, "A blank name must be rejected.");
+
+            var reloaded = new DockLayoutPresetService(path);
+            Assert.That(reloaded.Items, Has.Count.EqualTo(1));
+            Assert.That(reloaded.Items[0].Name.Value, Is.EqualTo("Editing"));
+
+            Assert.That(reloaded.Rename(reloaded.Items[0], "Grading"), Is.True);
+            Assert.That(new DockLayoutPresetService(path).Items[0].Name.Value, Is.EqualTo("Grading"));
+
+            Assert.That(reloaded.Remove(reloaded.Items[0]), Is.True);
+            Assert.That(new DockLayoutPresetService(path).Items, Is.Empty);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+}

--- a/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
@@ -371,6 +371,33 @@ public class DockLayoutPresetTests
     }
 
     [Test]
+    public void A_failed_reload_blocks_later_writes()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"beutl-dock-presets-{Guid.NewGuid():N}.json");
+        try
+        {
+            var service = new DockLayoutPresetService(path);
+            var layout = new JsonObject { ["DockLayout"] = new JsonObject { ["$type"] = "root" } };
+            service.Save("Editing", layout);
+
+            // A reload that cannot read the file must re-arm the guard, so a later save does not
+            // overwrite whatever is on disk from the now-stale in-memory snapshot. Holding the
+            // file open for writing makes the read throw, the way a transient sharing error would.
+            using (File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            {
+                service.RestoreItems();
+            }
+
+            Assert.That(service.SaveItems(), Is.False, "a save after a failed reload must be refused");
+        }
+        finally
+        {
+            if (Directory.Exists(path)) Directory.Delete(path, recursive: true);
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Test]
     public void A_read_only_store_file_still_loads()
     {
         string path = Path.Combine(Path.GetTempPath(), $"beutl-dock-presets-{Guid.NewGuid():N}.json");

--- a/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
@@ -2,6 +2,10 @@
 using Avalonia.Controls;
 using Avalonia.Headless.NUnit;
 using Beutl.Editor.Components.LibraryTab;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Extensibility;
+using Beutl.Graphics.Shapes;
 using Beutl.ProjectSystem;
 using Beutl.Services;
 using Beutl.Services.PrimitiveImpls;
@@ -189,6 +193,48 @@ public class DockLayoutPresetTests
         finally
         {
             if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Capturing_a_layout_does_not_write_per_scene_view_state()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("preset-no-side-effects");
+
+        // The element property tab writes a per-element config from its serializer, but only once
+        // an element is selected — so select one to arm the side effect.
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        adder.AddElement(new ElementDescription(
+            Start: TimeSpan.Zero,
+            Length: TimeSpan.FromSeconds(1),
+            Layer: 0,
+            EngineObjectFactory: () => new RectShape()));
+        HeadlessTestHelpers.Settle();
+
+        var selection = (IEditorSelection)editor.GetService(typeof(IEditorSelection))!;
+        selection.SelectedObject.Value = editor.Scene.Children[0];
+        HeadlessTestHelpers.Settle();
+
+        // Some tool serializers write their own per-scene config as a side effect. Capturing a
+        // layout discards tool state anyway, so it must not invoke them at all.
+        string sceneDir = Path.GetDirectoryName(editor.Scene.Uri!.LocalPath)!;
+        string[] before = ConfigFiles(sceneDir);
+
+        editor.DockHost.CaptureLayout();
+        HeadlessTestHelpers.Settle();
+
+        Assert.That(ConfigFiles(sceneDir), Is.EqualTo(before),
+            "capturing a layout must not touch the scene's view-state files");
+
+        static string[] ConfigFiles(string dir)
+        {
+            return Directory.Exists(dir)
+                ? Directory.GetFiles(dir, "*.config", SearchOption.AllDirectories)
+                    .Select(f => $"{f}:{new FileInfo(f).Length}")
+                    .OrderBy(f => f)
+                    .ToArray()
+                : [];
         }
     }
 

--- a/tests/Beutl.HeadlessUITests/DockLayoutTabTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockLayoutTabTests.cs
@@ -259,6 +259,41 @@ public class DockLayoutTabTests
     }
 
     [AvaloniaTest]
+    public async Task A_failed_remove_keeps_the_layout_and_the_selection()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tab-remove-failure");
+
+        string path = Path.Combine(BeutlHomeIsolation.CurrentHome!, $"presets-{Guid.NewGuid():N}.json");
+        var service = new DockLayoutPresetService(path);
+        var viewModel = new DockLayoutViewModel(editor, service);
+        viewModel.Save("Editing");
+
+        // Replacing the store file with a directory makes the next write throw.
+        File.Delete(path);
+        Directory.CreateDirectory(path);
+
+        try
+        {
+            DockLayoutPresetItem target = service.Items[0];
+            viewModel.SelectedItem.Value = target;
+
+            viewModel.Remove(target);
+
+            // The service rolled the delete back, so clearing the selection would leave the tab
+            // claiming nothing is selected while the row is still listed.
+            Assert.That(service.Items, Has.Count.EqualTo(1));
+            Assert.That(viewModel.SelectedItem.Value, Is.SameAs(target));
+            Assert.That(viewModel.HasSelection.Value, Is.True);
+        }
+        finally
+        {
+            Directory.Delete(path, recursive: true);
+            viewModel.Dispose();
+        }
+    }
+
+    [AvaloniaTest]
     public async Task Revealing_the_row_actions_does_not_change_the_row_height()
     {
         await ResetProjectAsync();

--- a/tests/Beutl.HeadlessUITests/DockLayoutTabTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockLayoutTabTests.cs
@@ -1,0 +1,348 @@
+﻿using System.Text.Json.Nodes;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.LogicalTree;
+using Avalonia.VisualTree;
+using Beutl.Editor.Components.LibraryTab;
+using Beutl.Extensibility;
+using Beutl.Language;
+using Beutl.ProjectSystem;
+using Beutl.Services;
+using Beutl.Services.PrimitiveImpls;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.ViewModels.Dock;
+using Beutl.ViewModels.Tools;
+using Beutl.Views.Tools;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class DockLayoutTabTests
+{
+    private static Task ResetProjectAsync() => TestReset.ResetShellAsync();
+
+    private static string NewWorkspace(string name)
+    {
+        string location = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(location);
+        return location;
+    }
+
+    private static async Task<EditViewModel> OpenEditorForNewScene(string name)
+    {
+        Project project = (await TestShell.Project.CreateProject(
+            1920, 1080, 30, 44100, name, NewWorkspace(name)))!;
+        HeadlessTestHelpers.Settle();
+        Scene scene = project.Items.OfType<Scene>().First();
+
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+    }
+
+    private static DockLayoutPresetService NewService()
+    {
+        string path = Path.Combine(
+            BeutlHomeIsolation.CurrentHome!, $"dock-layout-presets-{Guid.NewGuid():N}.json");
+        return new DockLayoutPresetService(path);
+    }
+
+    private static string[] ToolExtensionNames(EditViewModel editor)
+    {
+        return editor.DockHost.Factory.EnumerateTools()
+            .Select(t => t.ToolContext.Extension.GetType().FullName!)
+            .OrderBy(n => n)
+            .ToArray();
+    }
+
+    [AvaloniaTest]
+    public async Task Tab_saves_the_current_arrangement_and_applies_it_back()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tab-save-apply");
+
+        var viewModel = new DockLayoutViewModel(editor, NewService());
+
+        Assert.That(viewModel.Save("Default"), Is.Not.Null);
+        string[] saved = ToolExtensionNames(editor);
+
+        // Saving selects the new entry so the row actions act on it.
+        Assert.That(viewModel.SelectedItem.Value?.Name.Value, Is.EqualTo("Default"));
+        Assert.That(viewModel.HasSelection.Value, Is.True);
+
+        BeutlToolDockable library = editor.DockHost.Factory.EnumerateTools()
+            .First(t => t.ToolContext.Extension is LibraryTabExtension);
+        editor.DockHost.CloseToolTab(library.ToolContext);
+        HeadlessTestHelpers.Settle();
+        Assert.That(ToolExtensionNames(editor), Is.Not.EqualTo(saved));
+
+        Assert.That(viewModel.Apply(), Is.True);
+        HeadlessTestHelpers.Settle();
+        Assert.That(ToolExtensionNames(editor), Is.EqualTo(saved));
+
+        viewModel.Dispose();
+    }
+
+    [AvaloniaTest]
+    public async Task Saving_over_an_existing_name_replaces_it_and_blank_names_are_rejected()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tab-overwrite");
+
+        DockLayoutPresetService service = NewService();
+        var viewModel = new DockLayoutViewModel(editor, service);
+
+        viewModel.Save("Editing");
+
+        // Case-insensitive: this overwrites rather than adding a second entry.
+        viewModel.Save("editing");
+        Assert.That(service.Items, Has.Count.EqualTo(1), "an overwrite must not add a second entry");
+
+        Assert.That(viewModel.Save("   "), Is.Null);
+        Assert.That(viewModel.Save(null), Is.Null);
+        Assert.That(service.Items, Has.Count.EqualTo(1));
+
+        viewModel.Dispose();
+    }
+
+    [AvaloniaTest]
+    public async Task Suggested_name_avoids_colliding_with_a_saved_layout()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tab-suggest");
+
+        DockLayoutPresetService service = NewService();
+        var viewModel = new DockLayoutViewModel(editor, service);
+
+        string first = viewModel.SuggestName();
+        Assert.That(first, Is.EqualTo(Strings.DockLayout));
+
+        viewModel.Save(first);
+        Assert.That(viewModel.SuggestName(), Is.EqualTo($"{Strings.DockLayout} 2"));
+
+        viewModel.Dispose();
+    }
+
+    [AvaloniaTest]
+    public async Task Tab_renames_and_removes_a_saved_layout()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tab-manage");
+
+        DockLayoutPresetService service = NewService();
+        var viewModel = new DockLayoutViewModel(editor, service);
+
+        viewModel.Save("Editing");
+        viewModel.Save("Grading");
+
+        DockLayoutPresetItem editing = service.Items[0];
+
+        // A name already taken by another layout is refused; an unchanged one is a no-op.
+        Assert.That(viewModel.Rename(editing, "Grading"), Is.False);
+        Assert.That(viewModel.Rename(editing, "  "), Is.False);
+        Assert.That(viewModel.Rename(editing, "Editing"), Is.True);
+        Assert.That(service.Items[0].Name.Value, Is.EqualTo("Editing"));
+
+        Assert.That(viewModel.Rename(editing, "Rough cut"), Is.True);
+        Assert.That(service.Items[0].Name.Value, Is.EqualTo("Rough cut"));
+
+        // Re-saving under an existing name is how a layout gets refreshed.
+        BeutlToolDockable library = editor.DockHost.Factory.EnumerateTools()
+            .First(t => t.ToolContext.Extension is LibraryTabExtension);
+        editor.DockHost.CloseToolTab(library.ToolContext);
+        HeadlessTestHelpers.Settle();
+
+        Assert.That(viewModel.Save("Rough cut"), Is.Not.Null);
+        Assert.That(service.Items, Has.Count.EqualTo(2));
+        Assert.That(viewModel.SelectedItem.Value?.Name.Value, Is.EqualTo("Rough cut"));
+
+        string[] afterClose = ToolExtensionNames(editor);
+        editor.DockHost.ResetLayout();
+        HeadlessTestHelpers.Settle();
+        Assert.That(viewModel.Apply(), Is.True);
+        HeadlessTestHelpers.Settle();
+        Assert.That(ToolExtensionNames(editor), Is.EqualTo(afterClose));
+
+        viewModel.Remove(service.Items[0]);
+        Assert.That(service.Items.Select(i => i.Name.Value), Is.EqualTo(new[] { "Grading" }));
+        Assert.That(viewModel.HasSelection.Value, Is.False, "removing the selected layout clears the selection");
+
+        viewModel.Dispose();
+    }
+
+    [AvaloniaTest]
+    public async Task Tab_extension_creates_its_view_and_context()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tab-extension");
+
+        Assert.That(
+            DockLayoutTabExtension.Instance.TryCreateContext(editor, out IToolContext? context), Is.True);
+        Assert.That(context, Is.InstanceOf<DockLayoutViewModel>());
+        Assert.That(context!.Extension, Is.SameAs(DockLayoutTabExtension.Instance));
+        Assert.That(context.Header, Is.EqualTo(Strings.DockLayout));
+
+        Assert.That(DockLayoutTabExtension.Instance.TryCreateContent(editor, out Control? control), Is.True);
+        Assert.That(control, Is.InstanceOf<DockLayoutView>());
+
+        DockLayoutPresetService service = NewService();
+        var viewModel = new DockLayoutViewModel(editor, service);
+        control!.DataContext = viewModel;
+
+        ListBox list = control.GetLogicalDescendants().OfType<ListBox>().Single();
+        Assert.That(list.ItemsSource, Is.SameAs(service.Items));
+
+        context.Dispose();
+        viewModel.Dispose();
+    }
+
+    [AvaloniaTest]
+    public async Task Row_actions_target_the_row_they_belong_to()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tab-row-actions");
+
+        DockLayoutPresetService service = NewService();
+        var viewModel = new DockLayoutViewModel(editor, service);
+        viewModel.Save("Editing");
+        viewModel.Save("Grading");
+
+        // Row actions must follow their own row, not the selection.
+        viewModel.SelectedItem.Value = service.Items[1];
+
+        Assert.That(viewModel.Rename(service.Items[0], "Rough cut"), Is.True);
+        Assert.That(service.Items[0].Name.Value, Is.EqualTo("Rough cut"));
+        Assert.That(viewModel.SelectedItem.Value?.Name.Value, Is.EqualTo("Grading"));
+
+        viewModel.Remove(service.Items[0]);
+        Assert.That(service.Items.Select(i => i.Name.Value), Is.EqualTo(new[] { "Grading" }));
+        Assert.That(
+            viewModel.HasSelection.Value, Is.True,
+            "removing another row must not clear the selection");
+
+        viewModel.Dispose();
+    }
+
+    [AvaloniaTest]
+    public async Task Apply_button_applies_the_row_it_belongs_to()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tab-apply-row");
+
+        DockLayoutPresetService service = NewService();
+        var viewModel = new DockLayoutViewModel(editor, service);
+
+        viewModel.Save("Full");
+        string[] full = ToolExtensionNames(editor);
+
+        BeutlToolDockable library = editor.DockHost.Factory.EnumerateTools()
+            .First(t => t.ToolContext.Extension is LibraryTabExtension);
+        editor.DockHost.CloseToolTab(library.ToolContext);
+        HeadlessTestHelpers.Settle();
+
+        viewModel.Save("No library");
+        string[] reduced = ToolExtensionNames(editor);
+        Assert.That(reduced, Is.Not.EqualTo(full));
+
+        // Saving selected "No library", so applying the other row proves the button follows it.
+        Assert.That(viewModel.SelectedItem.Value?.Name.Value, Is.EqualTo("No library"));
+
+        DockLayoutPresetItem fullItem = service.Items.First(i => i.Name.Value == "Full");
+        Assert.That(viewModel.Apply(fullItem), Is.True);
+        HeadlessTestHelpers.Settle();
+
+        Assert.That(ToolExtensionNames(editor), Is.EqualTo(full));
+
+        viewModel.Dispose();
+    }
+
+    [AvaloniaTest]
+    public async Task Revealing_the_row_actions_does_not_change_the_row_height()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tab-row-height");
+
+        DockLayoutPresetService service = NewService();
+        var viewModel = new DockLayoutViewModel(editor, service);
+        viewModel.Save("Editing");
+        viewModel.Save("Color grading");
+        viewModel.Save("Audio mixing");
+        viewModel.SelectedItem.Value = null;
+
+        var view = new DockLayoutView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 300, Height = 420 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            ListBoxItem[] rows = view.GetVisualDescendants().OfType<ListBoxItem>().ToArray();
+            Assert.That(rows, Has.Length.EqualTo(3));
+
+            double[] resting = rows.Select(r => r.Bounds.Height).ToArray();
+            Assert.That(resting, Has.All.GreaterThan(0));
+
+            // Selection uses the same style trigger as hovering, without synthetic pointer input.
+            viewModel.SelectedItem.Value = service.Items[1];
+            HeadlessTestHelpers.Render();
+
+            Assert.That(
+                rows.Select(r => r.Bounds.Height).ToArray(), Is.EqualTo(resting),
+                "rows must not grow when their actions become visible");
+
+            foreach (ListBoxItem row in rows)
+            {
+                foreach (Button button in row.GetVisualDescendants().OfType<Button>())
+                {
+                    Assert.That(
+                        VerticalCenterIn(button, row),
+                        Is.EqualTo(row.Bounds.Height / 2).Within(1.0),
+                        "a row action must be vertically centered in its row");
+                }
+            }
+        }
+        finally
+        {
+            window.Close();
+            viewModel.Dispose();
+        }
+    }
+
+    // Vertical center of `child` in `ancestor` coordinates.
+    private static double VerticalCenterIn(Visual child, Visual ancestor)
+    {
+        double y = child.Bounds.Height / 2;
+        Visual? visual = child;
+        while (visual is not null && !ReferenceEquals(visual, ancestor))
+        {
+            y += visual.Bounds.Y;
+            visual = visual.GetVisualParent();
+        }
+
+        return y;
+    }
+
+    [AvaloniaTest]
+    public async Task Tab_is_registered_and_opens_from_the_extension_provider()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tab-registered");
+
+        Assert.That(
+            editor.ExtensionProvider.AllExtensions.OfType<ToolTabExtension>(),
+            Does.Contain(DockLayoutTabExtension.Instance),
+            "the tab must be registered so it shows up in the tool tab menu");
+
+        Assert.That(editor.DockHost.FindToolContext(typeof(DockLayoutTabExtension)), Is.Null);
+
+        Assert.That(
+            DockLayoutTabExtension.Instance.TryCreateContext(editor, out IToolContext? context), Is.True);
+        Assert.That(editor.OpenToolTab(context!), Is.True);
+        HeadlessTestHelpers.Settle();
+
+        Assert.That(editor.DockHost.FindToolContext(typeof(DockLayoutTabExtension)), Is.SameAs(context));
+    }
+}

--- a/tests/Beutl.HeadlessUITests/MainViewModelExtensionTests.cs
+++ b/tests/Beutl.HeadlessUITests/MainViewModelExtensionTests.cs
@@ -32,6 +32,17 @@ public class MainViewModelExtensionTests
     }
 
     [AvaloniaTest]
+    public async Task ToolTabExtensions_include_the_dock_layout_tab()
+    {
+        await ResetProjectAsync();
+        MainViewModel vm = SharedMainViewModel;
+
+        // The tab is how the user saves and applies dock layouts, so it has to be listed in
+        // the tool tab menu.
+        Assert.That(vm.ToolTabExtensions, Does.Contain(DockLayoutTabExtension.Instance));
+    }
+
+    [AvaloniaTest]
     public async Task EditorExtensions_include_the_scene_editor()
     {
         await ResetProjectAsync();


### PR DESCRIPTION
## Summary

Dock arrangements could only be reset to the per-scene default. This adds **named dock layouts** that persist across projects, plus a tool tab to manage them.

- Save the current arrangement under a name, and apply it to any scene later.
- Manage saved layouts (apply / rename / delete) from a new **Dock layout** tool tab.
- The View menu lists saved layouts to apply directly; its manage entry opens the tab.

Layouts are stored in `$BEUTL_HOME/dock-layout-presets.json`, so they are shared across projects.

## Design notes

**No second layout format.** `DockHostViewModel` already serializes the dock tree into the per-scene view state, so `CaptureLayout` / `ApplyLayout` reuse that shape instead of introducing a parallel serializer.

**A layout carries arrangement, not state.** Capture strips per-tool state (selected element ids, search text, ...) — that belongs to the scene it was captured from. Without this, applying a layout saved elsewhere drags another scene's state into the current editor.

**Applying cannot brick the editor.** `ApplyLayout` builds the incoming root and validates the format version *before* disposing the outgoing tool contexts, so a malformed or version-mismatched layout leaves the current layout untouched.

**A tab, not a dialog.** Management stays open while the user rearranges docks, which a modal dialog cannot do. Row actions (apply / rename / delete) appear on hover or selection; names are collected through the existing `RenameFlyout`, so the tab stays a plain list with no permanent input row.

## Testing

- `dotnet format Beutl.slnx --verify-no-changes` — clean
- GPL/MIT boundary scan on the diff — clean
- `dotnet build Beutl.slnx` — succeeded
- `Beutl.HeadlessUITests`: 211 passed
- `Beutl.UnitTests`: 4956 passed, 6 skipped

New tests in `DockLayoutPresetTests` and `DockLayoutTabTests` cover the save/apply round trip across scenes, per-tool state stripping, rejection of malformed and version-mismatched layouts, store persistence (overwrite by name, rename, delete), row actions targeting their own row rather than the selection, and two layout regressions — rows must not change height when their actions appear, and the actions must be vertically centered.

Each new assertion was verified to fail against a deliberately reverted implementation before being kept.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dock layout presets that can be saved, applied, renamed, overwritten, removed, and reset.
  * Added a dock layout management panel with empty-state messaging and row actions.
  * Added View menu options for managing layouts and applying saved presets.
  * Added Japanese localization for dock layout features and messages.
* **Bug Fixes**
  * Invalid or incompatible layouts are safely rejected without replacing the current layout.
* **Tests**
  * Added coverage for persistence, validation, restoration, menu integration, and preset management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->