### PR TITLE
ci: add the Flatpak download link to release notes

### DIFF
--- a/.github/workflows/format-release-notes.yml
+++ b/.github/workflows/format-release-notes.yml
@@ -101,8 +101,8 @@ jobs:
             - DO NOT publish the release, edit the tag, modify assets, or open issues/PRs.
             - DO NOT touch any other release.
             - Idempotency — decide from the fetched body:
-              - It already contains `releases/download/${{ inputs.tag }}/Beutl-${{ inputs.semVer }}.flatpak` → already fully reformatted; exit without changes.
-              - It contains `releases/download/${{ inputs.tag }}/` but NOT that Flatpak link → it was formatted by an older revision of this workflow. Do NOT rebuild the whole body (it is no longer the auto-generated one, so a rebuild would mangle it): insert ONLY the Flatpak bullet directly after the `[Debian package](...)` bullet, leave every other byte of the body unchanged, and apply it with the step 3 `gh release edit` command. Preserve the release's current draft state — pass `--draft=true` only when the `isDraft` you fetched in step 1 was true, so repairing an already-published release does not unpublish it.
+              - It already contains `https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag }}/Beutl-${{ inputs.semVer }}.flatpak` → already fully reformatted; exit without changes.
+              - It contains `https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag }}/` but NOT that Flatpak link → it was formatted by an older revision of this workflow. Do NOT rebuild the whole body (it is no longer the auto-generated one, so a rebuild would mangle it): insert ONLY the Flatpak bullet directly after the `[Debian package](...)` bullet, leave every other byte of the body unchanged, and apply it with the step 3 `gh release edit` command. Preserve the release's current draft state — pass `--draft=true` only when the `isDraft` you fetched in step 1 was true, so repairing an already-published release does not unpublish it.
               - Neither → the body is the auto-generated one; do the full reformat described above.
 
       - name: Verify the release notes were reformatted
@@ -123,9 +123,10 @@ jobs:
             echo "::error::Release notes for $TAG were not reformatted (no download links found). The Claude step finished without editing the body."
             exit 1
           fi
-          if printf '%s' "$body" | grep -qF "releases/download/$TAG/Beutl-$SEM_VER.flatpak"; then
+          flatpak_url="https://github.com/$REPO/releases/download/$TAG/Beutl-$SEM_VER.flatpak"
+          if printf '%s' "$body" | grep -qF "$flatpak_url"; then
             echo "Release notes link the Flatpak bundle."
           else
-            echo "::error::Release notes for $TAG are missing the Flatpak download link (Beutl-$SEM_VER.flatpak)."
+            echo "::error::Release notes for $TAG are missing the Flatpak download link ($flatpak_url)."
             exit 1
           fi

--- a/.github/workflows/format-release-notes.yml
+++ b/.github/workflows/format-release-notes.yml
@@ -66,6 +66,7 @@ jobs:
                     - `[Zip (x64)](https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag }}/Beutl.osx_x64.app.zip)`
                   - Linux
                     - `[Debian package](https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag }}/beutl_${{ inputs.simpleVer }}-${{ inputs.revision }}ubuntu22.04_amd64.deb)`
+                    - `[Flatpak](https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag }}/Beutl-${{ inputs.semVer }}.flatpak)`
                     - `[Zip (.NET Runtime required)](https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag }}/Beutl-linux-x64-${{ inputs.semVer }}.zip)`
                     - `[Zip](https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag }}/Beutl-linux-x64-standalone-${{ inputs.semVer }}.zip)`
 
@@ -105,6 +106,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ inputs.tag }}
+          SEM_VER: ${{ inputs.semVer }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -116,5 +118,11 @@ jobs:
             echo "Release notes contain the platform download links — reformatting succeeded."
           else
             echo "::error::Release notes for $TAG were not reformatted (no download links found). The Claude step finished without editing the body."
+            exit 1
+          fi
+          if printf '%s' "$body" | grep -qF "releases/download/$TAG/Beutl-$SEM_VER.flatpak"; then
+            echo "Release notes link the Flatpak bundle."
+          else
+            echo "::error::Release notes for $TAG are missing the Flatpak download link (Beutl-$SEM_VER.flatpak)."
             exit 1
           fi

--- a/.github/workflows/format-release-notes.yml
+++ b/.github/workflows/format-release-notes.yml
@@ -102,7 +102,10 @@ jobs:
             - DO NOT touch any other release.
             - Idempotency — decide from the fetched body:
               - It already contains `https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag }}/Beutl-${{ inputs.semVer }}.flatpak` → already fully reformatted; exit without changes.
-              - It contains `https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag }}/` but NOT that Flatpak link → it was formatted by an older revision of this workflow. Do NOT rebuild the whole body (it is no longer the auto-generated one, so a rebuild would mangle it): insert ONLY the Flatpak bullet directly after the `[Debian package](...)` bullet, leave every other byte of the body unchanged, and apply it with the step 3 `gh release edit` command. Preserve the release's current draft state — pass `--draft=true` only when the `isDraft` you fetched in step 1 was true, so repairing an already-published release does not unpublish it.
+              - It contains `https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag }}/` but NOT that Flatpak link → it was formatted by an older revision of this workflow. Do NOT rebuild the whole body (it is no longer the auto-generated one, so a rebuild would mangle it). Bring only the Flatpak bullet in line, leaving every other byte of the body unchanged:
+                  - The body has no `[Flatpak](...)` bullet → insert one directly after the `[Debian package](...)` bullet.
+                  - The body has a `[Flatpak](...)` bullet with a different href → replace just that href. Never add a second bullet: a stale link must be corrected, not duplicated.
+                Apply the result with the step 3 `gh release edit` command, and preserve the release's current draft state — pass `--draft=true` only when the `isDraft` you fetched in step 1 was true, so repairing an already-published release does not unpublish it.
               - Neither → the body is the auto-generated one; do the full reformat described above.
 
       - name: Verify the release notes were reformatted

--- a/.github/workflows/format-release-notes.yml
+++ b/.github/workflows/format-release-notes.yml
@@ -96,11 +96,14 @@ jobs:
 
             ## Constraints
 
-            - The release MUST remain a draft (`--draft=true`).
+            - The release MUST remain a draft (`--draft=true`) on the normal path; on the repair path preserve the release's existing `isDraft` state (see Idempotency below).
             - DO NOT add a "日本語のリリースノートはこちら" line — that is appended later by a separate workflow when the corresponding Discussion is created.
             - DO NOT publish the release, edit the tag, modify assets, or open issues/PRs.
             - DO NOT touch any other release.
-            - If the fetched body already contains the substring `releases/download/${{ inputs.tag }}/` (the platform download links), it is already reformatted — exit without changes.
+            - Idempotency — decide from the fetched body:
+              - It already contains `releases/download/${{ inputs.tag }}/Beutl-${{ inputs.semVer }}.flatpak` → already fully reformatted; exit without changes.
+              - It contains `releases/download/${{ inputs.tag }}/` but NOT that Flatpak link → it was formatted by an older revision of this workflow. Do NOT rebuild the whole body (it is no longer the auto-generated one, so a rebuild would mangle it): insert ONLY the Flatpak bullet directly after the `[Debian package](...)` bullet, leave every other byte of the body unchanged, and apply it with the step 3 `gh release edit` command. Preserve the release's current draft state — pass `--draft=true` only when the `isDraft` you fetched in step 1 was true, so repairing an already-published release does not unpublish it.
+              - Neither → the body is the auto-generated one; do the full reformat described above.
 
       - name: Verify the release notes were reformatted
         env:

--- a/.github/workflows/translate-release-notes.yml
+++ b/.github/workflows/translate-release-notes.yml
@@ -84,6 +84,16 @@ jobs:
                ```
                Find the first comment whose body contains the marker line `<!-- japanese-release-notes -->`. Define `COMMENT_URL`:
                  - If such a comment exists, set `COMMENT_URL` to its `url`. Skip step 4 — do NOT post another comment.
+                   Then check one thing: if the release body has a `[Flatpak](...)` download bullet that this comment does NOT have, the comment predates the Flatpak link (the release notes were repaired by a later run of `format-release-notes.yml`). Insert ONLY the translated Flatpak bullet directly after the `[Debian パッケージ](...)` bullet and leave every other byte of the comment unchanged — do NOT re-translate the rest, which would clobber any manual edit. Write the result with the `Write` tool to `comment-body.md` (keep the `<!-- japanese-release-notes -->` marker line) and update the comment in place with its `id` from the query above:
+                   ```
+                   gh api graphql -F commentId='<comment id>' -F body=@comment-body.md -f query='
+                     mutation($commentId: ID!, $body: String!) {
+                       updateDiscussionComment(input: { commentId: $commentId, body: $body }) {
+                         comment { id url }
+                       }
+                     }'
+                   ```
+                   If the comment already has the Flatpak bullet, or the release body has none, leave the comment untouched.
                  - Otherwise, leave `COMMENT_URL` unset and proceed to step 4 to create the comment.
 
                In either case, ALWAYS continue to step 5 — a previous run may have posted the comment but failed to update the release body, and step 5 must be allowed to repair that.
@@ -112,7 +122,7 @@ jobs:
 
             ## Constraints
 
-            - Do not edit the discussion body, title, or category — only ADD a comment.
+            - Do not edit the discussion body, title, or category. The only comment you may edit is the one carrying the `<!-- japanese-release-notes -->` marker, and only to insert the missing Flatpak bullet as described in step 3; never edit anyone else's comment.
             - Do not publish the release, edit the tag, or touch assets.
             - Do not modify any other discussion or release.
             - If anything is ambiguous (release missing, translation refused, API error), exit without partial writes.

--- a/.github/workflows/translate-release-notes.yml
+++ b/.github/workflows/translate-release-notes.yml
@@ -84,7 +84,11 @@ jobs:
                ```
                Find the first comment whose body contains the marker line `<!-- japanese-release-notes -->`. Define `COMMENT_URL`:
                  - If such a comment exists, set `COMMENT_URL` to its `url`. Skip step 4 — do NOT post another comment.
-                   Then check one thing: if the release body has a `[Flatpak](...)` download bullet that this comment does NOT have, the comment predates the Flatpak link (the release notes were repaired by a later run of `format-release-notes.yml`). Insert ONLY the translated Flatpak bullet directly after the `[Debian パッケージ](...)` bullet and leave every other byte of the comment unchanged — do NOT re-translate the rest, which would clobber any manual edit. Write the result with the `Write` tool to `comment-body.md` (keep the `<!-- japanese-release-notes -->` marker line) and update the comment in place with its `id` from the query above:
+                   Then keep the comment's Flatpak link in step with the release. Take the EXACT href of the `[Flatpak](<url>)` bullet in the release body's Linux download list. If the release body has no such bullet, leave the comment untouched. Otherwise the comment must contain that exact url:
+                     - The comment has no Flatpak bullet → insert the translated bullet, copying that exact href, directly after the `[Debian パッケージ](...)` bullet.
+                     - The comment has a Flatpak bullet with a different href → replace just that href with the exact one. A stale link must neither suppress the repair nor produce a second bullet.
+                     - The comment already contains the exact url → leave it untouched.
+                   In every case leave every other byte of the comment unchanged — do NOT re-translate the rest, which would clobber any manual edit. Write the result with the `Write` tool to `comment-body.md` (keep the `<!-- japanese-release-notes -->` marker line) and update the comment in place with its `id` from the query above:
                    ```
                    gh api graphql -F commentId='<comment id>' -F body=@comment-body.md -f query='
                      mutation($commentId: ID!, $body: String!) {
@@ -93,7 +97,7 @@ jobs:
                        }
                      }'
                    ```
-                   If the comment already has the Flatpak bullet, or the release body has none, leave the comment untouched.
+                   The verification step below fails the job if the release links a Flatpak bundle that this comment does not, so a skipped or failed update cannot pass as success.
                  - Otherwise, leave `COMMENT_URL` unset and proceed to step 4 to create the comment.
 
                In either case, ALWAYS continue to step 5 — a previous run may have posted the comment but failed to update the release body, and step 5 must be allowed to repair that.
@@ -122,7 +126,7 @@ jobs:
 
             ## Constraints
 
-            - Do not edit the discussion body, title, or category. The only comment you may edit is the one carrying the `<!-- japanese-release-notes -->` marker, and only to insert the missing Flatpak bullet as described in step 3; never edit anyone else's comment.
+            - Do not edit the discussion body, title, or category. The only comment you may edit is the one carrying the `<!-- japanese-release-notes -->` marker, and only to bring its Flatpak bullet in line with the release as described in step 3; never edit anyone else's comment.
             - Do not publish the release, edit the tag, or touch assets.
             - Do not modify any other discussion or release.
             - If anything is ambiguous (release missing, translation refused, API error), exit without partial writes.
@@ -132,6 +136,9 @@ jobs:
           GH_TOKEN: ${{ secrets.DISCUSSION_TOKEN }}
           TAG: ${{ inputs.discussion_title }}
           REPO: ${{ github.repository }}
+          DISCUSSION_NUMBER: ${{ inputs.discussion_number }}
+          OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
           set -euo pipefail
           if ! err=$(gh release view "$TAG" -R "$REPO" --json url 2>&1 >/dev/null); then
@@ -148,4 +155,22 @@ jobs:
           else
             echo "::error::Release $TAG exists but its notes do not link to the Japanese translation. The Claude step finished without updating the release body."
             exit 1
+          fi
+          # The check above is already satisfied on a repair rerun, so it cannot tell whether the
+          # translation comment kept up with the release body. Releases are tagged "v" + semVer,
+          # so ${TAG#v} reconstructs the semVer that names the Flatpak bundle.
+          flatpak_url="https://github.com/$REPO/releases/download/$TAG/Beutl-${TAG#v}.flatpak"
+          if printf '%s' "$body" | grep -qF "$flatpak_url"; then
+            comment=$(gh api graphql -F number="$DISCUSSION_NUMBER" -F owner="$OWNER" -F repo="$REPO_NAME" -f query='
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  discussion(number: $number) { comments(first: 50) { nodes { body } } }
+                }
+              }' --jq '[.data.repository.discussion.comments.nodes[].body | select(contains("<!-- japanese-release-notes -->"))] | first // ""')
+            if printf '%s' "$comment" | grep -qF "$flatpak_url"; then
+              echo "The Japanese translation comment links the same Flatpak bundle as the release."
+            else
+              echo "::error::Release $TAG links $flatpak_url but the Japanese translation comment does not. The Claude step did not bring the comment up to date."
+              exit 1
+            fi
           fi

--- a/.github/workflows/translate-release-notes.yml
+++ b/.github/workflows/translate-release-notes.yml
@@ -84,7 +84,7 @@ jobs:
                ```
                Find the first comment whose body contains the marker line `<!-- japanese-release-notes -->`. Define `COMMENT_URL`:
                  - If such a comment exists, set `COMMENT_URL` to its `url`. Skip step 4 — do NOT post another comment.
-                   Then keep the comment's Flatpak link in step with the release. Take the EXACT href of the `[Flatpak](<url>)` bullet in the release body's Linux download list. If the release body has no such bullet, leave the comment untouched. Otherwise the comment must contain that exact url:
+                   Then keep the comment's Flatpak link in step with the release. Repair the comment the release body actually links to — the url inside its `日本語のリリースノートは[こちら](<url>)です。` paragraph — and fall back to this first marked comment only when the release body carries no such link; a discussion can hold more than one marked comment, and the one users reach is the linked one. Take the EXACT href of the `[Flatpak](<url>)` bullet in the release body's Linux download list. If the release body has no such bullet, leave the comment untouched. Otherwise the comment must contain that exact url:
                      - The comment has no Flatpak bullet → insert the translated bullet, copying that exact href, directly after the `[Debian パッケージ](...)` bullet.
                      - The comment has a Flatpak bullet with a different href → replace just that href with the exact one. A stale link must neither suppress the repair nor produce a second bullet.
                      - The comment already contains the exact url → leave it untouched.
@@ -157,16 +157,23 @@ jobs:
             exit 1
           fi
           # The check above is already satisfied on a repair rerun, so it cannot tell whether the
-          # translation comment kept up with the release body. Releases are tagged "v" + semVer,
-          # so ${TAG#v} reconstructs the semVer that names the Flatpak bundle.
-          flatpak_url="https://github.com/$REPO/releases/download/$TAG/Beutl-${TAG#v}.flatpak"
-          if printf '%s' "$body" | grep -qF "$flatpak_url"; then
-            comment=$(gh api graphql -F number="$DISCUSSION_NUMBER" -F owner="$OWNER" -F repo="$REPO_NAME" -f query='
+          # translation comment kept up with the release body. Use the release's own Flatpak href
+          # rather than reconstructing one from the tag, which would assume tag == "v" + semVer.
+          flatpak_url=$(printf '%s' "$body" | grep -oE '\[Flatpak\]\(https://[^)]+\.flatpak\)' | head -n1 | sed -E 's/^\[Flatpak\]\((.*)\)$/\1/') || flatpak_url=""
+          if [ -n "$flatpak_url" ]; then
+            # Check the comment the release actually links to; a discussion can hold more than one
+            # marked comment, and only the linked one is the one users reach.
+            linked_url=$(printf '%s' "$body" | grep -oE 'https://github\.com/[^)]*#discussioncomment-[0-9]+' | head -n1) || linked_url=""
+            comments=$(gh api graphql -F number="$DISCUSSION_NUMBER" -F owner="$OWNER" -F repo="$REPO_NAME" -f query='
               query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {
-                  discussion(number: $number) { comments(first: 50) { nodes { body } } }
+                  discussion(number: $number) { comments(first: 50) { nodes { url body } } }
                 }
-              }' --jq '[.data.repository.discussion.comments.nodes[].body | select(contains("<!-- japanese-release-notes -->"))] | first // ""')
+              }')
+            comment=$(printf '%s' "$comments" | jq -r --arg url "$linked_url" '
+              [.data.repository.discussion.comments.nodes[] | select($url != "" and .url == $url) | .body]
+              + [.data.repository.discussion.comments.nodes[] | select(.body | contains("<!-- japanese-release-notes -->")) | .body]
+              | first // ""')
             if printf '%s' "$comment" | grep -qF "$flatpak_url"; then
               echo "The Japanese translation comment links the same Flatpak bundle as the release."
             else

--- a/.github/workflows/translate-release-notes.yml
+++ b/.github/workflows/translate-release-notes.yml
@@ -68,7 +68,7 @@ jobs:
                  - `**Improvements & Refactoring**` → `**改善・リファクタリング**`
                  - `**Bug Fixes**` → `**バグ修正**`
                  - `**Other**` → `**その他**`
-                 - Download link labels: `Installer` → `インストーラー`, `Installer (.NET Runtime required)` → `インストーラー (.NET Runtime 必須)`, `Zip (arm64)` / `Zip (x64)` はそのまま、`Debian package` → `Debian パッケージ`, `Zip (.NET Runtime required)` → `Zip (.NET Runtime 必須)`.
+                 - Download link labels: `Installer` → `インストーラー`, `Installer (.NET Runtime required)` → `インストーラー (.NET Runtime 必須)`, `Zip (arm64)` / `Zip (x64)` はそのまま、`Debian package` → `Debian パッケージ`, `Flatpak` はそのまま、`Zip (.NET Runtime required)` → `Zip (.NET Runtime 必須)`.
                - Inside the `<details><summary>Changelog</summary>` block, keep the auto-generated `* <prefix>: ... by @user in <PR-URL>` lines untranslated (they are PR titles).
                - Translate the `**Full Changelog**` line label to `**フルチェンジログ**` but keep the URL.
                - Do not add or remove sections.


### PR DESCRIPTION
## Description

The release workflow already builds and attaches a Flatpak bundle (`Beutl-<semVer>.flatpak`), but the release-notes template in `format-release-notes.yml` never listed it. The Flatpak link in v2.0.0-preview.7 was added by hand afterwards, so every release needed the same manual fix.

- Add the Flatpak entry to the Linux download list, in the same position and URL form as the corrected v2.0.0-preview.7 body (right after the Debian package).
- Verify it: the post-run check only asserted that *some* download link existed, so a missing Flatpak line passed silently. It now fails the job when the repository-qualified Flatpak URL is absent — the guarantee is that the *correct* link is present, not merely some Flatpak link.
- Make reruns repairable. The idempotency guard exited as soon as the body contained any `releases/download/<tag>/` link, which combined with the new check would have deadlocked a rerun over a body formatted before the Flatpak link existed. It is now three-way: skip when the Flatpak link is present, insert just that one bullet when the body is an older formatted one (never rebuild it — it is no longer the auto-generated body), full reformat otherwise. The repair path preserves the release's existing `isDraft`, so it cannot unpublish an already-published release.
- Keep the Japanese side in step. `translate-release-notes.yml` posts its translation once and never edits it, so an English-side repair would have left Japanese readers with the old download list. It now mirrors the English repair, matching on the release body's exact Flatpak href: insert the bullet when the comment has none, correct the href when it has a stale one, leave it alone when it already matches — via `updateDiscussionComment`, with every other byte untouched so a manual edit to the translation is not clobbered. Its `Flatpak` download label is also pinned as untranslated.
- Verify the Japanese side too. Its final check only asserted that the release body links the translation, which is already true on a repair rerun, so a skipped or failed comment update reported success. It now also requires the marked comment to carry the release's exact Flatpak URL whenever the release has one.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [x] Build / CI / docs only

## Breaking changes

None.

## Test plan

- No production code changed. Both workflows parse as valid YAML and the verification step passes `bash -n`.
- Ran the English verification step against the real v2.0.0-preview.7 release body: it passes, and the same body with the Flatpak link rewritten to another repository now exits 1 — a case the previous suffix match accepted.
- Ran the Japanese verification step against real releases and discussions: v2.0.0-preview.7 + #2197 and v2.0.0-preview.6 + #2097 pass; preview.7's release checked against a comment lacking its URL exits 1; v2.0.0-preview.3, whose body predates Flatpak, skips the new assertion instead of failing.
- Checked the asset name against the release that produces it: `build-flatpak-package.yml` bundles `Beutl-<semVer>.flatpak`, and v2.0.0-preview.7 carries `Beutl-2.0.0-preview.7.flatpak`.
- Checked `UpdateDiscussionCommentInput` against the live GitHub GraphQL schema (`commentId: ID!`, `body: String!`); `Bash(gh api graphql:*)` was already in the job's `--allowed-tools` and it already has `discussions: write`.
- The next release run exercises the whole path end to end: `format-release-notes.yml` now fails loudly if the generated body lacks the Flatpak link.

## Fixed issues / References

None.

Out of scope, raised with the maintainer rather than filed away: `reflect-release.yml` does not register the Flatpak asset with the release distribution API. That is a distribution-API change (it needs the server side to accept a `flatpak` asset type), not a release-notes one.
