### PR TITLE
refactor!: make Resource.GetOriginal() nullable and add RequireOriginal()

### DIFF
--- a/docs/specs/004-gpu-pass-fusion/contracts/breaking-changes.md
+++ b/docs/specs/004-gpu-pass-fusion/contracts/breaking-changes.md
@@ -813,19 +813,20 @@ that promised it could not. `EngineResourceIdentity` already handled that null, 
 the declaration met a `NullReferenceException` instead of a diagnosable one.
 
 The base accessor and the `GetOriginal()` override the resource source generator emits now return a nullable
-reference. Nothing about the runtime behaviour changed. Under nullable reference types, a caller that only
-ever holds resources produced by `ToResource` states that:
+reference. Resources also expose `IsAttached` for checking that state and `RequireOriginal()` for code that
+cannot operate without a backing object. Nothing about the runtime behaviour of `GetOriginal()` changed.
+Under nullable reference types, a caller that only ever holds resources produced by `ToResource` states that:
 
 ```csharp
 // before
 Drawable drawable = resource.GetOriginal();
 
-// after — the resource came from ToResource, so it is attached
-Drawable drawable = resource.GetOriginal()!;
+// after — the operation requires an attached resource
+Drawable drawable = resource.RequireOriginal();
 ```
 
-A caller that may hold a detached resource handles the null it was already able to receive, or keys on
-`EngineResourceIdentity` when it only needs an equality-stable identity.
+A caller that may hold a detached resource checks `IsAttached` or handles the null from `GetOriginal()`, or
+keys on `EngineResourceIdentity` when it only needs an equality-stable identity.
 
 ## A hand-built resource's version is the author's to move
 

--- a/src/Beutl.Editor.Components/PathEditorTab/ViewModels/PathEditorViewModel.cs
+++ b/src/Beutl.Editor.Components/PathEditorTab/ViewModels/PathEditorViewModel.cs
@@ -114,7 +114,7 @@ public sealed class PathEditorViewModel : IDisposable, IPathEditorContext
                 matrix *= Graphics.Matrix.CreateTranslation(thickness, thickness);
             }
 
-            Matrix mat = drawable.GetOriginal()!.GetTransformMatrix(frameSize, size, drawable);
+            Matrix mat = drawable.RequireOriginal().GetTransformMatrix(frameSize, size, drawable);
             matrix *= mat;
         }
 
@@ -174,7 +174,7 @@ public sealed class PathEditorViewModel : IDisposable, IPathEditorContext
                 point.ToBtlPoint(), geometryShapeResource.Pen);
             if (figure != null)
             {
-                var figContext = context.FindPathFigureContext(figure.GetOriginal()!);
+                var figContext = context.FindPathFigureContext(figure.RequireOriginal());
                 if (figContext != null)
                 {
                     StartEdit(figContext);

--- a/src/Beutl.Editor/Services/ObjectTemplatePreviewRenderer.cs
+++ b/src/Beutl.Editor/Services/ObjectTemplatePreviewRenderer.cs
@@ -200,7 +200,7 @@ public static class ObjectTemplatePreviewRenderer
                 using var root = new DrawableRenderNode(resource);
                 using (var context = new GraphicsContext2D(root, availableSize, scale))
                 {
-                    resource.GetOriginal()!.Render(context, resource);
+                    resource.RequireOriginal().Render(context, resource);
                 }
 
                 using var renderer = new RenderNodeRenderer(
@@ -228,7 +228,7 @@ public static class ObjectTemplatePreviewRenderer
             using var root = new DrawableRenderNode(resource);
             using (var context = new GraphicsContext2D(root, availableSize))
             {
-                resource.GetOriginal()!.Render(context, resource);
+                resource.RequireOriginal().Render(context, resource);
             }
 
             try

--- a/src/Beutl.Engine.SourceGenerators/Emit/ResourceClassEmitter.cs
+++ b/src/Beutl.Engine.SourceGenerators/Emit/ResourceClassEmitter.cs
@@ -169,6 +169,11 @@ public static class ResourceClassEmitter
         sb.Append(innerIndent).AppendLine("{");
         sb.Append(innerIndent).AppendLine($"    return ({currentTypeDisplay}?)base.GetOriginal();");
         sb.Append(innerIndent).AppendLine("}");
+        sb.AppendLine();
+        sb.Append(innerIndent).AppendLine($"public new {currentTypeDisplay} RequireOriginal()");
+        sb.Append(innerIndent).AppendLine("{");
+        sb.Append(innerIndent).AppendLine($"    return ({currentTypeDisplay})base.RequireOriginal();");
+        sb.Append(innerIndent).AppendLine("}");
     }
 
     private static void EmitBindNodePortValues(StringBuilder sb, string innerIndent, ClassInfo info)
@@ -179,7 +184,7 @@ public static class ResourceClassEmitter
             sb.Append(innerIndent).AppendLine("public override void BindNodePortValues()");
             sb.Append(innerIndent).AppendLine("{");
             sb.Append(innerIndent).AppendLine("    base.BindNodePortValues();");
-            sb.Append(innerIndent).AppendLine("    var node = GetOriginal()!;");
+            sb.Append(innerIndent).AppendLine("    var node = RequireOriginal();");
 
             for (int i = 0; i < info.NodePortProperties.Length; i++)
             {

--- a/src/Beutl.Engine/Audio/Composing/Composer.cs
+++ b/src/Beutl.Engine/Audio/Composing/Composer.cs
@@ -845,7 +845,7 @@ public class Composer : IComposer
     /// </summary>
     protected void ComposeSound(Sound.Resource resource, TimeRange timeRange)
     {
-        Sound sound = resource.GetOriginal()!;
+        Sound sound = resource.RequireOriginal();
         // Get or create cache entry
         if (!_audioCache.TryGetValue(sound, out var entry))
         {

--- a/src/Beutl.Engine/Audio/SoundGroup.cs
+++ b/src/Beutl.Engine/Audio/SoundGroup.cs
@@ -33,7 +33,7 @@ public sealed partial class SoundGroup : Sound, IFlowOperator
         // そのまま通す
         foreach (var child in r.Children)
         {
-            Sound original = child.GetOriginal()!;
+            Sound original = child.RequireOriginal();
             if (original.TimeRange.Start < TimeRange.Start)
             {
                 var internalContext = new AudioContext(context.SampleRate, context.ChannelCount);
@@ -80,7 +80,7 @@ public sealed partial class SoundGroup : Sound, IFlowOperator
 
         foreach (var child in r.Children)
         {
-            Sound original = child.GetOriginal()!;
+            Sound original = child.RequireOriginal();
             var internalContext = new AudioContext(context.SampleRate, context.ChannelCount);
             original.Compose(internalContext, child);
             foreach (AudioNode node in internalContext.Nodes)

--- a/src/Beutl.Engine/Audio/SourceSound.Thumbnails.cs
+++ b/src/Beutl.Engine/Audio/SourceSound.Thumbnails.cs
@@ -86,7 +86,7 @@ public sealed partial class SourceSound : IThumbnailsProvider
             [resource],
             TimeRange,
             default,
-            new CompositionEligibility([resource.GetOriginal()!]));
+            new CompositionEligibility([resource.RequireOriginal()]));
 
         for (int chunkIndex = 0; chunkIndex < chunkCount; chunkIndex++)
         {

--- a/src/Beutl.Engine/Engine/EngineObject.cs
+++ b/src/Beutl.Engine/Engine/EngineObject.cs
@@ -410,13 +410,39 @@ public class EngineObject : Hierarchical, INotifyEdited
 
         public bool IsDisposed { get; private set; }
 
-        /// <summary>The object this resource was built from, or <see langword="null"/> when there is none.</summary>
+        /// <summary>
+        /// Gets whether this resource has a backing engine object.
+        /// </summary>
+        /// <remarks>
+        /// Only <see cref="Update"/> attaches one, so a resource built through its public constructor rather
+        /// than through <see cref="ToResource"/> is detached.
+        /// </remarks>
+        public bool IsAttached => _original is not null;
+
+        /// <summary>
+        /// Gets the object this resource was built from, or <see langword="null"/> when
+        /// <see cref="IsAttached"/> is <see langword="false"/>.
+        /// </summary>
         /// <remarks>
         /// A resource constructed directly instead of through <see cref="EngineObject.ToResource"/> - a
         /// detached resource - never receives a backing object. Engine code that only needs an
-        /// equality-stable key uses <c>EngineResourceIdentity</c> instead, which handles that case.
+        /// equality-stable key uses <c>EngineResourceIdentity</c> instead, which handles that case. Use
+        /// <see cref="RequireOriginal"/> when a missing backing object cannot be handled.
         /// </remarks>
         public EngineObject? GetOriginal() => _original;
+
+        /// <summary>
+        /// Gets the backing engine object, throwing when this resource is detached.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// This resource has no backing engine object.
+        /// </exception>
+        public EngineObject RequireOriginal()
+        {
+            return _original ?? throw new InvalidOperationException(
+                $"{GetType()} was constructed directly rather than through {nameof(EngineObject)}.{nameof(ToResource)}, "
+                + "so it has no backing engine object to dispatch to.");
+        }
 
         public virtual void Update(EngineObject obj, CompositionContext context, ref bool updateOnly)
         {

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/AudioVisualizerDrawable.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/AudioVisualizerDrawable.cs
@@ -191,7 +191,7 @@ public abstract partial class AudioVisualizerDrawable : Drawable
             if (!needsRecompose) return;
 
             var targetRange = new TimeRange(targetStart, targetDuration);
-            Sound sound = _source.GetOriginal()!;
+            Sound sound = _source.RequireOriginal();
 
             if (!ReferenceEquals(_frameObjectsSource, _source))
             {

--- a/src/Beutl.Engine/Graphics/DrawablePresenter.cs
+++ b/src/Beutl.Engine/Graphics/DrawablePresenter.cs
@@ -19,7 +19,7 @@ public sealed partial class DrawablePresenter : Drawable, IPresenter<Drawable>
     public override void Render(GraphicsContext2D context, Drawable.Resource resource)
     {
         var r = (Resource)resource;
-        r.Target?.GetOriginal()!.Render(context, r.Target);
+        r.Target?.RequireOriginal().Render(context, r.Target);
     }
 
     protected override void OnDraw(GraphicsContext2D context, Drawable.Resource resource)
@@ -29,6 +29,6 @@ public sealed partial class DrawablePresenter : Drawable, IPresenter<Drawable>
     protected override Size MeasureCore(Size availableSize, Drawable.Resource resource)
     {
         var r = (Resource)resource;
-        return r.Target?.GetOriginal()!.MeasureInternal(availableSize, r.Target) ?? Size.Empty;
+        return r.Target?.RequireOriginal().MeasureInternal(availableSize, r.Target) ?? Size.Empty;
     }
 }

--- a/src/Beutl.Engine/Graphics/DrawableTimeController.cs
+++ b/src/Beutl.Engine/Graphics/DrawableTimeController.cs
@@ -154,13 +154,13 @@ public sealed partial class DrawableTimeController : Drawable, IPresenter<Drawab
     public override void Render(GraphicsContext2D context, Drawable.Resource resource)
     {
         var r = (Resource)resource;
-        r.Target?.GetOriginal()!.Render(context, r.Target);
+        r.Target?.RequireOriginal().Render(context, r.Target);
     }
 
     protected override Size MeasureCore(Size availableSize, Drawable.Resource resource)
     {
         var r = (Resource)resource;
-        return r.Target?.GetOriginal()!.MeasureInternal(availableSize, r.Target) ?? Size.Empty;
+        return r.Target?.RequireOriginal().MeasureInternal(availableSize, r.Target) ?? Size.Empty;
     }
 
     protected override void OnDraw(GraphicsContext2D context, Drawable.Resource resource)

--- a/src/Beutl.Engine/Graphics/FilterEffects/DelayAnimationEffect.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/DelayAnimationEffect.cs
@@ -27,7 +27,7 @@ public partial class DelayAnimationEffect : FilterEffect
         var r = (Resource)resource;
         if (r.Effect == null) return;
 
-        FilterEffect childEffect = r.Effect.GetOriginal()!;
+        FilterEffect childEffect = r.Effect.RequireOriginal();
 
         context.CustomEffect(
             (delay: r.Delay, globalTime: r.GlobalTime, childEffect, cache: r.DelayedResources,

--- a/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectGroup.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectGroup.cs
@@ -21,7 +21,7 @@ public sealed partial class FilterEffectGroup : FilterEffect
         {
             foreach (FilterEffect.Resource item in r.Children)
             {
-                context.ApplyTransactional(item.GetOriginal()!, item);
+                context.ApplyTransactional(item.RequireOriginal(), item);
             }
         });
     }

--- a/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectPresenter.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectPresenter.cs
@@ -21,6 +21,6 @@ public sealed partial class FilterEffectPresenter : FilterEffect, IPresenter<Fil
         var r = (Resource)resource;
 
         if (r.Target is { } target)
-            context.ApplyTransactional(target.GetOriginal()!, target);
+            context.ApplyTransactional(target.RequireOriginal(), target);
     }
 }

--- a/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
+++ b/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
@@ -738,7 +738,7 @@ public partial class ImmediateCanvas : IDisposable, IPopable
         VerifyNestedExecutionOperation();
         using var node = new DrawableRenderNode(drawable);
         using var context = new GraphicsContext2D(node, LogicalSize, _currentDensity);
-        drawable.GetOriginal()!.Render(context, drawable);
+        drawable.RequireOriginal().Render(context, drawable);
         using var renderer = new RenderNodeRenderer(
             node,
             new RenderNodeRenderRequest

--- a/src/Beutl.Engine/Graphics/Particles/ParticleRenderNode.cs
+++ b/src/Beutl.Engine/Graphics/Particles/ParticleRenderNode.cs
@@ -97,7 +97,7 @@ internal sealed class ParticleRenderNode(ParticleEmitter.Resource particle) : Re
         {
             // This only builds the child's RenderNode tree. Pixel execution remains in the parent
             // request after RecordSubtree imports the complete child sequence.
-            drawable.GetOriginal()!.Render(graphics, drawable);
+            drawable.RequireOriginal().Render(graphics, drawable);
         }
 
         IReadOnlyList<RenderFragmentHandle> outputs = context.RecordSubtree(root);

--- a/src/Beutl.Engine/Graphics/Rendering/GraphicsContext2D.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/GraphicsContext2D.cs
@@ -456,7 +456,7 @@ public sealed class GraphicsContext2D(
         CompleteRecordingOperation(wasFaulted);
         try
         {
-            var obj = drawable.GetOriginal()!;
+            var obj = drawable.RequireOriginal();
             obj.Render(this, drawable);
         }
         catch

--- a/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
@@ -448,7 +448,7 @@ public class Renderer : IRenderer
 
     private Entry PrepareDrawable(Drawable.Resource resource)
     {
-        Drawable drawable = resource.GetOriginal()!;
+        Drawable drawable = resource.RequireOriginal();
         Entry entry;
         bool shouldRender;
 
@@ -601,7 +601,7 @@ public class Renderer : IRenderer
     {
         _dispatcher.VerifyAccess();
         return [.. _allCurrentEntries
-            .Where(e => e.Node.Drawable?.Resource.GetOriginal()!.ZIndex == zIndex)
+            .Where(e => e.Node.Drawable?.Resource.RequireOriginal().ZIndex == zIndex)
             .Select(e => e.GetBounds())];
     }
 
@@ -641,7 +641,7 @@ public class Renderer : IRenderer
     {
         _dispatcher.VerifyAccess();
         return [.. _allCurrentEntries
-            .Where(e => e.Node.Drawable?.Resource.GetOriginal()!.ZIndex == zIndex)
+            .Where(e => e.Node.Drawable?.Resource.RequireOriginal().ZIndex == zIndex)
             .Select(e => e.RecalculateBounds())];
     }
 

--- a/src/Beutl.Engine/Graphics/Rendering/Requests/RenderRequestExecutor.DrawableBrush.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/Requests/RenderRequestExecutor.DrawableBrush.cs
@@ -69,7 +69,7 @@ internal sealed partial class RenderRequestExecutor
                 root = new DrawableRenderNode(drawable);
                 using (var graphics = new GraphicsContext2D(root, domain.Size, scale))
                 {
-                    drawable.GetOriginal()!.Render(graphics, drawable);
+                    drawable.RequireOriginal().Render(graphics, drawable);
                 }
 
                 var cacheContext = new RenderCacheResolutionContext(

--- a/src/Beutl.Engine/Graphics3D/Textures/DrawableTextureSource.cs
+++ b/src/Beutl.Engine/Graphics3D/Textures/DrawableTextureSource.cs
@@ -65,7 +65,7 @@ public sealed partial class DrawableTextureSource : TextureSource
                 _drawableNode,
                 new Size(TextureWidth, TextureHeight),
                 sanitizedDensity);
-            Drawable.GetOriginal()!.Render(context, Drawable);
+            Drawable.RequireOriginal().Render(context, Drawable);
             return _drawableNode;
         }
 

--- a/src/Beutl.NodeGraph/Composition/GraphSnapshot.cs
+++ b/src/Beutl.NodeGraph/Composition/GraphSnapshot.cs
@@ -250,7 +250,7 @@ public sealed class GraphSnapshot : IDisposable
         // 各 ListInputPort について、Connections の順序で登録
         for (int resourceIdx = 0; resourceIdx < _resources.Length; resourceIdx++)
         {
-            GraphNode node = _resources[resourceIdx].GetOriginal()!;
+            GraphNode node = _resources[resourceIdx].RequireOriginal();
             for (int itemIdx = 0; itemIdx < node.Items.Count; itemIdx++)
             {
                 var item = node.Items[itemIdx];
@@ -364,7 +364,7 @@ public sealed class GraphSnapshot : IDisposable
 
     private void LoadAnimatedValues(GraphNode.Resource resource, TimeSpan time)
     {
-        GraphNode node = resource.GetOriginal()!;
+        GraphNode node = resource.RequireOriginal();
         for (int i = 0; i < node.Items.Count; i++)
         {
             INodeMember item = node.Items[i];
@@ -392,7 +392,7 @@ public sealed class GraphSnapshot : IDisposable
 
     private void PropagateOutputs(GraphNode.Resource resource)
     {
-        GraphNode node = resource.GetOriginal()!;
+        GraphNode node = resource.RequireOriginal();
         for (int itemIdx = 0; itemIdx < node.Items.Count; itemIdx++)
         {
             if (!_outputConnectionMap.TryGetValue((resource.SlotIndex, itemIdx), out var connIndices))

--- a/src/Beutl.NodeGraph/Nodes/ConfigureNode.cs
+++ b/src/Beutl.NodeGraph/Nodes/ConfigureNode.cs
@@ -19,7 +19,7 @@ public abstract partial class ConfigureNode : GraphNode
     {
         public override void Update(GraphCompositionContext context)
         {
-            var node = GetOriginal()!;
+            var node = RequireOriginal();
             var inputs = context.CollectListInputValues(node.InputPort);
 
             UpdateCore(context);

--- a/src/Beutl.NodeGraph/Nodes/FactoryNode.cs
+++ b/src/Beutl.NodeGraph/Nodes/FactoryNode.cs
@@ -53,7 +53,7 @@ public partial class FactoryNode<T> : GraphNode
     {
         public override void Update(GraphCompositionContext context)
         {
-            var node = GetOriginal()!;
+            var node = RequireOriginal();
             OutputPort = node.Object;
         }
     }

--- a/src/Beutl.NodeGraph/Nodes/FilterEffectNode.cs
+++ b/src/Beutl.NodeGraph/Nodes/FilterEffectNode.cs
@@ -52,7 +52,7 @@ public partial class FilterEffectNode<T> : ConfigureNode
     {
         protected override void UpdateCore(GraphCompositionContext context)
         {
-            var node = GetOriginal()!;
+            var node = RequireOriginal();
             FilterEffect.Resource? resource;
             var output = OutputPort;
 

--- a/src/Beutl.NodeGraph/Nodes/GeometryNode.cs
+++ b/src/Beutl.NodeGraph/Nodes/GeometryNode.cs
@@ -54,7 +54,7 @@ public partial class GeometryNode<T> : GraphNode
     {
         public override void Update(GraphCompositionContext context)
         {
-            var node = GetOriginal()!;
+            var node = RequireOriginal();
             OutputPort = node.Object;
         }
     }

--- a/src/Beutl.NodeGraph/Nodes/Group/GroupInput.cs
+++ b/src/Beutl.NodeGraph/Nodes/Group/GroupInput.cs
@@ -71,7 +71,6 @@ public partial class GroupInput : GraphNode, IDynamicPortNode
         {
             if (OuterInputValues == null) return;
 
-            var node = RequireOriginal();
             // 外部 GroupNode の入力値を GroupInput の出力値にコピー
             for (int i = 0; i < ItemValues.Length && i < OuterInputValues.Length; i++)
             {

--- a/src/Beutl.NodeGraph/Nodes/Group/GroupInput.cs
+++ b/src/Beutl.NodeGraph/Nodes/Group/GroupInput.cs
@@ -71,7 +71,7 @@ public partial class GroupInput : GraphNode, IDynamicPortNode
         {
             if (OuterInputValues == null) return;
 
-            var node = GetOriginal()!;
+            var node = RequireOriginal();
             // 外部 GroupNode の入力値を GroupInput の出力値にコピー
             for (int i = 0; i < ItemValues.Length && i < OuterInputValues.Length; i++)
             {

--- a/src/Beutl.NodeGraph/Nodes/Group/GroupNode.cs
+++ b/src/Beutl.NodeGraph/Nodes/Group/GroupNode.cs
@@ -293,7 +293,7 @@ public partial class GroupNode : GraphNode
 
         public override void Initialize(GraphCompositionContext context)
         {
-            var node = GetOriginal()!;
+            var node = RequireOriginal();
             node.Group.TopologyChanged += OnGroupTopologyChanged;
             _innerSnapshot = new GraphSnapshot();
             _innerSnapshot.Build(node.Group, context);
@@ -308,7 +308,7 @@ public partial class GroupNode : GraphNode
 
         public override void Uninitialize()
         {
-            var node = GetOriginal()!;
+            var node = RequireOriginal();
             node.Group.TopologyChanged -= OnGroupTopologyChanged;
             _innerSnapshot?.Dispose();
             _innerSnapshot = null;
@@ -318,7 +318,7 @@ public partial class GroupNode : GraphNode
 
         public override void Update(GraphCompositionContext context)
         {
-            var node = GetOriginal()!;
+            var node = RequireOriginal();
             if (_innerSnapshot == null) return;
 
             // GroupNodeの入力値からGroupInputの出力値に転送

--- a/src/Beutl.NodeGraph/Nodes/LayerInputNode.cs
+++ b/src/Beutl.NodeGraph/Nodes/LayerInputNode.cs
@@ -125,7 +125,7 @@ public partial class LayerInputNode : GraphNode, IDynamicPortNode
     {
         public override void Update(GraphCompositionContext context)
         {
-            var node = GetOriginal()!;
+            var node = RequireOriginal();
 
             // UseGlobalClock=false のアニメーションに対して、
             // Element.Start 分のオフセットを適用して再評価

--- a/src/Beutl.NodeGraph/Nodes/TextNode.cs
+++ b/src/Beutl.NodeGraph/Nodes/TextNode.cs
@@ -62,7 +62,7 @@ public partial class TextNode : GraphNode
     {
         public override void Update(GraphCompositionContext context)
         {
-            var node = GetOriginal()!;
+            var node = RequireOriginal();
             var output = Output;
             if (output?.Drawable?.Resource is not TextBlock.Resource resource)
             {

--- a/src/Beutl.NodeGraph/Nodes/TransformNode.cs
+++ b/src/Beutl.NodeGraph/Nodes/TransformNode.cs
@@ -17,7 +17,7 @@ public partial class TransformNode : ConfigureNode
     {
         protected override void UpdateCore(GraphCompositionContext context)
         {
-            var node = GetOriginal()!;
+            var node = RequireOriginal();
             var matrix = context.HasConnection(node.Matrix)
                 ? Matrix
                 : Graphics.Matrix.Identity;

--- a/src/Beutl.NodeGraph/Nodes/Utilities/ExpressionNode.cs
+++ b/src/Beutl.NodeGraph/Nodes/Utilities/ExpressionNode.cs
@@ -30,7 +30,7 @@ public partial class ExpressionNode : GraphNode
     {
         public override void Update(GraphCompositionContext context)
         {
-            var node = GetOriginal()!;
+            var node = RequireOriginal();
             var state = node._state;
             string? expression = Expression;
 

--- a/src/Beutl.NodeGraph/Nodes/Utilities/MatrixNode.cs
+++ b/src/Beutl.NodeGraph/Nodes/Utilities/MatrixNode.cs
@@ -19,7 +19,7 @@ public abstract partial class MatrixNode : GraphNode
     {
         public override void Update(GraphCompositionContext context)
         {
-            var node = GetOriginal()!;
+            var node = RequireOriginal();
             Matrix matrix = GetMatrix(context, node);
 
             if (context.HasConnection(node.Input))

--- a/src/Beutl.NodeGraph/Nodes/Utilities/PreviewNode.cs
+++ b/src/Beutl.NodeGraph/Nodes/Utilities/PreviewNode.cs
@@ -22,7 +22,7 @@ public partial class PreviewNode : GraphNode
     {
         public override void Update(GraphCompositionContext context)
         {
-            var node = GetOriginal()!;
+            var node = RequireOriginal();
             if (!node._preview.IsEnabled)
                 return;
 

--- a/src/Beutl.NodeGraph/Nodes/Utilities/TimeNode.cs
+++ b/src/Beutl.NodeGraph/Nodes/Utilities/TimeNode.cs
@@ -24,7 +24,7 @@ public partial class TimeNode : GraphNode
     {
         public override void Update(GraphCompositionContext context)
         {
-            var node = GetOriginal()!;
+            var node = RequireOriginal();
             float duration = (float)node.TimeRange.Duration.TotalSeconds;
             float start = (float)node.TimeRange.Start.TotalSeconds;
             float time = (float)context.Time.TotalSeconds - start;

--- a/src/Beutl.ProjectSystem/ProjectSystem/SceneDrawable.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/SceneDrawable.cs
@@ -229,7 +229,7 @@ public sealed partial class SceneDrawable : Drawable
                     if (item is not Drawable.Resource drawableResource)
                         continue;
 
-                    Drawable drawable = drawableResource.GetOriginal()!;
+                    Drawable drawable = drawableResource.RequireOriginal();
                     DrawableRenderNode? node = childIndex < Children.Count
                         ? Children[childIndex] as DrawableRenderNode
                         : null;

--- a/src/Beutl.ProjectSystem/SceneCompositor.cs
+++ b/src/Beutl.ProjectSystem/SceneCompositor.cs
@@ -148,7 +148,7 @@ public sealed class SceneCompositor : ICompositor
             allResources.AddRange(flow.Span);
             foreach (EngineObject.Resource resource in flow.Span)
             {
-                eligibleObjects.Add(resource.GetOriginal()!);
+                eligibleObjects.Add(resource.RequireOriginal());
             }
         }
 

--- a/src/Beutl/Helpers/AvaloniaTypeConverter.cs
+++ b/src/Beutl/Helpers/AvaloniaTypeConverter.cs
@@ -452,7 +452,7 @@ public static class AvaloniaTypeConverter
                 // TODO: UI側の物理的なサイズをもとに描画するように変更する
                 using (var context = new GraphicsContext2D(node, new Graphics.Size(1920, 1080)))
                 {
-                    _drawableBrush.Drawable.GetOriginal()!.Render(context, _drawableBrush.Drawable);
+                    _drawableBrush.Drawable.RequireOriginal().Render(context, _drawableBrush.Drawable);
                 }
 
                 using var renderer = new RenderNodeRenderer(

--- a/tests/Beutl.UnitTests/Engine/DetachedResourceTests.cs
+++ b/tests/Beutl.UnitTests/Engine/DetachedResourceTests.cs
@@ -1,0 +1,54 @@
+﻿using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+[TestFixture]
+public class DetachedResourceTests
+{
+    [Test]
+    public void ToBrushResource_ProducesADetachedResource()
+    {
+        SolidColorBrush.Resource resource = Colors.Red.ToBrushResource();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(resource.IsAttached, Is.False);
+            Assert.That(resource.GetOriginal(), Is.Null);
+        });
+    }
+
+    [Test]
+    public void RequireOriginal_OnADetachedResource_Throws()
+    {
+        SolidColorBrush.Resource resource = Colors.Red.ToBrushResource();
+
+        Assert.That(resource.RequireOriginal, Throws.InstanceOf<InvalidOperationException>());
+    }
+
+    [Test]
+    public void ToResource_ProducesAnAttachedResource()
+    {
+        var brush = new SolidColorBrush(Colors.Red);
+        using SolidColorBrush.Resource resource = brush.ToResource(CompositionContext.Default);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(resource.IsAttached, Is.True);
+            Assert.That(resource.GetOriginal(), Is.SameAs(brush));
+            Assert.That(resource.RequireOriginal(), Is.SameAs(brush));
+        });
+    }
+
+    [Test]
+    public void GetOriginal_IsTypedToTheDeclaringEngineObject()
+    {
+        var brush = new SolidColorBrush(Colors.Red);
+        using SolidColorBrush.Resource resource = brush.ToResource(CompositionContext.Default);
+
+        SolidColorBrush? original = resource.GetOriginal();
+
+        Assert.That(original, Is.SameAs(brush));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/DetachedResourceTests.cs
+++ b/tests/Beutl.UnitTests/Engine/DetachedResourceTests.cs
@@ -10,7 +10,7 @@ public class DetachedResourceTests
     [Test]
     public void ToBrushResource_ProducesADetachedResource()
     {
-        SolidColorBrush.Resource resource = Colors.Red.ToBrushResource();
+        using SolidColorBrush.Resource resource = Colors.Red.ToBrushResource();
 
         Assert.Multiple(() =>
         {
@@ -22,7 +22,7 @@ public class DetachedResourceTests
     [Test]
     public void RequireOriginal_OnADetachedResource_Throws()
     {
-        SolidColorBrush.Resource resource = Colors.Red.ToBrushResource();
+        using SolidColorBrush.Resource resource = Colors.Red.ToBrushResource();
 
         Assert.That(resource.RequireOriginal, Throws.InstanceOf<InvalidOperationException>());
     }

--- a/tests/Beutl.UnitTests/Engine/Graphics/DrawableResourceRenderTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/DrawableResourceRenderTests.cs
@@ -22,7 +22,7 @@ public sealed class DrawableResourceRenderTests
         using var node = new DrawableRenderNode(attached);
         using (var context = new GraphicsContext2D(node, new Size(64, 64)))
         {
-            attached.GetOriginal()!.Render(context, attached);
+            attached.RequireOriginal().Render(context, attached);
         }
 
         using var renderer = new RenderNodeRenderer(node, new RenderNodeRenderRequest

--- a/tests/Beutl.UnitTests/Engine/Graphics/FilterEffects/WholeSourceFilterEffectTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/FilterEffects/WholeSourceFilterEffectTests.cs
@@ -161,7 +161,7 @@ public sealed class WholeSourceFilterEffectTests
         var requestedRegion = new Rect(20, 10, 30, 20);
         using FilterEffect.Resource resource = new MosaicEffect().ToResource(CompositionContext.Default);
         using var context = new FilterEffectContext(outputBounds);
-        context.ApplyTransactional(resource.GetOriginal()!, resource);
+        context.ApplyTransactional(resource.RequireOriginal(), resource);
         ShaderDescription description = ((FEItem_Shader)context.GetOrderedItems().Single()).Description;
         ShaderUniformBinding binding = description.Uniforms.Single(static item => item.Name == "origin");
         SkslUniformDeclaration declaration = description.Source.Uniforms["origin"];

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/EngineResourceIdentityRoutingTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/EngineResourceIdentityRoutingTests.cs
@@ -148,11 +148,11 @@ public sealed class EngineResourceIdentityRoutingTests
             Compare(
                 "GeometryRenderNode.cs:48,50,52",
                 () => s_geometrySink = new GeometryHitTestIdentityShape(
-                    geometryResource.GetOriginal()!.Id,
+                    geometryResource.RequireOriginal().Id,
                     geometryResource.Version,
-                    fillResource.GetOriginal()!.Id,
+                    fillResource.RequireOriginal().Id,
                     fillResource.Version,
-                    penResource.GetOriginal()!.Id,
+                    penResource.RequireOriginal().Id,
                     penResource.Version),
                 () => s_geometrySink = new GeometryHitTestIdentityShape(
                     EngineResourceIdentity.Of(geometryResource),
@@ -165,7 +165,7 @@ public sealed class EngineResourceIdentityRoutingTests
                 "GeometryClipRenderNode.cs:46",
                 () =>
                 {
-                    s_geometryClipSink = geometryResource.GetOriginal()!.Id;
+                    s_geometryClipSink = geometryResource.RequireOriginal().Id;
                     s_geometryClipStateSink =
                         (s_geometryClipSink, geometryResource.Version, ClipOperation.Intersect);
                 },
@@ -178,7 +178,7 @@ public sealed class EngineResourceIdentityRoutingTests
             Compare(
                 "ParticleRenderNode.cs:55",
                 () => s_particleSink = new ParticleSnapshotIdentityShape(
-                    emitterResource.GetOriginal()!.Id,
+                    emitterResource.RequireOriginal().Id,
                     emitterResource.Version),
                 () => s_particleSink = new ParticleSnapshotIdentityShape(
                     EngineResourceIdentity.Of(emitterResource),
@@ -186,13 +186,13 @@ public sealed class EngineResourceIdentityRoutingTests
             Compare(
                 "FilterEffectRenderNode.cs:201",
                 () => s_filterEffectSink =
-                    (typeof(FilterEffectRenderNode), effectResource.GetOriginal()!.Id, 0),
+                    (typeof(FilterEffectRenderNode), effectResource.RequireOriginal().Id, 0),
                 () => s_filterEffectSink =
                     (typeof(FilterEffectRenderNode), EngineResourceIdentity.Of(effectResource), 0)),
             Compare(
                 "Scene3DRenderNode.cs:97",
                 () => s_sceneSnapshotSink = new SceneSnapshotIdentityShape(
-                    sceneResource.GetOriginal()!.Id,
+                    sceneResource.RequireOriginal().Id,
                     sceneResource.Version),
                 () => s_sceneSnapshotSink = new SceneSnapshotIdentityShape(
                     EngineResourceIdentity.Of(sceneResource),
@@ -200,7 +200,7 @@ public sealed class EngineResourceIdentityRoutingTests
             Compare(
                 "Scene3DRenderNode.cs:117",
                 () => s_sceneRuntimeSink = new SceneRuntimeIdentityShape(
-                    sceneResource.GetOriginal()!.Id,
+                    sceneResource.RequireOriginal().Id,
                     sceneResource.Version,
                     bounds),
                 () => s_sceneRuntimeSink = new SceneRuntimeIdentityShape(

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/BitmapSamplingQualityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/BitmapSamplingQualityTests.cs
@@ -178,7 +178,7 @@ public sealed class BitmapSamplingQualityTests
         using var node = new DrawableRenderNode(source);
         using (var context = new GraphicsContext2D(node, frame.ToSize(1), scale))
         {
-            source.GetOriginal()!.Render(context, source);
+            source.RequireOriginal().Render(context, source);
         }
 
         using var renderer = new RenderNodeRenderer(node, new RenderNodeRenderRequest

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/CurrentPixelQuantizationTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/CurrentPixelQuantizationTests.cs
@@ -97,7 +97,7 @@ public sealed class CurrentPixelQuantizationTests
         {
             using (var graphics = new GraphicsContext2D(node, s_frame.ToSize(1), 1))
             {
-                resource.GetOriginal()!.Render(graphics, resource);
+                resource.RequireOriginal().Render(graphics, resource);
             }
 
             using RenderTarget target = RenderTarget.Create(s_frame.Width, s_frame.Height)

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/GoldenImageHarness.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/GoldenImageHarness.cs
@@ -34,7 +34,7 @@ internal static class GoldenImageHarness
         using var node = new DrawableRenderNode(resource);
         using (var ctx = new GraphicsContext2D(node, logicalSize.ToSize(1), scale))
         {
-            resource.GetOriginal()!.Render(ctx, resource);
+            resource.RequireOriginal().Render(ctx, resource);
         }
 
         using var renderer = new RenderNodeRenderer(node, new RenderNodeRenderRequest

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/LosslessCompositeCoverageTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/LosslessCompositeCoverageTests.cs
@@ -655,7 +655,7 @@ public sealed class LosslessCompositeCoverageTests
 
     private static Bitmap RenderDirect(Drawable.Resource resource, float density)
     {
-        Shape shape = (Shape)resource.GetOriginal()!;
+        Shape shape = (Shape)resource.RequireOriginal();
         var shapeResource = (Shape.Resource)resource;
         Size frameSize = s_frame.ToSize(1);
         Size shapeSize = shape.MeasureInternal(frameSize, resource);
@@ -685,7 +685,7 @@ public sealed class LosslessCompositeCoverageTests
         using var node = new DrawableRenderNode(resource);
         using (var context = new GraphicsContext2D(node, frame.ToSize(1), density))
         {
-            resource.GetOriginal()!.Render(context, resource);
+            resource.RequireOriginal().Render(context, resource);
         }
 
         using var renderer = new RenderNodeRenderer(node, new RenderNodeRenderRequest

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/OpaqueSourceCoverageTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/OpaqueSourceCoverageTests.cs
@@ -68,7 +68,7 @@ public sealed class OpaqueSourceCoverageTests
         using var node = new DrawableRenderNode(drawable);
         using (var context = new GraphicsContext2D(node, brushSize, density))
         {
-            drawable.GetOriginal()!.Render(context, drawable);
+            drawable.RequireOriginal().Render(context, drawable);
         }
 
         using var renderer = new RenderNodeRenderer(node, new RenderNodeRenderRequest
@@ -96,7 +96,7 @@ public sealed class OpaqueSourceCoverageTests
     {
         var node = new DrawableRenderNode(resource);
         using var context = new GraphicsContext2D(node, s_frame.ToSize(1), density);
-        resource.GetOriginal()!.Render(context, resource);
+        resource.RequireOriginal().Render(context, resource);
         return node;
     }
 

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/RenderScaleBenchmarkTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/RenderScaleBenchmarkTests.cs
@@ -268,7 +268,7 @@ public class RenderScaleBenchmarkTests
             _node = new DrawableRenderNode(resource);
             using (var context = new GraphicsContext2D(_node, _logicalSize, scale))
             {
-                resource.GetOriginal()!.Render(context, resource);
+                resource.RequireOriginal().Render(context, resource);
             }
 
             _renderer = new RenderNodeRenderer(_node, new RenderNodeRenderRequest

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RecordingSideEffectTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RecordingSideEffectTests.cs
@@ -531,8 +531,8 @@ public sealed class RecordingSideEffectTests
     {
         if (invokedName != "Render"
             || invocation.Expression is not MemberAccessExpressionSyntax member
-            || Unsuppress(member.Expression) is not InvocationExpressionSyntax getOriginal
-            || GetInvokedName(getOriginal) is not "GetOriginal"
+            || Unsuppress(member.Expression) is not InvocationExpressionSyntax resourceAccessor
+            || GetInvokedName(resourceAccessor) is not "GetOriginal" and not "RequireOriginal"
             || invocation.ArgumentList.Arguments.Count < 1)
         {
             return false;
@@ -549,8 +549,8 @@ public sealed class RecordingSideEffectTests
                     .ValueText == "GraphicsContext2D") == true;
     }
 
-    // GetOriginal() is nullable, so a call site that knows its resource is attached writes GetOriginal()!,
-    // which wraps the invocation in a suppression before the member access reaches it.
+    // GetOriginal() is nullable and may be wrapped in a suppression before the member access reaches it.
+    // RequireOriginal() is non-nullable, so the same normalization also accepts it without a suppression.
     private static ExpressionSyntax Unsuppress(ExpressionSyntax expression)
         => expression is PostfixUnaryExpressionSyntax
         {

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/StrokeEffectOffsetBoundsTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/StrokeEffectOffsetBoundsTests.cs
@@ -28,7 +28,7 @@ public class StrokeEffectOffsetBoundsTests
         var resource = effect.ToResource(CompositionContext.Default);
         var context = new FilterEffectContext(Source);
         // CustomEffect updates context.Bounds via TransformBounds — no GPU needed for the bounds pass.
-        resource.GetOriginal()!.ApplyTo(context, resource);
+        resource.RequireOriginal().ApplyTo(context, resource);
         return context.Bounds;
     }
 

--- a/tests/Beutl.UnitTests/NodeGraph/ConfigureNodeOwnershipTests.cs
+++ b/tests/Beutl.UnitTests/NodeGraph/ConfigureNodeOwnershipTests.cs
@@ -228,14 +228,14 @@ internal sealed partial class FanOutConsumerNode : ConfigureNode
                 OutputPort = output;
             }
 
-            GetOriginal()!.OutputContainer = output;
+            RequireOriginal().OutputContainer = output;
         }
 
         partial void PostDispose(bool disposing)
         {
             OutputPort?.Dispose();
             OutputPort = null;
-            GetOriginal()!.OutputContainer = null;
+            RequireOriginal().OutputContainer = null;
         }
     }
 }
@@ -255,14 +255,14 @@ internal sealed partial class OwnedRenderNodeSource : GraphNode
     {
         public override void Update(GraphCompositionContext context)
         {
-            OwnedRenderNodeSource source = GetOriginal()!;
+            OwnedRenderNodeSource source = RequireOriginal();
             Output = source.RenderNode;
         }
 
         partial void PostDispose(bool disposing)
         {
             if (disposing)
-                GetOriginal()!.RenderNode.Dispose();
+                RequireOriginal().RenderNode.Dispose();
         }
     }
 }
@@ -295,14 +295,14 @@ internal sealed partial class MutableOwnedRenderNodeSource : GraphNode
     {
         public override void Update(GraphCompositionContext context)
         {
-            Output = GetOriginal()!.Current;
+            Output = RequireOriginal().Current;
         }
 
         partial void PostDispose(bool disposing)
         {
             if (!disposing) return;
 
-            foreach (TrackingRenderNode node in GetOriginal()!._ownedNodes)
+            foreach (TrackingRenderNode node in RequireOriginal()._ownedNodes)
             {
                 node.Dispose();
             }

--- a/tests/Beutl.UnitTests/NodeGraph/GraphSnapshotTests.cs
+++ b/tests/Beutl.UnitTests/NodeGraph/GraphSnapshotTests.cs
@@ -57,7 +57,7 @@ internal sealed partial class ContextCaptureNode : GraphNode
     {
         public override void Update(GraphCompositionContext context)
         {
-            ContextCaptureNode node = GetOriginal()!;
+            ContextCaptureNode node = RequireOriginal();
             node.CapturedContexts.Add(new CapturedGraphContext(
                 context.DisableResourceShare,
                 context.PreferProxy,

--- a/tests/Beutl.UnitTests/NodeGraph/NodeGraphFilterEffectRenderNodeTests.cs
+++ b/tests/Beutl.UnitTests/NodeGraph/NodeGraphFilterEffectRenderNodeTests.cs
@@ -1370,7 +1370,7 @@ internal sealed partial class MeasureCaptureNode : GraphNode
     {
         public override void Update(GraphCompositionContext context)
         {
-            MeasureCaptureNode node = GetOriginal()!;
+            MeasureCaptureNode node = RequireOriginal();
             node.Value = new Rect(X, Y, Width, Height);
         }
     }
@@ -1392,7 +1392,7 @@ internal sealed partial class FixedRenderNodeGraphNode : GraphNode
     {
         public override void Update(GraphCompositionContext context)
         {
-            Output = GetOriginal()!.Value;
+            Output = RequireOriginal().Value;
         }
     }
 }
@@ -1458,7 +1458,7 @@ internal sealed partial class CountingPassThroughGraphNode : GraphNode
 
         public override void Update(GraphCompositionContext context)
         {
-            CountingPassThroughGraphNode node = GetOriginal()!;
+            CountingPassThroughGraphNode node = RequireOriginal();
             node.EvaluationCount++;
             if (Input is null)
             {
@@ -1536,7 +1536,7 @@ internal sealed partial class MixedPreviewGraphNode : GraphNode
                 return;
             }
 
-            MixedPreviewGraphNode node = GetOriginal()!;
+            MixedPreviewGraphNode node = RequireOriginal();
             _renderNode ??= new NonOwningMixedContainerRenderNode(node);
             _renderNode.SetInput(Input);
             Output = _renderNode;

--- a/tests/SourceGeneratorTest/EngineObject.cs
+++ b/tests/SourceGeneratorTest/EngineObject.cs
@@ -30,7 +30,16 @@ public class EngineObject
 
         public int Version { get; protected set; }
 
+        public bool IsAttached => _original is not null;
+
         public EngineObject? GetOriginal() => _original;
+
+        public EngineObject RequireOriginal()
+        {
+            return _original ?? throw new InvalidOperationException(
+                $"{GetType()} was constructed directly rather than through {nameof(EngineObject)}.{nameof(ToResource)}, "
+                + "so it has no backing engine object to dispatch to.");
+        }
 
         public virtual void Update(EngineObject obj, CompositionContext context, ref bool updateOnly)
         {


### PR DESCRIPTION
## Description

`EngineObject.Resource.GetOriginal()` declared a non-nullable return type but could hand out `null`. Only `Update` attaches a backing engine object, so a resource built through its public constructor rather than through `ToResource()` is detached — and in-tree production code already mints and consumes exactly those:

- `Color.ToBrushResource()`, reached from `TextElementsBuilder`
- the `SolidColorBrush.Resource` and `Pen.Resource` that `FormattedTextParser` builds for a stroke tag
- the `GradientStop.Resource` the Avalonia editor adapters build

At each of those call sites the declared type was a lie, and the nullable analysis had nothing to warn about.

This change splits the accessor into the two things call sites actually want:

- `GetOriginal()` returns a nullable reference, for call sites that compare identity or already tolerate `null`.
- `RequireOriginal()` throws `InvalidOperationException` when the resource is detached, for call sites that dispatch to the backing object and cannot proceed without it.
- `IsAttached` exposes the same distinction without forcing a null check.

Every existing call site was classified individually rather than mechanically rewritten. The ~47 remaining `GetOriginal()` uses are identity comparisons (`ResourceReconciler`, the shape/mesh cache-invalidation checks, `GraphSnapshot.FindSlotIndex`) or null-tolerant lookups (`PlayerView` gizmo hit-testing, `Scene3DRenderNode`); the dispatch sites moved to `RequireOriginal()`.

The source generator mirrors both members onto the generated per-type `Resource`, so a generated `GetOriginal()` is nullable and a generated `RequireOriginal()` is not. Generated `BindNodePortValues` uses `RequireOriginal()`, since port binding cannot run against a detached resource.

## Affected areas

- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [x] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

Also touches `Beutl.Engine.SourceGenerators` (the generated `Resource` class shape).

## Breaking changes

`EngineObject.Resource.GetOriginal()` now returns a nullable reference, and the generated per-type override does the same.

Migration:

- A call site that dispatches to the backing engine object should call `RequireOriginal()`, which throws when the resource is detached.
- A call site that compares identity or already tolerates `null` can keep `GetOriginal()` and handle the `null`.
- `IsAttached` is available when the caller wants to branch without a null check.

This is a source-breaking change for out-of-tree plugins that call `GetOriginal()` in a non-nullable context. It surfaces a `null` those callers could already receive at runtime, so the fix is a compile-time signal rather than a behavior change.

## Test plan

- Added `tests/Beutl.UnitTests/Engine/DetachedResourceTests.cs` covering the new contract: `ToBrushResource()` produces a detached resource (`IsAttached == false`, `GetOriginal() == null`), `RequireOriginal()` throws on a detached resource, `ToResource()` produces an attached one, and the generated `GetOriginal()` stays typed to the declaring engine object.
- `dotnet build Beutl.slnx` — 0 warnings, 0 errors. The nullable analysis produced 32 warnings after the signature change; each was classified as dispatch or comparison and resolved individually rather than suppressed.
- `dotnet test tests/Beutl.UnitTests` — 4978 passed, 0 failed, 3 skipped.
- `dotnet test tests/SourceGeneratorTest` — 11 passed, 0 failed.

## Fixed issues / References

Split out of the feature 004 (GPU pass fusion) stack so it can be reviewed on its own merits; it has no dependency on that feature's rendering work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added resource attachment status checks.
  - Added a required-original accessor that clearly reports when a resource has no backing object.

- **Bug Fixes**
  - Rendering, audio composition, node-graph processing, previews, and resource updates now handle missing originals explicitly instead of relying on nullable access.

- **Documentation**
  - Updated guidance for working with detached resources, including migration examples and recommended error handling.

- **Tests**
  - Added coverage for attached and detached resource behavior, including expected failures when an original is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->