### PR TITLE
fix!: make MediaReader.AudioInfo null instead of throwing for no audio track

### DIFF
--- a/src/Beutl.AgentToolkit/Rendering/AudioRhythmAnalyzer.cs
+++ b/src/Beutl.AgentToolkit/Rendering/AudioRhythmAnalyzer.cs
@@ -84,7 +84,7 @@ public sealed class AudioRhythmAnalyzer
         int sampleRate = resource.SampleRate;
         double sourceDurationSeconds = resource.Duration > TimeSpan.Zero
             ? resource.Duration.TotalSeconds
-            : resource.MediaReader.AudioInfo.NumSamples.ToDouble() / Math.Max(1, sampleRate);
+            : resource.MediaReader.AudioInfo?.NumSamples.ToDouble() / Math.Max(1, sampleRate) ?? 0;
         if (sourceDurationSeconds <= 0)
         {
             throw new CodecUnavailableException($"Audio duration could not be read from '{fullPath}'.");

--- a/src/Beutl.Editor.Components/FileBrowserTab/Services/FileThumbnailService.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Services/FileThumbnailService.cs
@@ -235,9 +235,8 @@ public sealed class FileThumbnailService : IDisposable
                     int? sampleRate = null;
                     int? numChannels = null;
 
-                    if (reader.HasAudio)
+                    if (reader.HasAudio && reader.AudioInfo is { } ai)
                     {
-                        var ai = reader.AudioInfo;
                         audioCodec = ai.CodecName;
                         sampleRate = ai.SampleRate;
                         numChannels = ai.NumChannels;

--- a/src/Beutl.Engine/Audio/SourceSound.cs
+++ b/src/Beutl.Engine/Audio/SourceSound.cs
@@ -24,17 +24,22 @@ public sealed partial class SourceSound : Sound, IOriginalDurationProvider, ISpl
 
     public bool TryGetOriginalDuration(out TimeSpan timeSpan)
     {
-        using var resource = Source.CurrentValue?.ToResource(CompositionContext.Default);
-        if (resource != null && resource.Duration > TimeSpan.Zero)
+        try
         {
-            timeSpan = resource.Duration;
-            return true;
+            using var resource = Source.CurrentValue?.ToResource(CompositionContext.Default);
+            if (resource != null && resource.Duration > TimeSpan.Zero)
+            {
+                timeSpan = resource.Duration;
+                return true;
+            }
         }
-        else
+        catch
         {
-            timeSpan = TimeSpan.Zero;
-            return false;
+            // Try-pattern contract: resource loading must never leak an exception to the caller.
         }
+
+        timeSpan = TimeSpan.Zero;
+        return false;
     }
 
     public void NotifySplitted(bool backward, TimeSpan startDelta, TimeSpan durationDelta)

--- a/src/Beutl.Engine/Media/Decoding/AnimatedImageReader.cs
+++ b/src/Beutl.Engine/Media/Decoding/AnimatedImageReader.cs
@@ -34,7 +34,7 @@ public class AnimatedImageReader : MediaReader
 
     public override VideoStreamInfo VideoInfo { get; }
 
-    public override AudioStreamInfo AudioInfo => throw new NotSupportedException();
+    public override AudioStreamInfo? AudioInfo => null;
 
     public override bool HasVideo => true;
 

--- a/src/Beutl.Engine/Media/Decoding/AnimatedPngReader.cs
+++ b/src/Beutl.Engine/Media/Decoding/AnimatedPngReader.cs
@@ -46,7 +46,7 @@ public class AnimatedPngReader : MediaReader
 
     public override VideoStreamInfo VideoInfo { get; }
 
-    public override AudioStreamInfo AudioInfo => throw new NotSupportedException();
+    public override AudioStreamInfo? AudioInfo => null;
 
     public override bool HasVideo => true;
 

--- a/src/Beutl.Engine/Media/Decoding/MediaReader.cs
+++ b/src/Beutl.Engine/Media/Decoding/MediaReader.cs
@@ -16,7 +16,10 @@ public abstract class MediaReader : IDisposable
 
     public abstract VideoStreamInfo VideoInfo { get; }
 
-    public abstract AudioStreamInfo AudioInfo { get; }
+    /// <summary>
+    /// Gets the audio stream info, or <see langword="null"/> when the media has no audio stream.
+    /// </summary>
+    public abstract AudioStreamInfo? AudioInfo { get; }
 
     public abstract bool HasVideo { get; }
 

--- a/src/Beutl.Engine/Media/Proxy/ProxyMediaReader.cs
+++ b/src/Beutl.Engine/Media/Proxy/ProxyMediaReader.cs
@@ -12,7 +12,7 @@ internal sealed class ProxyMediaReader(
 {
     public override VideoStreamInfo VideoInfo => inner.VideoInfo;
 
-    public override AudioStreamInfo AudioInfo => inner.AudioInfo;
+    public override AudioStreamInfo? AudioInfo => inner.AudioInfo;
 
     public override bool HasVideo => inner.HasVideo;
 

--- a/src/Beutl.Engine/Media/Source/SoundSource.cs
+++ b/src/Beutl.Engine/Media/Source/SoundSource.cs
@@ -143,12 +143,11 @@ public sealed class SoundSource : MediaSource
                     }
                 }
 
-                // A media without an audio stream (e.g. a video-only file) cannot expose AudioInfo
-                // without throwing, so treat it as an unreadable source (#2183): release the reader
-                // and zero the metadata so callers safely see "no audio". Never publish such a
-                // counter to the shared cache, which would poison other resources with a silent
-                // source.
-                if (!_counter.Value.HasAudio)
+                // A media without an audio stream (e.g. a video-only file) exposes a null AudioInfo,
+                // so treat it as an unreadable source (#2183): release the reader and zero the
+                // metadata so callers safely see "no audio". Never publish such a counter to the
+                // shared cache, which would poison other resources with a silent source.
+                if (!_counter.Value.HasAudio || _counter.Value.AudioInfo is not { } audioInfo)
                 {
                     _counter.Release();
                     _counter = null;
@@ -167,9 +166,9 @@ public sealed class SoundSource : MediaSource
                     Volatile.Write(ref soundSource._mediaReaderRef, new WeakReference<Counter<MediaReader>>(_counter));
                 }
 
-                Duration = TimeSpan.FromSeconds(_counter.Value.AudioInfo.Duration.ToDouble());
-                SampleRate = _counter.Value.AudioInfo.SampleRate;
-                NumChannels = _counter.Value.AudioInfo.NumChannels;
+                Duration = TimeSpan.FromSeconds(audioInfo.Duration.ToDouble());
+                SampleRate = audioInfo.SampleRate;
+                NumChannels = audioInfo.NumChannels;
                 _loadedUri = soundSource.Uri;
 
                 if (!updateOnly)

--- a/src/Beutl.Engine/Media/Wave/WaveReader.cs
+++ b/src/Beutl.Engine/Media/Wave/WaveReader.cs
@@ -29,7 +29,7 @@ public sealed class WaveReader : MediaReader
 
     public override VideoStreamInfo VideoInfo => throw new NotSupportedException();
 
-    public override AudioStreamInfo AudioInfo { get; }
+    public override AudioStreamInfo? AudioInfo { get; }
 
     public override bool HasVideo => false;
 

--- a/src/Beutl.Extensions.AVFoundation/Decoding/AVFReader.cs
+++ b/src/Beutl.Extensions.AVFoundation/Decoding/AVFReader.cs
@@ -45,9 +45,8 @@ public sealed class AVFReader : MediaReader
         HasAudio = hasAudio != 0;
 
         // Fail construction when the caller explicitly asked for a stream that the file does
-        // not contain. Callers (SoundSource, VideoSource) dereference VideoInfo/AudioInfo
-        // immediately after a successful Open, so leaving these null would produce an NRE
-        // on video-only or audio-only inputs.
+        // not contain. VideoInfo stays non-nullable (it throws when absent), so a video-only
+        // request on an audio-only file must not leave a reader whose VideoInfo would throw.
         if (wantsVideo && !HasVideo)
         {
             _handle.Dispose();
@@ -94,7 +93,7 @@ public sealed class AVFReader : MediaReader
 
     public override VideoStreamInfo VideoInfo { get; } = default!;
 
-    public override AudioStreamInfo AudioInfo { get; } = default!;
+    public override AudioStreamInfo? AudioInfo { get; }
 
     public override bool HasVideo { get; }
 
@@ -137,14 +136,15 @@ public sealed class AVFReader : MediaReader
     public override bool ReadAudio(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
     {
         sound = null;
-        if (!HasAudio || _handle == null || _handle.IsClosed || _handle.IsInvalid)
+        if (!HasAudio || AudioInfo is not { } audioInfo
+            || _handle == null || _handle.IsClosed || _handle.IsInvalid)
         {
             return false;
         }
 
         if (length <= 0)
         {
-            sound = Ref<IPcm>.Create(new Pcm<Stereo32BitFloat>(AudioInfo.SampleRate, 0));
+            sound = Ref<IPcm>.Create(new Pcm<Stereo32BitFloat>(audioInfo.SampleRate, 0));
             return true;
         }
 
@@ -153,7 +153,7 @@ public sealed class AVFReader : MediaReader
         // EOF shape permitted by the ReadAudio contract: NumSamples is always == length here, so callers
         // must detect EOF by cross-checking `start + length` against the stream duration rather than by
         // a short read.
-        var buffer = new Pcm<Stereo32BitFloat>(AudioInfo.SampleRate, length);
+        var buffer = new Pcm<Stereo32BitFloat>(audioInfo.SampleRate, length);
         try
         {
             int capacityBytes = length * (int)buffer.SampleSize;

--- a/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegReaderProxy.cs
+++ b/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegReaderProxy.cs
@@ -64,7 +64,7 @@ public sealed class FFmpegReaderProxy : MediaReader
 
     public override VideoStreamInfo VideoInfo => field ?? throw new Exception("The stream does not exist.");
 
-    public override AudioStreamInfo AudioInfo => field ?? throw new Exception("The stream does not exist.");
+    public override AudioStreamInfo? AudioInfo => field;
 
     public override bool HasVideo => _openResponse.HasVideo;
 
@@ -124,7 +124,13 @@ public sealed class FFmpegReaderProxy : MediaReader
 
     public override bool ReadAudio(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
     {
-        int sampleRate = AudioInfo.SampleRate;
+        if (AudioInfo is not { } audioInfo)
+        {
+            sound = null;
+            return false;
+        }
+
+        int sampleRate = audioInfo.SampleRate;
 
         // SampleRate(1秒分)を超える場合はリクエストを分割
         if (length > sampleRate)
@@ -167,7 +173,7 @@ public sealed class FFmpegReaderProxy : MediaReader
 
     private bool ReadAudioChunked(int start, int length, int chunkSize, [NotNullWhen(true)] out Ref<IPcm>? sound)
     {
-        var scratch = new Pcm<Stereo32BitFloat>(AudioInfo.SampleRate, length);
+        var scratch = new Pcm<Stereo32BitFloat>(chunkSize, length);
         try
         {
             int offset = 0;
@@ -204,7 +210,7 @@ public sealed class FFmpegReaderProxy : MediaReader
             {
                 // Trim the trailing over-allocation so callers see the real decoded length
                 // (NumSamples == offset), not a zero-filled tail.
-                var trimmed = new Pcm<Stereo32BitFloat>(AudioInfo.SampleRate, offset);
+                var trimmed = new Pcm<Stereo32BitFloat>(chunkSize, offset);
                 scratch.DataSpan.Slice(0, offset).CopyTo(trimmed.DataSpan);
                 scratch.Dispose();
                 sound = Ref<IPcm>.Create(trimmed);

--- a/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegReaderProxy.cs
+++ b/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegReaderProxy.cs
@@ -135,7 +135,7 @@ public sealed class FFmpegReaderProxy : MediaReader
         // SampleRate(1秒分)を超える場合はリクエストを分割
         if (length > sampleRate)
         {
-            return ReadAudioChunked(start, length, sampleRate, out sound);
+            return ReadAudioChunked(start, length, sampleRate, sampleRate, out sound);
         }
 
         return ReadAudioCore(start, length, out sound);
@@ -171,9 +171,9 @@ public sealed class FFmpegReaderProxy : MediaReader
         }
     }
 
-    private bool ReadAudioChunked(int start, int length, int chunkSize, [NotNullWhen(true)] out Ref<IPcm>? sound)
+    private bool ReadAudioChunked(int start, int length, int chunkSize, int sampleRate, [NotNullWhen(true)] out Ref<IPcm>? sound)
     {
-        var scratch = new Pcm<Stereo32BitFloat>(chunkSize, length);
+        var scratch = new Pcm<Stereo32BitFloat>(sampleRate, length);
         try
         {
             int offset = 0;
@@ -210,7 +210,7 @@ public sealed class FFmpegReaderProxy : MediaReader
             {
                 // Trim the trailing over-allocation so callers see the real decoded length
                 // (NumSamples == offset), not a zero-filled tail.
-                var trimmed = new Pcm<Stereo32BitFloat>(chunkSize, offset);
+                var trimmed = new Pcm<Stereo32BitFloat>(sampleRate, offset);
                 scratch.DataSpan.Slice(0, offset).CopyTo(trimmed.DataSpan);
                 scratch.Dispose();
                 sound = Ref<IPcm>.Create(trimmed);

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
@@ -128,7 +128,7 @@ public class MFReader : MediaReader
 
     public override VideoStreamInfo VideoInfo => _videoInfo ?? throw new NotSupportedException();
 
-    public override AudioStreamInfo AudioInfo => _audioInfo ?? throw new NotSupportedException();
+    public override AudioStreamInfo? AudioInfo => _audioInfo;
 
     public override bool HasVideo { get; }
 

--- a/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
+++ b/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
@@ -141,7 +141,7 @@ public sealed class FFmpegReader : MediaReader
 
     public override VideoStreamInfo VideoInfo => field ?? throw new Exception("The stream does not exist.");
 
-    public override AudioStreamInfo AudioInfo => field ?? throw new Exception("The stream does not exist.");
+    public override AudioStreamInfo? AudioInfo => field;
 
     public override bool HasVideo => _hasVideo;
 
@@ -149,17 +149,23 @@ public sealed class FFmpegReader : MediaReader
 
     public override bool ReadAudio(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? result)
     {
+        if (AudioInfo is not { } audioInfo)
+        {
+            result = null;
+            return false;
+        }
+
         // Decoder側でResampleされるかのチェックのため
         if (length == 0)
         {
-            result = Ref<IPcm>.Create(new Pcm<Stereo32BitFloat>(AudioInfo.SampleRate, 0));
+            result = Ref<IPcm>.Create(new Pcm<Stereo32BitFloat>(audioInfo.SampleRate, 0));
             return true;
         }
 
         result = null;
         if (_audioDecoder == null || _currentAudioFrame == null) return false;
 
-        var sound = new Pcm<Stereo32BitFloat>(AudioInfo.SampleRate, length);
+        var sound = new Pcm<Stereo32BitFloat>(audioInfo.SampleRate, length);
         if (ReadAudio(start, length, MemoryMarshal.AsBytes(sound.DataSpan), out _))
         {
             result = Ref<IPcm>.Create(sound);
@@ -176,9 +182,12 @@ public sealed class FFmpegReader : MediaReader
     {
         info = default;
 
+        if (AudioInfo is not { } audioInfo)
+            return false;
+
         if (length == 0)
         {
-            info = new AudioFrameInfo { SampleRate = AudioInfo.SampleRate, NumSamples = 0, DataLength = 0, };
+            info = new AudioFrameInfo { SampleRate = audioInfo.SampleRate, NumSamples = 0, DataLength = 0, };
             return true;
         }
 
@@ -249,7 +258,7 @@ public sealed class FFmpegReader : MediaReader
                 {
                     info = new AudioFrameInfo
                     {
-                        SampleRate = AudioInfo.SampleRate,
+                        SampleRate = audioInfo.SampleRate,
                         NumSamples = decoded,
                         DataLength = decoded * sampleSize,
                     };
@@ -261,7 +270,7 @@ public sealed class FFmpegReader : MediaReader
 
             info = new AudioFrameInfo
             {
-                SampleRate = AudioInfo.SampleRate,
+                SampleRate = audioInfo.SampleRate,
                 NumSamples = decoded,
                 DataLength = decoded * sampleSize,
             };

--- a/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
+++ b/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
@@ -218,7 +218,7 @@ public sealed class FFmpegReader : MediaReader
                 // SampleConverterの設定
                 _sampleConverter.SetOpts(
                     AV_CHANNEL_LAYOUT_STEREO,
-                    AudioInfo.SampleRate,
+                    audioInfo.SampleRate,
                     AVSampleFormat.AV_SAMPLE_FMT_FLT,
                     _currentAudioFrame.NbSamples);
 

--- a/src/Beutl.FFmpegWorker/Handlers/DecodingHandler.cs
+++ b/src/Beutl.FFmpegWorker/Handlers/DecodingHandler.cs
@@ -52,9 +52,9 @@ internal sealed partial class DecodingHandler : IDisposable
                 () => Interlocked.Increment(ref _shmGeneration));
         }
 
-        if (reader.HasAudio)
+        if (reader.HasAudio && reader.AudioInfo is { } audioInfo)
         {
-            long audioBufferSize = reader.AudioInfo.SampleRate * 8 + 64; // 1 second stereo float
+            long audioBufferSize = audioInfo.SampleRate * 8 + 64; // 1 second stereo float
             string audioShmName = $"beutl-ffmpeg-audio-{Environment.ProcessId}-{id}";
             state.AudioBuffer = SharedMemoryBuffer.Create(audioShmName, audioBufferSize);
         }
@@ -85,9 +85,8 @@ internal sealed partial class DecodingHandler : IDisposable
             response.DurationDen = vi.Duration.Denominator;
         }
 
-        if (reader.HasAudio)
+        if (reader.HasAudio && reader.AudioInfo is { } ai)
         {
-            var ai = reader.AudioInfo;
             response.AudioCodecName = ai.CodecName;
             response.AudioDurationNum = ai.Duration.Numerator;
             response.AudioDurationDen = ai.Duration.Denominator;

--- a/src/Beutl/ViewModels/EditContext/ElementAdderImpl.cs
+++ b/src/Beutl/ViewModels/EditContext/ElementAdderImpl.cs
@@ -125,7 +125,7 @@ internal sealed class ElementAdderImpl(EditViewModel context) : IElementAdder
             {
                 _logger.LogDebug("File is a video.");
                 // Probe the audio track so a video-only file (e.g. an .mkv without sound) does not
-                // get a SourceSound element that would crash on AudioInfo access (#2183).
+                // get a SourceSound element with no audio stream (#2183).
                 bool hasAudio = HasAudioTrack(desc.FileName);
                 // The audio companion goes to desc.Layer + 1; refuse the whole import when that
                 // layer is locked and an audio companion is actually going to be created.

--- a/tests/Beutl.Extensions.AVFoundation.Tests/EncodeDecodeRoundTripTests.cs
+++ b/tests/Beutl.Extensions.AVFoundation.Tests/EncodeDecodeRoundTripTests.cs
@@ -69,7 +69,7 @@ public class EncodeDecodeRoundTripTests
         Assert.That(reader.VideoInfo.CodecName, Is.Not.Empty);
 
         Assert.That(reader.HasAudio, Is.True, "Decoded file should expose an audio track.");
-        Assert.That(reader.AudioInfo.SampleRate, Is.EqualTo(sampleRate));
+        Assert.That(reader.AudioInfo!.SampleRate, Is.EqualTo(sampleRate));
 
         // Read a representative frame from mid-clip; VideoToolbox is lossy so we only
         // check the decode succeeded without asserting pixel equality.
@@ -146,7 +146,7 @@ public class EncodeDecodeRoundTripTests
         var decodingExtension = new AVFDecodingExtension();
         using var reader = new AVFReader(outputPath, new MediaOptions(), decodingExtension);
         Assert.That(reader.HasAudio, Is.True);
-        Assert.That(reader.AudioInfo.SampleRate, Is.EqualTo(sampleRate));
+        Assert.That(reader.AudioInfo!.SampleRate, Is.EqualTo(sampleRate));
 
         int[] probes =
         {

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/MFReaderIntegrationTests.cs
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/MFReaderIntegrationTests.cs
@@ -66,8 +66,8 @@ public class MFReaderIntegrationTests
         {
             Assert.That(reader!.HasVideo, Is.False, "the WAV has no video stream");
             Assert.That(reader.HasAudio, Is.True);
-            Assert.That(reader.AudioInfo.SampleRate, Is.EqualTo(44100));
-            Assert.That(reader.AudioInfo.NumChannels, Is.EqualTo(2));
+            Assert.That(reader.AudioInfo!.SampleRate, Is.EqualTo(44100));
+            Assert.That(reader.AudioInfo!.NumChannels, Is.EqualTo(2));
         });
 
         bool read = reader!.ReadAudio(0, 4410, out var pcm);

--- a/tests/Beutl.FFmpegBenchmarks/Program.cs
+++ b/tests/Beutl.FFmpegBenchmarks/Program.cs
@@ -104,8 +104,8 @@ internal static class Program
 
         if (reader.HasAudio)
         {
-            int sampleRate = reader.AudioInfo.SampleRate;
-            Console.WriteLine($"  音声: {sampleRate}Hz, {reader.AudioInfo.NumChannels}ch");
+            int sampleRate = reader.AudioInfo!.SampleRate;
+            Console.WriteLine($"  音声: {sampleRate}Hz, {reader.AudioInfo!.NumChannels}ch");
 
             // 4. 音声読み取り
             results.Audio = MeasureAudio(reader, sampleRate);

--- a/tests/Beutl.HeadlessUITests/VideoFileImportTests.cs
+++ b/tests/Beutl.HeadlessUITests/VideoFileImportTests.cs
@@ -154,8 +154,9 @@ public class VideoFileImportTests
         public IEnumerable<string> AudioExtensions() => [];
     }
 
-    // Mirrors the real backends: AudioInfo/VideoInfo throw "The stream does not exist." when the
-    // reader was not created with the corresponding stream, exactly like FFmpegReaderProxy.
+    // Mirrors the real backends: VideoInfo throws "The stream does not exist." when the reader was
+    // not created with a video stream, exactly like FFmpegReaderProxy. AudioInfo is null when the
+    // reader has no audio stream.
     private sealed class ImportTestReader : MediaReader
     {
         private readonly VideoStreamInfo? _videoInfo;
@@ -185,7 +186,7 @@ public class VideoFileImportTests
 
         public override VideoStreamInfo VideoInfo => _videoInfo ?? throw new Exception("The stream does not exist.");
 
-        public override AudioStreamInfo AudioInfo => _audioInfo ?? throw new Exception("The stream does not exist.");
+        public override AudioStreamInfo? AudioInfo => _audioInfo;
 
         public override bool HasVideo { get; }
 

--- a/tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs
@@ -181,6 +181,27 @@ public class SourceSoundThumbnailTests
         Assert.That(duration, Is.EqualTo(TimeSpan.Zero));
     }
 
+    // Regression for #2183: a video-only source (no audio track) must yield no waveform chunks
+    // instead of throwing from AudioInfo dereference while the resource loads.
+    [Test]
+    public async Task GetWaveformChunks_VideoOnlySource_YieldsNothing()
+    {
+        string path = TestMediaHelper.CreateTestVideoFile(80, 80, new Rational(30, 1), 60);
+        var soundSource = new SoundSource();
+        soundSource.ReadFrom(new Uri(path));
+
+        var sound = new SourceSound
+        {
+            Source = { CurrentValue = soundSource },
+            TimeRange = new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(2)),
+        };
+
+        var chunks = await CollectAsync(sound, 50, 4096, new FakeWaveformCache());
+
+        Assert.That(chunks, Is.Empty,
+            "音声トラックのないソースは波形チャンクを生成しない (#2183)");
+    }
+
     private static async Task<List<WaveformChunk>> CollectAsync(
         SourceSound sound, int chunkCount, int samplesPerChunk, IThumbnailCacheService cache)
     {

--- a/tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs
@@ -202,6 +202,26 @@ public class SourceSoundThumbnailTests
             "音声トラックのないソースは波形チャンクを生成しない (#2183)");
     }
 
+    // Regression for #2183: a reader that reports HasAudio but whose AudioInfo getter throws (the old
+    // FFmpegReaderProxy behavior) must not leak the exception out of TryGetOriginalDuration.
+    [Test]
+    public void TryGetOriginalDuration_AudioInfoGetterThrows_ReturnsFalseWithoutThrowing()
+    {
+        string path = TestMediaHelper.CreateTestThrowingAudioFile();
+        var soundSource = new SoundSource();
+        soundSource.ReadFrom(new Uri(path));
+        var sound = new SourceSound
+        {
+            Source = { CurrentValue = soundSource }
+        };
+
+        bool result = sound.TryGetOriginalDuration(out TimeSpan duration);
+
+        Assert.That(result, Is.False,
+            "AudioInfo が例外を投げるソースでも TryGetOriginalDuration は例外を漏らさない (#2183)");
+        Assert.That(duration, Is.EqualTo(TimeSpan.Zero));
+    }
+
     private static async Task<List<WaveformChunk>> CollectAsync(
         SourceSound sound, int chunkCount, int samplesPerChunk, IThumbnailCacheService cache)
     {

--- a/tests/Beutl.UnitTests/Engine/Graphics/MediaSourceResourceShareTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/MediaSourceResourceShareTest.cs
@@ -233,8 +233,8 @@ public class MediaSourceResourceShareTest
     }
 
     // Regression for #2183: a video-only file (no audio track) must not crash SoundSource.Resource.
-    // The test decoder's TestMediaReader reports HasAudio == false for .testvideo files, mirroring the
-    // FFmpegReaderProxy behavior that threw "The stream does not exist." when AudioInfo was dereferenced.
+    // The test decoder's TestMediaReader reports HasAudio == false (and a null AudioInfo) for
+    // .testvideo files, mirroring the real backends.
     [Test]
     public void SoundSource_VideoOnlyFile_DoesNotThrowAndYieldsUnloadedResource()
     {

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/TestMediaHelper.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/TestMediaHelper.cs
@@ -102,6 +102,18 @@ internal static class TestMediaHelper
 
         return (int.Parse(match.Groups[1].Value), int.Parse(match.Groups[2].Value), int.Parse(match.Groups[3].Value));
     }
+
+    public static string CreateTestThrowingAudioFile()
+    {
+        var fileName = "test-throwing-audio.testthrowingaudio";
+        var filePath = Path.Combine(Path.GetTempPath(), fileName);
+        if (!File.Exists(filePath))
+        {
+            File.WriteAllBytes(filePath, []);
+        }
+
+        return filePath;
+    }
 }
 
 internal sealed class TestDecoderInfo : IDecoderInfo
@@ -116,6 +128,11 @@ internal sealed class TestDecoderInfo : IDecoderInfo
             return new TestAudioReader(rate, channels, TimeSpan.FromMilliseconds(ms));
         }
 
+        if (Path.GetExtension(file).Equals(".testthrowingaudio", StringComparison.OrdinalIgnoreCase))
+        {
+            return new TestThrowingAudioReader();
+        }
+
         if (!IsSupported(file))
             return null;
 
@@ -127,7 +144,8 @@ internal sealed class TestDecoderInfo : IDecoderInfo
     {
         var ext = Path.GetExtension(file);
         return ext.Equals(".testvideo", StringComparison.OrdinalIgnoreCase)
-            || ext.Equals(".testaudio", StringComparison.OrdinalIgnoreCase);
+            || ext.Equals(".testaudio", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".testthrowingaudio", StringComparison.OrdinalIgnoreCase);
     }
 
     public IEnumerable<string> VideoExtensions() => [".testvideo"];
@@ -239,5 +257,36 @@ internal sealed class TestAudioReader : MediaReader
 
         sound = Ref<IPcm>.Create(pcm);
         return true;
+    }
+}
+
+// Reports HasAudio but throws from the AudioInfo getter (old FFmpegReaderProxy behavior).
+internal sealed class TestThrowingAudioReader : MediaReader
+{
+    private readonly VideoStreamInfo _videoInfo;
+
+    public TestThrowingAudioReader()
+    {
+        _videoInfo = new VideoStreamInfo("test", 0, default, new Rational(1, 1));
+    }
+
+    public override VideoStreamInfo VideoInfo => _videoInfo;
+
+    public override AudioStreamInfo? AudioInfo => throw new Exception("The stream does not exist.");
+
+    public override bool HasVideo => false;
+
+    public override bool HasAudio => true;
+
+    public override bool ReadVideo(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
+    {
+        image = null;
+        return false;
+    }
+
+    public override bool ReadAudio(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
+    {
+        sound = null;
+        return false;
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/TestMediaHelper.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/TestMediaHelper.cs
@@ -141,7 +141,6 @@ internal sealed class TestMediaReader : MediaReader
     private readonly Rational _frameRate;
     private readonly int _frameCount;
     private readonly VideoStreamInfo _videoInfo;
-    private readonly AudioStreamInfo _audioInfo;
 
     public TestMediaReader(PixelSize frameSize, Rational frameRate, int frameCount)
     {
@@ -153,16 +152,11 @@ internal sealed class TestMediaReader : MediaReader
             frameCount,
             frameSize,
             frameRate);
-        _audioInfo = new AudioStreamInfo(
-            "test",
-            Rational.Zero,
-            44100,
-            2);
     }
 
     public override VideoStreamInfo VideoInfo => _videoInfo;
 
-    public override AudioStreamInfo AudioInfo => _audioInfo;
+    public override AudioStreamInfo? AudioInfo => null;
 
     public override bool HasVideo => true;
 

--- a/tests/Beutl.UnitTests/Media/Proxy/ProxyMediaReaderTests.cs
+++ b/tests/Beutl.UnitTests/Media/Proxy/ProxyMediaReaderTests.cs
@@ -141,11 +141,7 @@ public sealed class ProxyMediaReaderTests
             frameSize: new PixelSize(50, 40),
             frameRate: new Rational(30, 1));
 
-        public override AudioStreamInfo AudioInfo { get; } = new AudioStreamInfo(
-            CodecName: "test",
-            Duration: Rational.Zero,
-            SampleRate: 44100,
-            NumChannels: 2);
+        public override AudioStreamInfo? AudioInfo => null;
 
         public override bool HasVideo => true;
         public override bool HasAudio => false;


### PR DESCRIPTION
## Summary

Fixes the crash where opening media without an audio track threw `The stream does not exist.` from `FFmpegReaderProxy.get_AudioInfo()`, surfacing as an unhandled exception (Critical, `IsTerminating: true`) during clip resize, plus thumbnail-update and audio-playback failures.

**Root cause:** `MediaReader.AudioInfo` threw for the *normal* state of "no audio stream". The `Try`-prefixed APIs (`Element.TryGetOriginalDuration` / `SourceSound.TryGetOriginalDuration`) leaked that exception, and the resize path trusted the Try-pattern contract without try/catch.

**Fix:** `MediaReader.AudioInfo` is now `AudioStreamInfo?` and returns `null` for media without an audio stream. All 8 readers (`FFmpegReaderProxy`, GPL `FFmpegReader`, `AVFReader`, `MFReader`, `AnimatedPngReader`, `AnimatedImageReader`, `WaveReader`, `ProxyMediaReader`) and all callers were updated. `SourceSound.TryGetOriginalDuration` now honors the Try-pattern contract (never leaks a resource-loading exception).

## BREAKING CHANGE

`MediaReader.AudioInfo` is now nullable (`AudioStreamInfo?`) and returns `null` when the media has no audio stream instead of throwing. Subclasses must override it as nullable; callers must handle `null` (or check `HasAudio`) before dereferencing. Affected projects: `Beutl.Engine` and plugins subclassing `MediaReader`.

## Tests

- `TryGetOriginalDuration_AudioInfoGetterThrows` — red-first regression test: a reader with `HasAudio => true` whose `AudioInfo` getter throws; asserts `TryGetOriginalDuration` returns false without throwing (fails on old code, passes on new).
- `GetWaveformChunks_VideoOnlySource_YieldsNothing` — video-only source yields no waveform chunks.
- Full solution build 0 warnings/0 errors; all test projects green; `dotnet format --verify-no-changes` clean.

## Board

Refs: Project #9 item (音声トラックのないメディアで get_AudioInfo が例外を投げ、クリップのリサイズ操作でアプリがクラッシュする)

## Note for reviewer

The design reviewer flagged an asymmetric null-vs-throw contract between `AudioInfo?` (now null) and `VideoInfo` (still throws). This PR keeps the asymmetry (scoped to the audio bug); symmetric nullability of `VideoInfo` is a separate, larger breaking change touching the video pipeline and is left for a human decision.