### PR TITLE
refactor!(ffmpeg): suppress missing-libraries error spam and lengthen re-probe cooldown

### DIFF
--- a/src/Beutl.Extensions.FFmpeg.Core/FFmpegLibraryState.cs
+++ b/src/Beutl.Extensions.FFmpeg.Core/FFmpegLibraryState.cs
@@ -85,8 +85,22 @@ public static class FFmpegLibraryState
     // log a first discovery as an error and an already-known short-circuit quietly.
     public static bool RecordMissingObserved()
     {
+        bool wasKnownMissing = RecordMissingObservedCore(out PendingNotification? notification);
+        DrainNotifications(notification);
+        return wasKnownMissing;
+    }
+
+    internal static bool RecordMissingObservedDeferred(out Action dispatchNotifications)
+    {
+        bool wasKnownMissing = RecordMissingObservedCore(out PendingNotification? notification);
+        dispatchNotifications = () => DrainNotifications(notification);
+        return wasKnownMissing;
+    }
+
+    private static bool RecordMissingObservedCore(out PendingNotification? notification)
+    {
         bool wasKnownMissing;
-        PendingNotification? notification = null;
+        notification = null;
         lock (s_stateGate)
         {
             bool shouldNotify;
@@ -97,7 +111,6 @@ public static class FFmpegLibraryState
                 notification = QueueNotificationCore(NotificationKind.AvailabilityChanged, isLibrariesMissing: true);
         }
 
-        DrainNotifications(notification);
         return wasKnownMissing;
     }
 
@@ -167,7 +180,8 @@ public static class FFmpegLibraryState
 
         if (becameDispatcher)
         {
-            DrainAsDispatcher(notifications);
+            DrainAsDispatcher();
+            AwaitOwnedNotifications(notifications);
             return;
         }
 
@@ -200,9 +214,8 @@ public static class FFmpegLibraryState
         }
     }
 
-    private static void DrainAsDispatcher(PendingNotification?[] ownerNotifications)
+    private static void DrainAsDispatcher()
     {
-        Exception? firstException = null;
         while (true)
         {
             PendingNotification notification;
@@ -220,15 +233,25 @@ public static class FFmpegLibraryState
                 notification.IsClaimed = true;
             }
 
+            InvokeNotification(notification, rethrow: false);
+        }
+    }
+
+    private static void AwaitOwnedNotifications(PendingNotification?[] notifications)
+    {
+        Exception? firstException = null;
+        foreach (PendingNotification? notification in notifications)
+        {
+            if (notification is null)
+                continue;
+
             try
             {
-                bool belongsToDispatcher = Array.IndexOf(ownerNotifications, notification) >= 0;
-                InvokeNotification(notification, rethrow: belongsToDispatcher);
+                notification.Completion.Task.GetAwaiter().GetResult();
             }
             catch (Exception ex)
             {
                 firstException ??= ex;
-                _ = notification.Completion.Task.Exception;
             }
         }
 

--- a/src/Beutl.Extensions.FFmpeg.Core/FFmpegLibraryState.cs
+++ b/src/Beutl.Extensions.FFmpeg.Core/FFmpegLibraryState.cs
@@ -1,5 +1,10 @@
 ﻿namespace Beutl.Extensions.FFmpeg;
 
+public sealed class FFmpegLibraryAvailabilityChangedEventArgs(bool isLibrariesMissing) : EventArgs
+{
+    public bool IsLibrariesMissing { get; } = isLibrariesMissing;
+}
+
 public static class FFmpegLibraryState
 {
     private enum NotificationKind
@@ -19,7 +24,8 @@ public static class FFmpegLibraryState
     // subscribers, so callbacks can synchronously dispatch another state transition without a
     // cross-thread lock cycle.
     private static readonly object s_notificationGate = new();
-    private static readonly Queue<NotificationKind> s_pendingNotifications = new();
+    private static readonly LinkedList<PendingNotification> s_pendingNotifications = new();
+    private static readonly AsyncLocal<NotificationDispatchContext?> s_notificationContext = new();
     private static bool s_isDispatchingNotifications;
     private static volatile bool s_librariesMissing;
     private static long s_missingSinceTicks;
@@ -36,22 +42,27 @@ public static class FFmpegLibraryState
 
     public static void NotifyMissing()
     {
+        PendingNotification? availabilityNotification = null;
+        PendingNotification missingNotification;
         lock (s_stateGate)
         {
             bool shouldNotify = SetLibrariesMissingCore(true, notify: true, notifyWhenUnchanged: false);
 
             if (shouldNotify)
-                QueueNotificationCore(NotificationKind.AvailabilityChanged);
-            QueueNotificationCore(NotificationKind.LibrariesMissing);
+                availabilityNotification = QueueNotificationCore(
+                    NotificationKind.AvailabilityChanged,
+                    isLibrariesMissing: true);
+            missingNotification = QueueNotificationCore(NotificationKind.LibrariesMissing, isLibrariesMissing: true);
         }
 
-        DrainNotifications();
+        DrainNotifications(availabilityNotification, missingNotification);
     }
 
     public static void MarkInstalled() => SetLibrariesMissing(false, notifyWhenUnchanged: true);
 
     public static void MarkMissing()
     {
+        PendingNotification? notification = null;
         lock (s_stateGate)
         {
             bool shouldNotify;
@@ -62,10 +73,10 @@ public static class FFmpegLibraryState
             shouldNotify = SetLibrariesMissingCore(true, notify: true, notifyWhenUnchanged: false);
 
             if (shouldNotify)
-                QueueNotificationCore(NotificationKind.AvailabilityChanged);
+                notification = QueueNotificationCore(NotificationKind.AvailabilityChanged, isLibrariesMissing: true);
         }
 
-        DrainNotifications();
+        DrainNotifications(notification);
     }
 
     // Record the missing latch observed by a decode attempt WITHOUT re-arming the cooldown (a real
@@ -75,6 +86,7 @@ public static class FFmpegLibraryState
     public static bool RecordMissingObserved()
     {
         bool wasKnownMissing;
+        PendingNotification? notification = null;
         lock (s_stateGate)
         {
             bool shouldNotify;
@@ -82,10 +94,10 @@ public static class FFmpegLibraryState
             shouldNotify = SetLibrariesMissingCore(true, notify: true, notifyWhenUnchanged: false);
 
             if (shouldNotify)
-                QueueNotificationCore(NotificationKind.AvailabilityChanged);
+                notification = QueueNotificationCore(NotificationKind.AvailabilityChanged, isLibrariesMissing: true);
         }
 
-        DrainNotifications();
+        DrainNotifications(notification);
         return wasKnownMissing;
     }
 
@@ -120,37 +132,78 @@ public static class FFmpegLibraryState
 
     private static void SetLibrariesMissing(bool value, bool notify = true, bool notifyWhenUnchanged = false)
     {
+        PendingNotification? notification = null;
         lock (s_stateGate)
         {
             bool shouldNotify = SetLibrariesMissingCore(value, notify, notifyWhenUnchanged);
             if (notify && shouldNotify)
-                QueueNotificationCore(NotificationKind.AvailabilityChanged);
+                notification = QueueNotificationCore(NotificationKind.AvailabilityChanged, value);
         }
 
         if (notify)
-            DrainNotifications();
+            DrainNotifications(notification);
     }
 
-    private static void QueueNotificationCore(NotificationKind notification)
+    private static PendingNotification QueueNotificationCore(NotificationKind kind, bool isLibrariesMissing)
     {
+        var notification = new PendingNotification(kind, isLibrariesMissing);
         lock (s_notificationGate)
-            s_pendingNotifications.Enqueue(notification);
+            s_pendingNotifications.AddLast(notification);
+        return notification;
     }
 
-    private static void DrainNotifications()
+    private static void DrainNotifications(params PendingNotification?[] notifications)
     {
+        bool becameDispatcher;
         lock (s_notificationGate)
         {
-            if (s_isDispatchingNotifications)
-                return;
-
-            s_isDispatchingNotifications = true;
+            becameDispatcher = !s_isDispatchingNotifications;
+            if (becameDispatcher)
+                s_isDispatchingNotifications = true;
         }
 
+        if (becameDispatcher)
+        {
+            DrainAsDispatcher();
+            return;
+        }
+
+        foreach (PendingNotification? notification in notifications)
+        {
+            if (notification is null)
+                continue;
+
+            bool invokeDirectly;
+            lock (s_notificationGate)
+            {
+                NotificationDispatchContext? context = s_notificationContext.Value;
+                invokeDirectly = context is { IsActive: true }
+                    && TryClaimNotificationCore(notification);
+            }
+
+            if (invokeDirectly)
+            {
+                try
+                {
+                    InvokeNotification(notification, rethrow: true);
+                }
+                catch
+                {
+                    _ = notification.Completion.Task.Exception;
+                    throw;
+                }
+            }
+            else
+                notification.Completion.Task.GetAwaiter().GetResult();
+        }
+    }
+
+    private static void DrainAsDispatcher()
+    {
         Exception? firstException = null;
         while (true)
         {
-            NotificationKind notification;
+            PendingNotification notification;
             lock (s_notificationGate)
             {
                 if (s_pendingNotifications.Count == 0)
@@ -159,29 +212,92 @@ public static class FFmpegLibraryState
                     break;
                 }
 
-                notification = s_pendingNotifications.Dequeue();
+                notification = s_pendingNotifications.First!.Value;
+                s_pendingNotifications.RemoveFirst();
+                notification.IsClaimed = true;
             }
 
             try
             {
-                switch (notification)
-                {
-                    case NotificationKind.AvailabilityChanged:
-                        AvailabilityChanged?.Invoke(null, EventArgs.Empty);
-                        break;
-                    case NotificationKind.LibrariesMissing:
-                        LibrariesMissing?.Invoke(null, EventArgs.Empty);
-                        break;
-                }
+                InvokeNotification(notification, rethrow: true);
             }
             catch (Exception ex)
             {
                 firstException ??= ex;
+                _ = notification.Completion.Task.Exception;
             }
         }
 
         if (firstException is not null)
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(firstException).Throw();
+    }
+
+    private static bool TryClaimNotificationCore(PendingNotification notification)
+    {
+        if (notification.IsClaimed)
+            return false;
+
+        LinkedListNode<PendingNotification>? node = s_pendingNotifications.Find(notification);
+        if (node is null)
+            return false;
+
+        s_pendingNotifications.Remove(node);
+        notification.IsClaimed = true;
+        return true;
+    }
+
+    private static void InvokeNotification(PendingNotification notification, bool rethrow)
+    {
+        NotificationDispatchContext? previousContext = s_notificationContext.Value;
+        var context = new NotificationDispatchContext();
+        s_notificationContext.Value = context;
+        lock (s_notificationGate)
+            context.IsActive = true;
+        try
+        {
+            switch (notification.Kind)
+            {
+                case NotificationKind.AvailabilityChanged:
+                    AvailabilityChanged?.Invoke(
+                        null,
+                        new FFmpegLibraryAvailabilityChangedEventArgs(notification.IsLibrariesMissing));
+                    break;
+                case NotificationKind.LibrariesMissing:
+                    LibrariesMissing?.Invoke(null, EventArgs.Empty);
+                    break;
+            }
+
+            notification.Completion.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            notification.Completion.TrySetException(ex);
+            if (rethrow)
+                throw;
+        }
+        finally
+        {
+            lock (s_notificationGate)
+                context.IsActive = false;
+            s_notificationContext.Value = previousContext;
+        }
+    }
+
+    private sealed class NotificationDispatchContext
+    {
+        public bool IsActive { get; set; }
+    }
+
+    private sealed class PendingNotification(NotificationKind kind, bool isLibrariesMissing)
+    {
+        public NotificationKind Kind { get; } = kind;
+
+        public bool IsLibrariesMissing { get; } = isLibrariesMissing;
+
+        public TaskCompletionSource Completion { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool IsClaimed { get; set; }
     }
 
     private static bool SetLibrariesMissingCore(bool value, bool notify, bool notifyWhenUnchanged)

--- a/src/Beutl.Extensions.FFmpeg.Core/FFmpegLibraryState.cs
+++ b/src/Beutl.Extensions.FFmpeg.Core/FFmpegLibraryState.cs
@@ -5,7 +5,9 @@ public static class FFmpegLibraryState
     // After libraries are reported missing, skip fresh worker-start probes for this long, then allow
     // a probe so a transient failure (momentary file lock, crashed worker) can self-recover without
     // the user re-running the install wizard. A genuinely-missing install just re-arms the cooldown.
-    private const long ReprobeCooldownMs = 5_000;
+    // 30s bounds a missing-FFmpeg session to ~2 worker-start attempts per minute, so the worker's own
+    // "libraries not found" stdout error does not repeat on every frame/thumbnail request.
+    private const long ReprobeCooldownMs = 30_000;
     private static volatile bool s_librariesMissing;
     private static long s_missingSinceTicks;
 
@@ -36,11 +38,16 @@ public static class FFmpegLibraryState
         SetLibrariesMissing(true);
     }
 
-    // Record the missing latch observed by a decode attempt WITHOUT re-arming the cooldown. The
-    // short-circuit throw (ShouldSkipStartProbe) surfaces the same exception as a real failure, so
-    // re-arming here would push the re-probe window forward on every short-circuited decode and keep
-    // queued jobs from ever re-probing. A real worker-start failure arms the cooldown itself.
-    public static void MarkMissingObserved() => SetLibrariesMissing(true);
+    // Record the missing latch observed by a decode attempt WITHOUT re-arming the cooldown (a real
+    // worker-start failure arms it; re-arming on a short-circuited decode would keep the re-probe
+    // window from ever elapsing). Returns whether the condition was already known, so callers can
+    // log a first discovery as an error and an already-known short-circuit quietly.
+    public static bool RecordMissingObserved()
+    {
+        bool wasKnownMissing = s_librariesMissing;
+        SetLibrariesMissing(true);
+        return wasKnownMissing;
+    }
 
     // A worker process handshaked successfully, so FFmpeg loaded: clear any missing latch. This is
     // the self-recovery path for a transient failure that had latched the queue.

--- a/src/Beutl.Extensions.FFmpeg.Core/FFmpegLibraryState.cs
+++ b/src/Beutl.Extensions.FFmpeg.Core/FFmpegLibraryState.cs
@@ -21,12 +21,12 @@ public static class FFmpegLibraryState
     private const long ReprobeCooldownMs = 30_000;
     private static readonly object s_stateGate = new();
     // This gate protects only the pending notification queue. It is never held while invoking
-    // subscribers, so callbacks can synchronously dispatch another state transition without a
-    // cross-thread lock cycle.
+    // subscribers, so callbacks can synchronously dispatch another state transition on the
+    // dispatcher thread without a cross-thread lock cycle.
     private static readonly object s_notificationGate = new();
     private static readonly LinkedList<PendingNotification> s_pendingNotifications = new();
-    private static readonly AsyncLocal<NotificationDispatchContext?> s_notificationContext = new();
     private static bool s_isDispatchingNotifications;
+    private static int s_dispatcherThreadId;
     private static volatile bool s_librariesMissing;
     private static long s_missingSinceTicks;
 
@@ -159,12 +159,15 @@ public static class FFmpegLibraryState
         {
             becameDispatcher = !s_isDispatchingNotifications;
             if (becameDispatcher)
+            {
                 s_isDispatchingNotifications = true;
+                s_dispatcherThreadId = Environment.CurrentManagedThreadId;
+            }
         }
 
         if (becameDispatcher)
         {
-            DrainAsDispatcher();
+            DrainAsDispatcher(notifications);
             return;
         }
 
@@ -176,8 +179,7 @@ public static class FFmpegLibraryState
             bool invokeDirectly;
             lock (s_notificationGate)
             {
-                NotificationDispatchContext? context = s_notificationContext.Value;
-                invokeDirectly = context is { IsActive: true }
+                invokeDirectly = Environment.CurrentManagedThreadId == s_dispatcherThreadId
                     && TryClaimNotificationCore(notification);
             }
 
@@ -198,7 +200,7 @@ public static class FFmpegLibraryState
         }
     }
 
-    private static void DrainAsDispatcher()
+    private static void DrainAsDispatcher(PendingNotification?[] ownerNotifications)
     {
         Exception? firstException = null;
         while (true)
@@ -209,6 +211,7 @@ public static class FFmpegLibraryState
                 if (s_pendingNotifications.Count == 0)
                 {
                     s_isDispatchingNotifications = false;
+                    s_dispatcherThreadId = 0;
                     break;
                 }
 
@@ -219,7 +222,8 @@ public static class FFmpegLibraryState
 
             try
             {
-                InvokeNotification(notification, rethrow: true);
+                bool belongsToDispatcher = Array.IndexOf(ownerNotifications, notification) >= 0;
+                InvokeNotification(notification, rethrow: belongsToDispatcher);
             }
             catch (Exception ex)
             {
@@ -248,11 +252,6 @@ public static class FFmpegLibraryState
 
     private static void InvokeNotification(PendingNotification notification, bool rethrow)
     {
-        NotificationDispatchContext? previousContext = s_notificationContext.Value;
-        var context = new NotificationDispatchContext();
-        s_notificationContext.Value = context;
-        lock (s_notificationGate)
-            context.IsActive = true;
         try
         {
             switch (notification.Kind)
@@ -275,17 +274,6 @@ public static class FFmpegLibraryState
             if (rethrow)
                 throw;
         }
-        finally
-        {
-            lock (s_notificationGate)
-                context.IsActive = false;
-            s_notificationContext.Value = previousContext;
-        }
-    }
-
-    private sealed class NotificationDispatchContext
-    {
-        public bool IsActive { get; set; }
     }
 
     private sealed class PendingNotification(NotificationKind kind, bool isLibrariesMissing)

--- a/src/Beutl.Extensions.FFmpeg.Core/FFmpegLibraryState.cs
+++ b/src/Beutl.Extensions.FFmpeg.Core/FFmpegLibraryState.cs
@@ -2,6 +2,12 @@
 
 public static class FFmpegLibraryState
 {
+    private enum NotificationKind
+    {
+        AvailabilityChanged,
+        LibrariesMissing,
+    }
+
     // After libraries are reported missing, skip fresh worker-start probes for this long, then allow
     // a probe so a transient failure (momentary file lock, crashed worker) can self-recover without
     // the user re-running the install wizard. A genuinely-missing install just re-arms the cooldown.
@@ -9,7 +15,12 @@ public static class FFmpegLibraryState
     // "libraries not found" stdout error does not repeat on every frame/thumbnail request.
     private const long ReprobeCooldownMs = 30_000;
     private static readonly object s_stateGate = new();
+    // This gate protects only the pending notification queue. It is never held while invoking
+    // subscribers, so callbacks can synchronously dispatch another state transition without a
+    // cross-thread lock cycle.
     private static readonly object s_notificationGate = new();
+    private static readonly Queue<NotificationKind> s_pendingNotifications = new();
+    private static bool s_isDispatchingNotifications;
     private static volatile bool s_librariesMissing;
     private static long s_missingSinceTicks;
 
@@ -25,39 +36,36 @@ public static class FFmpegLibraryState
 
     public static void NotifyMissing()
     {
-        lock (s_notificationGate)
+        lock (s_stateGate)
         {
-            bool shouldNotify;
-            lock (s_stateGate)
-                shouldNotify = SetLibrariesMissingCore(true, notify: true, notifyWhenUnchanged: false);
+            bool shouldNotify = SetLibrariesMissingCore(true, notify: true, notifyWhenUnchanged: false);
 
             if (shouldNotify)
-                AvailabilityChanged?.Invoke(null, EventArgs.Empty);
-
-            LibrariesMissing?.Invoke(null, EventArgs.Empty);
+                QueueNotificationCore(NotificationKind.AvailabilityChanged);
+            QueueNotificationCore(NotificationKind.LibrariesMissing);
         }
+
+        DrainNotifications();
     }
 
     public static void MarkInstalled() => SetLibrariesMissing(false, notifyWhenUnchanged: true);
 
     public static void MarkMissing()
     {
-        lock (s_notificationGate)
+        lock (s_stateGate)
         {
             bool shouldNotify;
-            lock (s_stateGate)
-            {
-                // Arm the cooldown before notifying: SetLibrariesMissing raises AvailabilityChanged,
-                // and a listener that reacts synchronously must already see ShouldSkipStartProbe ==
-                // true, otherwise it can immediately re-probe the worker before the cooldown is in
-                // effect.
-                ArmReprobeCooldownCore();
-                shouldNotify = SetLibrariesMissingCore(true, notify: true, notifyWhenUnchanged: false);
-            }
+            // Arm the cooldown before notifying: SetLibrariesMissing raises AvailabilityChanged, and
+            // a listener that reacts synchronously must already see ShouldSkipStartProbe == true,
+            // otherwise it can immediately re-probe the worker before the cooldown is in effect.
+            ArmReprobeCooldownCore();
+            shouldNotify = SetLibrariesMissingCore(true, notify: true, notifyWhenUnchanged: false);
 
             if (shouldNotify)
-                AvailabilityChanged?.Invoke(null, EventArgs.Empty);
+                QueueNotificationCore(NotificationKind.AvailabilityChanged);
         }
+
+        DrainNotifications();
     }
 
     // Record the missing latch observed by a decode attempt WITHOUT re-arming the cooldown (a real
@@ -66,21 +74,19 @@ public static class FFmpegLibraryState
     // log a first discovery as an error and an already-known short-circuit quietly.
     public static bool RecordMissingObserved()
     {
-        lock (s_notificationGate)
+        bool wasKnownMissing;
+        lock (s_stateGate)
         {
-            bool wasKnownMissing;
             bool shouldNotify;
-            lock (s_stateGate)
-            {
-                wasKnownMissing = s_librariesMissing;
-                shouldNotify = SetLibrariesMissingCore(true, notify: true, notifyWhenUnchanged: false);
-            }
+            wasKnownMissing = s_librariesMissing;
+            shouldNotify = SetLibrariesMissingCore(true, notify: true, notifyWhenUnchanged: false);
 
             if (shouldNotify)
-                AvailabilityChanged?.Invoke(null, EventArgs.Empty);
-
-            return wasKnownMissing;
+                QueueNotificationCore(NotificationKind.AvailabilityChanged);
         }
+
+        DrainNotifications();
+        return wasKnownMissing;
     }
 
     // A worker process handshaked successfully, so FFmpeg loaded: clear any missing latch. This is
@@ -96,11 +102,8 @@ public static class FFmpegLibraryState
     // window forward and re-latch the queue.
     public static void ArmReprobeCooldown()
     {
-        lock (s_notificationGate)
-        {
-            lock (s_stateGate)
-                ArmReprobeCooldownCore();
-        }
+        lock (s_stateGate)
+            ArmReprobeCooldownCore();
     }
 
     // True while a fresh worker-start probe should be skipped (libraries reported missing and the
@@ -117,18 +120,68 @@ public static class FFmpegLibraryState
 
     private static void SetLibrariesMissing(bool value, bool notify = true, bool notifyWhenUnchanged = false)
     {
+        lock (s_stateGate)
+        {
+            bool shouldNotify = SetLibrariesMissingCore(value, notify, notifyWhenUnchanged);
+            if (notify && shouldNotify)
+                QueueNotificationCore(NotificationKind.AvailabilityChanged);
+        }
+
+        if (notify)
+            DrainNotifications();
+    }
+
+    private static void QueueNotificationCore(NotificationKind notification)
+    {
+        lock (s_notificationGate)
+            s_pendingNotifications.Enqueue(notification);
+    }
+
+    private static void DrainNotifications()
+    {
         lock (s_notificationGate)
         {
-            bool shouldNotify;
-            lock (s_stateGate)
-                shouldNotify = SetLibrariesMissingCore(value, notify, notifyWhenUnchanged);
-
-            if (!notify)
+            if (s_isDispatchingNotifications)
                 return;
 
-            if (shouldNotify)
-                AvailabilityChanged?.Invoke(null, EventArgs.Empty);
+            s_isDispatchingNotifications = true;
         }
+
+        Exception? firstException = null;
+        while (true)
+        {
+            NotificationKind notification;
+            lock (s_notificationGate)
+            {
+                if (s_pendingNotifications.Count == 0)
+                {
+                    s_isDispatchingNotifications = false;
+                    break;
+                }
+
+                notification = s_pendingNotifications.Dequeue();
+            }
+
+            try
+            {
+                switch (notification)
+                {
+                    case NotificationKind.AvailabilityChanged:
+                        AvailabilityChanged?.Invoke(null, EventArgs.Empty);
+                        break;
+                    case NotificationKind.LibrariesMissing:
+                        LibrariesMissing?.Invoke(null, EventArgs.Empty);
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                firstException ??= ex;
+            }
+        }
+
+        if (firstException is not null)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(firstException).Throw();
     }
 
     private static bool SetLibrariesMissingCore(bool value, bool notify, bool notifyWhenUnchanged)

--- a/src/Beutl.Extensions.FFmpeg.Core/FFmpegLibraryState.cs
+++ b/src/Beutl.Extensions.FFmpeg.Core/FFmpegLibraryState.cs
@@ -8,6 +8,8 @@ public static class FFmpegLibraryState
     // 30s bounds a missing-FFmpeg session to ~2 worker-start attempts per minute, so the worker's own
     // "libraries not found" stdout error does not repeat on every frame/thumbnail request.
     private const long ReprobeCooldownMs = 30_000;
+    private static readonly object s_stateGate = new();
+    private static readonly object s_notificationGate = new();
     private static volatile bool s_librariesMissing;
     private static long s_missingSinceTicks;
 
@@ -23,19 +25,39 @@ public static class FFmpegLibraryState
 
     public static void NotifyMissing()
     {
-        SetLibrariesMissing(true);
-        LibrariesMissing?.Invoke(null, EventArgs.Empty);
+        lock (s_notificationGate)
+        {
+            bool shouldNotify;
+            lock (s_stateGate)
+                shouldNotify = SetLibrariesMissingCore(true, notify: true, notifyWhenUnchanged: false);
+
+            if (shouldNotify)
+                AvailabilityChanged?.Invoke(null, EventArgs.Empty);
+
+            LibrariesMissing?.Invoke(null, EventArgs.Empty);
+        }
     }
 
     public static void MarkInstalled() => SetLibrariesMissing(false, notifyWhenUnchanged: true);
 
     public static void MarkMissing()
     {
-        // Arm the cooldown before notifying: SetLibrariesMissing raises AvailabilityChanged, and a
-        // listener that reacts synchronously must already see ShouldSkipStartProbe == true, otherwise
-        // it can immediately re-probe the worker before the cooldown is in effect.
-        ArmReprobeCooldown();
-        SetLibrariesMissing(true);
+        lock (s_notificationGate)
+        {
+            bool shouldNotify;
+            lock (s_stateGate)
+            {
+                // Arm the cooldown before notifying: SetLibrariesMissing raises AvailabilityChanged,
+                // and a listener that reacts synchronously must already see ShouldSkipStartProbe ==
+                // true, otherwise it can immediately re-probe the worker before the cooldown is in
+                // effect.
+                ArmReprobeCooldownCore();
+                shouldNotify = SetLibrariesMissingCore(true, notify: true, notifyWhenUnchanged: false);
+            }
+
+            if (shouldNotify)
+                AvailabilityChanged?.Invoke(null, EventArgs.Empty);
+        }
     }
 
     // Record the missing latch observed by a decode attempt WITHOUT re-arming the cooldown (a real
@@ -44,9 +66,21 @@ public static class FFmpegLibraryState
     // log a first discovery as an error and an already-known short-circuit quietly.
     public static bool RecordMissingObserved()
     {
-        bool wasKnownMissing = s_librariesMissing;
-        SetLibrariesMissing(true);
-        return wasKnownMissing;
+        lock (s_notificationGate)
+        {
+            bool wasKnownMissing;
+            bool shouldNotify;
+            lock (s_stateGate)
+            {
+                wasKnownMissing = s_librariesMissing;
+                shouldNotify = SetLibrariesMissingCore(true, notify: true, notifyWhenUnchanged: false);
+            }
+
+            if (shouldNotify)
+                AvailabilityChanged?.Invoke(null, EventArgs.Empty);
+
+            return wasKnownMissing;
+        }
     }
 
     // A worker process handshaked successfully, so FFmpeg loaded: clear any missing latch. This is
@@ -61,7 +95,13 @@ public static class FFmpegLibraryState
     // libraries missing, so gate short-circuits (which never start a worker) cannot keep pushing the
     // window forward and re-latch the queue.
     public static void ArmReprobeCooldown()
-        => Interlocked.Exchange(ref s_missingSinceTicks, Environment.TickCount64);
+    {
+        lock (s_notificationGate)
+        {
+            lock (s_stateGate)
+                ArmReprobeCooldownCore();
+        }
+    }
 
     // True while a fresh worker-start probe should be skipped (libraries reported missing and the
     // re-probe cooldown has not elapsed). After the cooldown, callers should attempt a real start so
@@ -77,15 +117,33 @@ public static class FFmpegLibraryState
 
     private static void SetLibrariesMissing(bool value, bool notify = true, bool notifyWhenUnchanged = false)
     {
+        lock (s_notificationGate)
+        {
+            bool shouldNotify;
+            lock (s_stateGate)
+                shouldNotify = SetLibrariesMissingCore(value, notify, notifyWhenUnchanged);
+
+            if (!notify)
+                return;
+
+            if (shouldNotify)
+                AvailabilityChanged?.Invoke(null, EventArgs.Empty);
+        }
+    }
+
+    private static bool SetLibrariesMissingCore(bool value, bool notify, bool notifyWhenUnchanged)
+    {
         bool changed = s_librariesMissing != value;
         if (!value)
             Interlocked.Exchange(ref s_missingSinceTicks, 0);
 
         if (!changed && !notifyWhenUnchanged)
-            return;
+            return false;
 
         s_librariesMissing = value;
-        if (notify)
-            AvailabilityChanged?.Invoke(null, EventArgs.Empty);
+        return notify;
     }
+
+    private static void ArmReprobeCooldownCore()
+        => Interlocked.Exchange(ref s_missingSinceTicks, Environment.TickCount64);
 }

--- a/src/Beutl.Extensions.FFmpeg.Core/FFmpegLibraryState.cs
+++ b/src/Beutl.Extensions.FFmpeg.Core/FFmpegLibraryState.cs
@@ -21,15 +21,12 @@ public static class FFmpegLibraryState
     private const long ReprobeCooldownMs = 30_000;
     private static readonly object s_stateGate = new();
     // This gate protects only the pending notification queue. It is never held while invoking
-    // subscribers, so callbacks can synchronously dispatch another state transition on the
-    // dispatcher thread without a cross-thread lock cycle.
+    // subscribers, so callback-dispatched transitions can be queued without a cross-thread lock
+    // cycle. The dispatcher exclusively drains the queue in FIFO order.
     private static readonly object s_notificationGate = new();
     private static readonly LinkedList<PendingNotification> s_pendingNotifications = new();
-    // This marker flows into callback-created tasks. Those descendants enqueue their transition and
-    // return instead of waiting for the dispatcher that is still executing their originating callback.
-    // They never claim queue entries; FIFO delivery remains exclusively owned by DrainAsDispatcher.
-    private static readonly AsyncLocal<NotificationDispatchContext?> s_dispatchContext = new();
     private static bool s_isDispatchingNotifications;
+    private static long s_notificationGeneration;
     private static volatile bool s_librariesMissing;
     private static long s_missingSinceTicks;
 
@@ -141,7 +138,14 @@ public static class FFmpegLibraryState
 
     // Clear the missing latch without signaling availability, used while a verification/install run
     // is in progress so consumers do not prematurely resume before the outcome is known.
-    public static void MarkVerificationStarted() => SetLibrariesMissing(false, notify: false);
+    public static void MarkVerificationStarted()
+    {
+        lock (s_stateGate)
+        {
+            SetLibrariesMissingCore(false, notify: false, notifyWhenUnchanged: false);
+            s_notificationGeneration++;
+        }
+    }
 
     // Start the re-probe throttle window. Called only when a real worker-start attempt observed the
     // libraries missing, so gate short-circuits (which never start a worker) cannot keep pushing the
@@ -176,7 +180,7 @@ public static class FFmpegLibraryState
 
     private static PendingNotification QueueNotificationCore(NotificationKind kind, bool isLibrariesMissing)
     {
-        var notification = new PendingNotification(kind, isLibrariesMissing, hasOwner: s_dispatchContext.Value is null);
+        var notification = new PendingNotification(kind, isLibrariesMissing, s_notificationGeneration);
         lock (s_notificationGate)
             s_pendingNotifications.AddLast(notification);
         return notification;
@@ -201,16 +205,9 @@ public static class FFmpegLibraryState
             return;
         }
 
-        if (s_dispatchContext.Value is not null)
-            return;
-
-        foreach (PendingNotification? notification in notifications)
-        {
-            if (notification is null)
-                continue;
-
-            notification.Completion.Task.GetAwaiter().GetResult();
-        }
+        // Never wait while another callback owns the dispatcher. The callback may synchronously wait
+        // for this transition even when ExecutionContext flow is suppressed, so waiting here would
+        // deadlock the callback and the worker that is trying to enqueue its notification.
     }
 
     private static void DrainAsDispatcher()
@@ -230,8 +227,20 @@ public static class FFmpegLibraryState
                 s_pendingNotifications.RemoveFirst();
             }
 
+            if (!IsNotificationCurrent(notification))
+            {
+                notification.Completion.TrySetResult();
+                continue;
+            }
+
             InvokeNotification(notification);
         }
+    }
+
+    private static bool IsNotificationCurrent(PendingNotification notification)
+    {
+        lock (s_stateGate)
+            return notification.Generation == s_notificationGeneration;
     }
 
     private static void AwaitOwnedNotifications(PendingNotification?[] notifications)
@@ -258,8 +267,6 @@ public static class FFmpegLibraryState
 
     private static void InvokeNotification(PendingNotification notification)
     {
-        NotificationDispatchContext? previousContext = s_dispatchContext.Value;
-        s_dispatchContext.Value = new NotificationDispatchContext();
         try
         {
             switch (notification.Kind)
@@ -279,26 +286,17 @@ public static class FFmpegLibraryState
         catch (Exception ex)
         {
             notification.Completion.TrySetException(ex);
-            if (!notification.HasOwner)
-                _ = notification.Completion.Task.Exception;
-        }
-        finally
-        {
-            s_dispatchContext.Value = previousContext;
+            _ = notification.Completion.Task.Exception;
         }
     }
 
-    private sealed class NotificationDispatchContext
-    {
-    }
-
-    private sealed class PendingNotification(NotificationKind kind, bool isLibrariesMissing, bool hasOwner)
+    private sealed class PendingNotification(NotificationKind kind, bool isLibrariesMissing, long generation)
     {
         public NotificationKind Kind { get; } = kind;
 
         public bool IsLibrariesMissing { get; } = isLibrariesMissing;
 
-        public bool HasOwner { get; } = hasOwner;
+        public long Generation { get; } = generation;
 
         public TaskCompletionSource Completion { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Beutl.Extensions.FFmpeg.Core/FFmpegLibraryState.cs
+++ b/src/Beutl.Extensions.FFmpeg.Core/FFmpegLibraryState.cs
@@ -28,6 +28,7 @@ public static class FFmpegLibraryState
     private static bool s_isDispatchingNotifications;
     private static long s_notificationGeneration;
     private static volatile bool s_librariesMissing;
+    private static volatile bool s_verificationInProgress;
     private static long s_missingSinceTicks;
 
     public static event EventHandler? LibrariesMissing;
@@ -37,6 +38,8 @@ public static class FFmpegLibraryState
     public static event EventHandler? AvailabilityChanged;
 
     public static bool IsLibrariesMissing => s_librariesMissing;
+
+    public static bool IsVerificationInProgress => s_verificationInProgress;
 
     public static long MissingSinceTicks => Interlocked.Read(ref s_missingSinceTicks);
 
@@ -58,13 +61,15 @@ public static class FFmpegLibraryState
         DrainNotifications(availabilityNotification, missingNotification);
     }
 
-    public static void MarkInstalled() => SetLibrariesMissing(false, notifyWhenUnchanged: true);
+    public static void MarkInstalled()
+        => SetLibrariesMissing(false, notifyWhenUnchanged: true, clearVerification: true);
 
     public static void MarkMissing()
     {
         PendingNotification? notification = null;
         lock (s_stateGate)
         {
+            s_verificationInProgress = false;
             bool shouldNotify;
             // Arm the cooldown before notifying: SetLibrariesMissing raises AvailabilityChanged, and
             // a listener that reacts synchronously must already see ShouldSkipStartProbe == true,
@@ -86,6 +91,7 @@ public static class FFmpegLibraryState
         PendingNotification? notification = null;
         lock (s_stateGate)
         {
+            s_verificationInProgress = false;
             if (!ShouldSkipStartProbeCore(Environment.TickCount64))
                 ArmReprobeCooldownCore();
 
@@ -134,7 +140,7 @@ public static class FFmpegLibraryState
 
     // A worker process handshaked successfully, so FFmpeg loaded: clear any missing latch. This is
     // the self-recovery path for a transient failure that had latched the queue.
-    public static void NotifyWorkerStarted() => SetLibrariesMissing(false);
+    public static void NotifyWorkerStarted() => SetLibrariesMissing(false, clearVerification: true);
 
     // Clear the missing latch without signaling availability, used while a verification/install run
     // is in progress so consumers do not prematurely resume before the outcome is known.
@@ -143,6 +149,7 @@ public static class FFmpegLibraryState
         lock (s_stateGate)
         {
             SetLibrariesMissingCore(false, notify: false, notifyWhenUnchanged: false);
+            s_verificationInProgress = true;
             s_notificationGeneration++;
         }
     }
@@ -164,11 +171,18 @@ public static class FFmpegLibraryState
         return ShouldSkipStartProbeCore(now);
     }
 
-    private static void SetLibrariesMissing(bool value, bool notify = true, bool notifyWhenUnchanged = false)
+    private static void SetLibrariesMissing(
+        bool value,
+        bool notify = true,
+        bool notifyWhenUnchanged = false,
+        bool clearVerification = false)
     {
         PendingNotification? notification = null;
         lock (s_stateGate)
         {
+            if (clearVerification)
+                s_verificationInProgress = false;
+
             bool shouldNotify = SetLibrariesMissingCore(value, notify, notifyWhenUnchanged);
             if (notify && shouldNotify)
                 notification = QueueNotificationCore(NotificationKind.AvailabilityChanged, value);

--- a/src/Beutl.Extensions.FFmpeg.Core/FFmpegLibraryState.cs
+++ b/src/Beutl.Extensions.FFmpeg.Core/FFmpegLibraryState.cs
@@ -79,6 +79,24 @@ public static class FFmpegLibraryState
         DrainNotifications(notification);
     }
 
+    // Mark libraries missing after a worker failure, but preserve an active cooldown when this is
+    // only a repeated short-circuit observation from another caller.
+    public static void MarkMissingIfNeeded()
+    {
+        PendingNotification? notification = null;
+        lock (s_stateGate)
+        {
+            if (!ShouldSkipStartProbeCore(Environment.TickCount64))
+                ArmReprobeCooldownCore();
+
+            bool shouldNotify = SetLibrariesMissingCore(true, notify: true, notifyWhenUnchanged: false);
+            if (shouldNotify)
+                notification = QueueNotificationCore(NotificationKind.AvailabilityChanged, isLibrariesMissing: true);
+        }
+
+        DrainNotifications(notification);
+    }
+
     // Record the missing latch observed by a decode attempt WITHOUT re-arming the cooldown (a real
     // worker-start failure arms it; re-arming on a short-circuited decode would keep the re-probe
     // window from ever elapsing). Returns whether the condition was already known, so callers can
@@ -136,11 +154,7 @@ public static class FFmpegLibraryState
     // the outcome re-probes actual FFmpeg availability instead of trusting the sticky flag.
     public static bool ShouldSkipStartProbe(long now)
     {
-        if (!s_librariesMissing)
-            return false;
-
-        long since = Interlocked.Read(ref s_missingSinceTicks);
-        return since != 0 && now - since < ReprobeCooldownMs;
+        return ShouldSkipStartProbeCore(now);
     }
 
     private static void SetLibrariesMissing(bool value, bool notify = true, bool notifyWhenUnchanged = false)
@@ -326,4 +340,13 @@ public static class FFmpegLibraryState
 
     private static void ArmReprobeCooldownCore()
         => Interlocked.Exchange(ref s_missingSinceTicks, Environment.TickCount64);
+
+    private static bool ShouldSkipStartProbeCore(long now)
+    {
+        if (!s_librariesMissing)
+            return false;
+
+        long since = Interlocked.Read(ref s_missingSinceTicks);
+        return since != 0 && now - since < ReprobeCooldownMs;
+    }
 }

--- a/src/Beutl.Extensions.FFmpeg.Core/FFmpegLibraryState.cs
+++ b/src/Beutl.Extensions.FFmpeg.Core/FFmpegLibraryState.cs
@@ -25,8 +25,11 @@ public static class FFmpegLibraryState
     // dispatcher thread without a cross-thread lock cycle.
     private static readonly object s_notificationGate = new();
     private static readonly LinkedList<PendingNotification> s_pendingNotifications = new();
+    // This marker flows into callback-created tasks. Those descendants enqueue their transition and
+    // return instead of waiting for the dispatcher that is still executing their originating callback.
+    // They never claim queue entries; FIFO delivery remains exclusively owned by DrainAsDispatcher.
+    private static readonly AsyncLocal<NotificationDispatchContext?> s_dispatchContext = new();
     private static bool s_isDispatchingNotifications;
-    private static int s_dispatcherThreadId;
     private static volatile bool s_librariesMissing;
     private static long s_missingSinceTicks;
 
@@ -173,7 +176,7 @@ public static class FFmpegLibraryState
 
     private static PendingNotification QueueNotificationCore(NotificationKind kind, bool isLibrariesMissing)
     {
-        var notification = new PendingNotification(kind, isLibrariesMissing);
+        var notification = new PendingNotification(kind, isLibrariesMissing, hasOwner: s_dispatchContext.Value is null);
         lock (s_notificationGate)
             s_pendingNotifications.AddLast(notification);
         return notification;
@@ -188,7 +191,6 @@ public static class FFmpegLibraryState
             if (becameDispatcher)
             {
                 s_isDispatchingNotifications = true;
-                s_dispatcherThreadId = Environment.CurrentManagedThreadId;
             }
         }
 
@@ -199,32 +201,15 @@ public static class FFmpegLibraryState
             return;
         }
 
+        if (s_dispatchContext.Value is not null)
+            return;
+
         foreach (PendingNotification? notification in notifications)
         {
             if (notification is null)
                 continue;
 
-            bool invokeDirectly;
-            lock (s_notificationGate)
-            {
-                invokeDirectly = Environment.CurrentManagedThreadId == s_dispatcherThreadId
-                    && TryClaimNotificationCore(notification);
-            }
-
-            if (invokeDirectly)
-            {
-                try
-                {
-                    InvokeNotification(notification, rethrow: true);
-                }
-                catch
-                {
-                    _ = notification.Completion.Task.Exception;
-                    throw;
-                }
-            }
-            else
-                notification.Completion.Task.GetAwaiter().GetResult();
+            notification.Completion.Task.GetAwaiter().GetResult();
         }
     }
 
@@ -238,16 +223,14 @@ public static class FFmpegLibraryState
                 if (s_pendingNotifications.Count == 0)
                 {
                     s_isDispatchingNotifications = false;
-                    s_dispatcherThreadId = 0;
                     break;
                 }
 
                 notification = s_pendingNotifications.First!.Value;
                 s_pendingNotifications.RemoveFirst();
-                notification.IsClaimed = true;
             }
 
-            InvokeNotification(notification, rethrow: false);
+            InvokeNotification(notification);
         }
     }
 
@@ -273,22 +256,10 @@ public static class FFmpegLibraryState
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(firstException).Throw();
     }
 
-    private static bool TryClaimNotificationCore(PendingNotification notification)
+    private static void InvokeNotification(PendingNotification notification)
     {
-        if (notification.IsClaimed)
-            return false;
-
-        LinkedListNode<PendingNotification>? node = s_pendingNotifications.Find(notification);
-        if (node is null)
-            return false;
-
-        s_pendingNotifications.Remove(node);
-        notification.IsClaimed = true;
-        return true;
-    }
-
-    private static void InvokeNotification(PendingNotification notification, bool rethrow)
-    {
+        NotificationDispatchContext? previousContext = s_dispatchContext.Value;
+        s_dispatchContext.Value = new NotificationDispatchContext();
         try
         {
             switch (notification.Kind)
@@ -308,21 +279,29 @@ public static class FFmpegLibraryState
         catch (Exception ex)
         {
             notification.Completion.TrySetException(ex);
-            if (rethrow)
-                throw;
+            if (!notification.HasOwner)
+                _ = notification.Completion.Task.Exception;
+        }
+        finally
+        {
+            s_dispatchContext.Value = previousContext;
         }
     }
 
-    private sealed class PendingNotification(NotificationKind kind, bool isLibrariesMissing)
+    private sealed class NotificationDispatchContext
+    {
+    }
+
+    private sealed class PendingNotification(NotificationKind kind, bool isLibrariesMissing, bool hasOwner)
     {
         public NotificationKind Kind { get; } = kind;
 
         public bool IsLibrariesMissing { get; } = isLibrariesMissing;
 
+        public bool HasOwner { get; } = hasOwner;
+
         public TaskCompletionSource Completion { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        public bool IsClaimed { get; set; }
     }
 
     private static bool SetLibrariesMissingCore(bool value, bool notify, bool notifyWhenUnchanged)

--- a/src/Beutl.Extensions.FFmpeg.Core/FFmpegWorkerCodecCache.cs
+++ b/src/Beutl.Extensions.FFmpeg.Core/FFmpegWorkerCodecCache.cs
@@ -1,4 +1,5 @@
 ﻿using Beutl.Extensions.FFmpeg.Encoding;
+using Beutl.FFmpegIpc;
 using Beutl.FFmpegIpc.Protocol;
 using Beutl.FFmpegIpc.Protocol.Messages;
 using Beutl.Logging;
@@ -58,6 +59,17 @@ internal static class FFmpegWorkerCodecCache
             _videoCodecs = result;
             return result;
         }
+        catch (FFmpegLibrariesNotFoundException ex)
+        {
+            // Only the first discovery is an error; later attempts are expected short-circuits that
+            // would otherwise spam the log every time the codec list is opened without FFmpeg.
+            bool wasKnownMissing = FFmpegLibraryState.RecordMissingObserved();
+            if (wasKnownMissing)
+                s_logger.LogDebug(ex, "FFmpeg libraries missing; skipping video codec query");
+            else
+                s_logger.LogError(ex, "Failed to query video codecs from worker");
+            return [CodecRecord.Default];
+        }
         catch (Exception ex)
         {
             s_logger.LogError(ex, "Failed to query video codecs from worker");
@@ -79,6 +91,17 @@ internal static class FFmpegWorkerCodecCache
                 .ToArray();
             _audioCodecs = result;
             return result;
+        }
+        catch (FFmpegLibrariesNotFoundException ex)
+        {
+            // Only the first discovery is an error; later attempts are expected short-circuits that
+            // would otherwise spam the log every time the codec list is opened without FFmpeg.
+            bool wasKnownMissing = FFmpegLibraryState.RecordMissingObserved();
+            if (wasKnownMissing)
+                s_logger.LogDebug(ex, "FFmpeg libraries missing; skipping audio codec query");
+            else
+                s_logger.LogError(ex, "Failed to query audio codecs from worker");
+            return [CodecRecord.Default];
         }
         catch (Exception ex)
         {

--- a/src/Beutl.Extensions.FFmpeg.Core/FFmpegWorkerCodecCache.cs
+++ b/src/Beutl.Extensions.FFmpeg.Core/FFmpegWorkerCodecCache.cs
@@ -17,17 +17,49 @@ internal static class FFmpegWorkerCodecCache
     private static readonly object s_lock = new();
     private static volatile IReadOnlyList<object>? _videoCodecs;
     private static volatile IReadOnlyList<object>? _audioCodecs;
+    private static bool s_missingQueryInFlight;
 
     public static IReadOnlyList<object> GetVideoCodecs()
     {
         var cached = _videoCodecs;
         if (cached != null) return cached;
 
+        (IReadOnlyList<object> Codecs, FFmpegLibrariesNotFoundException? MissingException) query;
+        Action? dispatchMissingNotification = null;
+        bool wasKnownMissing = false;
         lock (s_lock)
         {
             cached = _videoCodecs;
             if (cached != null) return cached;
-            return RefreshVideoCodecs();
+            if (s_missingQueryInFlight)
+                return [CodecRecord.Default];
+
+            query = RefreshVideoCodecs();
+            if (query.MissingException is not null)
+            {
+                wasKnownMissing = FFmpegLibraryState.RecordMissingObservedDeferred(
+                    out dispatchMissingNotification);
+                s_missingQueryInFlight = true;
+            }
+        }
+
+        try
+        {
+            if (dispatchMissingNotification is not null)
+            {
+                dispatchMissingNotification();
+                LogMissingIfNeeded(query.MissingException!, wasKnownMissing, "video");
+            }
+
+            return query.Codecs;
+        }
+        finally
+        {
+            if (dispatchMissingNotification is not null)
+            {
+                lock (s_lock)
+                    s_missingQueryInFlight = false;
+            }
         }
     }
 
@@ -36,15 +68,47 @@ internal static class FFmpegWorkerCodecCache
         var cached = _audioCodecs;
         if (cached != null) return cached;
 
+        (IReadOnlyList<object> Codecs, FFmpegLibrariesNotFoundException? MissingException) query;
+        Action? dispatchMissingNotification = null;
+        bool wasKnownMissing = false;
         lock (s_lock)
         {
             cached = _audioCodecs;
             if (cached != null) return cached;
-            return RefreshAudioCodecs();
+            if (s_missingQueryInFlight)
+                return [CodecRecord.Default];
+
+            query = RefreshAudioCodecs();
+            if (query.MissingException is not null)
+            {
+                wasKnownMissing = FFmpegLibraryState.RecordMissingObservedDeferred(
+                    out dispatchMissingNotification);
+                s_missingQueryInFlight = true;
+            }
+        }
+
+        try
+        {
+            if (dispatchMissingNotification is not null)
+            {
+                dispatchMissingNotification();
+                LogMissingIfNeeded(query.MissingException!, wasKnownMissing, "audio");
+            }
+
+            return query.Codecs;
+        }
+        finally
+        {
+            if (dispatchMissingNotification is not null)
+            {
+                lock (s_lock)
+                    s_missingQueryInFlight = false;
+            }
         }
     }
 
-    private static IReadOnlyList<object> RefreshVideoCodecs()
+    private static (IReadOnlyList<object> Codecs, FFmpegLibrariesNotFoundException? MissingException)
+        RefreshVideoCodecs()
     {
         try
         {
@@ -57,27 +121,21 @@ internal static class FFmpegWorkerCodecCache
                 .Prepend(CodecRecord.Default)
                 .ToArray();
             _videoCodecs = result;
-            return result;
+            return (result, null);
         }
         catch (FFmpegLibrariesNotFoundException ex)
         {
-            // Only the first discovery is an error; later attempts are expected short-circuits that
-            // would otherwise spam the log every time the codec list is opened without FFmpeg.
-            bool wasKnownMissing = FFmpegLibraryState.RecordMissingObserved();
-            if (wasKnownMissing)
-                s_logger.LogDebug(ex, "FFmpeg libraries missing; skipping video codec query");
-            else
-                s_logger.LogError(ex, "Failed to query video codecs from worker");
-            return [CodecRecord.Default];
+            return ([CodecRecord.Default], ex);
         }
         catch (Exception ex)
         {
             s_logger.LogError(ex, "Failed to query video codecs from worker");
-            return [CodecRecord.Default];
+            return ([CodecRecord.Default], null);
         }
     }
 
-    private static IReadOnlyList<object> RefreshAudioCodecs()
+    private static (IReadOnlyList<object> Codecs, FFmpegLibrariesNotFoundException? MissingException)
+        RefreshAudioCodecs()
     {
         try
         {
@@ -90,24 +148,30 @@ internal static class FFmpegWorkerCodecCache
                 .Prepend(CodecRecord.Default)
                 .ToArray();
             _audioCodecs = result;
-            return result;
+            return (result, null);
         }
         catch (FFmpegLibrariesNotFoundException ex)
         {
-            // Only the first discovery is an error; later attempts are expected short-circuits that
-            // would otherwise spam the log every time the codec list is opened without FFmpeg.
-            bool wasKnownMissing = FFmpegLibraryState.RecordMissingObserved();
-            if (wasKnownMissing)
-                s_logger.LogDebug(ex, "FFmpeg libraries missing; skipping audio codec query");
-            else
-                s_logger.LogError(ex, "Failed to query audio codecs from worker");
-            return [CodecRecord.Default];
+            return ([CodecRecord.Default], ex);
         }
         catch (Exception ex)
         {
             s_logger.LogError(ex, "Failed to query audio codecs from worker");
-            return [CodecRecord.Default];
+            return ([CodecRecord.Default], null);
         }
+    }
+
+    private static void LogMissingIfNeeded(
+        FFmpegLibrariesNotFoundException exception,
+        bool wasKnownMissing,
+        string mediaType)
+    {
+        // Only the first discovery is an error; later attempts are expected short-circuits that
+        // would otherwise spam the log every time the codec list is opened without FFmpeg.
+        if (wasKnownMissing)
+            s_logger.LogDebug(exception, "FFmpeg libraries missing; skipping {MediaType} codec query", mediaType);
+        else
+            s_logger.LogError(exception, "Failed to query {MediaType} codecs from worker", mediaType);
     }
 
     public static void Invalidate()

--- a/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegDecoderInfo.cs
+++ b/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegDecoderInfo.cs
@@ -52,9 +52,14 @@ public sealed class FFmpegDecoderInfo(FFmpegDecodingSettings settings) : IDecode
             // fallback-less open failure into "unavailable") but still return null, so a regular open
             // can fall through to another decoder — e.g. MediaFoundation can open an MP4 without FFmpeg.
             // Observe-only (no cooldown re-arm): a real worker-start failure arms it; re-arming on a
-            // short-circuited decode would keep the re-probe window from ever elapsing.
-            FFmpegInstallNotifier.MarkMissingObserved();
-            _logger.LogError(ex, "Failed to open media file '{File}'", file);
+            // short-circuited decode would keep the re-probe window from ever elapsing. Only the
+            // first discovery is an error; later attempts are expected short-circuits that would
+            // otherwise spam the log on every frame/thumbnail request.
+            bool wasKnownMissing = FFmpegInstallNotifier.RecordMissingObserved();
+            if (wasKnownMissing)
+                _logger.LogDebug(ex, "FFmpeg libraries missing; skipping open of '{File}'", file);
+            else
+                _logger.LogError(ex, "Failed to open media file '{File}'", file);
             return null;
         }
         catch (Exception ex)

--- a/src/Beutl.Extensions.FFmpeg/FFmpegInstallNotifier.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegInstallNotifier.cs
@@ -26,12 +26,21 @@ internal static class FFmpegInstallNotifier
         if (Interlocked.Exchange(ref s_hooked, 1) != 0)
             return;
 
-        FFmpegLibraryState.LibrariesMissing += (_, _) => NotifyMissing();
+        FFmpegLibraryState.LibrariesMissing += (_, _) => ShowMissingNotification();
     }
 
     public static void NotifyMissing()
     {
-        FFmpegLibraryState.MarkMissing();
+        if (FFmpegLibraryState.ShouldSkipStartProbe(Environment.TickCount64))
+            FFmpegLibraryState.RecordMissingObserved();
+        else
+            FFmpegLibraryState.MarkMissing();
+
+        ShowMissingNotification();
+    }
+
+    private static void ShowMissingNotification()
+    {
         if (!TryAcquireNotifySlot(Environment.TickCount64))
             return;
 

--- a/src/Beutl.Extensions.FFmpeg/FFmpegInstallNotifier.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegInstallNotifier.cs
@@ -61,7 +61,7 @@ internal static class FFmpegInstallNotifier
 
     public static void MarkMissing() => FFmpegLibraryState.MarkMissing();
 
-    internal static void MarkMissingObserved() => FFmpegLibraryState.MarkMissingObserved();
+    internal static bool RecordMissingObserved() => FFmpegLibraryState.RecordMissingObserved();
 
     internal static void NotifyWorkerStarted() => FFmpegLibraryState.NotifyWorkerStarted();
 

--- a/src/Beutl.Extensions.FFmpeg/FFmpegInstallNotifier.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegInstallNotifier.cs
@@ -31,10 +31,7 @@ internal static class FFmpegInstallNotifier
 
     public static void NotifyMissing()
     {
-        if (FFmpegLibraryState.ShouldSkipStartProbe(Environment.TickCount64))
-            FFmpegLibraryState.RecordMissingObserved();
-        else
-            FFmpegLibraryState.MarkMissing();
+        FFmpegLibraryState.MarkMissingIfNeeded();
 
         ShowMissingNotification();
     }

--- a/src/Beutl.Extensions.FFmpeg/FFmpegInstallNotifier.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegInstallNotifier.cs
@@ -13,6 +13,8 @@ internal static class FFmpegInstallNotifier
 
     public static bool IsLibrariesMissing => FFmpegLibraryState.IsLibrariesMissing;
 
+    internal static bool IsVerificationInProgress => FFmpegLibraryState.IsVerificationInProgress;
+
     internal static long MissingSinceTicks => FFmpegLibraryState.MissingSinceTicks;
 
     internal static event EventHandler? AvailabilityChanged

--- a/src/Beutl.Extensions.FFmpeg/Proxy/FFmpegProxyGenerator.cs
+++ b/src/Beutl.Extensions.FFmpeg/Proxy/FFmpegProxyGenerator.cs
@@ -25,7 +25,9 @@ public sealed class FFmpegProxyGenerator(IProxyStore store) : IProxyGenerator, I
         Converters = { new JsonStringEnumConverter() },
     };
 
-    public bool IsAvailable => !FFmpegInstallNotifier.IsLibrariesMissing;
+    public bool IsAvailable
+        => !FFmpegInstallNotifier.IsLibrariesMissing
+            && !FFmpegInstallNotifier.IsVerificationInProgress;
 
     public event EventHandler? AvailabilityChanged
     {

--- a/src/Beutl.FFmpegWorker/FFmpegLoaderWorker.cs
+++ b/src/Beutl.FFmpegWorker/FFmpegLoaderWorker.cs
@@ -98,7 +98,22 @@ internal static class FFmpegLoaderWorker
         // Surface the searched paths so a missing-FFmpeg failure is diagnosable: the worker's
         // "FFmpeg libraries not found" error (relayed to the host log) shows exactly where it looked.
         throw new FFmpegLibrariesNotFoundException(
-            $"FFmpeg libraries not found. Searched: {string.Join(", ", paths)}");
+            $"FFmpeg libraries not found. Searched: {string.Join(", ", paths.Select(RedactPath))}");
+    }
+
+    internal static string RedactPath(string path)
+    {
+        string home = BeutlEnvironment.GetHomeDirectoryPath();
+        if (path.Equals(home, StringComparison.OrdinalIgnoreCase))
+            return "~";
+
+        string homePrefix = home.EndsWith(Path.DirectorySeparatorChar)
+            ? home
+            : home + Path.DirectorySeparatorChar;
+        if (path.StartsWith(homePrefix, StringComparison.OrdinalIgnoreCase))
+            return "~" + path[home.Length..];
+
+        return path;
     }
 
     private static bool LibrariesExists(string basePath)

--- a/src/Beutl.FFmpegWorker/FFmpegLoaderWorker.cs
+++ b/src/Beutl.FFmpegWorker/FFmpegLoaderWorker.cs
@@ -103,15 +103,26 @@ internal static class FFmpegLoaderWorker
 
     internal static string RedactPath(string path)
     {
-        string home = BeutlEnvironment.GetHomeDirectoryPath();
-        if (path.Equals(home, StringComparison.OrdinalIgnoreCase))
-            return "~";
+        string[] privateRoots =
+        [
+            BeutlEnvironment.GetHomeDirectoryPath(),
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        ];
 
-        string homePrefix = home.EndsWith(Path.DirectorySeparatorChar)
-            ? home
-            : home + Path.DirectorySeparatorChar;
-        if (path.StartsWith(homePrefix, StringComparison.OrdinalIgnoreCase))
-            return "~" + path[home.Length..];
+        foreach (string root in privateRoots
+            .Where(static x => !string.IsNullOrEmpty(x))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderByDescending(static x => x.Length))
+        {
+            if (path.Equals(root, StringComparison.OrdinalIgnoreCase))
+                return "~";
+
+            string rootPrefix = root.EndsWith(Path.DirectorySeparatorChar)
+                ? root
+                : root + Path.DirectorySeparatorChar;
+            if (path.StartsWith(rootPrefix, StringComparison.OrdinalIgnoreCase))
+                return "~" + path[root.Length..];
+        }
 
         return path;
     }

--- a/src/Beutl.FFmpegWorker/FFmpegLoaderWorker.cs
+++ b/src/Beutl.FFmpegWorker/FFmpegLoaderWorker.cs
@@ -95,7 +95,10 @@ internal static class FFmpegLoaderWorker
                 return path;
         }
 
-        throw new FFmpegLibrariesNotFoundException("FFmpeg libraries not found");
+        // Surface the searched paths so a missing-FFmpeg failure is diagnosable: the worker's
+        // "FFmpeg libraries not found" error (relayed to the host log) shows exactly where it looked.
+        throw new FFmpegLibrariesNotFoundException(
+            $"FFmpeg libraries not found. Searched: {string.Join(", ", paths)}");
     }
 
     private static bool LibrariesExists(string basePath)

--- a/tests/Beutl.FFmpegWorker.Tests/EncodingCancellationTests.cs
+++ b/tests/Beutl.FFmpegWorker.Tests/EncodingCancellationTests.cs
@@ -16,6 +16,15 @@ namespace Beutl.FFmpegWorker.Tests;
 [TestFixture]
 public class EncodingCancellationTests
 {
+    [Test]
+    public void RedactPath_ReplacesBeutlHomePrefix()
+    {
+        string home = BeutlEnvironment.GetHomeDirectoryPath();
+        string path = Path.Combine(home, "ffmpeg", "native");
+
+        Assert.That(FFmpegLoaderWorker.RedactPath(path), Is.EqualTo("~" + path[home.Length..]));
+    }
+
     // FFmpegLoaderWorker.Initialize() throws FFmpegLibrariesNotFoundException (or another native-load
     // error) when the shared libraries are absent. Probe once; the FFmpeg-native tests self-skip if
     // the natives cannot be loaded on this machine.

--- a/tests/Beutl.FFmpegWorker.Tests/EncodingCancellationTests.cs
+++ b/tests/Beutl.FFmpegWorker.Tests/EncodingCancellationTests.cs
@@ -10,9 +10,6 @@ using FFmpegSharp;
 
 namespace Beutl.FFmpegWorker.Tests;
 
-// A cancelled Encode must throw OperationCanceledException. FFmpeg runs wherever its native
-// libraries are present, so this fixture guards on native availability (Assert.Ignore) rather than
-// a fixed [Platform].
 [TestFixture]
 public class EncodingCancellationTests
 {
@@ -23,6 +20,16 @@ public class EncodingCancellationTests
         string path = Path.Combine(home, "ffmpeg", "native");
 
         Assert.That(FFmpegLoaderWorker.RedactPath(path), Is.EqualTo("~" + path[home.Length..]));
+    }
+
+    [Test]
+    public void RedactPath_ReplacesUserProfilePrefix()
+    {
+        string profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        Assume.That(profile, Is.Not.Null.And.Not.Empty);
+        string path = Path.Combine(profile, "private", "ffmpeg");
+
+        Assert.That(FFmpegLoaderWorker.RedactPath(path), Is.EqualTo("~" + path[profile.Length..]));
     }
 
     // FFmpegLoaderWorker.Initialize() throws FFmpegLibrariesNotFoundException (or another native-load
@@ -82,6 +89,8 @@ public class EncodingCancellationTests
         catch { /* best-effort cleanup */ }
     }
 
+    // A cancelled Encode must throw OperationCanceledException. FFmpeg runs wherever its native
+    // libraries are present, so this test self-skips when the native path is unavailable.
     [Test]
     public void EncodeSurfacesCancellationAsOperationCanceledException()
     {

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
@@ -85,7 +85,7 @@ public class FFmpegInstallNotifierTests
     [Test]
     public void ShouldSkipStartProbe_SkipsWithinCooldownThenAllowsAfterElapsed()
     {
-        const long cooldownMs = 5_000; // mirrors FFmpegInstallNotifier.ReprobeCooldownMs
+        const long cooldownMs = 30_000; // mirrors FFmpegLibraryState.ReprobeCooldownMs
 
         FFmpegInstallNotifier.MarkMissing();
         long since = FFmpegInstallNotifier.MissingSinceTicks;
@@ -100,12 +100,30 @@ public class FFmpegInstallNotifierTests
     }
 
     [Test]
-    public void MarkMissingObserved_SetsLatchWithoutArmingCooldown()
+    public void ShouldSkipStartProbe_RepeatedProbesWithinCooldown_AllShortCircuit()
     {
-        FFmpegInstallNotifier.MarkMissingObserved();
+        // A burst of decode attempts inside the cooldown window must all short-circuit (no worker
+        // re-probe). This is what suppresses the hundreds-of-errors-per-session pattern: only the
+        // first attempt in the window pays for a real worker start.
+        FFmpegInstallNotifier.MarkMissing();
+        long since = FFmpegInstallNotifier.MissingSinceTicks;
+
+        for (long t = since; t < since + 25_000; t += 1_000)
+        {
+            Assert.That(FFmpegInstallNotifier.ShouldSkipStartProbe(t), Is.True,
+                $"expected a short-circuit at t={t - since}ms into the cooldown");
+        }
+    }
+
+    [Test]
+    public void RecordMissingObserved_FirstObservation_ReturnsFalse()
+    {
+        FFmpegInstallNotifier.MarkInstalled();
 
         Assert.Multiple(() =>
         {
+            Assert.That(FFmpegInstallNotifier.RecordMissingObserved(), Is.False,
+                "the first observation is a genuine discovery, so callers must log it as an error");
             Assert.That(FFmpegInstallNotifier.IsLibrariesMissing, Is.True);
             Assert.That(FFmpegInstallNotifier.MissingSinceTicks, Is.EqualTo(0),
                 "an observe-only decode failure must not arm the re-probe cooldown");
@@ -113,12 +131,22 @@ public class FFmpegInstallNotifierTests
     }
 
     [Test]
-    public void MarkMissingObserved_DoesNotPushCooldownWindowForward()
+    public void RecordMissingObserved_SecondObservation_ReturnsTrue()
+    {
+        FFmpegInstallNotifier.MarkInstalled();
+        FFmpegInstallNotifier.RecordMissingObserved();
+
+        Assert.That(FFmpegInstallNotifier.RecordMissingObserved(), Is.True,
+            "a later observation is an expected short-circuit, so callers must fail quietly");
+    }
+
+    [Test]
+    public void RecordMissingObserved_DoesNotPushCooldownWindowForward()
     {
         FFmpegInstallNotifier.MarkMissing();
         long since = FFmpegInstallNotifier.MissingSinceTicks;
 
-        FFmpegInstallNotifier.MarkMissingObserved();
+        FFmpegInstallNotifier.RecordMissingObserved();
 
         Assert.That(FFmpegInstallNotifier.MissingSinceTicks, Is.EqualTo(since),
             "a short-circuited decode must not re-arm and push the cooldown window forward");

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
@@ -153,6 +153,80 @@ public class FFmpegInstallNotifierTests
     }
 
     [Test]
+    public void RecordMissingObserved_UnderConcurrency_OnlyOneFirstObservation()
+    {
+        const int iterations = 25;
+        const int threads = 64;
+
+        for (int i = 0; i < iterations; i++)
+        {
+            FFmpegInstallNotifier.MarkInstalled();
+
+            int firstObservations = 0;
+            using var barrier = new Barrier(threads);
+            var tasks = new Task[threads];
+            for (int t = 0; t < threads; t++)
+            {
+                tasks[t] = Task.Run(() =>
+                {
+                    barrier.SignalAndWait();
+                    if (!FFmpegInstallNotifier.RecordMissingObserved())
+                        Interlocked.Increment(ref firstObservations);
+                });
+            }
+
+            Task.WaitAll(tasks);
+            Assert.That(firstObservations, Is.EqualTo(1),
+                $"iteration {i}: expected exactly one first observation");
+        }
+    }
+
+    [Test]
+    public void AvailabilityChanged_SerializesTransitionsUntilNotificationCompletes()
+    {
+        FFmpegInstallNotifier.MarkInstalled();
+        using var firstNotificationEntered = new ManualResetEventSlim();
+        using var releaseFirstNotification = new ManualResetEventSlim();
+        int callbackCount = 0;
+
+        void OnAvailabilityChanged(object? sender, EventArgs e)
+        {
+            if (Interlocked.Increment(ref callbackCount) == 1)
+            {
+                firstNotificationEntered.Set();
+                releaseFirstNotification.Wait();
+            }
+        }
+
+        FFmpegInstallNotifier.AvailabilityChanged += OnAvailabilityChanged;
+        try
+        {
+            Task first = Task.Run(FFmpegInstallNotifier.MarkMissing);
+            Assert.That(firstNotificationEntered.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "the first availability notification did not start");
+
+            Task second = Task.Run(FFmpegInstallNotifier.MarkInstalled);
+            Assert.Multiple(() =>
+            {
+                Assert.That(second.Wait(TimeSpan.FromMilliseconds(100)), Is.False,
+                    "the next transition must wait for the in-flight notification");
+                Assert.That(FFmpegInstallNotifier.IsLibrariesMissing, Is.True,
+                    "the next transition must not mutate state before its notification turn");
+            });
+
+            releaseFirstNotification.Set();
+            Task.WaitAll(first, second);
+            Assert.That(FFmpegInstallNotifier.IsLibrariesMissing, Is.False);
+        }
+        finally
+        {
+            releaseFirstNotification.Set();
+            FFmpegInstallNotifier.AvailabilityChanged -= OnAvailabilityChanged;
+            FFmpegInstallNotifier.MarkInstalled();
+        }
+    }
+
+    [Test]
     public void NotifyWorkerStarted_ClearsMissingLatchAndSignalsAvailability()
     {
         FFmpegInstallNotifier.MarkMissing();

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.Extensions.FFmpeg;
+﻿using System.Collections.Concurrent;
+using Beutl.Extensions.FFmpeg;
 
 namespace Beutl.UnitTests.Extensions.FFmpeg;
 
@@ -220,6 +221,74 @@ public class FFmpegInstallNotifierTests
         }
         finally
         {
+            FFmpegInstallNotifier.AvailabilityChanged -= OnAvailabilityChanged;
+            FFmpegInstallNotifier.MarkInstalled();
+        }
+    }
+
+    [Test]
+    public void AvailabilityChanged_PropagatesSubscriberException()
+    {
+        FFmpegInstallNotifier.MarkInstalled();
+        var expected = new InvalidOperationException("availability callback failed");
+
+        void OnAvailabilityChanged(object? sender, EventArgs e) => throw expected;
+
+        FFmpegInstallNotifier.AvailabilityChanged += OnAvailabilityChanged;
+        try
+        {
+            InvalidOperationException? actual = Assert.Throws<InvalidOperationException>(
+                FFmpegInstallNotifier.MarkMissing);
+            Assert.That(actual, Is.SameAs(expected));
+        }
+        finally
+        {
+            FFmpegInstallNotifier.AvailabilityChanged -= OnAvailabilityChanged;
+            FFmpegInstallNotifier.MarkInstalled();
+        }
+    }
+
+    [Test]
+    public void AvailabilityChanged_ReportsQueuedTransitionSnapshot()
+    {
+        FFmpegInstallNotifier.MarkInstalled();
+        using var firstNotificationEntered = new ManualResetEventSlim();
+        using var releaseFirstNotification = new ManualResetEventSlim();
+        var observedStates = new ConcurrentQueue<bool>();
+        int callbackCount = 0;
+
+        void OnAvailabilityChanged(object? sender, EventArgs e)
+        {
+            observedStates.Enqueue(((FFmpegLibraryAvailabilityChangedEventArgs)e).IsLibrariesMissing);
+            if (Interlocked.Increment(ref callbackCount) == 1)
+            {
+                firstNotificationEntered.Set();
+                releaseFirstNotification.Wait();
+            }
+        }
+
+        FFmpegInstallNotifier.AvailabilityChanged += OnAvailabilityChanged;
+        try
+        {
+            Task first = Task.Run(FFmpegInstallNotifier.MarkMissing);
+            Assert.That(firstNotificationEntered.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "the first availability notification did not start");
+
+            Task second = Task.Run(FFmpegInstallNotifier.MarkInstalled);
+            Assert.That(second.Wait(TimeSpan.FromMilliseconds(100)), Is.False,
+                "an unrelated transition must wait for the active callback to finish");
+
+            releaseFirstNotification.Set();
+            Assert.That(first.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "the first transition did not complete after its callback was released");
+            Assert.That(second.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "the queued transition did not complete after the first callback was released");
+            Assert.That(observedStates.ToArray(), Is.EqualTo(new[] { true, false }),
+                "each callback must receive the state snapshot for its queued transition");
+        }
+        finally
+        {
+            releaseFirstNotification.Set();
             FFmpegInstallNotifier.AvailabilityChanged -= OnAvailabilityChanged;
             FFmpegInstallNotifier.MarkInstalled();
         }

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
@@ -154,6 +154,18 @@ public class FFmpegInstallNotifierTests
     }
 
     [Test]
+    public void NotifyMissing_DoesNotPushActiveCooldownWindowForward()
+    {
+        FFmpegInstallNotifier.MarkMissing();
+        long since = FFmpegInstallNotifier.MissingSinceTicks;
+
+        FFmpegInstallNotifier.NotifyMissing();
+
+        Assert.That(FFmpegInstallNotifier.MissingSinceTicks, Is.EqualTo(since),
+            "a short-circuited encoding retry must not re-arm the cooldown");
+    }
+
+    [Test]
     public void RecordMissingObserved_UnderConcurrency_OnlyOneFirstObservation()
     {
         const int iterations = 25;

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
@@ -182,19 +182,21 @@ public class FFmpegInstallNotifierTests
     }
 
     [Test]
-    public void AvailabilityChanged_SerializesTransitionsUntilNotificationCompletes()
+    public void AvailabilityChanged_DoesNotDeadlockWhenSubscriberDispatchesTransition()
     {
         FFmpegInstallNotifier.MarkInstalled();
         using var firstNotificationEntered = new ManualResetEventSlim();
-        using var releaseFirstNotification = new ManualResetEventSlim();
         int callbackCount = 0;
+        int deadlocked = 0;
 
         void OnAvailabilityChanged(object? sender, EventArgs e)
         {
             if (Interlocked.Increment(ref callbackCount) == 1)
             {
                 firstNotificationEntered.Set();
-                releaseFirstNotification.Wait();
+                Task dispatchedTransition = Task.Run(FFmpegInstallNotifier.MarkInstalled);
+                if (!dispatchedTransition.Wait(TimeSpan.FromSeconds(2)))
+                    Interlocked.Exchange(ref deadlocked, 1);
             }
         }
 
@@ -205,22 +207,19 @@ public class FFmpegInstallNotifierTests
             Assert.That(firstNotificationEntered.Wait(TimeSpan.FromSeconds(5)), Is.True,
                 "the first availability notification did not start");
 
-            Task second = Task.Run(FFmpegInstallNotifier.MarkInstalled);
+            Assert.That(first.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "the state transition must complete while its subscriber is dispatching another transition");
             Assert.Multiple(() =>
             {
-                Assert.That(second.Wait(TimeSpan.FromMilliseconds(100)), Is.False,
-                    "the next transition must wait for the in-flight notification");
-                Assert.That(FFmpegInstallNotifier.IsLibrariesMissing, Is.True,
-                    "the next transition must not mutate state before its notification turn");
+                Assert.That(FFmpegInstallNotifier.IsLibrariesMissing, Is.False);
+                Assert.That(Volatile.Read(ref callbackCount), Is.EqualTo(2),
+                    "both transitions must raise AvailabilityChanged");
+                Assert.That(Volatile.Read(ref deadlocked), Is.Zero,
+                    "a subscriber-dispatched transition must not deadlock on the notification gate");
             });
-
-            releaseFirstNotification.Set();
-            Task.WaitAll(first, second);
-            Assert.That(FFmpegInstallNotifier.IsLibrariesMissing, Is.False);
         }
         finally
         {
-            releaseFirstNotification.Set();
             FFmpegInstallNotifier.AvailabilityChanged -= OnAvailabilityChanged;
             FFmpegInstallNotifier.MarkInstalled();
         }

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
@@ -187,17 +187,16 @@ public class FFmpegInstallNotifierTests
     {
         FFmpegInstallNotifier.MarkInstalled();
         using var firstNotificationEntered = new ManualResetEventSlim();
+        var observedStates = new List<bool>();
         int callbackCount = 0;
-        int deadlocked = 0;
 
         void OnAvailabilityChanged(object? sender, EventArgs e)
         {
+            observedStates.Add(((FFmpegLibraryAvailabilityChangedEventArgs)e).IsLibrariesMissing);
             if (Interlocked.Increment(ref callbackCount) == 1)
             {
                 firstNotificationEntered.Set();
-                Task dispatchedTransition = Task.Run(FFmpegInstallNotifier.MarkInstalled);
-                if (!dispatchedTransition.Wait(TimeSpan.FromSeconds(2)))
-                    Interlocked.Exchange(ref deadlocked, 1);
+                FFmpegInstallNotifier.MarkInstalled();
             }
         }
 
@@ -215,12 +214,67 @@ public class FFmpegInstallNotifierTests
                 Assert.That(FFmpegInstallNotifier.IsLibrariesMissing, Is.False);
                 Assert.That(Volatile.Read(ref callbackCount), Is.EqualTo(2),
                     "both transitions must raise AvailabilityChanged");
-                Assert.That(Volatile.Read(ref deadlocked), Is.Zero,
-                    "a subscriber-dispatched transition must not deadlock on the notification gate");
+                Assert.That(observedStates, Is.EqualTo(new[] { true, false }),
+                    "reentrant transitions must be delivered in callback order");
             });
         }
         finally
         {
+            FFmpegInstallNotifier.AvailabilityChanged -= OnAvailabilityChanged;
+            FFmpegInstallNotifier.MarkInstalled();
+        }
+    }
+
+    [Test]
+    public void AvailabilityChanged_PropagatesExceptionToOwningTransition()
+    {
+        FFmpegInstallNotifier.MarkInstalled();
+        using var firstNotificationEntered = new ManualResetEventSlim();
+        using var releaseFirstNotification = new ManualResetEventSlim();
+        using var secondTransitionStarted = new ManualResetEventSlim();
+        var expected = new InvalidOperationException("installed callback failed");
+
+        void OnAvailabilityChanged(object? sender, EventArgs e)
+        {
+            if (((FFmpegLibraryAvailabilityChangedEventArgs)e).IsLibrariesMissing)
+            {
+                firstNotificationEntered.Set();
+                releaseFirstNotification.Wait();
+            }
+            else
+            {
+                throw expected;
+            }
+        }
+
+        FFmpegInstallNotifier.AvailabilityChanged += OnAvailabilityChanged;
+        try
+        {
+            Task first = Task.Run(FFmpegInstallNotifier.MarkMissing);
+            Assert.That(firstNotificationEntered.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "the first availability notification did not start");
+
+            Task second = Task.Run(() =>
+            {
+                secondTransitionStarted.Set();
+                FFmpegInstallNotifier.MarkInstalled();
+            });
+            Assert.That(secondTransitionStarted.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "the second transition did not start");
+            Assert.That(second.Wait(TimeSpan.FromMilliseconds(100)), Is.False,
+                "the second transition should wait for its queued notification");
+
+            releaseFirstNotification.Set();
+            Assert.That(first.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "the dispatcher must not receive another caller's subscriber exception");
+            Assert.That(SpinWait.SpinUntil(() => second.IsCompleted, TimeSpan.FromSeconds(5)), Is.True,
+                "the owning transition did not complete");
+            Assert.That(second.IsFaulted, Is.True);
+            Assert.That(second.Exception!.GetBaseException(), Is.SameAs(expected));
+        }
+        finally
+        {
+            releaseFirstNotification.Set();
             FFmpegInstallNotifier.AvailabilityChanged -= OnAvailabilityChanged;
             FFmpegInstallNotifier.MarkInstalled();
         }

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
@@ -260,6 +260,133 @@ public class FFmpegInstallNotifierTests
     }
 
     [Test]
+    public void AvailabilityChanged_CallbackCanWaitForCrossThreadTransition()
+    {
+        FFmpegInstallNotifier.MarkInstalled();
+
+        void OnAvailabilityChanged(object? sender, EventArgs e)
+        {
+            if (((FFmpegLibraryAvailabilityChangedEventArgs)e).IsLibrariesMissing)
+            {
+                Task descendant = Task.Run(FFmpegInstallNotifier.MarkInstalled);
+                if (!descendant.Wait(TimeSpan.FromSeconds(1)))
+                    throw new TimeoutException("a callback-dispatched transition must not wait for the active dispatcher");
+            }
+        }
+
+        FFmpegInstallNotifier.AvailabilityChanged += OnAvailabilityChanged;
+        try
+        {
+            Task transition = Task.Run(FFmpegInstallNotifier.MarkMissing);
+
+            Assert.That(transition.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "the callback and its cross-thread transition must both complete");
+            transition.GetAwaiter().GetResult();
+            Assert.That(FFmpegInstallNotifier.IsLibrariesMissing, Is.False);
+        }
+        finally
+        {
+            FFmpegInstallNotifier.AvailabilityChanged -= OnAvailabilityChanged;
+            FFmpegInstallNotifier.MarkInstalled();
+        }
+    }
+
+    [Test]
+    public void AvailabilityChanged_ReentrantTransitionPreservesFifoOrder()
+    {
+        FFmpegInstallNotifier.MarkInstalled();
+        using var firstNotificationEntered = new ManualResetEventSlim();
+        using var allowReentrantTransition = new ManualResetEventSlim();
+        var observedStates = new ConcurrentQueue<bool>();
+        int missingNotifications = 0;
+
+        void OnAvailabilityChanged(object? sender, EventArgs e)
+        {
+            bool isMissing = ((FFmpegLibraryAvailabilityChangedEventArgs)e).IsLibrariesMissing;
+            observedStates.Enqueue(isMissing);
+            if (isMissing && Interlocked.Increment(ref missingNotifications) == 1)
+            {
+                firstNotificationEntered.Set();
+                if (!allowReentrantTransition.Wait(TimeSpan.FromSeconds(5)))
+                    throw new TimeoutException("the reentrant transition was not released");
+
+                FFmpegInstallNotifier.MarkMissing();
+            }
+        }
+
+        FFmpegInstallNotifier.AvailabilityChanged += OnAvailabilityChanged;
+        try
+        {
+            Task first = Task.Run(FFmpegInstallNotifier.MarkMissing);
+            Assert.That(firstNotificationEntered.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "the first availability notification did not start");
+
+            using var installedStarted = new ManualResetEventSlim();
+            Task installed = Task.Run(() =>
+            {
+                installedStarted.Set();
+                FFmpegInstallNotifier.MarkInstalled();
+            });
+            Assert.That(installedStarted.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "the installed transition did not start");
+            Assert.That(installed.Wait(TimeSpan.FromMilliseconds(100)), Is.False,
+                "the installed transition should remain queued while the first callback is blocked");
+
+            allowReentrantTransition.Set();
+            Assert.That(first.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            Assert.That(installed.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            first.GetAwaiter().GetResult();
+            installed.GetAwaiter().GetResult();
+
+            Assert.That(observedStates.ToArray(), Is.EqualTo(new[] { true, false, true }),
+                "reentrant notifications must remain behind already queued transitions");
+        }
+        finally
+        {
+            allowReentrantTransition.Set();
+            FFmpegInstallNotifier.AvailabilityChanged -= OnAvailabilityChanged;
+            FFmpegInstallNotifier.MarkInstalled();
+        }
+    }
+
+    [Test]
+    public void AvailabilityChanged_NestedSubscriberExceptionDoesNotFaultOwningTransition()
+    {
+        FFmpegInstallNotifier.MarkInstalled();
+        var expected = new InvalidOperationException("nested availability callback failed");
+
+        void QueueInstalledTransition(object? sender, EventArgs e)
+        {
+            if (((FFmpegLibraryAvailabilityChangedEventArgs)e).IsLibrariesMissing)
+                FFmpegInstallNotifier.MarkInstalled();
+        }
+
+        void ThrowForInstalledTransition(object? sender, EventArgs e)
+        {
+            if (!((FFmpegLibraryAvailabilityChangedEventArgs)e).IsLibrariesMissing)
+                throw expected;
+        }
+
+        FFmpegInstallNotifier.AvailabilityChanged += QueueInstalledTransition;
+        FFmpegInstallNotifier.AvailabilityChanged += ThrowForInstalledTransition;
+        try
+        {
+            Task transition = Task.Run(FFmpegInstallNotifier.MarkMissing);
+
+            Assert.That(transition.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "the owning transition must not receive a nested transition's exception");
+            transition.GetAwaiter().GetResult();
+            Assert.That(FFmpegInstallNotifier.IsLibrariesMissing, Is.False);
+        }
+        finally
+        {
+            FFmpegInstallNotifier.AvailabilityChanged -= QueueInstalledTransition;
+            FFmpegInstallNotifier.AvailabilityChanged -= ThrowForInstalledTransition;
+            FFmpegInstallNotifier.MarkInstalled();
+        }
+    }
+
+    [Test]
     public void AvailabilityChanged_PropagatesExceptionToOwningTransition()
     {
         FFmpegInstallNotifier.MarkInstalled();

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
@@ -70,6 +70,7 @@ public class FFmpegInstallNotifierTests
             Assert.Multiple(() =>
             {
                 Assert.That(FFmpegInstallNotifier.IsLibrariesMissing, Is.False);
+                Assert.That(FFmpegInstallNotifier.IsVerificationInProgress, Is.True);
                 Assert.That(changes, Is.EqualTo(0));
             });
 
@@ -81,6 +82,7 @@ public class FFmpegInstallNotifierTests
         }
 
         Assert.That(changes, Is.EqualTo(1));
+        Assert.That(FFmpegInstallNotifier.IsVerificationInProgress, Is.False);
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
@@ -84,6 +84,58 @@ public class FFmpegInstallNotifierTests
     }
 
     [Test]
+    public void MarkVerificationStarted_DropsQueuedAvailabilityNotifications()
+    {
+        FFmpegInstallNotifier.MarkInstalled();
+        using var firstNotificationEntered = new ManualResetEventSlim();
+        using var releaseFirstNotification = new ManualResetEventSlim();
+        var observedStates = new ConcurrentQueue<bool>();
+        int callbackCount = 0;
+
+        void OnAvailabilityChanged(object? sender, EventArgs e)
+        {
+            observedStates.Enqueue(((FFmpegLibraryAvailabilityChangedEventArgs)e).IsLibrariesMissing);
+            if (Interlocked.Increment(ref callbackCount) == 1)
+            {
+                firstNotificationEntered.Set();
+                releaseFirstNotification.Wait();
+            }
+        }
+
+        FFmpegInstallNotifier.AvailabilityChanged += OnAvailabilityChanged;
+        try
+        {
+            Task blocker = Task.Run(FFmpegInstallNotifier.MarkInstalled);
+            Assert.That(firstNotificationEntered.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "the first availability notification did not start");
+
+            Task missing = Task.Run(FFmpegInstallNotifier.MarkMissing);
+            Assert.That(SpinWait.SpinUntil(
+                () => FFmpegInstallNotifier.IsLibrariesMissing,
+                TimeSpan.FromSeconds(5)), Is.True,
+                "the missing transition did not update state");
+
+            FFmpegInstallNotifier.MarkVerificationStarted();
+            Assert.That(FFmpegInstallNotifier.IsLibrariesMissing, Is.False);
+
+            releaseFirstNotification.Set();
+            Assert.That(blocker.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            Assert.That(missing.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            blocker.GetAwaiter().GetResult();
+            missing.GetAwaiter().GetResult();
+
+            Assert.That(observedStates.ToArray(), Is.EqualTo(new[] { false }),
+                "verification must invalidate a queued missing snapshot");
+        }
+        finally
+        {
+            releaseFirstNotification.Set();
+            FFmpegInstallNotifier.AvailabilityChanged -= OnAvailabilityChanged;
+            FFmpegInstallNotifier.MarkInstalled();
+        }
+    }
+
+    [Test]
     public void ShouldSkipStartProbe_SkipsWithinCooldownThenAllowsAfterElapsed()
     {
         const long cooldownMs = 30_000; // mirrors FFmpegLibraryState.ReprobeCooldownMs
@@ -292,6 +344,41 @@ public class FFmpegInstallNotifierTests
     }
 
     [Test]
+    public void AvailabilityChanged_CallbackCanWaitForSuppressedFlowTransition()
+    {
+        FFmpegInstallNotifier.MarkInstalled();
+
+        void OnAvailabilityChanged(object? sender, EventArgs e)
+        {
+            if (((FFmpegLibraryAvailabilityChangedEventArgs)e).IsLibrariesMissing)
+            {
+                Task descendant;
+                using (ExecutionContext.SuppressFlow())
+                    descendant = Task.Run(FFmpegInstallNotifier.MarkInstalled);
+
+                if (!descendant.Wait(TimeSpan.FromSeconds(1)))
+                    throw new TimeoutException("a suppressed-flow transition must not wait for the active dispatcher");
+            }
+        }
+
+        FFmpegInstallNotifier.AvailabilityChanged += OnAvailabilityChanged;
+        try
+        {
+            Task transition = Task.Run(FFmpegInstallNotifier.MarkMissing);
+
+            Assert.That(transition.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "the callback and its suppressed-flow transition must both complete");
+            transition.GetAwaiter().GetResult();
+            Assert.That(FFmpegInstallNotifier.IsLibrariesMissing, Is.False);
+        }
+        finally
+        {
+            FFmpegInstallNotifier.AvailabilityChanged -= OnAvailabilityChanged;
+            FFmpegInstallNotifier.MarkInstalled();
+        }
+    }
+
+    [Test]
     public void AvailabilityChanged_ReentrantTransitionPreservesFifoOrder()
     {
         FFmpegInstallNotifier.MarkInstalled();
@@ -329,8 +416,8 @@ public class FFmpegInstallNotifierTests
             });
             Assert.That(installedStarted.Wait(TimeSpan.FromSeconds(5)), Is.True,
                 "the installed transition did not start");
-            Assert.That(installed.Wait(TimeSpan.FromMilliseconds(100)), Is.False,
-                "the installed transition should remain queued while the first callback is blocked");
+            Assert.That(installed.Wait(TimeSpan.FromSeconds(1)), Is.True,
+                "a transition racing an active callback must enqueue without waiting");
 
             allowReentrantTransition.Set();
             Assert.That(first.Wait(TimeSpan.FromSeconds(5)), Is.True);
@@ -387,7 +474,7 @@ public class FFmpegInstallNotifierTests
     }
 
     [Test]
-    public void AvailabilityChanged_PropagatesExceptionToOwningTransition()
+    public void AvailabilityChanged_ConcurrentTransitionDoesNotBlockOnForeignCallbackException()
     {
         FFmpegInstallNotifier.MarkInstalled();
         using var firstNotificationEntered = new ManualResetEventSlim();
@@ -422,16 +509,16 @@ public class FFmpegInstallNotifierTests
             });
             Assert.That(secondTransitionStarted.Wait(TimeSpan.FromSeconds(5)), Is.True,
                 "the second transition did not start");
-            Assert.That(second.Wait(TimeSpan.FromMilliseconds(100)), Is.False,
-                "the second transition should wait for its queued notification");
+            Assert.That(second.Wait(TimeSpan.FromSeconds(1)), Is.True,
+                "a transition racing an active callback must not wait for its notification");
 
             releaseFirstNotification.Set();
             Assert.That(first.Wait(TimeSpan.FromSeconds(5)), Is.True,
                 "the dispatcher must not receive another caller's subscriber exception");
-            Assert.That(SpinWait.SpinUntil(() => second.IsCompleted, TimeSpan.FromSeconds(5)), Is.True,
-                "the owning transition did not complete");
-            Assert.That(second.IsFaulted, Is.True);
-            Assert.That(second.Exception!.GetBaseException(), Is.SameAs(expected));
+            first.GetAwaiter().GetResult();
+            second.GetAwaiter().GetResult();
+            Assert.That(second.IsFaulted, Is.False,
+                "a foreign subscriber exception must remain isolated from a non-blocking transition");
         }
         finally
         {
@@ -490,14 +577,15 @@ public class FFmpegInstallNotifierTests
                 "the first availability notification did not start");
 
             Task second = Task.Run(FFmpegInstallNotifier.MarkInstalled);
-            Assert.That(second.Wait(TimeSpan.FromMilliseconds(100)), Is.False,
-                "an unrelated transition must wait for the active callback to finish");
+            Assert.That(second.Wait(TimeSpan.FromSeconds(1)), Is.True,
+                "an unrelated transition must enqueue without waiting for the active callback");
 
             releaseFirstNotification.Set();
             Assert.That(first.Wait(TimeSpan.FromSeconds(5)), Is.True,
                 "the first transition did not complete after its callback was released");
             Assert.That(second.Wait(TimeSpan.FromSeconds(5)), Is.True,
                 "the queued transition did not complete after the first callback was released");
+            second.GetAwaiter().GetResult();
             Assert.That(observedStates.ToArray(), Is.EqualTo(new[] { true, false }),
                 "each callback must receive the state snapshot for its queued transition");
         }

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
@@ -166,6 +166,28 @@ public class FFmpegInstallNotifierTests
     }
 
     [Test]
+    public void NotifyMissing_UnderConcurrency_DoesNotRearmActiveCooldown()
+    {
+        FFmpegInstallNotifier.MarkMissing();
+        long since = FFmpegInstallNotifier.MissingSinceTicks;
+        const int callers = 32;
+        using var barrier = new Barrier(callers);
+        var tasks = new Task[callers];
+
+        for (int i = 0; i < callers; i++)
+        {
+            tasks[i] = Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                FFmpegInstallNotifier.NotifyMissing();
+            });
+        }
+
+        Task.WaitAll(tasks);
+        Assert.That(FFmpegInstallNotifier.MissingSinceTicks, Is.EqualTo(since));
+    }
+
+    [Test]
     public void RecordMissingObserved_UnderConcurrency_OnlyOneFirstObservation()
     {
         const int iterations = 25;

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegProxyGeneratorPublishTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegProxyGeneratorPublishTests.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.Extensions.FFmpeg.Encoding;
+﻿using Beutl.Extensions.FFmpeg;
+using Beutl.Extensions.FFmpeg.Encoding;
 using Beutl.Extensions.FFmpeg.Proxy;
 using Beutl.FFmpegIpc;
 using Beutl.Media;
@@ -22,6 +23,27 @@ public sealed class FFmpegProxyGeneratorPublishTests
         FFmpegProxyGenerator.Configure(controller, videoInfo, new PixelSize(1920, 1080), ProxyPreset.Half);
 
         Assert.That(controller.VideoSettings.Options.Any(o => o.Name == "level"), Is.False);
+    }
+
+    [Test]
+    public void IsAvailable_RemainsFalseDuringVerification()
+    {
+        FFmpegInstallNotifier.MarkInstalled();
+        var generator = new FFmpegProxyGenerator(new TransitionRecordingStore(CreateRoot()));
+
+        try
+        {
+            Assert.That(generator.IsAvailable, Is.True);
+
+            FFmpegInstallNotifier.MarkVerificationStarted();
+
+            Assert.That(generator.IsAvailable, Is.False,
+                "proxy generation must stay paused while FFmpeg installation is being verified");
+        }
+        finally
+        {
+            FFmpegInstallNotifier.MarkInstalled();
+        }
     }
 
     // An animated APNG/GIF/WebP is exposed as multi-frame video by the animated-image readers, so the

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegWorkerCodecCacheTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegWorkerCodecCacheTests.cs
@@ -1,0 +1,50 @@
+﻿using Beutl.Extensions.FFmpeg;
+
+namespace Beutl.UnitTests.Extensions.FFmpeg;
+
+[TestFixture]
+public class FFmpegWorkerCodecCacheTests
+{
+    [Test]
+    public void MissingCodecNotification_DoesNotHoldCacheLock()
+    {
+        FFmpegInstallNotifier.MarkInstalled();
+        FFmpegWorkerCodecCache.Invalidate();
+
+        using var notificationEntered = new ManualResetEventSlim();
+        Task? nestedQuery = null;
+        int nestedTimedOut = 0;
+
+        void OnAvailabilityChanged(object? sender, EventArgs e)
+        {
+            notificationEntered.Set();
+            nestedQuery = Task.Run(() =>
+            {
+                FFmpegWorkerCodecCache.Invalidate();
+                _ = FFmpegWorkerCodecCache.GetVideoCodecs();
+            });
+
+            if (!nestedQuery.Wait(TimeSpan.FromSeconds(2)))
+                Interlocked.Exchange(ref nestedTimedOut, 1);
+        }
+
+        FFmpegInstallNotifier.AvailabilityChanged += OnAvailabilityChanged;
+        try
+        {
+            _ = FFmpegWorkerCodecCache.GetVideoCodecs();
+            if (!notificationEntered.IsSet)
+                Assert.Ignore("FFmpeg libraries are available; missing-codec notification was not raised.");
+
+            Assert.That(Volatile.Read(ref nestedTimedOut), Is.Zero,
+                "availability callbacks must not hold the codec-cache lock");
+        }
+        finally
+        {
+            FFmpegInstallNotifier.AvailabilityChanged -= OnAvailabilityChanged;
+            if (nestedQuery is not null)
+                nestedQuery.Wait(TimeSpan.FromSeconds(5));
+            FFmpegWorkerCodecCache.Invalidate();
+            FFmpegInstallNotifier.MarkInstalled();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the error spam where `FFmpegLibrariesNotFoundException` was thrown 1,057 times in 2 weeks (83% of all errors, ~60 per session) because every decode request retried the worker start without caching/suppressing the failure.

**Root cause:** In environments without FFmpeg installed, each frame/thumbnail request re-attempted the worker start, blocking the UI and flooding telemetry.

**Fix:**
- Only the first missing-libraries discovery logs `Error`; subsequent short-circuits log `Debug` via a new `FFmpegLibraryState.RecordMissingObserved` session-level latch.
- Re-probe cooldown extended 5s → 30s (bounded; the install wizard clears the latch immediately on success, so a wizard install re-probes on the next decode with no delay).
- `FFmpegLoaderWorker.GetRootPath` failure message now includes the searched paths for diagnosability.

## Tests

- `ShouldSkipStartProbe_RepeatedProbesWithinCooldown_AllShortCircuit` — regression-tests the burst short-circuit (the core of the fix).
- `RecordMissingObserved_FirstObservation_ReturnsFalse` / `_SecondObservation_ReturnsTrue` — pin the Error-vs-Debug decision.
- `_DoesNotPushCooldownWindowForward` — pins the no-re-arm invariant.
- Full `Beutl.UnitTests` green (4976 passed); `dotnet format --verify-no-changes` clean.

## Board

Refs: Project #9 item (FFmpeg ライブラリ未検出時にリトライ抑制がなく、1セッションで数百件のエラーを出し続ける)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FFmpeg missing-library handling to reduce repeated error noise while preserving clear diagnostics for the first occurrence.
  * Extended the FFmpeg re-probe cooldown to 30 seconds.
  * Enhanced missing-library errors to show all searched locations while protecting home-directory details.
  * Improved availability notifications to remain responsive during state changes and subscriber errors.
  * Ensured codec discovery continues gracefully when FFmpeg libraries are unavailable.
* **Tests**
  * Added coverage for probe suppression, missing-library detection, concurrency, notifications, path redaction, and cancellation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->