### PR TITLE
fix(ffmpegipc): make provider _disposed fields volatile

### DIFF
--- a/src/Beutl.FFmpegIpc/Providers/IpcFrameProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcFrameProvider.cs
@@ -17,7 +17,7 @@ internal sealed class IpcFrameProvider : IFrameProvider
     private readonly int _sourceHeight;
     private readonly PrefetchSlot<long, IpcMessage> _prefetch = new();
     private int _bufferIndex;
-    private bool _disposed;
+    private volatile bool _disposed;
 
     public IpcFrameProvider(IpcConnection connection, SharedMemoryBuffer[] videoBuffers,
         long frameCount, Rational frameRate, int sourceWidth, int sourceHeight)

--- a/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
@@ -23,7 +23,7 @@ internal sealed class IpcSampleProvider : ISampleProvider
 
     // 先行フェッチ（次の1秒分、バックグラウンド）
     private readonly PrefetchSlot<long, Pcm<Stereo32BitFloat>> _prefetch = new();
-    private bool _disposed;
+    private volatile bool _disposed;
 
     public IpcSampleProvider(IpcConnection connection, SharedMemoryBuffer[] audioBuffers,
         long sampleCount, long sampleRate)

--- a/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
@@ -1,4 +1,6 @@
 ﻿using System.IO.Pipes;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Beutl.FFmpegIpc;
 using Beutl.FFmpegIpc.Protocol;
@@ -301,6 +303,61 @@ public class IpcProviderContractTests
         catch (OperationCanceledException) { }
         catch (IOException) { }
         catch (ObjectDisposedException) { }
+    }
+
+    private static void AssertDisposedCallThrowsOnDifferentThreads(Action dispose, Action operation)
+    {
+        using var disposeCompleted = new ManualResetEventSlim();
+        Exception? disposeException = null;
+        Exception? operationException = null;
+        int disposeThreadId = 0;
+        int operationThreadId = 0;
+
+        var disposeThread = new Thread(() =>
+        {
+            disposeThreadId = Environment.CurrentManagedThreadId;
+            try
+            {
+                dispose();
+            }
+            catch (Exception ex)
+            {
+                disposeException = ex;
+            }
+            finally
+            {
+                disposeCompleted.Set();
+            }
+        })
+        {
+            IsBackground = true
+        };
+
+        var operationThread = new Thread(() =>
+        {
+            disposeCompleted.Wait();
+            operationThreadId = Environment.CurrentManagedThreadId;
+            try
+            {
+                operation();
+            }
+            catch (Exception ex)
+            {
+                operationException = ex;
+            }
+        })
+        {
+            IsBackground = true
+        };
+
+        disposeThread.Start();
+        operationThread.Start();
+
+        Assert.That(disposeThread.Join(TimeSpan.FromSeconds(5)), Is.True, "Dispose did not complete in time");
+        Assert.That(operationThread.Join(TimeSpan.FromSeconds(5)), Is.True, "The post-dispose call did not complete in time");
+        Assert.That(disposeException, Is.Null);
+        Assert.That(disposeThreadId, Is.Not.EqualTo(operationThreadId));
+        Assert.That(operationException, Is.TypeOf<ObjectDisposedException>());
     }
 
     [Test]
@@ -822,9 +879,22 @@ public class IpcProviderContractTests
     }
 
     [Test]
-    public async Task RenderFrame_AfterDispose_ThrowsObjectDisposedException()
+    public void ProviderDisposalFlags_AreVolatile()
     {
-        // A render issued after Dispose must be rejected by the _disposed guard (the cross-thread teardown signal).
+        foreach (Type providerType in new[] { typeof(IpcFrameProvider), typeof(IpcSampleProvider) })
+        {
+            FieldInfo field = providerType.GetField("_disposed", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?? throw new AssertionException($"{providerType.Name}._disposed was not found");
+
+            Assert.That(field.GetRequiredCustomModifiers(), Does.Contain(typeof(IsVolatile)),
+                $"{providerType.Name}._disposed must remain volatile");
+        }
+    }
+
+    [Test]
+    public async Task RenderFrame_AfterDisposeOnAnotherThread_ThrowsObjectDisposedException()
+    {
+        // Dispose and the rejected render run on distinct threads to exercise the cross-thread teardown signal.
         var (server, client) = ConnectPair();
         var buffers = CreateBuffers();
         var hostCts = new CancellationTokenSource();
@@ -835,11 +905,12 @@ public class IpcProviderContractTests
 
         try
         {
-            provider.Dispose();
-
-            Assert.That(async () => await provider.RenderFrame(0),
-                Throws.TypeOf<ObjectDisposedException>(),
-                "a render after Dispose must be rejected by the _disposed guard");
+            AssertDisposedCallThrowsOnDifferentThreads(
+                provider.Dispose,
+                () =>
+                {
+                    using Bitmap frame = provider.RenderFrame(0).GetAwaiter().GetResult();
+                });
         }
         finally
         {
@@ -849,9 +920,9 @@ public class IpcProviderContractTests
     }
 
     [Test]
-    public async Task Sample_AfterDispose_ThrowsObjectDisposedException()
+    public async Task Sample_AfterDisposeOnAnotherThread_ThrowsObjectDisposedException()
     {
-        // Mirror of the frame-side guard: a sample issued after Dispose must be rejected by the _disposed guard.
+        // Mirror of the frame-side guard: Dispose and the rejected sample run on distinct threads.
         var (server, client) = ConnectPair();
         var buffers = CreateBuffers();
         var hostCts = new CancellationTokenSource();
@@ -862,11 +933,12 @@ public class IpcProviderContractTests
 
         try
         {
-            provider.Dispose();
-
-            Assert.That(async () => await provider.Sample(0, 4),
-                Throws.TypeOf<ObjectDisposedException>(),
-                "a sample after Dispose must be rejected by the _disposed guard");
+            AssertDisposedCallThrowsOnDifferentThreads(
+                provider.Dispose,
+                () =>
+                {
+                    using Pcm<Stereo32BitFloat> sample = provider.Sample(0, 4).GetAwaiter().GetResult();
+                });
         }
         finally
         {

--- a/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
@@ -822,6 +822,60 @@ public class IpcProviderContractTests
     }
 
     [Test]
+    public async Task RenderFrame_AfterDispose_ThrowsObjectDisposedException()
+    {
+        // A render issued after Dispose must be rejected by the _disposed guard (the cross-thread teardown signal).
+        var (server, client) = ConnectPair();
+        var buffers = CreateBuffers();
+        var hostCts = new CancellationTokenSource();
+        var hostTask = RunFrameServingHost(server, buffers, new List<long>(), new object(), hostCts.Token);
+
+        using var conn = new IpcConnection(client);
+        var provider = new IpcFrameProvider(conn, buffers, frameCount: 1, frameRate: new Rational(30, 1), sourceWidth: 1, sourceHeight: 1);
+
+        try
+        {
+            provider.Dispose();
+
+            Assert.That(async () => await provider.RenderFrame(0),
+                Throws.TypeOf<ObjectDisposedException>(),
+                "a render after Dispose must be rejected by the _disposed guard");
+        }
+        finally
+        {
+            await StopHost(hostCts, server, hostTask);
+            DisposeBuffers(buffers);
+        }
+    }
+
+    [Test]
+    public async Task Sample_AfterDispose_ThrowsObjectDisposedException()
+    {
+        // Mirror of the frame-side guard: a sample issued after Dispose must be rejected by the _disposed guard.
+        var (server, client) = ConnectPair();
+        var buffers = CreateBuffers();
+        var hostCts = new CancellationTokenSource();
+        var hostTask = RunSampleServingHost(server, buffers, hostCts.Token);
+
+        using var conn = new IpcConnection(client);
+        var provider = new IpcSampleProvider(conn, buffers, sampleCount: 4, sampleRate: 4);
+
+        try
+        {
+            provider.Dispose();
+
+            Assert.That(async () => await provider.Sample(0, 4),
+                Throws.TypeOf<ObjectDisposedException>(),
+                "a sample after Dispose must be rejected by the _disposed guard");
+        }
+        finally
+        {
+            await StopHost(hostCts, server, hostTask);
+            DisposeBuffers(buffers);
+        }
+    }
+
+    [Test]
     public async Task RenderFrame_WhenHostCancels_ThrowsOperationCanceled()
     {
         var (server, client) = ConnectPair();


### PR DESCRIPTION
## Summary

Fixes a potential memory-visibility issue on weak memory models (ARM): `IpcFrameProvider._disposed` and `IpcSampleProvider._disposed` were non-volatile `bool` fields. `Dispose()` can be called from a different thread (e.g. UI-thread cancellation) while `RenderFrame()`/`Sample()` run on the encoding worker thread; on ARM the write may not be visible to the reading thread.

**Fix:** Both `_disposed` fields are now `volatile bool`, matching the established pattern in `HistoryMutationPlaybackGuard` (and `EditViewModel`, `ElementNudgeService`).

## Tests

- `RenderFrame_AfterDispose_ThrowsObjectDisposedException` and `Sample_AfterDispose_ThrowsObjectDisposedException` — dispose-guard contract regression tests (deterministic, no timing dependencies).
- Full `Beutl.FFmpegIpc.Tests` suite 58/58 green; `dotnet format --verify-no-changes` clean.

## Board

Refs: Project #9 item (IpcFrameProvider/IpcSampleProvider: _disposed not volatile, potential visibility on ARM)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disposal-state handling for safer concurrent operations.
  * Calls made after a provider is disposed now consistently report that the object is unavailable.

* **Tests**
  * Added coverage verifying correct errors are raised when rendering frames or sampling audio after disposal.
  * Added cleanup validation for related resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->