### PR TITLE
feat: add zh-CN, ko-KR, and es localization

### DIFF
--- a/src/Beutl.Editor.Components/AudioVisualizerTab/Views/AudioVisualizerTabView.axaml
+++ b/src/Beutl.Editor.Components/AudioVisualizerTab/Views/AudioVisualizerTabView.axaml
@@ -86,13 +86,13 @@
 
                             <!-- Spectrum section -->
                             <StackPanel Margin="16,12,16,8" Spacing="10">
-                                <TextBlock Classes="section" Text="Spectrum" />
+                                <TextBlock Classes="section" Text="{x:Static lang:Strings.Spectrum}" />
 
                                 <Grid ColumnDefinitions="92,*"
                                       RowDefinitions="Auto,Auto"
                                       ColumnSpacing="12"
                                       RowSpacing="8">
-                                    <TextBlock Classes="field" Text="FFT Size" />
+                                    <TextBlock Classes="field" Text="{x:Static lang:GraphicsStrings.AudioVisualizer_FftSize}" />
                                     <ComboBox Grid.Column="1"
                                               HorizontalAlignment="Stretch"
                                               ItemsSource="{Binding AvailableFftSizes}"
@@ -101,7 +101,7 @@
                                               PointerPressed="OnSettingPointerPressed"
                                               ToolTip.Tip="{x:Static lang:Strings.AudioVisualizer_ResetTooltip}" />
 
-                                    <TextBlock Grid.Row="1" Classes="field" Text="Shape" />
+                                    <TextBlock Grid.Row="1" Classes="field" Text="{x:Static lang:GraphicsStrings.AudioVisualizer_Shape}" />
                                     <ComboBox Grid.Row="1" Grid.Column="1"
                                               HorizontalAlignment="Stretch"
                                               ItemsSource="{Binding AvailableSpectrumShapes}"
@@ -116,7 +116,7 @@
                                             PointerPressed="OnSettingPointerPressed"
                                             ToolTip.Tip="{x:Static lang:Strings.AudioVisualizer_ResetTooltip}">
                                     <Grid ColumnDefinitions="*,Auto">
-                                        <TextBlock Classes="field" Text="Smoothing" />
+                                        <TextBlock Classes="field" Text="{x:Static lang:GraphicsStrings.AudioVisualizer_Smoothing}" />
                                         <Border Grid.Column="1" Classes="value-badge">
                                             <TextBlock Text="{Binding Smoothing.Value, StringFormat={}{0:0}%}" />
                                         </Border>
@@ -132,14 +132,14 @@
 
                             <!-- Display section -->
                             <StackPanel Margin="16,8,16,12" Spacing="10">
-                                <TextBlock Classes="section" Text="Display" />
+                                <TextBlock Classes="section" Text="{x:Static lang:Strings.AudioVisualizer_Display}" />
 
                                 <StackPanel Spacing="4"
                                             Tag="MinDecibels"
                                             PointerPressed="OnSettingPointerPressed"
                                             ToolTip.Tip="{x:Static lang:Strings.AudioVisualizer_ResetTooltip}">
                                     <Grid ColumnDefinitions="*,Auto">
-                                        <TextBlock Classes="field" Text="Min dB" />
+                                        <TextBlock Classes="field" Text="{x:Static lang:Strings.AudioVisualizer_MinDecibels}" />
                                         <Border Grid.Column="1" Classes="value-badge">
                                             <TextBlock Text="{Binding MinDecibels.Value, StringFormat={}{0:0} dB}" />
                                         </Border>

--- a/src/Beutl.ExceptionHandler/Properties/Resources.es.resx
+++ b/src/Beutl.ExceptionHandler/Properties/Resources.es.resx
@@ -1,0 +1,86 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  
+  <xs:schema id="root">
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xs:element name="root" ns1:IsDataSet="true">
+      <xs:complexType>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element name="metadata">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" />
+              </xs:sequence>
+              <xs:attribute name="name" use="required" type="xsd:string" />
+              <xs:attribute name="type" type="xsd:string" />
+              <xs:attribute name="mimetype" type="xsd:string" />
+              <xs:attribute ref="xml:space" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="assembly">
+            <xs:complexType>
+              <xs:attribute name="alias" type="xsd:string" />
+              <xs:attribute name="name" type="xsd:string" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="data">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+                <xs:element name="comment" type="xsd:string" minOccurs="0" ns1:Ordinal="2" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" ns1:Ordinal="1" />
+              <xs:attribute name="type" type="xsd:string" ns1:Ordinal="3" />
+              <xs:attribute name="mimetype" type="xsd:string" ns1:Ordinal="4" />
+              <xs:attribute ref="xml:space" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="resheader">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" />
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Close" xml:space="preserve">
+    <value>Cerrar</value>
+  </data>
+  <data name="Content" xml:space="preserve">
+    <value>Lo sentimos.
+Se produjo un error que Beutl no manejó correctamente.
+
+Si la recopilación de telemetría está habilitada, los registros se recopilan automáticamente.</value>
+  </data>
+  <data name="ErrorOccurred" xml:space="preserve">
+    <value>Se produjo un error.</value>
+  </data>
+  <data name="LogFileNotFound" xml:space="preserve">
+    <value>No se encontró el archivo de registro</value>
+  </data>
+  <data name="MoreDetails" xml:space="preserve">
+    <value>Más detalles</value>
+  </data>
+  <data name="ShowLog" xml:space="preserve">
+    <value>Mostrar registro</value>
+  </data>
+  <data name="SendFeedback" xml:space="preserve">
+    <value>Enviar comentarios</value>
+  </data>
+</root>

--- a/src/Beutl.ExceptionHandler/Properties/Resources.es.resx
+++ b/src/Beutl.ExceptionHandler/Properties/Resources.es.resx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   
   <xs:schema id="root">
     <xs:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/Beutl.ExceptionHandler/Properties/Resources.ko-KR.resx
+++ b/src/Beutl.ExceptionHandler/Properties/Resources.ko-KR.resx
@@ -1,0 +1,86 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  
+  <xs:schema id="root">
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xs:element name="root" ns1:IsDataSet="true">
+      <xs:complexType>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element name="metadata">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" />
+              </xs:sequence>
+              <xs:attribute name="name" use="required" type="xsd:string" />
+              <xs:attribute name="type" type="xsd:string" />
+              <xs:attribute name="mimetype" type="xsd:string" />
+              <xs:attribute ref="xml:space" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="assembly">
+            <xs:complexType>
+              <xs:attribute name="alias" type="xsd:string" />
+              <xs:attribute name="name" type="xsd:string" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="data">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+                <xs:element name="comment" type="xsd:string" minOccurs="0" ns1:Ordinal="2" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" ns1:Ordinal="1" />
+              <xs:attribute name="type" type="xsd:string" ns1:Ordinal="3" />
+              <xs:attribute name="mimetype" type="xsd:string" ns1:Ordinal="4" />
+              <xs:attribute ref="xml:space" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="resheader">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" />
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Close" xml:space="preserve">
+    <value>닫기</value>
+  </data>
+  <data name="Content" xml:space="preserve">
+    <value>죄송합니다.
+Beutl에서 올바르게 처리되지 않은 오류가 발생했습니다.
+
+원격 분석 수집이 활성화된 경우 로그가 자동으로 수집됩니다.</value>
+  </data>
+  <data name="ErrorOccurred" xml:space="preserve">
+    <value>오류가 발생했습니다.</value>
+  </data>
+  <data name="LogFileNotFound" xml:space="preserve">
+    <value>로그 파일을 찾을 수 없습니다</value>
+  </data>
+  <data name="MoreDetails" xml:space="preserve">
+    <value>자세한 정보</value>
+  </data>
+  <data name="ShowLog" xml:space="preserve">
+    <value>로그 표시</value>
+  </data>
+  <data name="SendFeedback" xml:space="preserve">
+    <value>피드백 보내기</value>
+  </data>
+</root>

--- a/src/Beutl.ExceptionHandler/Properties/Resources.ko-KR.resx
+++ b/src/Beutl.ExceptionHandler/Properties/Resources.ko-KR.resx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   
   <xs:schema id="root">
     <xs:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/Beutl.ExceptionHandler/Properties/Resources.zh-CN.resx
+++ b/src/Beutl.ExceptionHandler/Properties/Resources.zh-CN.resx
@@ -64,7 +64,7 @@
   </data>
   <data name="Content" xml:space="preserve">
     <value>抱歉。
-Beutl 发生了未正确处理错误。
+Beutl 遇到了一个未处理的错误。
 
 如果启用了遥测收集，将自动收集日志。</value>
   </data>

--- a/src/Beutl.ExceptionHandler/Properties/Resources.zh-CN.resx
+++ b/src/Beutl.ExceptionHandler/Properties/Resources.zh-CN.resx
@@ -1,0 +1,86 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  
+  <xs:schema id="root">
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xs:element name="root" ns1:IsDataSet="true">
+      <xs:complexType>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element name="metadata">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" />
+              </xs:sequence>
+              <xs:attribute name="name" use="required" type="xsd:string" />
+              <xs:attribute name="type" type="xsd:string" />
+              <xs:attribute name="mimetype" type="xsd:string" />
+              <xs:attribute ref="xml:space" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="assembly">
+            <xs:complexType>
+              <xs:attribute name="alias" type="xsd:string" />
+              <xs:attribute name="name" type="xsd:string" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="data">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+                <xs:element name="comment" type="xsd:string" minOccurs="0" ns1:Ordinal="2" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" ns1:Ordinal="1" />
+              <xs:attribute name="type" type="xsd:string" ns1:Ordinal="3" />
+              <xs:attribute name="mimetype" type="xsd:string" ns1:Ordinal="4" />
+              <xs:attribute ref="xml:space" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="resheader">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" />
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Close" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="Content" xml:space="preserve">
+    <value>抱歉。
+Beutl 发生了未正确处理错误。
+
+如果启用了遥测收集，将自动收集日志。</value>
+  </data>
+  <data name="ErrorOccurred" xml:space="preserve">
+    <value>发生错误。</value>
+  </data>
+  <data name="LogFileNotFound" xml:space="preserve">
+    <value>未找到日志文件</value>
+  </data>
+  <data name="MoreDetails" xml:space="preserve">
+    <value>更多详细信息</value>
+  </data>
+  <data name="ShowLog" xml:space="preserve">
+    <value>显示日志</value>
+  </data>
+  <data name="SendFeedback" xml:space="preserve">
+    <value>发送反馈</value>
+  </data>
+</root>

--- a/src/Beutl.ExceptionHandler/Properties/Resources.zh-CN.resx
+++ b/src/Beutl.ExceptionHandler/Properties/Resources.zh-CN.resx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   
   <xs:schema id="root">
     <xs:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/Beutl.Extensions.FFmpeg/Properties/Strings.es.resx
+++ b/src/Beutl.Extensions.FFmpeg/Properties/Strings.es.resx
@@ -1,0 +1,137 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  
+  <xs:schema id="root">
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xs:element name="root" ns1:IsDataSet="true">
+      <xs:complexType>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element name="metadata">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" />
+              </xs:sequence>
+              <xs:attribute name="name" use="required" type="xsd:string" />
+              <xs:attribute name="type" type="xsd:string" />
+              <xs:attribute name="mimetype" type="xsd:string" />
+              <xs:attribute ref="xml:space" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="assembly">
+            <xs:complexType>
+              <xs:attribute name="alias" type="xsd:string" />
+              <xs:attribute name="name" type="xsd:string" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="data">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+                <xs:element name="comment" type="xsd:string" minOccurs="0" ns1:Ordinal="2" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" ns1:Ordinal="1" />
+              <xs:attribute name="type" type="xsd:string" ns1:Ordinal="3" />
+              <xs:attribute name="mimetype" type="xsd:string" ns1:Ordinal="4" />
+              <xs:attribute ref="xml:space" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="resheader">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" />
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="FFmpegError" xml:space="preserve">
+    <value>Error de FFmpeg</value>
+  </data>
+  <data name="Make_sure_you_have_FFmpeg_installed" xml:space="preserve">
+    <value>Asegúrate de tener FFmpeg instalado.</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>Instalar</value>
+  </data>
+  <data name="Install_FFmpeg" xml:space="preserve">
+    <value>Instalar FFmpeg</value>
+  </data>
+  <data name="Preparing" xml:space="preserve">
+    <value>Preparando...</value>
+  </data>
+  <data name="Fetching_release_information" xml:space="preserve">
+    <value>Obteniendo información de la versión...</value>
+  </data>
+  <data name="Failed_to_find_FFmpeg_release" xml:space="preserve">
+    <value>No se pudo encontrar la versión de FFmpeg. Plataforma no compatible o error de red.</value>
+  </data>
+  <data name="Installation_complete" xml:space="preserve">
+    <value>Instalación completada.</value>
+  </data>
+  <data name="Installing_FFmpeg_via_Homebrew" xml:space="preserve">
+    <value>Instalando FFmpeg mediante Homebrew...</value>
+  </data>
+  <data name="Homebrew_not_found" xml:space="preserve">
+    <value>No se encontró Homebrew. Instala Homebrew primero: https://brew.sh</value>
+  </data>
+  <data name="Installation_failed" xml:space="preserve">
+    <value>Error de instalación: {0}</value>
+  </data>
+  <data name="Failed_to_run_Homebrew" xml:space="preserve">
+    <value>Error al ejecutar Homebrew: {0}</value>
+  </data>
+  <data name="Download_FFmpeg_from_BtbN" xml:space="preserve">
+    <value>Descargar FFmpeg 8.0 desde BtbN/FFmpeg-Builds (GitHub)</value>
+  </data>
+  <data name="Install_FFmpeg_using_Homebrew" xml:space="preserve">
+    <value>Instalar FFmpeg 8.0 con Homebrew (brew install ffmpeg@8)</value>
+  </data>
+  <data name="Unknown_method" xml:space="preserve">
+    <value>Método desconocido</value>
+  </data>
+  <data name="Verifying_FFmpeg_installation" xml:space="preserve">
+    <value>Verificando la instalación de FFmpeg...</value>
+  </data>
+  <data name="FFmpeg_installation_successful" xml:space="preserve">
+    <value>FFmpeg se ha instalado correctamente.</value>
+  </data>
+  <data name="FFmpeg_verification_failed" xml:space="preserve">
+    <value>La instalación de FFmpeg se completó, pero la verificación falló. Reinicia la aplicación.</value>
+  </data>
+  <data name="Installing_Homebrew" xml:space="preserve">
+    <value>Instalando Homebrew...</value>
+  </data>
+  <data name="Homebrew_not_found_installing" xml:space="preserve">
+    <value>No se encontró Homebrew. Instalando Homebrew...</value>
+  </data>
+  <data name="Homebrew_installation_failed" xml:space="preserve">
+    <value>Error de instalación de Homebrew: {0}</value>
+  </data>
+  <data name="Homebrew_not_found_after_installation" xml:space="preserve">
+    <value>No se encontró Homebrew después de la instalación.</value>
+  </data>
+  <data name="Failed_to_install_Homebrew" xml:space="preserve">
+    <value>Error al instalar Homebrew: {0}</value>
+  </data>
+  <data name="FFmpegEncoder" xml:space="preserve">
+    <value>Codificador FFmpeg</value>
+  </data>
+  <data name="FFmpegDecoder" xml:space="preserve">
+    <value>Decodificador FFmpeg</value>
+  </data>
+</root>

--- a/src/Beutl.Extensions.FFmpeg/Properties/Strings.es.resx
+++ b/src/Beutl.Extensions.FFmpeg/Properties/Strings.es.resx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   
   <xs:schema id="root">
     <xs:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/Beutl.Extensions.FFmpeg/Properties/Strings.ko-KR.resx
+++ b/src/Beutl.Extensions.FFmpeg/Properties/Strings.ko-KR.resx
@@ -1,0 +1,137 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  
+  <xs:schema id="root">
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xs:element name="root" ns1:IsDataSet="true">
+      <xs:complexType>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element name="metadata">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" />
+              </xs:sequence>
+              <xs:attribute name="name" use="required" type="xsd:string" />
+              <xs:attribute name="type" type="xsd:string" />
+              <xs:attribute name="mimetype" type="xsd:string" />
+              <xs:attribute ref="xml:space" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="assembly">
+            <xs:complexType>
+              <xs:attribute name="alias" type="xsd:string" />
+              <xs:attribute name="name" type="xsd:string" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="data">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+                <xs:element name="comment" type="xsd:string" minOccurs="0" ns1:Ordinal="2" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" ns1:Ordinal="1" />
+              <xs:attribute name="type" type="xsd:string" ns1:Ordinal="3" />
+              <xs:attribute name="mimetype" type="xsd:string" ns1:Ordinal="4" />
+              <xs:attribute ref="xml:space" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="resheader">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" />
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="FFmpegError" xml:space="preserve">
+    <value>FFmpeg 오류</value>
+  </data>
+  <data name="Make_sure_you_have_FFmpeg_installed" xml:space="preserve">
+    <value>FFmpeg가 설치되어 있는지 확인하세요.</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>설치</value>
+  </data>
+  <data name="Install_FFmpeg" xml:space="preserve">
+    <value>FFmpeg 설치</value>
+  </data>
+  <data name="Preparing" xml:space="preserve">
+    <value>준비 중...</value>
+  </data>
+  <data name="Fetching_release_information" xml:space="preserve">
+    <value>릴리스 정보를 가져오는 중...</value>
+  </data>
+  <data name="Failed_to_find_FFmpeg_release" xml:space="preserve">
+    <value>FFmpeg 릴리스를 찾을 수 없습니다. 지원되지 않는 플랫폼 또는 네트워크 오류입니다.</value>
+  </data>
+  <data name="Installation_complete" xml:space="preserve">
+    <value>설치가 완료되었습니다.</value>
+  </data>
+  <data name="Installing_FFmpeg_via_Homebrew" xml:space="preserve">
+    <value>Homebrew를 통해 FFmpeg를 설치하는 중...</value>
+  </data>
+  <data name="Homebrew_not_found" xml:space="preserve">
+    <value>Homebrew를 찾을 수 없습니다. 먼저 Homebrew를 설치하세요: https://brew.sh</value>
+  </data>
+  <data name="Installation_failed" xml:space="preserve">
+    <value>설치 실패: {0}</value>
+  </data>
+  <data name="Failed_to_run_Homebrew" xml:space="preserve">
+    <value>Homebrew 실행 실패: {0}</value>
+  </data>
+  <data name="Download_FFmpeg_from_BtbN" xml:space="preserve">
+    <value>BtbN/FFmpeg-Builds(GitHub)에서 FFmpeg 8.0 다운로드</value>
+  </data>
+  <data name="Install_FFmpeg_using_Homebrew" xml:space="preserve">
+    <value>Homebrew로 FFmpeg 8.0 설치 (brew install ffmpeg@8)</value>
+  </data>
+  <data name="Unknown_method" xml:space="preserve">
+    <value>알 수 없는 방법</value>
+  </data>
+  <data name="Verifying_FFmpeg_installation" xml:space="preserve">
+    <value>FFmpeg 설치를 확인하는 중...</value>
+  </data>
+  <data name="FFmpeg_installation_successful" xml:space="preserve">
+    <value>FFmpeg가 성공적으로 설치되었습니다.</value>
+  </data>
+  <data name="FFmpeg_verification_failed" xml:space="preserve">
+    <value>FFmpeg 설치가 완료되었지만 확인에 실패했습니다. 애플리케이션을 다시 시작하세요.</value>
+  </data>
+  <data name="Installing_Homebrew" xml:space="preserve">
+    <value>Homebrew를 설치하는 중...</value>
+  </data>
+  <data name="Homebrew_not_found_installing" xml:space="preserve">
+    <value>Homebrew를 찾을 수 없습니다. Homebrew를 설치하는 중...</value>
+  </data>
+  <data name="Homebrew_installation_failed" xml:space="preserve">
+    <value>Homebrew 설치 실패: {0}</value>
+  </data>
+  <data name="Homebrew_not_found_after_installation" xml:space="preserve">
+    <value>설치 후에도 Homebrew를 찾을 수 없습니다.</value>
+  </data>
+  <data name="Failed_to_install_Homebrew" xml:space="preserve">
+    <value>Homebrew 설치 실패: {0}</value>
+  </data>
+  <data name="FFmpegEncoder" xml:space="preserve">
+    <value>FFmpeg 인코더</value>
+  </data>
+  <data name="FFmpegDecoder" xml:space="preserve">
+    <value>FFmpeg 디코더</value>
+  </data>
+</root>

--- a/src/Beutl.Extensions.FFmpeg/Properties/Strings.ko-KR.resx
+++ b/src/Beutl.Extensions.FFmpeg/Properties/Strings.ko-KR.resx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   
   <xs:schema id="root">
     <xs:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/Beutl.Extensions.FFmpeg/Properties/Strings.zh-CN.resx
+++ b/src/Beutl.Extensions.FFmpeg/Properties/Strings.zh-CN.resx
@@ -1,0 +1,137 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  
+  <xs:schema id="root">
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xs:element name="root" ns1:IsDataSet="true">
+      <xs:complexType>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element name="metadata">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" />
+              </xs:sequence>
+              <xs:attribute name="name" use="required" type="xsd:string" />
+              <xs:attribute name="type" type="xsd:string" />
+              <xs:attribute name="mimetype" type="xsd:string" />
+              <xs:attribute ref="xml:space" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="assembly">
+            <xs:complexType>
+              <xs:attribute name="alias" type="xsd:string" />
+              <xs:attribute name="name" type="xsd:string" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="data">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+                <xs:element name="comment" type="xsd:string" minOccurs="0" ns1:Ordinal="2" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" ns1:Ordinal="1" />
+              <xs:attribute name="type" type="xsd:string" ns1:Ordinal="3" />
+              <xs:attribute name="mimetype" type="xsd:string" ns1:Ordinal="4" />
+              <xs:attribute ref="xml:space" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="resheader">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" />
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="FFmpegError" xml:space="preserve">
+    <value>FFmpeg 错误</value>
+  </data>
+  <data name="Make_sure_you_have_FFmpeg_installed" xml:space="preserve">
+    <value>请确保已安装 FFmpeg。</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>安装</value>
+  </data>
+  <data name="Install_FFmpeg" xml:space="preserve">
+    <value>安装 FFmpeg</value>
+  </data>
+  <data name="Preparing" xml:space="preserve">
+    <value>准备中...</value>
+  </data>
+  <data name="Fetching_release_information" xml:space="preserve">
+    <value>正在获取发布信息...</value>
+  </data>
+  <data name="Failed_to_find_FFmpeg_release" xml:space="preserve">
+    <value>找不到 FFmpeg 发布版本。平台不受支持或网络错误。</value>
+  </data>
+  <data name="Installation_complete" xml:space="preserve">
+    <value>安装完成。</value>
+  </data>
+  <data name="Installing_FFmpeg_via_Homebrew" xml:space="preserve">
+    <value>正在通过 Homebrew 安装 FFmpeg...</value>
+  </data>
+  <data name="Homebrew_not_found" xml:space="preserve">
+    <value>未找到 Homebrew。请先安装 Homebrew: https://brew.sh</value>
+  </data>
+  <data name="Installation_failed" xml:space="preserve">
+    <value>安装失败: {0}</value>
+  </data>
+  <data name="Failed_to_run_Homebrew" xml:space="preserve">
+    <value>运行 Homebrew 失败: {0}</value>
+  </data>
+  <data name="Download_FFmpeg_from_BtbN" xml:space="preserve">
+    <value>从 BtbN/FFmpeg-Builds (GitHub) 下载 FFmpeg 8.0</value>
+  </data>
+  <data name="Install_FFmpeg_using_Homebrew" xml:space="preserve">
+    <value>使用 Homebrew 安装 FFmpeg 8.0 (brew install ffmpeg@8)</value>
+  </data>
+  <data name="Unknown_method" xml:space="preserve">
+    <value>未知方法</value>
+  </data>
+  <data name="Verifying_FFmpeg_installation" xml:space="preserve">
+    <value>正在验证 FFmpeg 安装...</value>
+  </data>
+  <data name="FFmpeg_installation_successful" xml:space="preserve">
+    <value>FFmpeg 已成功安装。</value>
+  </data>
+  <data name="FFmpeg_verification_failed" xml:space="preserve">
+    <value>FFmpeg 安装已完成，但验证失败。请重新启动应用程序。</value>
+  </data>
+  <data name="Installing_Homebrew" xml:space="preserve">
+    <value>正在安装 Homebrew...</value>
+  </data>
+  <data name="Homebrew_not_found_installing" xml:space="preserve">
+    <value>未找到 Homebrew。正在安装 Homebrew...</value>
+  </data>
+  <data name="Homebrew_installation_failed" xml:space="preserve">
+    <value>Homebrew 安装失败: {0}</value>
+  </data>
+  <data name="Homebrew_not_found_after_installation" xml:space="preserve">
+    <value>安装后未找到 Homebrew。</value>
+  </data>
+  <data name="Failed_to_install_Homebrew" xml:space="preserve">
+    <value>安装 Homebrew 失败: {0}</value>
+  </data>
+  <data name="FFmpegEncoder" xml:space="preserve">
+    <value>FFmpeg 编码器</value>
+  </data>
+  <data name="FFmpegDecoder" xml:space="preserve">
+    <value>FFmpeg 解码器</value>
+  </data>
+</root>

--- a/src/Beutl.Extensions.FFmpeg/Properties/Strings.zh-CN.resx
+++ b/src/Beutl.Extensions.FFmpeg/Properties/Strings.zh-CN.resx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   
   <xs:schema id="root">
     <xs:import namespace="http://www.w3.org/XML/1998/namespace" />

--- a/src/Beutl.Extensions.MediaFoundation/Properties/Strings.es.resx
+++ b/src/Beutl.Extensions.MediaFoundation/Properties/Strings.es.resx
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+      <xs:complexType>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element name="data">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+                <xs:element name="comment" type="xsd:string" minOccurs="0" ns1:Ordinal="2" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" ns1:Ordinal="1" />
+              <xs:attribute name="type" type="xsd:string" ns1:Ordinal="3" />
+              <xs:attribute name="mimetype" type="xsd:string" ns1:Ordinal="4" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="resheader">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" />
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DecodingName" xml:space="preserve">
+    <value>Decodificación de Media Foundation</value>
+  </data>
+  <data name="SeekThresholdInVideoStream" xml:space="preserve">
+    <value>Umbral de búsqueda en el flujo de video</value>
+  </data>
+  <data name="SeekThresholdInVideoStream_Description" xml:space="preserve">
+    <value>Si se leen fotogramas más allá de este número, se realiza una búsqueda.</value>
+  </data>
+  <data name="MaxVideoBufferSize" xml:space="preserve">
+    <value>Número de fotogramas a almacenar en caché</value>
+  </data>
+  <data name="Cache" xml:space="preserve">
+    <value>Caché</value>
+  </data>
+</root>

--- a/src/Beutl.Extensions.MediaFoundation/Properties/Strings.es.resx
+++ b/src/Beutl.Extensions.MediaFoundation/Properties/Strings.es.resx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   
   <xs:schema id="root">
     <xs:element name="root" ns1:IsDataSet="true">

--- a/src/Beutl.Extensions.MediaFoundation/Properties/Strings.ko-KR.resx
+++ b/src/Beutl.Extensions.MediaFoundation/Properties/Strings.ko-KR.resx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   
   <xs:schema id="root">
     <xs:element name="root" ns1:IsDataSet="true">

--- a/src/Beutl.Extensions.MediaFoundation/Properties/Strings.ko-KR.resx
+++ b/src/Beutl.Extensions.MediaFoundation/Properties/Strings.ko-KR.resx
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+      <xs:complexType>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element name="data">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+                <xs:element name="comment" type="xsd:string" minOccurs="0" ns1:Ordinal="2" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" ns1:Ordinal="1" />
+              <xs:attribute name="type" type="xsd:string" ns1:Ordinal="3" />
+              <xs:attribute name="mimetype" type="xsd:string" ns1:Ordinal="4" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="resheader">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" />
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DecodingName" xml:space="preserve">
+    <value>Media Foundation 디코딩</value>
+  </data>
+  <data name="SeekThresholdInVideoStream" xml:space="preserve">
+    <value>비디오 스트림의 탐색 임계값</value>
+  </data>
+  <data name="SeekThresholdInVideoStream_Description" xml:space="preserve">
+    <value>이 프레임 수보다 더 멀리 있는 프레임을 읽으면 탐색이 수행됩니다.</value>
+  </data>
+  <data name="MaxVideoBufferSize" xml:space="preserve">
+    <value>캐시할 프레임 수</value>
+  </data>
+  <data name="Cache" xml:space="preserve">
+    <value>캐시</value>
+  </data>
+</root>

--- a/src/Beutl.Extensions.MediaFoundation/Properties/Strings.zh-CN.resx
+++ b/src/Beutl.Extensions.MediaFoundation/Properties/Strings.zh-CN.resx
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+      <xs:complexType>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element name="data">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+                <xs:element name="comment" type="xsd:string" minOccurs="0" ns1:Ordinal="2" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" ns1:Ordinal="1" />
+              <xs:attribute name="type" type="xsd:string" ns1:Ordinal="3" />
+              <xs:attribute name="mimetype" type="xsd:string" ns1:Ordinal="4" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="resheader">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" />
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DecodingName" xml:space="preserve">
+    <value>Media Foundation 解码</value>
+  </data>
+  <data name="SeekThresholdInVideoStream" xml:space="preserve">
+    <value>视频流中的搜索阈值</value>
+  </data>
+  <data name="SeekThresholdInVideoStream_Description" xml:space="preserve">
+    <value>如果读取的帧超过此帧数，则执行搜索。</value>
+  </data>
+  <data name="MaxVideoBufferSize" xml:space="preserve">
+    <value>要缓存的帧数</value>
+  </data>
+  <data name="Cache" xml:space="preserve">
+    <value>缓存</value>
+  </data>
+</root>

--- a/src/Beutl.Extensions.MediaFoundation/Properties/Strings.zh-CN.resx
+++ b/src/Beutl.Extensions.MediaFoundation/Properties/Strings.zh-CN.resx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   
   <xs:schema id="root">
     <xs:element name="root" ns1:IsDataSet="true">

--- a/src/Beutl.Extensions.MediaFoundation/Properties/Strings.zh-CN.resx
+++ b/src/Beutl.Extensions.MediaFoundation/Properties/Strings.zh-CN.resx
@@ -44,10 +44,10 @@
     <value>Media Foundation 解码</value>
   </data>
   <data name="SeekThresholdInVideoStream" xml:space="preserve">
-    <value>视频流中的搜索阈值</value>
+    <value>视频流中的跳转阈值</value>
   </data>
   <data name="SeekThresholdInVideoStream_Description" xml:space="preserve">
-    <value>如果读取的帧超过此帧数，则执行搜索。</value>
+    <value>如果读取的帧距离当前帧超过此帧数，则执行跳转。</value>
   </data>
   <data name="MaxVideoBufferSize" xml:space="preserve">
     <value>要缓存的帧数</value>

--- a/src/Beutl.Language/AudioStrings.es.resx
+++ b/src/Beutl.Language/AudioStrings.es.resx
@@ -1,0 +1,188 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="SourceSound" xml:space="preserve">
+    <value>Sonido</value>
+  </data>
+  <data name="SourceSound_Source" xml:space="preserve">
+    <value>Fuente</value>
+  </data>
+  <data name="SoundGroup" xml:space="preserve">
+    <value>Grupo de sonido</value>
+  </data>
+  <data name="Sound_OffsetPosition" xml:space="preserve">
+    <value>Posición de desplazamiento</value>
+  </data>
+  <data name="Sound_Gain" xml:space="preserve">
+    <value>Ganancia</value>
+  </data>
+  <data name="Sound_Speed" xml:space="preserve">
+    <value>Velocidad</value>
+  </data>
+  <data name="AudioEffect" xml:space="preserve">
+    <value>Efecto de audio</value>
+  </data>
+  <data name="DelayEffect" xml:space="preserve">
+    <value>Retardo</value>
+  </data>
+  <data name="DelayEffect_DelayTime" xml:space="preserve">
+    <value>Tiempo de retardo (ms)</value>
+  </data>
+  <data name="DelayEffect_Feedback" xml:space="preserve">
+    <value>Retroalimentación (%)</value>
+  </data>
+  <data name="DelayEffect_DryMix" xml:space="preserve">
+    <value>Mezcla seca (%)</value>
+  </data>
+  <data name="DelayEffect_WetMix" xml:space="preserve">
+    <value>Mezcla húmeda (%)</value>
+  </data>
+  <data name="AudioEffectGroup" xml:space="preserve">
+    <value>Grupo</value>
+  </data>
+  <data name="SceneSound" xml:space="preserve">
+    <value>Referencia de escena (audio)</value>
+  </data>
+  <data name="SceneSound_ReferencedScene" xml:space="preserve">
+    <value>Escena referenciada</value>
+  </data>
+  <data name="Equalizer" xml:space="preserve">
+    <value>Ecualizador</value>
+  </data>
+  <data name="Equalizer_Band" xml:space="preserve">
+    <value>Banda del ecualizador</value>
+  </data>
+  <data name="Equalizer_FilterType" xml:space="preserve">
+    <value>Tipo de filtro</value>
+  </data>
+  <data name="Equalizer_Frequency" xml:space="preserve">
+    <value>Frecuencia (Hz)</value>
+  </data>
+  <data name="Equalizer_Q" xml:space="preserve">
+    <value>Q</value>
+  </data>
+  <data name="Equalizer_BandCount" xml:space="preserve">
+    <value>Número de bandas</value>
+  </data>
+  <data name="Equalizer_Bands" xml:space="preserve">
+    <value>Bandas</value>
+  </data>
+  <data name="Equalizer_Gain" xml:space="preserve">
+    <value>Ganancia</value>
+  </data>
+  <data name="CompressorEffect" xml:space="preserve">
+    <value>Compresor</value>
+  </data>
+  <data name="CompressorEffect_Threshold" xml:space="preserve">
+    <value>Umbral (dB)</value>
+  </data>
+  <data name="CompressorEffect_Ratio" xml:space="preserve">
+    <value>Relación</value>
+  </data>
+  <data name="CompressorEffect_Attack" xml:space="preserve">
+    <value>Ataque (ms)</value>
+  </data>
+  <data name="CompressorEffect_Release" xml:space="preserve">
+    <value>Liberación (ms)</value>
+  </data>
+  <data name="CompressorEffect_Knee" xml:space="preserve">
+    <value>Rodilla (dB)</value>
+  </data>
+  <data name="CompressorEffect_MakeupGain" xml:space="preserve">
+    <value>Ganancia de compensación (dB)</value>
+  </data>
+  <data name="CompressorEffect_Threshold_Description" xml:space="preserve">
+    <value>El nivel por encima del cual se comprime la señal.</value>
+  </data>
+  <data name="CompressorEffect_Ratio_Description" xml:space="preserve">
+    <value>La cantidad de compresión aplicada por encima del umbral. Los valores más altos comprimen con más fuerza.</value>
+  </data>
+  <data name="CompressorEffect_Attack_Description" xml:space="preserve">
+    <value>La rapidez con la que la compresión se activa después de que la señal cruza el umbral.</value>
+  </data>
+  <data name="CompressorEffect_Release_Description" xml:space="preserve">
+    <value>La rapidez con la que la compresión se libera después de que la señal cae por debajo del umbral.</value>
+  </data>
+  <data name="CompressorEffect_Knee_Description" xml:space="preserve">
+    <value>La gradualidad con la que la compresión se activa alrededor del umbral. 0 es una rodilla dura; los valores más grandes son más suaves.</value>
+  </data>
+  <data name="CompressorEffect_MakeupGain_Description" xml:space="preserve">
+    <value>Ganancia aplicada después de la compresión para compensar el nivel reducido.</value>
+  </data>
+  <data name="LimiterEffect" xml:space="preserve">
+    <value>Limitador</value>
+  </data>
+  <data name="LimiterEffect_Threshold" xml:space="preserve">
+    <value>Umbral (dB)</value>
+  </data>
+  <data name="LimiterEffect_Release" xml:space="preserve">
+    <value>Liberación (ms)</value>
+  </data>
+  <data name="LimiterEffect_Lookahead" xml:space="preserve">
+    <value>Anticipación (ms)</value>
+  </data>
+  <data name="LimiterEffect_MakeupGain" xml:space="preserve">
+    <value>Ganancia de compensación (dB)</value>
+  </data>
+  <data name="LimiterEffect_Threshold_Description" xml:space="preserve">
+    <value>El techo de salida. Los picos dentro de la ventana de anticipación se reducen para que la salida se mantenga en o por debajo de este nivel.</value>
+  </data>
+  <data name="LimiterEffect_Release_Description" xml:space="preserve">
+    <value>La rapidez con la que la ganancia se recupera después de que pasa un pico.</value>
+  </data>
+  <data name="LimiterEffect_Lookahead_Description" xml:space="preserve">
+    <value>Cuánto mira hacia adelante el limitador para capturar los picos antes de que lleguen. 0 ms mantiene la precisión de muestra de audio; los valores más altos intercambian un retardo fijo por una limitación más suave.</value>
+  </data>
+  <data name="LimiterEffect_MakeupGain_Description" xml:space="preserve">
+    <value>Ganancia aplicada después de la limitación. El pico final puede alcanzar Umbral + Ganancia de compensación.</value>
+  </data>
+  <data name="GateEffect" xml:space="preserve">
+    <value>Puerta</value>
+  </data>
+  <data name="GateEffect_Threshold" xml:space="preserve">
+    <value>Umbral (dB)</value>
+  </data>
+  <data name="GateEffect_Attack" xml:space="preserve">
+    <value>Ataque (ms)</value>
+  </data>
+  <data name="GateEffect_Hold" xml:space="preserve">
+    <value>Retención (ms)</value>
+  </data>
+  <data name="GateEffect_Release" xml:space="preserve">
+    <value>Liberación (ms)</value>
+  </data>
+  <data name="GateEffect_Range" xml:space="preserve">
+    <value>Rango (dB)</value>
+  </data>
+  <data name="GateEffect_Threshold_Description" xml:space="preserve">
+    <value>El nivel por debajo del cual la puerta se cierra y atenúa la señal.</value>
+  </data>
+  <data name="GateEffect_Attack_Description" xml:space="preserve">
+    <value>La rapidez con la que la puerta se abre una vez que la señal supera el umbral.</value>
+  </data>
+  <data name="GateEffect_Hold_Description" xml:space="preserve">
+    <value>Cuánto tiempo permanece abierta la puerta después de que la señal cae por debajo del umbral, antes de liberarse.</value>
+  </data>
+  <data name="GateEffect_Release_Description" xml:space="preserve">
+    <value>La rapidez con la que la puerta se cierra después de que transcurre el tiempo de retención.</value>
+  </data>
+  <data name="GateEffect_Range_Description" xml:space="preserve">
+    <value>Atenuación aplicada mientras la puerta está cerrada. 0 desactiva la puerta; los valores más negativos atenúan con más fuerza.</value>
+  </data>
+</root>

--- a/src/Beutl.Language/AudioStrings.ko-KR.resx
+++ b/src/Beutl.Language/AudioStrings.ko-KR.resx
@@ -1,0 +1,188 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="SourceSound" xml:space="preserve">
+    <value>사운드</value>
+  </data>
+  <data name="SourceSound_Source" xml:space="preserve">
+    <value>소스</value>
+  </data>
+  <data name="SoundGroup" xml:space="preserve">
+    <value>사운드 그룹</value>
+  </data>
+  <data name="Sound_OffsetPosition" xml:space="preserve">
+    <value>오프셋 위치</value>
+  </data>
+  <data name="Sound_Gain" xml:space="preserve">
+    <value>게인</value>
+  </data>
+  <data name="Sound_Speed" xml:space="preserve">
+    <value>속도</value>
+  </data>
+  <data name="AudioEffect" xml:space="preserve">
+    <value>오디오 효과</value>
+  </data>
+  <data name="DelayEffect" xml:space="preserve">
+    <value>딜레이</value>
+  </data>
+  <data name="DelayEffect_DelayTime" xml:space="preserve">
+    <value>딜레이 시간 (ms)</value>
+  </data>
+  <data name="DelayEffect_Feedback" xml:space="preserve">
+    <value>피드백 (%)</value>
+  </data>
+  <data name="DelayEffect_DryMix" xml:space="preserve">
+    <value>드라이 믹스 (%)</value>
+  </data>
+  <data name="DelayEffect_WetMix" xml:space="preserve">
+    <value>웻 믹스 (%)</value>
+  </data>
+  <data name="AudioEffectGroup" xml:space="preserve">
+    <value>그룹</value>
+  </data>
+  <data name="SceneSound" xml:space="preserve">
+    <value>장면 참조 (오디오)</value>
+  </data>
+  <data name="SceneSound_ReferencedScene" xml:space="preserve">
+    <value>참조된 장면</value>
+  </data>
+  <data name="Equalizer" xml:space="preserve">
+    <value>이퀄라이저</value>
+  </data>
+  <data name="Equalizer_Band" xml:space="preserve">
+    <value>이퀄라이저 밴드</value>
+  </data>
+  <data name="Equalizer_FilterType" xml:space="preserve">
+    <value>필터 유형</value>
+  </data>
+  <data name="Equalizer_Frequency" xml:space="preserve">
+    <value>주파수 (Hz)</value>
+  </data>
+  <data name="Equalizer_Q" xml:space="preserve">
+    <value>Q</value>
+  </data>
+  <data name="Equalizer_BandCount" xml:space="preserve">
+    <value>밴드 수</value>
+  </data>
+  <data name="Equalizer_Bands" xml:space="preserve">
+    <value>밴드</value>
+  </data>
+  <data name="Equalizer_Gain" xml:space="preserve">
+    <value>게인</value>
+  </data>
+  <data name="CompressorEffect" xml:space="preserve">
+    <value>컴프레서</value>
+  </data>
+  <data name="CompressorEffect_Threshold" xml:space="preserve">
+    <value>임계값 (dB)</value>
+  </data>
+  <data name="CompressorEffect_Ratio" xml:space="preserve">
+    <value>비율</value>
+  </data>
+  <data name="CompressorEffect_Attack" xml:space="preserve">
+    <value>어택 (ms)</value>
+  </data>
+  <data name="CompressorEffect_Release" xml:space="preserve">
+    <value>릴리즈 (ms)</value>
+  </data>
+  <data name="CompressorEffect_Knee" xml:space="preserve">
+    <value>니 (dB)</value>
+  </data>
+  <data name="CompressorEffect_MakeupGain" xml:space="preserve">
+    <value>메이크업 게인 (dB)</value>
+  </data>
+  <data name="CompressorEffect_Threshold_Description" xml:space="preserve">
+    <value>신호가 압축되는 레벨 임계값입니다.</value>
+  </data>
+  <data name="CompressorEffect_Ratio_Description" xml:space="preserve">
+    <value>임계값 이상에서 적용되는 압축량입니다. 값이 높을수록 더 강하게 압축됩니다.</value>
+  </data>
+  <data name="CompressorEffect_Attack_Description" xml:space="preserve">
+    <value>신호가 임계값을 넘은 후 압축이 시작되는 속도입니다.</value>
+  </data>
+  <data name="CompressorEffect_Release_Description" xml:space="preserve">
+    <value>신호가 임계값 아래로 떨어진 후 압축이 해제되는 속도입니다.</value>
+  </data>
+  <data name="CompressorEffect_Knee_Description" xml:space="preserve">
+    <value>임계값 주변에서 압축이 시작되는 완만함입니다. 0은 하드 니이고, 값이 클수록 더 부드럽습니다.</value>
+  </data>
+  <data name="CompressorEffect_MakeupGain_Description" xml:space="preserve">
+    <value>압축 후 감소된 레벨을 보상하기 위해 적용되는 게인입니다.</value>
+  </data>
+  <data name="LimiterEffect" xml:space="preserve">
+    <value>리미터</value>
+  </data>
+  <data name="LimiterEffect_Threshold" xml:space="preserve">
+    <value>임계값 (dB)</value>
+  </data>
+  <data name="LimiterEffect_Release" xml:space="preserve">
+    <value>릴리즈 (ms)</value>
+  </data>
+  <data name="LimiterEffect_Lookahead" xml:space="preserve">
+    <value>룩어헤드 (ms)</value>
+  </data>
+  <data name="LimiterEffect_MakeupGain" xml:space="preserve">
+    <value>메이크업 게인 (dB)</value>
+  </data>
+  <data name="LimiterEffect_Threshold_Description" xml:space="preserve">
+    <value>출력 상한입니다. 룩어헤드 창 내의 피크가 줄어들어 출력이 이 레벨 이하로 유지됩니다.</value>
+  </data>
+  <data name="LimiterEffect_Release_Description" xml:space="preserve">
+    <value>피크가 지나간 후 게인이 회복되는 속도입니다.</value>
+  </data>
+  <data name="LimiterEffect_Lookahead_Description" xml:space="preserve">
+    <value>리미터가 피크를 미리 감지하기 위해 앞을 보는 거리입니다. 0ms는 오디오 샘플 정확도를 유지하고, 값이 클수록 고정 지연을 희생하여 더 부드러운 리미팅을 제공합니다.</value>
+  </data>
+  <data name="LimiterEffect_MakeupGain_Description" xml:space="preserve">
+    <value>리미팅 후 적용되는 게인입니다. 최종 피크는 임계값 + 메이크업 게인에 도달할 수 있습니다.</value>
+  </data>
+  <data name="GateEffect" xml:space="preserve">
+    <value>게이트</value>
+  </data>
+  <data name="GateEffect_Threshold" xml:space="preserve">
+    <value>임계값 (dB)</value>
+  </data>
+  <data name="GateEffect_Attack" xml:space="preserve">
+    <value>어택 (ms)</value>
+  </data>
+  <data name="GateEffect_Hold" xml:space="preserve">
+    <value>홀드 (ms)</value>
+  </data>
+  <data name="GateEffect_Release" xml:space="preserve">
+    <value>릴리즈 (ms)</value>
+  </data>
+  <data name="GateEffect_Range" xml:space="preserve">
+    <value>범위 (dB)</value>
+  </data>
+  <data name="GateEffect_Threshold_Description" xml:space="preserve">
+    <value>게이트가 닫히고 신호를 감쇠시키는 레벨입니다.</value>
+  </data>
+  <data name="GateEffect_Attack_Description" xml:space="preserve">
+    <value>신호가 임계값 위로 올라가면 게이트가 열리는 속도입니다.</value>
+  </data>
+  <data name="GateEffect_Hold_Description" xml:space="preserve">
+    <value>신호가 임계값 아래로 떨어진 후 게이트가 열린 상태를 유지하는 시간입니다.</value>
+  </data>
+  <data name="GateEffect_Release_Description" xml:space="preserve">
+    <value>홀드 시간이 지난 후 게이트가 닫히는 속도입니다.</value>
+  </data>
+  <data name="GateEffect_Range_Description" xml:space="preserve">
+    <value>게이트가 닫혀 있는 동안 적용되는 감쇠입니다. 0은 게이팅을 비활성화하고, 더 음수 값은 더 강하게 감쇠합니다.</value>
+  </data>
+</root>

--- a/src/Beutl.Language/AudioStrings.zh-CN.resx
+++ b/src/Beutl.Language/AudioStrings.zh-CN.resx
@@ -1,0 +1,188 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="SourceSound" xml:space="preserve">
+    <value>声音</value>
+  </data>
+  <data name="SourceSound_Source" xml:space="preserve">
+    <value>源</value>
+  </data>
+  <data name="SoundGroup" xml:space="preserve">
+    <value>声音组</value>
+  </data>
+  <data name="Sound_OffsetPosition" xml:space="preserve">
+    <value>偏移位置</value>
+  </data>
+  <data name="Sound_Gain" xml:space="preserve">
+    <value>增益</value>
+  </data>
+  <data name="Sound_Speed" xml:space="preserve">
+    <value>速度</value>
+  </data>
+  <data name="AudioEffect" xml:space="preserve">
+    <value>音频效果</value>
+  </data>
+  <data name="DelayEffect" xml:space="preserve">
+    <value>延迟</value>
+  </data>
+  <data name="DelayEffect_DelayTime" xml:space="preserve">
+    <value>延迟时间 (ms)</value>
+  </data>
+  <data name="DelayEffect_Feedback" xml:space="preserve">
+    <value>反馈 (%)</value>
+  </data>
+  <data name="DelayEffect_DryMix" xml:space="preserve">
+    <value>干声混合 (%)</value>
+  </data>
+  <data name="DelayEffect_WetMix" xml:space="preserve">
+    <value>湿声混合 (%)</value>
+  </data>
+  <data name="AudioEffectGroup" xml:space="preserve">
+    <value>组</value>
+  </data>
+  <data name="SceneSound" xml:space="preserve">
+    <value>场景引用（音频）</value>
+  </data>
+  <data name="SceneSound_ReferencedScene" xml:space="preserve">
+    <value>引用的场景</value>
+  </data>
+  <data name="Equalizer" xml:space="preserve">
+    <value>均衡器</value>
+  </data>
+  <data name="Equalizer_Band" xml:space="preserve">
+    <value>均衡器频段</value>
+  </data>
+  <data name="Equalizer_FilterType" xml:space="preserve">
+    <value>滤波器类型</value>
+  </data>
+  <data name="Equalizer_Frequency" xml:space="preserve">
+    <value>频率 (Hz)</value>
+  </data>
+  <data name="Equalizer_Q" xml:space="preserve">
+    <value>Q</value>
+  </data>
+  <data name="Equalizer_BandCount" xml:space="preserve">
+    <value>频段数</value>
+  </data>
+  <data name="Equalizer_Bands" xml:space="preserve">
+    <value>频段</value>
+  </data>
+  <data name="Equalizer_Gain" xml:space="preserve">
+    <value>增益</value>
+  </data>
+  <data name="CompressorEffect" xml:space="preserve">
+    <value>压缩器</value>
+  </data>
+  <data name="CompressorEffect_Threshold" xml:space="preserve">
+    <value>阈值 (dB)</value>
+  </data>
+  <data name="CompressorEffect_Ratio" xml:space="preserve">
+    <value>压缩比</value>
+  </data>
+  <data name="CompressorEffect_Attack" xml:space="preserve">
+    <value>启动时间 (ms)</value>
+  </data>
+  <data name="CompressorEffect_Release" xml:space="preserve">
+    <value>释放时间 (ms)</value>
+  </data>
+  <data name="CompressorEffect_Knee" xml:space="preserve">
+    <value>拐点 (dB)</value>
+  </data>
+  <data name="CompressorEffect_MakeupGain" xml:space="preserve">
+    <value>补偿增益 (dB)</value>
+  </data>
+  <data name="CompressorEffect_Threshold_Description" xml:space="preserve">
+    <value>信号被压缩的电平阈值。</value>
+  </data>
+  <data name="CompressorEffect_Ratio_Description" xml:space="preserve">
+    <value>超过阈值后施加的压缩量。数值越大压缩越强。</value>
+  </data>
+  <data name="CompressorEffect_Attack_Description" xml:space="preserve">
+    <value>信号超过阈值后压缩启动的速度。</value>
+  </data>
+  <data name="CompressorEffect_Release_Description" xml:space="preserve">
+    <value>信号低于阈值后压缩释放的速度。</value>
+  </data>
+  <data name="CompressorEffect_Knee_Description" xml:space="preserve">
+    <value>压缩在阈值附近启动的平缓程度。0 为硬拐点；数值越大越平滑。</value>
+  </data>
+  <data name="CompressorEffect_MakeupGain_Description" xml:space="preserve">
+    <value>压缩后施加的增益，用于补偿电平的降低。</value>
+  </data>
+  <data name="LimiterEffect" xml:space="preserve">
+    <value>限制器</value>
+  </data>
+  <data name="LimiterEffect_Threshold" xml:space="preserve">
+    <value>阈值 (dB)</value>
+  </data>
+  <data name="LimiterEffect_Release" xml:space="preserve">
+    <value>释放时间 (ms)</value>
+  </data>
+  <data name="LimiterEffect_Lookahead" xml:space="preserve">
+    <value>前瞻 (ms)</value>
+  </data>
+  <data name="LimiterEffect_MakeupGain" xml:space="preserve">
+    <value>补偿增益 (dB)</value>
+  </data>
+  <data name="LimiterEffect_Threshold_Description" xml:space="preserve">
+    <value>输出上限。前瞻窗口内的峰值会被降低，使输出保持在此电平或以下。</value>
+  </data>
+  <data name="LimiterEffect_Release_Description" xml:space="preserve">
+    <value>峰值过后增益恢复的速度。</value>
+  </data>
+  <data name="LimiterEffect_Lookahead_Description" xml:space="preserve">
+    <value>限制器提前查看的距离，以便在峰值到达前捕捉它们。0 ms 保持音频采样精确；较大的值以固定延迟换取更平滑的限制。</value>
+  </data>
+  <data name="LimiterEffect_MakeupGain_Description" xml:space="preserve">
+    <value>限制后施加的增益。最终峰值可以达到阈值 + 补偿增益。</value>
+  </data>
+  <data name="GateEffect" xml:space="preserve">
+    <value>噪声门</value>
+  </data>
+  <data name="GateEffect_Threshold" xml:space="preserve">
+    <value>阈值 (dB)</value>
+  </data>
+  <data name="GateEffect_Attack" xml:space="preserve">
+    <value>启动时间 (ms)</value>
+  </data>
+  <data name="GateEffect_Hold" xml:space="preserve">
+    <value>保持时间 (ms)</value>
+  </data>
+  <data name="GateEffect_Release" xml:space="preserve">
+    <value>释放时间 (ms)</value>
+  </data>
+  <data name="GateEffect_Range" xml:space="preserve">
+    <value>范围 (dB)</value>
+  </data>
+  <data name="GateEffect_Threshold_Description" xml:space="preserve">
+    <value>门关闭并衰减信号的电平阈值。</value>
+  </data>
+  <data name="GateEffect_Attack_Description" xml:space="preserve">
+    <value>信号超过阈值后门打开的速度。</value>
+  </data>
+  <data name="GateEffect_Hold_Description" xml:space="preserve">
+    <value>信号低于阈值后门保持打开的时间，然后才释放。</value>
+  </data>
+  <data name="GateEffect_Release_Description" xml:space="preserve">
+    <value>保持时间结束后门关闭的速度。</value>
+  </data>
+  <data name="GateEffect_Range_Description" xml:space="preserve">
+    <value>门关闭时施加的衰减。0 禁用门控；更负的值衰减更强。</value>
+  </data>
+</root>

--- a/src/Beutl.Language/CommandNames.es.resx
+++ b/src/Beutl.Language/CommandNames.es.resx
@@ -1,0 +1,203 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AddElement" xml:space="preserve">
+    <value>Agregar elemento</value>
+  </data>
+  <data name="RemoveElement" xml:space="preserve">
+    <value>Quitar elemento</value>
+  </data>
+  <data name="CutElement" xml:space="preserve">
+    <value>Cortar elemento</value>
+  </data>
+  <data name="DeleteElement" xml:space="preserve">
+    <value>Eliminar elemento</value>
+  </data>
+  <data name="PasteElement" xml:space="preserve">
+    <value>Pegar elemento</value>
+  </data>
+  <data name="MoveElement" xml:space="preserve">
+    <value>Mover elemento</value>
+  </data>
+  <data name="SlipElement" xml:space="preserve">
+    <value>Deslizar elemento</value>
+  </data>
+  <data name="RollElements" xml:space="preserve">
+    <value>Rodar elementos</value>
+  </data>
+  <data name="SlideElements" xml:space="preserve">
+    <value>Deslizar elementos</value>
+  </data>
+  <data name="SplitElement" xml:space="preserve">
+    <value>Dividir elemento</value>
+  </data>
+  <data name="DuplicateElement" xml:space="preserve">
+    <value>Duplicar elemento</value>
+  </data>
+  <data name="ChangeElementColor" xml:space="preserve">
+    <value>Cambiar color del elemento</value>
+  </data>
+  <data name="ChangeElementEnabled" xml:space="preserve">
+    <value>Cambiar habilitación del elemento</value>
+  </data>
+  <data name="ChangeElementUseNode" xml:space="preserve">
+    <value>Cambiar uso de nodo del elemento</value>
+  </data>
+  <data name="GroupElements" xml:space="preserve">
+    <value>Agrupar elementos</value>
+  </data>
+  <data name="UngroupElements" xml:space="preserve">
+    <value>Desagrupar elementos</value>
+  </data>
+  <data name="CloseGap" xml:space="preserve">
+    <value>Cerrar espacio</value>
+  </data>
+  <data name="CloseAllGaps" xml:space="preserve">
+    <value>Cerrar todos los espacios</value>
+  </data>
+  <data name="ChangeSceneDuration" xml:space="preserve">
+    <value>Cambiar duración de la escena</value>
+  </data>
+  <data name="ChangeSceneStart" xml:space="preserve">
+    <value>Cambiar inicio de la escena</value>
+  </data>
+  <data name="MoveMarker" xml:space="preserve">
+    <value>Mover marcador</value>
+  </data>
+  <data name="EditMarker" xml:space="preserve">
+    <value>Editar marcador</value>
+  </data>
+  <data name="RemoveMarker" xml:space="preserve">
+    <value>Quitar marcador</value>
+  </data>
+  <data name="MoveLayer" xml:space="preserve">
+    <value>Mover capa</value>
+  </data>
+  <data name="ChangeLayerColor" xml:space="preserve">
+    <value>Cambiar color de la capa</value>
+  </data>
+  <data name="ChangeLayerLocked" xml:space="preserve">
+    <value>Cambiar bloqueo de la capa</value>
+  </data>
+  <data name="ChangeLayerAudioMuted" xml:space="preserve">
+    <value>Cambiar silencio de audio de la capa</value>
+  </data>
+  <data name="ChangeLayerVideoMuted" xml:space="preserve">
+    <value>Cambiar silencio de video de la capa</value>
+  </data>
+  <data name="ChangeLayerSolo" xml:space="preserve">
+    <value>Cambiar solo de la capa</value>
+  </data>
+  <data name="ChangeElementLocked" xml:space="preserve">
+    <value>Cambiar bloqueo del elemento</value>
+  </data>
+  <data name="InsertKeyFrame" xml:space="preserve">
+    <value>Insertar fotograma clave</value>
+  </data>
+  <data name="RemoveKeyFrame" xml:space="preserve">
+    <value>Quitar fotograma clave</value>
+  </data>
+  <data name="EditKeyFrame" xml:space="preserve">
+    <value>Editar fotograma clave</value>
+  </data>
+  <data name="MoveKeyFrame" xml:space="preserve">
+    <value>Mover fotograma clave</value>
+  </data>
+  <data name="ChangeEasing" xml:space="preserve">
+    <value>Cambiar suavizado</value>
+  </data>
+  <data name="PasteKeyFrame" xml:space="preserve">
+    <value>Pegar fotograma clave</value>
+  </data>
+  <data name="PasteAnimation" xml:space="preserve">
+    <value>Pegar animación</value>
+  </data>
+  <data name="ChangeUseGlobalClock" xml:space="preserve">
+    <value>Cambiar uso del reloj global</value>
+  </data>
+  <data name="DeleteAnimation" xml:space="preserve">
+    <value>Eliminar animación</value>
+  </data>
+  <data name="AddNode" xml:space="preserve">
+    <value>Agregar nodo</value>
+  </data>
+  <data name="RemoveNode" xml:space="preserve">
+    <value>Quitar nodo</value>
+  </data>
+  <data name="MoveNode" xml:space="preserve">
+    <value>Mover nodo</value>
+  </data>
+  <data name="RenameNode" xml:space="preserve">
+    <value>Renombrar nodo</value>
+  </data>
+  <data name="ConnectPort" xml:space="preserve">
+    <value>Conectar puerto</value>
+  </data>
+  <data name="DisconnectPort" xml:space="preserve">
+    <value>Desconectar puerto</value>
+  </data>
+  <data name="MoveConnection" xml:space="preserve">
+    <value>Mover conexión</value>
+  </data>
+  <data name="AddPort" xml:space="preserve">
+    <value>Agregar puerto</value>
+  </data>
+  <data name="RemovePort" xml:space="preserve">
+    <value>Quitar puerto</value>
+  </data>
+  <data name="RenamePort" xml:space="preserve">
+    <value>Renombrar puerto</value>
+  </data>
+  <data name="ChangeUseNode" xml:space="preserve">
+    <value>Cambiar uso de nodo</value>
+  </data>
+  <data name="AddObject" xml:space="preserve">
+    <value>Agregar objeto</value>
+  </data>
+  <data name="RemoveObject" xml:space="preserve">
+    <value>Quitar objeto</value>
+  </data>
+  <data name="ChangeObjectEnabled" xml:space="preserve">
+    <value>Cambiar habilitación del objeto</value>
+  </data>
+  <data name="PasteObject" xml:space="preserve">
+    <value>Pegar objeto</value>
+  </data>
+  <data name="MoveObject" xml:space="preserve">
+    <value>Mover objeto</value>
+  </data>
+  <data name="ChangeSceneSettings" xml:space="preserve">
+    <value>Cambiar configuración de la escena</value>
+  </data>
+  <data name="EditPathPoint" xml:space="preserve">
+    <value>Editar punto de trazado</value>
+  </data>
+  <data name="TransformElement" xml:space="preserve">
+    <value>Transformar elemento</value>
+  </data>
+  <data name="EditProperty" xml:space="preserve">
+    <value>Editar propiedad</value>
+  </data>
+  <data name="ApplyTemplate" xml:space="preserve">
+    <value>Aplicar plantilla</value>
+  </data>
+  <data name="AddElementFromTemplate" xml:space="preserve">
+    <value>Agregar elemento desde plantilla</value>
+  </data>
+</root>

--- a/src/Beutl.Language/CommandNames.ko-KR.resx
+++ b/src/Beutl.Language/CommandNames.ko-KR.resx
@@ -1,0 +1,203 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AddElement" xml:space="preserve">
+    <value>요소 추가</value>
+  </data>
+  <data name="RemoveElement" xml:space="preserve">
+    <value>요소 제거</value>
+  </data>
+  <data name="CutElement" xml:space="preserve">
+    <value>요소 잘라내기</value>
+  </data>
+  <data name="DeleteElement" xml:space="preserve">
+    <value>요소 삭제</value>
+  </data>
+  <data name="PasteElement" xml:space="preserve">
+    <value>요소 붙여넣기</value>
+  </data>
+  <data name="MoveElement" xml:space="preserve">
+    <value>요소 이동</value>
+  </data>
+  <data name="SlipElement" xml:space="preserve">
+    <value>요소 슬립</value>
+  </data>
+  <data name="RollElements" xml:space="preserve">
+    <value>요소 롤</value>
+  </data>
+  <data name="SlideElements" xml:space="preserve">
+    <value>요소 슬라이드</value>
+  </data>
+  <data name="SplitElement" xml:space="preserve">
+    <value>요소 분할</value>
+  </data>
+  <data name="DuplicateElement" xml:space="preserve">
+    <value>요소 복제</value>
+  </data>
+  <data name="ChangeElementColor" xml:space="preserve">
+    <value>요소 색상 변경</value>
+  </data>
+  <data name="ChangeElementEnabled" xml:space="preserve">
+    <value>요소 활성화 변경</value>
+  </data>
+  <data name="ChangeElementUseNode" xml:space="preserve">
+    <value>요소 노드 사용 변경</value>
+  </data>
+  <data name="GroupElements" xml:space="preserve">
+    <value>요소 그룹화</value>
+  </data>
+  <data name="UngroupElements" xml:space="preserve">
+    <value>요소 그룹 해제</value>
+  </data>
+  <data name="CloseGap" xml:space="preserve">
+    <value>간격 닫기</value>
+  </data>
+  <data name="CloseAllGaps" xml:space="preserve">
+    <value>모든 간격 닫기</value>
+  </data>
+  <data name="ChangeSceneDuration" xml:space="preserve">
+    <value>장면 길이 변경</value>
+  </data>
+  <data name="ChangeSceneStart" xml:space="preserve">
+    <value>장면 시작 변경</value>
+  </data>
+  <data name="MoveMarker" xml:space="preserve">
+    <value>마커 이동</value>
+  </data>
+  <data name="EditMarker" xml:space="preserve">
+    <value>마커 편집</value>
+  </data>
+  <data name="RemoveMarker" xml:space="preserve">
+    <value>마커 제거</value>
+  </data>
+  <data name="MoveLayer" xml:space="preserve">
+    <value>레이어 이동</value>
+  </data>
+  <data name="ChangeLayerColor" xml:space="preserve">
+    <value>레이어 색상 변경</value>
+  </data>
+  <data name="ChangeLayerLocked" xml:space="preserve">
+    <value>레이어 잠금 변경</value>
+  </data>
+  <data name="ChangeLayerAudioMuted" xml:space="preserve">
+    <value>레이어 오디오 음소거 변경</value>
+  </data>
+  <data name="ChangeLayerVideoMuted" xml:space="preserve">
+    <value>레이어 비디오 음소거 변경</value>
+  </data>
+  <data name="ChangeLayerSolo" xml:space="preserve">
+    <value>레이어 솔로 변경</value>
+  </data>
+  <data name="ChangeElementLocked" xml:space="preserve">
+    <value>요소 잠금 변경</value>
+  </data>
+  <data name="InsertKeyFrame" xml:space="preserve">
+    <value>키프레임 삽입</value>
+  </data>
+  <data name="RemoveKeyFrame" xml:space="preserve">
+    <value>키프레임 제거</value>
+  </data>
+  <data name="EditKeyFrame" xml:space="preserve">
+    <value>키프레임 편집</value>
+  </data>
+  <data name="MoveKeyFrame" xml:space="preserve">
+    <value>키프레임 이동</value>
+  </data>
+  <data name="ChangeEasing" xml:space="preserve">
+    <value>이징 변경</value>
+  </data>
+  <data name="PasteKeyFrame" xml:space="preserve">
+    <value>키프레임 붙여넣기</value>
+  </data>
+  <data name="PasteAnimation" xml:space="preserve">
+    <value>애니메이션 붙여넣기</value>
+  </data>
+  <data name="ChangeUseGlobalClock" xml:space="preserve">
+    <value>전역 클록 사용 변경</value>
+  </data>
+  <data name="DeleteAnimation" xml:space="preserve">
+    <value>애니메이션 삭제</value>
+  </data>
+  <data name="AddNode" xml:space="preserve">
+    <value>노드 추가</value>
+  </data>
+  <data name="RemoveNode" xml:space="preserve">
+    <value>노드 제거</value>
+  </data>
+  <data name="MoveNode" xml:space="preserve">
+    <value>노드 이동</value>
+  </data>
+  <data name="RenameNode" xml:space="preserve">
+    <value>노드 이름 변경</value>
+  </data>
+  <data name="ConnectPort" xml:space="preserve">
+    <value>포트 연결</value>
+  </data>
+  <data name="DisconnectPort" xml:space="preserve">
+    <value>포트 연결 끊기</value>
+  </data>
+  <data name="MoveConnection" xml:space="preserve">
+    <value>연결 이동</value>
+  </data>
+  <data name="AddPort" xml:space="preserve">
+    <value>포트 추가</value>
+  </data>
+  <data name="RemovePort" xml:space="preserve">
+    <value>포트 제거</value>
+  </data>
+  <data name="RenamePort" xml:space="preserve">
+    <value>포트 이름 변경</value>
+  </data>
+  <data name="ChangeUseNode" xml:space="preserve">
+    <value>노드 사용 변경</value>
+  </data>
+  <data name="AddObject" xml:space="preserve">
+    <value>개체 추가</value>
+  </data>
+  <data name="RemoveObject" xml:space="preserve">
+    <value>개체 제거</value>
+  </data>
+  <data name="ChangeObjectEnabled" xml:space="preserve">
+    <value>개체 활성화 변경</value>
+  </data>
+  <data name="PasteObject" xml:space="preserve">
+    <value>개체 붙여넣기</value>
+  </data>
+  <data name="MoveObject" xml:space="preserve">
+    <value>개체 이동</value>
+  </data>
+  <data name="ChangeSceneSettings" xml:space="preserve">
+    <value>장면 설정 변경</value>
+  </data>
+  <data name="EditPathPoint" xml:space="preserve">
+    <value>경로 점 편집</value>
+  </data>
+  <data name="TransformElement" xml:space="preserve">
+    <value>요소 변형</value>
+  </data>
+  <data name="EditProperty" xml:space="preserve">
+    <value>속성 편집</value>
+  </data>
+  <data name="ApplyTemplate" xml:space="preserve">
+    <value>템플릿 적용</value>
+  </data>
+  <data name="AddElementFromTemplate" xml:space="preserve">
+    <value>템플릿에서 요소 추가</value>
+  </data>
+</root>

--- a/src/Beutl.Language/CommandNames.zh-CN.resx
+++ b/src/Beutl.Language/CommandNames.zh-CN.resx
@@ -1,0 +1,203 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AddElement" xml:space="preserve">
+    <value>添加元素</value>
+  </data>
+  <data name="RemoveElement" xml:space="preserve">
+    <value>移除元素</value>
+  </data>
+  <data name="CutElement" xml:space="preserve">
+    <value>剪切元素</value>
+  </data>
+  <data name="DeleteElement" xml:space="preserve">
+    <value>删除元素</value>
+  </data>
+  <data name="PasteElement" xml:space="preserve">
+    <value>粘贴元素</value>
+  </data>
+  <data name="MoveElement" xml:space="preserve">
+    <value>移动元素</value>
+  </data>
+  <data name="SlipElement" xml:space="preserve">
+    <value>滑移元素</value>
+  </data>
+  <data name="RollElements" xml:space="preserve">
+    <value>滚动元素</value>
+  </data>
+  <data name="SlideElements" xml:space="preserve">
+    <value>滑动元素</value>
+  </data>
+  <data name="SplitElement" xml:space="preserve">
+    <value>分割元素</value>
+  </data>
+  <data name="DuplicateElement" xml:space="preserve">
+    <value>复制元素</value>
+  </data>
+  <data name="ChangeElementColor" xml:space="preserve">
+    <value>更改元素颜色</value>
+  </data>
+  <data name="ChangeElementEnabled" xml:space="preserve">
+    <value>更改元素启用状态</value>
+  </data>
+  <data name="ChangeElementUseNode" xml:space="preserve">
+    <value>更改元素使用节点</value>
+  </data>
+  <data name="GroupElements" xml:space="preserve">
+    <value>元素分组</value>
+  </data>
+  <data name="UngroupElements" xml:space="preserve">
+    <value>取消元素分组</value>
+  </data>
+  <data name="CloseGap" xml:space="preserve">
+    <value>关闭间隙</value>
+  </data>
+  <data name="CloseAllGaps" xml:space="preserve">
+    <value>关闭所有间隙</value>
+  </data>
+  <data name="ChangeSceneDuration" xml:space="preserve">
+    <value>更改场景时长</value>
+  </data>
+  <data name="ChangeSceneStart" xml:space="preserve">
+    <value>更改场景开始</value>
+  </data>
+  <data name="MoveMarker" xml:space="preserve">
+    <value>移动标记</value>
+  </data>
+  <data name="EditMarker" xml:space="preserve">
+    <value>编辑标记</value>
+  </data>
+  <data name="RemoveMarker" xml:space="preserve">
+    <value>移除标记</value>
+  </data>
+  <data name="MoveLayer" xml:space="preserve">
+    <value>移动图层</value>
+  </data>
+  <data name="ChangeLayerColor" xml:space="preserve">
+    <value>更改图层颜色</value>
+  </data>
+  <data name="ChangeLayerLocked" xml:space="preserve">
+    <value>更改图层锁定</value>
+  </data>
+  <data name="ChangeLayerAudioMuted" xml:space="preserve">
+    <value>更改图层音频静音</value>
+  </data>
+  <data name="ChangeLayerVideoMuted" xml:space="preserve">
+    <value>更改图层视频静音</value>
+  </data>
+  <data name="ChangeLayerSolo" xml:space="preserve">
+    <value>更改图层独奏</value>
+  </data>
+  <data name="ChangeElementLocked" xml:space="preserve">
+    <value>更改元素锁定</value>
+  </data>
+  <data name="InsertKeyFrame" xml:space="preserve">
+    <value>插入关键帧</value>
+  </data>
+  <data name="RemoveKeyFrame" xml:space="preserve">
+    <value>移除关键帧</value>
+  </data>
+  <data name="EditKeyFrame" xml:space="preserve">
+    <value>编辑关键帧</value>
+  </data>
+  <data name="MoveKeyFrame" xml:space="preserve">
+    <value>移动关键帧</value>
+  </data>
+  <data name="ChangeEasing" xml:space="preserve">
+    <value>更改缓动</value>
+  </data>
+  <data name="PasteKeyFrame" xml:space="preserve">
+    <value>粘贴关键帧</value>
+  </data>
+  <data name="PasteAnimation" xml:space="preserve">
+    <value>粘贴动画</value>
+  </data>
+  <data name="ChangeUseGlobalClock" xml:space="preserve">
+    <value>更改使用全局时钟</value>
+  </data>
+  <data name="DeleteAnimation" xml:space="preserve">
+    <value>删除动画</value>
+  </data>
+  <data name="AddNode" xml:space="preserve">
+    <value>添加节点</value>
+  </data>
+  <data name="RemoveNode" xml:space="preserve">
+    <value>移除节点</value>
+  </data>
+  <data name="MoveNode" xml:space="preserve">
+    <value>移动节点</value>
+  </data>
+  <data name="RenameNode" xml:space="preserve">
+    <value>重命名节点</value>
+  </data>
+  <data name="ConnectPort" xml:space="preserve">
+    <value>连接端口</value>
+  </data>
+  <data name="DisconnectPort" xml:space="preserve">
+    <value>断开端口</value>
+  </data>
+  <data name="MoveConnection" xml:space="preserve">
+    <value>移动连接</value>
+  </data>
+  <data name="AddPort" xml:space="preserve">
+    <value>添加端口</value>
+  </data>
+  <data name="RemovePort" xml:space="preserve">
+    <value>移除端口</value>
+  </data>
+  <data name="RenamePort" xml:space="preserve">
+    <value>重命名端口</value>
+  </data>
+  <data name="ChangeUseNode" xml:space="preserve">
+    <value>更改使用节点</value>
+  </data>
+  <data name="AddObject" xml:space="preserve">
+    <value>添加对象</value>
+  </data>
+  <data name="RemoveObject" xml:space="preserve">
+    <value>移除对象</value>
+  </data>
+  <data name="ChangeObjectEnabled" xml:space="preserve">
+    <value>更改对象启用状态</value>
+  </data>
+  <data name="PasteObject" xml:space="preserve">
+    <value>粘贴对象</value>
+  </data>
+  <data name="MoveObject" xml:space="preserve">
+    <value>移动对象</value>
+  </data>
+  <data name="ChangeSceneSettings" xml:space="preserve">
+    <value>更改场景设置</value>
+  </data>
+  <data name="EditPathPoint" xml:space="preserve">
+    <value>编辑路径点</value>
+  </data>
+  <data name="TransformElement" xml:space="preserve">
+    <value>变换元素</value>
+  </data>
+  <data name="EditProperty" xml:space="preserve">
+    <value>编辑属性</value>
+  </data>
+  <data name="ApplyTemplate" xml:space="preserve">
+    <value>应用模板</value>
+  </data>
+  <data name="AddElementFromTemplate" xml:space="preserve">
+    <value>从模板添加元素</value>
+  </data>
+</root>

--- a/src/Beutl.Language/DockStrings.es.resx
+++ b/src/Beutl.Language/DockStrings.es.resx
@@ -1,0 +1,65 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ToolChromeControlFloatString" xml:space="preserve">
+    <value>Flotar(_F)</value>
+  </data>
+  <data name="ToolChromeControlDockString" xml:space="preserve">
+    <value>Acoplar(_D)</value>
+  </data>
+  <data name="ToolChromeControlAutoHideString" xml:space="preserve">
+    <value>Ocultar automáticamente(_A)</value>
+  </data>
+  <data name="ToolChromeControlCloseString" xml:space="preserve">
+    <value>Cerrar(_C)</value>
+  </data>
+  <data name="ToolTabStripItemFloatString" xml:space="preserve">
+    <value>Flotar(_F)</value>
+  </data>
+  <data name="ToolTabStripItemFloatAllString" xml:space="preserve">
+    <value>Flotar todo</value>
+  </data>
+  <data name="ToolTabStripItemDockString" xml:space="preserve">
+    <value>Acoplar(_D)</value>
+  </data>
+  <data name="ToolTabStripItemAutoHideString" xml:space="preserve">
+    <value>Ocultar automáticamente(_A)</value>
+  </data>
+  <data name="ToolTabStripItemCloseString" xml:space="preserve">
+    <value>Cerrar(_C)</value>
+  </data>
+  <data name="ToolPinItemControlFloatString" xml:space="preserve">
+    <value>Flotar(_F)</value>
+  </data>
+  <data name="ToolPinItemControlShowString" xml:space="preserve">
+    <value>Mostrar(_S)</value>
+  </data>
+  <data name="ToolPinItemControlCloseString" xml:space="preserve">
+    <value>Cerrar(_C)</value>
+  </data>
+  <data name="DragPreviewControlDockString" xml:space="preserve">
+    <value>Acoplar</value>
+  </data>
+  <data name="DragPreviewControlFloatString" xml:space="preserve">
+    <value>Flotar</value>
+  </data>
+  <data name="DragPreviewControlNoneString" xml:space="preserve">
+    <value>Ninguno</value>
+  </data>
+</root>

--- a/src/Beutl.Language/DockStrings.ko-KR.resx
+++ b/src/Beutl.Language/DockStrings.ko-KR.resx
@@ -1,0 +1,65 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ToolChromeControlFloatString" xml:space="preserve">
+    <value>플로트(_F)</value>
+  </data>
+  <data name="ToolChromeControlDockString" xml:space="preserve">
+    <value>도킹(_D)</value>
+  </data>
+  <data name="ToolChromeControlAutoHideString" xml:space="preserve">
+    <value>자동 숨기기(_A)</value>
+  </data>
+  <data name="ToolChromeControlCloseString" xml:space="preserve">
+    <value>닫기(_C)</value>
+  </data>
+  <data name="ToolTabStripItemFloatString" xml:space="preserve">
+    <value>플로트(_F)</value>
+  </data>
+  <data name="ToolTabStripItemFloatAllString" xml:space="preserve">
+    <value>모두 플로트</value>
+  </data>
+  <data name="ToolTabStripItemDockString" xml:space="preserve">
+    <value>도킹(_D)</value>
+  </data>
+  <data name="ToolTabStripItemAutoHideString" xml:space="preserve">
+    <value>자동 숨기기(_A)</value>
+  </data>
+  <data name="ToolTabStripItemCloseString" xml:space="preserve">
+    <value>닫기(_C)</value>
+  </data>
+  <data name="ToolPinItemControlFloatString" xml:space="preserve">
+    <value>플로트(_F)</value>
+  </data>
+  <data name="ToolPinItemControlShowString" xml:space="preserve">
+    <value>표시(_S)</value>
+  </data>
+  <data name="ToolPinItemControlCloseString" xml:space="preserve">
+    <value>닫기(_C)</value>
+  </data>
+  <data name="DragPreviewControlDockString" xml:space="preserve">
+    <value>도킹</value>
+  </data>
+  <data name="DragPreviewControlFloatString" xml:space="preserve">
+    <value>플로트</value>
+  </data>
+  <data name="DragPreviewControlNoneString" xml:space="preserve">
+    <value>없음</value>
+  </data>
+</root>

--- a/src/Beutl.Language/DockStrings.zh-CN.resx
+++ b/src/Beutl.Language/DockStrings.zh-CN.resx
@@ -1,0 +1,65 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ToolChromeControlFloatString" xml:space="preserve">
+    <value>浮动(_F)</value>
+  </data>
+  <data name="ToolChromeControlDockString" xml:space="preserve">
+    <value>停靠(_D)</value>
+  </data>
+  <data name="ToolChromeControlAutoHideString" xml:space="preserve">
+    <value>自动隐藏(_A)</value>
+  </data>
+  <data name="ToolChromeControlCloseString" xml:space="preserve">
+    <value>关闭(_C)</value>
+  </data>
+  <data name="ToolTabStripItemFloatString" xml:space="preserve">
+    <value>浮动(_F)</value>
+  </data>
+  <data name="ToolTabStripItemFloatAllString" xml:space="preserve">
+    <value>全部浮动</value>
+  </data>
+  <data name="ToolTabStripItemDockString" xml:space="preserve">
+    <value>停靠(_D)</value>
+  </data>
+  <data name="ToolTabStripItemAutoHideString" xml:space="preserve">
+    <value>自动隐藏(_A)</value>
+  </data>
+  <data name="ToolTabStripItemCloseString" xml:space="preserve">
+    <value>关闭(_C)</value>
+  </data>
+  <data name="ToolPinItemControlFloatString" xml:space="preserve">
+    <value>浮动(_F)</value>
+  </data>
+  <data name="ToolPinItemControlShowString" xml:space="preserve">
+    <value>显示(_S)</value>
+  </data>
+  <data name="ToolPinItemControlCloseString" xml:space="preserve">
+    <value>关闭(_C)</value>
+  </data>
+  <data name="DragPreviewControlDockString" xml:space="preserve">
+    <value>停靠</value>
+  </data>
+  <data name="DragPreviewControlFloatString" xml:space="preserve">
+    <value>浮动</value>
+  </data>
+  <data name="DragPreviewControlNoneString" xml:space="preserve">
+    <value>无</value>
+  </data>
+</root>

--- a/src/Beutl.Language/ExtensionsStrings.es.resx
+++ b/src/Beutl.Language/ExtensionsStrings.es.resx
@@ -1,0 +1,139 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="NoLogoImageAvailable" xml:space="preserve">
+    <value>No hay imagen de logotipo disponible</value>
+  </data>
+  <data name="Package_Screenshots" xml:space="preserve">
+    <value>Capturas de pantalla</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>Instalar</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>Actualizar</value>
+  </data>
+  <data name="Uninstall" xml:space="preserve">
+    <value>Desinstalar</value>
+  </data>
+  <data name="Package_LatestRelease" xml:space="preserve">
+    <value>Última versión</value>
+  </data>
+  <data name="Package_Tags" xml:space="preserve">
+    <value>Etiquetas</value>
+  </data>
+  <data name="Package_LatestVersion" xml:space="preserve">
+    <value>Última versión</value>
+  </data>
+  <data name="Package_InstalledVersion" xml:space="preserve">
+    <value>Versión instalada</value>
+  </data>
+  <data name="OpenUrl_Title" xml:space="preserve">
+    <value>¿Abrir URL?</value>
+  </data>
+  <data name="OpenUrl_Content" xml:space="preserve">
+    <value>Estás intentando abrir '{0}'.
+Si la URL es sospechosa, te recomendamos que no la abras.</value>
+  </data>
+  <data name="Search_Packages" xml:space="preserve">
+    <value>Paquetes</value>
+  </data>
+  <data name="Profile_PublishedPackages" xml:space="preserve">
+    <value>Paquetes publicados</value>
+  </data>
+  <data name="RemoveFromLibrary" xml:space="preserve">
+    <value>Quitar de la biblioteca</value>
+  </data>
+  <data name="CheckUpdate" xml:space="preserve">
+    <value>Buscar actualizaciones</value>
+  </data>
+  <data name="LocalPackages" xml:space="preserve">
+    <value>Paquetes locales</value>
+  </data>
+  <data name="LocalPackage" xml:space="preserve">
+    <value>Paquete local</value>
+  </data>
+  <data name="Could_not_find_a_package_from_remote" xml:space="preserve">
+    <value>No se pudo encontrar '{0}' en el repositorio remoto.</value>
+  </data>
+  <data name="PackageInstaller" xml:space="preserve">
+    <value>Instalador de paquetes</value>
+  </data>
+  <data name="PackageInstaller_Installed" xml:space="preserve">
+    <value>'{0}' se ha instalado correctamente.</value>
+  </data>
+  <data name="PackageInstaller_Updated" xml:space="preserve">
+    <value>'{0}' se ha actualizado correctamente.</value>
+  </data>
+  <data name="PackageInstaller_Uninstalled" xml:space="preserve">
+    <value>'{0}' se ha desinstalado correctamente.</value>
+  </data>
+  <data name="PackageInstaller_ScheduledInstallation" xml:space="preserve">
+    <value>La instalación de '{0}' está programada.
+Para aplicar los cambios del paquete, sal de Beutl.</value>
+  </data>
+  <data name="PackageInstaller_ScheduledUpdate" xml:space="preserve">
+    <value>La actualización de '{0}' está programada.
+Para aplicar los cambios del paquete, sal de Beutl.</value>
+  </data>
+  <data name="PackageInstaller_ScheduledUninstallation" xml:space="preserve">
+    <value>La desinstalación de '{0}' está programada.
+Para aplicar los cambios del paquete, sal de Beutl.</value>
+  </data>
+  <data name="PackageInstaller_CloseProjectConfirmation" xml:space="preserve">
+    <value>Actualmente hay un proyecto abierto. Debe cerrarse antes de modificar los paquetes. ¿Quieres cerrarlo?</value>
+  </data>
+  <data name="PackageInstaller_SaveAndClose" xml:space="preserve">
+    <value>Guardar y cerrar</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>Descripción</value>
+  </data>
+  <data name="May_not_work_correctly_when_downgrading" xml:space="preserve">
+    <value>Puede que no funcione correctamente al degradar la versión</value>
+  </data>
+  <data name="Package_SelectedRelease" xml:space="preserve">
+    <value>Versión seleccionada</value>
+  </data>
+  <data name="Release_TargetVersion" xml:space="preserve">
+    <value>Versión de destino</value>
+  </data>
+  <data name="This_extension_does_not_support_your_Beutl_version" xml:space="preserve">
+    <value>Esta extensión no es compatible con tu versión de Beutl.
+Para forzar la instalación, usa la herramienta CLI.</value>
+  </data>
+  <data name="Installing" xml:space="preserve">
+    <value>Instalando...</value>
+  </data>
+  <data name="Updating" xml:space="preserve">
+    <value>Actualizando...</value>
+  </data>
+  <data name="Uninstalling" xml:space="preserve">
+    <value>Desinstalando...</value>
+  </data>
+  <data name="Free" xml:space="preserve">
+    <value>Gratis</value>
+  </data>
+  <data name="RemoveFromLibrary_Title" xml:space="preserve">
+    <value>Quitar de la biblioteca</value>
+  </data>
+  <data name="RemoveFromLibrary_PaidConfirmation" xml:space="preserve">
+    <value>Este es un paquete de pago ({0}). Si lo quitas de tu biblioteca, tendrás que volver a comprarlo para recuperarlo. ¿Estás seguro?</value>
+  </data>
+</root>

--- a/src/Beutl.Language/ExtensionsStrings.ko-KR.resx
+++ b/src/Beutl.Language/ExtensionsStrings.ko-KR.resx
@@ -1,0 +1,139 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="NoLogoImageAvailable" xml:space="preserve">
+    <value>사용 가능한 로고 이미지가 없습니다</value>
+  </data>
+  <data name="Package_Screenshots" xml:space="preserve">
+    <value>스크린샷</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>설치</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>업데이트</value>
+  </data>
+  <data name="Uninstall" xml:space="preserve">
+    <value>제거</value>
+  </data>
+  <data name="Package_LatestRelease" xml:space="preserve">
+    <value>최신 릴리스</value>
+  </data>
+  <data name="Package_Tags" xml:space="preserve">
+    <value>태그</value>
+  </data>
+  <data name="Package_LatestVersion" xml:space="preserve">
+    <value>최신 버전</value>
+  </data>
+  <data name="Package_InstalledVersion" xml:space="preserve">
+    <value>설치된 버전</value>
+  </data>
+  <data name="OpenUrl_Title" xml:space="preserve">
+    <value>URL을 여시겠습니까?</value>
+  </data>
+  <data name="OpenUrl_Content" xml:space="preserve">
+    <value>'{0}'을(를) 열려고 합니다.
+URL이 의심스러우면 열지 않는 것이 좋습니다.</value>
+  </data>
+  <data name="Search_Packages" xml:space="preserve">
+    <value>패키지</value>
+  </data>
+  <data name="Profile_PublishedPackages" xml:space="preserve">
+    <value>게시된 패키지</value>
+  </data>
+  <data name="RemoveFromLibrary" xml:space="preserve">
+    <value>라이브러리에서 제거</value>
+  </data>
+  <data name="CheckUpdate" xml:space="preserve">
+    <value>업데이트 확인</value>
+  </data>
+  <data name="LocalPackages" xml:space="preserve">
+    <value>로컬 패키지</value>
+  </data>
+  <data name="LocalPackage" xml:space="preserve">
+    <value>로컬 패키지</value>
+  </data>
+  <data name="Could_not_find_a_package_from_remote" xml:space="preserve">
+    <value>원격에서 '{0}'을(를) 찾을 수 없습니다.</value>
+  </data>
+  <data name="PackageInstaller" xml:space="preserve">
+    <value>패키지 설치 프로그램</value>
+  </data>
+  <data name="PackageInstaller_Installed" xml:space="preserve">
+    <value>'{0}'이(가) 성공적으로 설치되었습니다.</value>
+  </data>
+  <data name="PackageInstaller_Updated" xml:space="preserve">
+    <value>'{0}'이(가) 성공적으로 업데이트되었습니다.</value>
+  </data>
+  <data name="PackageInstaller_Uninstalled" xml:space="preserve">
+    <value>'{0}'이(가) 성공적으로 제거되었습니다.</value>
+  </data>
+  <data name="PackageInstaller_ScheduledInstallation" xml:space="preserve">
+    <value>'{0}' 설치가 예약되었습니다.
+패키지 변경 사항을 적용하려면 Beutl을 종료하세요.</value>
+  </data>
+  <data name="PackageInstaller_ScheduledUpdate" xml:space="preserve">
+    <value>'{0}' 업데이트가 예약되었습니다.
+패키지 변경 사항을 적용하려면 Beutl을 종료하세요.</value>
+  </data>
+  <data name="PackageInstaller_ScheduledUninstallation" xml:space="preserve">
+    <value>'{0}' 제거가 예약되었습니다.
+패키지 변경 사항을 적용하려면 Beutl을 종료하세요.</value>
+  </data>
+  <data name="PackageInstaller_CloseProjectConfirmation" xml:space="preserve">
+    <value>현재 프로젝트가 열려 있습니다. 패키지를 수정하기 전에 닫아야 합니다. 닫으시겠습니까?</value>
+  </data>
+  <data name="PackageInstaller_SaveAndClose" xml:space="preserve">
+    <value>저장 후 닫기</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>설명</value>
+  </data>
+  <data name="May_not_work_correctly_when_downgrading" xml:space="preserve">
+    <value>다운그레이드 시 제대로 작동하지 않을 수 있습니다</value>
+  </data>
+  <data name="Package_SelectedRelease" xml:space="preserve">
+    <value>선택한 릴리스</value>
+  </data>
+  <data name="Release_TargetVersion" xml:space="preserve">
+    <value>대상 버전</value>
+  </data>
+  <data name="This_extension_does_not_support_your_Beutl_version" xml:space="preserve">
+    <value>이 확장 프로그램은 현재 Beutl 버전을 지원하지 않습니다.
+강제 설치하려면 CLI 도구를 사용하세요.</value>
+  </data>
+  <data name="Installing" xml:space="preserve">
+    <value>설치 중...</value>
+  </data>
+  <data name="Updating" xml:space="preserve">
+    <value>업데이트 중...</value>
+  </data>
+  <data name="Uninstalling" xml:space="preserve">
+    <value>제거 중...</value>
+  </data>
+  <data name="Free" xml:space="preserve">
+    <value>무료</value>
+  </data>
+  <data name="RemoveFromLibrary_Title" xml:space="preserve">
+    <value>라이브러리에서 제거</value>
+  </data>
+  <data name="RemoveFromLibrary_PaidConfirmation" xml:space="preserve">
+    <value>이것은 유료 패키지({0})입니다. 라이브러리에서 제거하면 다시 구매해야 다시 획득할 수 있습니다. 계속하시겠습니까?</value>
+  </data>
+</root>

--- a/src/Beutl.Language/ExtensionsStrings.zh-CN.resx
+++ b/src/Beutl.Language/ExtensionsStrings.zh-CN.resx
@@ -1,0 +1,139 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="NoLogoImageAvailable" xml:space="preserve">
+    <value>没有可用的徽标图像</value>
+  </data>
+  <data name="Package_Screenshots" xml:space="preserve">
+    <value>截图</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>安装</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>更新</value>
+  </data>
+  <data name="Uninstall" xml:space="preserve">
+    <value>卸载</value>
+  </data>
+  <data name="Package_LatestRelease" xml:space="preserve">
+    <value>最新版本</value>
+  </data>
+  <data name="Package_Tags" xml:space="preserve">
+    <value>标签</value>
+  </data>
+  <data name="Package_LatestVersion" xml:space="preserve">
+    <value>最新版本</value>
+  </data>
+  <data name="Package_InstalledVersion" xml:space="preserve">
+    <value>已安装版本</value>
+  </data>
+  <data name="OpenUrl_Title" xml:space="preserve">
+    <value>打开 URL？</value>
+  </data>
+  <data name="OpenUrl_Content" xml:space="preserve">
+    <value>您正在尝试打开 '{0}'。
+如果该 URL 可疑，建议您不要打开它。</value>
+  </data>
+  <data name="Search_Packages" xml:space="preserve">
+    <value>包</value>
+  </data>
+  <data name="Profile_PublishedPackages" xml:space="preserve">
+    <value>已发布的包</value>
+  </data>
+  <data name="RemoveFromLibrary" xml:space="preserve">
+    <value>从库中移除</value>
+  </data>
+  <data name="CheckUpdate" xml:space="preserve">
+    <value>检查更新</value>
+  </data>
+  <data name="LocalPackages" xml:space="preserve">
+    <value>本地包</value>
+  </data>
+  <data name="LocalPackage" xml:space="preserve">
+    <value>本地包</value>
+  </data>
+  <data name="Could_not_find_a_package_from_remote" xml:space="preserve">
+    <value>无法从远程找到 '{0}'。</value>
+  </data>
+  <data name="PackageInstaller" xml:space="preserve">
+    <value>包安装程序</value>
+  </data>
+  <data name="PackageInstaller_Installed" xml:space="preserve">
+    <value>'{0}' 已成功安装。</value>
+  </data>
+  <data name="PackageInstaller_Updated" xml:space="preserve">
+    <value>'{0}' 已成功更新。</value>
+  </data>
+  <data name="PackageInstaller_Uninstalled" xml:space="preserve">
+    <value>'{0}' 已成功卸载。</value>
+  </data>
+  <data name="PackageInstaller_ScheduledInstallation" xml:space="preserve">
+    <value>'{0}' 的安装已计划。
+要应用包更改，请退出 Beutl。</value>
+  </data>
+  <data name="PackageInstaller_ScheduledUpdate" xml:space="preserve">
+    <value>'{0}' 的更新已计划。
+要应用包更改，请退出 Beutl。</value>
+  </data>
+  <data name="PackageInstaller_ScheduledUninstallation" xml:space="preserve">
+    <value>'{0}' 的卸载已计划。
+要应用包更改，请退出 Beutl。</value>
+  </data>
+  <data name="PackageInstaller_CloseProjectConfirmation" xml:space="preserve">
+    <value>当前有项目处于打开状态。修改包之前需要先关闭它。是否要关闭？</value>
+  </data>
+  <data name="PackageInstaller_SaveAndClose" xml:space="preserve">
+    <value>保存并关闭</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>描述</value>
+  </data>
+  <data name="May_not_work_correctly_when_downgrading" xml:space="preserve">
+    <value>降级时可能无法正常工作</value>
+  </data>
+  <data name="Package_SelectedRelease" xml:space="preserve">
+    <value>选定的版本</value>
+  </data>
+  <data name="Release_TargetVersion" xml:space="preserve">
+    <value>目标版本</value>
+  </data>
+  <data name="This_extension_does_not_support_your_Beutl_version" xml:space="preserve">
+    <value>此扩展不支持您的 Beutl 版本。
+要强制安装，请使用 CLI 工具。</value>
+  </data>
+  <data name="Installing" xml:space="preserve">
+    <value>正在安装...</value>
+  </data>
+  <data name="Updating" xml:space="preserve">
+    <value>正在更新...</value>
+  </data>
+  <data name="Uninstalling" xml:space="preserve">
+    <value>正在卸载...</value>
+  </data>
+  <data name="Free" xml:space="preserve">
+    <value>免费</value>
+  </data>
+  <data name="RemoveFromLibrary_Title" xml:space="preserve">
+    <value>从库中移除</value>
+  </data>
+  <data name="RemoveFromLibrary_PaidConfirmation" xml:space="preserve">
+    <value>这是一个付费包 ({0})。如果将其从库中移除，您需要再次购买才能重新获取。确定吗？</value>
+  </data>
+</root>

--- a/src/Beutl.Language/GraphicsStrings.es.resx
+++ b/src/Beutl.Language/GraphicsStrings.es.resx
@@ -1,0 +1,1475 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BlendEffect" xml:space="preserve">
+    <value>Mezcla</value>
+  </data>
+  <data name="BlendEffect_BlendMode" xml:space="preserve">
+    <value>Modo de mezcla</value>
+  </data>
+  <data name="BlendMode_Clear" xml:space="preserve">
+    <value>Borrar</value>
+  </data>
+  <data name="BlendMode_Clear_Description" xml:space="preserve">
+    <value>Borra el contenido a transparente.</value>
+  </data>
+  <data name="BlendMode_Color" xml:space="preserve">
+    <value>Color</value>
+  </data>
+  <data name="BlendMode_ColorBurn" xml:space="preserve">
+    <value>Subexponer color</value>
+  </data>
+  <data name="BlendMode_ColorBurn_Description" xml:space="preserve">
+    <value>Oscurece el fondo quemándolo con el color del primer plano.</value>
+  </data>
+  <data name="BlendMode_ColorDodge" xml:space="preserve">
+    <value>Sobreexponer color</value>
+  </data>
+  <data name="BlendMode_ColorDodge_Description" xml:space="preserve">
+    <value>Aclara el fondo añadiendo el color del primer plano.</value>
+  </data>
+  <data name="BlendMode_Color_Description" xml:space="preserve">
+    <value>Aplica el tono y la saturación del primer plano a la luminancia del fondo.</value>
+  </data>
+  <data name="BlendMode_Darken" xml:space="preserve">
+    <value>Oscurecer</value>
+  </data>
+  <data name="BlendMode_Darken_Description" xml:space="preserve">
+    <value>Mantiene el color más oscuro del primer plano o del fondo.</value>
+  </data>
+  <data name="BlendMode_Difference" xml:space="preserve">
+    <value>Diferencia</value>
+  </data>
+  <data name="BlendMode_Difference_Description" xml:space="preserve">
+    <value>Enfatiza las diferencias absolutas de color.</value>
+  </data>
+  <data name="BlendMode_Dst" xml:space="preserve">
+    <value>Conservar original</value>
+  </data>
+  <data name="BlendMode_DstATop" xml:space="preserve">
+    <value>Fondo encima</value>
+  </data>
+  <data name="BlendMode_DstATop_Description" xml:space="preserve">
+    <value>Coloca el fondo encima y conserva el área exterior del primer plano.</value>
+  </data>
+  <data name="BlendMode_DstIn" xml:space="preserve">
+    <value>Fondo dentro</value>
+  </data>
+  <data name="BlendMode_DstIn_Description" xml:space="preserve">
+    <value>Recorta el fondo a la forma del primer plano.</value>
+  </data>
+  <data name="BlendMode_DstOut" xml:space="preserve">
+    <value>Fondo fuera</value>
+  </data>
+  <data name="BlendMode_DstOut_Description" xml:space="preserve">
+    <value>Conserva el área exterior al primer plano para el fondo.</value>
+  </data>
+  <data name="BlendMode_DstOver" xml:space="preserve">
+    <value>Fondo sobre</value>
+  </data>
+  <data name="BlendMode_DstOver_Description" xml:space="preserve">
+    <value>Coloca el fondo debajo del primer plano.</value>
+  </data>
+  <data name="BlendMode_Dst_Description" xml:space="preserve">
+    <value>Mantiene el contenido original sin cambios.</value>
+  </data>
+  <data name="BlendMode_Exclusion" xml:space="preserve">
+    <value>Exclusión</value>
+  </data>
+  <data name="BlendMode_Exclusion_Description" xml:space="preserve">
+    <value>Crea un efecto de diferencia más suave.</value>
+  </data>
+  <data name="BlendMode_HardLight" xml:space="preserve">
+    <value>Luz fuerte</value>
+  </data>
+  <data name="BlendMode_HardLight_Description" xml:space="preserve">
+    <value>Simula un efecto de foco intenso para realzar el contraste.</value>
+  </data>
+  <data name="BlendMode_Hue" xml:space="preserve">
+    <value>Tono</value>
+  </data>
+  <data name="BlendMode_Hue_Description" xml:space="preserve">
+    <value>Aplica el tono del primer plano a la luminancia y saturación del fondo.</value>
+  </data>
+  <data name="BlendMode_Lighten" xml:space="preserve">
+    <value>Aclarar</value>
+  </data>
+  <data name="BlendMode_Lighten_Description" xml:space="preserve">
+    <value>Mantiene el color más claro del primer plano o del fondo.</value>
+  </data>
+  <data name="BlendMode_Luminosity" xml:space="preserve">
+    <value>Luminosidad</value>
+  </data>
+  <data name="BlendMode_Luminosity_Description" xml:space="preserve">
+    <value>Aplica la luminancia del primer plano al tono y la saturación del fondo.</value>
+  </data>
+  <data name="BlendMode_Modulate" xml:space="preserve">
+    <value>Mezclar por opacidad</value>
+  </data>
+  <data name="BlendMode_Modulate_Description" xml:space="preserve">
+    <value>Combina los colores del primer plano y del fondo según su transparencia (valores alfa).</value>
+  </data>
+  <data name="BlendMode_Multiply" xml:space="preserve">
+    <value>Multiplicar colores</value>
+  </data>
+  <data name="BlendMode_Multiply_Description" xml:space="preserve">
+    <value>Multiplica los valores de color RGB del primer plano y del fondo, creando un efecto más oscuro.</value>
+  </data>
+  <data name="BlendMode_Overlay" xml:space="preserve">
+    <value>Superponer</value>
+  </data>
+  <data name="BlendMode_Overlay_Description" xml:space="preserve">
+    <value>Combina el primer plano y el fondo para realzar el contraste.</value>
+  </data>
+  <data name="BlendMode_Plus" xml:space="preserve">
+    <value>Aditivo</value>
+  </data>
+  <data name="BlendMode_Plus_Description" xml:space="preserve">
+    <value>Suma los colores del primer plano y del fondo.</value>
+  </data>
+  <data name="BlendMode_Saturation" xml:space="preserve">
+    <value>Saturación</value>
+  </data>
+  <data name="BlendMode_Saturation_Description" xml:space="preserve">
+    <value>Aplica la saturación del primer plano al tono y la luminancia del fondo.</value>
+  </data>
+  <data name="BlendMode_Screen" xml:space="preserve">
+    <value>Pantalla</value>
+  </data>
+  <data name="BlendMode_Screen_Description" xml:space="preserve">
+    <value>Multiplica los colores invertidos del primer plano y del fondo, creando un efecto más claro.</value>
+  </data>
+  <data name="BlendMode_SoftLight" xml:space="preserve">
+    <value>Luz suave</value>
+  </data>
+  <data name="BlendMode_SoftLight_Description" xml:space="preserve">
+    <value>Simula un foco difuso para efectos de iluminación más suaves.</value>
+  </data>
+  <data name="BlendMode_Src" xml:space="preserve">
+    <value>Sobrescribir</value>
+  </data>
+  <data name="BlendMode_SrcATop" xml:space="preserve">
+    <value>Primer plano encima</value>
+  </data>
+  <data name="BlendMode_SrcATop_Description" xml:space="preserve">
+    <value>Coloca el primer plano encima y conserva el área exterior del fondo.</value>
+  </data>
+  <data name="BlendMode_SrcIn" xml:space="preserve">
+    <value>Primer plano dentro</value>
+  </data>
+  <data name="BlendMode_SrcIn_Description" xml:space="preserve">
+    <value>Recorta el primer plano a la forma del fondo.</value>
+  </data>
+  <data name="BlendMode_SrcOut" xml:space="preserve">
+    <value>Primer plano fuera</value>
+  </data>
+  <data name="BlendMode_SrcOut_Description" xml:space="preserve">
+    <value>Conserva el área exterior al fondo para el primer plano.</value>
+  </data>
+  <data name="BlendMode_SrcOver" xml:space="preserve">
+    <value>Primer plano sobre</value>
+  </data>
+  <data name="BlendMode_SrcOver_Description" xml:space="preserve">
+    <value>Coloca el primer plano sobre el fondo.</value>
+  </data>
+  <data name="BlendMode_Src_Description" xml:space="preserve">
+    <value>Pinta sobre el contenido existente.</value>
+  </data>
+  <data name="BlendMode_Xor" xml:space="preserve">
+    <value>Mezcla exclusiva</value>
+  </data>
+  <data name="BlendMode_Xor_Description" xml:space="preserve">
+    <value>Hace transparentes las áreas superpuestas, conservando las no superpuestas.</value>
+  </data>
+  <data name="Blur" xml:space="preserve">
+    <value>Desenfoque</value>
+  </data>
+  <data name="Brightness" xml:space="preserve">
+    <value>Brillo</value>
+  </data>
+  <data name="ChromaKey" xml:space="preserve">
+    <value>Clave de croma</value>
+  </data>
+  <data name="ChromaKey_Boundary" xml:space="preserve">
+    <value>Corrección de límite</value>
+  </data>
+  <data name="ChromaKey_HueRange" xml:space="preserve">
+    <value>Rango de tono</value>
+  </data>
+  <data name="ChromaKey_SaturationRange" xml:space="preserve">
+    <value>Rango de saturación</value>
+  </data>
+  <data name="Clipping" xml:space="preserve">
+    <value>Recorte</value>
+  </data>
+  <data name="Clipping_AutoCenter" xml:space="preserve">
+    <value>Centrado automático</value>
+  </data>
+  <data name="Clipping_AutoClip" xml:space="preserve">
+    <value>Recortar área transparente</value>
+  </data>
+  <data name="Clipping_Bottom" xml:space="preserve">
+    <value>Inferior</value>
+  </data>
+  <data name="Clipping_Left" xml:space="preserve">
+    <value>Izquierda</value>
+  </data>
+  <data name="Clipping_Right" xml:space="preserve">
+    <value>Derecha</value>
+  </data>
+  <data name="Clipping_Top" xml:space="preserve">
+    <value>Superior</value>
+  </data>
+  <data name="ColorGrading" xml:space="preserve">
+    <value>Gradación de color</value>
+  </data>
+  <data name="ColorGrading_Contrast" xml:space="preserve">
+    <value>Contraste</value>
+  </data>
+  <data name="ColorGrading_ContrastPivot" xml:space="preserve">
+    <value>Pivote de contraste</value>
+  </data>
+  <data name="ColorGrading_Exposure" xml:space="preserve">
+    <value>Exposición</value>
+  </data>
+  <data name="ColorGrading_Gain" xml:space="preserve">
+    <value>Ganancia</value>
+  </data>
+  <data name="ColorGrading_Gamma" xml:space="preserve">
+    <value>Gamma</value>
+  </data>
+  <data name="ColorGrading_HighRange" xml:space="preserve">
+    <value>Rango alto</value>
+  </data>
+  <data name="ColorGrading_Highlights" xml:space="preserve">
+    <value>Iluminaciones</value>
+  </data>
+  <data name="ColorGrading_Hue" xml:space="preserve">
+    <value>Tono</value>
+  </data>
+  <data name="ColorGrading_Lift" xml:space="preserve">
+    <value>Elevación</value>
+  </data>
+  <data name="ColorGrading_LowRange" xml:space="preserve">
+    <value>Rango bajo</value>
+  </data>
+  <data name="ColorGrading_Midtones" xml:space="preserve">
+    <value>Tonos medios</value>
+  </data>
+  <data name="ColorGrading_Offset" xml:space="preserve">
+    <value>Desplazamiento</value>
+  </data>
+  <data name="ColorGrading_Saturation" xml:space="preserve">
+    <value>Saturación</value>
+  </data>
+  <data name="ColorGrading_Shadows" xml:space="preserve">
+    <value>Sombras</value>
+  </data>
+  <data name="ColorGrading_Temperature" xml:space="preserve">
+    <value>Temperatura</value>
+  </data>
+  <data name="ColorGrading_Tint" xml:space="preserve">
+    <value>Tinte</value>
+  </data>
+  <data name="ColorGrading_Vibrance" xml:space="preserve">
+    <value>Vibración</value>
+  </data>
+  <data name="ColorKey" xml:space="preserve">
+    <value>Clave de color</value>
+  </data>
+  <data name="ColorKey_Boundary" xml:space="preserve">
+    <value>Corrección de límite</value>
+  </data>
+  <data name="ColorKey_Range" xml:space="preserve">
+    <value>Rango de brillo</value>
+  </data>
+  <data name="ColorShift" xml:space="preserve">
+    <value>Desplazamiento de color</value>
+  </data>
+  <data name="ColorShift_AlphaOffset" xml:space="preserve">
+    <value>Desplazamiento alfa</value>
+  </data>
+  <data name="ColorShift_BlueOffset" xml:space="preserve">
+    <value>Desplazamiento azul</value>
+  </data>
+  <data name="ColorShift_GreenOffset" xml:space="preserve">
+    <value>Desplazamiento verde</value>
+  </data>
+  <data name="ColorShift_RedOffset" xml:space="preserve">
+    <value>Desplazamiento rojo</value>
+  </data>
+  <data name="Curves" xml:space="preserve">
+    <value>Curvas</value>
+  </data>
+  <data name="Curves_BlueCurve" xml:space="preserve">
+    <value>Curva azul</value>
+  </data>
+  <data name="Curves_GreenCurve" xml:space="preserve">
+    <value>Curva verde</value>
+  </data>
+  <data name="Curves_HueVsHue" xml:space="preserve">
+    <value>Tono vs Tono</value>
+  </data>
+  <data name="Curves_HueVsLuminance" xml:space="preserve">
+    <value>Tono vs Luminancia</value>
+  </data>
+  <data name="Curves_HueVsSaturation" xml:space="preserve">
+    <value>Tono vs Saturación</value>
+  </data>
+  <data name="Curves_LuminanceVsSaturation" xml:space="preserve">
+    <value>Luminancia vs Saturación</value>
+  </data>
+  <data name="Curves_MasterCurve" xml:space="preserve">
+    <value>Personalizado (RGB)</value>
+  </data>
+  <data name="Curves_RedCurve" xml:space="preserve">
+    <value>Curva roja</value>
+  </data>
+  <data name="Curves_SaturationVsSaturation" xml:space="preserve">
+    <value>Saturación vs Saturación</value>
+  </data>
+  <data name="DelayAnimationEffect" xml:space="preserve">
+    <value>Retardo de animación</value>
+  </data>
+  <data name="DelayAnimationEffect_Delay" xml:space="preserve">
+    <value>Retardo</value>
+  </data>
+  <data name="DelayAnimationEffect_Effect" xml:space="preserve">
+    <value>Efecto de filtro</value>
+  </data>
+  <data name="Dilate" xml:space="preserve">
+    <value>Dilatar</value>
+  </data>
+  <data name="Dilate_RadiusX" xml:space="preserve">
+    <value>Radio X</value>
+  </data>
+  <data name="Dilate_RadiusY" xml:space="preserve">
+    <value>Radio Y</value>
+  </data>
+  <data name="DisplacementMapEffect" xml:space="preserve">
+    <value>Mapa de desplazamiento</value>
+  </data>
+  <data name="DisplacementMapEffect_DisplacementMap" xml:space="preserve">
+    <value>Mapa de desplazamiento</value>
+  </data>
+  <data name="DisplacementMapEffect_ShowDisplacementMap" xml:space="preserve">
+    <value>Mostrar mapa de desplazamiento</value>
+  </data>
+  <data name="DisplacementMapEffect_Channel" xml:space="preserve">
+    <value>Canal</value>
+  </data>
+  <data name="DisplacementMapEffect_Signed" xml:space="preserve">
+    <value>Con signo</value>
+  </data>
+  <data name="DisplacementMapEffect_SpreadMethod" xml:space="preserve">
+    <value>Método de extensión</value>
+  </data>
+  <data name="PixelSortEffect" xml:space="preserve">
+    <value>Ordenar píxeles</value>
+  </data>
+  <data name="PixelSortEffect_Direction" xml:space="preserve">
+    <value>Dirección de ordenación</value>
+  </data>
+  <data name="PixelSortEffect_SortKey" xml:space="preserve">
+    <value>Clave de ordenación</value>
+  </data>
+  <data name="PixelSortEffect_ThresholdMin" xml:space="preserve">
+    <value>Umbral mínimo</value>
+  </data>
+  <data name="PixelSortEffect_ThresholdMax" xml:space="preserve">
+    <value>Umbral máximo</value>
+  </data>
+  <data name="PixelSortEffect_Ascending" xml:space="preserve">
+    <value>Ascendente</value>
+  </data>
+  <data name="DrawableDecorator" xml:space="preserve">
+    <value>Decorador</value>
+  </data>
+  <data name="DrawableTimeController" xml:space="preserve">
+    <value>Controlador de tiempo (video)</value>
+  </data>
+  <data name="DrawableTimeController_AdjustTimeRange" xml:space="preserve">
+    <value>Ajustar rango de tiempo</value>
+  </data>
+  <data name="DrawableTimeController_FrameRate" xml:space="preserve">
+    <value>Velocidad de fotogramas</value>
+  </data>
+  <data name="DrawableTimeController_HoldFirstFrame" xml:space="preserve">
+    <value>Mantener primer fotograma</value>
+  </data>
+  <data name="DrawableTimeController_HoldLastFrame" xml:space="preserve">
+    <value>Mantener último fotograma</value>
+  </data>
+  <data name="DrawableTimeController_Loop" xml:space="preserve">
+    <value>Bucle</value>
+  </data>
+  <data name="DrawableTimeController_OffsetPosition" xml:space="preserve">
+    <value>Posición de desplazamiento</value>
+  </data>
+  <data name="DrawableTimeController_Reverse" xml:space="preserve">
+    <value>Invertir</value>
+  </data>
+  <data name="Drawable_AlignmentX" xml:space="preserve">
+    <value>Alineación X</value>
+  </data>
+  <data name="Drawable_AlignmentY" xml:space="preserve">
+    <value>Alineación Y</value>
+  </data>
+  <data name="Drawable_BlendMode" xml:space="preserve">
+    <value>Modo de mezcla</value>
+  </data>
+  <data name="DropShadow" xml:space="preserve">
+    <value>Sombra proyectada</value>
+  </data>
+  <data name="EllipseShape" xml:space="preserve">
+    <value>Elipse</value>
+  </data>
+  <data name="Erode" xml:space="preserve">
+    <value>Erosionar</value>
+  </data>
+  <data name="Erode_RadiusX" xml:space="preserve">
+    <value>Radio X</value>
+  </data>
+  <data name="Erode_RadiusY" xml:space="preserve">
+    <value>Radio Y</value>
+  </data>
+  <data name="FlatShadow" xml:space="preserve">
+    <value>Sombra plana</value>
+  </data>
+  <data name="FlatShadow_Length" xml:space="preserve">
+    <value>Longitud</value>
+  </data>
+  <data name="SKSLScriptEffect" xml:space="preserve">
+    <value>Script SKSL</value>
+  </data>
+  <data name="GLSLScriptEffect" xml:space="preserve">
+    <value>Script GLSL</value>
+  </data>
+  <data name="CSharpScriptEffect" xml:space="preserve">
+    <value>Script C#</value>
+  </data>
+  <data name="Gamma" xml:space="preserve">
+    <value>Gamma</value>
+  </data>
+  <data name="GeometryShape" xml:space="preserve">
+    <value>Geometría</value>
+  </data>
+  <data name="GeometryShape_Data" xml:space="preserve">
+    <value>Datos</value>
+  </data>
+  <data name="HighContrast" xml:space="preserve">
+    <value>Alto contraste</value>
+  </data>
+  <data name="HighContrast_Contrast" xml:space="preserve">
+    <value>Contraste</value>
+  </data>
+  <data name="HighContrast_Grayscale" xml:space="preserve">
+    <value>Escala de grises</value>
+  </data>
+  <data name="HighContrast_InvertStyle" xml:space="preserve">
+    <value>Estilo de inversión</value>
+  </data>
+  <data name="HueRotate" xml:space="preserve">
+    <value>Rotación de tono</value>
+  </data>
+  <data name="InnerShadow" xml:space="preserve">
+    <value>Sombra interior</value>
+  </data>
+  <data name="Invert" xml:space="preserve">
+    <value>Invertir</value>
+  </data>
+  <data name="Invert_ExcludeAlphaChannel" xml:space="preserve">
+    <value>Excluir canal alfa</value>
+  </data>
+  <data name="LayerEffect" xml:space="preserve">
+    <value>Capa</value>
+  </data>
+  <data name="Lighting" xml:space="preserve">
+    <value>Iluminación</value>
+  </data>
+  <data name="Lighting_Add" xml:space="preserve">
+    <value>Adición</value>
+  </data>
+  <data name="Lighting_Multiply" xml:space="preserve">
+    <value>Multiplicación</value>
+  </data>
+  <data name="LumaColor" xml:space="preserve">
+    <value>Color de luma</value>
+  </data>
+  <data name="LutEffect" xml:space="preserve">
+    <value>LUT (archivo de cubo)</value>
+  </data>
+  <data name="MatrixTransform" xml:space="preserve">
+    <value>Transformación de matriz</value>
+  </data>
+  <data name="MatrixTransform_Matrix" xml:space="preserve">
+    <value>Matriz</value>
+  </data>
+  <data name="MosaicEffect" xml:space="preserve">
+    <value>Mosaico</value>
+  </data>
+  <data name="MosaicEffect_Origin" xml:space="preserve">
+    <value>Origen</value>
+  </data>
+  <data name="MosaicEffect_TileSize" xml:space="preserve">
+    <value>Tamaño de mosaico</value>
+  </data>
+  <data name="Negaposi" xml:space="preserve">
+    <value>Negaposi</value>
+  </data>
+  <data name="Negaposi_Blue" xml:space="preserve">
+    <value>Azul</value>
+  </data>
+  <data name="Negaposi_Green" xml:space="preserve">
+    <value>Verde</value>
+  </data>
+  <data name="Negaposi_Red" xml:space="preserve">
+    <value>Rojo</value>
+  </data>
+  <data name="ParticleEmitter" xml:space="preserve">
+    <value>Emisor de partículas</value>
+  </data>
+  <data name="ParticleEmitter_AirResistance" xml:space="preserve">
+    <value>Resistencia del aire</value>
+  </data>
+  <data name="ParticleEmitter_AngularVelocity" xml:space="preserve">
+    <value>Velocidad angular</value>
+  </data>
+  <data name="ParticleEmitter_EmissionGroup" xml:space="preserve">
+    <value>Emisión</value>
+  </data>
+  <data name="ParticleEmitter_EmissionRate" xml:space="preserve">
+    <value>Velocidad de emisión</value>
+  </data>
+  <data name="ParticleEmitter_EmitterGroup" xml:space="preserve">
+    <value>Emisor</value>
+  </data>
+  <data name="ParticleEmitter_EmitterHeight" xml:space="preserve">
+    <value>Altura del emisor</value>
+  </data>
+  <data name="ParticleEmitter_EmitterShape" xml:space="preserve">
+    <value>Forma del emisor</value>
+  </data>
+  <data name="ParticleEmitter_EmitterWidth" xml:space="preserve">
+    <value>Ancho del emisor</value>
+  </data>
+  <data name="ParticleEmitter_EndColor" xml:space="preserve">
+    <value>Color final</value>
+  </data>
+  <data name="ParticleEmitter_EndOpacityMultiplier" xml:space="preserve">
+    <value>Multiplicador de opacidad final</value>
+  </data>
+  <data name="ParticleEmitter_EndSizeMultiplier" xml:space="preserve">
+    <value>Multiplicador de tamaño final</value>
+  </data>
+  <data name="ParticleEmitter_Gravity" xml:space="preserve">
+    <value>Gravedad</value>
+  </data>
+  <data name="ParticleEmitter_InitialRotation" xml:space="preserve">
+    <value>Rotación inicial</value>
+  </data>
+  <data name="ParticleEmitter_InitialRotationRandom" xml:space="preserve">
+    <value>Rotación inicial aleatoria</value>
+  </data>
+  <data name="ParticleEmitter_Lifetime" xml:space="preserve">
+    <value>Vida útil</value>
+  </data>
+  <data name="ParticleEmitter_LifetimeRandom" xml:space="preserve">
+    <value>Vida útil aleatoria</value>
+  </data>
+  <data name="ParticleEmitter_MaxParticles" xml:space="preserve">
+    <value>Máximo de partículas</value>
+  </data>
+  <data name="ParticleEmitter_OverLifeGroup" xml:space="preserve">
+    <value>Durante la vida</value>
+  </data>
+  <data name="ParticleEmitter_ParticleDrawable" xml:space="preserve">
+    <value>Dibujable de partícula</value>
+  </data>
+  <data name="ParticleEmitter_ParticleOpacity" xml:space="preserve">
+    <value>Opacidad de partícula</value>
+  </data>
+  <data name="ParticleEmitter_ParticleSize" xml:space="preserve">
+    <value>Tamaño de partícula</value>
+  </data>
+  <data name="ParticleEmitter_PhysicsGroup" xml:space="preserve">
+    <value>Física</value>
+  </data>
+  <data name="ParticleEmitter_Seed" xml:space="preserve">
+    <value>Semilla</value>
+  </data>
+  <data name="ParticleEmitter_SizeRandom" xml:space="preserve">
+    <value>Tamaño aleatorio</value>
+  </data>
+  <data name="ParticleEmitter_SpeedRandom" xml:space="preserve">
+    <value>Velocidad aleatoria</value>
+  </data>
+  <data name="ParticleEmitter_Spread" xml:space="preserve">
+    <value>Dispersión</value>
+  </data>
+  <data name="ParticleEmitter_TurbulenceScale" xml:space="preserve">
+    <value>Escala de turbulencia</value>
+  </data>
+  <data name="ParticleEmitter_TurbulenceSpeed" xml:space="preserve">
+    <value>Velocidad de turbulencia</value>
+  </data>
+  <data name="ParticleEmitter_TurbulenceStrength" xml:space="preserve">
+    <value>Fuerza de turbulencia</value>
+  </data>
+  <data name="ParticleEmitter_UseEndColor" xml:space="preserve">
+    <value>Usar color final</value>
+  </data>
+  <data name="ParticleEmitter_VelocityGroup" xml:space="preserve">
+    <value>Velocidad</value>
+  </data>
+  <data name="ParticleEmitter_VisualGroup" xml:space="preserve">
+    <value>Visual</value>
+  </data>
+  <data name="PartsSplitEffect" xml:space="preserve">
+    <value>Dividir por partes</value>
+  </data>
+  <data name="PathFollowEffect" xml:space="preserve">
+    <value>Seguir ruta</value>
+  </data>
+  <data name="PathFollowEffect_FollowRotation" xml:space="preserve">
+    <value>Seguir rotación</value>
+  </data>
+  <data name="PathFollowEffect_Geometry" xml:space="preserve">
+    <value>Geometría</value>
+  </data>
+  <data name="PathFollowEffect_Progress" xml:space="preserve">
+    <value>Progreso</value>
+  </data>
+  <data name="RectShape" xml:space="preserve">
+    <value>Rectángulo</value>
+  </data>
+  <data name="Rotation3DTransform" xml:space="preserve">
+    <value>Rotación 3D</value>
+  </data>
+  <data name="Rotation3DTransform_CenterZ" xml:space="preserve">
+    <value>Centro Z</value>
+  </data>
+  <data name="Rotation3DTransform_RotationX" xml:space="preserve">
+    <value>Rotación X</value>
+  </data>
+  <data name="Rotation3DTransform_RotationY" xml:space="preserve">
+    <value>Rotación Y</value>
+  </data>
+  <data name="Rotation3DTransform_RotationZ" xml:space="preserve">
+    <value>Rotación Z</value>
+  </data>
+  <data name="RoundedRectShape" xml:space="preserve">
+    <value>Rectángulo redondeado</value>
+  </data>
+  <data name="RoundedRectShape_CornerRadius" xml:space="preserve">
+    <value>Radio de esquina</value>
+  </data>
+  <data name="Saturate" xml:space="preserve">
+    <value>Saturar</value>
+  </data>
+  <data name="ScaleTransform_ScaleX" xml:space="preserve">
+    <value>Escala X</value>
+  </data>
+  <data name="ScaleTransform_ScaleY" xml:space="preserve">
+    <value>Escala Y</value>
+  </data>
+  <data name="ShakeEffect" xml:space="preserve">
+    <value>Sacudida</value>
+  </data>
+  <data name="ShakeEffect_StrengthX" xml:space="preserve">
+    <value>Fuerza X</value>
+  </data>
+  <data name="ShakeEffect_StrengthY" xml:space="preserve">
+    <value>Fuerza Y</value>
+  </data>
+  <data name="Fill" xml:space="preserve">
+    <value>Relleno</value>
+  </data>
+  <data name="SkewTransform" xml:space="preserve">
+    <value>Sesgar</value>
+  </data>
+  <data name="SkewTransform_SkewX" xml:space="preserve">
+    <value>Sesgo X</value>
+  </data>
+  <data name="SkewTransform_SkewY" xml:space="preserve">
+    <value>Sesgo Y</value>
+  </data>
+  <data name="SourceBackdrop" xml:space="preserve">
+    <value>Fondo</value>
+  </data>
+  <data name="SourceBackdrop_Clear" xml:space="preserve">
+    <value>Borrar búfer</value>
+  </data>
+  <data name="SourceImage" xml:space="preserve">
+    <value>Imagen</value>
+  </data>
+  <data name="SourceVideo" xml:space="preserve">
+    <value>Video</value>
+  </data>
+  <data name="SourceVideo_IsLoop" xml:space="preserve">
+    <value>Bucle</value>
+  </data>
+  <data name="SourceVideo_OffsetPosition" xml:space="preserve">
+    <value>Posición de desplazamiento</value>
+  </data>
+  <data name="SplitEffect" xml:space="preserve">
+    <value>Dividir en partes iguales</value>
+  </data>
+  <data name="SplitEffect_HorizontalDivisions" xml:space="preserve">
+    <value>Divisiones horizontales</value>
+  </data>
+  <data name="SplitEffect_HorizontalSpacing" xml:space="preserve">
+    <value>Espaciado horizontal</value>
+  </data>
+  <data name="SplitEffect_VerticalDivisions" xml:space="preserve">
+    <value>Divisiones verticales</value>
+  </data>
+  <data name="SplitEffect_VerticalSpacing" xml:space="preserve">
+    <value>Espaciado vertical</value>
+  </data>
+  <data name="StrokeEffect_Style" xml:space="preserve">
+    <value>Estilo de borde</value>
+  </data>
+  <data name="TextBlock" xml:space="preserve">
+    <value>Texto</value>
+  </data>
+  <data name="TextBlock_FontFamily" xml:space="preserve">
+    <value>Familia de fuente</value>
+  </data>
+  <data name="TextBlock_FontStyle" xml:space="preserve">
+    <value>Estilo de fuente</value>
+  </data>
+  <data name="TextBlock_FontWeight" xml:space="preserve">
+    <value>Peso de fuente</value>
+  </data>
+  <data name="TextBlock_Size" xml:space="preserve">
+    <value>Tamaño</value>
+  </data>
+  <data name="TextBlock_Spacing" xml:space="preserve">
+    <value>Espaciado de caracteres</value>
+  </data>
+  <data name="TextBlock_SplitByCharacters" xml:space="preserve">
+    <value>Dividir por caracteres</value>
+  </data>
+  <data name="TextBlock_Text" xml:space="preserve">
+    <value>Texto</value>
+  </data>
+  <data name="Threshold" xml:space="preserve">
+    <value>Umbral</value>
+  </data>
+  <data name="TransformEffect_BitmapInterpolationMode" xml:space="preserve">
+    <value>Modo de interpolación de mapa de bits</value>
+  </data>
+  <data name="TranslateTransform" xml:space="preserve">
+    <value>Traslación</value>
+  </data>
+  <data name="TranslateTransform_X" xml:space="preserve">
+    <value>X</value>
+  </data>
+  <data name="TranslateTransform_Y" xml:space="preserve">
+    <value>Y</value>
+  </data>
+  <data name="ArcSegment" xml:space="preserve">
+    <value>Arco elíptico</value>
+  </data>
+  <data name="ArcSegment_IsLargeArc" xml:space="preserve">
+    <value>Arco grande</value>
+  </data>
+  <data name="ArcSegment_Point" xml:space="preserve">
+    <value>Punto</value>
+  </data>
+  <data name="ArcSegment_RotationAngle" xml:space="preserve">
+    <value>Ángulo de rotación</value>
+  </data>
+  <data name="ArcSegment_SweepClockwise" xml:space="preserve">
+    <value>Barrido en sentido horario</value>
+  </data>
+  <data name="BasicMaterial" xml:space="preserve">
+    <value>Material básico</value>
+  </data>
+  <data name="BasicMaterial_AmbientColor" xml:space="preserve">
+    <value>Color ambiental</value>
+  </data>
+  <data name="BasicMaterial_DiffuseColor" xml:space="preserve">
+    <value>Color difuso</value>
+  </data>
+  <data name="BasicMaterial_DiffuseMap" xml:space="preserve">
+    <value>Mapa difuso</value>
+  </data>
+  <data name="BasicMaterial_Shininess" xml:space="preserve">
+    <value>Brillo</value>
+  </data>
+  <data name="BasicMaterial_SpecularColor" xml:space="preserve">
+    <value>Color especular</value>
+  </data>
+  <data name="Camera3D_FarPlane" xml:space="preserve">
+    <value>Plano lejano</value>
+  </data>
+  <data name="Camera3D_NearPlane" xml:space="preserve">
+    <value>Plano cercano</value>
+  </data>
+  <data name="Camera3D_Up" xml:space="preserve">
+    <value>Arriba</value>
+  </data>
+  <data name="ConicGradientBrush" xml:space="preserve">
+    <value>Gradiente cónico</value>
+  </data>
+  <data name="ConicGradientBrush_Center" xml:space="preserve">
+    <value>Centro</value>
+  </data>
+  <data name="ConicSegment" xml:space="preserve">
+    <value>Cónico</value>
+  </data>
+  <data name="ConicSegment_ControlPoint" xml:space="preserve">
+    <value>Punto de control</value>
+  </data>
+  <data name="ConicSegment_Weight" xml:space="preserve">
+    <value>Peso</value>
+  </data>
+  <data name="Cube3D" xml:space="preserve">
+    <value>Cubo</value>
+  </data>
+  <data name="CubeMesh" xml:space="preserve">
+    <value>Malla de cubo</value>
+  </data>
+  <data name="CubicBezierSegment" xml:space="preserve">
+    <value>Curva de Bézier cúbica</value>
+  </data>
+  <data name="CubicBezierSegment_ControlPoint1" xml:space="preserve">
+    <value>Punto de control 1</value>
+  </data>
+  <data name="CubicBezierSegment_ControlPoint2" xml:space="preserve">
+    <value>Punto de control 2</value>
+  </data>
+  <data name="DirectionalLight3D" xml:space="preserve">
+    <value>Luz direccional</value>
+  </data>
+  <data name="DirectionalLight3D_ShadowDistance" xml:space="preserve">
+    <value>Distancia de sombra</value>
+  </data>
+  <data name="DirectionalLight3D_ShadowMapSize" xml:space="preserve">
+    <value>Tamaño del mapa de sombras</value>
+  </data>
+  <data name="DrawableTextureSource" xml:space="preserve">
+    <value>Textura dibujable</value>
+  </data>
+  <data name="DrawableTextureSource_TextureHeight" xml:space="preserve">
+    <value>Altura de textura</value>
+  </data>
+  <data name="DrawableTextureSource_TextureWidth" xml:space="preserve">
+    <value>Ancho de textura</value>
+  </data>
+  <data name="EllipseGeometry" xml:space="preserve">
+    <value>Elipse</value>
+  </data>
+  <data name="Geometry_FillType" xml:space="preserve">
+    <value>Tipo de relleno</value>
+  </data>
+  <data name="GradientBrush_GradientStops" xml:space="preserve">
+    <value>Paradas</value>
+  </data>
+  <data name="GradientBrush_SpreadMethod" xml:space="preserve">
+    <value>Método de extensión</value>
+  </data>
+  <data name="Children" xml:space="preserve">
+    <value>Elementos secundarios</value>
+  </data>
+  <data name="ImageTextureSource" xml:space="preserve">
+    <value>Textura de imagen</value>
+  </data>
+  <data name="Light3D_CastsShadow" xml:space="preserve">
+    <value>Proyecta sombra</value>
+  </data>
+  <data name="Light3D_Intensity" xml:space="preserve">
+    <value>Intensidad</value>
+  </data>
+  <data name="Light3D_ShadowBias" xml:space="preserve">
+    <value>Sesgo de sombra</value>
+  </data>
+  <data name="Light3D_ShadowNormalBias" xml:space="preserve">
+    <value>Sesgo normal de sombra</value>
+  </data>
+  <data name="Light3D_ShadowStrength" xml:space="preserve">
+    <value>Fuerza de sombra</value>
+  </data>
+  <data name="LineSegment" xml:space="preserve">
+    <value>Línea</value>
+  </data>
+  <data name="LineSegment_Point" xml:space="preserve">
+    <value>Punto</value>
+  </data>
+  <data name="LinearGradientBrush" xml:space="preserve">
+    <value>Gradiente lineal</value>
+  </data>
+  <data name="LinearGradientBrush_StartPoint" xml:space="preserve">
+    <value>Punto inicial</value>
+  </data>
+  <data name="MeshObject3D" xml:space="preserve">
+    <value>Objeto de malla</value>
+  </data>
+  <data name="MeshObject3D_Mesh" xml:space="preserve">
+    <value>Malla</value>
+  </data>
+  <data name="Model3D" xml:space="preserve">
+    <value>Modelo</value>
+  </data>
+  <data name="ModelMesh" xml:space="preserve">
+    <value>Malla de modelo</value>
+  </data>
+  <data name="ModelMesh_Indices" xml:space="preserve">
+    <value>Índices</value>
+  </data>
+  <data name="ModelMesh_Vertices" xml:space="preserve">
+    <value>Vértices</value>
+  </data>
+  <data name="Object3D_CastShadows" xml:space="preserve">
+    <value>Proyectar sombras</value>
+  </data>
+  <data name="Object3D_Material" xml:space="preserve">
+    <value>Material</value>
+  </data>
+  <data name="Object3D_ReceiveShadows" xml:space="preserve">
+    <value>Recibir sombras</value>
+  </data>
+  <data name="OrthographicCamera" xml:space="preserve">
+    <value>Cámara ortográfica</value>
+  </data>
+  <data name="PBRMaterial" xml:space="preserve">
+    <value>Material PBR</value>
+  </data>
+  <data name="PBRMaterial_AOMap" xml:space="preserve">
+    <value>Mapa AO</value>
+  </data>
+  <data name="PBRMaterial_Albedo" xml:space="preserve">
+    <value>Albedo</value>
+  </data>
+  <data name="PBRMaterial_AlbedoMap" xml:space="preserve">
+    <value>Mapa de albedo</value>
+  </data>
+  <data name="PBRMaterial_AmbientOcclusion" xml:space="preserve">
+    <value>Oclusión ambiental</value>
+  </data>
+  <data name="PBRMaterial_Emissive" xml:space="preserve">
+    <value>Emisivo</value>
+  </data>
+  <data name="PBRMaterial_EmissiveIntensity" xml:space="preserve">
+    <value>Intensidad emisiva</value>
+  </data>
+  <data name="PBRMaterial_EmissiveMap" xml:space="preserve">
+    <value>Mapa emisivo</value>
+  </data>
+  <data name="PBRMaterial_Metallic" xml:space="preserve">
+    <value>Metálico</value>
+  </data>
+  <data name="PBRMaterial_MetallicRoughnessMap" xml:space="preserve">
+    <value>Mapa metálico/rugosidad</value>
+  </data>
+  <data name="PBRMaterial_NormalMap" xml:space="preserve">
+    <value>Mapa de normales</value>
+  </data>
+  <data name="PBRMaterial_NormalMapStrength" xml:space="preserve">
+    <value>Fuerza del mapa de normales</value>
+  </data>
+  <data name="PBRMaterial_Roughness" xml:space="preserve">
+    <value>Rugosidad</value>
+  </data>
+  <data name="PathFigure" xml:space="preserve">
+    <value>Figura</value>
+  </data>
+  <data name="PathFigure_IsClosed" xml:space="preserve">
+    <value>Está cerrado</value>
+  </data>
+  <data name="PathFigure_StartPoint" xml:space="preserve">
+    <value>Punto inicial</value>
+  </data>
+  <data name="PathGeometry" xml:space="preserve">
+    <value>Geometría</value>
+  </data>
+  <data name="Pen_DashArray" xml:space="preserve">
+    <value>Guiones y espacios</value>
+  </data>
+  <data name="Pen_DashOffset" xml:space="preserve">
+    <value>Desplazamiento de guiones</value>
+  </data>
+  <data name="Pen_MiterLimit" xml:space="preserve">
+    <value>Límite de inglete</value>
+  </data>
+  <data name="Pen_StrokeAlignment" xml:space="preserve">
+    <value>Ubicación</value>
+  </data>
+  <data name="Pen_StrokeCap" xml:space="preserve">
+    <value>Estilo de extremo</value>
+  </data>
+  <data name="Pen_StrokeJoin" xml:space="preserve">
+    <value>Estilo de unión</value>
+  </data>
+  <data name="Pen_Thickness" xml:space="preserve">
+    <value>Grosor</value>
+  </data>
+  <data name="Pen_TrimEnd" xml:space="preserve">
+    <value>Recortar final</value>
+  </data>
+  <data name="Pen_TrimOffset" xml:space="preserve">
+    <value>Desplazamiento de recorte</value>
+  </data>
+  <data name="Pen_TrimStart" xml:space="preserve">
+    <value>Recortar inicio</value>
+  </data>
+  <data name="Pen_Offset" xml:space="preserve">
+    <value>Desplazamiento</value>
+  </data>
+  <data name="PerlinNoiseBrush" xml:space="preserve">
+    <value>Ruido de Perlin</value>
+  </data>
+  <data name="PerlinNoiseBrush_BaseFrequencyX" xml:space="preserve">
+    <value>Frecuencia base X</value>
+  </data>
+  <data name="PerlinNoiseBrush_BaseFrequencyY" xml:space="preserve">
+    <value>Frecuencia base Y</value>
+  </data>
+  <data name="PerlinNoiseBrush_Octaves" xml:space="preserve">
+    <value>Octavas</value>
+  </data>
+  <data name="PerlinNoiseBrush_PerlinNoiseType" xml:space="preserve">
+    <value>Tipo de ruido</value>
+  </data>
+  <data name="PerlinNoiseBrush_Seed" xml:space="preserve">
+    <value>Semilla</value>
+  </data>
+  <data name="PerspectiveCamera" xml:space="preserve">
+    <value>Cámara en perspectiva</value>
+  </data>
+  <data name="PerspectiveCamera_FieldOfView" xml:space="preserve">
+    <value>Campo de visión</value>
+  </data>
+  <data name="Plane3D" xml:space="preserve">
+    <value>Plano</value>
+  </data>
+  <data name="Plane3D_HeightSegments" xml:space="preserve">
+    <value>Segmentos de altura</value>
+  </data>
+  <data name="Plane3D_WidthSegments" xml:space="preserve">
+    <value>Segmentos de ancho</value>
+  </data>
+  <data name="PlaneMesh" xml:space="preserve">
+    <value>Malla de plano</value>
+  </data>
+  <data name="PlaneMesh_HeightSegments" xml:space="preserve">
+    <value>Segmentos de altura</value>
+  </data>
+  <data name="PlaneMesh_WidthSegments" xml:space="preserve">
+    <value>Segmentos de ancho</value>
+  </data>
+  <data name="PointLight3D" xml:space="preserve">
+    <value>Luz puntual</value>
+  </data>
+  <data name="PointLight3D_ConstantAttenuation" xml:space="preserve">
+    <value>Atenuación constante</value>
+  </data>
+  <data name="PointLight3D_LinearAttenuation" xml:space="preserve">
+    <value>Atenuación lineal</value>
+  </data>
+  <data name="PointLight3D_QuadraticAttenuation" xml:space="preserve">
+    <value>Atenuación cuadrática</value>
+  </data>
+  <data name="PointLight3D_Range" xml:space="preserve">
+    <value>Rango</value>
+  </data>
+  <data name="QuadraticBezierSegment" xml:space="preserve">
+    <value>Curva de Bézier cuadrática</value>
+  </data>
+  <data name="QuadraticBezierSegment_ControlPoint" xml:space="preserve">
+    <value>Punto de control</value>
+  </data>
+  <data name="RadialGradientBrush" xml:space="preserve">
+    <value>Gradiente radial</value>
+  </data>
+  <data name="RadialGradientBrush_Center" xml:space="preserve">
+    <value>Centro</value>
+  </data>
+  <data name="RadialGradientBrush_GradientOrigin" xml:space="preserve">
+    <value>Origen del gradiente</value>
+  </data>
+  <data name="RectGeometry" xml:space="preserve">
+    <value>Rectángulo</value>
+  </data>
+  <data name="RoundedRectGeometry" xml:space="preserve">
+    <value>Rectángulo redondeado</value>
+  </data>
+  <data name="RoundedRectGeometry_CornerRadius" xml:space="preserve">
+    <value>Radio de esquina</value>
+  </data>
+  <data name="Scene3D" xml:space="preserve">
+    <value>Escena 3D</value>
+  </data>
+  <data name="Scene3D_AmbientColor" xml:space="preserve">
+    <value>Color ambiental</value>
+  </data>
+  <data name="Scene3D_AmbientIntensity" xml:space="preserve">
+    <value>Intensidad ambiental</value>
+  </data>
+  <data name="Scene3D_BackgroundColor" xml:space="preserve">
+    <value>Color de fondo</value>
+  </data>
+  <data name="Scene3D_Camera" xml:space="preserve">
+    <value>Cámara</value>
+  </data>
+  <data name="Scene3D_Lights" xml:space="preserve">
+    <value>Luces</value>
+  </data>
+  <data name="Scene3D_Objects" xml:space="preserve">
+    <value>Objetos</value>
+  </data>
+  <data name="Scene3D_RenderHeight" xml:space="preserve">
+    <value>Altura de renderizado</value>
+  </data>
+  <data name="Scene3D_RenderWidth" xml:space="preserve">
+    <value>Ancho de renderizado</value>
+  </data>
+  <data name="SolidColorBrush" xml:space="preserve">
+    <value>Sólido</value>
+  </data>
+  <data name="Sphere3D" xml:space="preserve">
+    <value>Esfera</value>
+  </data>
+  <data name="Sphere3D_Rings" xml:space="preserve">
+    <value>Anillos</value>
+  </data>
+  <data name="Sphere3D_Segments" xml:space="preserve">
+    <value>Segmentos</value>
+  </data>
+  <data name="SphereMesh" xml:space="preserve">
+    <value>Malla de esfera</value>
+  </data>
+  <data name="SphereMesh_Rings" xml:space="preserve">
+    <value>Anillos</value>
+  </data>
+  <data name="SphereMesh_Segments" xml:space="preserve">
+    <value>Segmentos</value>
+  </data>
+  <data name="SpotLight3D" xml:space="preserve">
+    <value>Foco</value>
+  </data>
+  <data name="SpotLight3D_ConstantAttenuation" xml:space="preserve">
+    <value>Atenuación constante</value>
+  </data>
+  <data name="SpotLight3D_InnerConeAngle" xml:space="preserve">
+    <value>Ángulo del cono interior</value>
+  </data>
+  <data name="SpotLight3D_LinearAttenuation" xml:space="preserve">
+    <value>Atenuación lineal</value>
+  </data>
+  <data name="SpotLight3D_OuterConeAngle" xml:space="preserve">
+    <value>Ángulo del cono exterior</value>
+  </data>
+  <data name="SpotLight3D_QuadraticAttenuation" xml:space="preserve">
+    <value>Atenuación cuadrática</value>
+  </data>
+  <data name="SpotLight3D_Range" xml:space="preserve">
+    <value>Rango</value>
+  </data>
+  <data name="StrokeAlignment_Center" xml:space="preserve">
+    <value>Centro</value>
+  </data>
+  <data name="StrokeAlignment_Inside" xml:space="preserve">
+    <value>Interior</value>
+  </data>
+  <data name="StrokeAlignment_Outside" xml:space="preserve">
+    <value>Exterior</value>
+  </data>
+  <data name="StrokeCap_Flat" xml:space="preserve">
+    <value>Plano</value>
+  </data>
+  <data name="StrokeCap_Round" xml:space="preserve">
+    <value>Redondo</value>
+  </data>
+  <data name="StrokeCap_Square" xml:space="preserve">
+    <value>Cuadrado</value>
+  </data>
+  <data name="StrokeJoin_Bevel" xml:space="preserve">
+    <value>Unión biselada</value>
+  </data>
+  <data name="StrokeJoin_Miter" xml:space="preserve">
+    <value>Unión en inglete</value>
+  </data>
+  <data name="StrokeJoin_Round" xml:space="preserve">
+    <value>Unión circular</value>
+  </data>
+  <data name="TileBrush_AlignmentX" xml:space="preserve">
+    <value>Alineación X</value>
+  </data>
+  <data name="TileBrush_AlignmentY" xml:space="preserve">
+    <value>Alineación Y</value>
+  </data>
+  <data name="TileBrush_BitmapInterpolationMode" xml:space="preserve">
+    <value>Modo de interpolación de mapa de bits</value>
+  </data>
+  <data name="TileBrush_SourceRect" xml:space="preserve">
+    <value>Origen</value>
+  </data>
+  <data name="TileBrush_DestinationRect" xml:space="preserve">
+    <value>Destino</value>
+  </data>
+  <data name="TileBrush_Stretch" xml:space="preserve">
+    <value>Estirar</value>
+  </data>
+  <data name="TileBrush_TileMode" xml:space="preserve">
+    <value>Modo de mosaico</value>
+  </data>
+  <data name="TransparentMaterial" xml:space="preserve">
+    <value>Material transparente</value>
+  </data>
+  <data name="TransparentMaterial_ColorMap" xml:space="preserve">
+    <value>Mapa de color</value>
+  </data>
+  <data name="TransparentMaterial_IndexOfRefraction" xml:space="preserve">
+    <value>Índice de refracción</value>
+  </data>
+  <data name="TransparentMaterial_Roughness" xml:space="preserve">
+    <value>Rugosidad</value>
+  </data>
+  <data name="Amount" xml:space="preserve">
+    <value>Cantidad</value>
+  </data>
+  <data name="Angle" xml:space="preserve">
+    <value>Ángulo</value>
+  </data>
+  <data name="Brush" xml:space="preserve">
+    <value>Pincel</value>
+  </data>
+  <data name="CenterX" xml:space="preserve">
+    <value>Centro X</value>
+  </data>
+  <data name="CenterY" xml:space="preserve">
+    <value>Centro Y</value>
+  </data>
+  <data name="Color" xml:space="preserve">
+    <value>Color</value>
+  </data>
+  <data name="Depth" xml:space="preserve">
+    <value>Profundidad</value>
+  </data>
+  <data name="Direction" xml:space="preserve">
+    <value>Dirección</value>
+  </data>
+  <data name="Drawable" xml:space="preserve">
+    <value>Dibujable</value>
+  </data>
+  <data name="EndPoint" xml:space="preserve">
+    <value>Punto final</value>
+  </data>
+  <data name="FixImageSize" xml:space="preserve">
+    <value>Fijar tamaño de imagen</value>
+  </data>
+  <data name="Group" xml:space="preserve">
+    <value>Grupo</value>
+  </data>
+  <data name="Height" xml:space="preserve">
+    <value>Altura</value>
+  </data>
+  <data name="KernelSize" xml:space="preserve">
+    <value>Tamaño del núcleo</value>
+  </data>
+  <data name="Offset" xml:space="preserve">
+    <value>Desplazamiento</value>
+  </data>
+  <data name="Opacity" xml:space="preserve">
+    <value>Opacidad</value>
+  </data>
+  <data name="Position" xml:space="preserve">
+    <value>Posición</value>
+  </data>
+  <data name="Presenter" xml:space="preserve">
+    <value>Presentador</value>
+  </data>
+  <data name="Radius" xml:space="preserve">
+    <value>Radio</value>
+  </data>
+  <data name="Rotation" xml:space="preserve">
+    <value>Rotación</value>
+  </data>
+  <data name="Scale" xml:space="preserve">
+    <value>Escala</value>
+  </data>
+  <data name="Script" xml:space="preserve">
+    <value>Script</value>
+  </data>
+  <data name="ShadowOnly" xml:space="preserve">
+    <value>Solo sombra</value>
+  </data>
+  <data name="Sigma" xml:space="preserve">
+    <value>Sigma</value>
+  </data>
+  <data name="Smoothing" xml:space="preserve">
+    <value>Suavizado</value>
+  </data>
+  <data name="Source" xml:space="preserve">
+    <value>Origen</value>
+  </data>
+  <data name="Speed" xml:space="preserve">
+    <value>Velocidad</value>
+  </data>
+  <data name="Strength" xml:space="preserve">
+    <value>Fuerza</value>
+  </data>
+  <data name="Stroke" xml:space="preserve">
+    <value>Trazo</value>
+  </data>
+  <data name="Target" xml:space="preserve">
+    <value>Destino</value>
+  </data>
+  <data name="Transform" xml:space="preserve">
+    <value>Transformación</value>
+  </data>
+  <data name="TransformOrigin" xml:space="preserve">
+    <value>Origen de transformación</value>
+  </data>
+  <data name="Width" xml:space="preserve">
+    <value>Ancho</value>
+  </data>
+  <data name="NodeGraphDrawable" xml:space="preserve">
+    <value>Grafo de nodos (video)</value>
+  </data>
+  <data name="NodeGraphFilterEffect" xml:space="preserve">
+    <value>Grafo de nodos (efecto)</value>
+  </data>
+  <data name="SceneDrawable" xml:space="preserve">
+    <value>Referencia de escena (video)</value>
+  </data>
+  <data name="SceneDrawable_ReferencedScene" xml:space="preserve">
+    <value>Escena referenciada</value>
+  </data>
+  <data name="FilterEffect" xml:space="preserve">
+    <value>Efecto de filtro</value>
+  </data>
+  <data name="AudioVisualizer" xml:space="preserve">
+    <value>Visualizador de audio</value>
+  </data>
+  <data name="AudioWaveform" xml:space="preserve">
+    <value>Forma de onda de audio</value>
+  </data>
+  <data name="AudioSpectrum" xml:space="preserve">
+    <value>Espectro de audio</value>
+  </data>
+  <data name="AudioSpectrogram" xml:space="preserve">
+    <value>Espectrograma de audio</value>
+  </data>
+  <data name="AudioVisualizer_BarCount" xml:space="preserve">
+    <value>Número de barras</value>
+  </data>
+  <data name="AudioVisualizer_WindowSeconds" xml:space="preserve">
+    <value>Ventana (segundos)</value>
+  </data>
+  <data name="AudioVisualizer_FftSize" xml:space="preserve">
+    <value>Tamaño FFT</value>
+  </data>
+  <data name="AudioVisualizer_FrequencyScale" xml:space="preserve">
+    <value>Escala de frecuencia</value>
+  </data>
+  <data name="AudioVisualizer_FloorDb" xml:space="preserve">
+    <value>Piso (dB)</value>
+  </data>
+  <data name="AudioVisualizer_TimeColumns" xml:space="preserve">
+    <value>Columnas de tiempo</value>
+  </data>
+  <data name="AudioVisualizer_Gain" xml:space="preserve">
+    <value>Ganancia</value>
+  </data>
+  <data name="AudioVisualizer_Smoothing" xml:space="preserve">
+    <value>Suavizado</value>
+  </data>
+  <data name="AudioVisualizer_Shape" xml:space="preserve">
+    <value>Forma</value>
+  </data>
+  <data name="SpectrumShape_Bar" xml:space="preserve">
+    <value>Barra</value>
+  </data>
+  <data name="SpectrumShape_Line" xml:space="preserve">
+    <value>Línea</value>
+  </data>
+  <data name="SpectrumShape_FilledArea" xml:space="preserve">
+    <value>Área rellena</value>
+  </data>
+  <data name="SpectrumShape_MirroredBars" xml:space="preserve">
+    <value>Barras reflejadas</value>
+  </data>
+  <data name="SpectrumShape_Radial" xml:space="preserve">
+    <value>Radial</value>
+  </data>
+  <data name="SpectrumShape_CornerRadius" xml:space="preserve">
+    <value>Radio de esquina</value>
+  </data>
+  <data name="SpectrumShape_Thickness" xml:space="preserve">
+    <value>Grosor</value>
+  </data>
+  <data name="SpectrumShape_Smoothness" xml:space="preserve">
+    <value>Suavidad</value>
+  </data>
+  <data name="SpectrumShape_InnerRadius" xml:space="preserve">
+    <value>Radio interior</value>
+  </data>
+  <data name="SpectrumShape_StartAngle" xml:space="preserve">
+    <value>Ángulo inicial</value>
+  </data>
+  <data name="SpectrumShape_BarWidth" xml:space="preserve">
+    <value>Ancho de barra</value>
+  </data>
+  <data name="SpectrumShape_Direction" xml:space="preserve">
+    <value>Dirección</value>
+  </data>
+  <data name="WaveformShape_MinMaxBar" xml:space="preserve">
+    <value>Barra mín/máx</value>
+  </data>
+  <data name="WaveformShape_Line" xml:space="preserve">
+    <value>Línea</value>
+  </data>
+  <data name="WaveformShape_FilledMirror" xml:space="preserve">
+    <value>Espejo relleno</value>
+  </data>
+  <data name="WaveformShape_FilledEnvelope" xml:space="preserve">
+    <value>Envolvente rellena</value>
+  </data>
+  <data name="WaveformShape_Block" xml:space="preserve">
+    <value>Bloque</value>
+  </data>
+  <data name="WaveformShape_Dots" xml:space="preserve">
+    <value>Puntos</value>
+  </data>
+  <data name="WaveformShape_Radial" xml:space="preserve">
+    <value>Radial</value>
+  </data>
+  <data name="WaveformShape_BlockCount" xml:space="preserve">
+    <value>Número de bloques</value>
+  </data>
+  <data name="WaveformShape_BlockGap" xml:space="preserve">
+    <value>Espacio entre bloques</value>
+  </data>
+  <data name="WaveformShape_Mirrored" xml:space="preserve">
+    <value>Reflejado</value>
+  </data>
+  <data name="WaveformShape_Symmetric" xml:space="preserve">
+    <value>Simétrico</value>
+  </data>
+  <data name="WaveformShape_DotRadius" xml:space="preserve">
+    <value>Radio de punto</value>
+  </data>
+  <data name="WaveformShape_DotMode" xml:space="preserve">
+    <value>Modo de punto</value>
+  </data>
+</root>

--- a/src/Beutl.Language/GraphicsStrings.ko-KR.resx
+++ b/src/Beutl.Language/GraphicsStrings.ko-KR.resx
@@ -1,0 +1,1475 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BlendEffect" xml:space="preserve">
+    <value>혼합</value>
+  </data>
+  <data name="BlendEffect_BlendMode" xml:space="preserve">
+    <value>혼합 모드</value>
+  </data>
+  <data name="BlendMode_Clear" xml:space="preserve">
+    <value>지우기</value>
+  </data>
+  <data name="BlendMode_Clear_Description" xml:space="preserve">
+    <value>내용을 투명하게 지웁니다.</value>
+  </data>
+  <data name="BlendMode_Color" xml:space="preserve">
+    <value>색상</value>
+  </data>
+  <data name="BlendMode_ColorBurn" xml:space="preserve">
+    <value>색상 번</value>
+  </data>
+  <data name="BlendMode_ColorBurn_Description" xml:space="preserve">
+    <value>전경 색상으로 배경을 태워 어둡게 만듭니다.</value>
+  </data>
+  <data name="BlendMode_ColorDodge" xml:space="preserve">
+    <value>색상 닷지</value>
+  </data>
+  <data name="BlendMode_ColorDodge_Description" xml:space="preserve">
+    <value>전경 색상을 더해 배경을 밝게 만듭니다.</value>
+  </data>
+  <data name="BlendMode_Color_Description" xml:space="preserve">
+    <value>전경의 색조와 채도를 배경의 휘도에 적용합니다.</value>
+  </data>
+  <data name="BlendMode_Darken" xml:space="preserve">
+    <value>어둡게</value>
+  </data>
+  <data name="BlendMode_Darken_Description" xml:space="preserve">
+    <value>전경 또는 배경 중 더 어두운 색상을 유지합니다.</value>
+  </data>
+  <data name="BlendMode_Difference" xml:space="preserve">
+    <value>차이</value>
+  </data>
+  <data name="BlendMode_Difference_Description" xml:space="preserve">
+    <value>절대 색상 차이를 강조합니다.</value>
+  </data>
+  <data name="BlendMode_Dst" xml:space="preserve">
+    <value>원본 유지</value>
+  </data>
+  <data name="BlendMode_DstATop" xml:space="preserve">
+    <value>배경 위에</value>
+  </data>
+  <data name="BlendMode_DstATop_Description" xml:space="preserve">
+    <value>배경을 위에 배치하고 전경 바깥 영역을 유지합니다.</value>
+  </data>
+  <data name="BlendMode_DstIn" xml:space="preserve">
+    <value>배경 안쪽</value>
+  </data>
+  <data name="BlendMode_DstIn_Description" xml:space="preserve">
+    <value>배경을 전경의 모양으로 클리핑합니다.</value>
+  </data>
+  <data name="BlendMode_DstOut" xml:space="preserve">
+    <value>배경 바깥쪽</value>
+  </data>
+  <data name="BlendMode_DstOut_Description" xml:space="preserve">
+    <value>배경에 대해 전경 바깥 영역을 유지합니다.</value>
+  </data>
+  <data name="BlendMode_DstOver" xml:space="preserve">
+    <value>배경 위</value>
+  </data>
+  <data name="BlendMode_DstOver_Description" xml:space="preserve">
+    <value>배경을 전경 아래에 배치합니다.</value>
+  </data>
+  <data name="BlendMode_Dst_Description" xml:space="preserve">
+    <value>원본 내용을 변경하지 않고 유지합니다.</value>
+  </data>
+  <data name="BlendMode_Exclusion" xml:space="preserve">
+    <value>제외</value>
+  </data>
+  <data name="BlendMode_Exclusion_Description" xml:space="preserve">
+    <value>더 부드러운 차이 효과를 만듭니다.</value>
+  </data>
+  <data name="BlendMode_HardLight" xml:space="preserve">
+    <value>하드 라이트</value>
+  </data>
+  <data name="BlendMode_HardLight_Description" xml:space="preserve">
+    <value>대비를 강화하는 강한 스포트라이트 효과를 시뮬레이션합니다.</value>
+  </data>
+  <data name="BlendMode_Hue" xml:space="preserve">
+    <value>색조</value>
+  </data>
+  <data name="BlendMode_Hue_Description" xml:space="preserve">
+    <value>전경의 색조를 배경의 휘도와 채도에 적용합니다.</value>
+  </data>
+  <data name="BlendMode_Lighten" xml:space="preserve">
+    <value>밝게</value>
+  </data>
+  <data name="BlendMode_Lighten_Description" xml:space="preserve">
+    <value>전경 또는 배경 중 더 밝은 색상을 유지합니다.</value>
+  </data>
+  <data name="BlendMode_Luminosity" xml:space="preserve">
+    <value>휘도</value>
+  </data>
+  <data name="BlendMode_Luminosity_Description" xml:space="preserve">
+    <value>전경의 휘도를 배경의 색조와 채도에 적용합니다.</value>
+  </data>
+  <data name="BlendMode_Modulate" xml:space="preserve">
+    <value>불투명도로 혼합</value>
+  </data>
+  <data name="BlendMode_Modulate_Description" xml:space="preserve">
+    <value>전경과 배경의 투명도(알파 값)에 따라 색상을 결합합니다.</value>
+  </data>
+  <data name="BlendMode_Multiply" xml:space="preserve">
+    <value>곱하기</value>
+  </data>
+  <data name="BlendMode_Multiply_Description" xml:space="preserve">
+    <value>전경과 배경의 RGB 색상 값을 곱하여 더 어두운 효과를 만듭니다.</value>
+  </data>
+  <data name="BlendMode_Overlay" xml:space="preserve">
+    <value>오버레이</value>
+  </data>
+  <data name="BlendMode_Overlay_Description" xml:space="preserve">
+    <value>전경과 배경을 결합하여 대비를 강화합니다.</value>
+  </data>
+  <data name="BlendMode_Plus" xml:space="preserve">
+    <value>더하기</value>
+  </data>
+  <data name="BlendMode_Plus_Description" xml:space="preserve">
+    <value>전경과 배경의 색상을 더합니다.</value>
+  </data>
+  <data name="BlendMode_Saturation" xml:space="preserve">
+    <value>채도</value>
+  </data>
+  <data name="BlendMode_Saturation_Description" xml:space="preserve">
+    <value>전경의 채도를 배경의 색조와 휘도에 적용합니다.</value>
+  </data>
+  <data name="BlendMode_Screen" xml:space="preserve">
+    <value>스크린</value>
+  </data>
+  <data name="BlendMode_Screen_Description" xml:space="preserve">
+    <value>전경과 배경의 반전 색상을 곱하여 더 밝은 효과를 만듭니다.</value>
+  </data>
+  <data name="BlendMode_SoftLight" xml:space="preserve">
+    <value>소프트 라이트</value>
+  </data>
+  <data name="BlendMode_SoftLight_Description" xml:space="preserve">
+    <value>더 부드러운 조명 효과를 위해 확산된 스포트라이트를 시뮬레이션합니다.</value>
+  </data>
+  <data name="BlendMode_Src" xml:space="preserve">
+    <value>덮어쓰기</value>
+  </data>
+  <data name="BlendMode_SrcATop" xml:space="preserve">
+    <value>전경 위에</value>
+  </data>
+  <data name="BlendMode_SrcATop_Description" xml:space="preserve">
+    <value>전경을 위에 배치하고 배경 바깥 영역을 유지합니다.</value>
+  </data>
+  <data name="BlendMode_SrcIn" xml:space="preserve">
+    <value>전경 안쪽</value>
+  </data>
+  <data name="BlendMode_SrcIn_Description" xml:space="preserve">
+    <value>전경을 배경의 모양으로 클리핑합니다.</value>
+  </data>
+  <data name="BlendMode_SrcOut" xml:space="preserve">
+    <value>전경 바깥쪽</value>
+  </data>
+  <data name="BlendMode_SrcOut_Description" xml:space="preserve">
+    <value>전경에 대해 배경 바깥 영역을 유지합니다.</value>
+  </data>
+  <data name="BlendMode_SrcOver" xml:space="preserve">
+    <value>전경 위</value>
+  </data>
+  <data name="BlendMode_SrcOver_Description" xml:space="preserve">
+    <value>전경을 배경 위에 배치합니다.</value>
+  </data>
+  <data name="BlendMode_Src_Description" xml:space="preserve">
+    <value>기존 내용 위에 그립니다.</value>
+  </data>
+  <data name="BlendMode_Xor" xml:space="preserve">
+    <value>배타적 혼합</value>
+  </data>
+  <data name="BlendMode_Xor_Description" xml:space="preserve">
+    <value>겹치는 영역을 투명하게 만들고 겹치지 않는 영역을 유지합니다.</value>
+  </data>
+  <data name="Blur" xml:space="preserve">
+    <value>흐림</value>
+  </data>
+  <data name="Brightness" xml:space="preserve">
+    <value>밝기</value>
+  </data>
+  <data name="ChromaKey" xml:space="preserve">
+    <value>크로마 키</value>
+  </data>
+  <data name="ChromaKey_Boundary" xml:space="preserve">
+    <value>경계 보정</value>
+  </data>
+  <data name="ChromaKey_HueRange" xml:space="preserve">
+    <value>색조 범위</value>
+  </data>
+  <data name="ChromaKey_SaturationRange" xml:space="preserve">
+    <value>채도 범위</value>
+  </data>
+  <data name="Clipping" xml:space="preserve">
+    <value>클리핑</value>
+  </data>
+  <data name="Clipping_AutoCenter" xml:space="preserve">
+    <value>자동 가운데 맞춤</value>
+  </data>
+  <data name="Clipping_AutoClip" xml:space="preserve">
+    <value>투명 영역 클리핑</value>
+  </data>
+  <data name="Clipping_Bottom" xml:space="preserve">
+    <value>아래</value>
+  </data>
+  <data name="Clipping_Left" xml:space="preserve">
+    <value>왼쪽</value>
+  </data>
+  <data name="Clipping_Right" xml:space="preserve">
+    <value>오른쪽</value>
+  </data>
+  <data name="Clipping_Top" xml:space="preserve">
+    <value>위</value>
+  </data>
+  <data name="ColorGrading" xml:space="preserve">
+    <value>색상 그레이딩</value>
+  </data>
+  <data name="ColorGrading_Contrast" xml:space="preserve">
+    <value>대비</value>
+  </data>
+  <data name="ColorGrading_ContrastPivot" xml:space="preserve">
+    <value>대비 피벗</value>
+  </data>
+  <data name="ColorGrading_Exposure" xml:space="preserve">
+    <value>노출</value>
+  </data>
+  <data name="ColorGrading_Gain" xml:space="preserve">
+    <value>게인</value>
+  </data>
+  <data name="ColorGrading_Gamma" xml:space="preserve">
+    <value>감마</value>
+  </data>
+  <data name="ColorGrading_HighRange" xml:space="preserve">
+    <value>높은 범위</value>
+  </data>
+  <data name="ColorGrading_Highlights" xml:space="preserve">
+    <value>하이라이트</value>
+  </data>
+  <data name="ColorGrading_Hue" xml:space="preserve">
+    <value>색조</value>
+  </data>
+  <data name="ColorGrading_Lift" xml:space="preserve">
+    <value>리프트</value>
+  </data>
+  <data name="ColorGrading_LowRange" xml:space="preserve">
+    <value>낮은 범위</value>
+  </data>
+  <data name="ColorGrading_Midtones" xml:space="preserve">
+    <value>중간톤</value>
+  </data>
+  <data name="ColorGrading_Offset" xml:space="preserve">
+    <value>오프셋</value>
+  </data>
+  <data name="ColorGrading_Saturation" xml:space="preserve">
+    <value>채도</value>
+  </data>
+  <data name="ColorGrading_Shadows" xml:space="preserve">
+    <value>그림자</value>
+  </data>
+  <data name="ColorGrading_Temperature" xml:space="preserve">
+    <value>색온도</value>
+  </data>
+  <data name="ColorGrading_Tint" xml:space="preserve">
+    <value>틴트</value>
+  </data>
+  <data name="ColorGrading_Vibrance" xml:space="preserve">
+    <value>생동감</value>
+  </data>
+  <data name="ColorKey" xml:space="preserve">
+    <value>색상 키</value>
+  </data>
+  <data name="ColorKey_Boundary" xml:space="preserve">
+    <value>경계 보정</value>
+  </data>
+  <data name="ColorKey_Range" xml:space="preserve">
+    <value>밝기 범위</value>
+  </data>
+  <data name="ColorShift" xml:space="preserve">
+    <value>색상 이동</value>
+  </data>
+  <data name="ColorShift_AlphaOffset" xml:space="preserve">
+    <value>알파 오프셋</value>
+  </data>
+  <data name="ColorShift_BlueOffset" xml:space="preserve">
+    <value>파란색 오프셋</value>
+  </data>
+  <data name="ColorShift_GreenOffset" xml:space="preserve">
+    <value>녹색 오프셋</value>
+  </data>
+  <data name="ColorShift_RedOffset" xml:space="preserve">
+    <value>빨간색 오프셋</value>
+  </data>
+  <data name="Curves" xml:space="preserve">
+    <value>곡선</value>
+  </data>
+  <data name="Curves_BlueCurve" xml:space="preserve">
+    <value>파란색 곡선</value>
+  </data>
+  <data name="Curves_GreenCurve" xml:space="preserve">
+    <value>녹색 곡선</value>
+  </data>
+  <data name="Curves_HueVsHue" xml:space="preserve">
+    <value>색조 vs 색조</value>
+  </data>
+  <data name="Curves_HueVsLuminance" xml:space="preserve">
+    <value>색조 vs 휘도</value>
+  </data>
+  <data name="Curves_HueVsSaturation" xml:space="preserve">
+    <value>색조 vs 채도</value>
+  </data>
+  <data name="Curves_LuminanceVsSaturation" xml:space="preserve">
+    <value>휘도 vs 채도</value>
+  </data>
+  <data name="Curves_MasterCurve" xml:space="preserve">
+    <value>사용자 지정 (RGB)</value>
+  </data>
+  <data name="Curves_RedCurve" xml:space="preserve">
+    <value>빨간색 곡선</value>
+  </data>
+  <data name="Curves_SaturationVsSaturation" xml:space="preserve">
+    <value>채도 vs 채도</value>
+  </data>
+  <data name="DelayAnimationEffect" xml:space="preserve">
+    <value>지연 애니메이션</value>
+  </data>
+  <data name="DelayAnimationEffect_Delay" xml:space="preserve">
+    <value>지연</value>
+  </data>
+  <data name="DelayAnimationEffect_Effect" xml:space="preserve">
+    <value>필터 효과</value>
+  </data>
+  <data name="Dilate" xml:space="preserve">
+    <value>팽창</value>
+  </data>
+  <data name="Dilate_RadiusX" xml:space="preserve">
+    <value>반경 X</value>
+  </data>
+  <data name="Dilate_RadiusY" xml:space="preserve">
+    <value>반경 Y</value>
+  </data>
+  <data name="DisplacementMapEffect" xml:space="preserve">
+    <value>변위 맵</value>
+  </data>
+  <data name="DisplacementMapEffect_DisplacementMap" xml:space="preserve">
+    <value>변위 맵</value>
+  </data>
+  <data name="DisplacementMapEffect_ShowDisplacementMap" xml:space="preserve">
+    <value>변위 맵 표시</value>
+  </data>
+  <data name="DisplacementMapEffect_Channel" xml:space="preserve">
+    <value>채널</value>
+  </data>
+  <data name="DisplacementMapEffect_Signed" xml:space="preserve">
+    <value>부호 있음</value>
+  </data>
+  <data name="DisplacementMapEffect_SpreadMethod" xml:space="preserve">
+    <value>확산 방법</value>
+  </data>
+  <data name="PixelSortEffect" xml:space="preserve">
+    <value>픽셀 정렬</value>
+  </data>
+  <data name="PixelSortEffect_Direction" xml:space="preserve">
+    <value>정렬 방향</value>
+  </data>
+  <data name="PixelSortEffect_SortKey" xml:space="preserve">
+    <value>정렬 키</value>
+  </data>
+  <data name="PixelSortEffect_ThresholdMin" xml:space="preserve">
+    <value>최소 임계값</value>
+  </data>
+  <data name="PixelSortEffect_ThresholdMax" xml:space="preserve">
+    <value>최대 임계값</value>
+  </data>
+  <data name="PixelSortEffect_Ascending" xml:space="preserve">
+    <value>오름차순</value>
+  </data>
+  <data name="DrawableDecorator" xml:space="preserve">
+    <value>데코레이터</value>
+  </data>
+  <data name="DrawableTimeController" xml:space="preserve">
+    <value>시간 컨트롤러 (비디오)</value>
+  </data>
+  <data name="DrawableTimeController_AdjustTimeRange" xml:space="preserve">
+    <value>시간 범위 조정</value>
+  </data>
+  <data name="DrawableTimeController_FrameRate" xml:space="preserve">
+    <value>프레임 속도</value>
+  </data>
+  <data name="DrawableTimeController_HoldFirstFrame" xml:space="preserve">
+    <value>첫 프레임 유지</value>
+  </data>
+  <data name="DrawableTimeController_HoldLastFrame" xml:space="preserve">
+    <value>마지막 프레임 유지</value>
+  </data>
+  <data name="DrawableTimeController_Loop" xml:space="preserve">
+    <value>반복</value>
+  </data>
+  <data name="DrawableTimeController_OffsetPosition" xml:space="preserve">
+    <value>오프셋 위치</value>
+  </data>
+  <data name="DrawableTimeController_Reverse" xml:space="preserve">
+    <value>역방향</value>
+  </data>
+  <data name="Drawable_AlignmentX" xml:space="preserve">
+    <value>정렬 X</value>
+  </data>
+  <data name="Drawable_AlignmentY" xml:space="preserve">
+    <value>정렬 Y</value>
+  </data>
+  <data name="Drawable_BlendMode" xml:space="preserve">
+    <value>혼합 모드</value>
+  </data>
+  <data name="DropShadow" xml:space="preserve">
+    <value>그림자</value>
+  </data>
+  <data name="EllipseShape" xml:space="preserve">
+    <value>타원</value>
+  </data>
+  <data name="Erode" xml:space="preserve">
+    <value>침식</value>
+  </data>
+  <data name="Erode_RadiusX" xml:space="preserve">
+    <value>반경 X</value>
+  </data>
+  <data name="Erode_RadiusY" xml:space="preserve">
+    <value>반경 Y</value>
+  </data>
+  <data name="FlatShadow" xml:space="preserve">
+    <value>평면 그림자</value>
+  </data>
+  <data name="FlatShadow_Length" xml:space="preserve">
+    <value>길이</value>
+  </data>
+  <data name="SKSLScriptEffect" xml:space="preserve">
+    <value>SKSL 스크립트</value>
+  </data>
+  <data name="GLSLScriptEffect" xml:space="preserve">
+    <value>GLSL 스크립트</value>
+  </data>
+  <data name="CSharpScriptEffect" xml:space="preserve">
+    <value>C# 스크립트</value>
+  </data>
+  <data name="Gamma" xml:space="preserve">
+    <value>감마</value>
+  </data>
+  <data name="GeometryShape" xml:space="preserve">
+    <value>기하 도형</value>
+  </data>
+  <data name="GeometryShape_Data" xml:space="preserve">
+    <value>데이터</value>
+  </data>
+  <data name="HighContrast" xml:space="preserve">
+    <value>고대비</value>
+  </data>
+  <data name="HighContrast_Contrast" xml:space="preserve">
+    <value>대비</value>
+  </data>
+  <data name="HighContrast_Grayscale" xml:space="preserve">
+    <value>회색조</value>
+  </data>
+  <data name="HighContrast_InvertStyle" xml:space="preserve">
+    <value>반전 스타일</value>
+  </data>
+  <data name="HueRotate" xml:space="preserve">
+    <value>색조 회전</value>
+  </data>
+  <data name="InnerShadow" xml:space="preserve">
+    <value>내부 그림자</value>
+  </data>
+  <data name="Invert" xml:space="preserve">
+    <value>반전</value>
+  </data>
+  <data name="Invert_ExcludeAlphaChannel" xml:space="preserve">
+    <value>알파 채널 제외</value>
+  </data>
+  <data name="LayerEffect" xml:space="preserve">
+    <value>레이어</value>
+  </data>
+  <data name="Lighting" xml:space="preserve">
+    <value>조명</value>
+  </data>
+  <data name="Lighting_Add" xml:space="preserve">
+    <value>더하기</value>
+  </data>
+  <data name="Lighting_Multiply" xml:space="preserve">
+    <value>곱하기</value>
+  </data>
+  <data name="LumaColor" xml:space="preserve">
+    <value>루마 색상</value>
+  </data>
+  <data name="LutEffect" xml:space="preserve">
+    <value>LUT (큐브 파일)</value>
+  </data>
+  <data name="MatrixTransform" xml:space="preserve">
+    <value>행렬 변환</value>
+  </data>
+  <data name="MatrixTransform_Matrix" xml:space="preserve">
+    <value>행렬</value>
+  </data>
+  <data name="MosaicEffect" xml:space="preserve">
+    <value>모자이크</value>
+  </data>
+  <data name="MosaicEffect_Origin" xml:space="preserve">
+    <value>원점</value>
+  </data>
+  <data name="MosaicEffect_TileSize" xml:space="preserve">
+    <value>타일 크기</value>
+  </data>
+  <data name="Negaposi" xml:space="preserve">
+    <value>네가포지</value>
+  </data>
+  <data name="Negaposi_Blue" xml:space="preserve">
+    <value>파란색</value>
+  </data>
+  <data name="Negaposi_Green" xml:space="preserve">
+    <value>녹색</value>
+  </data>
+  <data name="Negaposi_Red" xml:space="preserve">
+    <value>빨간색</value>
+  </data>
+  <data name="ParticleEmitter" xml:space="preserve">
+    <value>입자 방출기</value>
+  </data>
+  <data name="ParticleEmitter_AirResistance" xml:space="preserve">
+    <value>공기 저항</value>
+  </data>
+  <data name="ParticleEmitter_AngularVelocity" xml:space="preserve">
+    <value>각속도</value>
+  </data>
+  <data name="ParticleEmitter_EmissionGroup" xml:space="preserve">
+    <value>방출</value>
+  </data>
+  <data name="ParticleEmitter_EmissionRate" xml:space="preserve">
+    <value>방출 속도</value>
+  </data>
+  <data name="ParticleEmitter_EmitterGroup" xml:space="preserve">
+    <value>방출기</value>
+  </data>
+  <data name="ParticleEmitter_EmitterHeight" xml:space="preserve">
+    <value>방출기 높이</value>
+  </data>
+  <data name="ParticleEmitter_EmitterShape" xml:space="preserve">
+    <value>방출기 모양</value>
+  </data>
+  <data name="ParticleEmitter_EmitterWidth" xml:space="preserve">
+    <value>방출기 너비</value>
+  </data>
+  <data name="ParticleEmitter_EndColor" xml:space="preserve">
+    <value>끝 색상</value>
+  </data>
+  <data name="ParticleEmitter_EndOpacityMultiplier" xml:space="preserve">
+    <value>끝 불투명도 배율</value>
+  </data>
+  <data name="ParticleEmitter_EndSizeMultiplier" xml:space="preserve">
+    <value>끝 크기 배율</value>
+  </data>
+  <data name="ParticleEmitter_Gravity" xml:space="preserve">
+    <value>중력</value>
+  </data>
+  <data name="ParticleEmitter_InitialRotation" xml:space="preserve">
+    <value>초기 회전</value>
+  </data>
+  <data name="ParticleEmitter_InitialRotationRandom" xml:space="preserve">
+    <value>초기 회전 무작위</value>
+  </data>
+  <data name="ParticleEmitter_Lifetime" xml:space="preserve">
+    <value>수명</value>
+  </data>
+  <data name="ParticleEmitter_LifetimeRandom" xml:space="preserve">
+    <value>수명 무작위</value>
+  </data>
+  <data name="ParticleEmitter_MaxParticles" xml:space="preserve">
+    <value>최대 입자 수</value>
+  </data>
+  <data name="ParticleEmitter_OverLifeGroup" xml:space="preserve">
+    <value>수명 동안</value>
+  </data>
+  <data name="ParticleEmitter_ParticleDrawable" xml:space="preserve">
+    <value>입자 드로어블</value>
+  </data>
+  <data name="ParticleEmitter_ParticleOpacity" xml:space="preserve">
+    <value>입자 불투명도</value>
+  </data>
+  <data name="ParticleEmitter_ParticleSize" xml:space="preserve">
+    <value>입자 크기</value>
+  </data>
+  <data name="ParticleEmitter_PhysicsGroup" xml:space="preserve">
+    <value>물리</value>
+  </data>
+  <data name="ParticleEmitter_Seed" xml:space="preserve">
+    <value>시드</value>
+  </data>
+  <data name="ParticleEmitter_SizeRandom" xml:space="preserve">
+    <value>크기 무작위</value>
+  </data>
+  <data name="ParticleEmitter_SpeedRandom" xml:space="preserve">
+    <value>속도 무작위</value>
+  </data>
+  <data name="ParticleEmitter_Spread" xml:space="preserve">
+    <value>확산</value>
+  </data>
+  <data name="ParticleEmitter_TurbulenceScale" xml:space="preserve">
+    <value>난류 배율</value>
+  </data>
+  <data name="ParticleEmitter_TurbulenceSpeed" xml:space="preserve">
+    <value>난류 속도</value>
+  </data>
+  <data name="ParticleEmitter_TurbulenceStrength" xml:space="preserve">
+    <value>난류 강도</value>
+  </data>
+  <data name="ParticleEmitter_UseEndColor" xml:space="preserve">
+    <value>끝 색상 사용</value>
+  </data>
+  <data name="ParticleEmitter_VelocityGroup" xml:space="preserve">
+    <value>속도</value>
+  </data>
+  <data name="ParticleEmitter_VisualGroup" xml:space="preserve">
+    <value>시각</value>
+  </data>
+  <data name="PartsSplitEffect" xml:space="preserve">
+    <value>부품별 분할</value>
+  </data>
+  <data name="PathFollowEffect" xml:space="preserve">
+    <value>경로 따라가기</value>
+  </data>
+  <data name="PathFollowEffect_FollowRotation" xml:space="preserve">
+    <value>회전 따라가기</value>
+  </data>
+  <data name="PathFollowEffect_Geometry" xml:space="preserve">
+    <value>기하 도형</value>
+  </data>
+  <data name="PathFollowEffect_Progress" xml:space="preserve">
+    <value>진행</value>
+  </data>
+  <data name="RectShape" xml:space="preserve">
+    <value>사각형</value>
+  </data>
+  <data name="Rotation3DTransform" xml:space="preserve">
+    <value>3D 회전</value>
+  </data>
+  <data name="Rotation3DTransform_CenterZ" xml:space="preserve">
+    <value>중심 Z</value>
+  </data>
+  <data name="Rotation3DTransform_RotationX" xml:space="preserve">
+    <value>회전 X</value>
+  </data>
+  <data name="Rotation3DTransform_RotationY" xml:space="preserve">
+    <value>회전 Y</value>
+  </data>
+  <data name="Rotation3DTransform_RotationZ" xml:space="preserve">
+    <value>회전 Z</value>
+  </data>
+  <data name="RoundedRectShape" xml:space="preserve">
+    <value>둥근 사각형</value>
+  </data>
+  <data name="RoundedRectShape_CornerRadius" xml:space="preserve">
+    <value>모서리 반경</value>
+  </data>
+  <data name="Saturate" xml:space="preserve">
+    <value>채도</value>
+  </data>
+  <data name="ScaleTransform_ScaleX" xml:space="preserve">
+    <value>배율 X</value>
+  </data>
+  <data name="ScaleTransform_ScaleY" xml:space="preserve">
+    <value>배율 Y</value>
+  </data>
+  <data name="ShakeEffect" xml:space="preserve">
+    <value>흔들기</value>
+  </data>
+  <data name="ShakeEffect_StrengthX" xml:space="preserve">
+    <value>강도 X</value>
+  </data>
+  <data name="ShakeEffect_StrengthY" xml:space="preserve">
+    <value>강도 Y</value>
+  </data>
+  <data name="Fill" xml:space="preserve">
+    <value>채우기</value>
+  </data>
+  <data name="SkewTransform" xml:space="preserve">
+    <value>기울이기</value>
+  </data>
+  <data name="SkewTransform_SkewX" xml:space="preserve">
+    <value>기울이기 X</value>
+  </data>
+  <data name="SkewTransform_SkewY" xml:space="preserve">
+    <value>기울이기 Y</value>
+  </data>
+  <data name="SourceBackdrop" xml:space="preserve">
+    <value>배경</value>
+  </data>
+  <data name="SourceBackdrop_Clear" xml:space="preserve">
+    <value>버퍼 지우기</value>
+  </data>
+  <data name="SourceImage" xml:space="preserve">
+    <value>이미지</value>
+  </data>
+  <data name="SourceVideo" xml:space="preserve">
+    <value>비디오</value>
+  </data>
+  <data name="SourceVideo_IsLoop" xml:space="preserve">
+    <value>반복</value>
+  </data>
+  <data name="SourceVideo_OffsetPosition" xml:space="preserve">
+    <value>오프셋 위치</value>
+  </data>
+  <data name="SplitEffect" xml:space="preserve">
+    <value>균등 분할</value>
+  </data>
+  <data name="SplitEffect_HorizontalDivisions" xml:space="preserve">
+    <value>가로 분할 수</value>
+  </data>
+  <data name="SplitEffect_HorizontalSpacing" xml:space="preserve">
+    <value>가로 간격</value>
+  </data>
+  <data name="SplitEffect_VerticalDivisions" xml:space="preserve">
+    <value>세로 분할 수</value>
+  </data>
+  <data name="SplitEffect_VerticalSpacing" xml:space="preserve">
+    <value>세로 간격</value>
+  </data>
+  <data name="StrokeEffect_Style" xml:space="preserve">
+    <value>테두리 스타일</value>
+  </data>
+  <data name="TextBlock" xml:space="preserve">
+    <value>텍스트</value>
+  </data>
+  <data name="TextBlock_FontFamily" xml:space="preserve">
+    <value>글꼴 모음</value>
+  </data>
+  <data name="TextBlock_FontStyle" xml:space="preserve">
+    <value>글꼴 스타일</value>
+  </data>
+  <data name="TextBlock_FontWeight" xml:space="preserve">
+    <value>글꼴 두께</value>
+  </data>
+  <data name="TextBlock_Size" xml:space="preserve">
+    <value>크기</value>
+  </data>
+  <data name="TextBlock_Spacing" xml:space="preserve">
+    <value>문자 간격</value>
+  </data>
+  <data name="TextBlock_SplitByCharacters" xml:space="preserve">
+    <value>문자별 분할</value>
+  </data>
+  <data name="TextBlock_Text" xml:space="preserve">
+    <value>텍스트</value>
+  </data>
+  <data name="Threshold" xml:space="preserve">
+    <value>임계값</value>
+  </data>
+  <data name="TransformEffect_BitmapInterpolationMode" xml:space="preserve">
+    <value>비트맵 보간 모드</value>
+  </data>
+  <data name="TranslateTransform" xml:space="preserve">
+    <value>이동</value>
+  </data>
+  <data name="TranslateTransform_X" xml:space="preserve">
+    <value>X</value>
+  </data>
+  <data name="TranslateTransform_Y" xml:space="preserve">
+    <value>Y</value>
+  </data>
+  <data name="ArcSegment" xml:space="preserve">
+    <value>타원 호</value>
+  </data>
+  <data name="ArcSegment_IsLargeArc" xml:space="preserve">
+    <value>큰 호</value>
+  </data>
+  <data name="ArcSegment_Point" xml:space="preserve">
+    <value>점</value>
+  </data>
+  <data name="ArcSegment_RotationAngle" xml:space="preserve">
+    <value>회전 각도</value>
+  </data>
+  <data name="ArcSegment_SweepClockwise" xml:space="preserve">
+    <value>시계 방향 스윕</value>
+  </data>
+  <data name="BasicMaterial" xml:space="preserve">
+    <value>기본 재질</value>
+  </data>
+  <data name="BasicMaterial_AmbientColor" xml:space="preserve">
+    <value>주변 색상</value>
+  </data>
+  <data name="BasicMaterial_DiffuseColor" xml:space="preserve">
+    <value>확산 색상</value>
+  </data>
+  <data name="BasicMaterial_DiffuseMap" xml:space="preserve">
+    <value>확산 맵</value>
+  </data>
+  <data name="BasicMaterial_Shininess" xml:space="preserve">
+    <value>광택</value>
+  </data>
+  <data name="BasicMaterial_SpecularColor" xml:space="preserve">
+    <value>반사 색상</value>
+  </data>
+  <data name="Camera3D_FarPlane" xml:space="preserve">
+    <value>원거리 평면</value>
+  </data>
+  <data name="Camera3D_NearPlane" xml:space="preserve">
+    <value>근거리 평면</value>
+  </data>
+  <data name="Camera3D_Up" xml:space="preserve">
+    <value>위</value>
+  </data>
+  <data name="ConicGradientBrush" xml:space="preserve">
+    <value>원뿔형 그라데이션</value>
+  </data>
+  <data name="ConicGradientBrush_Center" xml:space="preserve">
+    <value>중심</value>
+  </data>
+  <data name="ConicSegment" xml:space="preserve">
+    <value>원뿔 곡선</value>
+  </data>
+  <data name="ConicSegment_ControlPoint" xml:space="preserve">
+    <value>제어점</value>
+  </data>
+  <data name="ConicSegment_Weight" xml:space="preserve">
+    <value>가중치</value>
+  </data>
+  <data name="Cube3D" xml:space="preserve">
+    <value>정육면체</value>
+  </data>
+  <data name="CubeMesh" xml:space="preserve">
+    <value>정육면체 메시</value>
+  </data>
+  <data name="CubicBezierSegment" xml:space="preserve">
+    <value>3차 베지어 곡선</value>
+  </data>
+  <data name="CubicBezierSegment_ControlPoint1" xml:space="preserve">
+    <value>제어점 1</value>
+  </data>
+  <data name="CubicBezierSegment_ControlPoint2" xml:space="preserve">
+    <value>제어점 2</value>
+  </data>
+  <data name="DirectionalLight3D" xml:space="preserve">
+    <value>방향광</value>
+  </data>
+  <data name="DirectionalLight3D_ShadowDistance" xml:space="preserve">
+    <value>그림자 거리</value>
+  </data>
+  <data name="DirectionalLight3D_ShadowMapSize" xml:space="preserve">
+    <value>그림자 맵 크기</value>
+  </data>
+  <data name="DrawableTextureSource" xml:space="preserve">
+    <value>드로어블 텍스처</value>
+  </data>
+  <data name="DrawableTextureSource_TextureHeight" xml:space="preserve">
+    <value>텍스처 높이</value>
+  </data>
+  <data name="DrawableTextureSource_TextureWidth" xml:space="preserve">
+    <value>텍스처 너비</value>
+  </data>
+  <data name="EllipseGeometry" xml:space="preserve">
+    <value>타원</value>
+  </data>
+  <data name="Geometry_FillType" xml:space="preserve">
+    <value>채우기 유형</value>
+  </data>
+  <data name="GradientBrush_GradientStops" xml:space="preserve">
+    <value>그라데이션 중지점</value>
+  </data>
+  <data name="GradientBrush_SpreadMethod" xml:space="preserve">
+    <value>확산 방법</value>
+  </data>
+  <data name="Children" xml:space="preserve">
+    <value>자식</value>
+  </data>
+  <data name="ImageTextureSource" xml:space="preserve">
+    <value>이미지 텍스처</value>
+  </data>
+  <data name="Light3D_CastsShadow" xml:space="preserve">
+    <value>그림자 투사</value>
+  </data>
+  <data name="Light3D_Intensity" xml:space="preserve">
+    <value>강도</value>
+  </data>
+  <data name="Light3D_ShadowBias" xml:space="preserve">
+    <value>그림자 바이어스</value>
+  </data>
+  <data name="Light3D_ShadowNormalBias" xml:space="preserve">
+    <value>그림자 법선 바이어스</value>
+  </data>
+  <data name="Light3D_ShadowStrength" xml:space="preserve">
+    <value>그림자 강도</value>
+  </data>
+  <data name="LineSegment" xml:space="preserve">
+    <value>선</value>
+  </data>
+  <data name="LineSegment_Point" xml:space="preserve">
+    <value>점</value>
+  </data>
+  <data name="LinearGradientBrush" xml:space="preserve">
+    <value>선형 그라데이션</value>
+  </data>
+  <data name="LinearGradientBrush_StartPoint" xml:space="preserve">
+    <value>시작점</value>
+  </data>
+  <data name="MeshObject3D" xml:space="preserve">
+    <value>메시 개체</value>
+  </data>
+  <data name="MeshObject3D_Mesh" xml:space="preserve">
+    <value>메시</value>
+  </data>
+  <data name="Model3D" xml:space="preserve">
+    <value>모델</value>
+  </data>
+  <data name="ModelMesh" xml:space="preserve">
+    <value>모델 메시</value>
+  </data>
+  <data name="ModelMesh_Indices" xml:space="preserve">
+    <value>인덱스</value>
+  </data>
+  <data name="ModelMesh_Vertices" xml:space="preserve">
+    <value>정점</value>
+  </data>
+  <data name="Object3D_CastShadows" xml:space="preserve">
+    <value>그림자 투사</value>
+  </data>
+  <data name="Object3D_Material" xml:space="preserve">
+    <value>재질</value>
+  </data>
+  <data name="Object3D_ReceiveShadows" xml:space="preserve">
+    <value>그림자 받기</value>
+  </data>
+  <data name="OrthographicCamera" xml:space="preserve">
+    <value>직교 카메라</value>
+  </data>
+  <data name="PBRMaterial" xml:space="preserve">
+    <value>PBR 재질</value>
+  </data>
+  <data name="PBRMaterial_AOMap" xml:space="preserve">
+    <value>AO 맵</value>
+  </data>
+  <data name="PBRMaterial_Albedo" xml:space="preserve">
+    <value>알베도</value>
+  </data>
+  <data name="PBRMaterial_AlbedoMap" xml:space="preserve">
+    <value>알베도 맵</value>
+  </data>
+  <data name="PBRMaterial_AmbientOcclusion" xml:space="preserve">
+    <value>앰비언트 오클루전</value>
+  </data>
+  <data name="PBRMaterial_Emissive" xml:space="preserve">
+    <value>자체 발광</value>
+  </data>
+  <data name="PBRMaterial_EmissiveIntensity" xml:space="preserve">
+    <value>자체 발광 강도</value>
+  </data>
+  <data name="PBRMaterial_EmissiveMap" xml:space="preserve">
+    <value>자체 발광 맵</value>
+  </data>
+  <data name="PBRMaterial_Metallic" xml:space="preserve">
+    <value>금속성</value>
+  </data>
+  <data name="PBRMaterial_MetallicRoughnessMap" xml:space="preserve">
+    <value>금속성/거칠기 맵</value>
+  </data>
+  <data name="PBRMaterial_NormalMap" xml:space="preserve">
+    <value>법선 맵</value>
+  </data>
+  <data name="PBRMaterial_NormalMapStrength" xml:space="preserve">
+    <value>법선 맵 강도</value>
+  </data>
+  <data name="PBRMaterial_Roughness" xml:space="preserve">
+    <value>거칠기</value>
+  </data>
+  <data name="PathFigure" xml:space="preserve">
+    <value>도형</value>
+  </data>
+  <data name="PathFigure_IsClosed" xml:space="preserve">
+    <value>닫힘</value>
+  </data>
+  <data name="PathFigure_StartPoint" xml:space="preserve">
+    <value>시작점</value>
+  </data>
+  <data name="PathGeometry" xml:space="preserve">
+    <value>기하 도형</value>
+  </data>
+  <data name="Pen_DashArray" xml:space="preserve">
+    <value>점선과 공백</value>
+  </data>
+  <data name="Pen_DashOffset" xml:space="preserve">
+    <value>점선 오프셋</value>
+  </data>
+  <data name="Pen_MiterLimit" xml:space="preserve">
+    <value>마이터 제한</value>
+  </data>
+  <data name="Pen_StrokeAlignment" xml:space="preserve">
+    <value>위치</value>
+  </data>
+  <data name="Pen_StrokeCap" xml:space="preserve">
+    <value>끝 모양</value>
+  </data>
+  <data name="Pen_StrokeJoin" xml:space="preserve">
+    <value>연결 모양</value>
+  </data>
+  <data name="Pen_Thickness" xml:space="preserve">
+    <value>두께</value>
+  </data>
+  <data name="Pen_TrimEnd" xml:space="preserve">
+    <value>끝 트림</value>
+  </data>
+  <data name="Pen_TrimOffset" xml:space="preserve">
+    <value>트림 오프셋</value>
+  </data>
+  <data name="Pen_TrimStart" xml:space="preserve">
+    <value>시작 트림</value>
+  </data>
+  <data name="Pen_Offset" xml:space="preserve">
+    <value>오프셋</value>
+  </data>
+  <data name="PerlinNoiseBrush" xml:space="preserve">
+    <value>펄린 노이즈</value>
+  </data>
+  <data name="PerlinNoiseBrush_BaseFrequencyX" xml:space="preserve">
+    <value>기본 주파수 X</value>
+  </data>
+  <data name="PerlinNoiseBrush_BaseFrequencyY" xml:space="preserve">
+    <value>기본 주파수 Y</value>
+  </data>
+  <data name="PerlinNoiseBrush_Octaves" xml:space="preserve">
+    <value>옥타브</value>
+  </data>
+  <data name="PerlinNoiseBrush_PerlinNoiseType" xml:space="preserve">
+    <value>노이즈 유형</value>
+  </data>
+  <data name="PerlinNoiseBrush_Seed" xml:space="preserve">
+    <value>시드</value>
+  </data>
+  <data name="PerspectiveCamera" xml:space="preserve">
+    <value>원근 카메라</value>
+  </data>
+  <data name="PerspectiveCamera_FieldOfView" xml:space="preserve">
+    <value>시야</value>
+  </data>
+  <data name="Plane3D" xml:space="preserve">
+    <value>평면</value>
+  </data>
+  <data name="Plane3D_HeightSegments" xml:space="preserve">
+    <value>높이 세그먼트</value>
+  </data>
+  <data name="Plane3D_WidthSegments" xml:space="preserve">
+    <value>너비 세그먼트</value>
+  </data>
+  <data name="PlaneMesh" xml:space="preserve">
+    <value>평면 메시</value>
+  </data>
+  <data name="PlaneMesh_HeightSegments" xml:space="preserve">
+    <value>높이 세그먼트</value>
+  </data>
+  <data name="PlaneMesh_WidthSegments" xml:space="preserve">
+    <value>너비 세그먼트</value>
+  </data>
+  <data name="PointLight3D" xml:space="preserve">
+    <value>점광</value>
+  </data>
+  <data name="PointLight3D_ConstantAttenuation" xml:space="preserve">
+    <value>상수 감쇠</value>
+  </data>
+  <data name="PointLight3D_LinearAttenuation" xml:space="preserve">
+    <value>선형 감쇠</value>
+  </data>
+  <data name="PointLight3D_QuadraticAttenuation" xml:space="preserve">
+    <value>2차 감쇠</value>
+  </data>
+  <data name="PointLight3D_Range" xml:space="preserve">
+    <value>범위</value>
+  </data>
+  <data name="QuadraticBezierSegment" xml:space="preserve">
+    <value>2차 베지어 곡선</value>
+  </data>
+  <data name="QuadraticBezierSegment_ControlPoint" xml:space="preserve">
+    <value>제어점</value>
+  </data>
+  <data name="RadialGradientBrush" xml:space="preserve">
+    <value>방사형 그라데이션</value>
+  </data>
+  <data name="RadialGradientBrush_Center" xml:space="preserve">
+    <value>중심</value>
+  </data>
+  <data name="RadialGradientBrush_GradientOrigin" xml:space="preserve">
+    <value>그라데이션 원점</value>
+  </data>
+  <data name="RectGeometry" xml:space="preserve">
+    <value>사각형</value>
+  </data>
+  <data name="RoundedRectGeometry" xml:space="preserve">
+    <value>둥근 사각형</value>
+  </data>
+  <data name="RoundedRectGeometry_CornerRadius" xml:space="preserve">
+    <value>모서리 반경</value>
+  </data>
+  <data name="Scene3D" xml:space="preserve">
+    <value>3D 장면</value>
+  </data>
+  <data name="Scene3D_AmbientColor" xml:space="preserve">
+    <value>주변 색상</value>
+  </data>
+  <data name="Scene3D_AmbientIntensity" xml:space="preserve">
+    <value>주변광 강도</value>
+  </data>
+  <data name="Scene3D_BackgroundColor" xml:space="preserve">
+    <value>배경 색상</value>
+  </data>
+  <data name="Scene3D_Camera" xml:space="preserve">
+    <value>카메라</value>
+  </data>
+  <data name="Scene3D_Lights" xml:space="preserve">
+    <value>조명</value>
+  </data>
+  <data name="Scene3D_Objects" xml:space="preserve">
+    <value>개체</value>
+  </data>
+  <data name="Scene3D_RenderHeight" xml:space="preserve">
+    <value>렌더 높이</value>
+  </data>
+  <data name="Scene3D_RenderWidth" xml:space="preserve">
+    <value>렌더 너비</value>
+  </data>
+  <data name="SolidColorBrush" xml:space="preserve">
+    <value>단색</value>
+  </data>
+  <data name="Sphere3D" xml:space="preserve">
+    <value>구</value>
+  </data>
+  <data name="Sphere3D_Rings" xml:space="preserve">
+    <value>링</value>
+  </data>
+  <data name="Sphere3D_Segments" xml:space="preserve">
+    <value>세그먼트</value>
+  </data>
+  <data name="SphereMesh" xml:space="preserve">
+    <value>구 메시</value>
+  </data>
+  <data name="SphereMesh_Rings" xml:space="preserve">
+    <value>링</value>
+  </data>
+  <data name="SphereMesh_Segments" xml:space="preserve">
+    <value>세그먼트</value>
+  </data>
+  <data name="SpotLight3D" xml:space="preserve">
+    <value>스포트라이트</value>
+  </data>
+  <data name="SpotLight3D_ConstantAttenuation" xml:space="preserve">
+    <value>상수 감쇠</value>
+  </data>
+  <data name="SpotLight3D_InnerConeAngle" xml:space="preserve">
+    <value>내부 원뿔 각도</value>
+  </data>
+  <data name="SpotLight3D_LinearAttenuation" xml:space="preserve">
+    <value>선형 감쇠</value>
+  </data>
+  <data name="SpotLight3D_OuterConeAngle" xml:space="preserve">
+    <value>외부 원뿔 각도</value>
+  </data>
+  <data name="SpotLight3D_QuadraticAttenuation" xml:space="preserve">
+    <value>2차 감쇠</value>
+  </data>
+  <data name="SpotLight3D_Range" xml:space="preserve">
+    <value>범위</value>
+  </data>
+  <data name="StrokeAlignment_Center" xml:space="preserve">
+    <value>가운데</value>
+  </data>
+  <data name="StrokeAlignment_Inside" xml:space="preserve">
+    <value>안쪽</value>
+  </data>
+  <data name="StrokeAlignment_Outside" xml:space="preserve">
+    <value>바깥쪽</value>
+  </data>
+  <data name="StrokeCap_Flat" xml:space="preserve">
+    <value>납작</value>
+  </data>
+  <data name="StrokeCap_Round" xml:space="preserve">
+    <value>둥근</value>
+  </data>
+  <data name="StrokeCap_Square" xml:space="preserve">
+    <value>사각</value>
+  </data>
+  <data name="StrokeJoin_Bevel" xml:space="preserve">
+    <value>베벨 연결</value>
+  </data>
+  <data name="StrokeJoin_Miter" xml:space="preserve">
+    <value>마이터 연결</value>
+  </data>
+  <data name="StrokeJoin_Round" xml:space="preserve">
+    <value>원형 연결</value>
+  </data>
+  <data name="TileBrush_AlignmentX" xml:space="preserve">
+    <value>정렬 X</value>
+  </data>
+  <data name="TileBrush_AlignmentY" xml:space="preserve">
+    <value>정렬 Y</value>
+  </data>
+  <data name="TileBrush_BitmapInterpolationMode" xml:space="preserve">
+    <value>비트맵 보간 모드</value>
+  </data>
+  <data name="TileBrush_SourceRect" xml:space="preserve">
+    <value>원본</value>
+  </data>
+  <data name="TileBrush_DestinationRect" xml:space="preserve">
+    <value>대상</value>
+  </data>
+  <data name="TileBrush_Stretch" xml:space="preserve">
+    <value>늘이기</value>
+  </data>
+  <data name="TileBrush_TileMode" xml:space="preserve">
+    <value>타일 모드</value>
+  </data>
+  <data name="TransparentMaterial" xml:space="preserve">
+    <value>투명 재질</value>
+  </data>
+  <data name="TransparentMaterial_ColorMap" xml:space="preserve">
+    <value>색상 맵</value>
+  </data>
+  <data name="TransparentMaterial_IndexOfRefraction" xml:space="preserve">
+    <value>굴절률</value>
+  </data>
+  <data name="TransparentMaterial_Roughness" xml:space="preserve">
+    <value>거칠기</value>
+  </data>
+  <data name="Amount" xml:space="preserve">
+    <value>양</value>
+  </data>
+  <data name="Angle" xml:space="preserve">
+    <value>각도</value>
+  </data>
+  <data name="Brush" xml:space="preserve">
+    <value>브러시</value>
+  </data>
+  <data name="CenterX" xml:space="preserve">
+    <value>중심 X</value>
+  </data>
+  <data name="CenterY" xml:space="preserve">
+    <value>중심 Y</value>
+  </data>
+  <data name="Color" xml:space="preserve">
+    <value>색상</value>
+  </data>
+  <data name="Depth" xml:space="preserve">
+    <value>깊이</value>
+  </data>
+  <data name="Direction" xml:space="preserve">
+    <value>방향</value>
+  </data>
+  <data name="Drawable" xml:space="preserve">
+    <value>드로어블</value>
+  </data>
+  <data name="EndPoint" xml:space="preserve">
+    <value>끝점</value>
+  </data>
+  <data name="FixImageSize" xml:space="preserve">
+    <value>이미지 크기 고정</value>
+  </data>
+  <data name="Group" xml:space="preserve">
+    <value>그룹</value>
+  </data>
+  <data name="Height" xml:space="preserve">
+    <value>높이</value>
+  </data>
+  <data name="KernelSize" xml:space="preserve">
+    <value>커널 크기</value>
+  </data>
+  <data name="Offset" xml:space="preserve">
+    <value>오프셋</value>
+  </data>
+  <data name="Opacity" xml:space="preserve">
+    <value>불투명도</value>
+  </data>
+  <data name="Position" xml:space="preserve">
+    <value>위치</value>
+  </data>
+  <data name="Presenter" xml:space="preserve">
+    <value>프레젠터</value>
+  </data>
+  <data name="Radius" xml:space="preserve">
+    <value>반경</value>
+  </data>
+  <data name="Rotation" xml:space="preserve">
+    <value>회전</value>
+  </data>
+  <data name="Scale" xml:space="preserve">
+    <value>배율</value>
+  </data>
+  <data name="Script" xml:space="preserve">
+    <value>스크립트</value>
+  </data>
+  <data name="ShadowOnly" xml:space="preserve">
+    <value>그림자만</value>
+  </data>
+  <data name="Sigma" xml:space="preserve">
+    <value>시그마</value>
+  </data>
+  <data name="Smoothing" xml:space="preserve">
+    <value>스무딩</value>
+  </data>
+  <data name="Source" xml:space="preserve">
+    <value>원본</value>
+  </data>
+  <data name="Speed" xml:space="preserve">
+    <value>속도</value>
+  </data>
+  <data name="Strength" xml:space="preserve">
+    <value>강도</value>
+  </data>
+  <data name="Stroke" xml:space="preserve">
+    <value>획</value>
+  </data>
+  <data name="Target" xml:space="preserve">
+    <value>대상</value>
+  </data>
+  <data name="Transform" xml:space="preserve">
+    <value>변형</value>
+  </data>
+  <data name="TransformOrigin" xml:space="preserve">
+    <value>변형 원점</value>
+  </data>
+  <data name="Width" xml:space="preserve">
+    <value>너비</value>
+  </data>
+  <data name="NodeGraphDrawable" xml:space="preserve">
+    <value>노드 그래프 (비디오)</value>
+  </data>
+  <data name="NodeGraphFilterEffect" xml:space="preserve">
+    <value>노드 그래프 (효과)</value>
+  </data>
+  <data name="SceneDrawable" xml:space="preserve">
+    <value>장면 참조 (비디오)</value>
+  </data>
+  <data name="SceneDrawable_ReferencedScene" xml:space="preserve">
+    <value>참조된 장면</value>
+  </data>
+  <data name="FilterEffect" xml:space="preserve">
+    <value>필터 효과</value>
+  </data>
+  <data name="AudioVisualizer" xml:space="preserve">
+    <value>오디오 시각화</value>
+  </data>
+  <data name="AudioWaveform" xml:space="preserve">
+    <value>오디오 파형</value>
+  </data>
+  <data name="AudioSpectrum" xml:space="preserve">
+    <value>오디오 스펙트럼</value>
+  </data>
+  <data name="AudioSpectrogram" xml:space="preserve">
+    <value>오디오 스펙트로그램</value>
+  </data>
+  <data name="AudioVisualizer_BarCount" xml:space="preserve">
+    <value>막대 수</value>
+  </data>
+  <data name="AudioVisualizer_WindowSeconds" xml:space="preserve">
+    <value>창 (초)</value>
+  </data>
+  <data name="AudioVisualizer_FftSize" xml:space="preserve">
+    <value>FFT 크기</value>
+  </data>
+  <data name="AudioVisualizer_FrequencyScale" xml:space="preserve">
+    <value>주파수 배율</value>
+  </data>
+  <data name="AudioVisualizer_FloorDb" xml:space="preserve">
+    <value>하한 (dB)</value>
+  </data>
+  <data name="AudioVisualizer_TimeColumns" xml:space="preserve">
+    <value>시간 열</value>
+  </data>
+  <data name="AudioVisualizer_Gain" xml:space="preserve">
+    <value>게인</value>
+  </data>
+  <data name="AudioVisualizer_Smoothing" xml:space="preserve">
+    <value>스무딩</value>
+  </data>
+  <data name="AudioVisualizer_Shape" xml:space="preserve">
+    <value>모양</value>
+  </data>
+  <data name="SpectrumShape_Bar" xml:space="preserve">
+    <value>막대</value>
+  </data>
+  <data name="SpectrumShape_Line" xml:space="preserve">
+    <value>선</value>
+  </data>
+  <data name="SpectrumShape_FilledArea" xml:space="preserve">
+    <value>채워진 영역</value>
+  </data>
+  <data name="SpectrumShape_MirroredBars" xml:space="preserve">
+    <value>대칭 막대</value>
+  </data>
+  <data name="SpectrumShape_Radial" xml:space="preserve">
+    <value>방사형</value>
+  </data>
+  <data name="SpectrumShape_CornerRadius" xml:space="preserve">
+    <value>모서리 반경</value>
+  </data>
+  <data name="SpectrumShape_Thickness" xml:space="preserve">
+    <value>두께</value>
+  </data>
+  <data name="SpectrumShape_Smoothness" xml:space="preserve">
+    <value>부드러움</value>
+  </data>
+  <data name="SpectrumShape_InnerRadius" xml:space="preserve">
+    <value>내부 반경</value>
+  </data>
+  <data name="SpectrumShape_StartAngle" xml:space="preserve">
+    <value>시작 각도</value>
+  </data>
+  <data name="SpectrumShape_BarWidth" xml:space="preserve">
+    <value>막대 너비</value>
+  </data>
+  <data name="SpectrumShape_Direction" xml:space="preserve">
+    <value>방향</value>
+  </data>
+  <data name="WaveformShape_MinMaxBar" xml:space="preserve">
+    <value>최소최대 막대</value>
+  </data>
+  <data name="WaveformShape_Line" xml:space="preserve">
+    <value>선</value>
+  </data>
+  <data name="WaveformShape_FilledMirror" xml:space="preserve">
+    <value>채워진 대칭</value>
+  </data>
+  <data name="WaveformShape_FilledEnvelope" xml:space="preserve">
+    <value>채워진 엔벨로프</value>
+  </data>
+  <data name="WaveformShape_Block" xml:space="preserve">
+    <value>블록</value>
+  </data>
+  <data name="WaveformShape_Dots" xml:space="preserve">
+    <value>점</value>
+  </data>
+  <data name="WaveformShape_Radial" xml:space="preserve">
+    <value>방사형</value>
+  </data>
+  <data name="WaveformShape_BlockCount" xml:space="preserve">
+    <value>블록 수</value>
+  </data>
+  <data name="WaveformShape_BlockGap" xml:space="preserve">
+    <value>블록 간격</value>
+  </data>
+  <data name="WaveformShape_Mirrored" xml:space="preserve">
+    <value>상하 대칭</value>
+  </data>
+  <data name="WaveformShape_Symmetric" xml:space="preserve">
+    <value>진폭 대칭</value>
+  </data>
+  <data name="WaveformShape_DotRadius" xml:space="preserve">
+    <value>점 반경</value>
+  </data>
+  <data name="WaveformShape_DotMode" xml:space="preserve">
+    <value>점 모드</value>
+  </data>
+</root>

--- a/src/Beutl.Language/GraphicsStrings.zh-CN.resx
+++ b/src/Beutl.Language/GraphicsStrings.zh-CN.resx
@@ -1,0 +1,1475 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BlendEffect" xml:space="preserve">
+    <value>混合</value>
+  </data>
+  <data name="BlendEffect_BlendMode" xml:space="preserve">
+    <value>混合模式</value>
+  </data>
+  <data name="BlendMode_Clear" xml:space="preserve">
+    <value>清除</value>
+  </data>
+  <data name="BlendMode_Clear_Description" xml:space="preserve">
+    <value>将内容清除为透明。</value>
+  </data>
+  <data name="BlendMode_Color" xml:space="preserve">
+    <value>颜色</value>
+  </data>
+  <data name="BlendMode_ColorBurn" xml:space="preserve">
+    <value>颜色加深</value>
+  </data>
+  <data name="BlendMode_ColorBurn_Description" xml:space="preserve">
+    <value>通过用前景色烧灼背景来使其变暗。</value>
+  </data>
+  <data name="BlendMode_ColorDodge" xml:space="preserve">
+    <value>颜色减淡</value>
+  </data>
+  <data name="BlendMode_ColorDodge_Description" xml:space="preserve">
+    <value>通过添加前景色来提亮背景。</value>
+  </data>
+  <data name="BlendMode_Color_Description" xml:space="preserve">
+    <value>将前景色的色相和饱和度应用于背景的亮度。</value>
+  </data>
+  <data name="BlendMode_Darken" xml:space="preserve">
+    <value>变暗</value>
+  </data>
+  <data name="BlendMode_Darken_Description" xml:space="preserve">
+    <value>保留前景或背景中较暗的颜色。</value>
+  </data>
+  <data name="BlendMode_Difference" xml:space="preserve">
+    <value>差值</value>
+  </data>
+  <data name="BlendMode_Difference_Description" xml:space="preserve">
+    <value>强调绝对颜色差异。</value>
+  </data>
+  <data name="BlendMode_Dst" xml:space="preserve">
+    <value>保留原图</value>
+  </data>
+  <data name="BlendMode_DstATop" xml:space="preserve">
+    <value>背景置于顶部</value>
+  </data>
+  <data name="BlendMode_DstATop_Description" xml:space="preserve">
+    <value>将背景置于顶部，并保留前景外部的区域。</value>
+  </data>
+  <data name="BlendMode_DstIn" xml:space="preserve">
+    <value>背景在内</value>
+  </data>
+  <data name="BlendMode_DstIn_Description" xml:space="preserve">
+    <value>将背景裁剪为前景的形状。</value>
+  </data>
+  <data name="BlendMode_DstOut" xml:space="preserve">
+    <value>背景在外</value>
+  </data>
+  <data name="BlendMode_DstOut_Description" xml:space="preserve">
+    <value>为背景保留前景外部的区域。</value>
+  </data>
+  <data name="BlendMode_DstOver" xml:space="preserve">
+    <value>背景覆盖</value>
+  </data>
+  <data name="BlendMode_DstOver_Description" xml:space="preserve">
+    <value>将背景置于前景下方。</value>
+  </data>
+  <data name="BlendMode_Dst_Description" xml:space="preserve">
+    <value>保持原始内容不变。</value>
+  </data>
+  <data name="BlendMode_Exclusion" xml:space="preserve">
+    <value>排除</value>
+  </data>
+  <data name="BlendMode_Exclusion_Description" xml:space="preserve">
+    <value>创建更柔和的差值效果。</value>
+  </data>
+  <data name="BlendMode_HardLight" xml:space="preserve">
+    <value>强光</value>
+  </data>
+  <data name="BlendMode_HardLight_Description" xml:space="preserve">
+    <value>模拟强烈的聚光灯效果以增强对比度。</value>
+  </data>
+  <data name="BlendMode_Hue" xml:space="preserve">
+    <value>色相</value>
+  </data>
+  <data name="BlendMode_Hue_Description" xml:space="preserve">
+    <value>将前景色的色相应用于背景的亮度和饱和度。</value>
+  </data>
+  <data name="BlendMode_Lighten" xml:space="preserve">
+    <value>变亮</value>
+  </data>
+  <data name="BlendMode_Lighten_Description" xml:space="preserve">
+    <value>保留前景或背景中较亮的颜色。</value>
+  </data>
+  <data name="BlendMode_Luminosity" xml:space="preserve">
+    <value>明度</value>
+  </data>
+  <data name="BlendMode_Luminosity_Description" xml:space="preserve">
+    <value>将前景色的亮度应用于背景的色相和饱和度。</value>
+  </data>
+  <data name="BlendMode_Modulate" xml:space="preserve">
+    <value>按不透明度混合</value>
+  </data>
+  <data name="BlendMode_Modulate_Description" xml:space="preserve">
+    <value>根据前景和背景的透明度（alpha 值）组合它们的颜色。</value>
+  </data>
+  <data name="BlendMode_Multiply" xml:space="preserve">
+    <value>正片叠底</value>
+  </data>
+  <data name="BlendMode_Multiply_Description" xml:space="preserve">
+    <value>将前景和背景的 RGB 颜色值相乘，产生变暗的效果。</value>
+  </data>
+  <data name="BlendMode_Overlay" xml:space="preserve">
+    <value>叠加</value>
+  </data>
+  <data name="BlendMode_Overlay_Description" xml:space="preserve">
+    <value>组合前景和背景以增强对比度。</value>
+  </data>
+  <data name="BlendMode_Plus" xml:space="preserve">
+    <value>相加</value>
+  </data>
+  <data name="BlendMode_Plus_Description" xml:space="preserve">
+    <value>将前景和背景的颜色相加。</value>
+  </data>
+  <data name="BlendMode_Saturation" xml:space="preserve">
+    <value>饱和度</value>
+  </data>
+  <data name="BlendMode_Saturation_Description" xml:space="preserve">
+    <value>将前景色的饱和度应用于背景的色相和亮度。</value>
+  </data>
+  <data name="BlendMode_Screen" xml:space="preserve">
+    <value>滤色</value>
+  </data>
+  <data name="BlendMode_Screen_Description" xml:space="preserve">
+    <value>将前景和背景的反色相乘，产生变亮的效果。</value>
+  </data>
+  <data name="BlendMode_SoftLight" xml:space="preserve">
+    <value>柔光</value>
+  </data>
+  <data name="BlendMode_SoftLight_Description" xml:space="preserve">
+    <value>模拟漫射的聚光灯以获得更柔和的光照效果。</value>
+  </data>
+  <data name="BlendMode_Src" xml:space="preserve">
+    <value>覆盖</value>
+  </data>
+  <data name="BlendMode_SrcATop" xml:space="preserve">
+    <value>前景置于顶部</value>
+  </data>
+  <data name="BlendMode_SrcATop_Description" xml:space="preserve">
+    <value>将前景置于顶部，并保留背景外部的区域。</value>
+  </data>
+  <data name="BlendMode_SrcIn" xml:space="preserve">
+    <value>前景在内</value>
+  </data>
+  <data name="BlendMode_SrcIn_Description" xml:space="preserve">
+    <value>将前景裁剪为背景的形状。</value>
+  </data>
+  <data name="BlendMode_SrcOut" xml:space="preserve">
+    <value>前景在外</value>
+  </data>
+  <data name="BlendMode_SrcOut_Description" xml:space="preserve">
+    <value>为前景保留背景外部的区域。</value>
+  </data>
+  <data name="BlendMode_SrcOver" xml:space="preserve">
+    <value>前景覆盖</value>
+  </data>
+  <data name="BlendMode_SrcOver_Description" xml:space="preserve">
+    <value>将前景置于背景之上。</value>
+  </data>
+  <data name="BlendMode_Src_Description" xml:space="preserve">
+    <value>在现有内容上绘制。</value>
+  </data>
+  <data name="BlendMode_Xor" xml:space="preserve">
+    <value>异或混合</value>
+  </data>
+  <data name="BlendMode_Xor_Description" xml:space="preserve">
+    <value>使重叠区域透明，保留不重叠的区域。</value>
+  </data>
+  <data name="Blur" xml:space="preserve">
+    <value>模糊</value>
+  </data>
+  <data name="Brightness" xml:space="preserve">
+    <value>亮度</value>
+  </data>
+  <data name="ChromaKey" xml:space="preserve">
+    <value>色度键</value>
+  </data>
+  <data name="ChromaKey_Boundary" xml:space="preserve">
+    <value>边界校正</value>
+  </data>
+  <data name="ChromaKey_HueRange" xml:space="preserve">
+    <value>色相范围</value>
+  </data>
+  <data name="ChromaKey_SaturationRange" xml:space="preserve">
+    <value>饱和度范围</value>
+  </data>
+  <data name="Clipping" xml:space="preserve">
+    <value>裁剪</value>
+  </data>
+  <data name="Clipping_AutoCenter" xml:space="preserve">
+    <value>自动居中</value>
+  </data>
+  <data name="Clipping_AutoClip" xml:space="preserve">
+    <value>裁剪透明区域</value>
+  </data>
+  <data name="Clipping_Bottom" xml:space="preserve">
+    <value>底部</value>
+  </data>
+  <data name="Clipping_Left" xml:space="preserve">
+    <value>左侧</value>
+  </data>
+  <data name="Clipping_Right" xml:space="preserve">
+    <value>右侧</value>
+  </data>
+  <data name="Clipping_Top" xml:space="preserve">
+    <value>顶部</value>
+  </data>
+  <data name="ColorGrading" xml:space="preserve">
+    <value>颜色分级</value>
+  </data>
+  <data name="ColorGrading_Contrast" xml:space="preserve">
+    <value>对比度</value>
+  </data>
+  <data name="ColorGrading_ContrastPivot" xml:space="preserve">
+    <value>对比度枢轴</value>
+  </data>
+  <data name="ColorGrading_Exposure" xml:space="preserve">
+    <value>曝光</value>
+  </data>
+  <data name="ColorGrading_Gain" xml:space="preserve">
+    <value>增益</value>
+  </data>
+  <data name="ColorGrading_Gamma" xml:space="preserve">
+    <value>伽马</value>
+  </data>
+  <data name="ColorGrading_HighRange" xml:space="preserve">
+    <value>高范围</value>
+  </data>
+  <data name="ColorGrading_Highlights" xml:space="preserve">
+    <value>高光</value>
+  </data>
+  <data name="ColorGrading_Hue" xml:space="preserve">
+    <value>色相</value>
+  </data>
+  <data name="ColorGrading_Lift" xml:space="preserve">
+    <value>提升</value>
+  </data>
+  <data name="ColorGrading_LowRange" xml:space="preserve">
+    <value>低范围</value>
+  </data>
+  <data name="ColorGrading_Midtones" xml:space="preserve">
+    <value>中间调</value>
+  </data>
+  <data name="ColorGrading_Offset" xml:space="preserve">
+    <value>偏移</value>
+  </data>
+  <data name="ColorGrading_Saturation" xml:space="preserve">
+    <value>饱和度</value>
+  </data>
+  <data name="ColorGrading_Shadows" xml:space="preserve">
+    <value>阴影</value>
+  </data>
+  <data name="ColorGrading_Temperature" xml:space="preserve">
+    <value>色温</value>
+  </data>
+  <data name="ColorGrading_Tint" xml:space="preserve">
+    <value>色调</value>
+  </data>
+  <data name="ColorGrading_Vibrance" xml:space="preserve">
+    <value>自然饱和度</value>
+  </data>
+  <data name="ColorKey" xml:space="preserve">
+    <value>颜色键</value>
+  </data>
+  <data name="ColorKey_Boundary" xml:space="preserve">
+    <value>边界校正</value>
+  </data>
+  <data name="ColorKey_Range" xml:space="preserve">
+    <value>亮度范围</value>
+  </data>
+  <data name="ColorShift" xml:space="preserve">
+    <value>颜色偏移</value>
+  </data>
+  <data name="ColorShift_AlphaOffset" xml:space="preserve">
+    <value>Alpha 偏移</value>
+  </data>
+  <data name="ColorShift_BlueOffset" xml:space="preserve">
+    <value>蓝色偏移</value>
+  </data>
+  <data name="ColorShift_GreenOffset" xml:space="preserve">
+    <value>绿色偏移</value>
+  </data>
+  <data name="ColorShift_RedOffset" xml:space="preserve">
+    <value>红色偏移</value>
+  </data>
+  <data name="Curves" xml:space="preserve">
+    <value>曲线</value>
+  </data>
+  <data name="Curves_BlueCurve" xml:space="preserve">
+    <value>蓝色曲线</value>
+  </data>
+  <data name="Curves_GreenCurve" xml:space="preserve">
+    <value>绿色曲线</value>
+  </data>
+  <data name="Curves_HueVsHue" xml:space="preserve">
+    <value>色相 vs 色相</value>
+  </data>
+  <data name="Curves_HueVsLuminance" xml:space="preserve">
+    <value>色相 vs 亮度</value>
+  </data>
+  <data name="Curves_HueVsSaturation" xml:space="preserve">
+    <value>色相 vs 饱和度</value>
+  </data>
+  <data name="Curves_LuminanceVsSaturation" xml:space="preserve">
+    <value>亮度 vs 饱和度</value>
+  </data>
+  <data name="Curves_MasterCurve" xml:space="preserve">
+    <value>自定义 (RGB)</value>
+  </data>
+  <data name="Curves_RedCurve" xml:space="preserve">
+    <value>红色曲线</value>
+  </data>
+  <data name="Curves_SaturationVsSaturation" xml:space="preserve">
+    <value>饱和度 vs 饱和度</value>
+  </data>
+  <data name="DelayAnimationEffect" xml:space="preserve">
+    <value>延迟动画</value>
+  </data>
+  <data name="DelayAnimationEffect_Delay" xml:space="preserve">
+    <value>延迟</value>
+  </data>
+  <data name="DelayAnimationEffect_Effect" xml:space="preserve">
+    <value>滤镜效果</value>
+  </data>
+  <data name="Dilate" xml:space="preserve">
+    <value>膨胀</value>
+  </data>
+  <data name="Dilate_RadiusX" xml:space="preserve">
+    <value>半径 X</value>
+  </data>
+  <data name="Dilate_RadiusY" xml:space="preserve">
+    <value>半径 Y</value>
+  </data>
+  <data name="DisplacementMapEffect" xml:space="preserve">
+    <value>置换贴图</value>
+  </data>
+  <data name="DisplacementMapEffect_DisplacementMap" xml:space="preserve">
+    <value>置换贴图</value>
+  </data>
+  <data name="DisplacementMapEffect_ShowDisplacementMap" xml:space="preserve">
+    <value>显示置换贴图</value>
+  </data>
+  <data name="DisplacementMapEffect_Channel" xml:space="preserve">
+    <value>通道</value>
+  </data>
+  <data name="DisplacementMapEffect_Signed" xml:space="preserve">
+    <value>有符号</value>
+  </data>
+  <data name="DisplacementMapEffect_SpreadMethod" xml:space="preserve">
+    <value>扩散方法</value>
+  </data>
+  <data name="PixelSortEffect" xml:space="preserve">
+    <value>像素排序</value>
+  </data>
+  <data name="PixelSortEffect_Direction" xml:space="preserve">
+    <value>排序方向</value>
+  </data>
+  <data name="PixelSortEffect_SortKey" xml:space="preserve">
+    <value>排序键</value>
+  </data>
+  <data name="PixelSortEffect_ThresholdMin" xml:space="preserve">
+    <value>最小阈值</value>
+  </data>
+  <data name="PixelSortEffect_ThresholdMax" xml:space="preserve">
+    <value>最大阈值</value>
+  </data>
+  <data name="PixelSortEffect_Ascending" xml:space="preserve">
+    <value>升序</value>
+  </data>
+  <data name="DrawableDecorator" xml:space="preserve">
+    <value>装饰器</value>
+  </data>
+  <data name="DrawableTimeController" xml:space="preserve">
+    <value>时间控制器（视频）</value>
+  </data>
+  <data name="DrawableTimeController_AdjustTimeRange" xml:space="preserve">
+    <value>调整时间范围</value>
+  </data>
+  <data name="DrawableTimeController_FrameRate" xml:space="preserve">
+    <value>帧率</value>
+  </data>
+  <data name="DrawableTimeController_HoldFirstFrame" xml:space="preserve">
+    <value>保持第一帧</value>
+  </data>
+  <data name="DrawableTimeController_HoldLastFrame" xml:space="preserve">
+    <value>保持最后一帧</value>
+  </data>
+  <data name="DrawableTimeController_Loop" xml:space="preserve">
+    <value>循环</value>
+  </data>
+  <data name="DrawableTimeController_OffsetPosition" xml:space="preserve">
+    <value>偏移位置</value>
+  </data>
+  <data name="DrawableTimeController_Reverse" xml:space="preserve">
+    <value>反向</value>
+  </data>
+  <data name="Drawable_AlignmentX" xml:space="preserve">
+    <value>对齐 X</value>
+  </data>
+  <data name="Drawable_AlignmentY" xml:space="preserve">
+    <value>对齐 Y</value>
+  </data>
+  <data name="Drawable_BlendMode" xml:space="preserve">
+    <value>混合模式</value>
+  </data>
+  <data name="DropShadow" xml:space="preserve">
+    <value>投影</value>
+  </data>
+  <data name="EllipseShape" xml:space="preserve">
+    <value>椭圆</value>
+  </data>
+  <data name="Erode" xml:space="preserve">
+    <value>腐蚀</value>
+  </data>
+  <data name="Erode_RadiusX" xml:space="preserve">
+    <value>半径 X</value>
+  </data>
+  <data name="Erode_RadiusY" xml:space="preserve">
+    <value>半径 Y</value>
+  </data>
+  <data name="FlatShadow" xml:space="preserve">
+    <value>平面阴影</value>
+  </data>
+  <data name="FlatShadow_Length" xml:space="preserve">
+    <value>长度</value>
+  </data>
+  <data name="SKSLScriptEffect" xml:space="preserve">
+    <value>SKSL 脚本</value>
+  </data>
+  <data name="GLSLScriptEffect" xml:space="preserve">
+    <value>GLSL 脚本</value>
+  </data>
+  <data name="CSharpScriptEffect" xml:space="preserve">
+    <value>C# 脚本</value>
+  </data>
+  <data name="Gamma" xml:space="preserve">
+    <value>伽马</value>
+  </data>
+  <data name="GeometryShape" xml:space="preserve">
+    <value>几何图形</value>
+  </data>
+  <data name="GeometryShape_Data" xml:space="preserve">
+    <value>数据</value>
+  </data>
+  <data name="HighContrast" xml:space="preserve">
+    <value>高对比度</value>
+  </data>
+  <data name="HighContrast_Contrast" xml:space="preserve">
+    <value>对比度</value>
+  </data>
+  <data name="HighContrast_Grayscale" xml:space="preserve">
+    <value>灰度</value>
+  </data>
+  <data name="HighContrast_InvertStyle" xml:space="preserve">
+    <value>反相样式</value>
+  </data>
+  <data name="HueRotate" xml:space="preserve">
+    <value>色相旋转</value>
+  </data>
+  <data name="InnerShadow" xml:space="preserve">
+    <value>内阴影</value>
+  </data>
+  <data name="Invert" xml:space="preserve">
+    <value>反相</value>
+  </data>
+  <data name="Invert_ExcludeAlphaChannel" xml:space="preserve">
+    <value>排除 Alpha 通道</value>
+  </data>
+  <data name="LayerEffect" xml:space="preserve">
+    <value>图层</value>
+  </data>
+  <data name="Lighting" xml:space="preserve">
+    <value>光照</value>
+  </data>
+  <data name="Lighting_Add" xml:space="preserve">
+    <value>相加</value>
+  </data>
+  <data name="Lighting_Multiply" xml:space="preserve">
+    <value>相乘</value>
+  </data>
+  <data name="LumaColor" xml:space="preserve">
+    <value>亮度颜色</value>
+  </data>
+  <data name="LutEffect" xml:space="preserve">
+    <value>LUT（立方体文件）</value>
+  </data>
+  <data name="MatrixTransform" xml:space="preserve">
+    <value>矩阵变换</value>
+  </data>
+  <data name="MatrixTransform_Matrix" xml:space="preserve">
+    <value>矩阵</value>
+  </data>
+  <data name="MosaicEffect" xml:space="preserve">
+    <value>马赛克</value>
+  </data>
+  <data name="MosaicEffect_Origin" xml:space="preserve">
+    <value>原点</value>
+  </data>
+  <data name="MosaicEffect_TileSize" xml:space="preserve">
+    <value>平铺大小</value>
+  </data>
+  <data name="Negaposi" xml:space="preserve">
+    <value>负片</value>
+  </data>
+  <data name="Negaposi_Blue" xml:space="preserve">
+    <value>蓝色</value>
+  </data>
+  <data name="Negaposi_Green" xml:space="preserve">
+    <value>绿色</value>
+  </data>
+  <data name="Negaposi_Red" xml:space="preserve">
+    <value>红色</value>
+  </data>
+  <data name="ParticleEmitter" xml:space="preserve">
+    <value>粒子发射器</value>
+  </data>
+  <data name="ParticleEmitter_AirResistance" xml:space="preserve">
+    <value>空气阻力</value>
+  </data>
+  <data name="ParticleEmitter_AngularVelocity" xml:space="preserve">
+    <value>角速度</value>
+  </data>
+  <data name="ParticleEmitter_EmissionGroup" xml:space="preserve">
+    <value>发射</value>
+  </data>
+  <data name="ParticleEmitter_EmissionRate" xml:space="preserve">
+    <value>发射速率</value>
+  </data>
+  <data name="ParticleEmitter_EmitterGroup" xml:space="preserve">
+    <value>发射器</value>
+  </data>
+  <data name="ParticleEmitter_EmitterHeight" xml:space="preserve">
+    <value>发射器高度</value>
+  </data>
+  <data name="ParticleEmitter_EmitterShape" xml:space="preserve">
+    <value>发射器形状</value>
+  </data>
+  <data name="ParticleEmitter_EmitterWidth" xml:space="preserve">
+    <value>发射器宽度</value>
+  </data>
+  <data name="ParticleEmitter_EndColor" xml:space="preserve">
+    <value>结束颜色</value>
+  </data>
+  <data name="ParticleEmitter_EndOpacityMultiplier" xml:space="preserve">
+    <value>结束不透明度乘数</value>
+  </data>
+  <data name="ParticleEmitter_EndSizeMultiplier" xml:space="preserve">
+    <value>结束大小乘数</value>
+  </data>
+  <data name="ParticleEmitter_Gravity" xml:space="preserve">
+    <value>重力</value>
+  </data>
+  <data name="ParticleEmitter_InitialRotation" xml:space="preserve">
+    <value>初始旋转</value>
+  </data>
+  <data name="ParticleEmitter_InitialRotationRandom" xml:space="preserve">
+    <value>初始旋转随机</value>
+  </data>
+  <data name="ParticleEmitter_Lifetime" xml:space="preserve">
+    <value>生命周期</value>
+  </data>
+  <data name="ParticleEmitter_LifetimeRandom" xml:space="preserve">
+    <value>生命周期随机</value>
+  </data>
+  <data name="ParticleEmitter_MaxParticles" xml:space="preserve">
+    <value>最大粒子数</value>
+  </data>
+  <data name="ParticleEmitter_OverLifeGroup" xml:space="preserve">
+    <value>生命周期内</value>
+  </data>
+  <data name="ParticleEmitter_ParticleDrawable" xml:space="preserve">
+    <value>粒子可绘制对象</value>
+  </data>
+  <data name="ParticleEmitter_ParticleOpacity" xml:space="preserve">
+    <value>粒子不透明度</value>
+  </data>
+  <data name="ParticleEmitter_ParticleSize" xml:space="preserve">
+    <value>粒子大小</value>
+  </data>
+  <data name="ParticleEmitter_PhysicsGroup" xml:space="preserve">
+    <value>物理</value>
+  </data>
+  <data name="ParticleEmitter_Seed" xml:space="preserve">
+    <value>种子</value>
+  </data>
+  <data name="ParticleEmitter_SizeRandom" xml:space="preserve">
+    <value>大小随机</value>
+  </data>
+  <data name="ParticleEmitter_SpeedRandom" xml:space="preserve">
+    <value>速度随机</value>
+  </data>
+  <data name="ParticleEmitter_Spread" xml:space="preserve">
+    <value>扩散</value>
+  </data>
+  <data name="ParticleEmitter_TurbulenceScale" xml:space="preserve">
+    <value>湍流缩放</value>
+  </data>
+  <data name="ParticleEmitter_TurbulenceSpeed" xml:space="preserve">
+    <value>湍流速度</value>
+  </data>
+  <data name="ParticleEmitter_TurbulenceStrength" xml:space="preserve">
+    <value>湍流强度</value>
+  </data>
+  <data name="ParticleEmitter_UseEndColor" xml:space="preserve">
+    <value>使用结束颜色</value>
+  </data>
+  <data name="ParticleEmitter_VelocityGroup" xml:space="preserve">
+    <value>速度</value>
+  </data>
+  <data name="ParticleEmitter_VisualGroup" xml:space="preserve">
+    <value>视觉</value>
+  </data>
+  <data name="PartsSplitEffect" xml:space="preserve">
+    <value>按部件分割</value>
+  </data>
+  <data name="PathFollowEffect" xml:space="preserve">
+    <value>路径跟随</value>
+  </data>
+  <data name="PathFollowEffect_FollowRotation" xml:space="preserve">
+    <value>跟随旋转</value>
+  </data>
+  <data name="PathFollowEffect_Geometry" xml:space="preserve">
+    <value>几何图形</value>
+  </data>
+  <data name="PathFollowEffect_Progress" xml:space="preserve">
+    <value>进度</value>
+  </data>
+  <data name="RectShape" xml:space="preserve">
+    <value>矩形</value>
+  </data>
+  <data name="Rotation3DTransform" xml:space="preserve">
+    <value>3D 旋转</value>
+  </data>
+  <data name="Rotation3DTransform_CenterZ" xml:space="preserve">
+    <value>中心 Z</value>
+  </data>
+  <data name="Rotation3DTransform_RotationX" xml:space="preserve">
+    <value>旋转 X</value>
+  </data>
+  <data name="Rotation3DTransform_RotationY" xml:space="preserve">
+    <value>旋转 Y</value>
+  </data>
+  <data name="Rotation3DTransform_RotationZ" xml:space="preserve">
+    <value>旋转 Z</value>
+  </data>
+  <data name="RoundedRectShape" xml:space="preserve">
+    <value>圆角矩形</value>
+  </data>
+  <data name="RoundedRectShape_CornerRadius" xml:space="preserve">
+    <value>圆角半径</value>
+  </data>
+  <data name="Saturate" xml:space="preserve">
+    <value>饱和度</value>
+  </data>
+  <data name="ScaleTransform_ScaleX" xml:space="preserve">
+    <value>缩放 X</value>
+  </data>
+  <data name="ScaleTransform_ScaleY" xml:space="preserve">
+    <value>缩放 Y</value>
+  </data>
+  <data name="ShakeEffect" xml:space="preserve">
+    <value>抖动</value>
+  </data>
+  <data name="ShakeEffect_StrengthX" xml:space="preserve">
+    <value>强度 X</value>
+  </data>
+  <data name="ShakeEffect_StrengthY" xml:space="preserve">
+    <value>强度 Y</value>
+  </data>
+  <data name="Fill" xml:space="preserve">
+    <value>填充</value>
+  </data>
+  <data name="SkewTransform" xml:space="preserve">
+    <value>倾斜</value>
+  </data>
+  <data name="SkewTransform_SkewX" xml:space="preserve">
+    <value>倾斜 X</value>
+  </data>
+  <data name="SkewTransform_SkewY" xml:space="preserve">
+    <value>倾斜 Y</value>
+  </data>
+  <data name="SourceBackdrop" xml:space="preserve">
+    <value>背景</value>
+  </data>
+  <data name="SourceBackdrop_Clear" xml:space="preserve">
+    <value>清除缓冲区</value>
+  </data>
+  <data name="SourceImage" xml:space="preserve">
+    <value>图像</value>
+  </data>
+  <data name="SourceVideo" xml:space="preserve">
+    <value>视频</value>
+  </data>
+  <data name="SourceVideo_IsLoop" xml:space="preserve">
+    <value>循环</value>
+  </data>
+  <data name="SourceVideo_OffsetPosition" xml:space="preserve">
+    <value>偏移位置</value>
+  </data>
+  <data name="SplitEffect" xml:space="preserve">
+    <value>等分分割</value>
+  </data>
+  <data name="SplitEffect_HorizontalDivisions" xml:space="preserve">
+    <value>水平分割数</value>
+  </data>
+  <data name="SplitEffect_HorizontalSpacing" xml:space="preserve">
+    <value>水平间距</value>
+  </data>
+  <data name="SplitEffect_VerticalDivisions" xml:space="preserve">
+    <value>垂直分割数</value>
+  </data>
+  <data name="SplitEffect_VerticalSpacing" xml:space="preserve">
+    <value>垂直间距</value>
+  </data>
+  <data name="StrokeEffect_Style" xml:space="preserve">
+    <value>边框样式</value>
+  </data>
+  <data name="TextBlock" xml:space="preserve">
+    <value>文本</value>
+  </data>
+  <data name="TextBlock_FontFamily" xml:space="preserve">
+    <value>字体族</value>
+  </data>
+  <data name="TextBlock_FontStyle" xml:space="preserve">
+    <value>字体样式</value>
+  </data>
+  <data name="TextBlock_FontWeight" xml:space="preserve">
+    <value>字体粗细</value>
+  </data>
+  <data name="TextBlock_Size" xml:space="preserve">
+    <value>大小</value>
+  </data>
+  <data name="TextBlock_Spacing" xml:space="preserve">
+    <value>字符间距</value>
+  </data>
+  <data name="TextBlock_SplitByCharacters" xml:space="preserve">
+    <value>按字符分割</value>
+  </data>
+  <data name="TextBlock_Text" xml:space="preserve">
+    <value>文本</value>
+  </data>
+  <data name="Threshold" xml:space="preserve">
+    <value>阈值</value>
+  </data>
+  <data name="TransformEffect_BitmapInterpolationMode" xml:space="preserve">
+    <value>位图插值模式</value>
+  </data>
+  <data name="TranslateTransform" xml:space="preserve">
+    <value>平移</value>
+  </data>
+  <data name="TranslateTransform_X" xml:space="preserve">
+    <value>X</value>
+  </data>
+  <data name="TranslateTransform_Y" xml:space="preserve">
+    <value>Y</value>
+  </data>
+  <data name="ArcSegment" xml:space="preserve">
+    <value>椭圆弧</value>
+  </data>
+  <data name="ArcSegment_IsLargeArc" xml:space="preserve">
+    <value>大弧</value>
+  </data>
+  <data name="ArcSegment_Point" xml:space="preserve">
+    <value>点</value>
+  </data>
+  <data name="ArcSegment_RotationAngle" xml:space="preserve">
+    <value>旋转角度</value>
+  </data>
+  <data name="ArcSegment_SweepClockwise" xml:space="preserve">
+    <value>顺时针扫掠</value>
+  </data>
+  <data name="BasicMaterial" xml:space="preserve">
+    <value>基础材质</value>
+  </data>
+  <data name="BasicMaterial_AmbientColor" xml:space="preserve">
+    <value>环境色</value>
+  </data>
+  <data name="BasicMaterial_DiffuseColor" xml:space="preserve">
+    <value>漫反射颜色</value>
+  </data>
+  <data name="BasicMaterial_DiffuseMap" xml:space="preserve">
+    <value>漫反射贴图</value>
+  </data>
+  <data name="BasicMaterial_Shininess" xml:space="preserve">
+    <value>光泽度</value>
+  </data>
+  <data name="BasicMaterial_SpecularColor" xml:space="preserve">
+    <value>高光颜色</value>
+  </data>
+  <data name="Camera3D_FarPlane" xml:space="preserve">
+    <value>远平面</value>
+  </data>
+  <data name="Camera3D_NearPlane" xml:space="preserve">
+    <value>近平面</value>
+  </data>
+  <data name="Camera3D_Up" xml:space="preserve">
+    <value>向上</value>
+  </data>
+  <data name="ConicGradientBrush" xml:space="preserve">
+    <value>锥形渐变</value>
+  </data>
+  <data name="ConicGradientBrush_Center" xml:space="preserve">
+    <value>中心</value>
+  </data>
+  <data name="ConicSegment" xml:space="preserve">
+    <value>圆锥曲线</value>
+  </data>
+  <data name="ConicSegment_ControlPoint" xml:space="preserve">
+    <value>控制点</value>
+  </data>
+  <data name="ConicSegment_Weight" xml:space="preserve">
+    <value>权重</value>
+  </data>
+  <data name="Cube3D" xml:space="preserve">
+    <value>立方体</value>
+  </data>
+  <data name="CubeMesh" xml:space="preserve">
+    <value>立方体网格</value>
+  </data>
+  <data name="CubicBezierSegment" xml:space="preserve">
+    <value>三次贝塞尔曲线</value>
+  </data>
+  <data name="CubicBezierSegment_ControlPoint1" xml:space="preserve">
+    <value>控制点 1</value>
+  </data>
+  <data name="CubicBezierSegment_ControlPoint2" xml:space="preserve">
+    <value>控制点 2</value>
+  </data>
+  <data name="DirectionalLight3D" xml:space="preserve">
+    <value>方向光</value>
+  </data>
+  <data name="DirectionalLight3D_ShadowDistance" xml:space="preserve">
+    <value>阴影距离</value>
+  </data>
+  <data name="DirectionalLight3D_ShadowMapSize" xml:space="preserve">
+    <value>阴影贴图大小</value>
+  </data>
+  <data name="DrawableTextureSource" xml:space="preserve">
+    <value>可绘制纹理</value>
+  </data>
+  <data name="DrawableTextureSource_TextureHeight" xml:space="preserve">
+    <value>纹理高度</value>
+  </data>
+  <data name="DrawableTextureSource_TextureWidth" xml:space="preserve">
+    <value>纹理宽度</value>
+  </data>
+  <data name="EllipseGeometry" xml:space="preserve">
+    <value>椭圆</value>
+  </data>
+  <data name="Geometry_FillType" xml:space="preserve">
+    <value>填充类型</value>
+  </data>
+  <data name="GradientBrush_GradientStops" xml:space="preserve">
+    <value>渐变停止点</value>
+  </data>
+  <data name="GradientBrush_SpreadMethod" xml:space="preserve">
+    <value>扩散方法</value>
+  </data>
+  <data name="Children" xml:space="preserve">
+    <value>子项</value>
+  </data>
+  <data name="ImageTextureSource" xml:space="preserve">
+    <value>图像纹理</value>
+  </data>
+  <data name="Light3D_CastsShadow" xml:space="preserve">
+    <value>投射阴影</value>
+  </data>
+  <data name="Light3D_Intensity" xml:space="preserve">
+    <value>强度</value>
+  </data>
+  <data name="Light3D_ShadowBias" xml:space="preserve">
+    <value>阴影偏移</value>
+  </data>
+  <data name="Light3D_ShadowNormalBias" xml:space="preserve">
+    <value>阴影法线偏移</value>
+  </data>
+  <data name="Light3D_ShadowStrength" xml:space="preserve">
+    <value>阴影强度</value>
+  </data>
+  <data name="LineSegment" xml:space="preserve">
+    <value>直线</value>
+  </data>
+  <data name="LineSegment_Point" xml:space="preserve">
+    <value>点</value>
+  </data>
+  <data name="LinearGradientBrush" xml:space="preserve">
+    <value>线性渐变</value>
+  </data>
+  <data name="LinearGradientBrush_StartPoint" xml:space="preserve">
+    <value>起点</value>
+  </data>
+  <data name="MeshObject3D" xml:space="preserve">
+    <value>网格对象</value>
+  </data>
+  <data name="MeshObject3D_Mesh" xml:space="preserve">
+    <value>网格</value>
+  </data>
+  <data name="Model3D" xml:space="preserve">
+    <value>模型</value>
+  </data>
+  <data name="ModelMesh" xml:space="preserve">
+    <value>模型网格</value>
+  </data>
+  <data name="ModelMesh_Indices" xml:space="preserve">
+    <value>索引</value>
+  </data>
+  <data name="ModelMesh_Vertices" xml:space="preserve">
+    <value>顶点</value>
+  </data>
+  <data name="Object3D_CastShadows" xml:space="preserve">
+    <value>投射阴影</value>
+  </data>
+  <data name="Object3D_Material" xml:space="preserve">
+    <value>材质</value>
+  </data>
+  <data name="Object3D_ReceiveShadows" xml:space="preserve">
+    <value>接收阴影</value>
+  </data>
+  <data name="OrthographicCamera" xml:space="preserve">
+    <value>正交相机</value>
+  </data>
+  <data name="PBRMaterial" xml:space="preserve">
+    <value>PBR 材质</value>
+  </data>
+  <data name="PBRMaterial_AOMap" xml:space="preserve">
+    <value>AO 贴图</value>
+  </data>
+  <data name="PBRMaterial_Albedo" xml:space="preserve">
+    <value>反照率</value>
+  </data>
+  <data name="PBRMaterial_AlbedoMap" xml:space="preserve">
+    <value>反照率贴图</value>
+  </data>
+  <data name="PBRMaterial_AmbientOcclusion" xml:space="preserve">
+    <value>环境光遮蔽</value>
+  </data>
+  <data name="PBRMaterial_Emissive" xml:space="preserve">
+    <value>自发光</value>
+  </data>
+  <data name="PBRMaterial_EmissiveIntensity" xml:space="preserve">
+    <value>自发光强度</value>
+  </data>
+  <data name="PBRMaterial_EmissiveMap" xml:space="preserve">
+    <value>自发光贴图</value>
+  </data>
+  <data name="PBRMaterial_Metallic" xml:space="preserve">
+    <value>金属度</value>
+  </data>
+  <data name="PBRMaterial_MetallicRoughnessMap" xml:space="preserve">
+    <value>金属度/粗糙度贴图</value>
+  </data>
+  <data name="PBRMaterial_NormalMap" xml:space="preserve">
+    <value>法线贴图</value>
+  </data>
+  <data name="PBRMaterial_NormalMapStrength" xml:space="preserve">
+    <value>法线贴图强度</value>
+  </data>
+  <data name="PBRMaterial_Roughness" xml:space="preserve">
+    <value>粗糙度</value>
+  </data>
+  <data name="PathFigure" xml:space="preserve">
+    <value>图形</value>
+  </data>
+  <data name="PathFigure_IsClosed" xml:space="preserve">
+    <value>已闭合</value>
+  </data>
+  <data name="PathFigure_StartPoint" xml:space="preserve">
+    <value>起点</value>
+  </data>
+  <data name="PathGeometry" xml:space="preserve">
+    <value>几何图形</value>
+  </data>
+  <data name="Pen_DashArray" xml:space="preserve">
+    <value>虚线和空格</value>
+  </data>
+  <data name="Pen_DashOffset" xml:space="preserve">
+    <value>虚线偏移</value>
+  </data>
+  <data name="Pen_MiterLimit" xml:space="preserve">
+    <value>斜接限制</value>
+  </data>
+  <data name="Pen_StrokeAlignment" xml:space="preserve">
+    <value>位置</value>
+  </data>
+  <data name="Pen_StrokeCap" xml:space="preserve">
+    <value>端点样式</value>
+  </data>
+  <data name="Pen_StrokeJoin" xml:space="preserve">
+    <value>连接样式</value>
+  </data>
+  <data name="Pen_Thickness" xml:space="preserve">
+    <value>粗细</value>
+  </data>
+  <data name="Pen_TrimEnd" xml:space="preserve">
+    <value>修剪末尾</value>
+  </data>
+  <data name="Pen_TrimOffset" xml:space="preserve">
+    <value>修剪偏移</value>
+  </data>
+  <data name="Pen_TrimStart" xml:space="preserve">
+    <value>修剪开头</value>
+  </data>
+  <data name="Pen_Offset" xml:space="preserve">
+    <value>偏移</value>
+  </data>
+  <data name="PerlinNoiseBrush" xml:space="preserve">
+    <value>柏林噪声</value>
+  </data>
+  <data name="PerlinNoiseBrush_BaseFrequencyX" xml:space="preserve">
+    <value>基础频率 X</value>
+  </data>
+  <data name="PerlinNoiseBrush_BaseFrequencyY" xml:space="preserve">
+    <value>基础频率 Y</value>
+  </data>
+  <data name="PerlinNoiseBrush_Octaves" xml:space="preserve">
+    <value>八度</value>
+  </data>
+  <data name="PerlinNoiseBrush_PerlinNoiseType" xml:space="preserve">
+    <value>噪声类型</value>
+  </data>
+  <data name="PerlinNoiseBrush_Seed" xml:space="preserve">
+    <value>种子</value>
+  </data>
+  <data name="PerspectiveCamera" xml:space="preserve">
+    <value>透视相机</value>
+  </data>
+  <data name="PerspectiveCamera_FieldOfView" xml:space="preserve">
+    <value>视野</value>
+  </data>
+  <data name="Plane3D" xml:space="preserve">
+    <value>平面</value>
+  </data>
+  <data name="Plane3D_HeightSegments" xml:space="preserve">
+    <value>高度分段</value>
+  </data>
+  <data name="Plane3D_WidthSegments" xml:space="preserve">
+    <value>宽度分段</value>
+  </data>
+  <data name="PlaneMesh" xml:space="preserve">
+    <value>平面网格</value>
+  </data>
+  <data name="PlaneMesh_HeightSegments" xml:space="preserve">
+    <value>高度分段</value>
+  </data>
+  <data name="PlaneMesh_WidthSegments" xml:space="preserve">
+    <value>宽度分段</value>
+  </data>
+  <data name="PointLight3D" xml:space="preserve">
+    <value>点光源</value>
+  </data>
+  <data name="PointLight3D_ConstantAttenuation" xml:space="preserve">
+    <value>恒定衰减</value>
+  </data>
+  <data name="PointLight3D_LinearAttenuation" xml:space="preserve">
+    <value>线性衰减</value>
+  </data>
+  <data name="PointLight3D_QuadraticAttenuation" xml:space="preserve">
+    <value>二次衰减</value>
+  </data>
+  <data name="PointLight3D_Range" xml:space="preserve">
+    <value>范围</value>
+  </data>
+  <data name="QuadraticBezierSegment" xml:space="preserve">
+    <value>二次贝塞尔曲线</value>
+  </data>
+  <data name="QuadraticBezierSegment_ControlPoint" xml:space="preserve">
+    <value>控制点</value>
+  </data>
+  <data name="RadialGradientBrush" xml:space="preserve">
+    <value>径向渐变</value>
+  </data>
+  <data name="RadialGradientBrush_Center" xml:space="preserve">
+    <value>中心</value>
+  </data>
+  <data name="RadialGradientBrush_GradientOrigin" xml:space="preserve">
+    <value>渐变原点</value>
+  </data>
+  <data name="RectGeometry" xml:space="preserve">
+    <value>矩形</value>
+  </data>
+  <data name="RoundedRectGeometry" xml:space="preserve">
+    <value>圆角矩形</value>
+  </data>
+  <data name="RoundedRectGeometry_CornerRadius" xml:space="preserve">
+    <value>圆角半径</value>
+  </data>
+  <data name="Scene3D" xml:space="preserve">
+    <value>3D 场景</value>
+  </data>
+  <data name="Scene3D_AmbientColor" xml:space="preserve">
+    <value>环境色</value>
+  </data>
+  <data name="Scene3D_AmbientIntensity" xml:space="preserve">
+    <value>环境光强度</value>
+  </data>
+  <data name="Scene3D_BackgroundColor" xml:space="preserve">
+    <value>背景颜色</value>
+  </data>
+  <data name="Scene3D_Camera" xml:space="preserve">
+    <value>相机</value>
+  </data>
+  <data name="Scene3D_Lights" xml:space="preserve">
+    <value>灯光</value>
+  </data>
+  <data name="Scene3D_Objects" xml:space="preserve">
+    <value>对象</value>
+  </data>
+  <data name="Scene3D_RenderHeight" xml:space="preserve">
+    <value>渲染高度</value>
+  </data>
+  <data name="Scene3D_RenderWidth" xml:space="preserve">
+    <value>渲染宽度</value>
+  </data>
+  <data name="SolidColorBrush" xml:space="preserve">
+    <value>纯色</value>
+  </data>
+  <data name="Sphere3D" xml:space="preserve">
+    <value>球体</value>
+  </data>
+  <data name="Sphere3D_Rings" xml:space="preserve">
+    <value>环</value>
+  </data>
+  <data name="Sphere3D_Segments" xml:space="preserve">
+    <value>分段</value>
+  </data>
+  <data name="SphereMesh" xml:space="preserve">
+    <value>球体网格</value>
+  </data>
+  <data name="SphereMesh_Rings" xml:space="preserve">
+    <value>环</value>
+  </data>
+  <data name="SphereMesh_Segments" xml:space="preserve">
+    <value>分段</value>
+  </data>
+  <data name="SpotLight3D" xml:space="preserve">
+    <value>聚光灯</value>
+  </data>
+  <data name="SpotLight3D_ConstantAttenuation" xml:space="preserve">
+    <value>恒定衰减</value>
+  </data>
+  <data name="SpotLight3D_InnerConeAngle" xml:space="preserve">
+    <value>内锥角</value>
+  </data>
+  <data name="SpotLight3D_LinearAttenuation" xml:space="preserve">
+    <value>线性衰减</value>
+  </data>
+  <data name="SpotLight3D_OuterConeAngle" xml:space="preserve">
+    <value>外锥角</value>
+  </data>
+  <data name="SpotLight3D_QuadraticAttenuation" xml:space="preserve">
+    <value>二次衰减</value>
+  </data>
+  <data name="SpotLight3D_Range" xml:space="preserve">
+    <value>范围</value>
+  </data>
+  <data name="StrokeAlignment_Center" xml:space="preserve">
+    <value>居中</value>
+  </data>
+  <data name="StrokeAlignment_Inside" xml:space="preserve">
+    <value>内侧</value>
+  </data>
+  <data name="StrokeAlignment_Outside" xml:space="preserve">
+    <value>外侧</value>
+  </data>
+  <data name="StrokeCap_Flat" xml:space="preserve">
+    <value>平头</value>
+  </data>
+  <data name="StrokeCap_Round" xml:space="preserve">
+    <value>圆头</value>
+  </data>
+  <data name="StrokeCap_Square" xml:space="preserve">
+    <value>方头</value>
+  </data>
+  <data name="StrokeJoin_Bevel" xml:space="preserve">
+    <value>斜角连接</value>
+  </data>
+  <data name="StrokeJoin_Miter" xml:space="preserve">
+    <value>斜接连接</value>
+  </data>
+  <data name="StrokeJoin_Round" xml:space="preserve">
+    <value>圆角连接</value>
+  </data>
+  <data name="TileBrush_AlignmentX" xml:space="preserve">
+    <value>对齐 X</value>
+  </data>
+  <data name="TileBrush_AlignmentY" xml:space="preserve">
+    <value>对齐 Y</value>
+  </data>
+  <data name="TileBrush_BitmapInterpolationMode" xml:space="preserve">
+    <value>位图插值模式</value>
+  </data>
+  <data name="TileBrush_SourceRect" xml:space="preserve">
+    <value>源</value>
+  </data>
+  <data name="TileBrush_DestinationRect" xml:space="preserve">
+    <value>目标</value>
+  </data>
+  <data name="TileBrush_Stretch" xml:space="preserve">
+    <value>拉伸</value>
+  </data>
+  <data name="TileBrush_TileMode" xml:space="preserve">
+    <value>平铺模式</value>
+  </data>
+  <data name="TransparentMaterial" xml:space="preserve">
+    <value>透明材质</value>
+  </data>
+  <data name="TransparentMaterial_ColorMap" xml:space="preserve">
+    <value>颜色贴图</value>
+  </data>
+  <data name="TransparentMaterial_IndexOfRefraction" xml:space="preserve">
+    <value>折射率</value>
+  </data>
+  <data name="TransparentMaterial_Roughness" xml:space="preserve">
+    <value>粗糙度</value>
+  </data>
+  <data name="Amount" xml:space="preserve">
+    <value>数量</value>
+  </data>
+  <data name="Angle" xml:space="preserve">
+    <value>角度</value>
+  </data>
+  <data name="Brush" xml:space="preserve">
+    <value>画笔</value>
+  </data>
+  <data name="CenterX" xml:space="preserve">
+    <value>中心 X</value>
+  </data>
+  <data name="CenterY" xml:space="preserve">
+    <value>中心 Y</value>
+  </data>
+  <data name="Color" xml:space="preserve">
+    <value>颜色</value>
+  </data>
+  <data name="Depth" xml:space="preserve">
+    <value>深度</value>
+  </data>
+  <data name="Direction" xml:space="preserve">
+    <value>方向</value>
+  </data>
+  <data name="Drawable" xml:space="preserve">
+    <value>可绘制对象</value>
+  </data>
+  <data name="EndPoint" xml:space="preserve">
+    <value>终点</value>
+  </data>
+  <data name="FixImageSize" xml:space="preserve">
+    <value>固定图像大小</value>
+  </data>
+  <data name="Group" xml:space="preserve">
+    <value>组</value>
+  </data>
+  <data name="Height" xml:space="preserve">
+    <value>高度</value>
+  </data>
+  <data name="KernelSize" xml:space="preserve">
+    <value>内核大小</value>
+  </data>
+  <data name="Offset" xml:space="preserve">
+    <value>偏移</value>
+  </data>
+  <data name="Opacity" xml:space="preserve">
+    <value>不透明度</value>
+  </data>
+  <data name="Position" xml:space="preserve">
+    <value>位置</value>
+  </data>
+  <data name="Presenter" xml:space="preserve">
+    <value>呈现器</value>
+  </data>
+  <data name="Radius" xml:space="preserve">
+    <value>半径</value>
+  </data>
+  <data name="Rotation" xml:space="preserve">
+    <value>旋转</value>
+  </data>
+  <data name="Scale" xml:space="preserve">
+    <value>缩放</value>
+  </data>
+  <data name="Script" xml:space="preserve">
+    <value>脚本</value>
+  </data>
+  <data name="ShadowOnly" xml:space="preserve">
+    <value>仅阴影</value>
+  </data>
+  <data name="Sigma" xml:space="preserve">
+    <value>西格玛</value>
+  </data>
+  <data name="Smoothing" xml:space="preserve">
+    <value>平滑</value>
+  </data>
+  <data name="Source" xml:space="preserve">
+    <value>源</value>
+  </data>
+  <data name="Speed" xml:space="preserve">
+    <value>速度</value>
+  </data>
+  <data name="Strength" xml:space="preserve">
+    <value>强度</value>
+  </data>
+  <data name="Stroke" xml:space="preserve">
+    <value>描边</value>
+  </data>
+  <data name="Target" xml:space="preserve">
+    <value>目标</value>
+  </data>
+  <data name="Transform" xml:space="preserve">
+    <value>变换</value>
+  </data>
+  <data name="TransformOrigin" xml:space="preserve">
+    <value>变换原点</value>
+  </data>
+  <data name="Width" xml:space="preserve">
+    <value>宽度</value>
+  </data>
+  <data name="NodeGraphDrawable" xml:space="preserve">
+    <value>节点图（视频）</value>
+  </data>
+  <data name="NodeGraphFilterEffect" xml:space="preserve">
+    <value>节点图（效果）</value>
+  </data>
+  <data name="SceneDrawable" xml:space="preserve">
+    <value>场景引用（视频）</value>
+  </data>
+  <data name="SceneDrawable_ReferencedScene" xml:space="preserve">
+    <value>引用的场景</value>
+  </data>
+  <data name="FilterEffect" xml:space="preserve">
+    <value>滤镜效果</value>
+  </data>
+  <data name="AudioVisualizer" xml:space="preserve">
+    <value>音频可视化</value>
+  </data>
+  <data name="AudioWaveform" xml:space="preserve">
+    <value>音频波形</value>
+  </data>
+  <data name="AudioSpectrum" xml:space="preserve">
+    <value>音频频谱</value>
+  </data>
+  <data name="AudioSpectrogram" xml:space="preserve">
+    <value>音频声谱图</value>
+  </data>
+  <data name="AudioVisualizer_BarCount" xml:space="preserve">
+    <value>条数</value>
+  </data>
+  <data name="AudioVisualizer_WindowSeconds" xml:space="preserve">
+    <value>窗口（秒）</value>
+  </data>
+  <data name="AudioVisualizer_FftSize" xml:space="preserve">
+    <value>FFT 大小</value>
+  </data>
+  <data name="AudioVisualizer_FrequencyScale" xml:space="preserve">
+    <value>频率刻度</value>
+  </data>
+  <data name="AudioVisualizer_FloorDb" xml:space="preserve">
+    <value>下限 (dB)</value>
+  </data>
+  <data name="AudioVisualizer_TimeColumns" xml:space="preserve">
+    <value>时间列</value>
+  </data>
+  <data name="AudioVisualizer_Gain" xml:space="preserve">
+    <value>增益</value>
+  </data>
+  <data name="AudioVisualizer_Smoothing" xml:space="preserve">
+    <value>平滑</value>
+  </data>
+  <data name="AudioVisualizer_Shape" xml:space="preserve">
+    <value>形状</value>
+  </data>
+  <data name="SpectrumShape_Bar" xml:space="preserve">
+    <value>条形</value>
+  </data>
+  <data name="SpectrumShape_Line" xml:space="preserve">
+    <value>线条</value>
+  </data>
+  <data name="SpectrumShape_FilledArea" xml:space="preserve">
+    <value>填充区域</value>
+  </data>
+  <data name="SpectrumShape_MirroredBars" xml:space="preserve">
+    <value>镜像条形</value>
+  </data>
+  <data name="SpectrumShape_Radial" xml:space="preserve">
+    <value>径向</value>
+  </data>
+  <data name="SpectrumShape_CornerRadius" xml:space="preserve">
+    <value>圆角半径</value>
+  </data>
+  <data name="SpectrumShape_Thickness" xml:space="preserve">
+    <value>粗细</value>
+  </data>
+  <data name="SpectrumShape_Smoothness" xml:space="preserve">
+    <value>平滑度</value>
+  </data>
+  <data name="SpectrumShape_InnerRadius" xml:space="preserve">
+    <value>内半径</value>
+  </data>
+  <data name="SpectrumShape_StartAngle" xml:space="preserve">
+    <value>起始角度</value>
+  </data>
+  <data name="SpectrumShape_BarWidth" xml:space="preserve">
+    <value>条宽</value>
+  </data>
+  <data name="SpectrumShape_Direction" xml:space="preserve">
+    <value>方向</value>
+  </data>
+  <data name="WaveformShape_MinMaxBar" xml:space="preserve">
+    <value>最小最大条形</value>
+  </data>
+  <data name="WaveformShape_Line" xml:space="preserve">
+    <value>线条</value>
+  </data>
+  <data name="WaveformShape_FilledMirror" xml:space="preserve">
+    <value>填充镜像</value>
+  </data>
+  <data name="WaveformShape_FilledEnvelope" xml:space="preserve">
+    <value>填充包络</value>
+  </data>
+  <data name="WaveformShape_Block" xml:space="preserve">
+    <value>块</value>
+  </data>
+  <data name="WaveformShape_Dots" xml:space="preserve">
+    <value>点</value>
+  </data>
+  <data name="WaveformShape_Radial" xml:space="preserve">
+    <value>径向</value>
+  </data>
+  <data name="WaveformShape_BlockCount" xml:space="preserve">
+    <value>块数</value>
+  </data>
+  <data name="WaveformShape_BlockGap" xml:space="preserve">
+    <value>块间距</value>
+  </data>
+  <data name="WaveformShape_Mirrored" xml:space="preserve">
+    <value>镜像</value>
+  </data>
+  <data name="WaveformShape_Symmetric" xml:space="preserve">
+    <value>对称</value>
+  </data>
+  <data name="WaveformShape_DotRadius" xml:space="preserve">
+    <value>点半径</value>
+  </data>
+  <data name="WaveformShape_DotMode" xml:space="preserve">
+    <value>点模式</value>
+  </data>
+</root>

--- a/src/Beutl.Language/LocalizeService.cs
+++ b/src/Beutl.Language/LocalizeService.cs
@@ -5,19 +5,36 @@ namespace Beutl.Language;
 public sealed class LocalizeService
 {
     public static readonly LocalizeService Instance = new();
-    private readonly string[] _supported =
+
+    private static readonly string[] s_supported =
     [
         "en-US",
         "ja-JP",
+        "zh-CN",
+        "ko-KR",
+        "es",
     ];
 
     public bool IsSupportedCulture(CultureInfo ci)
     {
-        return _supported.Contains(ci.Name);
+        return ResolveSupportedCulture(ci) is not null;
+    }
+
+    // The list mixes specific ("ja-JP") and neutral ("es") entries, so a specific culture such as
+    // es-MX can only match through its parent.
+    public CultureInfo? ResolveSupportedCulture(CultureInfo ci)
+    {
+        foreach (string name in s_supported)
+        {
+            if (name == ci.Name || name == ci.Parent.Name)
+                return CultureInfo.GetCultureInfo(name);
+        }
+
+        return null;
     }
 
     public IEnumerable<CultureInfo> SupportedCultures()
     {
-        return _supported.Select(CultureInfo.GetCultureInfo);
+        return s_supported.Select(CultureInfo.GetCultureInfo);
     }
 }

--- a/src/Beutl.Language/MessageStrings.es.resx
+++ b/src/Beutl.Language/MessageStrings.es.resx
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<root>
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:element name="root" msdata:IsDataSet="true">
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
 
-    </xsd:element>
-  </xsd:schema>
+    </xs:element>
+  </xs:schema>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -18,413 +18,414 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ItemsSaved" xml:space="preserve">
-    <value>{0} items saved.</value>
+    <value>Se guardaron {0} elementos.</value>
   </data>
   <data name="ItemSaved" xml:space="preserve">
-    <value>{0} was saved.</value>
+    <value>Se guardó {0}.</value>
   </data>
   <data name="OperationFailed" xml:space="preserve">
-    <value>The operation could not be executed.</value>
+    <value>No se pudo ejecutar la operación.</value>
   </data>
   <data name="OperationCompletedSuccessfully" xml:space="preserve">
-    <value>The operation completed successfully.</value>
+    <value>La operación se completó correctamente.</value>
   </data>
   <data name="NoDockLayoutPresets" xml:space="preserve">
-    <value>No dock layouts have been saved yet.</value>
+    <value>Aún no se han guardado diseños de acoplamiento.</value>
   </data>
   <data name="DockLayoutSaved" xml:space="preserve">
-    <value>Saved the dock layout '{0}'.</value>
+    <value>Se guardó el diseño de acoplamiento '{0}'.</value>
   </data>
   <data name="ExportProjectPartialFailure" xml:space="preserve">
-    <value>Export completed, but {0} resources failed to copy. The exported package may be incomplete.</value>
+    <value>La exportación se completó, pero {0} recursos no se pudieron copiar. El paquete exportado puede estar incompleto.</value>
   </data>
   <data name="ConfirmDeleteDirectory" xml:space="preserve">
-    <value>Do you want to delete this directory?</value>
+    <value>¿Quieres eliminar este directorio?</value>
   </data>
   <data name="ConfirmDeleteFile" xml:space="preserve">
-    <value>Do you want to delete this file?</value>
+    <value>¿Quieres eliminar este archivo?</value>
   </data>
   <data name="ConfirmExcludeItem" xml:space="preserve">
-    <value>Do you want to exclude this item from the project?</value>
+    <value>¿Quieres excluir este elemento del proyecto?</value>
   </data>
   <data name="FailedToOpenFileWithExtension" xml:space="preserve">
-    <value>Could not open the following file with '{0}'.
+    <value>No se pudo abrir el siguiente archivo con '{0}'.
 '{1}'</value>
   </data>
   <data name="CannotDisplayContext" xml:space="preserve">
-    <value>Cannot display this context.</value>
+    <value>No se puede mostrar este contexto.</value>
   </data>
   <data name="ContextNotCreated" xml:space="preserve">
-    <value>Context not created.</value>
+    <value>No se creó el contexto.</value>
   </data>
   <data name="EditorContextAlreadyCreated" xml:space="preserve">
-    <value>The editor context has already been created.</value>
+    <value>El contexto del editor ya se ha creado.</value>
   </data>
   <data name="EditorContextNull" xml:space="preserve">
-    <value>Null was specified for the editor context.</value>
+    <value>Se especificó null para el contexto del editor.</value>
   </data>
   <data name="InputRequired" xml:space="preserve">
-    <value>Please enter a string.</value>
+    <value>Introduce una cadena.</value>
   </data>
   <data name="InvalidString" xml:space="preserve">
-    <value>Invalid string.</value>
+    <value>Cadena no válida.</value>
   </data>
   <data name="MultipleTypesAvailable" xml:space="preserve">
-    <value>Multiple types are available.</value>
+    <value>Hay varios tipos disponibles.</value>
   </data>
   <data name="AnimationIsEnabled" xml:space="preserve">
-    <value>Animation is enabled</value>
+    <value>La animación está habilitada</value>
   </data>
   <data name="AlreadyExists" xml:space="preserve">
-    <value>It already exists.</value>
+    <value>Ya existe.</value>
   </data>
   <data name="ValueLessThanOrEqualToZero" xml:space="preserve">
-    <value>Cannot specify a value less than or equal to 0.</value>
+    <value>No se puede especificar un valor menor o igual a 0.</value>
   </data>
   <data name="ValueLessThanZero" xml:space="preserve">
-    <value>Cannot specify a value less than to 0.</value>
+    <value>No se puede especificar un valor menor que 0.</value>
   </data>
   <data name="RenameConflict" xml:space="preserve">
-    <value>Cannot rename from "{0}" to "{1}"
-because the new name conflicts with an existing folder.</value>
+    <value>No se puede renombrar de "{0}" a "{1}"
+porque el nuevo nombre entra en conflicto con una carpeta existente.</value>
   </data>
   <data name="FileDoesNotExist" xml:space="preserve">
-    <value>File does not exist.</value>
+    <value>El archivo no existe.</value>
   </data>
   <data name="FailedToOpenProject" xml:space="preserve">
-    <value>Could not open project.</value>
+    <value>No se pudo abrir el proyecto.</value>
   </data>
   <data name="ProjectStateDiverged" xml:space="preserve">
-    <value>The project could not be saved and the change could not be undone. The editor no longer matches the saved file — please reopen the project.</value>
+    <value>El proyecto no se pudo guardar y el cambio no se pudo deshacer. El editor ya no coincide con el archivo guardado; vuelve a abrir el proyecto.</value>
   </data>
   <data name="ApiErrorOccurred" xml:space="preserve">
-    <value>API error occurred.</value>
+    <value>Se produjo un error de API.</value>
   </data>
   <data name="UnexpectedError" xml:space="preserve">
-    <value>An unexpected error has occurred.</value>
+    <value>Se ha producido un error inesperado.</value>
   </data>
   <data name="ConfirmLoadSideloadExtensions" xml:space="preserve">
-    <value>Do you want to load sideload extensions?</value>
+    <value>¿Quieres cargar las extensiones de carga lateral?</value>
   </data>
   <data name="AndMorePackages" xml:space="preserve">
-    <value>... and {0} more packages</value>
+    <value>... y {0} paquetes más</value>
   </data>
   <data name="UnableToSaveFile" xml:space="preserve">
-    <value>Unable to save file.</value>
+    <value>No se puede guardar el archivo.</value>
   </data>
   <data name="FailedToLoadPackage" xml:space="preserve">
-    <value>Failed to load package.</value>
+    <value>No se pudo cargar el paquete.</value>
   </data>
   <data name="FailedToLoadNPackages" xml:space="preserve">
-    <value>Failed to load {0} packages.</value>
+    <value>No se pudieron cargar {0} paquetes.</value>
   </data>
   <data name="AudioPlaybackException" xml:space="preserve">
-    <value>An exception occurred during audio playback.</value>
+    <value>Se produjo una excepción durante la reproducción de audio.</value>
   </data>
   <data name="FrameDrawingException" xml:space="preserve">
-    <value>An exception occurred while drawing the frame.</value>
+    <value>Se produjo una excepción al dibujar el fotograma.</value>
   </data>
   <data name="OutputException" xml:space="preserve">
-    <value>An exception occurred during output.</value>
+    <value>Se produjo una excepción durante la salida.</value>
   </data>
   <data name="PreviousSessionErrorTitle" xml:space="preserve">
-    <value>Looks like it ended with an error last time.</value>
+    <value>Parece que la última vez terminó con un error.</value>
   </data>
   <data name="CrashRecoveryDescription" xml:space="preserve">
-    <value>Beutl was closed unexpectedly last time. Choose how to start this session.</value>
+    <value>Beutl se cerró inesperadamente la última vez. Elige cómo iniciar esta sesión.</value>
   </data>
   <data name="CrashRecoveryRestoreOption" xml:space="preserve">
-    <value>Reopen the previous project "{0}".</value>
+    <value>Volver a abrir el proyecto anterior "{0}".</value>
   </data>
   <data name="CrashRecoveryRestrictedModeOption" xml:space="preserve">
-    <value>Run in restricted mode (extensions are not loaded).</value>
+    <value>Ejecutar en modo restringido (las extensiones no se cargan).</value>
   </data>
   <data name="PackageChangesInProgress" xml:space="preserve">
-    <value>Changes to the package are in progress.</value>
+    <value>Los cambios del paquete están en curso.</value>
   </data>
   <data name="OpeningBeutl" xml:space="preserve">
-    <value>Opening Beutl</value>
+    <value>Abriendo Beutl</value>
   </data>
   <data name="ClosePackageToolsToOpenBeutl" xml:space="preserve">
-    <value>To open Beutl, close Beutl.PackageTools.</value>
+    <value>Para abrir Beutl, cierra Beutl.PackageTools.</value>
   </data>
   <data name="NewVersionAvailable" xml:space="preserve">
-    <value>A new version is available.</value>
+    <value>Hay una nueva versión disponible.</value>
   </data>
   <data name="UpdateCheckTimedOut" xml:space="preserve">
-    <value>Update check timed out. Please check your network connection.</value>
+    <value>La comprobación de actualización agotó el tiempo. Comprueba tu conexión de red.</value>
   </data>
   <data name="RestoreFailedTypeNotFound" xml:space="preserve">
-    <value>Could not restore because the type could not be found.</value>
+    <value>No se pudo restaurar porque no se encontró el tipo.</value>
   </data>
   <data name="RestoreFailedDeserializationError" xml:space="preserve">
-    <value>Could not restore because an exception occurred during deserialization.</value>
+    <value>No se pudo restaurar porque se produjo una excepción durante la deserialización.</value>
   </data>
   <data name="UpgradeRequired" xml:space="preserve">
-    <value>Must upgrade for continued use</value>
+    <value>Debes actualizar para continuar usando</value>
   </data>
   <data name="VersionDiscontinued" xml:space="preserve">
-    <value>This version has been discontinued for compatibility reasons. Please upgrade to a newer version.</value>
+    <value>Esta versión se ha interrumpido por motivos de compatibilidad. Actualiza a una versión más reciente.</value>
   </data>
   <data name="DoubleClickToHideGroup" xml:space="preserve">
-    <value>Double-click to hide group</value>
+    <value>Doble clic para ocultar el grupo</value>
   </data>
   <data name="NoSupportedExtensionsFound" xml:space="preserve">
-    <value>No supported extensions were found</value>
+    <value>No se encontraron extensiones compatibles</value>
   </data>
   <data name="PropertyUnset" xml:space="preserve">
-    <value>Property is unset.</value>
+    <value>La propiedad no está establecida.</value>
   </data>
   <data name="RightClickToShowMenu" xml:space="preserve">
-    <value>Right-click to show menu</value>
+    <value>Clic derecho para mostrar el menú</value>
   </data>
   <data name="FailedToSaveImage" xml:space="preserve">
-    <value>Failed to save image.</value>
+    <value>No se pudo guardar la imagen.</value>
   </data>
   <data name="OpeningProject" xml:space="preserve">
-    <value>Opening a project</value>
+    <value>Abriendo un proyecto</value>
   </data>
   <data name="PleaseWaitAMoment" xml:space="preserve">
-    <value>Please wait a moment.</value>
+    <value>Espera un momento.</value>
   </data>
   <data name="OpeningProjectMessage" xml:space="preserve">
-    <value>Opening '{0}'.
-Please wait a moment.</value>
+    <value>Abriendo '{0}'.
+Espera un momento.</value>
   </data>
   <data name="FileSaveException" xml:space="preserve">
-    <value>An exception occurred while saving the file.</value>
+    <value>Se produjo una excepción al guardar el archivo.</value>
   </data>
   <data name="FilesAutoSaved" xml:space="preserve">
-    <value>Files are saved automatically.</value>
+    <value>Los archivos se guardan automáticamente.</value>
   </data>
   <data name="ViewStateSaveSuppressed" xml:space="preserve">
-    <value>The editor layout could not be saved because the existing layout file is unreadable. Restart Beutl to retry, or remove the *.config file under .beutl/view-state.</value>
+    <value>No se pudo guardar el diseño del editor porque el archivo de diseño existente no se puede leer. Reinicia Beutl para reintentar o elimina el archivo *.config en .beutl/view-state.</value>
   </data>
   <data name="DefaultTabsOpenFailed" xml:space="preserve">
-    <value>The default editor layout could not be opened. Some tool tabs may be missing — see the log for details.</value>
+    <value>No se pudo abrir el diseño predeterminado del editor. Es posible que falten algunas pestañas de herramientas; consulta el registro para obtener más detalles.</value>
   </data>
   <data name="SvgPathParsingException" xml:space="preserve">
-    <value>An exception occurred while parsing the SVG path.</value>
+    <value>Se produjo una excepción al analizar la ruta SVG.</value>
   </data>
   <data name="SigninInvalid" xml:space="preserve">
-    <value>Sign-in has become invalid. Please sign in again.</value>
+    <value>El inicio de sesión ha dejado de ser válido. Vuelve a iniciar sesión.</value>
   </data>
   <data name="FileNotSelected" xml:space="preserve">
-    <value>File is not selected</value>
+    <value>No se seleccionó ningún archivo</value>
   </data>
   <data name="CheckDifferentVersion_Title" xml:space="preserve">
-    <value>Opening a file that was opened in a previous version may result in file corruption.</value>
+    <value>Abrir un archivo que se abrió en una versión anterior puede provocar daños en el archivo.</value>
   </data>
   <data name="CheckDifferentVersion_Content" xml:space="preserve">
-    <value>You are running on a different version than last time.</value>
+    <value>Estás ejecutando una versión diferente a la última vez.</value>
   </data>
   <data name="ProjectVersionMismatch_Title" xml:space="preserve">
-    <value>Version Mismatch</value>
+    <value>Desajuste de versión</value>
   </data>
   <data name="ProjectVersionMismatch_Content" xml:space="preserve">
-    <value>The project was created with a newer version of Beutl (&gt;= {0}). Please update Beutl to open the project.</value>
+    <value>El proyecto se creó con una versión más reciente de Beutl (&gt;= {0}). Actualiza Beutl para abrir el proyecto.</value>
   </data>
   <data name="FailedToLoadMetadata" xml:space="preserve">
-    <value>Failed to retrieve metadata.</value>
+    <value>No se pudieron recuperar los metadatos.</value>
   </data>
   <data name="DownloadFailed" xml:space="preserve">
-    <value>Download failed.</value>
+    <value>La descarga falló.</value>
   </data>
   <data name="FailedToLoadScript" xml:space="preserve">
-    <value>Failed to load script.</value>
+    <value>No se pudo cargar el script.</value>
   </data>
   <data name="ExportMissingSourceFile" xml:space="preserve">
-    <value>Export cannot start because a referenced source file is missing: {0} ({1} missing).</value>
+    <value>La exportación no puede comenzar porque falta un archivo de origen referenciado: {0} ({1} faltantes).</value>
   </data>
   <data name="SaveFrameMissingSourceFile" xml:space="preserve">
-    <value>Cannot render the frame because a referenced source file is missing: {0} ({1} missing).</value>
+    <value>No se puede renderizar el fotograma porque falta un archivo de origen referenciado: {0} ({1} faltantes).</value>
   </data>
   <data name="ApplicationRestartRequired" xml:space="preserve">
-    <value>The application needs to be restarted.
-Do you want to restart the application?</value>
+    <value>La aplicación debe reiniciarse.
+¿Quieres reiniciar la aplicación?</value>
   </data>
   <data name="StartInstaller" xml:space="preserve">
-    <value>Start the installer,</value>
+    <value>Iniciar el instalador,</value>
   </data>
   <data name="Downloading" xml:space="preserve">
-    <value>Downloading...</value>
+    <value>Descargando...</value>
   </data>
   <data name="DownloadComplete" xml:space="preserve">
-    <value>Download is complete.</value>
+    <value>La descarga está completa.</value>
   </data>
   <data name="Canceled" xml:space="preserve">
-    <value>Canceled.</value>
+    <value>Cancelado.</value>
   </data>
   <data name="Extracting" xml:space="preserve">
-    <value>Extracting...</value>
+    <value>Extrayendo...</value>
   </data>
   <data name="ExtractionComplete" xml:space="preserve">
-    <value>Extraction is complete.</value>
+    <value>La extracción está completa.</value>
   </data>
   <data name="ScriptErrorTerminated" xml:space="preserve">
-    <value>An error has occurred. Terminate script.</value>
+    <value>Se ha producido un error. Terminar el script.</value>
   </data>
   <data name="PressEnterToContinue" xml:space="preserve">
-    <value>Press Enter to continue...</value>
+    <value>Pulsa Enter para continuar...</value>
   </data>
   <data name="UpdateDirectoryNotFound" xml:space="preserve">
-    <value>Error: Update directory does not exist.</value>
+    <value>Error: el directorio de actualización no existe.</value>
   </data>
   <data name="ExitApplication" xml:space="preserve">
-    <value>Exit the application (Beutl).</value>
+    <value>Salir de la aplicación (Beutl).</value>
   </data>
   <data name="PressEnterWhenFinished" xml:space="preserve">
-    <value>Press the Enter key when finished.</value>
+    <value>Pulsa la tecla Enter cuando termines.</value>
   </data>
   <data name="AcquiringLock" xml:space="preserve">
-    <value>Getting a lock...</value>
+    <value>Obteniendo un bloqueo...</value>
   </data>
   <data name="LockAcquired" xml:space="preserve">
-    <value>Lock acquired.</value>
+    <value>Bloqueo adquirido.</value>
   </data>
   <data name="FailedToAcquireLock" xml:space="preserve">
-    <value>Failed to acquire lock.</value>
+    <value>No se pudo adquirir el bloqueo.</value>
   </data>
   <data name="CreatingBackup" xml:space="preserve">
-    <value>Create backup of current application:</value>
+    <value>Crear copia de seguridad de la aplicación actual:</value>
   </data>
   <data name="FailedToCreateBackup" xml:space="preserve">
-    <value>Failed to create backup.</value>
+    <value>No se pudo crear la copia de seguridad.</value>
   </data>
   <data name="UpdatingFiles" xml:space="preserve">
-    <value>Updating files in place...</value>
+    <value>Actualizando archivos en su lugar...</value>
   </data>
   <data name="UpdateFailedRestoringBackup" xml:space="preserve">
-    <value>Update placement failed. Restore backup...</value>
+    <value>La colocación de la actualización falló. Restaurando copia de seguridad...</value>
   </data>
   <data name="UpdateCompleted" xml:space="preserve">
-    <value>The update has been completed.</value>
+    <value>La actualización se ha completado.</value>
   </data>
   <data name="LockReleased" xml:space="preserve">
-    <value>Unlocked.</value>
+    <value>Desbloqueado.</value>
   </data>
   <data name="UpdateCompletedLaunchPrompt" xml:space="preserve">
-    <value>Update completed. Do you want to start the application? (y/n):</value>
+    <value>Actualización completada. ¿Quieres iniciar la aplicación? (s/n):</value>
   </data>
   <data name="LaunchingApplication" xml:space="preserve">
-    <value>Launch the application...</value>
+    <value>Iniciando la aplicación...</value>
   </data>
   <data name="FailedToChangePermissions" xml:space="preserve">
-    <value>Failed to change application execution permissions.</value>
+    <value>No se pudieron cambiar los permisos de ejecución de la aplicación.</value>
   </data>
   <data name="ApplicationPathNotSpecified" xml:space="preserve">
-    <value>The application execution path is not specified.</value>
+    <value>No se especificó la ruta de ejecución de la aplicación.</value>
   </data>
   <data name="ApplicationNotLaunched" xml:space="preserve">
-    <value>The application was not launched.</value>
+    <value>La aplicación no se inició.</value>
   </data>
   <data name="ClickOkAfterCompletion" xml:space="preserve">
-    <value>Click OK after completion</value>
+    <value>Haz clic en Aceptar después de completar</value>
   </data>
   <data name="UpdateCompletedLaunchConfirm" xml:space="preserve">
-    <value>Update completed. Do you want to start the ߋn application?</value>
+    <value>Actualización completada. ¿Quieres iniciar la aplicación?</value>
   </data>
   <data name="FailedToRestoreBackup" xml:space="preserve">
-    <value>Failed to restore backup.</value>
+    <value>No se pudo restaurar la copia de seguridad.</value>
   </data>
   <data name="FailedToDeleteBackup" xml:space="preserve">
-    <value>Failed to delete backup.</value>
+    <value>No se pudo eliminar la copia de seguridad.</value>
   </data>
   <data name="ConfirmInstall" xml:space="preserve">
-    <value>Do you want to install?
-(The update function is an experimental feature.)</value>
+    <value>¿Quieres instalar?
+(La función de actualización es una característica experimental.)</value>
   </data>
   <data name="ExpressionIsSet" xml:space="preserve">
-    <value>Expression is set</value>
+    <value>La expresión está establecida</value>
   </data>
   <data name="PackageUpdatesAvailable" xml:space="preserve">
-    <value>Package updates are available.</value>
+    <value>Hay actualizaciones de paquetes disponibles.</value>
   </data>
   <data name="PackagesCanBeUpdated" xml:space="preserve">
-    <value>{0} package(s) can be updated.</value>
+    <value>Se pueden actualizar {0} paquete(s).</value>
   </data>
   <data name="IsNotValid" xml:space="preserve">
-    <value>{0} is not a valid.</value>
+    <value>{0} no es válido.</value>
   </data>
   <data name="InvalidJson" xml:space="preserve">
-    <value>Invalid Json.</value>
+    <value>JSON no válido.</value>
   </data>
   <data name="ColorGradingMissing" xml:space="preserve">
-    <value>No Color Grading effect is selected.</value>
+    <value>No se seleccionó ningún efecto de gradación de color.</value>
   </data>
   <data name="ColorCurvesMissing" xml:space="preserve">
-    <value>No Color Curves effect is selected.</value>
+    <value>No se seleccionó ningún efecto de curvas de color.</value>
   </data>
   <data name="FailedToCopyKeyframe" xml:space="preserve">
-    <value>Failed to copy keyframe</value>
+    <value>No se pudo copiar el fotograma clave</value>
   </data>
   <data name="FailedToPasteKeyframe" xml:space="preserve">
-    <value>Failed to paste keyframe</value>
+    <value>No se pudo pegar el fotograma clave</value>
   </data>
   <data name="FailedToCopyAnimation" xml:space="preserve">
-    <value>Failed to copy animation</value>
+    <value>No se pudo copiar la animación</value>
   </data>
   <data name="InvalidKeyframeDataFormat" xml:space="preserve">
-    <value>Invalid keyframe data format.</value>
+    <value>Formato de datos de fotograma clave no válido.</value>
   </data>
   <data name="InvalidKeyframeDataFormat_MissingType" xml:space="preserve">
-    <value>Invalid keyframe data format. missing $type.</value>
+    <value>Formato de datos de fotograma clave no válido. Falta $type.</value>
   </data>
   <data name="InvalidKeyframeDataFormat_TypeIsNotKeyFrame" xml:space="preserve">
-    <value>Invalid keyframe data format. $type is not KeyFrame.</value>
+    <value>Formato de datos de fotograma clave no válido. $type no es KeyFrame.</value>
   </data>
   <data name="KeyframePropertyTypeMismatch_EasingApplied" xml:space="preserve">
-    <value>The property type of the pasted keyframe does not match. Only the easing is applied.</value>
+    <value>El tipo de propiedad del fotograma clave pegado no coincide. Solo se aplicó el suavizado.</value>
   </data>
   <data name="InvalidJSON_MissingType" xml:space="preserve">
-    <value>Invalid JSON: missing $type</value>
+    <value>JSON no válido: falta $type</value>
   </data>
   <data name="InvalidJSON_TypeIsNotKeyFrameAnimation" xml:space="preserve">
-    <value>Invalid JSON: $type is not a KeyFrameAnimation</value>
+    <value>JSON no válido: $type no es KeyFrameAnimation</value>
   </data>
   <data name="InvalidJSON_TypeIsNotKeyFrame" xml:space="preserve">
-    <value>Invalid JSON: $type is not a KeyFrame</value>
+    <value>JSON no válido: $type no es KeyFrame</value>
   </data>
   <data name="AnimationPropertyTypeMismatch" xml:space="preserve">
-    <value>The property type of the pasted animation does not match. (Expected: {0}, Actual: {1})</value>
+    <value>El tipo de propiedad de la animación pegada no coincide. (Esperado: {0}, Real: {1})</value>
   </data>
   <data name="KeyframeExistsAtPastePosition" xml:space="preserve">
-    <value>A keyframe already exists at the paste position. The easing and value have been updated.</value>
+    <value>Ya existe un fotograma clave en la posición de pegado. El suavizado y el valor se han actualizado.</value>
   </data>
   <data name="CannotPasteFromClipboard" xml:space="preserve">
-    <value>Cannot paste: clipboard does not contain a compatible object.</value>
+    <value>No se puede pegar: el portapapeles no contiene un objeto compatible.</value>
   </data>
   <data name="ExportCompleted_File" xml:space="preserve">
-    <value>Export completed: {0}</value>
+    <value>Exportación completada: {0}</value>
   </data>
   <data name="SupersamplingExceedsMaxRenderSize" xml:space="preserve">
-    <value>Supersampling {0}× requires a {1}×{2} px render surface, which exceeds the limit of {3} px per axis. Choose a lower supersampling factor.</value>
+    <value>El supermuestreo {0}× requiere una superficie de renderizado de {1}×{2} px, que supera el límite de {3} px por eje. Elige un factor de supermuestreo más bajo.</value>
   </data>
   <data name="SaveImageExceedsMaxRenderSize" xml:space="preserve">
-    <value>Scale {0}× requires a {1}×{2} px render surface, which exceeds the limit of {3} px per axis. Choose a lower scale.</value>
+    <value>La escala {0}× requiere una superficie de renderizado de {1}×{2} px, que supera el límite de {3} px por eje. Elige una escala más baja.</value>
   </data>
   <data name="SaveImageElementRendersNothing" xml:space="preserve">
-    <value>The selected element renders nothing (0 × 0 px), so it cannot be saved as an image.</value>
+    <value>El elemento seleccionado no renderiza nada (0 × 0 px), por lo que no se puede guardar como imagen.</value>
   </data>
   <data name="SceneSettings_ApplyCanceledInputsInvalid" xml:space="preserve">
-    <value>Apply was canceled because the scene settings became invalid while pausing playback.</value>
+    <value>Se canceló la aplicación porque la configuración de la escena se volvió no válida al pausar la reproducción.</value>
   </data>
   <data name="ScriptValidationUnavailable" xml:space="preserve">
-    <value>Validation is unavailable here (no graphics context); the script was not checked.</value>
+    <value>La validación no está disponible aquí (sin contexto gráfico); el script no se comprobó.</value>
   </data>
   <data name="WindowCapture_RecordingStarted" xml:space="preserve">
-    <value>Recording started: {0}x{1} @ {2}fps</value>
+    <value>Grabación iniciada: {0}x{1} @ {2}fps</value>
   </data>
   <data name="WindowCapture_NoActiveSession" xml:space="preserve">
-    <value>No active capture session.</value>
+    <value>No hay una sesión de captura activa.</value>
   </data>
   <data name="WindowCapture_Saved" xml:space="preserve">
-    <value>Saved: {0}&#10;Captured {1} frames (dropped {2}).</value>
+    <value>Guardado: {0}
+Se capturaron {1} fotogramas (se descartaron {2}).</value>
   </data>
   <data name="WindowCapture_AlreadyRunning" xml:space="preserve">
-    <value>A capture session is already running. Stop it before starting a new one.</value>
+    <value>Ya hay una sesión de captura en ejecución. Detenla antes de iniciar una nueva.</value>
   </data>
   <data name="WindowCapture_FfmpegNotFound" xml:space="preserve">
-    <value>ffmpeg executable was not found. Install ffmpeg and ensure it is on PATH.</value>
+    <value>No se encontró el ejecutable de ffmpeg. Instala ffmpeg y asegúrate de que esté en PATH.</value>
   </data>
 </root>

--- a/src/Beutl.Language/MessageStrings.ja.resx
+++ b/src/Beutl.Language/MessageStrings.ja.resx
@@ -407,4 +407,19 @@
   <data name="ScriptValidationUnavailable" xml:space="preserve">
     <value>ここでは検証を利用できません（グラフィックスコンテキストがないため）。スクリプトはチェックされていません。</value>
   </data>
+  <data name="WindowCapture_RecordingStarted" xml:space="preserve">
+    <value>録画を開始しました: {0}x{1} @ {2}fps</value>
+  </data>
+  <data name="WindowCapture_NoActiveSession" xml:space="preserve">
+    <value>アクティブなキャプチャセッションがありません。</value>
+  </data>
+  <data name="WindowCapture_Saved" xml:space="preserve">
+    <value>保存しました: {0}&#10;キャプチャ {1} フレーム (ドロップ {2})。</value>
+  </data>
+  <data name="WindowCapture_AlreadyRunning" xml:space="preserve">
+    <value>キャプチャセッションは既に実行中です。新しいセッションを開始する前に停止してください。</value>
+  </data>
+  <data name="WindowCapture_FfmpegNotFound" xml:space="preserve">
+    <value>ffmpeg 実行ファイルが見つかりませんでした。ffmpeg をインストールして PATH に追加してください。</value>
+  </data>
 </root>

--- a/src/Beutl.Language/MessageStrings.ko-KR.resx
+++ b/src/Beutl.Language/MessageStrings.ko-KR.resx
@@ -1,0 +1,431 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ItemsSaved" xml:space="preserve">
+    <value>{0}개 항목이 저장되었습니다.</value>
+  </data>
+  <data name="ItemSaved" xml:space="preserve">
+    <value>{0}이(가) 저장되었습니다.</value>
+  </data>
+  <data name="OperationFailed" xml:space="preserve">
+    <value>작업을 실행할 수 없습니다.</value>
+  </data>
+  <data name="OperationCompletedSuccessfully" xml:space="preserve">
+    <value>작업이 성공적으로 완료되었습니다.</value>
+  </data>
+  <data name="NoDockLayoutPresets" xml:space="preserve">
+    <value>저장된 도킹 레이아웃이 아직 없습니다.</value>
+  </data>
+  <data name="DockLayoutSaved" xml:space="preserve">
+    <value>도킹 레이아웃 '{0}'을(를) 저장했습니다.</value>
+  </data>
+  <data name="ExportProjectPartialFailure" xml:space="preserve">
+    <value>내보내기가 완료되었지만 {0}개 리소스를 복사하지 못했습니다. 내보낸 패키지가 불완전할 수 있습니다.</value>
+  </data>
+  <data name="ConfirmDeleteDirectory" xml:space="preserve">
+    <value>이 디렉터리를 삭제하시겠습니까?</value>
+  </data>
+  <data name="ConfirmDeleteFile" xml:space="preserve">
+    <value>이 파일을 삭제하시겠습니까?</value>
+  </data>
+  <data name="ConfirmExcludeItem" xml:space="preserve">
+    <value>이 항목을 프로젝트에서 제외하시겠습니까?</value>
+  </data>
+  <data name="FailedToOpenFileWithExtension" xml:space="preserve">
+    <value>'{0}'(으)로 다음 파일을 열 수 없습니다.
+'{1}'</value>
+  </data>
+  <data name="CannotDisplayContext" xml:space="preserve">
+    <value>이 컨텍스트를 표시할 수 없습니다.</value>
+  </data>
+  <data name="ContextNotCreated" xml:space="preserve">
+    <value>컨텍스트가 생성되지 않았습니다.</value>
+  </data>
+  <data name="EditorContextAlreadyCreated" xml:space="preserve">
+    <value>편집기 컨텍스트가 이미 생성되었습니다.</value>
+  </data>
+  <data name="EditorContextNull" xml:space="preserve">
+    <value>편집기 컨텍스트에 null이 지정되었습니다.</value>
+  </data>
+  <data name="InputRequired" xml:space="preserve">
+    <value>문자열을 입력하세요.</value>
+  </data>
+  <data name="InvalidString" xml:space="preserve">
+    <value>잘못된 문자열입니다.</value>
+  </data>
+  <data name="MultipleTypesAvailable" xml:space="preserve">
+    <value>여러 유형을 사용할 수 있습니다.</value>
+  </data>
+  <data name="AnimationIsEnabled" xml:space="preserve">
+    <value>애니메이션이 활성화되었습니다</value>
+  </data>
+  <data name="AlreadyExists" xml:space="preserve">
+    <value>이미 존재합니다.</value>
+  </data>
+  <data name="ValueLessThanOrEqualToZero" xml:space="preserve">
+    <value>0보다 작거나 같은 값을 지정할 수 없습니다.</value>
+  </data>
+  <data name="ValueLessThanZero" xml:space="preserve">
+    <value>0보다 작은 값을 지정할 수 없습니다.</value>
+  </data>
+  <data name="RenameConflict" xml:space="preserve">
+    <value>'{0}'을(를) '{1}'(으)로 이름을 바꿀 수 없습니다.
+새 이름이 기존 폴더와 충돌하기 때문입니다.</value>
+  </data>
+  <data name="FileDoesNotExist" xml:space="preserve">
+    <value>파일이 존재하지 않습니다.</value>
+  </data>
+  <data name="FailedToOpenProject" xml:space="preserve">
+    <value>프로젝트를 열 수 없습니다.</value>
+  </data>
+  <data name="ProjectStateDiverged" xml:space="preserve">
+    <value>프로젝트를 저장할 수 없고 변경 사항을 실행 취소할 수 없습니다. 편집기가 저장된 파일과 더 이상 일치하지 않습니다. 프로젝트를 다시 여세요.</value>
+  </data>
+  <data name="ApiErrorOccurred" xml:space="preserve">
+    <value>API 오류가 발생했습니다.</value>
+  </data>
+  <data name="UnexpectedError" xml:space="preserve">
+    <value>예기치 않은 오류가 발생했습니다.</value>
+  </data>
+  <data name="ConfirmLoadSideloadExtensions" xml:space="preserve">
+    <value>사이드로드 확장 프로그램을 로드하시겠습니까?</value>
+  </data>
+  <data name="AndMorePackages" xml:space="preserve">
+    <value>... 외 {0}개 패키지</value>
+  </data>
+  <data name="UnableToSaveFile" xml:space="preserve">
+    <value>파일을 저장할 수 없습니다.</value>
+  </data>
+  <data name="FailedToLoadPackage" xml:space="preserve">
+    <value>패키지를 로드하지 못했습니다.</value>
+  </data>
+  <data name="FailedToLoadNPackages" xml:space="preserve">
+    <value>{0}개 패키지를 로드하지 못했습니다.</value>
+  </data>
+  <data name="AudioPlaybackException" xml:space="preserve">
+    <value>오디오 재생 중 예외가 발생했습니다.</value>
+  </data>
+  <data name="FrameDrawingException" xml:space="preserve">
+    <value>프레임을 그리는 동안 예외가 발생했습니다.</value>
+  </data>
+  <data name="OutputException" xml:space="preserve">
+    <value>출력 중 예외가 발생했습니다.</value>
+  </data>
+  <data name="PreviousSessionErrorTitle" xml:space="preserve">
+    <value>지난번에 오류로 종료된 것 같습니다.</value>
+  </data>
+  <data name="CrashRecoveryDescription" xml:space="preserve">
+    <value>지난번에 Beutl이 예기치 않게 종료되었습니다. 이 세션을 시작할 방법을 선택하세요.</value>
+  </data>
+  <data name="CrashRecoveryRestoreOption" xml:space="preserve">
+    <value>이전 프로젝트 '{0}'을(를) 다시 엽니다.</value>
+  </data>
+  <data name="CrashRecoveryRestrictedModeOption" xml:space="preserve">
+    <value>제한 모드로 실행합니다(확장 프로그램이 로드되지 않음).</value>
+  </data>
+  <data name="PackageChangesInProgress" xml:space="preserve">
+    <value>패키지 변경이 진행 중입니다.</value>
+  </data>
+  <data name="OpeningBeutl" xml:space="preserve">
+    <value>Beutl 여는 중</value>
+  </data>
+  <data name="ClosePackageToolsToOpenBeutl" xml:space="preserve">
+    <value>Beutl을 열려면 Beutl.PackageTools를 닫으세요.</value>
+  </data>
+  <data name="NewVersionAvailable" xml:space="preserve">
+    <value>새 버전을 사용할 수 있습니다.</value>
+  </data>
+  <data name="UpdateCheckTimedOut" xml:space="preserve">
+    <value>업데이트 확인 시간이 초과되었습니다. 네트워크 연결을 확인하세요.</value>
+  </data>
+  <data name="RestoreFailedTypeNotFound" xml:space="preserve">
+    <value>유형을 찾을 수 없어 복원할 수 없습니다.</value>
+  </data>
+  <data name="RestoreFailedDeserializationError" xml:space="preserve">
+    <value>역직렬화 중 예외가 발생하여 복원할 수 없습니다.</value>
+  </data>
+  <data name="UpgradeRequired" xml:space="preserve">
+    <value>계속 사용하려면 업그레이드해야 합니다</value>
+  </data>
+  <data name="VersionDiscontinued" xml:space="preserve">
+    <value>호환성 이유로 이 버전은 중단되었습니다. 최신 버전으로 업그레이드하세요.</value>
+  </data>
+  <data name="DoubleClickToHideGroup" xml:space="preserve">
+    <value>그룹을 숨기려면 두 번 클릭</value>
+  </data>
+  <data name="NoSupportedExtensionsFound" xml:space="preserve">
+    <value>지원되는 확장 프로그램을 찾을 수 없습니다</value>
+  </data>
+  <data name="PropertyUnset" xml:space="preserve">
+    <value>속성이 설정되지 않았습니다.</value>
+  </data>
+  <data name="RightClickToShowMenu" xml:space="preserve">
+    <value>메뉴를 표시하려면 마우스 오른쪽 버튼 클릭</value>
+  </data>
+  <data name="FailedToSaveImage" xml:space="preserve">
+    <value>이미지를 저장하지 못했습니다.</value>
+  </data>
+  <data name="OpeningProject" xml:space="preserve">
+    <value>프로젝트 여는 중</value>
+  </data>
+  <data name="PleaseWaitAMoment" xml:space="preserve">
+    <value>잠시 기다려 주세요.</value>
+  </data>
+  <data name="OpeningProjectMessage" xml:space="preserve">
+    <value>'{0}'을(를) 여는 중입니다.
+잠시 기다려 주세요.</value>
+  </data>
+  <data name="FileSaveException" xml:space="preserve">
+    <value>파일을 저장하는 동안 예외가 발생했습니다.</value>
+  </data>
+  <data name="FilesAutoSaved" xml:space="preserve">
+    <value>파일이 자동으로 저장됩니다.</value>
+  </data>
+  <data name="ViewStateSaveSuppressed" xml:space="preserve">
+    <value>기존 레이아웃 파일을 읽을 수 없어 편집기 레이아웃을 저장할 수 없습니다. Beutl을 다시 시작하여 재시도하거나 .beutl/view-state 아래의 *.config 파일을 제거하세요.</value>
+  </data>
+  <data name="DefaultTabsOpenFailed" xml:space="preserve">
+    <value>기본 편집기 레이아웃을 열 수 없습니다. 일부 도구 탭이 없을 수 있습니다. 자세한 내용은 로그를 참조하세요.</value>
+  </data>
+  <data name="SvgPathParsingException" xml:space="preserve">
+    <value>SVG 경로를 구문 분석하는 동안 예외가 발생했습니다.</value>
+  </data>
+  <data name="SigninInvalid" xml:space="preserve">
+    <value>로그인이 유효하지 않게 되었습니다. 다시 로그인하세요.</value>
+  </data>
+  <data name="FileNotSelected" xml:space="preserve">
+    <value>파일이 선택되지 않았습니다</value>
+  </data>
+  <data name="CheckDifferentVersion_Title" xml:space="preserve">
+    <value>이전 버전에서 열었던 파일을 열면 파일이 손상될 수 있습니다.</value>
+  </data>
+  <data name="CheckDifferentVersion_Content" xml:space="preserve">
+    <value>지난번과 다른 버전으로 실행 중입니다.</value>
+  </data>
+  <data name="ProjectVersionMismatch_Title" xml:space="preserve">
+    <value>버전 불일치</value>
+  </data>
+  <data name="ProjectVersionMismatch_Content" xml:space="preserve">
+    <value>이 프로젝트는 최신 버전의 Beutl(&gt;= {0})로 생성되었습니다. 프로젝트를 열려면 Beutl을 업데이트하세요.</value>
+  </data>
+  <data name="FailedToLoadMetadata" xml:space="preserve">
+    <value>메타데이터를 검색하지 못했습니다.</value>
+  </data>
+  <data name="DownloadFailed" xml:space="preserve">
+    <value>다운로드에 실패했습니다.</value>
+  </data>
+  <data name="FailedToLoadScript" xml:space="preserve">
+    <value>스크립트를 로드하지 못했습니다.</value>
+  </data>
+  <data name="ExportMissingSourceFile" xml:space="preserve">
+    <value>참조된 소스 파일이 없어 내보내기를 시작할 수 없습니다: {0}({1}개 누락).</value>
+  </data>
+  <data name="SaveFrameMissingSourceFile" xml:space="preserve">
+    <value>참조된 소스 파일이 없어 프레임을 렌더링할 수 없습니다: {0}({1}개 누락).</value>
+  </data>
+  <data name="ApplicationRestartRequired" xml:space="preserve">
+    <value>애플리케이션을 다시 시작해야 합니다.
+애플리케이션을 다시 시작하시겠습니까?</value>
+  </data>
+  <data name="StartInstaller" xml:space="preserve">
+    <value>설치 프로그램을 시작합니다.</value>
+  </data>
+  <data name="Downloading" xml:space="preserve">
+    <value>다운로드 중...</value>
+  </data>
+  <data name="DownloadComplete" xml:space="preserve">
+    <value>다운로드가 완료되었습니다.</value>
+  </data>
+  <data name="Canceled" xml:space="preserve">
+    <value>취소되었습니다.</value>
+  </data>
+  <data name="Extracting" xml:space="preserve">
+    <value>추출 중...</value>
+  </data>
+  <data name="ExtractionComplete" xml:space="preserve">
+    <value>추출이 완료되었습니다.</value>
+  </data>
+  <data name="ScriptErrorTerminated" xml:space="preserve">
+    <value>오류가 발생했습니다. 스크립트를 종료합니다.</value>
+  </data>
+  <data name="PressEnterToContinue" xml:space="preserve">
+    <value>계속하려면 Enter를 누르세요...</value>
+  </data>
+  <data name="UpdateDirectoryNotFound" xml:space="preserve">
+    <value>오류: 업데이트 디렉터리가 존재하지 않습니다.</value>
+  </data>
+  <data name="ExitApplication" xml:space="preserve">
+    <value>애플리케이션(Beutl)을 종료합니다.</value>
+  </data>
+  <data name="PressEnterWhenFinished" xml:space="preserve">
+    <value>완료되면 Enter 키를 누르세요.</value>
+  </data>
+  <data name="AcquiringLock" xml:space="preserve">
+    <value>잠금을 가져오는 중...</value>
+  </data>
+  <data name="LockAcquired" xml:space="preserve">
+    <value>잠금을 획득했습니다.</value>
+  </data>
+  <data name="FailedToAcquireLock" xml:space="preserve">
+    <value>잠금을 획득하지 못했습니다.</value>
+  </data>
+  <data name="CreatingBackup" xml:space="preserve">
+    <value>현재 애플리케이션의 백업 만들기:</value>
+  </data>
+  <data name="FailedToCreateBackup" xml:space="preserve">
+    <value>백업을 만들지 못했습니다.</value>
+  </data>
+  <data name="UpdatingFiles" xml:space="preserve">
+    <value>파일을 제자리에서 업데이트하는 중...</value>
+  </data>
+  <data name="UpdateFailedRestoringBackup" xml:space="preserve">
+    <value>업데이트 배치에 실패했습니다. 백업을 복원하는 중...</value>
+  </data>
+  <data name="UpdateCompleted" xml:space="preserve">
+    <value>업데이트가 완료되었습니다.</value>
+  </data>
+  <data name="LockReleased" xml:space="preserve">
+    <value>잠금이 해제되었습니다.</value>
+  </data>
+  <data name="UpdateCompletedLaunchPrompt" xml:space="preserve">
+    <value>업데이트가 완료되었습니다. 애플리케이션을 시작하시겠습니까? (y/n):</value>
+  </data>
+  <data name="LaunchingApplication" xml:space="preserve">
+    <value>애플리케이션을 시작하는 중...</value>
+  </data>
+  <data name="FailedToChangePermissions" xml:space="preserve">
+    <value>애플리케이션 실행 권한을 변경하지 못했습니다.</value>
+  </data>
+  <data name="ApplicationPathNotSpecified" xml:space="preserve">
+    <value>애플리케이션 실행 경로가 지정되지 않았습니다.</value>
+  </data>
+  <data name="ApplicationNotLaunched" xml:space="preserve">
+    <value>애플리케이션이 시작되지 않았습니다.</value>
+  </data>
+  <data name="ClickOkAfterCompletion" xml:space="preserve">
+    <value>완료 후 확인을 클릭하세요</value>
+  </data>
+  <data name="UpdateCompletedLaunchConfirm" xml:space="preserve">
+    <value>업데이트가 완료되었습니다. 애플리케이션을 시작하시겠습니까?</value>
+  </data>
+  <data name="FailedToRestoreBackup" xml:space="preserve">
+    <value>백업을 복원하지 못했습니다.</value>
+  </data>
+  <data name="FailedToDeleteBackup" xml:space="preserve">
+    <value>백업을 삭제하지 못했습니다.</value>
+  </data>
+  <data name="ConfirmInstall" xml:space="preserve">
+    <value>설치하시겠습니까?
+(업데이트 기능은 실험적 기능입니다.)</value>
+  </data>
+  <data name="ExpressionIsSet" xml:space="preserve">
+    <value>식이 설정되었습니다</value>
+  </data>
+  <data name="PackageUpdatesAvailable" xml:space="preserve">
+    <value>패키지 업데이트를 사용할 수 있습니다.</value>
+  </data>
+  <data name="PackagesCanBeUpdated" xml:space="preserve">
+    <value>{0}개 패키지를 업데이트할 수 있습니다.</value>
+  </data>
+  <data name="IsNotValid" xml:space="preserve">
+    <value>{0}은(는) 유효하지 않습니다.</value>
+  </data>
+  <data name="InvalidJson" xml:space="preserve">
+    <value>잘못된 JSON입니다.</value>
+  </data>
+  <data name="ColorGradingMissing" xml:space="preserve">
+    <value>선택된 색상 그레이딩 효과가 없습니다.</value>
+  </data>
+  <data name="ColorCurvesMissing" xml:space="preserve">
+    <value>선택된 색상 곡선 효과가 없습니다.</value>
+  </data>
+  <data name="FailedToCopyKeyframe" xml:space="preserve">
+    <value>키프레임을 복사하지 못했습니다</value>
+  </data>
+  <data name="FailedToPasteKeyframe" xml:space="preserve">
+    <value>키프레임을 붙여넣지 못했습니다</value>
+  </data>
+  <data name="FailedToCopyAnimation" xml:space="preserve">
+    <value>애니메이션을 복사하지 못했습니다</value>
+  </data>
+  <data name="InvalidKeyframeDataFormat" xml:space="preserve">
+    <value>잘못된 키프레임 데이터 형식입니다.</value>
+  </data>
+  <data name="InvalidKeyframeDataFormat_MissingType" xml:space="preserve">
+    <value>잘못된 키프레임 데이터 형식입니다. $type이(가) 없습니다.</value>
+  </data>
+  <data name="InvalidKeyframeDataFormat_TypeIsNotKeyFrame" xml:space="preserve">
+    <value>잘못된 키프레임 데이터 형식입니다. $type이(가) KeyFrame이 아닙니다.</value>
+  </data>
+  <data name="KeyframePropertyTypeMismatch_EasingApplied" xml:space="preserve">
+    <value>붙여넣은 키프레임의 속성 유형이 일치하지 않습니다. 이징만 적용되었습니다.</value>
+  </data>
+  <data name="InvalidJSON_MissingType" xml:space="preserve">
+    <value>잘못된 JSON: $type이(가) 없습니다</value>
+  </data>
+  <data name="InvalidJSON_TypeIsNotKeyFrameAnimation" xml:space="preserve">
+    <value>잘못된 JSON: $type이(가) KeyFrameAnimation이 아닙니다</value>
+  </data>
+  <data name="InvalidJSON_TypeIsNotKeyFrame" xml:space="preserve">
+    <value>잘못된 JSON: $type이(가) KeyFrame이 아닙니다</value>
+  </data>
+  <data name="AnimationPropertyTypeMismatch" xml:space="preserve">
+    <value>붙여넣은 애니메이션의 속성 유형이 일치하지 않습니다. (예상: {0}, 실제: {1})</value>
+  </data>
+  <data name="KeyframeExistsAtPastePosition" xml:space="preserve">
+    <value>붙여넣기 위치에 키프레임이 이미 있습니다. 이징과 값이 업데이트되었습니다.</value>
+  </data>
+  <data name="CannotPasteFromClipboard" xml:space="preserve">
+    <value>붙여넣을 수 없습니다: 클립보드에 호환되는 개체가 없습니다.</value>
+  </data>
+  <data name="ExportCompleted_File" xml:space="preserve">
+    <value>내보내기 완료: {0}</value>
+  </data>
+  <data name="SupersamplingExceedsMaxRenderSize" xml:space="preserve">
+    <value>슈퍼샘플링 {0}×에는 {1}×{2}px 렌더 표면이 필요하며, 이는 축당 {3}px 제한을 초과합니다. 더 낮은 슈퍼샘플링 계수를 선택하세요.</value>
+  </data>
+  <data name="SaveImageExceedsMaxRenderSize" xml:space="preserve">
+    <value>배율 {0}×에는 {1}×{2}px 렌더 표면이 필요하며, 이는 축당 {3}px 제한을 초과합니다. 더 낮은 배율을 선택하세요.</value>
+  </data>
+  <data name="SaveImageElementRendersNothing" xml:space="preserve">
+    <value>선택한 요소는 아무것도 렌더링하지 않으므로(0 × 0px) 이미지로 저장할 수 없습니다.</value>
+  </data>
+  <data name="SceneSettings_ApplyCanceledInputsInvalid" xml:space="preserve">
+    <value>재생을 일시 중지하는 동안 장면 설정이 유효하지 않게 되어 적용이 취소되었습니다.</value>
+  </data>
+  <data name="ScriptValidationUnavailable" xml:space="preserve">
+    <value>여기서는 검증을 사용할 수 없습니다(그래픽 컨텍스트 없음). 스크립트가 확인되지 않았습니다.</value>
+  </data>
+  <data name="WindowCapture_RecordingStarted" xml:space="preserve">
+    <value>녹화 시작됨: {0}x{1} @ {2}fps</value>
+  </data>
+  <data name="WindowCapture_NoActiveSession" xml:space="preserve">
+    <value>활성 캡처 세션이 없습니다.</value>
+  </data>
+  <data name="WindowCapture_Saved" xml:space="preserve">
+    <value>저장됨: {0}
+{1}프레임 캡처(드롭 {2}).</value>
+  </data>
+  <data name="WindowCapture_AlreadyRunning" xml:space="preserve">
+    <value>캡처 세션이 이미 실행 중입니다. 새 세션을 시작하기 전에 중지하세요.</value>
+  </data>
+  <data name="WindowCapture_FfmpegNotFound" xml:space="preserve">
+    <value>ffmpeg 실행 파일을 찾을 수 없습니다. ffmpeg를 설치하고 PATH에 있는지 확인하세요.</value>
+  </data>
+</root>

--- a/src/Beutl.Language/MessageStrings.zh-CN.resx
+++ b/src/Beutl.Language/MessageStrings.zh-CN.resx
@@ -295,7 +295,7 @@
     <value>正在就地更新文件...</value>
   </data>
   <data name="UpdateFailedRestoringBackup" xml:space="preserve">
-    <value>更新放置失败。正在还原备份...</value>
+    <value>更新失败。正在还原备份...</value>
   </data>
   <data name="UpdateCompleted" xml:space="preserve">
     <value>更新已完成。</value>

--- a/src/Beutl.Language/MessageStrings.zh-CN.resx
+++ b/src/Beutl.Language/MessageStrings.zh-CN.resx
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<root>
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:element name="root" msdata:IsDataSet="true">
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
 
-    </xsd:element>
-  </xsd:schema>
+    </xs:element>
+  </xs:schema>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -18,413 +18,414 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ItemsSaved" xml:space="preserve">
-    <value>{0} items saved.</value>
+    <value>已保存 {0} 个项目。</value>
   </data>
   <data name="ItemSaved" xml:space="preserve">
-    <value>{0} was saved.</value>
+    <value>{0} 已保存。</value>
   </data>
   <data name="OperationFailed" xml:space="preserve">
-    <value>The operation could not be executed.</value>
+    <value>无法执行该操作。</value>
   </data>
   <data name="OperationCompletedSuccessfully" xml:space="preserve">
-    <value>The operation completed successfully.</value>
+    <value>操作已成功完成。</value>
   </data>
   <data name="NoDockLayoutPresets" xml:space="preserve">
-    <value>No dock layouts have been saved yet.</value>
+    <value>尚未保存任何停靠布局。</value>
   </data>
   <data name="DockLayoutSaved" xml:space="preserve">
-    <value>Saved the dock layout '{0}'.</value>
+    <value>已保存停靠布局“{0}”。</value>
   </data>
   <data name="ExportProjectPartialFailure" xml:space="preserve">
-    <value>Export completed, but {0} resources failed to copy. The exported package may be incomplete.</value>
+    <value>导出已完成，但 {0} 个资源复制失败。导出的包可能不完整。</value>
   </data>
   <data name="ConfirmDeleteDirectory" xml:space="preserve">
-    <value>Do you want to delete this directory?</value>
+    <value>是否要删除此目录？</value>
   </data>
   <data name="ConfirmDeleteFile" xml:space="preserve">
-    <value>Do you want to delete this file?</value>
+    <value>是否要删除此文件？</value>
   </data>
   <data name="ConfirmExcludeItem" xml:space="preserve">
-    <value>Do you want to exclude this item from the project?</value>
+    <value>是否要将此项目从项目中排除？</value>
   </data>
   <data name="FailedToOpenFileWithExtension" xml:space="preserve">
-    <value>Could not open the following file with '{0}'.
-'{1}'</value>
+    <value>无法使用“{0}”打开以下文件。
+“{1}”</value>
   </data>
   <data name="CannotDisplayContext" xml:space="preserve">
-    <value>Cannot display this context.</value>
+    <value>无法显示此上下文。</value>
   </data>
   <data name="ContextNotCreated" xml:space="preserve">
-    <value>Context not created.</value>
+    <value>上下文未创建。</value>
   </data>
   <data name="EditorContextAlreadyCreated" xml:space="preserve">
-    <value>The editor context has already been created.</value>
+    <value>编辑器上下文已创建。</value>
   </data>
   <data name="EditorContextNull" xml:space="preserve">
-    <value>Null was specified for the editor context.</value>
+    <value>为编辑器上下文指定了 null。</value>
   </data>
   <data name="InputRequired" xml:space="preserve">
-    <value>Please enter a string.</value>
+    <value>请输入字符串。</value>
   </data>
   <data name="InvalidString" xml:space="preserve">
-    <value>Invalid string.</value>
+    <value>无效的字符串。</value>
   </data>
   <data name="MultipleTypesAvailable" xml:space="preserve">
-    <value>Multiple types are available.</value>
+    <value>有多个可用类型。</value>
   </data>
   <data name="AnimationIsEnabled" xml:space="preserve">
-    <value>Animation is enabled</value>
+    <value>动画已启用</value>
   </data>
   <data name="AlreadyExists" xml:space="preserve">
-    <value>It already exists.</value>
+    <value>它已存在。</value>
   </data>
   <data name="ValueLessThanOrEqualToZero" xml:space="preserve">
-    <value>Cannot specify a value less than or equal to 0.</value>
+    <value>不能指定小于或等于 0 的值。</value>
   </data>
   <data name="ValueLessThanZero" xml:space="preserve">
-    <value>Cannot specify a value less than to 0.</value>
+    <value>不能指定小于 0 的值。</value>
   </data>
   <data name="RenameConflict" xml:space="preserve">
-    <value>Cannot rename from "{0}" to "{1}"
-because the new name conflicts with an existing folder.</value>
+    <value>无法将“{0}”重命名为“{1}”
+因为新名称与现有文件夹冲突。</value>
   </data>
   <data name="FileDoesNotExist" xml:space="preserve">
-    <value>File does not exist.</value>
+    <value>文件不存在。</value>
   </data>
   <data name="FailedToOpenProject" xml:space="preserve">
-    <value>Could not open project.</value>
+    <value>无法打开项目。</value>
   </data>
   <data name="ProjectStateDiverged" xml:space="preserve">
-    <value>The project could not be saved and the change could not be undone. The editor no longer matches the saved file — please reopen the project.</value>
+    <value>项目无法保存，更改也无法撤销。编辑器不再与保存的文件一致——请重新打开项目。</value>
   </data>
   <data name="ApiErrorOccurred" xml:space="preserve">
-    <value>API error occurred.</value>
+    <value>发生 API 错误。</value>
   </data>
   <data name="UnexpectedError" xml:space="preserve">
-    <value>An unexpected error has occurred.</value>
+    <value>发生了意外错误。</value>
   </data>
   <data name="ConfirmLoadSideloadExtensions" xml:space="preserve">
-    <value>Do you want to load sideload extensions?</value>
+    <value>是否要加载旁加载扩展？</value>
   </data>
   <data name="AndMorePackages" xml:space="preserve">
-    <value>... and {0} more packages</value>
+    <value>... 以及另外 {0} 个包</value>
   </data>
   <data name="UnableToSaveFile" xml:space="preserve">
-    <value>Unable to save file.</value>
+    <value>无法保存文件。</value>
   </data>
   <data name="FailedToLoadPackage" xml:space="preserve">
-    <value>Failed to load package.</value>
+    <value>加载包失败。</value>
   </data>
   <data name="FailedToLoadNPackages" xml:space="preserve">
-    <value>Failed to load {0} packages.</value>
+    <value>加载 {0} 个包失败。</value>
   </data>
   <data name="AudioPlaybackException" xml:space="preserve">
-    <value>An exception occurred during audio playback.</value>
+    <value>音频播放期间发生异常。</value>
   </data>
   <data name="FrameDrawingException" xml:space="preserve">
-    <value>An exception occurred while drawing the frame.</value>
+    <value>绘制帧时发生异常。</value>
   </data>
   <data name="OutputException" xml:space="preserve">
-    <value>An exception occurred during output.</value>
+    <value>输出期间发生异常。</value>
   </data>
   <data name="PreviousSessionErrorTitle" xml:space="preserve">
-    <value>Looks like it ended with an error last time.</value>
+    <value>上次似乎以错误结束。</value>
   </data>
   <data name="CrashRecoveryDescription" xml:space="preserve">
-    <value>Beutl was closed unexpectedly last time. Choose how to start this session.</value>
+    <value>上次 Beutl 意外关闭。选择如何启动此会话。</value>
   </data>
   <data name="CrashRecoveryRestoreOption" xml:space="preserve">
-    <value>Reopen the previous project "{0}".</value>
+    <value>重新打开上一个项目“{0}”。</value>
   </data>
   <data name="CrashRecoveryRestrictedModeOption" xml:space="preserve">
-    <value>Run in restricted mode (extensions are not loaded).</value>
+    <value>以受限模式运行（不加载扩展）。</value>
   </data>
   <data name="PackageChangesInProgress" xml:space="preserve">
-    <value>Changes to the package are in progress.</value>
+    <value>包的更改正在进行中。</value>
   </data>
   <data name="OpeningBeutl" xml:space="preserve">
-    <value>Opening Beutl</value>
+    <value>正在打开 Beutl</value>
   </data>
   <data name="ClosePackageToolsToOpenBeutl" xml:space="preserve">
-    <value>To open Beutl, close Beutl.PackageTools.</value>
+    <value>要打开 Beutl，请关闭 Beutl.PackageTools。</value>
   </data>
   <data name="NewVersionAvailable" xml:space="preserve">
-    <value>A new version is available.</value>
+    <value>有新版本可用。</value>
   </data>
   <data name="UpdateCheckTimedOut" xml:space="preserve">
-    <value>Update check timed out. Please check your network connection.</value>
+    <value>更新检查超时。请检查您的网络连接。</value>
   </data>
   <data name="RestoreFailedTypeNotFound" xml:space="preserve">
-    <value>Could not restore because the type could not be found.</value>
+    <value>无法还原，因为找不到该类型。</value>
   </data>
   <data name="RestoreFailedDeserializationError" xml:space="preserve">
-    <value>Could not restore because an exception occurred during deserialization.</value>
+    <value>无法还原，因为反序列化期间发生异常。</value>
   </data>
   <data name="UpgradeRequired" xml:space="preserve">
-    <value>Must upgrade for continued use</value>
+    <value>必须升级才能继续使用</value>
   </data>
   <data name="VersionDiscontinued" xml:space="preserve">
-    <value>This version has been discontinued for compatibility reasons. Please upgrade to a newer version.</value>
+    <value>出于兼容性原因，此版本已停止使用。请升级到较新版本。</value>
   </data>
   <data name="DoubleClickToHideGroup" xml:space="preserve">
-    <value>Double-click to hide group</value>
+    <value>双击以隐藏组</value>
   </data>
   <data name="NoSupportedExtensionsFound" xml:space="preserve">
-    <value>No supported extensions were found</value>
+    <value>未找到受支持的扩展</value>
   </data>
   <data name="PropertyUnset" xml:space="preserve">
-    <value>Property is unset.</value>
+    <value>属性未设置。</value>
   </data>
   <data name="RightClickToShowMenu" xml:space="preserve">
-    <value>Right-click to show menu</value>
+    <value>右键单击以显示菜单</value>
   </data>
   <data name="FailedToSaveImage" xml:space="preserve">
-    <value>Failed to save image.</value>
+    <value>保存图像失败。</value>
   </data>
   <data name="OpeningProject" xml:space="preserve">
-    <value>Opening a project</value>
+    <value>正在打开项目</value>
   </data>
   <data name="PleaseWaitAMoment" xml:space="preserve">
-    <value>Please wait a moment.</value>
+    <value>请稍候。</value>
   </data>
   <data name="OpeningProjectMessage" xml:space="preserve">
-    <value>Opening '{0}'.
-Please wait a moment.</value>
+    <value>正在打开“{0}”。
+请稍候。</value>
   </data>
   <data name="FileSaveException" xml:space="preserve">
-    <value>An exception occurred while saving the file.</value>
+    <value>保存文件时发生异常。</value>
   </data>
   <data name="FilesAutoSaved" xml:space="preserve">
-    <value>Files are saved automatically.</value>
+    <value>文件会自动保存。</value>
   </data>
   <data name="ViewStateSaveSuppressed" xml:space="preserve">
-    <value>The editor layout could not be saved because the existing layout file is unreadable. Restart Beutl to retry, or remove the *.config file under .beutl/view-state.</value>
+    <value>无法保存编辑器布局，因为现有布局文件不可读。请重新启动 Beutl 重试，或删除 .beutl/view-state 下的 *.config 文件。</value>
   </data>
   <data name="DefaultTabsOpenFailed" xml:space="preserve">
-    <value>The default editor layout could not be opened. Some tool tabs may be missing — see the log for details.</value>
+    <value>无法打开默认编辑器布局。某些工具选项卡可能缺失——有关详细信息，请参阅日志。</value>
   </data>
   <data name="SvgPathParsingException" xml:space="preserve">
-    <value>An exception occurred while parsing the SVG path.</value>
+    <value>解析 SVG 路径时发生异常。</value>
   </data>
   <data name="SigninInvalid" xml:space="preserve">
-    <value>Sign-in has become invalid. Please sign in again.</value>
+    <value>登录已失效。请重新登录。</value>
   </data>
   <data name="FileNotSelected" xml:space="preserve">
-    <value>File is not selected</value>
+    <value>未选择文件</value>
   </data>
   <data name="CheckDifferentVersion_Title" xml:space="preserve">
-    <value>Opening a file that was opened in a previous version may result in file corruption.</value>
+    <value>打开在先前版本中打开过的文件可能会导致文件损坏。</value>
   </data>
   <data name="CheckDifferentVersion_Content" xml:space="preserve">
-    <value>You are running on a different version than last time.</value>
+    <value>您运行的版本与上次不同。</value>
   </data>
   <data name="ProjectVersionMismatch_Title" xml:space="preserve">
-    <value>Version Mismatch</value>
+    <value>版本不匹配</value>
   </data>
   <data name="ProjectVersionMismatch_Content" xml:space="preserve">
-    <value>The project was created with a newer version of Beutl (&gt;= {0}). Please update Beutl to open the project.</value>
+    <value>此项目是使用较新版本的 Beutl (&gt;= {0}) 创建的。请更新 Beutl 以打开此项目。</value>
   </data>
   <data name="FailedToLoadMetadata" xml:space="preserve">
-    <value>Failed to retrieve metadata.</value>
+    <value>检索元数据失败。</value>
   </data>
   <data name="DownloadFailed" xml:space="preserve">
-    <value>Download failed.</value>
+    <value>下载失败。</value>
   </data>
   <data name="FailedToLoadScript" xml:space="preserve">
-    <value>Failed to load script.</value>
+    <value>加载脚本失败。</value>
   </data>
   <data name="ExportMissingSourceFile" xml:space="preserve">
-    <value>Export cannot start because a referenced source file is missing: {0} ({1} missing).</value>
+    <value>无法开始导出，因为引用的源文件缺失：{0}（缺少 {1} 个）。</value>
   </data>
   <data name="SaveFrameMissingSourceFile" xml:space="preserve">
-    <value>Cannot render the frame because a referenced source file is missing: {0} ({1} missing).</value>
+    <value>无法渲染帧，因为引用的源文件缺失：{0}（缺少 {1} 个）。</value>
   </data>
   <data name="ApplicationRestartRequired" xml:space="preserve">
-    <value>The application needs to be restarted.
-Do you want to restart the application?</value>
+    <value>需要重新启动应用程序。
+是否要重新启动应用程序？</value>
   </data>
   <data name="StartInstaller" xml:space="preserve">
-    <value>Start the installer,</value>
+    <value>启动安装程序，</value>
   </data>
   <data name="Downloading" xml:space="preserve">
-    <value>Downloading...</value>
+    <value>正在下载...</value>
   </data>
   <data name="DownloadComplete" xml:space="preserve">
-    <value>Download is complete.</value>
+    <value>下载完成。</value>
   </data>
   <data name="Canceled" xml:space="preserve">
-    <value>Canceled.</value>
+    <value>已取消。</value>
   </data>
   <data name="Extracting" xml:space="preserve">
-    <value>Extracting...</value>
+    <value>正在解压...</value>
   </data>
   <data name="ExtractionComplete" xml:space="preserve">
-    <value>Extraction is complete.</value>
+    <value>解压完成。</value>
   </data>
   <data name="ScriptErrorTerminated" xml:space="preserve">
-    <value>An error has occurred. Terminate script.</value>
+    <value>发生错误。终止脚本。</value>
   </data>
   <data name="PressEnterToContinue" xml:space="preserve">
-    <value>Press Enter to continue...</value>
+    <value>按 Enter 继续...</value>
   </data>
   <data name="UpdateDirectoryNotFound" xml:space="preserve">
-    <value>Error: Update directory does not exist.</value>
+    <value>错误：更新目录不存在。</value>
   </data>
   <data name="ExitApplication" xml:space="preserve">
-    <value>Exit the application (Beutl).</value>
+    <value>退出应用程序 (Beutl)。</value>
   </data>
   <data name="PressEnterWhenFinished" xml:space="preserve">
-    <value>Press the Enter key when finished.</value>
+    <value>完成后按 Enter 键。</value>
   </data>
   <data name="AcquiringLock" xml:space="preserve">
-    <value>Getting a lock...</value>
+    <value>正在获取锁...</value>
   </data>
   <data name="LockAcquired" xml:space="preserve">
-    <value>Lock acquired.</value>
+    <value>已获取锁。</value>
   </data>
   <data name="FailedToAcquireLock" xml:space="preserve">
-    <value>Failed to acquire lock.</value>
+    <value>获取锁失败。</value>
   </data>
   <data name="CreatingBackup" xml:space="preserve">
-    <value>Create backup of current application:</value>
+    <value>创建当前应用程序的备份：</value>
   </data>
   <data name="FailedToCreateBackup" xml:space="preserve">
-    <value>Failed to create backup.</value>
+    <value>创建备份失败。</value>
   </data>
   <data name="UpdatingFiles" xml:space="preserve">
-    <value>Updating files in place...</value>
+    <value>正在就地更新文件...</value>
   </data>
   <data name="UpdateFailedRestoringBackup" xml:space="preserve">
-    <value>Update placement failed. Restore backup...</value>
+    <value>更新放置失败。正在还原备份...</value>
   </data>
   <data name="UpdateCompleted" xml:space="preserve">
-    <value>The update has been completed.</value>
+    <value>更新已完成。</value>
   </data>
   <data name="LockReleased" xml:space="preserve">
-    <value>Unlocked.</value>
+    <value>已解锁。</value>
   </data>
   <data name="UpdateCompletedLaunchPrompt" xml:space="preserve">
-    <value>Update completed. Do you want to start the application? (y/n):</value>
+    <value>更新完成。是否要启动应用程序？(y/n)：</value>
   </data>
   <data name="LaunchingApplication" xml:space="preserve">
-    <value>Launch the application...</value>
+    <value>正在启动应用程序...</value>
   </data>
   <data name="FailedToChangePermissions" xml:space="preserve">
-    <value>Failed to change application execution permissions.</value>
+    <value>更改应用程序执行权限失败。</value>
   </data>
   <data name="ApplicationPathNotSpecified" xml:space="preserve">
-    <value>The application execution path is not specified.</value>
+    <value>未指定应用程序执行路径。</value>
   </data>
   <data name="ApplicationNotLaunched" xml:space="preserve">
-    <value>The application was not launched.</value>
+    <value>应用程序未启动。</value>
   </data>
   <data name="ClickOkAfterCompletion" xml:space="preserve">
-    <value>Click OK after completion</value>
+    <value>完成后单击“确定”</value>
   </data>
   <data name="UpdateCompletedLaunchConfirm" xml:space="preserve">
-    <value>Update completed. Do you want to start the ߋn application?</value>
+    <value>更新完成。是否要启动应用程序？</value>
   </data>
   <data name="FailedToRestoreBackup" xml:space="preserve">
-    <value>Failed to restore backup.</value>
+    <value>还原备份失败。</value>
   </data>
   <data name="FailedToDeleteBackup" xml:space="preserve">
-    <value>Failed to delete backup.</value>
+    <value>删除备份失败。</value>
   </data>
   <data name="ConfirmInstall" xml:space="preserve">
-    <value>Do you want to install?
-(The update function is an experimental feature.)</value>
+    <value>是否要安装？
+（更新功能是实验性功能。）</value>
   </data>
   <data name="ExpressionIsSet" xml:space="preserve">
-    <value>Expression is set</value>
+    <value>已设置表达式</value>
   </data>
   <data name="PackageUpdatesAvailable" xml:space="preserve">
-    <value>Package updates are available.</value>
+    <value>有可用的包更新。</value>
   </data>
   <data name="PackagesCanBeUpdated" xml:space="preserve">
-    <value>{0} package(s) can be updated.</value>
+    <value>有 {0} 个包可以更新。</value>
   </data>
   <data name="IsNotValid" xml:space="preserve">
-    <value>{0} is not a valid.</value>
+    <value>{0} 无效。</value>
   </data>
   <data name="InvalidJson" xml:space="preserve">
-    <value>Invalid Json.</value>
+    <value>无效的 JSON。</value>
   </data>
   <data name="ColorGradingMissing" xml:space="preserve">
-    <value>No Color Grading effect is selected.</value>
+    <value>未选择颜色分级效果。</value>
   </data>
   <data name="ColorCurvesMissing" xml:space="preserve">
-    <value>No Color Curves effect is selected.</value>
+    <value>未选择颜色曲线效果。</value>
   </data>
   <data name="FailedToCopyKeyframe" xml:space="preserve">
-    <value>Failed to copy keyframe</value>
+    <value>复制关键帧失败</value>
   </data>
   <data name="FailedToPasteKeyframe" xml:space="preserve">
-    <value>Failed to paste keyframe</value>
+    <value>粘贴关键帧失败</value>
   </data>
   <data name="FailedToCopyAnimation" xml:space="preserve">
-    <value>Failed to copy animation</value>
+    <value>复制动画失败</value>
   </data>
   <data name="InvalidKeyframeDataFormat" xml:space="preserve">
-    <value>Invalid keyframe data format.</value>
+    <value>无效的关键帧数据格式。</value>
   </data>
   <data name="InvalidKeyframeDataFormat_MissingType" xml:space="preserve">
-    <value>Invalid keyframe data format. missing $type.</value>
+    <value>无效的关键帧数据格式。缺少 $type。</value>
   </data>
   <data name="InvalidKeyframeDataFormat_TypeIsNotKeyFrame" xml:space="preserve">
-    <value>Invalid keyframe data format. $type is not KeyFrame.</value>
+    <value>无效的关键帧数据格式。$type 不是 KeyFrame。</value>
   </data>
   <data name="KeyframePropertyTypeMismatch_EasingApplied" xml:space="preserve">
-    <value>The property type of the pasted keyframe does not match. Only the easing is applied.</value>
+    <value>粘贴的关键帧的属性类型不匹配。仅应用了缓动。</value>
   </data>
   <data name="InvalidJSON_MissingType" xml:space="preserve">
-    <value>Invalid JSON: missing $type</value>
+    <value>无效的 JSON：缺少 $type</value>
   </data>
   <data name="InvalidJSON_TypeIsNotKeyFrameAnimation" xml:space="preserve">
-    <value>Invalid JSON: $type is not a KeyFrameAnimation</value>
+    <value>无效的 JSON：$type 不是 KeyFrameAnimation</value>
   </data>
   <data name="InvalidJSON_TypeIsNotKeyFrame" xml:space="preserve">
-    <value>Invalid JSON: $type is not a KeyFrame</value>
+    <value>无效的 JSON：$type 不是 KeyFrame</value>
   </data>
   <data name="AnimationPropertyTypeMismatch" xml:space="preserve">
-    <value>The property type of the pasted animation does not match. (Expected: {0}, Actual: {1})</value>
+    <value>粘贴的动画的属性类型不匹配。（预期：{0}，实际：{1}）</value>
   </data>
   <data name="KeyframeExistsAtPastePosition" xml:space="preserve">
-    <value>A keyframe already exists at the paste position. The easing and value have been updated.</value>
+    <value>粘贴位置已存在关键帧。缓动和值已更新。</value>
   </data>
   <data name="CannotPasteFromClipboard" xml:space="preserve">
-    <value>Cannot paste: clipboard does not contain a compatible object.</value>
+    <value>无法粘贴：剪贴板不包含兼容的对象。</value>
   </data>
   <data name="ExportCompleted_File" xml:space="preserve">
-    <value>Export completed: {0}</value>
+    <value>导出完成：{0}</value>
   </data>
   <data name="SupersamplingExceedsMaxRenderSize" xml:space="preserve">
-    <value>Supersampling {0}× requires a {1}×{2} px render surface, which exceeds the limit of {3} px per axis. Choose a lower supersampling factor.</value>
+    <value>超采样 {0}× 需要 {1}×{2} px 的渲染表面，超过了每轴 {3} px 的限制。请选择较低的超采样系数。</value>
   </data>
   <data name="SaveImageExceedsMaxRenderSize" xml:space="preserve">
-    <value>Scale {0}× requires a {1}×{2} px render surface, which exceeds the limit of {3} px per axis. Choose a lower scale.</value>
+    <value>缩放 {0}× 需要 {1}×{2} px 的渲染表面，超过了每轴 {3} px 的限制。请选择较低的缩放。</value>
   </data>
   <data name="SaveImageElementRendersNothing" xml:space="preserve">
-    <value>The selected element renders nothing (0 × 0 px), so it cannot be saved as an image.</value>
+    <value>所选元素不渲染任何内容（0 × 0 px），因此无法保存为图像。</value>
   </data>
   <data name="SceneSettings_ApplyCanceledInputsInvalid" xml:space="preserve">
-    <value>Apply was canceled because the scene settings became invalid while pausing playback.</value>
+    <value>暂停播放期间场景设置变得无效，因此取消了应用。</value>
   </data>
   <data name="ScriptValidationUnavailable" xml:space="preserve">
-    <value>Validation is unavailable here (no graphics context); the script was not checked.</value>
+    <value>此处无法进行验证（没有图形上下文）；脚本未检查。</value>
   </data>
   <data name="WindowCapture_RecordingStarted" xml:space="preserve">
-    <value>Recording started: {0}x{1} @ {2}fps</value>
+    <value>录制已开始：{0}x{1} @ {2}fps</value>
   </data>
   <data name="WindowCapture_NoActiveSession" xml:space="preserve">
-    <value>No active capture session.</value>
+    <value>没有活动的捕获会话。</value>
   </data>
   <data name="WindowCapture_Saved" xml:space="preserve">
-    <value>Saved: {0}&#10;Captured {1} frames (dropped {2}).</value>
+    <value>已保存：{0}
+捕获了 {1} 帧（丢弃了 {2} 帧）。</value>
   </data>
   <data name="WindowCapture_AlreadyRunning" xml:space="preserve">
-    <value>A capture session is already running. Stop it before starting a new one.</value>
+    <value>捕获会话已在运行。在开始新会话之前请先停止它。</value>
   </data>
   <data name="WindowCapture_FfmpegNotFound" xml:space="preserve">
-    <value>ffmpeg executable was not found. Install ffmpeg and ensure it is on PATH.</value>
+    <value>未找到 ffmpeg 可执行文件。请安装 ffmpeg 并确保它在 PATH 中。</value>
   </data>
 </root>

--- a/src/Beutl.Language/SettingsStrings.es.resx
+++ b/src/Beutl.Language/SettingsStrings.es.resx
@@ -1,0 +1,630 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="SignOut" xml:space="preserve">
+    <value>Cerrar sesión</value>
+    <comment />
+  </data>
+  <data name="ChangeAccountSettings" xml:space="preserve">
+    <value>Cambiar la configuración de la cuenta</value>
+    <comment />
+  </data>
+  <data name="SignIn" xml:space="preserve">
+    <value>Iniciar sesión</value>
+    <comment />
+  </data>
+  <data name="SignInWith" xml:space="preserve">
+    <value>Inicia sesión con tus cuentas sociales</value>
+    <comment />
+  </data>
+  <data name="SignInViaBrowser" xml:space="preserve">
+    <value>Iniciar sesión mediante el navegador</value>
+    <comment />
+  </data>
+  <data name="Editor_Extension_Priority" xml:space="preserve">
+    <value>Prioridad de extensión del editor</value>
+    <comment />
+  </data>
+  <data name="Higher" xml:space="preserve">
+    <value>Más alta</value>
+    <comment />
+  </data>
+  <data name="Lower" xml:space="preserve">
+    <value>Más baja</value>
+    <comment />
+  </data>
+  <data name="All_Editor_Extensions" xml:space="preserve">
+    <value>Todas las extensiones del editor</value>
+    <comment />
+  </data>
+  <data name="Add_file_extension" xml:space="preserve">
+    <value>Agregar extensión de archivo</value>
+    <comment />
+  </data>
+  <data name="Theme_Tip" xml:space="preserve">
+    <value>Selecciona el tema de la aplicación que quieres mostrar.</value>
+    <comment />
+  </data>
+  <data name="Please_enter_a_file_extension" xml:space="preserve">
+    <value>Introduce una extensión de archivo.</value>
+    <comment />
+  </data>
+  <data name="The_following_characters_are_not_allowed" xml:space="preserve">
+    <value>No se permiten los siguientes caracteres (" &gt; &lt; | : ? * \\ /)</value>
+    <comment />
+  </data>
+  <data name="This_file_extension_already_exists" xml:space="preserve">
+    <value>Esta extensión de archivo ya existe.</value>
+    <comment />
+  </data>
+  <data name="CopyVersionInfo" xml:space="preserve">
+    <value>Copiar información de versión</value>
+    <comment />
+  </data>
+  <data name="DeviceInformation" xml:space="preserve">
+    <value>Información del dispositivo</value>
+  </data>
+  <data name="EditorSettings" xml:space="preserve">
+    <value>Configuración del editor</value>
+    <comment />
+  </data>
+  <data name="DecoderPriority" xml:space="preserve">
+    <value>Prioridad del decodificador</value>
+    <comment />
+  </data>
+  <data name="DecoderPriority_Description" xml:space="preserve">
+    <value>Puedes cambiar el orden de prioridad de los decodificadores. El decodificador superior tiene prioridad.</value>
+    <comment />
+  </data>
+  <data name="AccentColor" xml:space="preserve">
+    <value>Color de acento</value>
+    <comment />
+  </data>
+  <data name="CustomColor" xml:space="preserve">
+    <value>Color personalizado</value>
+    <comment />
+  </data>
+  <data name="UseCustomAccentColor" xml:space="preserve">
+    <value>Usar color de acento personalizado</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Beutl_Application" xml:space="preserve">
+    <value>Aplicación</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Description_Beutl_Application" xml:space="preserve">
+    <value>Se recopila la siguiente información para mejorar el rendimiento de la aplicación: hora de inicio de la aplicación, tiempo transcurrido de la operación y número de elementos recuperados por la API</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Beutl_PackageManagement" xml:space="preserve">
+    <value>Gestión de paquetes</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Description_Beutl_PackageManagement" xml:space="preserve">
+    <value>Recopila el tiempo que se tarda en instalar y cargar las extensiones.</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Beutl_Api_Client" xml:space="preserve">
+    <value>Cliente de API</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Description_Beutl_Api_Client" xml:space="preserve">
+    <value>Recopila los tiempos de llamada a la API utilizados por la tienda de extensiones y las funciones de la cuenta.</value>
+    <comment />
+  </data>
+  <data name="Telemetry" xml:space="preserve">
+    <value>Telemetría</value>
+    <comment />
+  </data>
+  <data name="Telemetry_ShortDescription" xml:space="preserve">
+    <value>Configuración sobre los datos que se recopilarán</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Description" xml:space="preserve">
+    <value>Para mejorar Beutl, recopilamos datos de uso anónimos. Esta configuración se aplicará después de reiniciar la aplicación. Para obtener más información, consulta las siguientes páginas.</value>
+    <comment />
+  </data>
+  <data name="ShowExactBoundaries_Description" xml:space="preserve">
+    <value>Muestra los límites de los elementos con precisión durante la vista previa. Habilitar esta configuración puede hacer que el borde sea invisible.</value>
+    <comment />
+  </data>
+  <data name="ShowExactBoundaries" xml:space="preserve">
+    <value>Mostrar límites precisos</value>
+    <comment />
+  </data>
+  <data name="AutoAdjustSceneDuration" xml:space="preserve">
+    <value>Ajustar automáticamente la duración de la escena</value>
+    <comment />
+  </data>
+  <data name="AutoAdjustSceneDuration_Description" xml:space="preserve">
+    <value>Cuando se agregan elementos, si es necesario ajustar la duración de la escena, se hará automáticamente.</value>
+    <comment />
+  </data>
+  <data name="SomeSettingsHaveBeenMoved" xml:space="preserve">
+    <value>Algunos ajustes se han movido.</value>
+    <comment />
+  </data>
+  <data name="EnablePointerLockInProperty" xml:space="preserve">
+    <value>Habilitar bloqueo de puntero</value>
+    <comment />
+  </data>
+  <data name="EnablePointerLockInProperty_Description" xml:space="preserve">
+    <value>Oculta el cursor durante las operaciones de arrastre en el editor de propiedades. (Solo Windows)</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Beutl_Logging" xml:space="preserve">
+    <value>Registro</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Description_Beutl_Logging" xml:space="preserve">
+    <value>Se recopila información de uso más detallada. Los registros enviados también se almacenan en el directorio ".beutl/log".</value>
+    <comment />
+  </data>
+  <data name="EnableAutoSave" xml:space="preserve">
+    <value>Habilitar guardado automático</value>
+    <comment />
+  </data>
+  <data name="EnableAutoSave_Description" xml:space="preserve">
+    <value>El archivo se guarda automáticamente después de realizar la operación.</value>
+    <comment />
+  </data>
+  <data name="ProxyMedia" xml:space="preserve">
+    <value>Medios proxy</value>
+    <comment />
+  </data>
+  <data name="ProxyStoreRootPath" xml:space="preserve">
+    <value>Ubicación de almacenamiento</value>
+    <comment />
+  </data>
+  <data name="ProxyStoreRootPath_Description" xml:space="preserve">
+    <value>Los archivos proxy se almacenan en esta carpeta. Los cambios surten efecto después de reiniciar.</value>
+    <comment />
+  </data>
+  <data name="ProxyStoreMaxTotalGiB" xml:space="preserve">
+    <value>Tamaño máximo de almacenamiento</value>
+    <comment />
+  </data>
+  <data name="ProxyStoreMaxTotalGiB_Description" xml:space="preserve">
+    <value>Los proxies usados menos recientemente se eliminan cuando el almacenamiento supera este tamaño. Los cambios surten efecto después de reiniciar.</value>
+    <comment />
+  </data>
+  <data name="ProxyDefaultPreset" xml:space="preserve">
+    <value>Ajuste preestablecido predeterminado</value>
+    <comment />
+  </data>
+  <data name="ProxyDefaultPreset_Description" xml:space="preserve">
+    <value>Ajuste preestablecido seleccionado por defecto en la pestaña de herramientas Proxies.</value>
+    <comment />
+  </data>
+  <data name="FrameCacheMaxSize" xml:space="preserve">
+    <value>Bytes máximos</value>
+    <comment />
+  </data>
+  <data name="FrameCacheMaxSize_Description" xml:space="preserve">
+    <value>El número de cachés se ajustará para que no supere este número de bytes.</value>
+    <comment />
+  </data>
+  <data name="FrameCacheScale" xml:space="preserve">
+    <value>Escala</value>
+    <comment />
+  </data>
+  <data name="FrameCacheScale_Original" xml:space="preserve">
+    <value>Original</value>
+    <comment />
+  </data>
+  <data name="FrameCacheScale_FitToPreviewer" xml:space="preserve">
+    <value>Ajustar a la pantalla de vista previa</value>
+    <comment />
+  </data>
+  <data name="FrameCacheScale_Half" xml:space="preserve">
+    <value>Mitad</value>
+    <comment />
+  </data>
+  <data name="FrameCacheScale_Quarter" xml:space="preserve">
+    <value>Cuarto</value>
+    <comment />
+  </data>
+  <data name="FrameCacheColorType" xml:space="preserve">
+    <value>Espacio de color</value>
+    <comment />
+  </data>
+  <data name="PropertyEditor" xml:space="preserve">
+    <value>Editor de propiedades</value>
+    <comment />
+  </data>
+  <data name="EnableFrameCache" xml:space="preserve">
+    <value>Habilitar caché de fotogramas</value>
+    <comment />
+  </data>
+  <data name="NodeCache" xml:space="preserve">
+    <value>Caché de nodos</value>
+    <comment />
+  </data>
+  <data name="EnableNodeCache" xml:space="preserve">
+    <value>Habilitar caché de nodos</value>
+    <comment />
+  </data>
+  <data name="NodeCacheMaxPixels" xml:space="preserve">
+    <value>Píxeles máximos</value>
+    <comment />
+  </data>
+  <data name="NodeCacheMinPixels" xml:space="preserve">
+    <value>Píxeles mínimos</value>
+    <comment />
+  </data>
+  <data name="SwapTimelineScrollDirection" xml:space="preserve">
+    <value>Invertir la dirección de desplazamiento de la línea de tiempo</value>
+    <comment />
+  </data>
+  <data name="TimelineAutoScrollMode" xml:space="preserve">
+    <value>Desplazamiento automático de la línea de tiempo durante la reproducción</value>
+    <comment />
+  </data>
+  <data name="TimelineAutoScrollMode_Description" xml:space="preserve">
+    <value>Desplaza automáticamente la línea de tiempo para seguir la posición de reproducción</value>
+    <comment />
+  </data>
+  <data name="TimelineAutoScrollMode_None" xml:space="preserve">
+    <value>Desactivado</value>
+    <comment />
+  </data>
+  <data name="TimelineAutoScrollMode_AlwaysFollow" xml:space="preserve">
+    <value>Seguir siempre</value>
+    <comment />
+  </data>
+  <data name="TimelineAutoScrollMode_PageScroll" xml:space="preserve">
+    <value>Desplazamiento por página</value>
+    <comment />
+  </data>
+  <data name="ClampResizeToOriginalLength" xml:space="preserve">
+    <value>Limitar el cambio de tamaño a la duración original del medio</value>
+    <comment />
+  </data>
+  <data name="ClampResizeToOriginalLength_Description" xml:space="preserve">
+    <value>Evita que los elementos de la línea de tiempo se redimensionen más allá de la duración original del medio</value>
+    <comment />
+  </data>
+  <data name="Graphics" xml:space="preserve">
+    <value>Gráficos</value>
+    <comment />
+  </data>
+  <data name="SelectedGpu" xml:space="preserve">
+    <value>GPU</value>
+    <comment />
+  </data>
+  <data name="SelectedGpu_Description" xml:space="preserve">
+    <value>Selecciona la GPU que se usará para el renderizado. Los cambios surtirán efecto después de reiniciar.</value>
+    <comment />
+  </data>
+  <data name="SelectedGpu_Auto" xml:space="preserve">
+    <value>Automático</value>
+    <comment />
+  </data>
+  <data name="Account" xml:space="preserve">
+    <value>Cuenta</value>
+  </data>
+  <data name="ColorPalette" xml:space="preserve">
+    <value>Paleta de colores</value>
+  </data>
+  <data name="AvailableGPUs" xml:space="preserve">
+    <value>GPU disponibles</value>
+  </data>
+  <data name="AvailableMemory" xml:space="preserve">
+    <value>Memoria disponible</value>
+  </data>
+  <data name="Dark" xml:space="preserve">
+    <value>Oscuro</value>
+  </data>
+  <data name="DarkClassic" xml:space="preserve">
+    <value>Oscuro (clásico)</value>
+  </data>
+  <data name="ExtensionsSettings" xml:space="preserve">
+    <value>Configuración de extensiones</value>
+  </data>
+  <data name="Keymap" xml:space="preserve">
+    <value>Mapa de teclas</value>
+  </data>
+  <data name="Language" xml:space="preserve">
+    <value>Idioma</value>
+  </data>
+  <data name="License" xml:space="preserve">
+    <value>Licencia</value>
+  </data>
+  <data name="Links" xml:space="preserve">
+    <value>Enlaces</value>
+  </data>
+  <data name="PrivacyPolicy" xml:space="preserve">
+    <value>Política de privacidad</value>
+  </data>
+  <data name="TermsOfService" xml:space="preserve">
+    <value>Términos de servicio</value>
+  </data>
+  <data name="Theme" xml:space="preserve">
+    <value>Tema</value>
+  </data>
+  <data name="ThirdPartyLicenses" xml:space="preserve">
+    <value>Licencias de terceros</value>
+  </data>
+  <data name="VulkanVersion" xml:space="preserve">
+    <value>Versión de Vulkan</value>
+  </data>
+  <data name="EnabledExtensions" xml:space="preserve">
+    <value>Extensiones habilitadas</value>
+  </data>
+  <data name="Light" xml:space="preserve">
+    <value>Claro</value>
+  </data>
+  <data name="HighContrast" xml:space="preserve">
+    <value>Alto contraste</value>
+  </data>
+  <data name="FollowSystem" xml:space="preserve">
+    <value>Seguir sistema</value>
+  </data>
+  <data name="SourceCode" xml:space="preserve">
+    <value>Código fuente</value>
+  </data>
+  <data name="Font" xml:space="preserve">
+    <value>Fuente</value>
+  </data>
+  <data name="ToneMapping" xml:space="preserve">
+    <value>Mapeo de tonos</value>
+    <comment />
+  </data>
+  <data name="ToneMappingMode" xml:space="preserve">
+    <value>Mapeo de tonos</value>
+    <comment />
+  </data>
+  <data name="ToneMappingMode_Description" xml:space="preserve">
+    <value>Selecciona el operador de mapeo de tonos para la vista previa</value>
+    <comment />
+  </data>
+  <data name="ToneMappingMode_None" xml:space="preserve">
+    <value>Ninguno</value>
+    <comment />
+  </data>
+  <data name="ToneMappingMode_Reinhard" xml:space="preserve">
+    <value>Reinhard</value>
+    <comment />
+  </data>
+  <data name="ToneMappingMode_ACES" xml:space="preserve">
+    <value>ACES</value>
+    <comment />
+  </data>
+  <data name="ToneMappingMode_Hable" xml:space="preserve">
+    <value>Hable</value>
+    <comment />
+  </data>
+  <data name="ToneMappingExposure" xml:space="preserve">
+    <value>Exposición</value>
+    <comment />
+  </data>
+  <data name="ToneMappingExposure_Description" xml:space="preserve">
+    <value>Ajusta el nivel de exposición para el mapeo de tonos</value>
+    <comment />
+  </data>
+  <data name="UseHdrPreview" xml:space="preserve">
+    <value>Vista previa HDR</value>
+    <comment />
+  </data>
+  <data name="UseHdrPreview_Description" xml:space="preserve">
+    <value>Usa renderizado HDR para el reproductor de vista previa (las operaciones del mouse, etc., estarán restringidas)</value>
+    <comment />
+  </data>
+  <data name="AiAgents" xml:space="preserve">
+    <value>Agentes de IA</value>
+    <comment />
+  </data>
+  <data name="AiAgents_PageDescription" xml:space="preserve">
+    <value>Configura agentes de codificación de IA (como Claude Code) para editar proyectos de Beutl: instala habilidades, subagentes y entradas del servidor MCP en las carpetas del agente.</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Target" xml:space="preserve">
+    <value>Destino de instalación</value>
+    <comment />
+  </data>
+  <data name="AiAgents_WorkspaceRoot" xml:space="preserve">
+    <value>Raíz del espacio de trabajo</value>
+    <comment />
+  </data>
+  <data name="AiAgents_WorkspaceRoot_Description" xml:space="preserve">
+    <value>Carpeta en la que el servidor MCP puede crear y editar proyectos</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Components" xml:space="preserve">
+    <value>Componentes</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Skills" xml:space="preserve">
+    <value>Habilidades</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Skills_Description" xml:space="preserve">
+    <value>Conocimientos de edición de Beutl que el agente carga bajo demanda</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Subagents" xml:space="preserve">
+    <value>Subagentes</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Subagents_Description" xml:space="preserve">
+    <value>Definiciones de agentes especializados para tareas de línea de tiempo, apariencia y revisión de calidad</value>
+    <comment />
+  </data>
+  <data name="AiAgents_StdioMcp" xml:space="preserve">
+    <value>Servidor MCP Stdio</value>
+    <comment />
+  </data>
+  <data name="AiAgents_StdioMcp_Description" xml:space="preserve">
+    <value>Servidor sin interfaz opcional que edita archivos de proyecto sin iniciar la GUI</value>
+    <comment />
+  </data>
+  <data name="AiAgents_LiveMcp" xml:space="preserve">
+    <value>Servidor MCP en vivo</value>
+    <comment />
+  </data>
+  <data name="AiAgents_LiveMcp_Description" xml:space="preserve">
+    <value>Recomendado: conecta agentes a este editor en ejecución; las ediciones aparecen en vivo en la vista previa y el historial de deshacer</value>
+    <comment />
+  </data>
+  <data name="AiAgents_LiveMcp_NotRunning" xml:space="preserve">
+    <value>El punto de conexión MCP en vivo no está en ejecución</value>
+    <comment />
+  </data>
+  <data name="AiAgents_LiveMcpUrl" xml:space="preserve">
+    <value>URL de MCP en vivo</value>
+    <comment />
+  </data>
+  <data name="AiAgents_LiveMcpUrl_Description" xml:space="preserve">
+    <value>URL de conexión para clientes MCP. Envía el encabezado de autenticación de abajo con cada solicitud; trátalo como una contraseña</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Advanced" xml:space="preserve">
+    <value>Avanzado</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Advanced_Description" xml:space="preserve">
+    <value>Anulaciones para nombres de carpeta y el archivo de configuración MCP, y la línea de comandos del servidor stdio. Los campos vacíos usan los valores predeterminados del agente seleccionado</value>
+    <comment />
+  </data>
+  <data name="AiAgents_SkillsDirectory" xml:space="preserve">
+    <value>Carpeta de habilidades</value>
+    <comment />
+  </data>
+  <data name="AiAgents_SubagentsDirectory" xml:space="preserve">
+    <value>Carpeta de subagentes</value>
+    <comment />
+  </data>
+  <data name="AiAgents_McpConfigFileName" xml:space="preserve">
+    <value>Archivo de configuración MCP</value>
+    <comment />
+  </data>
+  <data name="AiAgents_McpServersPropertyName" xml:space="preserve">
+    <value>Propiedad de servidores</value>
+    <comment />
+  </data>
+  <data name="AiAgents_McpCommand" xml:space="preserve">
+    <value>Comando</value>
+    <comment />
+  </data>
+  <data name="AiAgents_McpArguments" xml:space="preserve">
+    <value>Argumentos (uno por línea)</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Install" xml:space="preserve">
+    <value>Instalar</value>
+    <comment />
+  </data>
+  <data name="AiAgents_InstallCompleted" xml:space="preserve">
+    <value>Se instalaron {0} archivo(s).</value>
+    <comment />
+  </data>
+  <data name="AiAgents_InstalledFiles" xml:space="preserve">
+    <value>Archivos instalados</value>
+    <comment />
+  </data>
+  <data name="AiAgents_SelectWorkspaceRoot" xml:space="preserve">
+    <value>Selecciona la raíz del espacio de trabajo</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Agent" xml:space="preserve">
+    <value>Agente</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Agent_Description" xml:space="preserve">
+    <value>El agente de codificación de IA para el que instalar el kit de herramientas (las convenciones de carpeta siguen a cada agente)</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Agent_Custom" xml:space="preserve">
+    <value>Personalizado (rutas manuales)</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Scope" xml:space="preserve">
+    <value>Ámbito de instalación</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Scope_Description" xml:space="preserve">
+    <value>Las instalaciones de proyecto van a una carpeta de proyecto; las globales van a tu perfil de usuario</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Scope_Project" xml:space="preserve">
+    <value>Proyecto</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Scope_Global" xml:space="preserve">
+    <value>Global (perfil de usuario)</value>
+    <comment />
+  </data>
+  <data name="AiAgents_ProjectFolder" xml:space="preserve">
+    <value>Carpeta del proyecto</value>
+    <comment />
+  </data>
+  <data name="AiAgents_ProjectFolder_Description" xml:space="preserve">
+    <value>Carpeta del repositorio o proyecto en la que se ejecuta el agente</value>
+    <comment />
+  </data>
+  <data name="AiAgents_SelectProjectFolder" xml:space="preserve">
+    <value>Selecciona la carpeta del proyecto</value>
+    <comment />
+  </data>
+  <data name="AiAgents_ProjectFolderMissing" xml:space="preserve">
+    <value>Selecciona primero una carpeta de proyecto.</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Destinations" xml:space="preserve">
+    <value>Destinos de instalación</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Destinations_Description" xml:space="preserve">
+    <value>Dónde coloca cada componente el agente y ámbito seleccionados</value>
+    <comment />
+  </data>
+  <data name="AiAgents_NotSupported" xml:space="preserve">
+    <value>No compatible con este agente</value>
+    <comment />
+  </data>
+  <data name="AiAgents_McpManual" xml:space="preserve">
+    <value>La configuración MCP de este agente no se puede escribir automáticamente. Registra el servidor MCP manualmente en la configuración del propio agente.</value>
+    <comment />
+  </data>
+  <data name="AiAgents_CliFailed" xml:space="preserve">
+    <value>El registro MCP a través de la CLI del agente falló. Ejecuta el comando manualmente:
+{0}</value>
+    <comment />
+  </data>
+  <data name="AiAgents_StdioMissing" xml:space="preserve">
+    <value>No se encontró el binario del servidor MCP stdio junto a la aplicación. Introduce un comando en Avanzado o reinstala Beutl.</value>
+    <comment />
+  </data>
+  <data name="AiAgents_LiveMcpAuthHeader" xml:space="preserve">
+    <value>Encabezado de autenticación</value>
+    <comment />
+  </data>
+  <data name="AiAgents_UpdateAvailable_Title" xml:space="preserve">
+    <value>Se actualizaron los recursos del agente de IA</value>
+    <comment />
+  </data>
+  <data name="AiAgents_UpdateAvailable_Content" xml:space="preserve">
+    <value>Esta versión de Beutl incluye habilidades y subagentes más nuevos que los que instalaste. ¿Reinstalarlos ahora con tu configuración guardada? Los archivos que editaste manualmente en el destino se sobrescribirán.</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Reinstall" xml:space="preserve">
+    <value>Reinstalar</value>
+    <comment />
+  </data>
+</root>

--- a/src/Beutl.Language/SettingsStrings.ko-KR.resx
+++ b/src/Beutl.Language/SettingsStrings.ko-KR.resx
@@ -1,0 +1,630 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="SignOut" xml:space="preserve">
+    <value>로그아웃</value>
+    <comment />
+  </data>
+  <data name="ChangeAccountSettings" xml:space="preserve">
+    <value>계정 설정 변경</value>
+    <comment />
+  </data>
+  <data name="SignIn" xml:space="preserve">
+    <value>로그인</value>
+    <comment />
+  </data>
+  <data name="SignInWith" xml:space="preserve">
+    <value>소셜 계정으로 로그인</value>
+    <comment />
+  </data>
+  <data name="SignInViaBrowser" xml:space="preserve">
+    <value>브라우저로 로그인</value>
+    <comment />
+  </data>
+  <data name="Editor_Extension_Priority" xml:space="preserve">
+    <value>편집기 확장 우선 순위</value>
+    <comment />
+  </data>
+  <data name="Higher" xml:space="preserve">
+    <value>높음</value>
+    <comment />
+  </data>
+  <data name="Lower" xml:space="preserve">
+    <value>낮음</value>
+    <comment />
+  </data>
+  <data name="All_Editor_Extensions" xml:space="preserve">
+    <value>모든 편집기 확장</value>
+    <comment />
+  </data>
+  <data name="Add_file_extension" xml:space="preserve">
+    <value>파일 확장자 추가</value>
+    <comment />
+  </data>
+  <data name="Theme_Tip" xml:space="preserve">
+    <value>표시할 앱의 테마를 선택하세요.</value>
+    <comment />
+  </data>
+  <data name="Please_enter_a_file_extension" xml:space="preserve">
+    <value>파일 확장자를 입력하세요.</value>
+    <comment />
+  </data>
+  <data name="The_following_characters_are_not_allowed" xml:space="preserve">
+    <value>다음 문자는 사용할 수 없습니다 (" &gt; &lt; | : ? * \\ /)</value>
+    <comment />
+  </data>
+  <data name="This_file_extension_already_exists" xml:space="preserve">
+    <value>이 파일 확장자는 이미 존재합니다.</value>
+    <comment />
+  </data>
+  <data name="CopyVersionInfo" xml:space="preserve">
+    <value>버전 정보 복사</value>
+    <comment />
+  </data>
+  <data name="DeviceInformation" xml:space="preserve">
+    <value>장치 정보</value>
+  </data>
+  <data name="EditorSettings" xml:space="preserve">
+    <value>편집기 설정</value>
+    <comment />
+  </data>
+  <data name="DecoderPriority" xml:space="preserve">
+    <value>디코더 우선 순위</value>
+    <comment />
+  </data>
+  <data name="DecoderPriority_Description" xml:space="preserve">
+    <value>디코더의 우선 순위를 변경할 수 있습니다. 위쪽 디코더가 우선합니다.</value>
+    <comment />
+  </data>
+  <data name="AccentColor" xml:space="preserve">
+    <value>강조 색상</value>
+    <comment />
+  </data>
+  <data name="CustomColor" xml:space="preserve">
+    <value>사용자 지정 색상</value>
+    <comment />
+  </data>
+  <data name="UseCustomAccentColor" xml:space="preserve">
+    <value>사용자 지정 강조 색상 사용</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Beutl_Application" xml:space="preserve">
+    <value>애플리케이션</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Description_Beutl_Application" xml:space="preserve">
+    <value>애플리케이션 성능을 개선하기 위해 다음 정보를 수집합니다: 애플리케이션 시작 시간, 작업 경과 시간, API로 검색된 항목 수</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Beutl_PackageManagement" xml:space="preserve">
+    <value>패키지 관리</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Description_Beutl_PackageManagement" xml:space="preserve">
+    <value>확장 프로그램을 설치하고 로드하는 데 걸린 시간을 수집합니다.</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Beutl_Api_Client" xml:space="preserve">
+    <value>API 클라이언트</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Description_Beutl_Api_Client" xml:space="preserve">
+    <value>확장 스토어 및 계정 기능에서 사용하는 API 호출 시간을 수집합니다.</value>
+    <comment />
+  </data>
+  <data name="Telemetry" xml:space="preserve">
+    <value>원격 분석</value>
+    <comment />
+  </data>
+  <data name="Telemetry_ShortDescription" xml:space="preserve">
+    <value>수집할 데이터에 대한 설정</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Description" xml:space="preserve">
+    <value>Beutl을 개선하기 위해 익명 사용 데이터를 수집합니다. 이 설정은 애플리케이션을 다시 시작한 후 적용됩니다. 자세한 내용은 다음 페이지를 참조하세요.</value>
+    <comment />
+  </data>
+  <data name="ShowExactBoundaries_Description" xml:space="preserve">
+    <value>미리 보기 중에 요소의 경계를 정확하게 표시합니다. 이 설정을 사용하면 테두리가 보이지 않을 수 있습니다.</value>
+    <comment />
+  </data>
+  <data name="ShowExactBoundaries" xml:space="preserve">
+    <value>정확한 경계 표시</value>
+    <comment />
+  </data>
+  <data name="AutoAdjustSceneDuration" xml:space="preserve">
+    <value>장면 길이 자동 조정</value>
+    <comment />
+  </data>
+  <data name="AutoAdjustSceneDuration_Description" xml:space="preserve">
+    <value>요소가 추가될 때 장면의 길이를 조정해야 하면 자동으로 조정합니다.</value>
+    <comment />
+  </data>
+  <data name="SomeSettingsHaveBeenMoved" xml:space="preserve">
+    <value>일부 설정이 이동되었습니다.</value>
+    <comment />
+  </data>
+  <data name="EnablePointerLockInProperty" xml:space="preserve">
+    <value>포인터 잠금 사용</value>
+    <comment />
+  </data>
+  <data name="EnablePointerLockInProperty_Description" xml:space="preserve">
+    <value>속성 편집기에서 끌기 작업 중에 커서를 숨깁니다. (Windows 전용)</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Beutl_Logging" xml:space="preserve">
+    <value>로깅</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Description_Beutl_Logging" xml:space="preserve">
+    <value>더 자세한 사용 정보를 수집합니다. 전송된 로그는 ".beutl/log" 디렉터리에도 저장됩니다.</value>
+    <comment />
+  </data>
+  <data name="EnableAutoSave" xml:space="preserve">
+    <value>자동 저장 사용</value>
+    <comment />
+  </data>
+  <data name="EnableAutoSave_Description" xml:space="preserve">
+    <value>작업이 수행된 후 파일이 자동으로 저장됩니다.</value>
+    <comment />
+  </data>
+  <data name="ProxyMedia" xml:space="preserve">
+    <value>프록시 미디어</value>
+    <comment />
+  </data>
+  <data name="ProxyStoreRootPath" xml:space="preserve">
+    <value>저장 위치</value>
+    <comment />
+  </data>
+  <data name="ProxyStoreRootPath_Description" xml:space="preserve">
+    <value>프록시 파일이 이 폴더에 저장됩니다. 변경 사항은 다시 시작 후 적용됩니다.</value>
+    <comment />
+  </data>
+  <data name="ProxyStoreMaxTotalGiB" xml:space="preserve">
+    <value>최대 저장 크기</value>
+    <comment />
+  </data>
+  <data name="ProxyStoreMaxTotalGiB_Description" xml:space="preserve">
+    <value>저장소가 이 크기를 초과하면 가장 오래 사용하지 않은 프록시가 제거됩니다. 변경 사항은 다시 시작 후 적용됩니다.</value>
+    <comment />
+  </data>
+  <data name="ProxyDefaultPreset" xml:space="preserve">
+    <value>기본 프리셋</value>
+    <comment />
+  </data>
+  <data name="ProxyDefaultPreset_Description" xml:space="preserve">
+    <value>프록시 도구 탭에서 기본적으로 선택되는 프리셋입니다.</value>
+    <comment />
+  </data>
+  <data name="FrameCacheMaxSize" xml:space="preserve">
+    <value>최대 바이트</value>
+    <comment />
+  </data>
+  <data name="FrameCacheMaxSize_Description" xml:space="preserve">
+    <value>이 바이트 수를 초과하지 않도록 캐시 수가 조정됩니다.</value>
+    <comment />
+  </data>
+  <data name="FrameCacheScale" xml:space="preserve">
+    <value>배율</value>
+    <comment />
+  </data>
+  <data name="FrameCacheScale_Original" xml:space="preserve">
+    <value>원본</value>
+    <comment />
+  </data>
+  <data name="FrameCacheScale_FitToPreviewer" xml:space="preserve">
+    <value>미리 보기 화면에 맞춤</value>
+    <comment />
+  </data>
+  <data name="FrameCacheScale_Half" xml:space="preserve">
+    <value>절반</value>
+    <comment />
+  </data>
+  <data name="FrameCacheScale_Quarter" xml:space="preserve">
+    <value>1/4</value>
+    <comment />
+  </data>
+  <data name="FrameCacheColorType" xml:space="preserve">
+    <value>색상 공간</value>
+    <comment />
+  </data>
+  <data name="PropertyEditor" xml:space="preserve">
+    <value>속성 편집기</value>
+    <comment />
+  </data>
+  <data name="EnableFrameCache" xml:space="preserve">
+    <value>프레임 캐시 사용</value>
+    <comment />
+  </data>
+  <data name="NodeCache" xml:space="preserve">
+    <value>노드 캐시</value>
+    <comment />
+  </data>
+  <data name="EnableNodeCache" xml:space="preserve">
+    <value>노드 캐시 사용</value>
+    <comment />
+  </data>
+  <data name="NodeCacheMaxPixels" xml:space="preserve">
+    <value>최대 픽셀</value>
+    <comment />
+  </data>
+  <data name="NodeCacheMinPixels" xml:space="preserve">
+    <value>최소 픽셀</value>
+    <comment />
+  </data>
+  <data name="SwapTimelineScrollDirection" xml:space="preserve">
+    <value>타임라인 스크롤 방향 바꾸기</value>
+    <comment />
+  </data>
+  <data name="TimelineAutoScrollMode" xml:space="preserve">
+    <value>재생 중 타임라인 자동 스크롤</value>
+    <comment />
+  </data>
+  <data name="TimelineAutoScrollMode_Description" xml:space="preserve">
+    <value>재생 위치를 따라가도록 타임라인을 자동으로 스크롤합니다</value>
+    <comment />
+  </data>
+  <data name="TimelineAutoScrollMode_None" xml:space="preserve">
+    <value>끄기</value>
+    <comment />
+  </data>
+  <data name="TimelineAutoScrollMode_AlwaysFollow" xml:space="preserve">
+    <value>항상 따라가기</value>
+    <comment />
+  </data>
+  <data name="TimelineAutoScrollMode_PageScroll" xml:space="preserve">
+    <value>페이지 스크롤</value>
+    <comment />
+  </data>
+  <data name="ClampResizeToOriginalLength" xml:space="preserve">
+    <value>원본 미디어 길이로 크기 조정 제한</value>
+    <comment />
+  </data>
+  <data name="ClampResizeToOriginalLength_Description" xml:space="preserve">
+    <value>타임라인 요소가 원본 미디어 길이를 초과하여 크기가 조정되지 않도록 방지합니다</value>
+    <comment />
+  </data>
+  <data name="Graphics" xml:space="preserve">
+    <value>그래픽</value>
+    <comment />
+  </data>
+  <data name="SelectedGpu" xml:space="preserve">
+    <value>GPU</value>
+    <comment />
+  </data>
+  <data name="SelectedGpu_Description" xml:space="preserve">
+    <value>렌더링에 사용할 GPU를 선택하세요. 변경 사항은 다시 시작 후 적용됩니다.</value>
+    <comment />
+  </data>
+  <data name="SelectedGpu_Auto" xml:space="preserve">
+    <value>자동</value>
+    <comment />
+  </data>
+  <data name="Account" xml:space="preserve">
+    <value>계정</value>
+  </data>
+  <data name="ColorPalette" xml:space="preserve">
+    <value>색상 팔레트</value>
+  </data>
+  <data name="AvailableGPUs" xml:space="preserve">
+    <value>사용 가능한 GPU</value>
+  </data>
+  <data name="AvailableMemory" xml:space="preserve">
+    <value>사용 가능한 메모리</value>
+  </data>
+  <data name="Dark" xml:space="preserve">
+    <value>어두움</value>
+  </data>
+  <data name="DarkClassic" xml:space="preserve">
+    <value>어두움(클래식)</value>
+  </data>
+  <data name="ExtensionsSettings" xml:space="preserve">
+    <value>확장 설정</value>
+  </data>
+  <data name="Keymap" xml:space="preserve">
+    <value>키맵</value>
+  </data>
+  <data name="Language" xml:space="preserve">
+    <value>언어</value>
+  </data>
+  <data name="License" xml:space="preserve">
+    <value>라이선스</value>
+  </data>
+  <data name="Links" xml:space="preserve">
+    <value>링크</value>
+  </data>
+  <data name="PrivacyPolicy" xml:space="preserve">
+    <value>개인정보 처리방침</value>
+  </data>
+  <data name="TermsOfService" xml:space="preserve">
+    <value>서비스 약관</value>
+  </data>
+  <data name="Theme" xml:space="preserve">
+    <value>테마</value>
+  </data>
+  <data name="ThirdPartyLicenses" xml:space="preserve">
+    <value>타사 라이선스</value>
+  </data>
+  <data name="VulkanVersion" xml:space="preserve">
+    <value>Vulkan 버전</value>
+  </data>
+  <data name="EnabledExtensions" xml:space="preserve">
+    <value>사용하도록 설정된 확장</value>
+  </data>
+  <data name="Light" xml:space="preserve">
+    <value>밝음</value>
+  </data>
+  <data name="HighContrast" xml:space="preserve">
+    <value>고대비</value>
+  </data>
+  <data name="FollowSystem" xml:space="preserve">
+    <value>시스템 따르기</value>
+  </data>
+  <data name="SourceCode" xml:space="preserve">
+    <value>소스 코드</value>
+  </data>
+  <data name="Font" xml:space="preserve">
+    <value>글꼴</value>
+  </data>
+  <data name="ToneMapping" xml:space="preserve">
+    <value>톤 매핑</value>
+    <comment />
+  </data>
+  <data name="ToneMappingMode" xml:space="preserve">
+    <value>톤 매핑</value>
+    <comment />
+  </data>
+  <data name="ToneMappingMode_Description" xml:space="preserve">
+    <value>미리 보기에 사용할 톤 매핑 연산자를 선택하세요</value>
+    <comment />
+  </data>
+  <data name="ToneMappingMode_None" xml:space="preserve">
+    <value>없음</value>
+    <comment />
+  </data>
+  <data name="ToneMappingMode_Reinhard" xml:space="preserve">
+    <value>Reinhard</value>
+    <comment />
+  </data>
+  <data name="ToneMappingMode_ACES" xml:space="preserve">
+    <value>ACES</value>
+    <comment />
+  </data>
+  <data name="ToneMappingMode_Hable" xml:space="preserve">
+    <value>Hable</value>
+    <comment />
+  </data>
+  <data name="ToneMappingExposure" xml:space="preserve">
+    <value>노출</value>
+    <comment />
+  </data>
+  <data name="ToneMappingExposure_Description" xml:space="preserve">
+    <value>톤 매핑의 노출 수준을 조정합니다</value>
+    <comment />
+  </data>
+  <data name="UseHdrPreview" xml:space="preserve">
+    <value>HDR 미리 보기</value>
+    <comment />
+  </data>
+  <data name="UseHdrPreview_Description" xml:space="preserve">
+    <value>미리 보기 플레이어에 HDR 렌더링을 사용합니다(마우스 조작 등이 제한됨)</value>
+    <comment />
+  </data>
+  <data name="AiAgents" xml:space="preserve">
+    <value>AI 에이전트</value>
+    <comment />
+  </data>
+  <data name="AiAgents_PageDescription" xml:space="preserve">
+    <value>Beutl 프로젝트를 편집하도록 AI 코딩 에이전트(예: Claude Code)를 설정합니다: 에이전트의 폴더에 스킬, 하위 에이전트, MCP 서버 항목을 설치합니다.</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Target" xml:space="preserve">
+    <value>설치 대상</value>
+    <comment />
+  </data>
+  <data name="AiAgents_WorkspaceRoot" xml:space="preserve">
+    <value>작업 영역 루트</value>
+    <comment />
+  </data>
+  <data name="AiAgents_WorkspaceRoot_Description" xml:space="preserve">
+    <value>MCP 서버가 프로젝트를 만들고 편집할 수 있는 폴더</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Components" xml:space="preserve">
+    <value>구성 요소</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Skills" xml:space="preserve">
+    <value>스킬</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Skills_Description" xml:space="preserve">
+    <value>에이전트가 필요 시 로드하는 Beutl 편집 노하우</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Subagents" xml:space="preserve">
+    <value>하위 에이전트</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Subagents_Description" xml:space="preserve">
+    <value>타임라인, 룩, 품질 검토 작업을 위한 전용 에이전트 정의</value>
+    <comment />
+  </data>
+  <data name="AiAgents_StdioMcp" xml:space="preserve">
+    <value>Stdio MCP 서버</value>
+    <comment />
+  </data>
+  <data name="AiAgents_StdioMcp_Description" xml:space="preserve">
+    <value>GUI를 시작하지 않고 프로젝트 파일을 편집하는 선택적 헤드리스 서버</value>
+    <comment />
+  </data>
+  <data name="AiAgents_LiveMcp" xml:space="preserve">
+    <value>라이브 MCP 서버</value>
+    <comment />
+  </data>
+  <data name="AiAgents_LiveMcp_Description" xml:space="preserve">
+    <value>권장: 에이전트를 실행 중인 편집기에 연결합니다. 편집 내용이 미리 보기와 실행 취소 기록에 실시간으로 표시됩니다</value>
+    <comment />
+  </data>
+  <data name="AiAgents_LiveMcp_NotRunning" xml:space="preserve">
+    <value>라이브 MCP 엔드포인트가 실행 중이 아닙니다</value>
+    <comment />
+  </data>
+  <data name="AiAgents_LiveMcpUrl" xml:space="preserve">
+    <value>라이브 MCP URL</value>
+    <comment />
+  </data>
+  <data name="AiAgents_LiveMcpUrl_Description" xml:space="preserve">
+    <value>MCP 클라이언트용 연결 URL입니다. 아래 인증 헤더를 모든 요청과 함께 보내세요. 비밀번호처럼 취급하세요</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Advanced" xml:space="preserve">
+    <value>고급</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Advanced_Description" xml:space="preserve">
+    <value>폴더 이름과 MCP 구성 파일, stdio 서버 명령줄에 대한 재정의입니다. 빈 필드는 선택한 에이전트의 기본값을 사용합니다</value>
+    <comment />
+  </data>
+  <data name="AiAgents_SkillsDirectory" xml:space="preserve">
+    <value>스킬 폴더</value>
+    <comment />
+  </data>
+  <data name="AiAgents_SubagentsDirectory" xml:space="preserve">
+    <value>하위 에이전트 폴더</value>
+    <comment />
+  </data>
+  <data name="AiAgents_McpConfigFileName" xml:space="preserve">
+    <value>MCP 구성 파일</value>
+    <comment />
+  </data>
+  <data name="AiAgents_McpServersPropertyName" xml:space="preserve">
+    <value>서버 속성</value>
+    <comment />
+  </data>
+  <data name="AiAgents_McpCommand" xml:space="preserve">
+    <value>명령</value>
+    <comment />
+  </data>
+  <data name="AiAgents_McpArguments" xml:space="preserve">
+    <value>인수(줄당 하나)</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Install" xml:space="preserve">
+    <value>설치</value>
+    <comment />
+  </data>
+  <data name="AiAgents_InstallCompleted" xml:space="preserve">
+    <value>{0}개 파일을 설치했습니다.</value>
+    <comment />
+  </data>
+  <data name="AiAgents_InstalledFiles" xml:space="preserve">
+    <value>설치된 파일</value>
+    <comment />
+  </data>
+  <data name="AiAgents_SelectWorkspaceRoot" xml:space="preserve">
+    <value>작업 영역 루트 선택</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Agent" xml:space="preserve">
+    <value>에이전트</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Agent_Description" xml:space="preserve">
+    <value>도구 키트를 설치할 AI 코딩 에이전트(폴더 규칙은 각 에이전트를 따름)</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Agent_Custom" xml:space="preserve">
+    <value>사용자 지정(수동 경로)</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Scope" xml:space="preserve">
+    <value>설치 범위</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Scope_Description" xml:space="preserve">
+    <value>프로젝트 설치는 프로젝트 폴더에, 전역 설치는 사용자 프로필에 설치합니다</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Scope_Project" xml:space="preserve">
+    <value>프로젝트</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Scope_Global" xml:space="preserve">
+    <value>전역(사용자 프로필)</value>
+    <comment />
+  </data>
+  <data name="AiAgents_ProjectFolder" xml:space="preserve">
+    <value>프로젝트 폴더</value>
+    <comment />
+  </data>
+  <data name="AiAgents_ProjectFolder_Description" xml:space="preserve">
+    <value>에이전트가 실행되는 리포지토리 또는 프로젝트 폴더</value>
+    <comment />
+  </data>
+  <data name="AiAgents_SelectProjectFolder" xml:space="preserve">
+    <value>프로젝트 폴더 선택</value>
+    <comment />
+  </data>
+  <data name="AiAgents_ProjectFolderMissing" xml:space="preserve">
+    <value>먼저 프로젝트 폴더를 선택하세요.</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Destinations" xml:space="preserve">
+    <value>설치 대상 경로</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Destinations_Description" xml:space="preserve">
+    <value>선택한 에이전트와 범위가 각 구성 요소를 배치하는 위치</value>
+    <comment />
+  </data>
+  <data name="AiAgents_NotSupported" xml:space="preserve">
+    <value>이 에이전트에서 지원하지 않음</value>
+    <comment />
+  </data>
+  <data name="AiAgents_McpManual" xml:space="preserve">
+    <value>이 에이전트의 MCP 구성을 자동으로 작성할 수 없습니다. 에이전트 자체 설정에서 MCP 서버를 수동으로 등록하세요.</value>
+    <comment />
+  </data>
+  <data name="AiAgents_CliFailed" xml:space="preserve">
+    <value>에이전트의 CLI를 통한 MCP 등록에 실패했습니다. 명령을 수동으로 실행하세요:
+{0}</value>
+    <comment />
+  </data>
+  <data name="AiAgents_StdioMissing" xml:space="preserve">
+    <value>앱 옆에서 stdio MCP 서버 바이너리를 찾을 수 없습니다. 고급에서 명령을 입력하거나 Beutl을 다시 설치하세요.</value>
+    <comment />
+  </data>
+  <data name="AiAgents_LiveMcpAuthHeader" xml:space="preserve">
+    <value>인증 헤더</value>
+    <comment />
+  </data>
+  <data name="AiAgents_UpdateAvailable_Title" xml:space="preserve">
+    <value>AI 에이전트 자산이 업데이트되었습니다</value>
+    <comment />
+  </data>
+  <data name="AiAgents_UpdateAvailable_Content" xml:space="preserve">
+    <value>이 버전의 Beutl에는 설치한 것보다 최신 스킬과 하위 에이전트가 포함되어 있습니다. 저장된 설정으로 지금 다시 설치하시겠습니까? 대상에서 직접 편집한 파일은 덮어쓰여집니다.</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Reinstall" xml:space="preserve">
+    <value>다시 설치</value>
+    <comment />
+  </data>
+</root>

--- a/src/Beutl.Language/SettingsStrings.zh-CN.resx
+++ b/src/Beutl.Language/SettingsStrings.zh-CN.resx
@@ -1,0 +1,630 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="SignOut" xml:space="preserve">
+    <value>退出登录</value>
+    <comment />
+  </data>
+  <data name="ChangeAccountSettings" xml:space="preserve">
+    <value>更改账户设置</value>
+    <comment />
+  </data>
+  <data name="SignIn" xml:space="preserve">
+    <value>登录</value>
+    <comment />
+  </data>
+  <data name="SignInWith" xml:space="preserve">
+    <value>使用您的社交账户登录</value>
+    <comment />
+  </data>
+  <data name="SignInViaBrowser" xml:space="preserve">
+    <value>通过浏览器登录</value>
+    <comment />
+  </data>
+  <data name="Editor_Extension_Priority" xml:space="preserve">
+    <value>编辑器扩展优先级</value>
+    <comment />
+  </data>
+  <data name="Higher" xml:space="preserve">
+    <value>更高</value>
+    <comment />
+  </data>
+  <data name="Lower" xml:space="preserve">
+    <value>更低</value>
+    <comment />
+  </data>
+  <data name="All_Editor_Extensions" xml:space="preserve">
+    <value>所有编辑器扩展</value>
+    <comment />
+  </data>
+  <data name="Add_file_extension" xml:space="preserve">
+    <value>添加文件扩展名</value>
+    <comment />
+  </data>
+  <data name="Theme_Tip" xml:space="preserve">
+    <value>选择要显示的应用程序主题。</value>
+    <comment />
+  </data>
+  <data name="Please_enter_a_file_extension" xml:space="preserve">
+    <value>请输入文件扩展名。</value>
+    <comment />
+  </data>
+  <data name="The_following_characters_are_not_allowed" xml:space="preserve">
+    <value>不允许使用以下字符 (" &gt; &lt; | : ? * \\ /)</value>
+    <comment />
+  </data>
+  <data name="This_file_extension_already_exists" xml:space="preserve">
+    <value>此文件扩展名已存在。</value>
+    <comment />
+  </data>
+  <data name="CopyVersionInfo" xml:space="preserve">
+    <value>复制版本信息</value>
+    <comment />
+  </data>
+  <data name="DeviceInformation" xml:space="preserve">
+    <value>设备信息</value>
+  </data>
+  <data name="EditorSettings" xml:space="preserve">
+    <value>编辑器设置</value>
+    <comment />
+  </data>
+  <data name="DecoderPriority" xml:space="preserve">
+    <value>解码器优先级</value>
+    <comment />
+  </data>
+  <data name="DecoderPriority_Description" xml:space="preserve">
+    <value>您可以更改解码器的优先级顺序。上方的解码器具有优先权。</value>
+    <comment />
+  </data>
+  <data name="AccentColor" xml:space="preserve">
+    <value>强调色</value>
+    <comment />
+  </data>
+  <data name="CustomColor" xml:space="preserve">
+    <value>自定义颜色</value>
+    <comment />
+  </data>
+  <data name="UseCustomAccentColor" xml:space="preserve">
+    <value>使用自定义强调色</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Beutl_Application" xml:space="preserve">
+    <value>应用程序</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Description_Beutl_Application" xml:space="preserve">
+    <value>收集以下信息以改进应用程序性能：应用程序启动时间、操作经过时间以及 API 检索的项目数</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Beutl_PackageManagement" xml:space="preserve">
+    <value>包管理</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Description_Beutl_PackageManagement" xml:space="preserve">
+    <value>收集安装和加载扩展所花费的时间。</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Beutl_Api_Client" xml:space="preserve">
+    <value>API 客户端</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Description_Beutl_Api_Client" xml:space="preserve">
+    <value>收集扩展商店和账户功能使用的 API 调用时间。</value>
+    <comment />
+  </data>
+  <data name="Telemetry" xml:space="preserve">
+    <value>遥测</value>
+    <comment />
+  </data>
+  <data name="Telemetry_ShortDescription" xml:space="preserve">
+    <value>关于要收集的数据的设置</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Description" xml:space="preserve">
+    <value>为了改进 Beutl，我们收集匿名的使用数据。这些设置将在应用程序重新启动后生效。有关详细信息，请参阅以下页面。</value>
+    <comment />
+  </data>
+  <data name="ShowExactBoundaries_Description" xml:space="preserve">
+    <value>在预览期间准确显示元素的边界。启用此设置可能会使边框不可见。</value>
+    <comment />
+  </data>
+  <data name="ShowExactBoundaries" xml:space="preserve">
+    <value>显示精确边界</value>
+    <comment />
+  </data>
+  <data name="AutoAdjustSceneDuration" xml:space="preserve">
+    <value>自动调整场景时长</value>
+    <comment />
+  </data>
+  <data name="AutoAdjustSceneDuration_Description" xml:space="preserve">
+    <value>添加元素时，如果需要调整场景的时长，将自动进行调整。</value>
+    <comment />
+  </data>
+  <data name="SomeSettingsHaveBeenMoved" xml:space="preserve">
+    <value>某些设置已移动。</value>
+    <comment />
+  </data>
+  <data name="EnablePointerLockInProperty" xml:space="preserve">
+    <value>启用指针锁定</value>
+    <comment />
+  </data>
+  <data name="EnablePointerLockInProperty_Description" xml:space="preserve">
+    <value>在属性编辑器中拖动操作期间隐藏光标。（仅限 Windows）</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Beutl_Logging" xml:space="preserve">
+    <value>日志记录</value>
+    <comment />
+  </data>
+  <data name="Telemetry_Description_Beutl_Logging" xml:space="preserve">
+    <value>收集更详细的使用信息。发送的日志也会存储在 ".beutl/log" 目录下。</value>
+    <comment />
+  </data>
+  <data name="EnableAutoSave" xml:space="preserve">
+    <value>启用自动保存</value>
+    <comment />
+  </data>
+  <data name="EnableAutoSave_Description" xml:space="preserve">
+    <value>执行操作后自动保存文件。</value>
+    <comment />
+  </data>
+  <data name="ProxyMedia" xml:space="preserve">
+    <value>代理媒体</value>
+    <comment />
+  </data>
+  <data name="ProxyStoreRootPath" xml:space="preserve">
+    <value>存储位置</value>
+    <comment />
+  </data>
+  <data name="ProxyStoreRootPath_Description" xml:space="preserve">
+    <value>代理文件存储在此文件夹中。更改在重新启动后生效。</value>
+    <comment />
+  </data>
+  <data name="ProxyStoreMaxTotalGiB" xml:space="preserve">
+    <value>最大存储大小</value>
+    <comment />
+  </data>
+  <data name="ProxyStoreMaxTotalGiB_Description" xml:space="preserve">
+    <value>当存储超过此大小时，将移除最近最少使用的代理。更改在重新启动后生效。</value>
+    <comment />
+  </data>
+  <data name="ProxyDefaultPreset" xml:space="preserve">
+    <value>默认预设</value>
+    <comment />
+  </data>
+  <data name="ProxyDefaultPreset_Description" xml:space="preserve">
+    <value>在代理工具选项卡中默认选择的预设。</value>
+    <comment />
+  </data>
+  <data name="FrameCacheMaxSize" xml:space="preserve">
+    <value>最大字节数</value>
+    <comment />
+  </data>
+  <data name="FrameCacheMaxSize_Description" xml:space="preserve">
+    <value>缓存数量将进行调整，使其不超过此字节数。</value>
+    <comment />
+  </data>
+  <data name="FrameCacheScale" xml:space="preserve">
+    <value>缩放</value>
+    <comment />
+  </data>
+  <data name="FrameCacheScale_Original" xml:space="preserve">
+    <value>原始</value>
+    <comment />
+  </data>
+  <data name="FrameCacheScale_FitToPreviewer" xml:space="preserve">
+    <value>适应预览屏幕</value>
+    <comment />
+  </data>
+  <data name="FrameCacheScale_Half" xml:space="preserve">
+    <value>一半</value>
+    <comment />
+  </data>
+  <data name="FrameCacheScale_Quarter" xml:space="preserve">
+    <value>四分之一</value>
+    <comment />
+  </data>
+  <data name="FrameCacheColorType" xml:space="preserve">
+    <value>色彩空间</value>
+    <comment />
+  </data>
+  <data name="PropertyEditor" xml:space="preserve">
+    <value>属性编辑器</value>
+    <comment />
+  </data>
+  <data name="EnableFrameCache" xml:space="preserve">
+    <value>启用帧缓存</value>
+    <comment />
+  </data>
+  <data name="NodeCache" xml:space="preserve">
+    <value>节点缓存</value>
+    <comment />
+  </data>
+  <data name="EnableNodeCache" xml:space="preserve">
+    <value>启用节点缓存</value>
+    <comment />
+  </data>
+  <data name="NodeCacheMaxPixels" xml:space="preserve">
+    <value>最大像素数</value>
+    <comment />
+  </data>
+  <data name="NodeCacheMinPixels" xml:space="preserve">
+    <value>最小像素数</value>
+    <comment />
+  </data>
+  <data name="SwapTimelineScrollDirection" xml:space="preserve">
+    <value>交换时间轴的滚动方向</value>
+    <comment />
+  </data>
+  <data name="TimelineAutoScrollMode" xml:space="preserve">
+    <value>播放期间时间轴自动滚动</value>
+    <comment />
+  </data>
+  <data name="TimelineAutoScrollMode_Description" xml:space="preserve">
+    <value>自动滚动时间轴以跟随播放位置</value>
+    <comment />
+  </data>
+  <data name="TimelineAutoScrollMode_None" xml:space="preserve">
+    <value>关闭</value>
+    <comment />
+  </data>
+  <data name="TimelineAutoScrollMode_AlwaysFollow" xml:space="preserve">
+    <value>始终跟随</value>
+    <comment />
+  </data>
+  <data name="TimelineAutoScrollMode_PageScroll" xml:space="preserve">
+    <value>页面滚动</value>
+    <comment />
+  </data>
+  <data name="ClampResizeToOriginalLength" xml:space="preserve">
+    <value>将调整大小限制为原始媒体长度</value>
+    <comment />
+  </data>
+  <data name="ClampResizeToOriginalLength_Description" xml:space="preserve">
+    <value>防止时间轴元素被调整到超出原始媒体时长</value>
+    <comment />
+  </data>
+  <data name="Graphics" xml:space="preserve">
+    <value>图形</value>
+    <comment />
+  </data>
+  <data name="SelectedGpu" xml:space="preserve">
+    <value>GPU</value>
+    <comment />
+  </data>
+  <data name="SelectedGpu_Description" xml:space="preserve">
+    <value>选择用于渲染的 GPU。更改将在重新启动后生效。</value>
+    <comment />
+  </data>
+  <data name="SelectedGpu_Auto" xml:space="preserve">
+    <value>自动</value>
+    <comment />
+  </data>
+  <data name="Account" xml:space="preserve">
+    <value>账户</value>
+  </data>
+  <data name="ColorPalette" xml:space="preserve">
+    <value>调色板</value>
+  </data>
+  <data name="AvailableGPUs" xml:space="preserve">
+    <value>可用的 GPU</value>
+  </data>
+  <data name="AvailableMemory" xml:space="preserve">
+    <value>可用内存</value>
+  </data>
+  <data name="Dark" xml:space="preserve">
+    <value>深色</value>
+  </data>
+  <data name="DarkClassic" xml:space="preserve">
+    <value>深色（经典）</value>
+  </data>
+  <data name="ExtensionsSettings" xml:space="preserve">
+    <value>扩展设置</value>
+  </data>
+  <data name="Keymap" xml:space="preserve">
+    <value>键位映射</value>
+  </data>
+  <data name="Language" xml:space="preserve">
+    <value>语言</value>
+  </data>
+  <data name="License" xml:space="preserve">
+    <value>许可证</value>
+  </data>
+  <data name="Links" xml:space="preserve">
+    <value>链接</value>
+  </data>
+  <data name="PrivacyPolicy" xml:space="preserve">
+    <value>隐私政策</value>
+  </data>
+  <data name="TermsOfService" xml:space="preserve">
+    <value>服务条款</value>
+  </data>
+  <data name="Theme" xml:space="preserve">
+    <value>主题</value>
+  </data>
+  <data name="ThirdPartyLicenses" xml:space="preserve">
+    <value>第三方许可证</value>
+  </data>
+  <data name="VulkanVersion" xml:space="preserve">
+    <value>Vulkan 版本</value>
+  </data>
+  <data name="EnabledExtensions" xml:space="preserve">
+    <value>已启用的扩展</value>
+  </data>
+  <data name="Light" xml:space="preserve">
+    <value>浅色</value>
+  </data>
+  <data name="HighContrast" xml:space="preserve">
+    <value>高对比度</value>
+  </data>
+  <data name="FollowSystem" xml:space="preserve">
+    <value>跟随系统</value>
+  </data>
+  <data name="SourceCode" xml:space="preserve">
+    <value>源代码</value>
+  </data>
+  <data name="Font" xml:space="preserve">
+    <value>字体</value>
+  </data>
+  <data name="ToneMapping" xml:space="preserve">
+    <value>色调映射</value>
+    <comment />
+  </data>
+  <data name="ToneMappingMode" xml:space="preserve">
+    <value>色调映射</value>
+    <comment />
+  </data>
+  <data name="ToneMappingMode_Description" xml:space="preserve">
+    <value>为预览选择色调映射运算符</value>
+    <comment />
+  </data>
+  <data name="ToneMappingMode_None" xml:space="preserve">
+    <value>无</value>
+    <comment />
+  </data>
+  <data name="ToneMappingMode_Reinhard" xml:space="preserve">
+    <value>Reinhard</value>
+    <comment />
+  </data>
+  <data name="ToneMappingMode_ACES" xml:space="preserve">
+    <value>ACES</value>
+    <comment />
+  </data>
+  <data name="ToneMappingMode_Hable" xml:space="preserve">
+    <value>Hable</value>
+    <comment />
+  </data>
+  <data name="ToneMappingExposure" xml:space="preserve">
+    <value>曝光</value>
+    <comment />
+  </data>
+  <data name="ToneMappingExposure_Description" xml:space="preserve">
+    <value>调整色调映射的曝光级别</value>
+    <comment />
+  </data>
+  <data name="UseHdrPreview" xml:space="preserve">
+    <value>HDR 预览</value>
+    <comment />
+  </data>
+  <data name="UseHdrPreview_Description" xml:space="preserve">
+    <value>为预览播放器使用 HDR 渲染（鼠标操作等将受到限制）</value>
+    <comment />
+  </data>
+  <data name="AiAgents" xml:space="preserve">
+    <value>AI 代理</value>
+    <comment />
+  </data>
+  <data name="AiAgents_PageDescription" xml:space="preserve">
+    <value>设置 AI 编码代理（如 Claude Code）以编辑 Beutl 项目：将技能、子代理和 MCP 服务器条目安装到代理的文件夹中。</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Target" xml:space="preserve">
+    <value>安装目标</value>
+    <comment />
+  </data>
+  <data name="AiAgents_WorkspaceRoot" xml:space="preserve">
+    <value>工作区根目录</value>
+    <comment />
+  </data>
+  <data name="AiAgents_WorkspaceRoot_Description" xml:space="preserve">
+    <value>允许 MCP 服务器在其中创建和编辑项目的文件夹</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Components" xml:space="preserve">
+    <value>组件</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Skills" xml:space="preserve">
+    <value>技能</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Skills_Description" xml:space="preserve">
+    <value>代理按需加载的 Beutl 编辑专业知识</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Subagents" xml:space="preserve">
+    <value>子代理</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Subagents_Description" xml:space="preserve">
+    <value>用于时间轴、外观和质量审查任务的专用代理定义</value>
+    <comment />
+  </data>
+  <data name="AiAgents_StdioMcp" xml:space="preserve">
+    <value>Stdio MCP 服务器</value>
+    <comment />
+  </data>
+  <data name="AiAgents_StdioMcp_Description" xml:space="preserve">
+    <value>可选的无头服务器，无需启动 GUI 即可编辑项目文件</value>
+    <comment />
+  </data>
+  <data name="AiAgents_LiveMcp" xml:space="preserve">
+    <value>实时 MCP 服务器</value>
+    <comment />
+  </data>
+  <data name="AiAgents_LiveMcp_Description" xml:space="preserve">
+    <value>推荐：将代理连接到正在运行的编辑器；编辑会实时显示在预览和撤销历史中</value>
+    <comment />
+  </data>
+  <data name="AiAgents_LiveMcp_NotRunning" xml:space="preserve">
+    <value>实时 MCP 端点未运行</value>
+    <comment />
+  </data>
+  <data name="AiAgents_LiveMcpUrl" xml:space="preserve">
+    <value>实时 MCP URL</value>
+    <comment />
+  </data>
+  <data name="AiAgents_LiveMcpUrl_Description" xml:space="preserve">
+    <value>MCP 客户端的连接 URL。每次请求都发送下面的身份验证标头——像对待密码一样对待它</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Advanced" xml:space="preserve">
+    <value>高级</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Advanced_Description" xml:space="preserve">
+    <value>覆盖文件夹名称和 MCP 配置文件，以及 stdio 服务器命令行。空字段使用所选代理的默认值</value>
+    <comment />
+  </data>
+  <data name="AiAgents_SkillsDirectory" xml:space="preserve">
+    <value>技能文件夹</value>
+    <comment />
+  </data>
+  <data name="AiAgents_SubagentsDirectory" xml:space="preserve">
+    <value>子代理文件夹</value>
+    <comment />
+  </data>
+  <data name="AiAgents_McpConfigFileName" xml:space="preserve">
+    <value>MCP 配置文件</value>
+    <comment />
+  </data>
+  <data name="AiAgents_McpServersPropertyName" xml:space="preserve">
+    <value>服务器属性</value>
+    <comment />
+  </data>
+  <data name="AiAgents_McpCommand" xml:space="preserve">
+    <value>命令</value>
+    <comment />
+  </data>
+  <data name="AiAgents_McpArguments" xml:space="preserve">
+    <value>参数（每行一个）</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Install" xml:space="preserve">
+    <value>安装</value>
+    <comment />
+  </data>
+  <data name="AiAgents_InstallCompleted" xml:space="preserve">
+    <value>已安装 {0} 个文件。</value>
+    <comment />
+  </data>
+  <data name="AiAgents_InstalledFiles" xml:space="preserve">
+    <value>已安装的文件</value>
+    <comment />
+  </data>
+  <data name="AiAgents_SelectWorkspaceRoot" xml:space="preserve">
+    <value>选择工作区根目录</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Agent" xml:space="preserve">
+    <value>代理</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Agent_Description" xml:space="preserve">
+    <value>要为其安装工具包的 AI 编码代理（文件夹约定遵循每个代理）</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Agent_Custom" xml:space="preserve">
+    <value>自定义（手动路径）</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Scope" xml:space="preserve">
+    <value>安装范围</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Scope_Description" xml:space="preserve">
+    <value>项目安装到项目文件夹中；全局安装到您的用户配置文件中</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Scope_Project" xml:space="preserve">
+    <value>项目</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Scope_Global" xml:space="preserve">
+    <value>全局（用户配置文件）</value>
+    <comment />
+  </data>
+  <data name="AiAgents_ProjectFolder" xml:space="preserve">
+    <value>项目文件夹</value>
+    <comment />
+  </data>
+  <data name="AiAgents_ProjectFolder_Description" xml:space="preserve">
+    <value>代理在其中运行的存储库或项目文件夹</value>
+    <comment />
+  </data>
+  <data name="AiAgents_SelectProjectFolder" xml:space="preserve">
+    <value>选择项目文件夹</value>
+    <comment />
+  </data>
+  <data name="AiAgents_ProjectFolderMissing" xml:space="preserve">
+    <value>请先选择项目文件夹。</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Destinations" xml:space="preserve">
+    <value>安装目标路径</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Destinations_Description" xml:space="preserve">
+    <value>所选代理和范围放置每个组件的位置</value>
+    <comment />
+  </data>
+  <data name="AiAgents_NotSupported" xml:space="preserve">
+    <value>此代理不支持</value>
+    <comment />
+  </data>
+  <data name="AiAgents_McpManual" xml:space="preserve">
+    <value>无法自动写入此代理的 MCP 配置。请在代理自己的设置中手动注册 MCP 服务器。</value>
+    <comment />
+  </data>
+  <data name="AiAgents_CliFailed" xml:space="preserve">
+    <value>通过代理的 CLI 进行 MCP 注册失败。请手动运行该命令：
+{0}</value>
+    <comment />
+  </data>
+  <data name="AiAgents_StdioMissing" xml:space="preserve">
+    <value>在应用程序旁边未找到 stdio MCP 服务器二进制文件。在“高级”下输入命令，或重新安装 Beutl。</value>
+    <comment />
+  </data>
+  <data name="AiAgents_LiveMcpAuthHeader" xml:space="preserve">
+    <value>身份验证标头</value>
+    <comment />
+  </data>
+  <data name="AiAgents_UpdateAvailable_Title" xml:space="preserve">
+    <value>AI 代理资源已更新</value>
+    <comment />
+  </data>
+  <data name="AiAgents_UpdateAvailable_Content" xml:space="preserve">
+    <value>此版本的 Beutl 捆绑了比您安装的更新的技能和子代理。现在使用您保存的设置重新安装它们吗？您在目标位置手动编辑的文件将被覆盖。</value>
+    <comment />
+  </data>
+  <data name="AiAgents_Reinstall" xml:space="preserve">
+    <value>重新安装</value>
+    <comment />
+  </data>
+</root>

--- a/src/Beutl.Language/Strings.es.resx
+++ b/src/Beutl.Language/Strings.es.resx
@@ -63,7 +63,7 @@
     <value>Cerrar</value>
   </data>
   <data name="ColorScopes" xml:space="preserve">
-    <value>Osciloscopios</value>
+    <value>Scopes de color</value>
   </data>
   <data name="CloseProject" xml:space="preserve">
     <value>Cerrar proyecto</value>

--- a/src/Beutl.Language/Strings.es.resx
+++ b/src/Beutl.Language/Strings.es.resx
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<root>
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:element name="root" msdata:IsDataSet="true">
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
 
-    </xsd:element>
-  </xsd:schema>
+    </xs:element>
+  </xs:schema>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -18,430 +18,430 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="File" xml:space="preserve">
-    <value>File</value>
+    <value>Archivo</value>
   </data>
   <data name="Curves" xml:space="preserve">
-    <value>Curves</value>
+    <value>Curvas</value>
   </data>
   <data name="CustomCurve" xml:space="preserve">
-    <value>Custom (RGB)</value>
+    <value>Personalizado (RGB)</value>
   </data>
   <data name="HueVsHue" xml:space="preserve">
-    <value>Hue vs Hue</value>
+    <value>Tono vs Tono</value>
   </data>
   <data name="HueVsLuminance" xml:space="preserve">
-    <value>Hue vs Luminance</value>
+    <value>Tono vs Luminancia</value>
   </data>
   <data name="HueVsSaturation" xml:space="preserve">
-    <value>Hue vs Saturation</value>
+    <value>Tono vs Saturación</value>
   </data>
   <data name="LuminanceVsSaturation" xml:space="preserve">
-    <value>Luminance vs Saturation</value>
+    <value>Luminancia vs Saturación</value>
   </data>
   <data name="SaturationVsSaturation" xml:space="preserve">
-    <value>Saturation vs Saturation</value>
+    <value>Saturación vs Saturación</value>
   </data>
   <data name="CreateNew" xml:space="preserve">
-    <value>Create New</value>
+    <value>Crear nuevo</value>
   </data>
   <data name="CreateNewProject" xml:space="preserve">
-    <value>Create new project</value>
+    <value>Crear nuevo proyecto</value>
   </data>
   <data name="CreateNewScene" xml:space="preserve">
-    <value>Create new scene</value>
+    <value>Crear nueva escena</value>
   </data>
   <data name="Project" xml:space="preserve">
-    <value>Project</value>
+    <value>Proyecto</value>
   </data>
   <data name="Scene" xml:space="preserve">
-    <value>Scene</value>
+    <value>Escena</value>
   </data>
   <data name="Open" xml:space="preserve">
-    <value>Open</value>
+    <value>Abrir</value>
   </data>
   <data name="Close" xml:space="preserve">
-    <value>Close</value>
+    <value>Cerrar</value>
   </data>
   <data name="ColorScopes" xml:space="preserve">
-    <value>Scopes</value>
+    <value>Osciloscopios</value>
   </data>
   <data name="CloseProject" xml:space="preserve">
-    <value>Close Project</value>
+    <value>Cerrar proyecto</value>
   </data>
   <data name="Save" xml:space="preserve">
-    <value>Save</value>
+    <value>Guardar</value>
   </data>
   <data name="SaveAll" xml:space="preserve">
-    <value>Save All</value>
+    <value>Guardar todo</value>
   </data>
   <data name="Exit" xml:space="preserve">
-    <value>Exit</value>
+    <value>Salir</value>
   </data>
   <data name="Edit" xml:space="preserve">
-    <value>Edit</value>
+    <value>Editar</value>
   </data>
   <data name="Undo" xml:space="preserve">
-    <value>Undo</value>
+    <value>Deshacer</value>
   </data>
   <data name="Redo" xml:space="preserve">
-    <value>Redo</value>
+    <value>Rehacer</value>
   </data>
   <data name="View" xml:space="preserve">
-    <value>View</value>
+    <value>Ver</value>
   </data>
   <data name="Object" xml:space="preserve">
-    <value>Object</value>
+    <value>Objeto</value>
   </data>
   <data name="Help" xml:space="preserve">
-    <value>Help</value>
+    <value>Ayuda</value>
   </data>
   <data name="Extensions" xml:space="preserve">
-    <value>Extensions</value>
+    <value>Extensiones</value>
   </data>
   <data name="Output" xml:space="preserve">
-    <value>Output</value>
+    <value>Salida</value>
   </data>
   <data name="History" xml:space="preserve">
-    <value>History</value>
+    <value>Historial</value>
   </data>
   <data name="History_Initial" xml:space="preserve">
-    <value>Initial state</value>
+    <value>Estado inicial</value>
   </data>
   <data name="History_Unnamed" xml:space="preserve">
-    <value>(Unnamed)</value>
+    <value>(Sin nombre)</value>
   </data>
   <data name="History_OperationFailed" xml:space="preserve">
-    <value>History operation failed.</value>
+    <value>La operación del historial falló.</value>
   </data>
   <data name="Settings" xml:space="preserve">
-    <value>Settings</value>
+    <value>Configuración</value>
   </data>
   <data name="Properties" xml:space="preserve">
-    <value>Properties</value>
+    <value>Propiedades</value>
   </data>
   <data name="Easings" xml:space="preserve">
-    <value>Easings</value>
+    <value>Suavizados</value>
   </data>
   <data name="Timeline" xml:space="preserve">
-    <value>Timeline</value>
+    <value>Línea de tiempo</value>
   </data>
   <data name="SceneFile" xml:space="preserve">
-    <value>Scene File</value>
+    <value>Archivo de escena</value>
   </data>
   <data name="Info" xml:space="preserve">
-    <value>Info</value>
+    <value>Información</value>
   </data>
   <data name="Add" xml:space="preserve">
-    <value>Add</value>
+    <value>Agregar</value>
   </data>
   <data name="Search" xml:space="preserve">
-    <value>Search</value>
+    <value>Buscar</value>
   </data>
   <data name="Name" xml:space="preserve">
-    <value>Name</value>
+    <value>Nombre</value>
   </data>
   <data name="Note" xml:space="preserve">
-    <value>Note</value>
+    <value>Nota</value>
   </data>
   <data name="Color" xml:space="preserve">
     <value>Color</value>
   </data>
   <data name="EditMarker" xml:space="preserve">
-    <value>Edit Marker</value>
+    <value>Editar marcador</value>
   </data>
   <data name="StartTime" xml:space="preserve">
-    <value>Start Time</value>
+    <value>Hora de inicio</value>
   </data>
   <data name="DurationTime" xml:space="preserve">
-    <value>Duration Time</value>
+    <value>Duración</value>
   </data>
   <data name="Cut" xml:space="preserve">
-    <value>Cut</value>
+    <value>Cortar</value>
   </data>
   <data name="Copy" xml:space="preserve">
-    <value>Copy</value>
+    <value>Copiar</value>
   </data>
   <data name="Paste" xml:space="preserve">
-    <value>Paste</value>
+    <value>Pegar</value>
   </data>
   <data name="Split" xml:space="preserve">
-    <value>Split</value>
+    <value>Dividir</value>
   </data>
   <data name="Duplicate" xml:space="preserve">
-    <value>Duplicate</value>
+    <value>Duplicar</value>
   </data>
   <data name="EditingMode" xml:space="preserve">
-    <value>Editing Mode</value>
+    <value>Modo de edición</value>
   </data>
   <data name="RazorTool" xml:space="preserve">
-    <value>Razor Tool</value>
+    <value>Herramienta de cuchilla</value>
   </data>
   <data name="RazorTool_Description" xml:space="preserve">
-    <value>Toggle razor (split) tool. Click on a clip to split it.</value>
+    <value>Alterna la herramienta de cuchilla (dividir). Haz clic en un clip para dividirlo.</value>
   </data>
   <data name="ExitRazorTool" xml:space="preserve">
-    <value>Exit Razor Tool</value>
+    <value>Salir de la herramienta de cuchilla</value>
   </data>
   <data name="ExitRazorTool_Description" xml:space="preserve">
-    <value>Exit razor mode and return to selection tool.</value>
+    <value>Sale del modo de cuchilla y vuelve a la herramienta de selección.</value>
   </data>
   <data name="SlipTool" xml:space="preserve">
-    <value>Slip Tool</value>
+    <value>Herramienta de desplazamiento</value>
   </data>
   <data name="SlipTool_Description" xml:space="preserve">
-    <value>Toggle slip tool. Drag a clip to shift its source-media window without moving the clip.</value>
+    <value>Alterna la herramienta de desplazamiento. Arrastra un clip para desplazar su ventana de medio de origen sin mover el clip.</value>
   </data>
   <data name="ExitSlipTool" xml:space="preserve">
-    <value>Exit Slip Tool</value>
+    <value>Salir de la herramienta de desplazamiento</value>
   </data>
   <data name="ExitSlipTool_Description" xml:space="preserve">
-    <value>Exit slip mode and return to selection tool.</value>
+    <value>Sale del modo de desplazamiento y vuelve a la herramienta de selección.</value>
   </data>
   <data name="RollTool" xml:space="preserve">
-    <value>Roll Tool</value>
+    <value>Herramienta de rodadura</value>
   </data>
   <data name="RollTool_Description" xml:space="preserve">
-    <value>Toggle roll tool. Drag a clip edge to shift the boundary with its neighbor, preserving total length.</value>
+    <value>Alterna la herramienta de rodadura. Arrastra el borde de un clip para desplazar el límite con su vecino, conservando la longitud total.</value>
   </data>
   <data name="ExitRollTool" xml:space="preserve">
-    <value>Exit Roll Tool</value>
+    <value>Salir de la herramienta de rodadura</value>
   </data>
   <data name="ExitRollTool_Description" xml:space="preserve">
-    <value>Exit roll mode and return to selection tool.</value>
+    <value>Sale del modo de rodadura y vuelve a la herramienta de selección.</value>
   </data>
   <data name="SlideTool" xml:space="preserve">
-    <value>Slide Tool</value>
+    <value>Herramienta de deslizamiento</value>
   </data>
   <data name="SlideTool_Description" xml:space="preserve">
-    <value>Toggle slide tool. Drag a clip to shift it while neighbors compensate, preserving total length.</value>
+    <value>Alterna la herramienta de deslizamiento. Arrastra un clip para desplazarlo mientras los vecinos compensan, conservando la longitud total.</value>
   </data>
   <data name="ExitSlideTool" xml:space="preserve">
-    <value>Exit Slide Tool</value>
+    <value>Salir de la herramienta de deslizamiento</value>
   </data>
   <data name="ExitSlideTool_Description" xml:space="preserve">
-    <value>Exit slide mode and return to selection tool.</value>
+    <value>Sale del modo de deslizamiento y vuelve a la herramienta de selección.</value>
   </data>
   <data name="Delete" xml:space="preserve">
-    <value>Delete</value>
+    <value>Eliminar</value>
   </data>
   <data name="Remove" xml:space="preserve">
-    <value>Remove</value>
+    <value>Quitar</value>
   </data>
   <data name="Exclude" xml:space="preserve">
-    <value>Exclude</value>
+    <value>Excluir</value>
   </data>
   <data name="Back" xml:space="preserve">
-    <value>Back</value>
+    <value>Atrás</value>
   </data>
   <data name="Next" xml:space="preserve">
-    <value>Next</value>
+    <value>Siguiente</value>
   </data>
   <data name="Element" xml:space="preserve">
-    <value>Element</value>
+    <value>Elemento</value>
   </data>
   <data name="AddElement" xml:space="preserve">
-    <value>Add Element</value>
+    <value>Agregar elemento</value>
   </data>
   <data name="AddAdjustmentLayer" xml:space="preserve">
-    <value>Add Adjustment Layer</value>
+    <value>Agregar capa de ajuste</value>
   </data>
   <data name="AdjustmentLayer" xml:space="preserve">
-    <value>Adjustment Layer</value>
+    <value>Capa de ajuste</value>
   </data>
   <data name="Location" xml:space="preserve">
-    <value>Location</value>
+    <value>Ubicación</value>
   </data>
   <data name="Size" xml:space="preserve">
-    <value>Size</value>
+    <value>Tamaño</value>
   </data>
   <data name="FrameRate" xml:space="preserve">
-    <value>Frame rate</value>
+    <value>Velocidad de fotogramas</value>
   </data>
   <data name="SampleRate" xml:space="preserve">
-    <value>Sample rate</value>
+    <value>Frecuencia de muestreo</value>
   </data>
   <data name="SceneSettings" xml:space="preserve">
-    <value>Scene settings</value>
+    <value>Configuración de la escena</value>
   </data>
   <data name="Apply" xml:space="preserve">
-    <value>Apply</value>
+    <value>Aplicar</value>
   </data>
   <data name="Width" xml:space="preserve">
-    <value>Width</value>
+    <value>Ancho</value>
   </data>
   <data name="Height" xml:space="preserve">
-    <value>Height</value>
+    <value>Altura</value>
   </data>
   <data name="Reset" xml:space="preserve">
-    <value>Reset</value>
+    <value>Restablecer</value>
   </data>
   <data name="ResetDockLayout" xml:space="preserve">
-    <value>Reset dock layout</value>
+    <value>Restablecer diseño de acoplamiento</value>
   </data>
   <data name="DockLayout" xml:space="preserve">
-    <value>Dock layout</value>
+    <value>Diseño de acoplamiento</value>
   </data>
   <data name="ApplyDockLayout" xml:space="preserve">
-    <value>Apply dock layout</value>
+    <value>Aplicar diseño de acoplamiento</value>
   </data>
   <data name="ManageDockLayouts" xml:space="preserve">
-    <value>Manage dock layouts</value>
+    <value>Administrar diseños de acoplamiento</value>
   </data>
   <data name="SaveCurrentDockLayout" xml:space="preserve">
-    <value>Save the current layout</value>
+    <value>Guardar el diseño actual</value>
   </data>
   <data name="SavedDockLayouts" xml:space="preserve">
-    <value>Saved layouts</value>
+    <value>Diseños guardados</value>
   </data>
   <data name="EditAnimation" xml:space="preserve">
-    <value>Edit animation</value>
+    <value>Editar animación</value>
   </data>
   <data name="NewFolder" xml:space="preserve">
-    <value>New Folder</value>
+    <value>Nueva carpeta</value>
   </data>
   <data name="Left" xml:space="preserve">
-    <value>Left</value>
+    <value>Izquierda</value>
   </data>
   <data name="Right" xml:space="preserve">
-    <value>Right</value>
+    <value>Derecha</value>
   </data>
   <data name="Top" xml:space="preserve">
-    <value>Top</value>
+    <value>Arriba</value>
   </data>
   <data name="Bottom" xml:space="preserve">
-    <value>Bottom</value>
+    <value>Abajo</value>
   </data>
   <data name="Cancel" xml:space="preserve">
-    <value>Cancel</value>
+    <value>Cancelar</value>
   </data>
   <data name="Yes" xml:space="preserve">
-    <value>Yes</value>
+    <value>Sí</value>
   </data>
   <data name="No" xml:space="preserve">
     <value>No</value>
   </data>
   <data name="DiscardChanges" xml:space="preserve">
-    <value>Discard changes</value>
+    <value>Descartar cambios</value>
   </data>
   <data name="Others" xml:space="preserve">
-    <value>Others</value>
+    <value>Otros</value>
   </data>
   <data name="Link" xml:space="preserve">
-    <value>Link</value>
+    <value>Enlace</value>
   </data>
   <data name="ShowMore" xml:space="preserve">
-    <value>Show more</value>
+    <value>Mostrar más</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>Aceptar</value>
   </data>
   <data name="Animation" xml:space="preserve">
-    <value>Animation</value>
+    <value>Animación</value>
   </data>
   <data name="Easing" xml:space="preserve">
-    <value>Easing</value>
+    <value>Suavizado</value>
   </data>
   <data name="Hold" xml:space="preserve">
-    <value>Hold</value>
+    <value>Mantener</value>
   </data>
   <data name="ElementProperty" xml:space="preserve">
-    <value>Element Property</value>
+    <value>Propiedad del elemento</value>
   </data>
   <data name="ProjectFile" xml:space="preserve">
-    <value>Project File</value>
+    <value>Archivo de proyecto</value>
   </data>
   <data name="RecentFiles" xml:space="preserve">
-    <value>Recent Files</value>
+    <value>Archivos recientes</value>
   </data>
   <data name="RecentProjects" xml:space="preserve">
-    <value>Recent Projects</value>
+    <value>Proyectos recientes</value>
   </data>
   <data name="Editors" xml:space="preserve">
-    <value>Editors</value>
+    <value>Editores</value>
   </data>
   <data name="Tools" xml:space="preserve">
-    <value>Tools</value>
+    <value>Herramientas</value>
   </data>
   <data name="Rename" xml:space="preserve">
-    <value>Rename</value>
+    <value>Renombrar</value>
   </data>
   <data name="FinishEditing" xml:space="preserve">
-    <value>Finish editing</value>
+    <value>Terminar edición</value>
   </data>
   <data name="BringToTop" xml:space="preserve">
-    <value>Bring to the top</value>
+    <value>Traer al frente</value>
   </data>
   <data name="StartEditing" xml:space="preserve">
-    <value>Start editing</value>
+    <value>Comenzar edición</value>
   </data>
   <data name="CreateNewProjectOrScene" xml:space="preserve">
-    <value>Create new project or scene</value>
+    <value>Crear nuevo proyecto o escena</value>
   </data>
   <data name="OpenAFileYouHaveAlreadyCreated" xml:space="preserve">
-    <value>Open a file you have already created</value>
+    <value>Abrir un archivo que ya has creado</value>
   </data>
   <data name="Recently" xml:space="preserve">
-    <value>Recently</value>
+    <value>Recientemente</value>
   </data>
   <data name="Projects" xml:space="preserve">
-    <value>Projects</value>
+    <value>Proyectos</value>
   </data>
   <data name="Files" xml:space="preserve">
-    <value>Files</value>
+    <value>Archivos</value>
   </data>
   <data name="All" xml:space="preserve">
-    <value>All</value>
+    <value>Todo</value>
   </data>
   <data name="NoFilesUsedRecently" xml:space="preserve">
-    <value>No files used recently.</value>
+    <value>No se usaron archivos recientemente.</value>
   </data>
   <data name="AddOutputProfile" xml:space="preserve">
-    <value>Add Profile</value>
+    <value>Agregar perfil</value>
   </data>
   <data name="Encode" xml:space="preserve">
-    <value>Encode</value>
+    <value>Codificar</value>
   </data>
   <data name="DestinationToSaveTo_Tip" xml:space="preserve">
-    <value>Set the destination</value>
+    <value>Establecer el destino</value>
   </data>
   <data name="DestinationToSaveTo" xml:space="preserve">
-    <value>Destination to save to</value>
+    <value>Destino de guardado</value>
   </data>
   <data name="Encoder_Tip" xml:space="preserve">
-    <value>Select an encoder</value>
+    <value>Seleccionar un codificador</value>
   </data>
   <data name="Encoder" xml:space="preserve">
-    <value>Encoder</value>
+    <value>Codificador</value>
   </data>
   <data name="FrameSize" xml:space="preserve">
-    <value>Frame size</value>
+    <value>Tamaño de fotograma</value>
   </data>
   <data name="FrameSize_Tip" xml:space="preserve">
-    <value>Set the frame size</value>
+    <value>Establecer el tamaño de fotograma</value>
   </data>
   <data name="FrameRate_Tip" xml:space="preserve">
-    <value>Set the framerate</value>
+    <value>Establecer la velocidad de fotogramas</value>
   </data>
   <data name="Bitrate" xml:space="preserve">
-    <value>Bitrate</value>
+    <value>Tasa de bits</value>
   </data>
   <data name="Bitrate_Tip" xml:space="preserve">
-    <value>Set the bitrate</value>
+    <value>Establecer la tasa de bits</value>
   </data>
   <data name="KeyframeRate" xml:space="preserve">
-    <value>Keyframe rate</value>
+    <value>Velocidad de fotogramas clave</value>
   </data>
   <data name="KeyframeRate_Tip" xml:space="preserve">
-    <value>Set the keyframe rate</value>
+    <value>Establecer la velocidad de fotogramas clave</value>
   </data>
   <data name="SampleRate_Tip" xml:space="preserve">
-    <value>Set the sample rate</value>
+    <value>Establecer la frecuencia de muestreo</value>
   </data>
   <data name="Channels" xml:space="preserve">
-    <value>Channels</value>
+    <value>Canales</value>
   </data>
   <data name="Channels_Tip" xml:space="preserve">
-    <value>Set the number of channels</value>
+    <value>Establecer el número de canales</value>
   </data>
   <data name="Video" xml:space="preserve">
     <value>Video</value>
@@ -450,837 +450,837 @@
     <value>Audio</value>
   </data>
   <data name="Off" xml:space="preserve">
-    <value>Off</value>
+    <value>Desactivado</value>
   </data>
   <data name="On" xml:space="preserve">
-    <value>On</value>
+    <value>Activado</value>
   </data>
   <data name="NodeGraph" xml:space="preserve">
-    <value>Node Graph</value>
+    <value>Grafo de nodos</value>
   </data>
   <data name="Library" xml:space="preserve">
-    <value>Library</value>
+    <value>Biblioteca</value>
   </data>
   <data name="FileBrowser" xml:space="preserve">
-    <value>File Browser</value>
+    <value>Explorador de archivos</value>
   </data>
   <data name="ListView" xml:space="preserve">
-    <value>List View</value>
+    <value>Vista de lista</value>
   </data>
   <data name="TreeView" xml:space="preserve">
-    <value>Tree View</value>
+    <value>Vista de árbol</value>
   </data>
   <data name="IconView" xml:space="preserve">
-    <value>Icon View</value>
+    <value>Vista de iconos</value>
   </data>
   <data name="Refresh" xml:space="preserve">
-    <value>Refresh</value>
+    <value>Actualizar</value>
   </data>
   <data name="OpenFolder" xml:space="preserve">
-    <value>Open Folder</value>
+    <value>Abrir carpeta</value>
   </data>
   <data name="Favorites" xml:space="preserve">
-    <value>Favorites</value>
+    <value>Favoritos</value>
   </data>
   <data name="Feedback" xml:space="preserve">
-    <value>Feedback</value>
+    <value>Comentarios</value>
   </data>
   <data name="AddToFavorites" xml:space="preserve">
-    <value>Add to Favorites</value>
+    <value>Agregar a favoritos</value>
   </data>
   <data name="RemoveFromFavorites" xml:space="preserve">
-    <value>Remove from Favorites</value>
+    <value>Quitar de favoritos</value>
   </data>
   <data name="NoFavorites" xml:space="preserve">
-    <value>No favorites</value>
+    <value>Sin favoritos</value>
   </data>
   <data name="DeleteSelectedItems" xml:space="preserve">
-    <value>Delete {0} items?</value>
+    <value>¿Eliminar {0} elementos?</value>
   </data>
   <data name="Group" xml:space="preserve">
-    <value>Group</value>
+    <value>Grupo</value>
   </data>
   <data name="GraphEditor" xml:space="preserve">
-    <value>Graph Editor</value>
+    <value>Editor de gráficos</value>
   </data>
   <data name="Unknown" xml:space="preserve">
-    <value>Unknown</value>
+    <value>Desconocido</value>
   </data>
   <data name="Details" xml:space="preserve">
-    <value>Details</value>
+    <value>Detalles</value>
   </data>
   <data name="Completed" xml:space="preserve">
-    <value>Completed</value>
+    <value>Completado</value>
   </data>
   <data name="Brightness" xml:space="preserve">
-    <value>Brightness</value>
+    <value>Brillo</value>
   </data>
   <data name="ColorGrading" xml:space="preserve">
-    <value>Color Grading</value>
+    <value>Gradación de color</value>
   </data>
   <data name="Number_of_Layers" xml:space="preserve">
-    <value>Number of Layers</value>
+    <value>Número de capas</value>
   </data>
   <data name="ChangeColor" xml:space="preserve">
-    <value>Change color</value>
+    <value>Cambiar color</value>
   </data>
   <data name="EditAnimationInInlineView" xml:space="preserve">
-    <value>Edit animation in inline view</value>
+    <value>Editar animación en vista en línea</value>
   </data>
   <data name="EnableLivePreview" xml:space="preserve">
-    <value>Enable Live Preview</value>
+    <value>Habilitar vista previa en vivo</value>
   </data>
   <data name="DisableThumbnails" xml:space="preserve">
-    <value>Disable Thumbnails</value>
+    <value>Deshabilitar miniaturas</value>
   </data>
   <data name="Unsupported" xml:space="preserve">
-    <value>Unsupported</value>
+    <value>No compatible</value>
   </data>
   <data name="TimelineZoom" xml:space="preserve">
     <value>Zoom</value>
   </data>
   <data name="TimelineSnap" xml:space="preserve">
-    <value>Snap</value>
+    <value>Ajuste</value>
   </data>
   <data name="RippleEdit" xml:space="preserve">
-    <value>Ripple Edit</value>
+    <value>Edición de ondulación</value>
   </data>
   <data name="UseGlobalClock" xml:space="preserve">
-    <value>Use the Global Clock</value>
+    <value>Usar el reloj global</value>
   </data>
   <data name="EditJson" xml:space="preserve">
-    <value>Edit Json</value>
+    <value>Editar JSON</value>
   </data>
   <data name="AddNode" xml:space="preserve">
-    <value>Add node</value>
+    <value>Agregar nodo</value>
   </data>
   <data name="Change" xml:space="preserve">
-    <value>Change</value>
+    <value>Cambiar</value>
   </data>
   <data name="Disconnect" xml:space="preserve">
-    <value>Disconnect</value>
+    <value>Desconectar</value>
   </data>
   <data name="Initialize" xml:space="preserve">
-    <value>Initialize</value>
+    <value>Inicializar</value>
   </data>
   <data name="ResetZoom" xml:space="preserve">
-    <value>Reset zoom</value>
+    <value>Restablecer zoom</value>
   </data>
   <data name="RemoveAnimation" xml:space="preserve">
-    <value>Remove animation</value>
+    <value>Quitar animación</value>
   </data>
   <data name="EditExpression" xml:space="preserve">
-    <value>Edit expression</value>
+    <value>Editar expresión</value>
   </data>
   <data name="RemoveExpression" xml:space="preserve">
-    <value>Remove expression</value>
+    <value>Quitar expresión</value>
   </data>
   <data name="ExpressionHelp" xml:space="preserve">
-    <value>Enter a mathematical expression. Available variables: Time, Start, Duration, Progress. Use GetProperty&lt;T&gt;("{GUID}.Property") to reference other properties.</value>
+    <value>Introduce una expresión matemática. Variables disponibles: Time, Start, Duration, Progress. Usa GetProperty&lt;T&gt;("{GUID}.Property") para hacer referencia a otras propiedades.</value>
   </data>
   <data name="CopyPropertyPath" xml:space="preserve">
-    <value>Copy property path</value>
+    <value>Copiar ruta de propiedad</value>
   </data>
   <data name="CopyGetPropertyCode" xml:space="preserve">
-    <value>Copy GetProperty code</value>
+    <value>Copiar código GetProperty</value>
   </data>
   <data name="ChangeToOriginalLength" xml:space="preserve">
-    <value>Change to original length</value>
+    <value>Cambiar a la longitud original</value>
   </data>
   <data name="SplitByCurrentFrame" xml:space="preserve">
-    <value>Split by current frame</value>
+    <value>Dividir por el fotograma actual</value>
   </data>
   <data name="GroupSelectedElements" xml:space="preserve">
-    <value>Group selected elements</value>
+    <value>Agrupar elementos seleccionados</value>
   </data>
   <data name="UngroupSelectedElements" xml:space="preserve">
-    <value>Ungroup selected elements</value>
+    <value>Desagrupar elementos seleccionados</value>
   </data>
   <data name="Agree" xml:space="preserve">
-    <value>Agree</value>
+    <value>Aceptar</value>
   </data>
   <data name="Disagree" xml:space="preserve">
-    <value>Disagree</value>
+    <value>Rechazar</value>
   </data>
   <data name="ShowDetails" xml:space="preserve">
-    <value>Show Details</value>
+    <value>Mostrar detalles</value>
   </data>
   <data name="SaveSelectedElementAsImage" xml:space="preserve">
-    <value>Save a selected element as an image</value>
+    <value>Guardar un elemento seleccionado como imagen</value>
   </data>
   <data name="SaveFrameAsImage" xml:space="preserve">
-    <value>Save a frame as an image</value>
+    <value>Guardar un fotograma como imagen</value>
   </data>
   <data name="SaveImageScale" xml:space="preserve">
-    <value>Scale</value>
+    <value>Escala</value>
   </data>
   <data name="SaveImageScale_OutputSize" xml:space="preserve">
-    <value>Output size</value>
+    <value>Tamaño de salida</value>
   </data>
   <data name="Move" xml:space="preserve">
-    <value>Move</value>
+    <value>Mover</value>
   </data>
   <data name="Hand" xml:space="preserve">
-    <value>Hand</value>
+    <value>Mano</value>
   </data>
   <data name="SetStartTime" xml:space="preserve">
-    <value>Set start time</value>
+    <value>Establecer hora de inicio</value>
   </data>
   <data name="SetEndTime" xml:space="preserve">
-    <value>Set end time</value>
+    <value>Establecer hora de fin</value>
   </data>
   <data name="NudgeLeftFrame" xml:space="preserve">
-    <value>Nudge left (1 frame)</value>
+    <value>Desplazar a la izquierda (1 fotograma)</value>
   </data>
   <data name="NudgeRightFrame" xml:space="preserve">
-    <value>Nudge right (1 frame)</value>
+    <value>Desplazar a la derecha (1 fotograma)</value>
   </data>
   <data name="NudgeLeftLarge" xml:space="preserve">
-    <value>Nudge left (10 frames)</value>
+    <value>Desplazar a la izquierda (10 fotogramas)</value>
   </data>
   <data name="NudgeRightLarge" xml:space="preserve">
-    <value>Nudge right (10 frames)</value>
+    <value>Desplazar a la derecha (10 fotogramas)</value>
   </data>
   <data name="NudgeLeftSecond" xml:space="preserve">
-    <value>Nudge left (1 second)</value>
+    <value>Desplazar a la izquierda (1 segundo)</value>
   </data>
   <data name="NudgeRightSecond" xml:space="preserve">
-    <value>Nudge right (1 second)</value>
+    <value>Desplazar a la derecha (1 segundo)</value>
   </data>
   <data name="CloseGap" xml:space="preserve">
-    <value>Close Gap</value>
+    <value>Cerrar espacio</value>
   </data>
   <data name="Gaps" xml:space="preserve">
-    <value>Gaps</value>
+    <value>Espacios</value>
   </data>
   <data name="CloseAllGaps" xml:space="preserve">
-    <value>Close All Gaps</value>
+    <value>Cerrar todos los espacios</value>
   </data>
   <data name="GoToNextGap" xml:space="preserve">
-    <value>Go to Next Gap</value>
+    <value>Ir al siguiente espacio</value>
   </data>
   <data name="GoToPreviousGap" xml:space="preserve">
-    <value>Go to Previous Gap</value>
+    <value>Ir al espacio anterior</value>
   </data>
   <data name="NoGapsToClose" xml:space="preserve">
-    <value>There are no gaps to close</value>
+    <value>No hay espacios para cerrar</value>
   </data>
   <data name="NoGapsToGoTo" xml:space="preserve">
-    <value>There are no gaps to go to</value>
+    <value>No hay espacios a los que ir</value>
   </data>
   <data name="NoElementSelected" xml:space="preserve">
-    <value>No element is selected</value>
+    <value>No se seleccionó ningún elemento</value>
   </data>
   <data name="Editor" xml:space="preserve">
     <value>Editor</value>
   </data>
   <data name="RunningStartupTasks" xml:space="preserve">
-    <value>Running startup tasks</value>
+    <value>Ejecutando tareas de inicio</value>
   </data>
   <data name="SaveAsImage" xml:space="preserve">
-    <value>Save as image</value>
+    <value>Guardar como imagen</value>
   </data>
   <data name="CopyAsImage" xml:space="preserve">
-    <value>Copy as image</value>
+    <value>Copiar como imagen</value>
   </data>
   <data name="AlwaysDisplay" xml:space="preserve">
-    <value>Always display</value>
+    <value>Mostrar siempre</value>
   </data>
   <data name="MemoryUsage" xml:space="preserve">
-    <value>Memory usage</value>
+    <value>Uso de memoria</value>
   </data>
   <data name="Locked" xml:space="preserve">
-    <value>Locked</value>
+    <value>Bloqueado</value>
   </data>
   <data name="Unlocked" xml:space="preserve">
-    <value>Unlocked</value>
+    <value>Desbloqueado</value>
   </data>
   <data name="DeleteAll" xml:space="preserve">
-    <value>Delete All</value>
+    <value>Eliminar todo</value>
   </data>
   <data name="Lock" xml:space="preserve">
-    <value>Lock</value>
+    <value>Bloquear</value>
   </data>
   <data name="Unlock" xml:space="preserve">
-    <value>Unlock</value>
+    <value>Desbloquear</value>
   </data>
   <data name="Solo" xml:space="preserve">
     <value>Solo</value>
   </data>
   <data name="LayerIsLocked" xml:space="preserve">
-    <value>The layer is locked.</value>
+    <value>La capa está bloqueada.</value>
   </data>
   <data name="FrameCache" xml:space="preserve">
-    <value>Frame cache</value>
+    <value>Caché de fotogramas</value>
   </data>
   <data name="RightClickToOperateCache" xml:space="preserve">
-    <value>Right-click to operate cache</value>
+    <value>Clic derecho para operar la caché</value>
   </data>
   <data name="Linear" xml:space="preserve">
-    <value>Linear</value>
+    <value>Lineal</value>
   </data>
   <data name="Conical" xml:space="preserve">
-    <value>Conical</value>
+    <value>Cónico</value>
   </data>
   <data name="Radial" xml:space="preserve">
     <value>Radial</value>
   </data>
   <data name="Red" xml:space="preserve">
-    <value>Red</value>
+    <value>Rojo</value>
   </data>
   <data name="Green" xml:space="preserve">
-    <value>Green</value>
+    <value>Verde</value>
   </data>
   <data name="Blue" xml:space="preserve">
-    <value>Blue</value>
+    <value>Azul</value>
   </data>
   <data name="Master" xml:space="preserve">
-    <value>Master</value>
+    <value>Maestro</value>
   </data>
   <data name="Hue" xml:space="preserve">
-    <value>Hue</value>
+    <value>Tono</value>
   </data>
   <data name="Saturation" xml:space="preserve">
-    <value>Saturation</value>
+    <value>Saturación</value>
   </data>
   <data name="ShowSliders" xml:space="preserve">
-    <value>Show sliders</value>
+    <value>Mostrar controles deslizantes</value>
   </data>
   <data name="ShowRing" xml:space="preserve">
-    <value>Show ring</value>
+    <value>Mostrar anillo</value>
   </data>
   <data name="Symmetry" xml:space="preserve">
-    <value>Symmetry</value>
+    <value>Simetría</value>
   </data>
   <data name="Asymmetry" xml:space="preserve">
-    <value>Asymmetry</value>
+    <value>Asimetría</value>
   </data>
   <data name="Separately" xml:space="preserve">
-    <value>Separately</value>
+    <value>Por separado</value>
   </data>
   <data name="Figure" xml:space="preserve">
-    <value>Figure</value>
+    <value>Figura</value>
   </data>
   <data name="Import" xml:space="preserve">
-    <value>Import</value>
+    <value>Importar</value>
   </data>
   <data name="ImportSvgPath" xml:space="preserve">
-    <value>Import SVG path</value>
+    <value>Importar ruta SVG</value>
   </data>
   <data name="ImportSvgPath_Description" xml:space="preserve">
-    <value>The current shape will be overwritten.</value>
+    <value>La forma actual se sobrescribirá.</value>
   </data>
   <data name="EditInFrame" xml:space="preserve">
-    <value>Edit in frame</value>
+    <value>Editar en fotograma</value>
   </data>
   <data name="EditInTab" xml:space="preserve">
-    <value>Edit in tab</value>
+    <value>Editar en pestaña</value>
   </data>
   <data name="PathEditor" xml:space="preserve">
-    <value>Path editor</value>
+    <value>Editor de trazado</value>
   </data>
   <data name="CopyAll" xml:space="preserve">
-    <value>Copy All</value>
+    <value>Copiar todo</value>
   </data>
   <data name="EnableElement" xml:space="preserve">
-    <value>Enable element</value>
+    <value>Habilitar elemento</value>
   </data>
   <data name="DockArea_LeftTop" xml:space="preserve">
-    <value>Left Top</value>
+    <value>Superior izquierda</value>
   </data>
   <data name="DockArea_LeftBottom" xml:space="preserve">
-    <value>Left Bottom</value>
+    <value>Inferior izquierda</value>
   </data>
   <data name="DockArea_RightTop" xml:space="preserve">
-    <value>Right Top</value>
+    <value>Superior derecha</value>
   </data>
   <data name="DockArea_RightBottom" xml:space="preserve">
-    <value>Right Bottom</value>
+    <value>Inferior derecha</value>
   </data>
   <data name="DockArea_BottomLeft" xml:space="preserve">
-    <value>Bottom Left</value>
+    <value>Inferior izquierda</value>
   </data>
   <data name="DockArea_BottomRight" xml:space="preserve">
-    <value>Bottom Right</value>
+    <value>Inferior derecha</value>
   </data>
   <data name="DockArea_TopLeft" xml:space="preserve">
-    <value>Top Left</value>
+    <value>Superior izquierda</value>
   </data>
   <data name="DockArea_TopRight" xml:space="preserve">
-    <value>Top Right</value>
+    <value>Superior derecha</value>
   </data>
   <data name="MoveTo" xml:space="preserve">
-    <value>Move to</value>
+    <value>Mover a</value>
   </data>
   <data name="MainView" xml:space="preserve">
-    <value>Main View</value>
+    <value>Vista principal</value>
   </data>
   <data name="OpenProject" xml:space="preserve">
-    <value>Open Project</value>
+    <value>Abrir proyecto</value>
   </data>
   <data name="OpenFile" xml:space="preserve">
-    <value>Open File</value>
+    <value>Abrir archivo</value>
   </data>
   <data name="Save_Description" xml:space="preserve">
-    <value>Save the current file</value>
+    <value>Guardar el archivo actual</value>
   </data>
   <data name="SaveAll_Description" xml:space="preserve">
-    <value>Save all files</value>
+    <value>Guardar todos los archivos</value>
   </data>
   <data name="CloseProject_Description" xml:space="preserve">
-    <value>Close the current project</value>
+    <value>Cerrar el proyecto actual</value>
   </data>
   <data name="Undo_Description" xml:space="preserve">
-    <value>Undo the last operation</value>
+    <value>Deshacer la última operación</value>
   </data>
   <data name="Redo_Description" xml:space="preserve">
-    <value>Redo the last operation</value>
+    <value>Rehacer la última operación</value>
   </data>
   <data name="Exit_Description" xml:space="preserve">
-    <value>Exit the application</value>
+    <value>Salir de la aplicación</value>
   </data>
   <data name="PlayPause" xml:space="preserve">
-    <value>Play/Pause</value>
+    <value>Reproducir/Pausar</value>
   </data>
   <data name="PlayPause_Description" xml:space="preserve">
-    <value>Switches between play and pause.</value>
+    <value>Alterna entre reproducir y pausar.</value>
   </data>
   <data name="MoveToNext" xml:space="preserve">
-    <value>Move to next</value>
+    <value>Mover al siguiente</value>
   </data>
   <data name="MoveToPrevious" xml:space="preserve">
-    <value>Move to previous</value>
+    <value>Mover al anterior</value>
   </data>
   <data name="MoveToNext_Description" xml:space="preserve">
-    <value>Move to the next frame.</value>
+    <value>Mover al siguiente fotograma.</value>
   </data>
   <data name="MoveToPrevious_Description" xml:space="preserve">
-    <value>Move to the previous frame.</value>
+    <value>Mover al fotograma anterior.</value>
   </data>
   <data name="MoveToStart" xml:space="preserve">
-    <value>Move to start</value>
+    <value>Mover al inicio</value>
   </data>
   <data name="MoveToEnd" xml:space="preserve">
-    <value>Move to end</value>
+    <value>Mover al final</value>
   </data>
   <data name="MoveToStart_Description" xml:space="preserve">
-    <value>Move to the start of the scene.</value>
+    <value>Mover al inicio de la escena.</value>
   </data>
   <data name="MoveToEnd_Description" xml:space="preserve">
-    <value>Move to the end of the scene.</value>
+    <value>Mover al final de la escena.</value>
   </data>
   <data name="ToggleMarker" xml:space="preserve">
-    <value>Toggle marker</value>
+    <value>Alternar marcador</value>
   </data>
   <data name="ToggleMarker_Description" xml:space="preserve">
-    <value>Toggle a marker at the current playhead. Removes the existing marker if one already exists at this position.</value>
+    <value>Alterna un marcador en el cabezal de reproducción actual. Elimina el marcador existente si ya hay uno en esta posición.</value>
   </data>
   <data name="NextMarker" xml:space="preserve">
-    <value>Next marker</value>
+    <value>Siguiente marcador</value>
   </data>
   <data name="NextMarker_Description" xml:space="preserve">
-    <value>Seek to the next marker.</value>
+    <value>Ir al siguiente marcador.</value>
   </data>
   <data name="PreviousMarker" xml:space="preserve">
-    <value>Previous marker</value>
+    <value>Marcador anterior</value>
   </data>
   <data name="PreviousMarker_Description" xml:space="preserve">
-    <value>Seek to the previous marker.</value>
+    <value>Ir al marcador anterior.</value>
   </data>
   <data name="NextKeyFrame" xml:space="preserve">
-    <value>Next keyframe</value>
+    <value>Siguiente fotograma clave</value>
   </data>
   <data name="NextKeyFrame_Description" xml:space="preserve">
-    <value>Seek to the next keyframe within the selected element (or scene-wide if none).</value>
+    <value>Ir al siguiente fotograma clave dentro del elemento seleccionado (o de toda la escena si no hay ninguno).</value>
   </data>
   <data name="PreviousKeyFrame" xml:space="preserve">
-    <value>Previous keyframe</value>
+    <value>Fotograma clave anterior</value>
   </data>
   <data name="PreviousKeyFrame_Description" xml:space="preserve">
-    <value>Seek to the previous keyframe within the selected element (or scene-wide if none).</value>
+    <value>Ir al fotograma clave anterior dentro del elemento seleccionado (o de toda la escena si no hay ninguno).</value>
   </data>
   <data name="NoKeyFrameToSeek" xml:space="preserve">
-    <value>No keyframe to seek.</value>
+    <value>No hay fotograma clave al que ir.</value>
   </data>
   <data name="ShuttleForward" xml:space="preserve">
-    <value>Shuttle forward</value>
+    <value>Avance rápido</value>
   </data>
   <data name="ShuttleForward_Description" xml:space="preserve">
-    <value>Shuttle forward (L). Press repeatedly to accelerate.</value>
+    <value>Avance rápido (L). Pulsa repetidamente para acelerar.</value>
   </data>
   <data name="ShuttleForwardFine" xml:space="preserve">
-    <value>Shuttle forward (fine)</value>
+    <value>Avance rápido (fino)</value>
   </data>
   <data name="ShuttleForwardFine_Description" xml:space="preserve">
-    <value>Shuttle forward at half speed.</value>
+    <value>Avance rápido a media velocidad.</value>
   </data>
   <data name="ShuttleBackward" xml:space="preserve">
-    <value>Shuttle backward</value>
+    <value>Retroceso rápido</value>
   </data>
   <data name="ShuttleBackward_Description" xml:space="preserve">
-    <value>Shuttle backward (J). Press repeatedly to accelerate.</value>
+    <value>Retroceso rápido (J). Pulsa repetidamente para acelerar.</value>
   </data>
   <data name="ShuttleBackwardFine" xml:space="preserve">
-    <value>Shuttle backward (fine)</value>
+    <value>Retroceso rápido (fino)</value>
   </data>
   <data name="ShuttleBackwardFine_Description" xml:space="preserve">
-    <value>Shuttle backward at half speed.</value>
+    <value>Retroceso rápido a media velocidad.</value>
   </data>
   <data name="ShuttleStop" xml:space="preserve">
-    <value>Shuttle stop</value>
+    <value>Detener avance</value>
   </data>
   <data name="ShuttleStop_Description" xml:space="preserve">
-    <value>Stop shuttle playback.</value>
+    <value>Detener la reproducción de avance.</value>
   </data>
   <data name="ToggleLoop" xml:space="preserve">
-    <value>Toggle loop</value>
+    <value>Alternar bucle</value>
   </data>
   <data name="ToggleLoop_Description" xml:space="preserve">
-    <value>Toggle loop playback.</value>
+    <value>Alternar la reproducción en bucle.</value>
   </data>
   <data name="GotoTimecode" xml:space="preserve">
-    <value>Goto timecode</value>
+    <value>Ir al código de tiempo</value>
   </data>
   <data name="GotoTimecode_Description" xml:space="preserve">
-    <value>Edit the current timecode to seek. Accepts absolute (00:01:23.45), frame (60f or #60), relative (+5s/-10f/+1m) or marker name (@Intro).</value>
+    <value>Edita el código de tiempo actual para ir a una posición. Acepta absoluto (00:01:23.45), fotogramas (60f o #60), relativo (+5s/-10f/+1m) o nombre de marcador (@Intro).</value>
   </data>
   <data name="GotoTimecode_InputHint" xml:space="preserve">
-    <value>00:01:23 / 60f / +5s / @marker</value>
+    <value>00:01:23 / 60f / +5s / @marcador</value>
   </data>
   <data name="GotoTimecode_InvalidFormat" xml:space="preserve">
-    <value>Invalid timecode format.</value>
+    <value>Formato de código de tiempo no válido.</value>
   </data>
   <data name="GotoTimecode_MarkerNotFound" xml:space="preserve">
-    <value>Marker not found.</value>
+    <value>No se encontró el marcador.</value>
   </data>
   <data name="GotoTimecode_NoScene" xml:space="preserve">
-    <value>No scene is loaded.</value>
+    <value>No hay ninguna escena cargada.</value>
   </data>
   <data name="GotoTimecode_OutOfRange" xml:space="preserve">
-    <value>Timecode is out of range.</value>
+    <value>El código de tiempo está fuera de rango.</value>
   </data>
   <data name="Paste_Description" xml:space="preserve">
-    <value>Paste the copied data.</value>
+    <value>Pegar los datos copiados.</value>
   </data>
   <data name="Rename_Description" xml:space="preserve">
-    <value>Rename the selected item.</value>
+    <value>Renombrar el elemento seleccionado.</value>
   </data>
   <data name="Exclude_Description" xml:space="preserve">
-    <value>Exclude the selected item.</value>
+    <value>Excluir el elemento seleccionado.</value>
   </data>
   <data name="Delete_Description" xml:space="preserve">
-    <value>Delete the selected item.</value>
+    <value>Eliminar el elemento seleccionado.</value>
   </data>
   <data name="Copy_Description" xml:space="preserve">
-    <value>Copy the selected item.</value>
+    <value>Copiar el elemento seleccionado.</value>
   </data>
   <data name="Cut_Description" xml:space="preserve">
-    <value>Cut the selected item.</value>
+    <value>Cortar el elemento seleccionado.</value>
   </data>
   <data name="Duplicate_Description" xml:space="preserve">
-    <value>Duplicate the selected item.</value>
+    <value>Duplicar el elemento seleccionado.</value>
   </data>
   <data name="Duplicate_Failed" xml:space="preserve">
-    <value>Failed to duplicate</value>
+    <value>No se pudo duplicar</value>
   </data>
   <data name="Duplicate_ProjectNotSaved" xml:space="preserve">
-    <value>Save the project before duplicating clips.</value>
+    <value>Guarda el proyecto antes de duplicar clips.</value>
   </data>
   <data name="Duplicate_IOFailed" xml:space="preserve">
-    <value>Could not write the duplicated element to disk.</value>
+    <value>No se pudo escribir el elemento duplicado en el disco.</value>
   </data>
   <data name="Duplicate_NoEmptySlot" xml:space="preserve">
-    <value>Could not find an empty slot on the timeline; the duplicate was placed where it may overlap an existing clip.</value>
+    <value>No se pudo encontrar un espacio vacío en la línea de tiempo; el duplicado se colocó donde puede superponerse a un clip existente.</value>
   </data>
   <data name="Duplicate_FallbackToMove" xml:space="preserve">
-    <value>Duplicate failed; falling back to a plain move of the original clips.</value>
+    <value>La duplicación falló; se recurre a un simple movimiento de los clips originales.</value>
   </data>
   <data name="Duplicate_FallbackFailed" xml:space="preserve">
-    <value>The move fallback also failed; the timeline state may not match what you see.</value>
+    <value>El movimiento de respaldo también falló; el estado de la línea de tiempo puede no coincidir con lo que ves.</value>
   </data>
   <data name="AboutBeutl" xml:space="preserve">
-    <value>About Beutl</value>
+    <value>Acerca de Beutl</value>
   </data>
   <data name="Update" xml:space="preserve">
-    <value>Update</value>
+    <value>Actualizar</value>
   </data>
   <data name="EditDrawable" xml:space="preserve">
-    <value>Edit drawable</value>
+    <value>Editar dibujable</value>
   </data>
   <data name="Item" xml:space="preserve">
-    <value>Item</value>
+    <value>Elemento</value>
   </data>
   <data name="Profiles" xml:space="preserve">
-    <value>Profiles</value>
+    <value>Perfiles</value>
   </data>
   <data name="Presets" xml:space="preserve">
-    <value>Presets</value>
+    <value>Ajustes preestablecidos</value>
   </data>
   <data name="Convert_to_preset" xml:space="preserve">
-    <value>Convert to preset</value>
+    <value>Convertir en ajuste preestablecido</value>
   </data>
   <data name="Expression_Input" xml:space="preserve">
-    <value>Input</value>
+    <value>Entrada</value>
   </data>
   <data name="Expression_Help" xml:space="preserve">
-    <value>Help</value>
+    <value>Ayuda</value>
   </data>
   <data name="Expression_Variables" xml:space="preserve">
     <value>Variables</value>
   </data>
   <data name="Expression_Functions" xml:space="preserve">
-    <value>Functions</value>
+    <value>Funciones</value>
   </data>
   <data name="Expression_Variables_Description" xml:space="preserve">
-    <value>Time: Current time relative to the element start (seconds)
-Start: Element start time (seconds)
-Duration: Element duration (seconds)
-Progress: Normalized progress (0.0 to 1.0)
-PI: Mathematical constant π (3.14159...)</value>
+    <value>Time: tiempo actual relativo al inicio del elemento (segundos)
+Start: hora de inicio del elemento (segundos)
+Duration: duración del elemento (segundos)
+Progress: progreso normalizado (0.0 a 1.0)
+PI: constante matemática π (3.14159...)</value>
   </data>
   <data name="Expression_Functions_Trigonometric" xml:space="preserve">
-    <value>Trigonometric: Sin, Cos, Tan, Asin, Acos, Atan, Atan2
-Hyperbolic: Sinh, Cosh, Tanh</value>
+    <value>Trigonométricas: Sin, Cos, Tan, Asin, Acos, Atan, Atan2
+Hiperbólicas: Sinh, Cosh, Tanh</value>
   </data>
   <data name="Expression_Functions_Math" xml:space="preserve">
-    <value>Math: Sqrt, Pow, Exp, Log, Log10, Log2
-Rounding: Abs, Floor, Ceil, Round, Truncate, Sign
-Range: Min, Max, Clamp</value>
+    <value>Matemáticas: Sqrt, Pow, Exp, Log, Log10, Log2
+Redondeo: Abs, Floor, Ceil, Round, Truncate, Sign
+Rango: Min, Max, Clamp</value>
   </data>
   <data name="Expression_Functions_Interpolation" xml:space="preserve">
-    <value>Interpolation: Lerp, InverseLerp, Remap, Smoothstep</value>
+    <value>Interpolación: Lerp, InverseLerp, Remap, Smoothstep</value>
   </data>
   <data name="Expression_Functions_Utility" xml:space="preserve">
-    <value>Utility: Radians, Degrees, Mod, Frac
-Random: Random(seed), Random(seed, min, max), FrameRandom(), FrameRandom(min, max)</value>
+    <value>Utilidad: Radians, Degrees, Mod, Frac
+Aleatorio: Random(seed), Random(seed, min, max), FrameRandom(), FrameRandom(min, max)</value>
   </data>
   <data name="Expression_GetProperty_Description" xml:space="preserve">
-    <value>Reference other properties:
-GetProperty&lt;T&gt;("path") or GetProperty&lt;T&gt;(guid, "propertyName")
-Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
+    <value>Referencia otras propiedades:
+GetProperty&lt;T&gt;("path") o GetProperty&lt;T&gt;(guid, "propertyName")
+Ejemplo: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
   </data>
   <data name="Histogram" xml:space="preserve">
-    <value>Histogram</value>
+    <value>Histograma</value>
   </data>
   <data name="Vectorscope" xml:space="preserve">
-    <value>Vectorscope</value>
+    <value>Vectoscopio</value>
   </data>
   <data name="Waveform" xml:space="preserve">
-    <value>Waveform</value>
+    <value>Forma de onda</value>
   </data>
   <data name="FalseColor" xml:space="preserve">
-    <value>False Color</value>
+    <value>Color falso</value>
   </data>
   <data name="Zebra" xml:space="preserve">
-    <value>Zebra</value>
+    <value>Cebra</value>
   </data>
   <data name="Threshold" xml:space="preserve">
-    <value>Threshold</value>
+    <value>Umbral</value>
   </data>
   <data name="ZebraHighThreshold" xml:space="preserve">
-    <value>High</value>
+    <value>Alto</value>
   </data>
   <data name="ZebraLowThreshold" xml:space="preserve">
-    <value>Low</value>
+    <value>Bajo</value>
   </data>
   <data name="Spectrum" xml:space="preserve">
-    <value>Spectrum</value>
+    <value>Espectro</value>
   </data>
   <data name="Meter" xml:space="preserve">
-    <value>Meter</value>
+    <value>Medidor</value>
   </data>
   <data name="AudioVisualizer" xml:space="preserve">
-    <value>Audio Visualizer</value>
+    <value>Visualizador de audio</value>
   </data>
   <data name="Spectrogram" xml:space="preserve">
-    <value>Spectrogram</value>
+    <value>Espectrograma</value>
   </data>
   <data name="PhaseScope" xml:space="preserve">
-    <value>Phase Scope</value>
+    <value>Osciloscopio de fase</value>
   </data>
   <data name="AudioVisualizer_ResetTooltip" xml:space="preserve">
-    <value>Right-click to reset to default</value>
+    <value>Clic derecho para restablecer a los valores predeterminados</value>
   </data>
   <data name="AudioVisualizer_Waveform_Description" xml:space="preserve">
-    <value>Time-domain L/R waveform of the most recent audio. The upper trace is the left channel, the lower trace is the right channel; both share a center axis line. Use this view to spot transients, clipping, asymmetric or DC-offset signals, and to confirm at a glance that audio is actually flowing.</value>
+    <value>Forma de onda L/R en el dominio del tiempo del audio más reciente. La traza superior es el canal izquierdo, la inferior el derecho; ambos comparten una línea de eje central. Usa esta vista para detectar transitorios, recortes, señales asimétricas o con desplazamiento de CC, y para confirmar de un vistazo que el audio realmente fluye.</value>
   </data>
   <data name="AudioVisualizer_Spectrum_Description" xml:space="preserve">
-    <value>Real-time FFT frequency spectrum on a logarithmic frequency axis (~20 Hz to Nyquist). Bar height represents energy in dB at each frequency band. The settings flyout exposes shape (Bar / Line / FilledArea / MirroredBars), FFT size, smoothing, and the noise floor (Min dB). Useful for EQ work, spotting hum or whistles, and confirming that the mix has the expected high-frequency content.</value>
+    <value>Espectro de frecuencia FFT en tiempo real sobre un eje de frecuencia logarítmico (~20 Hz a Nyquist). La altura de la barra representa la energía en dB en cada banda de frecuencia. El panel de configuración expone la forma (Barra / Línea / Área rellena / Barras reflejadas), el tamaño FFT, el suavizado y el piso de ruido (Min dB). Útil para trabajo de EQ, detectar zumbidos o silbidos y confirmar que la mezcla tiene el contenido de alta frecuencia esperado.</value>
   </data>
   <data name="AudioVisualizer_Meter_Description" xml:space="preserve">
-    <value>Stereo level meter combining several broadcast-standard readouts. Bars show RMS with a peak-hold marker that decays at ~6 dB/sec. Red LEDs at the top latch on for 2 seconds when the channel reaches 0 dBFS. The M number is momentary LUFS (BS.1770-4 K-weighted, 400 ms window). TP L / TP R are true peak in dBTP, computed by 4× polyphase oversampling. Use this view to verify loudness against delivery targets (-14 LUFS for YouTube, -23 LUFS for EBU R128) and to catch inter-sample peaks before encoding.</value>
+    <value>Medidor de nivel estéreo que combina varias lecturas estándar de radiodifusión. Las barras muestran RMS con un marcador de retención de pico que decae a ~6 dB/seg. Los LED rojos de la parte superior se encienden durante 2 segundos cuando el canal alcanza 0 dBFS. El número M es LUFS momentáneo (BS.1770-4 ponderado K, ventana de 400 ms). TP L / TP R son picos reales en dBTP, calculados mediante sobremuestreo polifásico de 4×. Usa esta vista para verificar la sonoridad según los objetivos de entrega (-14 LUFS para YouTube, -23 LUFS para EBU R128) y detectar picos entre muestras antes de codificar.</value>
   </data>
   <data name="AudioVisualizer_Spectrogram_Description" xml:space="preserve">
-    <value>Time-frequency heatmap of roughly the last 4 seconds. The vertical axis is logarithmic frequency (low at the bottom, high at the top); the horizontal axis is time (older on the left, newer on the right). Brightness represents energy in dB above the noise floor. Use this view to see how the spectrum evolves over time — identifying sweeping filters, vibrato, room modes, and the harmonic structure of sustained notes.</value>
+    <value>Mapa de calor tiempo-frecuencia de aproximadamente los últimos 4 segundos. El eje vertical es la frecuencia logarítmica (baja abajo, alta arriba); el horizontal es el tiempo (más antiguo a la izquierda, más reciente a la derecha). El brillo representa la energía en dB por encima del piso de ruido. Usa esta vista para ver cómo evoluciona el espectro con el tiempo: identifica filtros de barrido, vibrato, modos de sala y la estructura armónica de las notas sostenidas.</value>
   </data>
   <data name="AudioVisualizer_PhaseScope_Description" xml:space="preserve">
-    <value>Stereo Lissajous (goniometer) rotated 45° — the broadcast-standard convention. Pure mono content traces a vertical line on the M (mono) axis; fully out-of-phase material spreads horizontally toward the S (anti-phase) axis; a single channel traces the L or R diagonal. The "corr" value at the top-left is the Pearson correlation between channels: +1 means perfectly mono, 0 uncorrelated, -1 fully anti-phase. Use this view to catch channel-flipped or phase-cancelling material that would collapse during mono playback.</value>
+    <value>Lissajous estéreo (goniómetro) rotado 45°: la convención estándar de radiodifusión. El contenido mono puro traza una línea vertical en el eje M (mono); el material totalmente fuera de fase se extiende horizontalmente hacia el eje S (antifase); un solo canal traza la diagonal L o R. El valor "corr" en la parte superior izquierda es la correlación de Pearson entre canales: +1 significa perfectamente mono, 0 sin correlación, -1 totalmente en antifase. Usa esta vista para detectar material con canales invertidos o cancelación de fase que colapsaría durante la reproducción mono.</value>
   </data>
   <data name="Luma" xml:space="preserve">
     <value>Luma</value>
   </data>
   <data name="RgbOverlay" xml:space="preserve">
-    <value>RGB Overlay</value>
+    <value>Superposición RGB</value>
   </data>
   <data name="RgbParade" xml:space="preserve">
-    <value>RGB Parade</value>
+    <value>Desfile RGB</value>
   </data>
   <data name="Gamma" xml:space="preserve">
     <value>Gamma</value>
   </data>
   <data name="AVFoundationEncoder" xml:space="preserve">
-    <value>AVFoundation Encoder</value>
+    <value>Codificador AVFoundation</value>
   </data>
   <data name="AVFoundationDecoder" xml:space="preserve">
-    <value>AVFoundation Decoder</value>
+    <value>Decodificador AVFoundation</value>
   </data>
   <data name="UniformValue" xml:space="preserve">
-    <value>Uniform value</value>
+    <value>Valor uniforme</value>
   </data>
   <data name="Null" xml:space="preserve">
-    <value>Null</value>
+    <value>Nulo</value>
   </data>
   <data name="OpenInTab" xml:space="preserve">
-    <value>Open in tab</value>
+    <value>Abrir en pestaña</value>
   </data>
   <data name="Previous" xml:space="preserve">
-    <value>Previous</value>
+    <value>Anterior</value>
   </data>
   <data name="Current" xml:space="preserve">
-    <value>Current</value>
+    <value>Actual</value>
   </data>
   <data name="Result" xml:space="preserve">
-    <value>Result</value>
+    <value>Resultado</value>
   </data>
   <data name="ElapsedTime" xml:space="preserve">
-    <value>Elapsed time</value>
+    <value>Tiempo transcurrido</value>
   </data>
   <data name="Difference" xml:space="preserve">
-    <value>Difference</value>
+    <value>Diferencia</value>
   </data>
   <data name="Error" xml:space="preserve">
     <value>Error</value>
   </data>
   <data name="APIError" xml:space="preserve">
-    <value>API Error</value>
+    <value>Error de API</value>
   </data>
   <data name="Website" xml:space="preserve">
-    <value>Website</value>
+    <value>Sitio web</value>
   </data>
   <data name="DisplayMode" xml:space="preserve">
-    <value>Display mode</value>
+    <value>Modo de visualización</value>
   </data>
   <data name="Docked" xml:space="preserve">
-    <value>Docked</value>
+    <value>Acoplado</value>
   </data>
   <data name="Floating" xml:space="preserve">
-    <value>Floating</value>
+    <value>Flotante</value>
   </data>
   <data name="CropSelection" xml:space="preserve">
-    <value>Crop selection</value>
+    <value>Recortar selección</value>
   </data>
   <data name="Camera3DControl" xml:space="preserve">
-    <value>3D camera control</value>
+    <value>Control de cámara 3D</value>
   </data>
   <data name="Gizmo_Translate" xml:space="preserve">
-    <value>Translate</value>
+    <value>Trasladar</value>
   </data>
   <data name="Gizmo_Rotate" xml:space="preserve">
-    <value>Rotate</value>
+    <value>Rotar</value>
   </data>
   <data name="Gizmo_Scale" xml:space="preserve">
-    <value>Scale</value>
+    <value>Escalar</value>
   </data>
   <data name="Portal" xml:space="preserve">
     <value>Portal</value>
   </data>
   <data name="Portal_Count" xml:space="preserve">
-    <value>Count</value>
+    <value>Cantidad</value>
   </data>
   <data name="Portal_Clear" xml:space="preserve">
-    <value>Clear</value>
+    <value>Borrar</value>
   </data>
   <data name="ExportProject" xml:space="preserve">
-    <value>Export Project...</value>
+    <value>Exportar proyecto...</value>
   </data>
   <data name="ImportProject" xml:space="preserve">
-    <value>Import Project...</value>
+    <value>Importar proyecto...</value>
   </data>
   <data name="ExportingProject" xml:space="preserve">
-    <value>Exporting project...</value>
+    <value>Exportando proyecto...</value>
   </data>
   <data name="ImportingProject" xml:space="preserve">
-    <value>Importing project...</value>
+    <value>Importando proyecto...</value>
   </data>
   <data name="ProjectPackage" xml:space="preserve">
-    <value>Project Package</value>
+    <value>Paquete de proyecto</value>
   </data>
   <data name="SelectDestinationFolder" xml:space="preserve">
-    <value>Select Destination Folder</value>
+    <value>Seleccionar carpeta de destino</value>
   </data>
-  <!-- 3D Graphics -->
+  
   <data name="Experimental" xml:space="preserve">
     <value>Experimental</value>
   </data>
   <data name="Home" xml:space="preserve">
-    <value>Home</value>
+    <value>Inicio</value>
   </data>
   <data name="ProjectDirectory" xml:space="preserve">
-    <value>Project Directory</value>
+    <value>Directorio del proyecto</value>
   </data>
   <data name="MediaFiles" xml:space="preserve">
-    <value>Media Files</value>
+    <value>Archivos multimedia</value>
   </data>
   <data name="SearchingMediaFiles" xml:space="preserve">
-    <value>Searching for media files...</value>
+    <value>Buscando archivos multimedia...</value>
   </data>
   <data name="NoMediaFilesFound" xml:space="preserve">
-    <value>No media files found</value>
+    <value>No se encontraron archivos multimedia</value>
   </data>
   <data name="Tutorials" xml:space="preserve">
-    <value>Tutorials</value>
+    <value>Tutoriales</value>
   </data>
   <data name="BpmGrid" xml:space="preserve">
-    <value>BPM Grid</value>
+    <value>Cuadrícula BPM</value>
   </data>
   <data name="ShowBpmGrid" xml:space="preserve">
-    <value>Show BPM Grid</value>
+    <value>Mostrar cuadrícula BPM</value>
   </data>
   <data name="BpmValue" xml:space="preserve">
     <value>BPM</value>
   </data>
   <data name="BeatSubdivisions" xml:space="preserve">
-    <value>Subdivisions</value>
+    <value>Subdivisiones</value>
   </data>
   <data name="BpmOffset" xml:space="preserve">
-    <value>Offset</value>
+    <value>Desplazamiento</value>
   </data>
   <data name="Preview" xml:space="preserve">
-    <value>Preview</value>
+    <value>Vista previa</value>
   </data>
   <data name="PreviewSettings" xml:space="preserve">
-    <value>Preview Settings</value>
+    <value>Configuración de vista previa</value>
   </data>
   <data name="Templates" xml:space="preserve">
-    <value>Templates</value>
+    <value>Plantillas</value>
   </data>
   <data name="SaveAsTemplate" xml:space="preserve">
-    <value>Save as Template</value>
+    <value>Guardar como plantilla</value>
   </data>
   <data name="ApplyTemplate" xml:space="preserve">
-    <value>Apply Template</value>
+    <value>Aplicar plantilla</value>
   </data>
   <data name="AddFromTemplate" xml:space="preserve">
-    <value>Add from Template</value>
+    <value>Agregar desde plantilla</value>
   </data>
   <data name="TemplateSaved" xml:space="preserve">
-    <value>Template has been saved.</value>
+    <value>La plantilla se ha guardado.</value>
   </data>
   <data name="DeleteTemplateConfirm" xml:space="preserve">
-    <value>Are you sure you want to delete this template?</value>
+    <value>¿Seguro que quieres eliminar esta plantilla?</value>
   </data>
   <data name="EnterTemplateName" xml:space="preserve">
-    <value>Enter template name</value>
+    <value>Introduce el nombre de la plantilla</value>
   </data>
   <data name="Preset_YouTube_1080p60" xml:space="preserve">
     <value>YouTube 1080p 60fps</value>
@@ -1289,10 +1289,10 @@ Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
     <value>YouTube 4K 60fps</value>
   </data>
   <data name="Preset_Twitter_1080p" xml:space="preserve">
-    <value>Twitter (X) 1080p (max 2:20)</value>
+    <value>Twitter (X) 1080p (máx. 2:20)</value>
   </data>
   <data name="Preset_Instagram_Reels" xml:space="preserve">
-    <value>Instagram Reels 9:16 (max 90s)</value>
+    <value>Instagram Reels 9:16 (máx. 90 s)</value>
   </data>
   <data name="Preset_Instagram_Feed" xml:space="preserve">
     <value>Instagram Feed 1:1</value>
@@ -1304,270 +1304,270 @@ Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
     <value>Discord 8MB (~1 min)</value>
   </data>
   <data name="Encoding" xml:space="preserve">
-    <value>Encoding...</value>
+    <value>Codificando...</value>
   </data>
   <data name="RemainingTime" xml:space="preserve">
-    <value>Remaining</value>
+    <value>Restante</value>
   </data>
   <data name="Frames" xml:space="preserve">
-    <value>Frames</value>
+    <value>Fotogramas</value>
   </data>
   <data name="FileSize" xml:space="preserve">
-    <value>Size</value>
+    <value>Tamaño</value>
   </data>
   <data name="EstimatedSize" xml:space="preserve">
-    <value>Estimated</value>
+    <value>Estimado</value>
   </data>
   <data name="ShowCommandPalette" xml:space="preserve">
-    <value>Show command palette</value>
+    <value>Mostrar paleta de comandos</value>
   </data>
   <data name="ShowCommandPalette_Description" xml:space="preserve">
-    <value>Open the searchable command list</value>
+    <value>Abrir la lista de comandos buscable</value>
   </data>
   <data name="CommandPalette_Placeholder" xml:space="preserve">
-    <value>Type a command name…</value>
+    <value>Escribe un nombre de comando…</value>
   </data>
   <data name="CommandPalette_NoResults" xml:space="preserve">
-    <value>No matching commands</value>
+    <value>No hay comandos coincidentes</value>
   </data>
   <data name="CommandPalette_MenuCategory" xml:space="preserve">
-    <value>Menu</value>
+    <value>Menú</value>
   </data>
   <data name="OnionSkin" xml:space="preserve">
-    <value>Onion skin</value>
+    <value>Piel de cebolla</value>
   </data>
   <data name="OnionSkin_Description" xml:space="preserve">
-    <value>Show semi-transparent previous and next frames overlaid on the current frame.</value>
+    <value>Muestra los fotogramas anterior y siguiente semitransparentes superpuestos sobre el fotograma actual.</value>
   </data>
   <data name="ToggleOnionSkin" xml:space="preserve">
-    <value>Toggle onion skin</value>
+    <value>Alternar piel de cebolla</value>
   </data>
   <data name="ToggleOnionSkin_Description" xml:space="preserve">
-    <value>Toggle the onion skin overlay in the preview.</value>
+    <value>Alterna la superposición de piel de cebolla en la vista previa.</value>
   </data>
   <data name="OnionSkinPrevCount" xml:space="preserve">
-    <value>Previous frames</value>
+    <value>Fotogramas anteriores</value>
   </data>
   <data name="OnionSkinNextCount" xml:space="preserve">
-    <value>Next frames</value>
+    <value>Fotogramas siguientes</value>
   </data>
   <data name="OnionSkinPrevOpacity" xml:space="preserve">
-    <value>Previous opacity</value>
+    <value>Opacidad anterior</value>
   </data>
   <data name="OnionSkinNextOpacity" xml:space="preserve">
-    <value>Next opacity</value>
+    <value>Opacidad siguiente</value>
   </data>
   <data name="Supersampling" xml:space="preserve">
-    <value>Supersampling</value>
+    <value>Supermuestreo</value>
   </data>
   <data name="Supersampling_Tip" xml:space="preserve">
-    <value>Render at the selected multiple of the output resolution, then downscale to the output size for smoother edges</value>
+    <value>Renderiza al múltiplo seleccionado de la resolución de salida y luego reduce a la escala de salida para obtener bordes más suaves</value>
   </data>
   <data name="PreviewRenderQuality" xml:space="preserve">
-    <value>Preview render quality</value>
+    <value>Calidad de renderizado de vista previa</value>
   </data>
   <data name="PreviewRenderQuality_Tip" xml:space="preserve">
-    <value>Preview render quality. Cannot be changed during playback.</value>
+    <value>Calidad de renderizado de vista previa. No se puede cambiar durante la reproducción.</value>
   </data>
   <data name="RenderScale_Full" xml:space="preserve">
-    <value>Full</value>
+    <value>Completo</value>
   </data>
   <data name="RenderScale_Half" xml:space="preserve">
-    <value>Half (1/2)</value>
+    <value>Mitad (1/2)</value>
   </data>
   <data name="RenderScale_Quarter" xml:space="preserve">
-    <value>Quarter (1/4)</value>
+    <value>Cuarto (1/4)</value>
   </data>
   <data name="RenderScale_FitToPreviewer" xml:space="preserve">
-    <value>Fit to previewer</value>
+    <value>Ajustar al visor</value>
   </data>
   <data name="Terminal" xml:space="preserve">
     <value>Terminal</value>
   </data>
   <data name="TerminalSessionEnded" xml:space="preserve">
-    <value>The terminal session has ended.</value>
+    <value>La sesión de terminal ha terminado.</value>
   </data>
   <data name="Restart" xml:space="preserve">
-    <value>Restart</value>
+    <value>Reiniciar</value>
   </data>
   <data name="Proxies" xml:space="preserve">
     <value>Proxies</value>
   </data>
   <data name="ProxyPresetHalf" xml:space="preserve">
-    <value>Half proxy (1/2)</value>
+    <value>Proxy de mitad (1/2)</value>
   </data>
   <data name="ProxyQuality" xml:space="preserve">
-    <value>Proxy quality</value>
+    <value>Calidad del proxy</value>
   </data>
   <data name="PreviewSource" xml:space="preserve">
-    <value>Preview source</value>
+    <value>Fuente de vista previa</value>
   </data>
   <data name="PreviewSourcePreferProxy" xml:space="preserve">
-    <value>Prefer proxy</value>
+    <value>Preferir proxy</value>
   </data>
   <data name="PreviewSourceForceOriginal" xml:space="preserve">
-    <value>Force original</value>
+    <value>Forzar original</value>
   </data>
   <data name="ProxyPresetQuarter" xml:space="preserve">
-    <value>Quarter proxy (1/4)</value>
+    <value>Proxy de cuarto (1/4)</value>
   </data>
   <data name="ProxyPresetEighth" xml:space="preserve">
-    <value>Eighth proxy (1/8)</value>
+    <value>Proxy de octavo (1/8)</value>
   </data>
   <data name="ProxyStoreUsage" xml:space="preserve">
-    <value>Store</value>
+    <value>Almacenamiento</value>
   </data>
   <data name="ProxyStoreCap" xml:space="preserve">
-    <value>Cap</value>
+    <value>Límite</value>
   </data>
   <data name="ProxyClips" xml:space="preserve">
     <value>Clips</value>
   </data>
   <data name="ProxyQueue" xml:space="preserve">
-    <value>Queue</value>
+    <value>Cola</value>
   </data>
   <data name="ProxyGenerate" xml:space="preserve">
-    <value>Generate</value>
+    <value>Generar</value>
   </data>
   <data name="ProxyGenerateSelected" xml:space="preserve">
-    <value>Generate selected</value>
+    <value>Generar seleccionados</value>
   </data>
   <data name="ProxyGenerateAll" xml:space="preserve">
-    <value>Generate all</value>
+    <value>Generar todos</value>
   </data>
   <data name="ProxyRegenerate" xml:space="preserve">
-    <value>Regenerate</value>
+    <value>Regenerar</value>
   </data>
   <data name="ProxyRegenerateSelected" xml:space="preserve">
-    <value>Regenerate selected</value>
+    <value>Regenerar seleccionados</value>
   </data>
   <data name="ProxyDeleteSelected" xml:space="preserve">
-    <value>Delete selected</value>
+    <value>Eliminar seleccionados</value>
   </data>
   <data name="ProxyDeleteProjectProxies" xml:space="preserve">
-    <value>Delete project proxies</value>
+    <value>Eliminar proxies del proyecto</value>
   </data>
   <data name="ProxyDeleteProjectProxiesConfirmationFormat" xml:space="preserve">
-    <value>Proxies are stored in a machine-wide shared cache. Deleting the {0} proxy file(s) used by this project also removes them for every other project that references the same source files, and they will have to be regenerated. Continue?</value>
+    <value>Los proxies se almacenan en una caché compartida de toda la máquina. Eliminar los {0} archivos proxy usados por este proyecto también los elimina para todos los demás proyectos que hacen referencia a los mismos archivos de origen, y deberán regenerarse. ¿Continuar?</value>
   </data>
   <data name="ProxyReady" xml:space="preserve">
-    <value>Ready</value>
+    <value>Listo</value>
   </data>
   <data name="ProxyGenerating" xml:space="preserve">
-    <value>Generating</value>
+    <value>Generando</value>
   </data>
   <data name="ProxyStale" xml:space="preserve">
-    <value>Stale</value>
+    <value>Desactualizado</value>
   </data>
   <data name="ProxyFailed" xml:space="preserve">
-    <value>Failed</value>
+    <value>Fallido</value>
   </data>
   <data name="ProxyMissing" xml:space="preserve">
-    <value>Missing</value>
+    <value>Faltante</value>
   </data>
   <data name="ProxyPartial" xml:space="preserve">
-    <value>Partial</value>
+    <value>Parcial</value>
   </data>
   <data name="ProxyUnavailable" xml:space="preserve">
-    <value>Unavailable</value>
+    <value>No disponible</value>
   </data>
   <data name="ProxyStoreUnavailable" xml:space="preserve">
-    <value>Proxy store is not available.</value>
+    <value>El almacenamiento de proxies no está disponible.</value>
   </data>
   <data name="ProxyQueueUnavailable" xml:space="preserve">
-    <value>Proxy queue is not available.</value>
+    <value>La cola de proxies no está disponible.</value>
   </data>
   <data name="ProxyBulkNoEligibleClips" xml:space="preserve">
-    <value>No clips met the bulk-generation threshold; use per-clip generate.</value>
+    <value>Ningún clip alcanzó el umbral de generación masiva; usa la generación por clip.</value>
   </data>
   <data name="ProxyQueueIdle" xml:space="preserve">
-    <value>Queue idle</value>
+    <value>Cola inactiva</value>
   </data>
   <data name="ProxyQueuedJobSingular" xml:space="preserve">
-    <value>1 queued job</value>
+    <value>1 trabajo en cola</value>
   </data>
   <data name="ProxyQueuedJobPlural" xml:space="preserve">
-    <value>{0} queued jobs</value>
+    <value>{0} trabajos en cola</value>
   </data>
   <data name="ProxyDeleteFailedSingular" xml:space="preserve">
-    <value>1 proxy could not be deleted because its file is in use.</value>
+    <value>No se pudo eliminar 1 proxy porque su archivo está en uso.</value>
   </data>
   <data name="ProxyDeleteFailedPluralFormat" xml:space="preserve">
-    <value>{0} proxies could not be deleted because their files are in use.</value>
+    <value>No se pudieron eliminar {0} proxies porque sus archivos están en uso.</value>
   </data>
   <data name="ProxyClipSummaryFormat" xml:space="preserve">
-    <value>{0} clips / {1} ready / {2} stale / {3} failed / {4} missing</value>
+    <value>{0} clips / {1} listos / {2} desactualizados / {3} fallidos / {4} faltantes</value>
   </data>
   <data name="ProxySelectedSingular" xml:space="preserve">
-    <value>1 selected</value>
+    <value>1 seleccionado</value>
   </data>
   <data name="ProxySelectedPlural" xml:space="preserve">
-    <value>{0} selected</value>
+    <value>{0} seleccionados</value>
   </data>
   <data name="ProxyStoreSummaryFormat" xml:space="preserve">
-    <value>Project {0} / Store {1} / Cap {2}</value>
+    <value>Proyecto {0} / Almacenamiento {1} / Límite {2}</value>
   </data>
   <data name="ProxySourceInfoFormat" xml:space="preserve">
-    <value>Source {0} / {1}</value>
+    <value>Fuente {0} / {1}</value>
   </data>
   <data name="ProxyInfoFormat" xml:space="preserve">
-    <value>Proxy {0} -> {1} / {2}</value>
+    <value>Proxy {0} -&gt; {1} / {2}</value>
   </data>
   <data name="ProxyMissingForSelectedPreset" xml:space="preserve">
-    <value>Proxy missing for selected preset</value>
+    <value>Falta el proxy para el ajuste preestablecido seleccionado</value>
   </data>
   <data name="ProxyLastUsedFormat" xml:space="preserve">
-    <value>Used {0}</value>
+    <value>Usado {0}</value>
   </data>
   <data name="ProxyJobStatusQueued" xml:space="preserve">
-    <value>Queued</value>
+    <value>En cola</value>
   </data>
   <data name="ProxyJobStatusRunning" xml:space="preserve">
-    <value>Running</value>
+    <value>En ejecución</value>
   </data>
   <data name="ProxyJobStatusSucceeded" xml:space="preserve">
-    <value>Succeeded</value>
+    <value>Correcto</value>
   </data>
   <data name="ProxyJobStatusFailed" xml:space="preserve">
-    <value>Failed</value>
+    <value>Fallido</value>
   </data>
   <data name="ProxyJobStatusCanceled" xml:space="preserve">
-    <value>Canceled</value>
+    <value>Cancelado</value>
   </data>
   <data name="ProxyJobStatusSkipped" xml:space="preserve">
-    <value>Skipped</value>
+    <value>Omitido</value>
   </data>
   <data name="ProxyJobStatusWithMessageFormat" xml:space="preserve">
     <value>{0}: {1}</value>
   </data>
   <data name="Start" xml:space="preserve">
-    <value>Start</value>
+    <value>Iniciar</value>
   </data>
   <data name="Debug" xml:space="preserve">
-    <value>Debug</value>
+    <value>Depuración</value>
   </data>
   <data name="AudioVisualizer_Display" xml:space="preserve">
-    <value>Display</value>
+    <value>Visualización</value>
   </data>
   <data name="WindowCapture" xml:space="preserve">
-    <value>Window Capture</value>
+    <value>Captura de ventana</value>
   </data>
   <data name="AudioVisualizer_MinDecibels" xml:space="preserve">
-    <value>Min dB</value>
+    <value>dB mín.</value>
   </data>
   <data name="WindowCapture_RenderScale" xml:space="preserve">
-    <value>Render scale</value>
+    <value>Escala de renderizado</value>
   </data>
   <data name="WindowCapture_FrameRate" xml:space="preserve">
-    <value>Frame rate (fps)</value>
+    <value>Velocidad de fotogramas (fps)</value>
   </data>
   <data name="WindowCapture_OutputFile" xml:space="preserve">
-    <value>Output file (.mp4)</value>
+    <value>Archivo de salida (.mp4)</value>
   </data>
   <data name="Browse" xml:space="preserve">
-    <value>Browse...</value>
+    <value>Examinar...</value>
   </data>
   <data name="ClickBrowse" xml:space="preserve">
-    <value>Click Browse...</value>
+    <value>Haz clic en Examinar...</value>
   </data>
 </root>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -1534,4 +1534,34 @@ GetProperty&lt;T&gt;("path") または GetProperty&lt;T&gt;(guid, "propertyName"
   <data name="ProxyJobStatusWithMessageFormat" xml:space="preserve">
     <value>{0}: {1}</value>
   </data>
+  <data name="Start" xml:space="preserve">
+    <value>開始</value>
+  </data>
+  <data name="Debug" xml:space="preserve">
+    <value>デバッグ</value>
+  </data>
+  <data name="AudioVisualizer_Display" xml:space="preserve">
+    <value>表示</value>
+  </data>
+  <data name="WindowCapture" xml:space="preserve">
+    <value>ウィンドウキャプチャ</value>
+  </data>
+  <data name="AudioVisualizer_MinDecibels" xml:space="preserve">
+    <value>最小dB</value>
+  </data>
+  <data name="WindowCapture_RenderScale" xml:space="preserve">
+    <value>レンダースケール</value>
+  </data>
+  <data name="WindowCapture_FrameRate" xml:space="preserve">
+    <value>フレームレート (fps)</value>
+  </data>
+  <data name="WindowCapture_OutputFile" xml:space="preserve">
+    <value>出力ファイル (.mp4)</value>
+  </data>
+  <data name="Browse" xml:space="preserve">
+    <value>参照...</value>
+  </data>
+  <data name="ClickBrowse" xml:space="preserve">
+    <value>参照をクリック...</value>
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.ko-KR.resx
+++ b/src/Beutl.Language/Strings.ko-KR.resx
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<root>
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:element name="root" msdata:IsDataSet="true">
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
 
-    </xsd:element>
-  </xsd:schema>
+    </xs:element>
+  </xs:schema>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -18,1269 +18,1269 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="File" xml:space="preserve">
-    <value>File</value>
+    <value>파일</value>
   </data>
   <data name="Curves" xml:space="preserve">
-    <value>Curves</value>
+    <value>곡선</value>
   </data>
   <data name="CustomCurve" xml:space="preserve">
-    <value>Custom (RGB)</value>
+    <value>사용자 지정 (RGB)</value>
   </data>
   <data name="HueVsHue" xml:space="preserve">
-    <value>Hue vs Hue</value>
+    <value>색조 vs 색조</value>
   </data>
   <data name="HueVsLuminance" xml:space="preserve">
-    <value>Hue vs Luminance</value>
+    <value>색조 vs 휘도</value>
   </data>
   <data name="HueVsSaturation" xml:space="preserve">
-    <value>Hue vs Saturation</value>
+    <value>색조 vs 채도</value>
   </data>
   <data name="LuminanceVsSaturation" xml:space="preserve">
-    <value>Luminance vs Saturation</value>
+    <value>휘도 vs 채도</value>
   </data>
   <data name="SaturationVsSaturation" xml:space="preserve">
-    <value>Saturation vs Saturation</value>
+    <value>채도 vs 채도</value>
   </data>
   <data name="CreateNew" xml:space="preserve">
-    <value>Create New</value>
+    <value>새로 만들기</value>
   </data>
   <data name="CreateNewProject" xml:space="preserve">
-    <value>Create new project</value>
+    <value>새 프로젝트 만들기</value>
   </data>
   <data name="CreateNewScene" xml:space="preserve">
-    <value>Create new scene</value>
+    <value>새 장면 만들기</value>
   </data>
   <data name="Project" xml:space="preserve">
-    <value>Project</value>
+    <value>프로젝트</value>
   </data>
   <data name="Scene" xml:space="preserve">
-    <value>Scene</value>
+    <value>장면</value>
   </data>
   <data name="Open" xml:space="preserve">
-    <value>Open</value>
+    <value>열기</value>
   </data>
   <data name="Close" xml:space="preserve">
-    <value>Close</value>
+    <value>닫기</value>
   </data>
   <data name="ColorScopes" xml:space="preserve">
-    <value>Scopes</value>
+    <value>스코프</value>
   </data>
   <data name="CloseProject" xml:space="preserve">
-    <value>Close Project</value>
+    <value>프로젝트 닫기</value>
   </data>
   <data name="Save" xml:space="preserve">
-    <value>Save</value>
+    <value>저장</value>
   </data>
   <data name="SaveAll" xml:space="preserve">
-    <value>Save All</value>
+    <value>모두 저장</value>
   </data>
   <data name="Exit" xml:space="preserve">
-    <value>Exit</value>
+    <value>종료</value>
   </data>
   <data name="Edit" xml:space="preserve">
-    <value>Edit</value>
+    <value>편집</value>
   </data>
   <data name="Undo" xml:space="preserve">
-    <value>Undo</value>
+    <value>실행 취소</value>
   </data>
   <data name="Redo" xml:space="preserve">
-    <value>Redo</value>
+    <value>다시 실행</value>
   </data>
   <data name="View" xml:space="preserve">
-    <value>View</value>
+    <value>보기</value>
   </data>
   <data name="Object" xml:space="preserve">
-    <value>Object</value>
+    <value>개체</value>
   </data>
   <data name="Help" xml:space="preserve">
-    <value>Help</value>
+    <value>도움말</value>
   </data>
   <data name="Extensions" xml:space="preserve">
-    <value>Extensions</value>
+    <value>확장</value>
   </data>
   <data name="Output" xml:space="preserve">
-    <value>Output</value>
+    <value>출력</value>
   </data>
   <data name="History" xml:space="preserve">
-    <value>History</value>
+    <value>기록</value>
   </data>
   <data name="History_Initial" xml:space="preserve">
-    <value>Initial state</value>
+    <value>초기 상태</value>
   </data>
   <data name="History_Unnamed" xml:space="preserve">
-    <value>(Unnamed)</value>
+    <value>(이름 없음)</value>
   </data>
   <data name="History_OperationFailed" xml:space="preserve">
-    <value>History operation failed.</value>
+    <value>기록 작업이 실패했습니다.</value>
   </data>
   <data name="Settings" xml:space="preserve">
-    <value>Settings</value>
+    <value>설정</value>
   </data>
   <data name="Properties" xml:space="preserve">
-    <value>Properties</value>
+    <value>속성</value>
   </data>
   <data name="Easings" xml:space="preserve">
-    <value>Easings</value>
+    <value>이징</value>
   </data>
   <data name="Timeline" xml:space="preserve">
-    <value>Timeline</value>
+    <value>타임라인</value>
   </data>
   <data name="SceneFile" xml:space="preserve">
-    <value>Scene File</value>
+    <value>장면 파일</value>
   </data>
   <data name="Info" xml:space="preserve">
-    <value>Info</value>
+    <value>정보</value>
   </data>
   <data name="Add" xml:space="preserve">
-    <value>Add</value>
+    <value>추가</value>
   </data>
   <data name="Search" xml:space="preserve">
-    <value>Search</value>
+    <value>검색</value>
   </data>
   <data name="Name" xml:space="preserve">
-    <value>Name</value>
+    <value>이름</value>
   </data>
   <data name="Note" xml:space="preserve">
-    <value>Note</value>
+    <value>메모</value>
   </data>
   <data name="Color" xml:space="preserve">
-    <value>Color</value>
+    <value>색상</value>
   </data>
   <data name="EditMarker" xml:space="preserve">
-    <value>Edit Marker</value>
+    <value>마커 편집</value>
   </data>
   <data name="StartTime" xml:space="preserve">
-    <value>Start Time</value>
+    <value>시작 시간</value>
   </data>
   <data name="DurationTime" xml:space="preserve">
-    <value>Duration Time</value>
+    <value>길이</value>
   </data>
   <data name="Cut" xml:space="preserve">
-    <value>Cut</value>
+    <value>잘라내기</value>
   </data>
   <data name="Copy" xml:space="preserve">
-    <value>Copy</value>
+    <value>복사</value>
   </data>
   <data name="Paste" xml:space="preserve">
-    <value>Paste</value>
+    <value>붙여넣기</value>
   </data>
   <data name="Split" xml:space="preserve">
-    <value>Split</value>
+    <value>분할</value>
   </data>
   <data name="Duplicate" xml:space="preserve">
-    <value>Duplicate</value>
+    <value>복제</value>
   </data>
   <data name="EditingMode" xml:space="preserve">
-    <value>Editing Mode</value>
+    <value>편집 모드</value>
   </data>
   <data name="RazorTool" xml:space="preserve">
-    <value>Razor Tool</value>
+    <value>면도칼 도구</value>
   </data>
   <data name="RazorTool_Description" xml:space="preserve">
-    <value>Toggle razor (split) tool. Click on a clip to split it.</value>
+    <value>면도칼(분할) 도구를 전환합니다. 클립을 클릭하여 분할합니다.</value>
   </data>
   <data name="ExitRazorTool" xml:space="preserve">
-    <value>Exit Razor Tool</value>
+    <value>면도칼 도구 종료</value>
   </data>
   <data name="ExitRazorTool_Description" xml:space="preserve">
-    <value>Exit razor mode and return to selection tool.</value>
+    <value>면도칼 모드를 종료하고 선택 도구로 돌아갑니다.</value>
   </data>
   <data name="SlipTool" xml:space="preserve">
-    <value>Slip Tool</value>
+    <value>슬립 도구</value>
   </data>
   <data name="SlipTool_Description" xml:space="preserve">
-    <value>Toggle slip tool. Drag a clip to shift its source-media window without moving the clip.</value>
+    <value>슬립 도구를 전환합니다. 클립을 끌어 클립을 이동하지 않고 소스 미디어 창을 이동합니다.</value>
   </data>
   <data name="ExitSlipTool" xml:space="preserve">
-    <value>Exit Slip Tool</value>
+    <value>슬립 도구 종료</value>
   </data>
   <data name="ExitSlipTool_Description" xml:space="preserve">
-    <value>Exit slip mode and return to selection tool.</value>
+    <value>슬립 모드를 종료하고 선택 도구로 돌아갑니다.</value>
   </data>
   <data name="RollTool" xml:space="preserve">
-    <value>Roll Tool</value>
+    <value>롤 도구</value>
   </data>
   <data name="RollTool_Description" xml:space="preserve">
-    <value>Toggle roll tool. Drag a clip edge to shift the boundary with its neighbor, preserving total length.</value>
+    <value>롤 도구를 전환합니다. 클립 가장자리를 끌어 이웃과의 경계를 이동하며 총 길이를 유지합니다.</value>
   </data>
   <data name="ExitRollTool" xml:space="preserve">
-    <value>Exit Roll Tool</value>
+    <value>롤 도구 종료</value>
   </data>
   <data name="ExitRollTool_Description" xml:space="preserve">
-    <value>Exit roll mode and return to selection tool.</value>
+    <value>롤 모드를 종료하고 선택 도구로 돌아갑니다.</value>
   </data>
   <data name="SlideTool" xml:space="preserve">
-    <value>Slide Tool</value>
+    <value>슬라이드 도구</value>
   </data>
   <data name="SlideTool_Description" xml:space="preserve">
-    <value>Toggle slide tool. Drag a clip to shift it while neighbors compensate, preserving total length.</value>
+    <value>슬라이드 도구를 전환합니다. 클립을 끌어 이동하면서 이웃이 보정하여 총 길이를 유지합니다.</value>
   </data>
   <data name="ExitSlideTool" xml:space="preserve">
-    <value>Exit Slide Tool</value>
+    <value>슬라이드 도구 종료</value>
   </data>
   <data name="ExitSlideTool_Description" xml:space="preserve">
-    <value>Exit slide mode and return to selection tool.</value>
+    <value>슬라이드 모드를 종료하고 선택 도구로 돌아갑니다.</value>
   </data>
   <data name="Delete" xml:space="preserve">
-    <value>Delete</value>
+    <value>삭제</value>
   </data>
   <data name="Remove" xml:space="preserve">
-    <value>Remove</value>
+    <value>제거</value>
   </data>
   <data name="Exclude" xml:space="preserve">
-    <value>Exclude</value>
+    <value>제외</value>
   </data>
   <data name="Back" xml:space="preserve">
-    <value>Back</value>
+    <value>뒤로</value>
   </data>
   <data name="Next" xml:space="preserve">
-    <value>Next</value>
+    <value>다음</value>
   </data>
   <data name="Element" xml:space="preserve">
-    <value>Element</value>
+    <value>요소</value>
   </data>
   <data name="AddElement" xml:space="preserve">
-    <value>Add Element</value>
+    <value>요소 추가</value>
   </data>
   <data name="AddAdjustmentLayer" xml:space="preserve">
-    <value>Add Adjustment Layer</value>
+    <value>조정 레이어 추가</value>
   </data>
   <data name="AdjustmentLayer" xml:space="preserve">
-    <value>Adjustment Layer</value>
+    <value>조정 레이어</value>
   </data>
   <data name="Location" xml:space="preserve">
-    <value>Location</value>
+    <value>위치</value>
   </data>
   <data name="Size" xml:space="preserve">
-    <value>Size</value>
+    <value>크기</value>
   </data>
   <data name="FrameRate" xml:space="preserve">
-    <value>Frame rate</value>
+    <value>프레임 속도</value>
   </data>
   <data name="SampleRate" xml:space="preserve">
-    <value>Sample rate</value>
+    <value>샘플 속도</value>
   </data>
   <data name="SceneSettings" xml:space="preserve">
-    <value>Scene settings</value>
+    <value>장면 설정</value>
   </data>
   <data name="Apply" xml:space="preserve">
-    <value>Apply</value>
+    <value>적용</value>
   </data>
   <data name="Width" xml:space="preserve">
-    <value>Width</value>
+    <value>너비</value>
   </data>
   <data name="Height" xml:space="preserve">
-    <value>Height</value>
+    <value>높이</value>
   </data>
   <data name="Reset" xml:space="preserve">
-    <value>Reset</value>
+    <value>재설정</value>
   </data>
   <data name="ResetDockLayout" xml:space="preserve">
-    <value>Reset dock layout</value>
+    <value>도킹 레이아웃 재설정</value>
   </data>
   <data name="DockLayout" xml:space="preserve">
-    <value>Dock layout</value>
+    <value>도킹 레이아웃</value>
   </data>
   <data name="ApplyDockLayout" xml:space="preserve">
-    <value>Apply dock layout</value>
+    <value>도킹 레이아웃 적용</value>
   </data>
   <data name="ManageDockLayouts" xml:space="preserve">
-    <value>Manage dock layouts</value>
+    <value>도킹 레이아웃 관리</value>
   </data>
   <data name="SaveCurrentDockLayout" xml:space="preserve">
-    <value>Save the current layout</value>
+    <value>현재 레이아웃 저장</value>
   </data>
   <data name="SavedDockLayouts" xml:space="preserve">
-    <value>Saved layouts</value>
+    <value>저장된 레이아웃</value>
   </data>
   <data name="EditAnimation" xml:space="preserve">
-    <value>Edit animation</value>
+    <value>애니메이션 편집</value>
   </data>
   <data name="NewFolder" xml:space="preserve">
-    <value>New Folder</value>
+    <value>새 폴더</value>
   </data>
   <data name="Left" xml:space="preserve">
-    <value>Left</value>
+    <value>왼쪽</value>
   </data>
   <data name="Right" xml:space="preserve">
-    <value>Right</value>
+    <value>오른쪽</value>
   </data>
   <data name="Top" xml:space="preserve">
-    <value>Top</value>
+    <value>위</value>
   </data>
   <data name="Bottom" xml:space="preserve">
-    <value>Bottom</value>
+    <value>아래</value>
   </data>
   <data name="Cancel" xml:space="preserve">
-    <value>Cancel</value>
+    <value>취소</value>
   </data>
   <data name="Yes" xml:space="preserve">
-    <value>Yes</value>
+    <value>예</value>
   </data>
   <data name="No" xml:space="preserve">
-    <value>No</value>
+    <value>아니요</value>
   </data>
   <data name="DiscardChanges" xml:space="preserve">
-    <value>Discard changes</value>
+    <value>변경 사항 버리기</value>
   </data>
   <data name="Others" xml:space="preserve">
-    <value>Others</value>
+    <value>기타</value>
   </data>
   <data name="Link" xml:space="preserve">
-    <value>Link</value>
+    <value>링크</value>
   </data>
   <data name="ShowMore" xml:space="preserve">
-    <value>Show more</value>
+    <value>더 보기</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>확인</value>
   </data>
   <data name="Animation" xml:space="preserve">
-    <value>Animation</value>
+    <value>애니메이션</value>
   </data>
   <data name="Easing" xml:space="preserve">
-    <value>Easing</value>
+    <value>이징</value>
   </data>
   <data name="Hold" xml:space="preserve">
-    <value>Hold</value>
+    <value>유지</value>
   </data>
   <data name="ElementProperty" xml:space="preserve">
-    <value>Element Property</value>
+    <value>요소 속성</value>
   </data>
   <data name="ProjectFile" xml:space="preserve">
-    <value>Project File</value>
+    <value>프로젝트 파일</value>
   </data>
   <data name="RecentFiles" xml:space="preserve">
-    <value>Recent Files</value>
+    <value>최근 파일</value>
   </data>
   <data name="RecentProjects" xml:space="preserve">
-    <value>Recent Projects</value>
+    <value>최근 프로젝트</value>
   </data>
   <data name="Editors" xml:space="preserve">
-    <value>Editors</value>
+    <value>편집기</value>
   </data>
   <data name="Tools" xml:space="preserve">
-    <value>Tools</value>
+    <value>도구</value>
   </data>
   <data name="Rename" xml:space="preserve">
-    <value>Rename</value>
+    <value>이름 바꾸기</value>
   </data>
   <data name="FinishEditing" xml:space="preserve">
-    <value>Finish editing</value>
+    <value>편집 완료</value>
   </data>
   <data name="BringToTop" xml:space="preserve">
-    <value>Bring to the top</value>
+    <value>맨 위로 가져오기</value>
   </data>
   <data name="StartEditing" xml:space="preserve">
-    <value>Start editing</value>
+    <value>편집 시작</value>
   </data>
   <data name="CreateNewProjectOrScene" xml:space="preserve">
-    <value>Create new project or scene</value>
+    <value>새 프로젝트 또는 장면 만들기</value>
   </data>
   <data name="OpenAFileYouHaveAlreadyCreated" xml:space="preserve">
-    <value>Open a file you have already created</value>
+    <value>이미 만든 파일 열기</value>
   </data>
   <data name="Recently" xml:space="preserve">
-    <value>Recently</value>
+    <value>최근</value>
   </data>
   <data name="Projects" xml:space="preserve">
-    <value>Projects</value>
+    <value>프로젝트</value>
   </data>
   <data name="Files" xml:space="preserve">
-    <value>Files</value>
+    <value>파일</value>
   </data>
   <data name="All" xml:space="preserve">
-    <value>All</value>
+    <value>모두</value>
   </data>
   <data name="NoFilesUsedRecently" xml:space="preserve">
-    <value>No files used recently.</value>
+    <value>최근에 사용한 파일이 없습니다.</value>
   </data>
   <data name="AddOutputProfile" xml:space="preserve">
-    <value>Add Profile</value>
+    <value>프로필 추가</value>
   </data>
   <data name="Encode" xml:space="preserve">
-    <value>Encode</value>
+    <value>인코딩</value>
   </data>
   <data name="DestinationToSaveTo_Tip" xml:space="preserve">
-    <value>Set the destination</value>
+    <value>대상 설정</value>
   </data>
   <data name="DestinationToSaveTo" xml:space="preserve">
-    <value>Destination to save to</value>
+    <value>저장 대상</value>
   </data>
   <data name="Encoder_Tip" xml:space="preserve">
-    <value>Select an encoder</value>
+    <value>인코더 선택</value>
   </data>
   <data name="Encoder" xml:space="preserve">
-    <value>Encoder</value>
+    <value>인코더</value>
   </data>
   <data name="FrameSize" xml:space="preserve">
-    <value>Frame size</value>
+    <value>프레임 크기</value>
   </data>
   <data name="FrameSize_Tip" xml:space="preserve">
-    <value>Set the frame size</value>
+    <value>프레임 크기 설정</value>
   </data>
   <data name="FrameRate_Tip" xml:space="preserve">
-    <value>Set the framerate</value>
+    <value>프레임 속도 설정</value>
   </data>
   <data name="Bitrate" xml:space="preserve">
-    <value>Bitrate</value>
+    <value>비트레이트</value>
   </data>
   <data name="Bitrate_Tip" xml:space="preserve">
-    <value>Set the bitrate</value>
+    <value>비트레이트 설정</value>
   </data>
   <data name="KeyframeRate" xml:space="preserve">
-    <value>Keyframe rate</value>
+    <value>키프레임 속도</value>
   </data>
   <data name="KeyframeRate_Tip" xml:space="preserve">
-    <value>Set the keyframe rate</value>
+    <value>키프레임 속도 설정</value>
   </data>
   <data name="SampleRate_Tip" xml:space="preserve">
-    <value>Set the sample rate</value>
+    <value>샘플 속도 설정</value>
   </data>
   <data name="Channels" xml:space="preserve">
-    <value>Channels</value>
+    <value>채널</value>
   </data>
   <data name="Channels_Tip" xml:space="preserve">
-    <value>Set the number of channels</value>
+    <value>채널 수 설정</value>
   </data>
   <data name="Video" xml:space="preserve">
-    <value>Video</value>
+    <value>비디오</value>
   </data>
   <data name="Audio" xml:space="preserve">
-    <value>Audio</value>
+    <value>오디오</value>
   </data>
   <data name="Off" xml:space="preserve">
-    <value>Off</value>
+    <value>끄기</value>
   </data>
   <data name="On" xml:space="preserve">
-    <value>On</value>
+    <value>켜기</value>
   </data>
   <data name="NodeGraph" xml:space="preserve">
-    <value>Node Graph</value>
+    <value>노드 그래프</value>
   </data>
   <data name="Library" xml:space="preserve">
-    <value>Library</value>
+    <value>라이브러리</value>
   </data>
   <data name="FileBrowser" xml:space="preserve">
-    <value>File Browser</value>
+    <value>파일 브라우저</value>
   </data>
   <data name="ListView" xml:space="preserve">
-    <value>List View</value>
+    <value>목록 보기</value>
   </data>
   <data name="TreeView" xml:space="preserve">
-    <value>Tree View</value>
+    <value>트리 보기</value>
   </data>
   <data name="IconView" xml:space="preserve">
-    <value>Icon View</value>
+    <value>아이콘 보기</value>
   </data>
   <data name="Refresh" xml:space="preserve">
-    <value>Refresh</value>
+    <value>새로 고침</value>
   </data>
   <data name="OpenFolder" xml:space="preserve">
-    <value>Open Folder</value>
+    <value>폴더 열기</value>
   </data>
   <data name="Favorites" xml:space="preserve">
-    <value>Favorites</value>
+    <value>즐겨찾기</value>
   </data>
   <data name="Feedback" xml:space="preserve">
-    <value>Feedback</value>
+    <value>피드백</value>
   </data>
   <data name="AddToFavorites" xml:space="preserve">
-    <value>Add to Favorites</value>
+    <value>즐겨찾기에 추가</value>
   </data>
   <data name="RemoveFromFavorites" xml:space="preserve">
-    <value>Remove from Favorites</value>
+    <value>즐겨찾기에서 제거</value>
   </data>
   <data name="NoFavorites" xml:space="preserve">
-    <value>No favorites</value>
+    <value>즐겨찾기 없음</value>
   </data>
   <data name="DeleteSelectedItems" xml:space="preserve">
-    <value>Delete {0} items?</value>
+    <value>{0}개 항목을 삭제하시겠습니까?</value>
   </data>
   <data name="Group" xml:space="preserve">
-    <value>Group</value>
+    <value>그룹</value>
   </data>
   <data name="GraphEditor" xml:space="preserve">
-    <value>Graph Editor</value>
+    <value>그래프 편집기</value>
   </data>
   <data name="Unknown" xml:space="preserve">
-    <value>Unknown</value>
+    <value>알 수 없음</value>
   </data>
   <data name="Details" xml:space="preserve">
-    <value>Details</value>
+    <value>자세한 정보</value>
   </data>
   <data name="Completed" xml:space="preserve">
-    <value>Completed</value>
+    <value>완료됨</value>
   </data>
   <data name="Brightness" xml:space="preserve">
-    <value>Brightness</value>
+    <value>밝기</value>
   </data>
   <data name="ColorGrading" xml:space="preserve">
-    <value>Color Grading</value>
+    <value>색상 그레이딩</value>
   </data>
   <data name="Number_of_Layers" xml:space="preserve">
-    <value>Number of Layers</value>
+    <value>레이어 수</value>
   </data>
   <data name="ChangeColor" xml:space="preserve">
-    <value>Change color</value>
+    <value>색상 변경</value>
   </data>
   <data name="EditAnimationInInlineView" xml:space="preserve">
-    <value>Edit animation in inline view</value>
+    <value>인라인 보기에서 애니메이션 편집</value>
   </data>
   <data name="EnableLivePreview" xml:space="preserve">
-    <value>Enable Live Preview</value>
+    <value>라이브 미리 보기 사용</value>
   </data>
   <data name="DisableThumbnails" xml:space="preserve">
-    <value>Disable Thumbnails</value>
+    <value>썸네일 비활성화</value>
   </data>
   <data name="Unsupported" xml:space="preserve">
-    <value>Unsupported</value>
+    <value>지원되지 않음</value>
   </data>
   <data name="TimelineZoom" xml:space="preserve">
-    <value>Zoom</value>
+    <value>확대/축소</value>
   </data>
   <data name="TimelineSnap" xml:space="preserve">
-    <value>Snap</value>
+    <value>스냅</value>
   </data>
   <data name="RippleEdit" xml:space="preserve">
-    <value>Ripple Edit</value>
+    <value>리플 편집</value>
   </data>
   <data name="UseGlobalClock" xml:space="preserve">
-    <value>Use the Global Clock</value>
+    <value>전역 클록 사용</value>
   </data>
   <data name="EditJson" xml:space="preserve">
-    <value>Edit Json</value>
+    <value>JSON 편집</value>
   </data>
   <data name="AddNode" xml:space="preserve">
-    <value>Add node</value>
+    <value>노드 추가</value>
   </data>
   <data name="Change" xml:space="preserve">
-    <value>Change</value>
+    <value>변경</value>
   </data>
   <data name="Disconnect" xml:space="preserve">
-    <value>Disconnect</value>
+    <value>연결 끊기</value>
   </data>
   <data name="Initialize" xml:space="preserve">
-    <value>Initialize</value>
+    <value>초기화</value>
   </data>
   <data name="ResetZoom" xml:space="preserve">
-    <value>Reset zoom</value>
+    <value>확대/축소 재설정</value>
   </data>
   <data name="RemoveAnimation" xml:space="preserve">
-    <value>Remove animation</value>
+    <value>애니메이션 제거</value>
   </data>
   <data name="EditExpression" xml:space="preserve">
-    <value>Edit expression</value>
+    <value>식 편집</value>
   </data>
   <data name="RemoveExpression" xml:space="preserve">
-    <value>Remove expression</value>
+    <value>식 제거</value>
   </data>
   <data name="ExpressionHelp" xml:space="preserve">
-    <value>Enter a mathematical expression. Available variables: Time, Start, Duration, Progress. Use GetProperty&lt;T&gt;("{GUID}.Property") to reference other properties.</value>
+    <value>수학 식을 입력하세요. 사용 가능한 변수: Time, Start, Duration, Progress. GetProperty&lt;T&gt;("{GUID}.Property")를 사용하여 다른 속성을 참조하세요.</value>
   </data>
   <data name="CopyPropertyPath" xml:space="preserve">
-    <value>Copy property path</value>
+    <value>속성 경로 복사</value>
   </data>
   <data name="CopyGetPropertyCode" xml:space="preserve">
-    <value>Copy GetProperty code</value>
+    <value>GetProperty 코드 복사</value>
   </data>
   <data name="ChangeToOriginalLength" xml:space="preserve">
-    <value>Change to original length</value>
+    <value>원본 길이로 변경</value>
   </data>
   <data name="SplitByCurrentFrame" xml:space="preserve">
-    <value>Split by current frame</value>
+    <value>현재 프레임으로 분할</value>
   </data>
   <data name="GroupSelectedElements" xml:space="preserve">
-    <value>Group selected elements</value>
+    <value>선택한 요소 그룹화</value>
   </data>
   <data name="UngroupSelectedElements" xml:space="preserve">
-    <value>Ungroup selected elements</value>
+    <value>선택한 요소 그룹 해제</value>
   </data>
   <data name="Agree" xml:space="preserve">
-    <value>Agree</value>
+    <value>동의</value>
   </data>
   <data name="Disagree" xml:space="preserve">
-    <value>Disagree</value>
+    <value>동의하지 않음</value>
   </data>
   <data name="ShowDetails" xml:space="preserve">
-    <value>Show Details</value>
+    <value>자세한 정보 표시</value>
   </data>
   <data name="SaveSelectedElementAsImage" xml:space="preserve">
-    <value>Save a selected element as an image</value>
+    <value>선택한 요소를 이미지로 저장</value>
   </data>
   <data name="SaveFrameAsImage" xml:space="preserve">
-    <value>Save a frame as an image</value>
+    <value>프레임을 이미지로 저장</value>
   </data>
   <data name="SaveImageScale" xml:space="preserve">
-    <value>Scale</value>
+    <value>배율</value>
   </data>
   <data name="SaveImageScale_OutputSize" xml:space="preserve">
-    <value>Output size</value>
+    <value>출력 크기</value>
   </data>
   <data name="Move" xml:space="preserve">
-    <value>Move</value>
+    <value>이동</value>
   </data>
   <data name="Hand" xml:space="preserve">
-    <value>Hand</value>
+    <value>손</value>
   </data>
   <data name="SetStartTime" xml:space="preserve">
-    <value>Set start time</value>
+    <value>시작 시간 설정</value>
   </data>
   <data name="SetEndTime" xml:space="preserve">
-    <value>Set end time</value>
+    <value>종료 시간 설정</value>
   </data>
   <data name="NudgeLeftFrame" xml:space="preserve">
-    <value>Nudge left (1 frame)</value>
+    <value>왼쪽으로 미세 이동 (1프레임)</value>
   </data>
   <data name="NudgeRightFrame" xml:space="preserve">
-    <value>Nudge right (1 frame)</value>
+    <value>오른쪽으로 미세 이동 (1프레임)</value>
   </data>
   <data name="NudgeLeftLarge" xml:space="preserve">
-    <value>Nudge left (10 frames)</value>
+    <value>왼쪽으로 미세 이동 (10프레임)</value>
   </data>
   <data name="NudgeRightLarge" xml:space="preserve">
-    <value>Nudge right (10 frames)</value>
+    <value>오른쪽으로 미세 이동 (10프레임)</value>
   </data>
   <data name="NudgeLeftSecond" xml:space="preserve">
-    <value>Nudge left (1 second)</value>
+    <value>왼쪽으로 미세 이동 (1초)</value>
   </data>
   <data name="NudgeRightSecond" xml:space="preserve">
-    <value>Nudge right (1 second)</value>
+    <value>오른쪽으로 미세 이동 (1초)</value>
   </data>
   <data name="CloseGap" xml:space="preserve">
-    <value>Close Gap</value>
+    <value>간격 닫기</value>
   </data>
   <data name="Gaps" xml:space="preserve">
-    <value>Gaps</value>
+    <value>간격</value>
   </data>
   <data name="CloseAllGaps" xml:space="preserve">
-    <value>Close All Gaps</value>
+    <value>모든 간격 닫기</value>
   </data>
   <data name="GoToNextGap" xml:space="preserve">
-    <value>Go to Next Gap</value>
+    <value>다음 간격으로 이동</value>
   </data>
   <data name="GoToPreviousGap" xml:space="preserve">
-    <value>Go to Previous Gap</value>
+    <value>이전 간격으로 이동</value>
   </data>
   <data name="NoGapsToClose" xml:space="preserve">
-    <value>There are no gaps to close</value>
+    <value>닫을 간격이 없습니다</value>
   </data>
   <data name="NoGapsToGoTo" xml:space="preserve">
-    <value>There are no gaps to go to</value>
+    <value>이동할 간격이 없습니다</value>
   </data>
   <data name="NoElementSelected" xml:space="preserve">
-    <value>No element is selected</value>
+    <value>선택된 요소가 없습니다</value>
   </data>
   <data name="Editor" xml:space="preserve">
-    <value>Editor</value>
+    <value>편집기</value>
   </data>
   <data name="RunningStartupTasks" xml:space="preserve">
-    <value>Running startup tasks</value>
+    <value>시작 작업 실행 중</value>
   </data>
   <data name="SaveAsImage" xml:space="preserve">
-    <value>Save as image</value>
+    <value>이미지로 저장</value>
   </data>
   <data name="CopyAsImage" xml:space="preserve">
-    <value>Copy as image</value>
+    <value>이미지로 복사</value>
   </data>
   <data name="AlwaysDisplay" xml:space="preserve">
-    <value>Always display</value>
+    <value>항상 표시</value>
   </data>
   <data name="MemoryUsage" xml:space="preserve">
-    <value>Memory usage</value>
+    <value>메모리 사용량</value>
   </data>
   <data name="Locked" xml:space="preserve">
-    <value>Locked</value>
+    <value>잠김</value>
   </data>
   <data name="Unlocked" xml:space="preserve">
-    <value>Unlocked</value>
+    <value>잠금 해제됨</value>
   </data>
   <data name="DeleteAll" xml:space="preserve">
-    <value>Delete All</value>
+    <value>모두 삭제</value>
   </data>
   <data name="Lock" xml:space="preserve">
-    <value>Lock</value>
+    <value>잠금</value>
   </data>
   <data name="Unlock" xml:space="preserve">
-    <value>Unlock</value>
+    <value>잠금 해제</value>
   </data>
   <data name="Solo" xml:space="preserve">
-    <value>Solo</value>
+    <value>솔로</value>
   </data>
   <data name="LayerIsLocked" xml:space="preserve">
-    <value>The layer is locked.</value>
+    <value>레이어가 잠겨 있습니다.</value>
   </data>
   <data name="FrameCache" xml:space="preserve">
-    <value>Frame cache</value>
+    <value>프레임 캐시</value>
   </data>
   <data name="RightClickToOperateCache" xml:space="preserve">
-    <value>Right-click to operate cache</value>
+    <value>캐시를 조작하려면 마우스 오른쪽 버튼 클릭</value>
   </data>
   <data name="Linear" xml:space="preserve">
-    <value>Linear</value>
+    <value>선형</value>
   </data>
   <data name="Conical" xml:space="preserve">
-    <value>Conical</value>
+    <value>원뿔형</value>
   </data>
   <data name="Radial" xml:space="preserve">
-    <value>Radial</value>
+    <value>방사형</value>
   </data>
   <data name="Red" xml:space="preserve">
-    <value>Red</value>
+    <value>빨간색</value>
   </data>
   <data name="Green" xml:space="preserve">
-    <value>Green</value>
+    <value>녹색</value>
   </data>
   <data name="Blue" xml:space="preserve">
-    <value>Blue</value>
+    <value>파란색</value>
   </data>
   <data name="Master" xml:space="preserve">
-    <value>Master</value>
+    <value>마스터</value>
   </data>
   <data name="Hue" xml:space="preserve">
-    <value>Hue</value>
+    <value>색조</value>
   </data>
   <data name="Saturation" xml:space="preserve">
-    <value>Saturation</value>
+    <value>채도</value>
   </data>
   <data name="ShowSliders" xml:space="preserve">
-    <value>Show sliders</value>
+    <value>슬라이더 표시</value>
   </data>
   <data name="ShowRing" xml:space="preserve">
-    <value>Show ring</value>
+    <value>링 표시</value>
   </data>
   <data name="Symmetry" xml:space="preserve">
-    <value>Symmetry</value>
+    <value>대칭</value>
   </data>
   <data name="Asymmetry" xml:space="preserve">
-    <value>Asymmetry</value>
+    <value>비대칭</value>
   </data>
   <data name="Separately" xml:space="preserve">
-    <value>Separately</value>
+    <value>개별적으로</value>
   </data>
   <data name="Figure" xml:space="preserve">
-    <value>Figure</value>
+    <value>도형</value>
   </data>
   <data name="Import" xml:space="preserve">
-    <value>Import</value>
+    <value>가져오기</value>
   </data>
   <data name="ImportSvgPath" xml:space="preserve">
-    <value>Import SVG path</value>
+    <value>SVG 경로 가져오기</value>
   </data>
   <data name="ImportSvgPath_Description" xml:space="preserve">
-    <value>The current shape will be overwritten.</value>
+    <value>현재 모양이 덮어쓰여집니다.</value>
   </data>
   <data name="EditInFrame" xml:space="preserve">
-    <value>Edit in frame</value>
+    <value>프레임에서 편집</value>
   </data>
   <data name="EditInTab" xml:space="preserve">
-    <value>Edit in tab</value>
+    <value>탭에서 편집</value>
   </data>
   <data name="PathEditor" xml:space="preserve">
-    <value>Path editor</value>
+    <value>경로 편집기</value>
   </data>
   <data name="CopyAll" xml:space="preserve">
-    <value>Copy All</value>
+    <value>모두 복사</value>
   </data>
   <data name="EnableElement" xml:space="preserve">
-    <value>Enable element</value>
+    <value>요소 사용</value>
   </data>
   <data name="DockArea_LeftTop" xml:space="preserve">
-    <value>Left Top</value>
+    <value>왼쪽 위</value>
   </data>
   <data name="DockArea_LeftBottom" xml:space="preserve">
-    <value>Left Bottom</value>
+    <value>왼쪽 아래</value>
   </data>
   <data name="DockArea_RightTop" xml:space="preserve">
-    <value>Right Top</value>
+    <value>오른쪽 위</value>
   </data>
   <data name="DockArea_RightBottom" xml:space="preserve">
-    <value>Right Bottom</value>
+    <value>오른쪽 아래</value>
   </data>
   <data name="DockArea_BottomLeft" xml:space="preserve">
-    <value>Bottom Left</value>
+    <value>아래 왼쪽</value>
   </data>
   <data name="DockArea_BottomRight" xml:space="preserve">
-    <value>Bottom Right</value>
+    <value>아래 오른쪽</value>
   </data>
   <data name="DockArea_TopLeft" xml:space="preserve">
-    <value>Top Left</value>
+    <value>위 왼쪽</value>
   </data>
   <data name="DockArea_TopRight" xml:space="preserve">
-    <value>Top Right</value>
+    <value>위 오른쪽</value>
   </data>
   <data name="MoveTo" xml:space="preserve">
-    <value>Move to</value>
+    <value>이동</value>
   </data>
   <data name="MainView" xml:space="preserve">
-    <value>Main View</value>
+    <value>기본 보기</value>
   </data>
   <data name="OpenProject" xml:space="preserve">
-    <value>Open Project</value>
+    <value>프로젝트 열기</value>
   </data>
   <data name="OpenFile" xml:space="preserve">
-    <value>Open File</value>
+    <value>파일 열기</value>
   </data>
   <data name="Save_Description" xml:space="preserve">
-    <value>Save the current file</value>
+    <value>현재 파일 저장</value>
   </data>
   <data name="SaveAll_Description" xml:space="preserve">
-    <value>Save all files</value>
+    <value>모든 파일 저장</value>
   </data>
   <data name="CloseProject_Description" xml:space="preserve">
-    <value>Close the current project</value>
+    <value>현재 프로젝트 닫기</value>
   </data>
   <data name="Undo_Description" xml:space="preserve">
-    <value>Undo the last operation</value>
+    <value>마지막 작업 실행 취소</value>
   </data>
   <data name="Redo_Description" xml:space="preserve">
-    <value>Redo the last operation</value>
+    <value>마지막 작업 다시 실행</value>
   </data>
   <data name="Exit_Description" xml:space="preserve">
-    <value>Exit the application</value>
+    <value>애플리케이션 종료</value>
   </data>
   <data name="PlayPause" xml:space="preserve">
-    <value>Play/Pause</value>
+    <value>재생/일시 정지</value>
   </data>
   <data name="PlayPause_Description" xml:space="preserve">
-    <value>Switches between play and pause.</value>
+    <value>재생과 일시 정지 사이를 전환합니다.</value>
   </data>
   <data name="MoveToNext" xml:space="preserve">
-    <value>Move to next</value>
+    <value>다음으로 이동</value>
   </data>
   <data name="MoveToPrevious" xml:space="preserve">
-    <value>Move to previous</value>
+    <value>이전으로 이동</value>
   </data>
   <data name="MoveToNext_Description" xml:space="preserve">
-    <value>Move to the next frame.</value>
+    <value>다음 프레임으로 이동합니다.</value>
   </data>
   <data name="MoveToPrevious_Description" xml:space="preserve">
-    <value>Move to the previous frame.</value>
+    <value>이전 프레임으로 이동합니다.</value>
   </data>
   <data name="MoveToStart" xml:space="preserve">
-    <value>Move to start</value>
+    <value>시작으로 이동</value>
   </data>
   <data name="MoveToEnd" xml:space="preserve">
-    <value>Move to end</value>
+    <value>끝으로 이동</value>
   </data>
   <data name="MoveToStart_Description" xml:space="preserve">
-    <value>Move to the start of the scene.</value>
+    <value>장면의 시작으로 이동합니다.</value>
   </data>
   <data name="MoveToEnd_Description" xml:space="preserve">
-    <value>Move to the end of the scene.</value>
+    <value>장면의 끝으로 이동합니다.</value>
   </data>
   <data name="ToggleMarker" xml:space="preserve">
-    <value>Toggle marker</value>
+    <value>마커 전환</value>
   </data>
   <data name="ToggleMarker_Description" xml:space="preserve">
-    <value>Toggle a marker at the current playhead. Removes the existing marker if one already exists at this position.</value>
+    <value>현재 재생 헤드에 마커를 전환합니다. 이 위치에 이미 마커가 있으면 제거합니다.</value>
   </data>
   <data name="NextMarker" xml:space="preserve">
-    <value>Next marker</value>
+    <value>다음 마커</value>
   </data>
   <data name="NextMarker_Description" xml:space="preserve">
-    <value>Seek to the next marker.</value>
+    <value>다음 마커로 이동합니다.</value>
   </data>
   <data name="PreviousMarker" xml:space="preserve">
-    <value>Previous marker</value>
+    <value>이전 마커</value>
   </data>
   <data name="PreviousMarker_Description" xml:space="preserve">
-    <value>Seek to the previous marker.</value>
+    <value>이전 마커로 이동합니다.</value>
   </data>
   <data name="NextKeyFrame" xml:space="preserve">
-    <value>Next keyframe</value>
+    <value>다음 키프레임</value>
   </data>
   <data name="NextKeyFrame_Description" xml:space="preserve">
-    <value>Seek to the next keyframe within the selected element (or scene-wide if none).</value>
+    <value>선택한 요소 내의 다음 키프레임으로 이동합니다(없으면 장면 전체).</value>
   </data>
   <data name="PreviousKeyFrame" xml:space="preserve">
-    <value>Previous keyframe</value>
+    <value>이전 키프레임</value>
   </data>
   <data name="PreviousKeyFrame_Description" xml:space="preserve">
-    <value>Seek to the previous keyframe within the selected element (or scene-wide if none).</value>
+    <value>선택한 요소 내의 이전 키프레임으로 이동합니다(없으면 장면 전체).</value>
   </data>
   <data name="NoKeyFrameToSeek" xml:space="preserve">
-    <value>No keyframe to seek.</value>
+    <value>이동할 키프레임이 없습니다.</value>
   </data>
   <data name="ShuttleForward" xml:space="preserve">
-    <value>Shuttle forward</value>
+    <value>셔틀 앞으로</value>
   </data>
   <data name="ShuttleForward_Description" xml:space="preserve">
-    <value>Shuttle forward (L). Press repeatedly to accelerate.</value>
+    <value>셔틀 앞으로 (L). 반복해서 누르면 가속됩니다.</value>
   </data>
   <data name="ShuttleForwardFine" xml:space="preserve">
-    <value>Shuttle forward (fine)</value>
+    <value>셔틀 앞으로 (미세)</value>
   </data>
   <data name="ShuttleForwardFine_Description" xml:space="preserve">
-    <value>Shuttle forward at half speed.</value>
+    <value>절반 속도로 셔틀 앞으로.</value>
   </data>
   <data name="ShuttleBackward" xml:space="preserve">
-    <value>Shuttle backward</value>
+    <value>셔틀 뒤로</value>
   </data>
   <data name="ShuttleBackward_Description" xml:space="preserve">
-    <value>Shuttle backward (J). Press repeatedly to accelerate.</value>
+    <value>셔틀 뒤로 (J). 반복해서 누르면 가속됩니다.</value>
   </data>
   <data name="ShuttleBackwardFine" xml:space="preserve">
-    <value>Shuttle backward (fine)</value>
+    <value>셔틀 뒤로 (미세)</value>
   </data>
   <data name="ShuttleBackwardFine_Description" xml:space="preserve">
-    <value>Shuttle backward at half speed.</value>
+    <value>절반 속도로 셔틀 뒤로.</value>
   </data>
   <data name="ShuttleStop" xml:space="preserve">
-    <value>Shuttle stop</value>
+    <value>셔틀 정지</value>
   </data>
   <data name="ShuttleStop_Description" xml:space="preserve">
-    <value>Stop shuttle playback.</value>
+    <value>셔틀 재생을 중지합니다.</value>
   </data>
   <data name="ToggleLoop" xml:space="preserve">
-    <value>Toggle loop</value>
+    <value>반복 전환</value>
   </data>
   <data name="ToggleLoop_Description" xml:space="preserve">
-    <value>Toggle loop playback.</value>
+    <value>반복 재생을 전환합니다.</value>
   </data>
   <data name="GotoTimecode" xml:space="preserve">
-    <value>Goto timecode</value>
+    <value>타임코드로 이동</value>
   </data>
   <data name="GotoTimecode_Description" xml:space="preserve">
-    <value>Edit the current timecode to seek. Accepts absolute (00:01:23.45), frame (60f or #60), relative (+5s/-10f/+1m) or marker name (@Intro).</value>
+    <value>현재 타임코드를 편집하여 이동합니다. 절대(00:01:23.45), 프레임(60f 또는 #60), 상대(+5s/-10f/+1m) 또는 마커 이름(@Intro)을 허용합니다.</value>
   </data>
   <data name="GotoTimecode_InputHint" xml:space="preserve">
     <value>00:01:23 / 60f / +5s / @marker</value>
   </data>
   <data name="GotoTimecode_InvalidFormat" xml:space="preserve">
-    <value>Invalid timecode format.</value>
+    <value>잘못된 타임코드 형식입니다.</value>
   </data>
   <data name="GotoTimecode_MarkerNotFound" xml:space="preserve">
-    <value>Marker not found.</value>
+    <value>마커를 찾을 수 없습니다.</value>
   </data>
   <data name="GotoTimecode_NoScene" xml:space="preserve">
-    <value>No scene is loaded.</value>
+    <value>로드된 장면이 없습니다.</value>
   </data>
   <data name="GotoTimecode_OutOfRange" xml:space="preserve">
-    <value>Timecode is out of range.</value>
+    <value>타임코드가 범위를 벗어났습니다.</value>
   </data>
   <data name="Paste_Description" xml:space="preserve">
-    <value>Paste the copied data.</value>
+    <value>복사한 데이터를 붙여넣습니다.</value>
   </data>
   <data name="Rename_Description" xml:space="preserve">
-    <value>Rename the selected item.</value>
+    <value>선택한 항목의 이름을 바꿉니다.</value>
   </data>
   <data name="Exclude_Description" xml:space="preserve">
-    <value>Exclude the selected item.</value>
+    <value>선택한 항목을 제외합니다.</value>
   </data>
   <data name="Delete_Description" xml:space="preserve">
-    <value>Delete the selected item.</value>
+    <value>선택한 항목을 삭제합니다.</value>
   </data>
   <data name="Copy_Description" xml:space="preserve">
-    <value>Copy the selected item.</value>
+    <value>선택한 항목을 복사합니다.</value>
   </data>
   <data name="Cut_Description" xml:space="preserve">
-    <value>Cut the selected item.</value>
+    <value>선택한 항목을 잘라냅니다.</value>
   </data>
   <data name="Duplicate_Description" xml:space="preserve">
-    <value>Duplicate the selected item.</value>
+    <value>선택한 항목을 복제합니다.</value>
   </data>
   <data name="Duplicate_Failed" xml:space="preserve">
-    <value>Failed to duplicate</value>
+    <value>복제 실패</value>
   </data>
   <data name="Duplicate_ProjectNotSaved" xml:space="preserve">
-    <value>Save the project before duplicating clips.</value>
+    <value>클립을 복제하기 전에 프로젝트를 저장하세요.</value>
   </data>
   <data name="Duplicate_IOFailed" xml:space="preserve">
-    <value>Could not write the duplicated element to disk.</value>
+    <value>복제된 요소를 디스크에 쓸 수 없습니다.</value>
   </data>
   <data name="Duplicate_NoEmptySlot" xml:space="preserve">
-    <value>Could not find an empty slot on the timeline; the duplicate was placed where it may overlap an existing clip.</value>
+    <value>타임라인에서 빈 슬롯을 찾을 수 없습니다. 복제본이 기존 클립과 겹칠 수 있는 위치에 배치되었습니다.</value>
   </data>
   <data name="Duplicate_FallbackToMove" xml:space="preserve">
-    <value>Duplicate failed; falling back to a plain move of the original clips.</value>
+    <value>복제에 실패했습니다. 원본 클립의 단순 이동으로 대체합니다.</value>
   </data>
   <data name="Duplicate_FallbackFailed" xml:space="preserve">
-    <value>The move fallback also failed; the timeline state may not match what you see.</value>
+    <value>이동 대체도 실패했습니다. 타임라인 상태가 표시된 것과 일치하지 않을 수 있습니다.</value>
   </data>
   <data name="AboutBeutl" xml:space="preserve">
-    <value>About Beutl</value>
+    <value>Beutl 정보</value>
   </data>
   <data name="Update" xml:space="preserve">
-    <value>Update</value>
+    <value>업데이트</value>
   </data>
   <data name="EditDrawable" xml:space="preserve">
-    <value>Edit drawable</value>
+    <value>드로어블 편집</value>
   </data>
   <data name="Item" xml:space="preserve">
-    <value>Item</value>
+    <value>항목</value>
   </data>
   <data name="Profiles" xml:space="preserve">
-    <value>Profiles</value>
+    <value>프로필</value>
   </data>
   <data name="Presets" xml:space="preserve">
-    <value>Presets</value>
+    <value>프리셋</value>
   </data>
   <data name="Convert_to_preset" xml:space="preserve">
-    <value>Convert to preset</value>
+    <value>프리셋으로 변환</value>
   </data>
   <data name="Expression_Input" xml:space="preserve">
-    <value>Input</value>
+    <value>입력</value>
   </data>
   <data name="Expression_Help" xml:space="preserve">
-    <value>Help</value>
+    <value>도움말</value>
   </data>
   <data name="Expression_Variables" xml:space="preserve">
-    <value>Variables</value>
+    <value>변수</value>
   </data>
   <data name="Expression_Functions" xml:space="preserve">
-    <value>Functions</value>
+    <value>함수</value>
   </data>
   <data name="Expression_Variables_Description" xml:space="preserve">
-    <value>Time: Current time relative to the element start (seconds)
-Start: Element start time (seconds)
-Duration: Element duration (seconds)
-Progress: Normalized progress (0.0 to 1.0)
-PI: Mathematical constant π (3.14159...)</value>
+    <value>Time: 요소 시작 기준 현재 시간(초)
+Start: 요소 시작 시간(초)
+Duration: 요소 길이(초)
+Progress: 정규화된 진행률(0.0~1.0)
+PI: 수학 상수 π (3.14159...)</value>
   </data>
   <data name="Expression_Functions_Trigonometric" xml:space="preserve">
-    <value>Trigonometric: Sin, Cos, Tan, Asin, Acos, Atan, Atan2
-Hyperbolic: Sinh, Cosh, Tanh</value>
+    <value>삼각: Sin, Cos, Tan, Asin, Acos, Atan, Atan2
+쌍곡선: Sinh, Cosh, Tanh</value>
   </data>
   <data name="Expression_Functions_Math" xml:space="preserve">
-    <value>Math: Sqrt, Pow, Exp, Log, Log10, Log2
-Rounding: Abs, Floor, Ceil, Round, Truncate, Sign
-Range: Min, Max, Clamp</value>
+    <value>수학: Sqrt, Pow, Exp, Log, Log10, Log2
+반올림: Abs, Floor, Ceil, Round, Truncate, Sign
+범위: Min, Max, Clamp</value>
   </data>
   <data name="Expression_Functions_Interpolation" xml:space="preserve">
-    <value>Interpolation: Lerp, InverseLerp, Remap, Smoothstep</value>
+    <value>보간: Lerp, InverseLerp, Remap, Smoothstep</value>
   </data>
   <data name="Expression_Functions_Utility" xml:space="preserve">
-    <value>Utility: Radians, Degrees, Mod, Frac
-Random: Random(seed), Random(seed, min, max), FrameRandom(), FrameRandom(min, max)</value>
+    <value>유틸리티: Radians, Degrees, Mod, Frac
+무작위: Random(seed), Random(seed, min, max), FrameRandom(), FrameRandom(min, max)</value>
   </data>
   <data name="Expression_GetProperty_Description" xml:space="preserve">
-    <value>Reference other properties:
-GetProperty&lt;T&gt;("path") or GetProperty&lt;T&gt;(guid, "propertyName")
-Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
+    <value>다른 속성 참조:
+GetProperty&lt;T&gt;("path") 또는 GetProperty&lt;T&gt;(guid, "propertyName")
+예: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
   </data>
   <data name="Histogram" xml:space="preserve">
-    <value>Histogram</value>
+    <value>히스토그램</value>
   </data>
   <data name="Vectorscope" xml:space="preserve">
-    <value>Vectorscope</value>
+    <value>벡터스코프</value>
   </data>
   <data name="Waveform" xml:space="preserve">
-    <value>Waveform</value>
+    <value>파형</value>
   </data>
   <data name="FalseColor" xml:space="preserve">
-    <value>False Color</value>
+    <value>가색</value>
   </data>
   <data name="Zebra" xml:space="preserve">
-    <value>Zebra</value>
+    <value>얼룩말</value>
   </data>
   <data name="Threshold" xml:space="preserve">
-    <value>Threshold</value>
+    <value>임계값</value>
   </data>
   <data name="ZebraHighThreshold" xml:space="preserve">
-    <value>High</value>
+    <value>높음</value>
   </data>
   <data name="ZebraLowThreshold" xml:space="preserve">
-    <value>Low</value>
+    <value>낮음</value>
   </data>
   <data name="Spectrum" xml:space="preserve">
-    <value>Spectrum</value>
+    <value>스펙트럼</value>
   </data>
   <data name="Meter" xml:space="preserve">
-    <value>Meter</value>
+    <value>미터</value>
   </data>
   <data name="AudioVisualizer" xml:space="preserve">
-    <value>Audio Visualizer</value>
+    <value>오디오 시각화</value>
   </data>
   <data name="Spectrogram" xml:space="preserve">
-    <value>Spectrogram</value>
+    <value>스펙트로그램</value>
   </data>
   <data name="PhaseScope" xml:space="preserve">
-    <value>Phase Scope</value>
+    <value>위상 스코프</value>
   </data>
   <data name="AudioVisualizer_ResetTooltip" xml:space="preserve">
-    <value>Right-click to reset to default</value>
+    <value>기본값으로 재설정하려면 마우스 오른쪽 버튼 클릭</value>
   </data>
   <data name="AudioVisualizer_Waveform_Description" xml:space="preserve">
-    <value>Time-domain L/R waveform of the most recent audio. The upper trace is the left channel, the lower trace is the right channel; both share a center axis line. Use this view to spot transients, clipping, asymmetric or DC-offset signals, and to confirm at a glance that audio is actually flowing.</value>
+    <value>최근 오디오의 시간 영역 L/R 파형입니다. 위쪽 트레이스는 왼쪽 채널, 아래쪽 트레이스는 오른쪽 채널이며 둘 다 중심 축선을 공유합니다. 이 보기를 사용하여 과도 현상, 클리핑, 비대칭 또는 DC 오프셋 신호를 발견하고 오디오가 실제로 흐르는지 한눈에 확인하세요.</value>
   </data>
   <data name="AudioVisualizer_Spectrum_Description" xml:space="preserve">
-    <value>Real-time FFT frequency spectrum on a logarithmic frequency axis (~20 Hz to Nyquist). Bar height represents energy in dB at each frequency band. The settings flyout exposes shape (Bar / Line / FilledArea / MirroredBars), FFT size, smoothing, and the noise floor (Min dB). Useful for EQ work, spotting hum or whistles, and confirming that the mix has the expected high-frequency content.</value>
+    <value>로그 주파수 축(약 20Hz~나이퀴스트)의 실시간 FFT 주파수 스펙트럼입니다. 막대 높이는 각 주파수 대역의 에너지(dB)를 나타냅니다. 설정 플라이아웃에서 모양(막대/선/채워진 영역/대칭 막대), FFT 크기, 스무딩, 노이즈 플로어(최소 dB)를 조정할 수 있습니다. EQ 작업, 험 또는 휘파람 소리 감지, 믹스에 예상된 고주파 콘텐츠가 있는지 확인하는 데 유용합니다.</value>
   </data>
   <data name="AudioVisualizer_Meter_Description" xml:space="preserve">
-    <value>Stereo level meter combining several broadcast-standard readouts. Bars show RMS with a peak-hold marker that decays at ~6 dB/sec. Red LEDs at the top latch on for 2 seconds when the channel reaches 0 dBFS. The M number is momentary LUFS (BS.1770-4 K-weighted, 400 ms window). TP L / TP R are true peak in dBTP, computed by 4× polyphase oversampling. Use this view to verify loudness against delivery targets (-14 LUFS for YouTube, -23 LUFS for EBU R128) and to catch inter-sample peaks before encoding.</value>
+    <value>여러 방송 표준 판독값을 결합한 스테레오 레벨 미터입니다. 막대는 RMS를 표시하고 약 6dB/초로 감쇠하는 피크 홀드 마커가 있습니다. 채널이 0dBFS에 도달하면 상단의 빨간색 LED가 2초 동안 켜집니다. M 숫자는 순간 LUFS(BS.1770-4 K 가중, 400ms 창)입니다. TP L / TP R은 4배 다상 오버샘플링으로 계산된 dBTP 단위의 실제 피크입니다. 이 보기를 사용하여 전달 목표(YouTube -14 LUFS, EBU R128 -23 LUFS)에 대한 음량을 확인하고 인코딩 전에 샘플 간 피크를 감지하세요.</value>
   </data>
   <data name="AudioVisualizer_Spectrogram_Description" xml:space="preserve">
-    <value>Time-frequency heatmap of roughly the last 4 seconds. The vertical axis is logarithmic frequency (low at the bottom, high at the top); the horizontal axis is time (older on the left, newer on the right). Brightness represents energy in dB above the noise floor. Use this view to see how the spectrum evolves over time — identifying sweeping filters, vibrato, room modes, and the harmonic structure of sustained notes.</value>
+    <value>약 마지막 4초의 시간-주파수 히트맵입니다. 세로 축은 로그 주파수(아래가 낮음, 위가 높음)이고 가로 축은 시간(왼쪽이 오래됨, 오른쪽이 최신)입니다. 밝기는 노이즈 플로어 위의 에너지(dB)를 나타냅니다. 이 보기를 사용하여 스펙트럼이 시간에 따라 어떻게 진화하는지 확인하세요. 스윕 필터, 비브라토, 룸 모드, 지속 음의 고조파 구조를 식별할 수 있습니다.</value>
   </data>
   <data name="AudioVisualizer_PhaseScope_Description" xml:space="preserve">
-    <value>Stereo Lissajous (goniometer) rotated 45° — the broadcast-standard convention. Pure mono content traces a vertical line on the M (mono) axis; fully out-of-phase material spreads horizontally toward the S (anti-phase) axis; a single channel traces the L or R diagonal. The "corr" value at the top-left is the Pearson correlation between channels: +1 means perfectly mono, 0 uncorrelated, -1 fully anti-phase. Use this view to catch channel-flipped or phase-cancelling material that would collapse during mono playback.</value>
+    <value>45° 회전된 스테레오 리사주(고니오미터)입니다. 방송 표준 규칙입니다. 순수 모노 콘텐츠는 M(모노) 축에 수직선을 그립니다. 완전히 역위상인 재료는 S(역위상) 축으로 수평으로 퍼집니다. 단일 채널은 L 또는 R 대각선을 그립니다. 왼쪽 위의 "corr" 값은 채널 간 피어슨 상관 관계입니다. +1은 완전 모노, 0은 무상관, -1은 완전 역위상입니다. 이 보기를 사용하여 모노 재생 중에 붕괴되는 채널 반전 또는 위상 상쇄 재료를 감지하세요.</value>
   </data>
   <data name="Luma" xml:space="preserve">
-    <value>Luma</value>
+    <value>루마</value>
   </data>
   <data name="RgbOverlay" xml:space="preserve">
-    <value>RGB Overlay</value>
+    <value>RGB 오버레이</value>
   </data>
   <data name="RgbParade" xml:space="preserve">
-    <value>RGB Parade</value>
+    <value>RGB 퍼레이드</value>
   </data>
   <data name="Gamma" xml:space="preserve">
-    <value>Gamma</value>
+    <value>감마</value>
   </data>
   <data name="AVFoundationEncoder" xml:space="preserve">
-    <value>AVFoundation Encoder</value>
+    <value>AVFoundation 인코더</value>
   </data>
   <data name="AVFoundationDecoder" xml:space="preserve">
-    <value>AVFoundation Decoder</value>
+    <value>AVFoundation 디코더</value>
   </data>
   <data name="UniformValue" xml:space="preserve">
-    <value>Uniform value</value>
+    <value>유니폼 값</value>
   </data>
   <data name="Null" xml:space="preserve">
     <value>Null</value>
   </data>
   <data name="OpenInTab" xml:space="preserve">
-    <value>Open in tab</value>
+    <value>탭에서 열기</value>
   </data>
   <data name="Previous" xml:space="preserve">
-    <value>Previous</value>
+    <value>이전</value>
   </data>
   <data name="Current" xml:space="preserve">
-    <value>Current</value>
+    <value>현재</value>
   </data>
   <data name="Result" xml:space="preserve">
-    <value>Result</value>
+    <value>결과</value>
   </data>
   <data name="ElapsedTime" xml:space="preserve">
-    <value>Elapsed time</value>
+    <value>경과 시간</value>
   </data>
   <data name="Difference" xml:space="preserve">
-    <value>Difference</value>
+    <value>차이</value>
   </data>
   <data name="Error" xml:space="preserve">
-    <value>Error</value>
+    <value>오류</value>
   </data>
   <data name="APIError" xml:space="preserve">
-    <value>API Error</value>
+    <value>API 오류</value>
   </data>
   <data name="Website" xml:space="preserve">
-    <value>Website</value>
+    <value>웹사이트</value>
   </data>
   <data name="DisplayMode" xml:space="preserve">
-    <value>Display mode</value>
+    <value>표시 모드</value>
   </data>
   <data name="Docked" xml:space="preserve">
-    <value>Docked</value>
+    <value>도킹됨</value>
   </data>
   <data name="Floating" xml:space="preserve">
-    <value>Floating</value>
+    <value>플로팅</value>
   </data>
   <data name="CropSelection" xml:space="preserve">
-    <value>Crop selection</value>
+    <value>선택 영역 자르기</value>
   </data>
   <data name="Camera3DControl" xml:space="preserve">
-    <value>3D camera control</value>
+    <value>3D 카메라 제어</value>
   </data>
   <data name="Gizmo_Translate" xml:space="preserve">
-    <value>Translate</value>
+    <value>이동</value>
   </data>
   <data name="Gizmo_Rotate" xml:space="preserve">
-    <value>Rotate</value>
+    <value>회전</value>
   </data>
   <data name="Gizmo_Scale" xml:space="preserve">
-    <value>Scale</value>
+    <value>배율</value>
   </data>
   <data name="Portal" xml:space="preserve">
-    <value>Portal</value>
+    <value>포털</value>
   </data>
   <data name="Portal_Count" xml:space="preserve">
-    <value>Count</value>
+    <value>개수</value>
   </data>
   <data name="Portal_Clear" xml:space="preserve">
-    <value>Clear</value>
+    <value>지우기</value>
   </data>
   <data name="ExportProject" xml:space="preserve">
-    <value>Export Project...</value>
+    <value>프로젝트 내보내기...</value>
   </data>
   <data name="ImportProject" xml:space="preserve">
-    <value>Import Project...</value>
+    <value>프로젝트 가져오기...</value>
   </data>
   <data name="ExportingProject" xml:space="preserve">
-    <value>Exporting project...</value>
+    <value>프로젝트 내보내는 중...</value>
   </data>
   <data name="ImportingProject" xml:space="preserve">
-    <value>Importing project...</value>
+    <value>프로젝트 가져오는 중...</value>
   </data>
   <data name="ProjectPackage" xml:space="preserve">
-    <value>Project Package</value>
+    <value>프로젝트 패키지</value>
   </data>
   <data name="SelectDestinationFolder" xml:space="preserve">
-    <value>Select Destination Folder</value>
+    <value>대상 폴더 선택</value>
   </data>
-  <!-- 3D Graphics -->
+  
   <data name="Experimental" xml:space="preserve">
-    <value>Experimental</value>
+    <value>실험적</value>
   </data>
   <data name="Home" xml:space="preserve">
-    <value>Home</value>
+    <value>홈</value>
   </data>
   <data name="ProjectDirectory" xml:space="preserve">
-    <value>Project Directory</value>
+    <value>프로젝트 디렉터리</value>
   </data>
   <data name="MediaFiles" xml:space="preserve">
-    <value>Media Files</value>
+    <value>미디어 파일</value>
   </data>
   <data name="SearchingMediaFiles" xml:space="preserve">
-    <value>Searching for media files...</value>
+    <value>미디어 파일 검색 중...</value>
   </data>
   <data name="NoMediaFilesFound" xml:space="preserve">
-    <value>No media files found</value>
+    <value>미디어 파일을 찾을 수 없습니다</value>
   </data>
   <data name="Tutorials" xml:space="preserve">
-    <value>Tutorials</value>
+    <value>튜토리얼</value>
   </data>
   <data name="BpmGrid" xml:space="preserve">
-    <value>BPM Grid</value>
+    <value>BPM 그리드</value>
   </data>
   <data name="ShowBpmGrid" xml:space="preserve">
-    <value>Show BPM Grid</value>
+    <value>BPM 그리드 표시</value>
   </data>
   <data name="BpmValue" xml:space="preserve">
     <value>BPM</value>
   </data>
   <data name="BeatSubdivisions" xml:space="preserve">
-    <value>Subdivisions</value>
+    <value>세분화</value>
   </data>
   <data name="BpmOffset" xml:space="preserve">
-    <value>Offset</value>
+    <value>오프셋</value>
   </data>
   <data name="Preview" xml:space="preserve">
-    <value>Preview</value>
+    <value>미리 보기</value>
   </data>
   <data name="PreviewSettings" xml:space="preserve">
-    <value>Preview Settings</value>
+    <value>미리 보기 설정</value>
   </data>
   <data name="Templates" xml:space="preserve">
-    <value>Templates</value>
+    <value>템플릿</value>
   </data>
   <data name="SaveAsTemplate" xml:space="preserve">
-    <value>Save as Template</value>
+    <value>템플릿으로 저장</value>
   </data>
   <data name="ApplyTemplate" xml:space="preserve">
-    <value>Apply Template</value>
+    <value>템플릿 적용</value>
   </data>
   <data name="AddFromTemplate" xml:space="preserve">
-    <value>Add from Template</value>
+    <value>템플릿에서 추가</value>
   </data>
   <data name="TemplateSaved" xml:space="preserve">
-    <value>Template has been saved.</value>
+    <value>템플릿이 저장되었습니다.</value>
   </data>
   <data name="DeleteTemplateConfirm" xml:space="preserve">
-    <value>Are you sure you want to delete this template?</value>
+    <value>이 템플릿을 삭제하시겠습니까?</value>
   </data>
   <data name="EnterTemplateName" xml:space="preserve">
-    <value>Enter template name</value>
+    <value>템플릿 이름 입력</value>
   </data>
   <data name="Preset_YouTube_1080p60" xml:space="preserve">
     <value>YouTube 1080p 60fps</value>
@@ -1289,10 +1289,10 @@ Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
     <value>YouTube 4K 60fps</value>
   </data>
   <data name="Preset_Twitter_1080p" xml:space="preserve">
-    <value>Twitter (X) 1080p (max 2:20)</value>
+    <value>Twitter (X) 1080p (최대 2:20)</value>
   </data>
   <data name="Preset_Instagram_Reels" xml:space="preserve">
-    <value>Instagram Reels 9:16 (max 90s)</value>
+    <value>Instagram Reels 9:16 (최대 90초)</value>
   </data>
   <data name="Preset_Instagram_Feed" xml:space="preserve">
     <value>Instagram Feed 1:1</value>
@@ -1301,273 +1301,273 @@ Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
     <value>TikTok 9:16</value>
   </data>
   <data name="Preset_Discord_8MB" xml:space="preserve">
-    <value>Discord 8MB (~1 min)</value>
+    <value>Discord 8MB (약 1분)</value>
   </data>
   <data name="Encoding" xml:space="preserve">
-    <value>Encoding...</value>
+    <value>인코딩 중...</value>
   </data>
   <data name="RemainingTime" xml:space="preserve">
-    <value>Remaining</value>
+    <value>남은 시간</value>
   </data>
   <data name="Frames" xml:space="preserve">
-    <value>Frames</value>
+    <value>프레임</value>
   </data>
   <data name="FileSize" xml:space="preserve">
-    <value>Size</value>
+    <value>크기</value>
   </data>
   <data name="EstimatedSize" xml:space="preserve">
-    <value>Estimated</value>
+    <value>예상</value>
   </data>
   <data name="ShowCommandPalette" xml:space="preserve">
-    <value>Show command palette</value>
+    <value>명령 팔레트 표시</value>
   </data>
   <data name="ShowCommandPalette_Description" xml:space="preserve">
-    <value>Open the searchable command list</value>
+    <value>검색 가능한 명령 목록 열기</value>
   </data>
   <data name="CommandPalette_Placeholder" xml:space="preserve">
-    <value>Type a command name…</value>
+    <value>명령 이름 입력…</value>
   </data>
   <data name="CommandPalette_NoResults" xml:space="preserve">
-    <value>No matching commands</value>
+    <value>일치하는 명령 없음</value>
   </data>
   <data name="CommandPalette_MenuCategory" xml:space="preserve">
-    <value>Menu</value>
+    <value>메뉴</value>
   </data>
   <data name="OnionSkin" xml:space="preserve">
-    <value>Onion skin</value>
+    <value>양파 껍질</value>
   </data>
   <data name="OnionSkin_Description" xml:space="preserve">
-    <value>Show semi-transparent previous and next frames overlaid on the current frame.</value>
+    <value>현재 프레임 위에 반투명한 이전 및 다음 프레임을 겹쳐 표시합니다.</value>
   </data>
   <data name="ToggleOnionSkin" xml:space="preserve">
-    <value>Toggle onion skin</value>
+    <value>양파 껍질 전환</value>
   </data>
   <data name="ToggleOnionSkin_Description" xml:space="preserve">
-    <value>Toggle the onion skin overlay in the preview.</value>
+    <value>미리 보기에서 양파 껍질 오버레이를 전환합니다.</value>
   </data>
   <data name="OnionSkinPrevCount" xml:space="preserve">
-    <value>Previous frames</value>
+    <value>이전 프레임 수</value>
   </data>
   <data name="OnionSkinNextCount" xml:space="preserve">
-    <value>Next frames</value>
+    <value>다음 프레임 수</value>
   </data>
   <data name="OnionSkinPrevOpacity" xml:space="preserve">
-    <value>Previous opacity</value>
+    <value>이전 불투명도</value>
   </data>
   <data name="OnionSkinNextOpacity" xml:space="preserve">
-    <value>Next opacity</value>
+    <value>다음 불투명도</value>
   </data>
   <data name="Supersampling" xml:space="preserve">
-    <value>Supersampling</value>
+    <value>슈퍼샘플링</value>
   </data>
   <data name="Supersampling_Tip" xml:space="preserve">
-    <value>Render at the selected multiple of the output resolution, then downscale to the output size for smoother edges</value>
+    <value>출력 해상도의 선택한 배수로 렌더링한 다음 출력 크기로 축소하여 더 부드러운 가장자리를 만듭니다</value>
   </data>
   <data name="PreviewRenderQuality" xml:space="preserve">
-    <value>Preview render quality</value>
+    <value>미리 보기 렌더 품질</value>
   </data>
   <data name="PreviewRenderQuality_Tip" xml:space="preserve">
-    <value>Preview render quality. Cannot be changed during playback.</value>
+    <value>미리 보기 렌더 품질. 재생 중에는 변경할 수 없습니다.</value>
   </data>
   <data name="RenderScale_Full" xml:space="preserve">
-    <value>Full</value>
+    <value>전체</value>
   </data>
   <data name="RenderScale_Half" xml:space="preserve">
-    <value>Half (1/2)</value>
+    <value>절반 (1/2)</value>
   </data>
   <data name="RenderScale_Quarter" xml:space="preserve">
-    <value>Quarter (1/4)</value>
+    <value>1/4 (1/4)</value>
   </data>
   <data name="RenderScale_FitToPreviewer" xml:space="preserve">
-    <value>Fit to previewer</value>
+    <value>미리 보기에 맞춤</value>
   </data>
   <data name="Terminal" xml:space="preserve">
-    <value>Terminal</value>
+    <value>터미널</value>
   </data>
   <data name="TerminalSessionEnded" xml:space="preserve">
-    <value>The terminal session has ended.</value>
+    <value>터미널 세션이 종료되었습니다.</value>
   </data>
   <data name="Restart" xml:space="preserve">
-    <value>Restart</value>
+    <value>다시 시작</value>
   </data>
   <data name="Proxies" xml:space="preserve">
-    <value>Proxies</value>
+    <value>프록시</value>
   </data>
   <data name="ProxyPresetHalf" xml:space="preserve">
-    <value>Half proxy (1/2)</value>
+    <value>절반 프록시 (1/2)</value>
   </data>
   <data name="ProxyQuality" xml:space="preserve">
-    <value>Proxy quality</value>
+    <value>프록시 품질</value>
   </data>
   <data name="PreviewSource" xml:space="preserve">
-    <value>Preview source</value>
+    <value>미리 보기 소스</value>
   </data>
   <data name="PreviewSourcePreferProxy" xml:space="preserve">
-    <value>Prefer proxy</value>
+    <value>프록시 우선</value>
   </data>
   <data name="PreviewSourceForceOriginal" xml:space="preserve">
-    <value>Force original</value>
+    <value>원본 강제</value>
   </data>
   <data name="ProxyPresetQuarter" xml:space="preserve">
-    <value>Quarter proxy (1/4)</value>
+    <value>1/4 프록시 (1/4)</value>
   </data>
   <data name="ProxyPresetEighth" xml:space="preserve">
-    <value>Eighth proxy (1/8)</value>
+    <value>1/8 프록시 (1/8)</value>
   </data>
   <data name="ProxyStoreUsage" xml:space="preserve">
-    <value>Store</value>
+    <value>저장소</value>
   </data>
   <data name="ProxyStoreCap" xml:space="preserve">
-    <value>Cap</value>
+    <value>상한</value>
   </data>
   <data name="ProxyClips" xml:space="preserve">
-    <value>Clips</value>
+    <value>클립</value>
   </data>
   <data name="ProxyQueue" xml:space="preserve">
-    <value>Queue</value>
+    <value>큐</value>
   </data>
   <data name="ProxyGenerate" xml:space="preserve">
-    <value>Generate</value>
+    <value>생성</value>
   </data>
   <data name="ProxyGenerateSelected" xml:space="preserve">
-    <value>Generate selected</value>
+    <value>선택 항목 생성</value>
   </data>
   <data name="ProxyGenerateAll" xml:space="preserve">
-    <value>Generate all</value>
+    <value>모두 생성</value>
   </data>
   <data name="ProxyRegenerate" xml:space="preserve">
-    <value>Regenerate</value>
+    <value>다시 생성</value>
   </data>
   <data name="ProxyRegenerateSelected" xml:space="preserve">
-    <value>Regenerate selected</value>
+    <value>선택 항목 다시 생성</value>
   </data>
   <data name="ProxyDeleteSelected" xml:space="preserve">
-    <value>Delete selected</value>
+    <value>선택 항목 삭제</value>
   </data>
   <data name="ProxyDeleteProjectProxies" xml:space="preserve">
-    <value>Delete project proxies</value>
+    <value>프로젝트 프록시 삭제</value>
   </data>
   <data name="ProxyDeleteProjectProxiesConfirmationFormat" xml:space="preserve">
-    <value>Proxies are stored in a machine-wide shared cache. Deleting the {0} proxy file(s) used by this project also removes them for every other project that references the same source files, and they will have to be regenerated. Continue?</value>
+    <value>프록시는 컴퓨터 전체 공유 캐시에 저장됩니다. 이 프로젝트에서 사용하는 {0}개 프록시 파일을 삭제하면 동일한 소스 파일을 참조하는 다른 모든 프로젝트에서도 제거되며 다시 생성해야 합니다. 계속하시겠습니까?</value>
   </data>
   <data name="ProxyReady" xml:space="preserve">
-    <value>Ready</value>
+    <value>준비됨</value>
   </data>
   <data name="ProxyGenerating" xml:space="preserve">
-    <value>Generating</value>
+    <value>생성 중</value>
   </data>
   <data name="ProxyStale" xml:space="preserve">
-    <value>Stale</value>
+    <value>오래됨</value>
   </data>
   <data name="ProxyFailed" xml:space="preserve">
-    <value>Failed</value>
+    <value>실패</value>
   </data>
   <data name="ProxyMissing" xml:space="preserve">
-    <value>Missing</value>
+    <value>누락</value>
   </data>
   <data name="ProxyPartial" xml:space="preserve">
-    <value>Partial</value>
+    <value>부분</value>
   </data>
   <data name="ProxyUnavailable" xml:space="preserve">
-    <value>Unavailable</value>
+    <value>사용할 수 없음</value>
   </data>
   <data name="ProxyStoreUnavailable" xml:space="preserve">
-    <value>Proxy store is not available.</value>
+    <value>프록시 저장소를 사용할 수 없습니다.</value>
   </data>
   <data name="ProxyQueueUnavailable" xml:space="preserve">
-    <value>Proxy queue is not available.</value>
+    <value>프록시 큐를 사용할 수 없습니다.</value>
   </data>
   <data name="ProxyBulkNoEligibleClips" xml:space="preserve">
-    <value>No clips met the bulk-generation threshold; use per-clip generate.</value>
+    <value>일괄 생성 임계값을 충족하는 클립이 없습니다. 클립별 생성을 사용하세요.</value>
   </data>
   <data name="ProxyQueueIdle" xml:space="preserve">
-    <value>Queue idle</value>
+    <value>큐 유휴</value>
   </data>
   <data name="ProxyQueuedJobSingular" xml:space="preserve">
-    <value>1 queued job</value>
+    <value>대기 중인 작업 1개</value>
   </data>
   <data name="ProxyQueuedJobPlural" xml:space="preserve">
-    <value>{0} queued jobs</value>
+    <value>대기 중인 작업 {0}개</value>
   </data>
   <data name="ProxyDeleteFailedSingular" xml:space="preserve">
-    <value>1 proxy could not be deleted because its file is in use.</value>
+    <value>파일이 사용 중이어서 프록시 1개를 삭제할 수 없습니다.</value>
   </data>
   <data name="ProxyDeleteFailedPluralFormat" xml:space="preserve">
-    <value>{0} proxies could not be deleted because their files are in use.</value>
+    <value>파일이 사용 중이어서 프록시 {0}개를 삭제할 수 없습니다.</value>
   </data>
   <data name="ProxyClipSummaryFormat" xml:space="preserve">
-    <value>{0} clips / {1} ready / {2} stale / {3} failed / {4} missing</value>
+    <value>클립 {0}개 / 준비 {1} / 오래됨 {2} / 실패 {3} / 누락 {4}</value>
   </data>
   <data name="ProxySelectedSingular" xml:space="preserve">
-    <value>1 selected</value>
+    <value>선택 1개</value>
   </data>
   <data name="ProxySelectedPlural" xml:space="preserve">
-    <value>{0} selected</value>
+    <value>선택 {0}개</value>
   </data>
   <data name="ProxyStoreSummaryFormat" xml:space="preserve">
-    <value>Project {0} / Store {1} / Cap {2}</value>
+    <value>프로젝트 {0} / 저장소 {1} / 상한 {2}</value>
   </data>
   <data name="ProxySourceInfoFormat" xml:space="preserve">
-    <value>Source {0} / {1}</value>
+    <value>소스 {0} / {1}</value>
   </data>
   <data name="ProxyInfoFormat" xml:space="preserve">
-    <value>Proxy {0} -> {1} / {2}</value>
+    <value>프록시 {0} -&gt; {1} / {2}</value>
   </data>
   <data name="ProxyMissingForSelectedPreset" xml:space="preserve">
-    <value>Proxy missing for selected preset</value>
+    <value>선택한 프리셋에 대한 프록시가 없습니다</value>
   </data>
   <data name="ProxyLastUsedFormat" xml:space="preserve">
-    <value>Used {0}</value>
+    <value>{0}에 사용됨</value>
   </data>
   <data name="ProxyJobStatusQueued" xml:space="preserve">
-    <value>Queued</value>
+    <value>대기 중</value>
   </data>
   <data name="ProxyJobStatusRunning" xml:space="preserve">
-    <value>Running</value>
+    <value>실행 중</value>
   </data>
   <data name="ProxyJobStatusSucceeded" xml:space="preserve">
-    <value>Succeeded</value>
+    <value>성공</value>
   </data>
   <data name="ProxyJobStatusFailed" xml:space="preserve">
-    <value>Failed</value>
+    <value>실패</value>
   </data>
   <data name="ProxyJobStatusCanceled" xml:space="preserve">
-    <value>Canceled</value>
+    <value>취소됨</value>
   </data>
   <data name="ProxyJobStatusSkipped" xml:space="preserve">
-    <value>Skipped</value>
+    <value>건너뜀</value>
   </data>
   <data name="ProxyJobStatusWithMessageFormat" xml:space="preserve">
     <value>{0}: {1}</value>
   </data>
   <data name="Start" xml:space="preserve">
-    <value>Start</value>
+    <value>시작</value>
   </data>
   <data name="Debug" xml:space="preserve">
-    <value>Debug</value>
+    <value>디버그</value>
   </data>
   <data name="AudioVisualizer_Display" xml:space="preserve">
-    <value>Display</value>
+    <value>표시</value>
   </data>
   <data name="WindowCapture" xml:space="preserve">
-    <value>Window Capture</value>
+    <value>창 캡처</value>
   </data>
   <data name="AudioVisualizer_MinDecibels" xml:space="preserve">
-    <value>Min dB</value>
+    <value>최소 dB</value>
   </data>
   <data name="WindowCapture_RenderScale" xml:space="preserve">
-    <value>Render scale</value>
+    <value>렌더 배율</value>
   </data>
   <data name="WindowCapture_FrameRate" xml:space="preserve">
-    <value>Frame rate (fps)</value>
+    <value>프레임 속도 (fps)</value>
   </data>
   <data name="WindowCapture_OutputFile" xml:space="preserve">
-    <value>Output file (.mp4)</value>
+    <value>출력 파일 (.mp4)</value>
   </data>
   <data name="Browse" xml:space="preserve">
-    <value>Browse...</value>
+    <value>찾아보기...</value>
   </data>
   <data name="ClickBrowse" xml:space="preserve">
-    <value>Click Browse...</value>
+    <value>찾아보기 클릭...</value>
   </data>
 </root>

--- a/src/Beutl.Language/Strings.ko-KR.resx
+++ b/src/Beutl.Language/Strings.ko-KR.resx
@@ -1313,10 +1313,10 @@ GetProperty&lt;T&gt;("path") 또는 GetProperty&lt;T&gt;(guid, "propertyName")
     <value>프레임</value>
   </data>
   <data name="FileSize" xml:space="preserve">
-    <value>크기</value>
+    <value>파일 크기</value>
   </data>
   <data name="EstimatedSize" xml:space="preserve">
-    <value>예상</value>
+    <value>예상 크기</value>
   </data>
   <data name="ShowCommandPalette" xml:space="preserve">
     <value>명령 팔레트 표시</value>
@@ -1334,16 +1334,16 @@ GetProperty&lt;T&gt;("path") 또는 GetProperty&lt;T&gt;(guid, "propertyName")
     <value>메뉴</value>
   </data>
   <data name="OnionSkin" xml:space="preserve">
-    <value>양파 껍질</value>
+    <value>어니언 스킨</value>
   </data>
   <data name="OnionSkin_Description" xml:space="preserve">
     <value>현재 프레임 위에 반투명한 이전 및 다음 프레임을 겹쳐 표시합니다.</value>
   </data>
   <data name="ToggleOnionSkin" xml:space="preserve">
-    <value>양파 껍질 전환</value>
+    <value>어니언 스킨 전환</value>
   </data>
   <data name="ToggleOnionSkin_Description" xml:space="preserve">
-    <value>미리 보기에서 양파 껍질 오버레이를 전환합니다.</value>
+    <value>미리 보기에서 어니언 스킨 오버레이를 전환합니다.</value>
   </data>
   <data name="OnionSkinPrevCount" xml:space="preserve">
     <value>이전 프레임 수</value>
@@ -1376,7 +1376,7 @@ GetProperty&lt;T&gt;("path") 또는 GetProperty&lt;T&gt;(guid, "propertyName")
     <value>절반 (1/2)</value>
   </data>
   <data name="RenderScale_Quarter" xml:space="preserve">
-    <value>1/4 (1/4)</value>
+    <value>1/4</value>
   </data>
   <data name="RenderScale_FitToPreviewer" xml:space="preserve">
     <value>미리 보기에 맞춤</value>

--- a/src/Beutl.Language/Strings.zh-CN.resx
+++ b/src/Beutl.Language/Strings.zh-CN.resx
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<root>
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:element name="root" msdata:IsDataSet="true">
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
 
-    </xsd:element>
-  </xsd:schema>
+    </xs:element>
+  </xs:schema>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -18,1269 +18,1269 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="File" xml:space="preserve">
-    <value>File</value>
+    <value>文件</value>
   </data>
   <data name="Curves" xml:space="preserve">
-    <value>Curves</value>
+    <value>曲线</value>
   </data>
   <data name="CustomCurve" xml:space="preserve">
-    <value>Custom (RGB)</value>
+    <value>自定义 (RGB)</value>
   </data>
   <data name="HueVsHue" xml:space="preserve">
-    <value>Hue vs Hue</value>
+    <value>色相 vs 色相</value>
   </data>
   <data name="HueVsLuminance" xml:space="preserve">
-    <value>Hue vs Luminance</value>
+    <value>色相 vs 亮度</value>
   </data>
   <data name="HueVsSaturation" xml:space="preserve">
-    <value>Hue vs Saturation</value>
+    <value>色相 vs 饱和度</value>
   </data>
   <data name="LuminanceVsSaturation" xml:space="preserve">
-    <value>Luminance vs Saturation</value>
+    <value>亮度 vs 饱和度</value>
   </data>
   <data name="SaturationVsSaturation" xml:space="preserve">
-    <value>Saturation vs Saturation</value>
+    <value>饱和度 vs 饱和度</value>
   </data>
   <data name="CreateNew" xml:space="preserve">
-    <value>Create New</value>
+    <value>新建</value>
   </data>
   <data name="CreateNewProject" xml:space="preserve">
-    <value>Create new project</value>
+    <value>创建新项目</value>
   </data>
   <data name="CreateNewScene" xml:space="preserve">
-    <value>Create new scene</value>
+    <value>创建新场景</value>
   </data>
   <data name="Project" xml:space="preserve">
-    <value>Project</value>
+    <value>项目</value>
   </data>
   <data name="Scene" xml:space="preserve">
-    <value>Scene</value>
+    <value>场景</value>
   </data>
   <data name="Open" xml:space="preserve">
-    <value>Open</value>
+    <value>打开</value>
   </data>
   <data name="Close" xml:space="preserve">
-    <value>Close</value>
+    <value>关闭</value>
   </data>
   <data name="ColorScopes" xml:space="preserve">
-    <value>Scopes</value>
+    <value>示波器</value>
   </data>
   <data name="CloseProject" xml:space="preserve">
-    <value>Close Project</value>
+    <value>关闭项目</value>
   </data>
   <data name="Save" xml:space="preserve">
-    <value>Save</value>
+    <value>保存</value>
   </data>
   <data name="SaveAll" xml:space="preserve">
-    <value>Save All</value>
+    <value>全部保存</value>
   </data>
   <data name="Exit" xml:space="preserve">
-    <value>Exit</value>
+    <value>退出</value>
   </data>
   <data name="Edit" xml:space="preserve">
-    <value>Edit</value>
+    <value>编辑</value>
   </data>
   <data name="Undo" xml:space="preserve">
-    <value>Undo</value>
+    <value>撤销</value>
   </data>
   <data name="Redo" xml:space="preserve">
-    <value>Redo</value>
+    <value>重做</value>
   </data>
   <data name="View" xml:space="preserve">
-    <value>View</value>
+    <value>视图</value>
   </data>
   <data name="Object" xml:space="preserve">
-    <value>Object</value>
+    <value>对象</value>
   </data>
   <data name="Help" xml:space="preserve">
-    <value>Help</value>
+    <value>帮助</value>
   </data>
   <data name="Extensions" xml:space="preserve">
-    <value>Extensions</value>
+    <value>扩展</value>
   </data>
   <data name="Output" xml:space="preserve">
-    <value>Output</value>
+    <value>输出</value>
   </data>
   <data name="History" xml:space="preserve">
-    <value>History</value>
+    <value>历史记录</value>
   </data>
   <data name="History_Initial" xml:space="preserve">
-    <value>Initial state</value>
+    <value>初始状态</value>
   </data>
   <data name="History_Unnamed" xml:space="preserve">
-    <value>(Unnamed)</value>
+    <value>（未命名）</value>
   </data>
   <data name="History_OperationFailed" xml:space="preserve">
-    <value>History operation failed.</value>
+    <value>历史记录操作失败。</value>
   </data>
   <data name="Settings" xml:space="preserve">
-    <value>Settings</value>
+    <value>设置</value>
   </data>
   <data name="Properties" xml:space="preserve">
-    <value>Properties</value>
+    <value>属性</value>
   </data>
   <data name="Easings" xml:space="preserve">
-    <value>Easings</value>
+    <value>缓动</value>
   </data>
   <data name="Timeline" xml:space="preserve">
-    <value>Timeline</value>
+    <value>时间轴</value>
   </data>
   <data name="SceneFile" xml:space="preserve">
-    <value>Scene File</value>
+    <value>场景文件</value>
   </data>
   <data name="Info" xml:space="preserve">
-    <value>Info</value>
+    <value>信息</value>
   </data>
   <data name="Add" xml:space="preserve">
-    <value>Add</value>
+    <value>添加</value>
   </data>
   <data name="Search" xml:space="preserve">
-    <value>Search</value>
+    <value>搜索</value>
   </data>
   <data name="Name" xml:space="preserve">
-    <value>Name</value>
+    <value>名称</value>
   </data>
   <data name="Note" xml:space="preserve">
-    <value>Note</value>
+    <value>备注</value>
   </data>
   <data name="Color" xml:space="preserve">
-    <value>Color</value>
+    <value>颜色</value>
   </data>
   <data name="EditMarker" xml:space="preserve">
-    <value>Edit Marker</value>
+    <value>编辑标记</value>
   </data>
   <data name="StartTime" xml:space="preserve">
-    <value>Start Time</value>
+    <value>开始时间</value>
   </data>
   <data name="DurationTime" xml:space="preserve">
-    <value>Duration Time</value>
+    <value>时长</value>
   </data>
   <data name="Cut" xml:space="preserve">
-    <value>Cut</value>
+    <value>剪切</value>
   </data>
   <data name="Copy" xml:space="preserve">
-    <value>Copy</value>
+    <value>复制</value>
   </data>
   <data name="Paste" xml:space="preserve">
-    <value>Paste</value>
+    <value>粘贴</value>
   </data>
   <data name="Split" xml:space="preserve">
-    <value>Split</value>
+    <value>分割</value>
   </data>
   <data name="Duplicate" xml:space="preserve">
-    <value>Duplicate</value>
+    <value>创建副本</value>
   </data>
   <data name="EditingMode" xml:space="preserve">
-    <value>Editing Mode</value>
+    <value>编辑模式</value>
   </data>
   <data name="RazorTool" xml:space="preserve">
-    <value>Razor Tool</value>
+    <value>剃刀工具</value>
   </data>
   <data name="RazorTool_Description" xml:space="preserve">
-    <value>Toggle razor (split) tool. Click on a clip to split it.</value>
+    <value>切换剃刀（分割）工具。单击剪辑以将其分割。</value>
   </data>
   <data name="ExitRazorTool" xml:space="preserve">
-    <value>Exit Razor Tool</value>
+    <value>退出剃刀工具</value>
   </data>
   <data name="ExitRazorTool_Description" xml:space="preserve">
-    <value>Exit razor mode and return to selection tool.</value>
+    <value>退出剃刀模式并返回选择工具。</value>
   </data>
   <data name="SlipTool" xml:space="preserve">
-    <value>Slip Tool</value>
+    <value>滑移工具</value>
   </data>
   <data name="SlipTool_Description" xml:space="preserve">
-    <value>Toggle slip tool. Drag a clip to shift its source-media window without moving the clip.</value>
+    <value>切换滑移工具。拖动剪辑以移动其源媒体窗口，而不移动剪辑。</value>
   </data>
   <data name="ExitSlipTool" xml:space="preserve">
-    <value>Exit Slip Tool</value>
+    <value>退出滑移工具</value>
   </data>
   <data name="ExitSlipTool_Description" xml:space="preserve">
-    <value>Exit slip mode and return to selection tool.</value>
+    <value>退出滑移模式并返回选择工具。</value>
   </data>
   <data name="RollTool" xml:space="preserve">
-    <value>Roll Tool</value>
+    <value>滚动工具</value>
   </data>
   <data name="RollTool_Description" xml:space="preserve">
-    <value>Toggle roll tool. Drag a clip edge to shift the boundary with its neighbor, preserving total length.</value>
+    <value>切换滚动工具。拖动剪辑边缘以移动与其相邻剪辑的边界，同时保持总长度。</value>
   </data>
   <data name="ExitRollTool" xml:space="preserve">
-    <value>Exit Roll Tool</value>
+    <value>退出滚动工具</value>
   </data>
   <data name="ExitRollTool_Description" xml:space="preserve">
-    <value>Exit roll mode and return to selection tool.</value>
+    <value>退出滚动模式并返回选择工具。</value>
   </data>
   <data name="SlideTool" xml:space="preserve">
-    <value>Slide Tool</value>
+    <value>滑动工具</value>
   </data>
   <data name="SlideTool_Description" xml:space="preserve">
-    <value>Toggle slide tool. Drag a clip to shift it while neighbors compensate, preserving total length.</value>
+    <value>切换滑动工具。拖动剪辑以移动它，同时相邻剪辑进行补偿，保持总长度。</value>
   </data>
   <data name="ExitSlideTool" xml:space="preserve">
-    <value>Exit Slide Tool</value>
+    <value>退出滑动工具</value>
   </data>
   <data name="ExitSlideTool_Description" xml:space="preserve">
-    <value>Exit slide mode and return to selection tool.</value>
+    <value>退出滑动模式并返回选择工具。</value>
   </data>
   <data name="Delete" xml:space="preserve">
-    <value>Delete</value>
+    <value>删除</value>
   </data>
   <data name="Remove" xml:space="preserve">
-    <value>Remove</value>
+    <value>移除</value>
   </data>
   <data name="Exclude" xml:space="preserve">
-    <value>Exclude</value>
+    <value>排除</value>
   </data>
   <data name="Back" xml:space="preserve">
-    <value>Back</value>
+    <value>返回</value>
   </data>
   <data name="Next" xml:space="preserve">
-    <value>Next</value>
+    <value>下一步</value>
   </data>
   <data name="Element" xml:space="preserve">
-    <value>Element</value>
+    <value>元素</value>
   </data>
   <data name="AddElement" xml:space="preserve">
-    <value>Add Element</value>
+    <value>添加元素</value>
   </data>
   <data name="AddAdjustmentLayer" xml:space="preserve">
-    <value>Add Adjustment Layer</value>
+    <value>添加调整图层</value>
   </data>
   <data name="AdjustmentLayer" xml:space="preserve">
-    <value>Adjustment Layer</value>
+    <value>调整图层</value>
   </data>
   <data name="Location" xml:space="preserve">
-    <value>Location</value>
+    <value>位置</value>
   </data>
   <data name="Size" xml:space="preserve">
-    <value>Size</value>
+    <value>大小</value>
   </data>
   <data name="FrameRate" xml:space="preserve">
-    <value>Frame rate</value>
+    <value>帧率</value>
   </data>
   <data name="SampleRate" xml:space="preserve">
-    <value>Sample rate</value>
+    <value>采样率</value>
   </data>
   <data name="SceneSettings" xml:space="preserve">
-    <value>Scene settings</value>
+    <value>场景设置</value>
   </data>
   <data name="Apply" xml:space="preserve">
-    <value>Apply</value>
+    <value>应用</value>
   </data>
   <data name="Width" xml:space="preserve">
-    <value>Width</value>
+    <value>宽度</value>
   </data>
   <data name="Height" xml:space="preserve">
-    <value>Height</value>
+    <value>高度</value>
   </data>
   <data name="Reset" xml:space="preserve">
-    <value>Reset</value>
+    <value>重置</value>
   </data>
   <data name="ResetDockLayout" xml:space="preserve">
-    <value>Reset dock layout</value>
+    <value>重置停靠布局</value>
   </data>
   <data name="DockLayout" xml:space="preserve">
-    <value>Dock layout</value>
+    <value>停靠布局</value>
   </data>
   <data name="ApplyDockLayout" xml:space="preserve">
-    <value>Apply dock layout</value>
+    <value>应用停靠布局</value>
   </data>
   <data name="ManageDockLayouts" xml:space="preserve">
-    <value>Manage dock layouts</value>
+    <value>管理停靠布局</value>
   </data>
   <data name="SaveCurrentDockLayout" xml:space="preserve">
-    <value>Save the current layout</value>
+    <value>保存当前布局</value>
   </data>
   <data name="SavedDockLayouts" xml:space="preserve">
-    <value>Saved layouts</value>
+    <value>已保存的布局</value>
   </data>
   <data name="EditAnimation" xml:space="preserve">
-    <value>Edit animation</value>
+    <value>编辑动画</value>
   </data>
   <data name="NewFolder" xml:space="preserve">
-    <value>New Folder</value>
+    <value>新建文件夹</value>
   </data>
   <data name="Left" xml:space="preserve">
-    <value>Left</value>
+    <value>左</value>
   </data>
   <data name="Right" xml:space="preserve">
-    <value>Right</value>
+    <value>右</value>
   </data>
   <data name="Top" xml:space="preserve">
-    <value>Top</value>
+    <value>上</value>
   </data>
   <data name="Bottom" xml:space="preserve">
-    <value>Bottom</value>
+    <value>下</value>
   </data>
   <data name="Cancel" xml:space="preserve">
-    <value>Cancel</value>
+    <value>取消</value>
   </data>
   <data name="Yes" xml:space="preserve">
-    <value>Yes</value>
+    <value>是</value>
   </data>
   <data name="No" xml:space="preserve">
-    <value>No</value>
+    <value>否</value>
   </data>
   <data name="DiscardChanges" xml:space="preserve">
-    <value>Discard changes</value>
+    <value>放弃更改</value>
   </data>
   <data name="Others" xml:space="preserve">
-    <value>Others</value>
+    <value>其他</value>
   </data>
   <data name="Link" xml:space="preserve">
-    <value>Link</value>
+    <value>链接</value>
   </data>
   <data name="ShowMore" xml:space="preserve">
-    <value>Show more</value>
+    <value>显示更多</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>OK</value>
+    <value>确定</value>
   </data>
   <data name="Animation" xml:space="preserve">
-    <value>Animation</value>
+    <value>动画</value>
   </data>
   <data name="Easing" xml:space="preserve">
-    <value>Easing</value>
+    <value>缓动</value>
   </data>
   <data name="Hold" xml:space="preserve">
-    <value>Hold</value>
+    <value>保持</value>
   </data>
   <data name="ElementProperty" xml:space="preserve">
-    <value>Element Property</value>
+    <value>元素属性</value>
   </data>
   <data name="ProjectFile" xml:space="preserve">
-    <value>Project File</value>
+    <value>项目文件</value>
   </data>
   <data name="RecentFiles" xml:space="preserve">
-    <value>Recent Files</value>
+    <value>最近的文件</value>
   </data>
   <data name="RecentProjects" xml:space="preserve">
-    <value>Recent Projects</value>
+    <value>最近的项目</value>
   </data>
   <data name="Editors" xml:space="preserve">
-    <value>Editors</value>
+    <value>编辑器</value>
   </data>
   <data name="Tools" xml:space="preserve">
-    <value>Tools</value>
+    <value>工具</value>
   </data>
   <data name="Rename" xml:space="preserve">
-    <value>Rename</value>
+    <value>重命名</value>
   </data>
   <data name="FinishEditing" xml:space="preserve">
-    <value>Finish editing</value>
+    <value>完成编辑</value>
   </data>
   <data name="BringToTop" xml:space="preserve">
-    <value>Bring to the top</value>
+    <value>置于顶部</value>
   </data>
   <data name="StartEditing" xml:space="preserve">
-    <value>Start editing</value>
+    <value>开始编辑</value>
   </data>
   <data name="CreateNewProjectOrScene" xml:space="preserve">
-    <value>Create new project or scene</value>
+    <value>创建新项目或场景</value>
   </data>
   <data name="OpenAFileYouHaveAlreadyCreated" xml:space="preserve">
-    <value>Open a file you have already created</value>
+    <value>打开已创建的文件</value>
   </data>
   <data name="Recently" xml:space="preserve">
-    <value>Recently</value>
+    <value>最近</value>
   </data>
   <data name="Projects" xml:space="preserve">
-    <value>Projects</value>
+    <value>项目</value>
   </data>
   <data name="Files" xml:space="preserve">
-    <value>Files</value>
+    <value>文件</value>
   </data>
   <data name="All" xml:space="preserve">
-    <value>All</value>
+    <value>全部</value>
   </data>
   <data name="NoFilesUsedRecently" xml:space="preserve">
-    <value>No files used recently.</value>
+    <value>最近没有使用过的文件。</value>
   </data>
   <data name="AddOutputProfile" xml:space="preserve">
-    <value>Add Profile</value>
+    <value>添加配置文件</value>
   </data>
   <data name="Encode" xml:space="preserve">
-    <value>Encode</value>
+    <value>编码</value>
   </data>
   <data name="DestinationToSaveTo_Tip" xml:space="preserve">
-    <value>Set the destination</value>
+    <value>设置目标位置</value>
   </data>
   <data name="DestinationToSaveTo" xml:space="preserve">
-    <value>Destination to save to</value>
+    <value>保存目标位置</value>
   </data>
   <data name="Encoder_Tip" xml:space="preserve">
-    <value>Select an encoder</value>
+    <value>选择编码器</value>
   </data>
   <data name="Encoder" xml:space="preserve">
-    <value>Encoder</value>
+    <value>编码器</value>
   </data>
   <data name="FrameSize" xml:space="preserve">
-    <value>Frame size</value>
+    <value>帧大小</value>
   </data>
   <data name="FrameSize_Tip" xml:space="preserve">
-    <value>Set the frame size</value>
+    <value>设置帧大小</value>
   </data>
   <data name="FrameRate_Tip" xml:space="preserve">
-    <value>Set the framerate</value>
+    <value>设置帧率</value>
   </data>
   <data name="Bitrate" xml:space="preserve">
-    <value>Bitrate</value>
+    <value>比特率</value>
   </data>
   <data name="Bitrate_Tip" xml:space="preserve">
-    <value>Set the bitrate</value>
+    <value>设置比特率</value>
   </data>
   <data name="KeyframeRate" xml:space="preserve">
-    <value>Keyframe rate</value>
+    <value>关键帧速率</value>
   </data>
   <data name="KeyframeRate_Tip" xml:space="preserve">
-    <value>Set the keyframe rate</value>
+    <value>设置关键帧速率</value>
   </data>
   <data name="SampleRate_Tip" xml:space="preserve">
-    <value>Set the sample rate</value>
+    <value>设置采样率</value>
   </data>
   <data name="Channels" xml:space="preserve">
-    <value>Channels</value>
+    <value>声道</value>
   </data>
   <data name="Channels_Tip" xml:space="preserve">
-    <value>Set the number of channels</value>
+    <value>设置声道数</value>
   </data>
   <data name="Video" xml:space="preserve">
-    <value>Video</value>
+    <value>视频</value>
   </data>
   <data name="Audio" xml:space="preserve">
-    <value>Audio</value>
+    <value>音频</value>
   </data>
   <data name="Off" xml:space="preserve">
-    <value>Off</value>
+    <value>关</value>
   </data>
   <data name="On" xml:space="preserve">
-    <value>On</value>
+    <value>开</value>
   </data>
   <data name="NodeGraph" xml:space="preserve">
-    <value>Node Graph</value>
+    <value>节点图</value>
   </data>
   <data name="Library" xml:space="preserve">
-    <value>Library</value>
+    <value>库</value>
   </data>
   <data name="FileBrowser" xml:space="preserve">
-    <value>File Browser</value>
+    <value>文件浏览器</value>
   </data>
   <data name="ListView" xml:space="preserve">
-    <value>List View</value>
+    <value>列表视图</value>
   </data>
   <data name="TreeView" xml:space="preserve">
-    <value>Tree View</value>
+    <value>树状视图</value>
   </data>
   <data name="IconView" xml:space="preserve">
-    <value>Icon View</value>
+    <value>图标视图</value>
   </data>
   <data name="Refresh" xml:space="preserve">
-    <value>Refresh</value>
+    <value>刷新</value>
   </data>
   <data name="OpenFolder" xml:space="preserve">
-    <value>Open Folder</value>
+    <value>打开文件夹</value>
   </data>
   <data name="Favorites" xml:space="preserve">
-    <value>Favorites</value>
+    <value>收藏夹</value>
   </data>
   <data name="Feedback" xml:space="preserve">
-    <value>Feedback</value>
+    <value>反馈</value>
   </data>
   <data name="AddToFavorites" xml:space="preserve">
-    <value>Add to Favorites</value>
+    <value>添加到收藏夹</value>
   </data>
   <data name="RemoveFromFavorites" xml:space="preserve">
-    <value>Remove from Favorites</value>
+    <value>从收藏夹移除</value>
   </data>
   <data name="NoFavorites" xml:space="preserve">
-    <value>No favorites</value>
+    <value>没有收藏夹</value>
   </data>
   <data name="DeleteSelectedItems" xml:space="preserve">
-    <value>Delete {0} items?</value>
+    <value>删除 {0} 个项目？</value>
   </data>
   <data name="Group" xml:space="preserve">
-    <value>Group</value>
+    <value>组</value>
   </data>
   <data name="GraphEditor" xml:space="preserve">
-    <value>Graph Editor</value>
+    <value>图形编辑器</value>
   </data>
   <data name="Unknown" xml:space="preserve">
-    <value>Unknown</value>
+    <value>未知</value>
   </data>
   <data name="Details" xml:space="preserve">
-    <value>Details</value>
+    <value>详细信息</value>
   </data>
   <data name="Completed" xml:space="preserve">
-    <value>Completed</value>
+    <value>已完成</value>
   </data>
   <data name="Brightness" xml:space="preserve">
-    <value>Brightness</value>
+    <value>亮度</value>
   </data>
   <data name="ColorGrading" xml:space="preserve">
-    <value>Color Grading</value>
+    <value>颜色分级</value>
   </data>
   <data name="Number_of_Layers" xml:space="preserve">
-    <value>Number of Layers</value>
+    <value>图层数</value>
   </data>
   <data name="ChangeColor" xml:space="preserve">
-    <value>Change color</value>
+    <value>更改颜色</value>
   </data>
   <data name="EditAnimationInInlineView" xml:space="preserve">
-    <value>Edit animation in inline view</value>
+    <value>在内联视图中编辑动画</value>
   </data>
   <data name="EnableLivePreview" xml:space="preserve">
-    <value>Enable Live Preview</value>
+    <value>启用实时预览</value>
   </data>
   <data name="DisableThumbnails" xml:space="preserve">
-    <value>Disable Thumbnails</value>
+    <value>禁用缩略图</value>
   </data>
   <data name="Unsupported" xml:space="preserve">
-    <value>Unsupported</value>
+    <value>不支持</value>
   </data>
   <data name="TimelineZoom" xml:space="preserve">
-    <value>Zoom</value>
+    <value>缩放</value>
   </data>
   <data name="TimelineSnap" xml:space="preserve">
-    <value>Snap</value>
+    <value>吸附</value>
   </data>
   <data name="RippleEdit" xml:space="preserve">
-    <value>Ripple Edit</value>
+    <value>波纹编辑</value>
   </data>
   <data name="UseGlobalClock" xml:space="preserve">
-    <value>Use the Global Clock</value>
+    <value>使用全局时钟</value>
   </data>
   <data name="EditJson" xml:space="preserve">
-    <value>Edit Json</value>
+    <value>编辑 JSON</value>
   </data>
   <data name="AddNode" xml:space="preserve">
-    <value>Add node</value>
+    <value>添加节点</value>
   </data>
   <data name="Change" xml:space="preserve">
-    <value>Change</value>
+    <value>更改</value>
   </data>
   <data name="Disconnect" xml:space="preserve">
-    <value>Disconnect</value>
+    <value>断开连接</value>
   </data>
   <data name="Initialize" xml:space="preserve">
-    <value>Initialize</value>
+    <value>初始化</value>
   </data>
   <data name="ResetZoom" xml:space="preserve">
-    <value>Reset zoom</value>
+    <value>重置缩放</value>
   </data>
   <data name="RemoveAnimation" xml:space="preserve">
-    <value>Remove animation</value>
+    <value>移除动画</value>
   </data>
   <data name="EditExpression" xml:space="preserve">
-    <value>Edit expression</value>
+    <value>编辑表达式</value>
   </data>
   <data name="RemoveExpression" xml:space="preserve">
-    <value>Remove expression</value>
+    <value>移除表达式</value>
   </data>
   <data name="ExpressionHelp" xml:space="preserve">
-    <value>Enter a mathematical expression. Available variables: Time, Start, Duration, Progress. Use GetProperty&lt;T&gt;("{GUID}.Property") to reference other properties.</value>
+    <value>输入数学表达式。可用变量：Time、Start、Duration、Progress。使用 GetProperty&lt;T&gt;("{GUID}.Property") 引用其他属性。</value>
   </data>
   <data name="CopyPropertyPath" xml:space="preserve">
-    <value>Copy property path</value>
+    <value>复制属性路径</value>
   </data>
   <data name="CopyGetPropertyCode" xml:space="preserve">
-    <value>Copy GetProperty code</value>
+    <value>复制 GetProperty 代码</value>
   </data>
   <data name="ChangeToOriginalLength" xml:space="preserve">
-    <value>Change to original length</value>
+    <value>更改为原始长度</value>
   </data>
   <data name="SplitByCurrentFrame" xml:space="preserve">
-    <value>Split by current frame</value>
+    <value>按当前帧分割</value>
   </data>
   <data name="GroupSelectedElements" xml:space="preserve">
-    <value>Group selected elements</value>
+    <value>对所选元素分组</value>
   </data>
   <data name="UngroupSelectedElements" xml:space="preserve">
-    <value>Ungroup selected elements</value>
+    <value>取消所选元素分组</value>
   </data>
   <data name="Agree" xml:space="preserve">
-    <value>Agree</value>
+    <value>同意</value>
   </data>
   <data name="Disagree" xml:space="preserve">
-    <value>Disagree</value>
+    <value>不同意</value>
   </data>
   <data name="ShowDetails" xml:space="preserve">
-    <value>Show Details</value>
+    <value>显示详细信息</value>
   </data>
   <data name="SaveSelectedElementAsImage" xml:space="preserve">
-    <value>Save a selected element as an image</value>
+    <value>将所选元素保存为图像</value>
   </data>
   <data name="SaveFrameAsImage" xml:space="preserve">
-    <value>Save a frame as an image</value>
+    <value>将帧保存为图像</value>
   </data>
   <data name="SaveImageScale" xml:space="preserve">
-    <value>Scale</value>
+    <value>缩放</value>
   </data>
   <data name="SaveImageScale_OutputSize" xml:space="preserve">
-    <value>Output size</value>
+    <value>输出大小</value>
   </data>
   <data name="Move" xml:space="preserve">
-    <value>Move</value>
+    <value>移动</value>
   </data>
   <data name="Hand" xml:space="preserve">
-    <value>Hand</value>
+    <value>抓手</value>
   </data>
   <data name="SetStartTime" xml:space="preserve">
-    <value>Set start time</value>
+    <value>设置开始时间</value>
   </data>
   <data name="SetEndTime" xml:space="preserve">
-    <value>Set end time</value>
+    <value>设置结束时间</value>
   </data>
   <data name="NudgeLeftFrame" xml:space="preserve">
-    <value>Nudge left (1 frame)</value>
+    <value>向左微调（1 帧）</value>
   </data>
   <data name="NudgeRightFrame" xml:space="preserve">
-    <value>Nudge right (1 frame)</value>
+    <value>向右微调（1 帧）</value>
   </data>
   <data name="NudgeLeftLarge" xml:space="preserve">
-    <value>Nudge left (10 frames)</value>
+    <value>向左微调（10 帧）</value>
   </data>
   <data name="NudgeRightLarge" xml:space="preserve">
-    <value>Nudge right (10 frames)</value>
+    <value>向右微调（10 帧）</value>
   </data>
   <data name="NudgeLeftSecond" xml:space="preserve">
-    <value>Nudge left (1 second)</value>
+    <value>向左微调（1 秒）</value>
   </data>
   <data name="NudgeRightSecond" xml:space="preserve">
-    <value>Nudge right (1 second)</value>
+    <value>向右微调（1 秒）</value>
   </data>
   <data name="CloseGap" xml:space="preserve">
-    <value>Close Gap</value>
+    <value>关闭间隙</value>
   </data>
   <data name="Gaps" xml:space="preserve">
-    <value>Gaps</value>
+    <value>间隙</value>
   </data>
   <data name="CloseAllGaps" xml:space="preserve">
-    <value>Close All Gaps</value>
+    <value>关闭所有间隙</value>
   </data>
   <data name="GoToNextGap" xml:space="preserve">
-    <value>Go to Next Gap</value>
+    <value>转到下一个间隙</value>
   </data>
   <data name="GoToPreviousGap" xml:space="preserve">
-    <value>Go to Previous Gap</value>
+    <value>转到上一个间隙</value>
   </data>
   <data name="NoGapsToClose" xml:space="preserve">
-    <value>There are no gaps to close</value>
+    <value>没有要关闭的间隙</value>
   </data>
   <data name="NoGapsToGoTo" xml:space="preserve">
-    <value>There are no gaps to go to</value>
+    <value>没有要转到的间隙</value>
   </data>
   <data name="NoElementSelected" xml:space="preserve">
-    <value>No element is selected</value>
+    <value>未选择元素</value>
   </data>
   <data name="Editor" xml:space="preserve">
-    <value>Editor</value>
+    <value>编辑器</value>
   </data>
   <data name="RunningStartupTasks" xml:space="preserve">
-    <value>Running startup tasks</value>
+    <value>正在运行启动任务</value>
   </data>
   <data name="SaveAsImage" xml:space="preserve">
-    <value>Save as image</value>
+    <value>另存为图像</value>
   </data>
   <data name="CopyAsImage" xml:space="preserve">
-    <value>Copy as image</value>
+    <value>复制为图像</value>
   </data>
   <data name="AlwaysDisplay" xml:space="preserve">
-    <value>Always display</value>
+    <value>始终显示</value>
   </data>
   <data name="MemoryUsage" xml:space="preserve">
-    <value>Memory usage</value>
+    <value>内存使用量</value>
   </data>
   <data name="Locked" xml:space="preserve">
-    <value>Locked</value>
+    <value>已锁定</value>
   </data>
   <data name="Unlocked" xml:space="preserve">
-    <value>Unlocked</value>
+    <value>已解锁</value>
   </data>
   <data name="DeleteAll" xml:space="preserve">
-    <value>Delete All</value>
+    <value>全部删除</value>
   </data>
   <data name="Lock" xml:space="preserve">
-    <value>Lock</value>
+    <value>锁定</value>
   </data>
   <data name="Unlock" xml:space="preserve">
-    <value>Unlock</value>
+    <value>解锁</value>
   </data>
   <data name="Solo" xml:space="preserve">
-    <value>Solo</value>
+    <value>独奏</value>
   </data>
   <data name="LayerIsLocked" xml:space="preserve">
-    <value>The layer is locked.</value>
+    <value>图层已锁定。</value>
   </data>
   <data name="FrameCache" xml:space="preserve">
-    <value>Frame cache</value>
+    <value>帧缓存</value>
   </data>
   <data name="RightClickToOperateCache" xml:space="preserve">
-    <value>Right-click to operate cache</value>
+    <value>右键单击以操作缓存</value>
   </data>
   <data name="Linear" xml:space="preserve">
-    <value>Linear</value>
+    <value>线性</value>
   </data>
   <data name="Conical" xml:space="preserve">
-    <value>Conical</value>
+    <value>锥形</value>
   </data>
   <data name="Radial" xml:space="preserve">
-    <value>Radial</value>
+    <value>径向</value>
   </data>
   <data name="Red" xml:space="preserve">
-    <value>Red</value>
+    <value>红色</value>
   </data>
   <data name="Green" xml:space="preserve">
-    <value>Green</value>
+    <value>绿色</value>
   </data>
   <data name="Blue" xml:space="preserve">
-    <value>Blue</value>
+    <value>蓝色</value>
   </data>
   <data name="Master" xml:space="preserve">
-    <value>Master</value>
+    <value>主</value>
   </data>
   <data name="Hue" xml:space="preserve">
-    <value>Hue</value>
+    <value>色相</value>
   </data>
   <data name="Saturation" xml:space="preserve">
-    <value>Saturation</value>
+    <value>饱和度</value>
   </data>
   <data name="ShowSliders" xml:space="preserve">
-    <value>Show sliders</value>
+    <value>显示滑块</value>
   </data>
   <data name="ShowRing" xml:space="preserve">
-    <value>Show ring</value>
+    <value>显示圆环</value>
   </data>
   <data name="Symmetry" xml:space="preserve">
-    <value>Symmetry</value>
+    <value>对称</value>
   </data>
   <data name="Asymmetry" xml:space="preserve">
-    <value>Asymmetry</value>
+    <value>不对称</value>
   </data>
   <data name="Separately" xml:space="preserve">
-    <value>Separately</value>
+    <value>分别</value>
   </data>
   <data name="Figure" xml:space="preserve">
-    <value>Figure</value>
+    <value>图形</value>
   </data>
   <data name="Import" xml:space="preserve">
-    <value>Import</value>
+    <value>导入</value>
   </data>
   <data name="ImportSvgPath" xml:space="preserve">
-    <value>Import SVG path</value>
+    <value>导入 SVG 路径</value>
   </data>
   <data name="ImportSvgPath_Description" xml:space="preserve">
-    <value>The current shape will be overwritten.</value>
+    <value>当前形状将被覆盖。</value>
   </data>
   <data name="EditInFrame" xml:space="preserve">
-    <value>Edit in frame</value>
+    <value>在帧中编辑</value>
   </data>
   <data name="EditInTab" xml:space="preserve">
-    <value>Edit in tab</value>
+    <value>在选项卡中编辑</value>
   </data>
   <data name="PathEditor" xml:space="preserve">
-    <value>Path editor</value>
+    <value>路径编辑器</value>
   </data>
   <data name="CopyAll" xml:space="preserve">
-    <value>Copy All</value>
+    <value>全部复制</value>
   </data>
   <data name="EnableElement" xml:space="preserve">
-    <value>Enable element</value>
+    <value>启用元素</value>
   </data>
   <data name="DockArea_LeftTop" xml:space="preserve">
-    <value>Left Top</value>
+    <value>左上</value>
   </data>
   <data name="DockArea_LeftBottom" xml:space="preserve">
-    <value>Left Bottom</value>
+    <value>左下</value>
   </data>
   <data name="DockArea_RightTop" xml:space="preserve">
-    <value>Right Top</value>
+    <value>右上</value>
   </data>
   <data name="DockArea_RightBottom" xml:space="preserve">
-    <value>Right Bottom</value>
+    <value>右下</value>
   </data>
   <data name="DockArea_BottomLeft" xml:space="preserve">
-    <value>Bottom Left</value>
+    <value>左下</value>
   </data>
   <data name="DockArea_BottomRight" xml:space="preserve">
-    <value>Bottom Right</value>
+    <value>右下</value>
   </data>
   <data name="DockArea_TopLeft" xml:space="preserve">
-    <value>Top Left</value>
+    <value>左上</value>
   </data>
   <data name="DockArea_TopRight" xml:space="preserve">
-    <value>Top Right</value>
+    <value>右上</value>
   </data>
   <data name="MoveTo" xml:space="preserve">
-    <value>Move to</value>
+    <value>移动到</value>
   </data>
   <data name="MainView" xml:space="preserve">
-    <value>Main View</value>
+    <value>主视图</value>
   </data>
   <data name="OpenProject" xml:space="preserve">
-    <value>Open Project</value>
+    <value>打开项目</value>
   </data>
   <data name="OpenFile" xml:space="preserve">
-    <value>Open File</value>
+    <value>打开文件</value>
   </data>
   <data name="Save_Description" xml:space="preserve">
-    <value>Save the current file</value>
+    <value>保存当前文件</value>
   </data>
   <data name="SaveAll_Description" xml:space="preserve">
-    <value>Save all files</value>
+    <value>保存所有文件</value>
   </data>
   <data name="CloseProject_Description" xml:space="preserve">
-    <value>Close the current project</value>
+    <value>关闭当前项目</value>
   </data>
   <data name="Undo_Description" xml:space="preserve">
-    <value>Undo the last operation</value>
+    <value>撤销上一个操作</value>
   </data>
   <data name="Redo_Description" xml:space="preserve">
-    <value>Redo the last operation</value>
+    <value>重做上一个操作</value>
   </data>
   <data name="Exit_Description" xml:space="preserve">
-    <value>Exit the application</value>
+    <value>退出应用程序</value>
   </data>
   <data name="PlayPause" xml:space="preserve">
-    <value>Play/Pause</value>
+    <value>播放/暂停</value>
   </data>
   <data name="PlayPause_Description" xml:space="preserve">
-    <value>Switches between play and pause.</value>
+    <value>在播放和暂停之间切换。</value>
   </data>
   <data name="MoveToNext" xml:space="preserve">
-    <value>Move to next</value>
+    <value>移到下一个</value>
   </data>
   <data name="MoveToPrevious" xml:space="preserve">
-    <value>Move to previous</value>
+    <value>移到上一个</value>
   </data>
   <data name="MoveToNext_Description" xml:space="preserve">
-    <value>Move to the next frame.</value>
+    <value>移到下一帧。</value>
   </data>
   <data name="MoveToPrevious_Description" xml:space="preserve">
-    <value>Move to the previous frame.</value>
+    <value>移到上一帧。</value>
   </data>
   <data name="MoveToStart" xml:space="preserve">
-    <value>Move to start</value>
+    <value>移到开头</value>
   </data>
   <data name="MoveToEnd" xml:space="preserve">
-    <value>Move to end</value>
+    <value>移到结尾</value>
   </data>
   <data name="MoveToStart_Description" xml:space="preserve">
-    <value>Move to the start of the scene.</value>
+    <value>移到场景的开头。</value>
   </data>
   <data name="MoveToEnd_Description" xml:space="preserve">
-    <value>Move to the end of the scene.</value>
+    <value>移到场景的结尾。</value>
   </data>
   <data name="ToggleMarker" xml:space="preserve">
-    <value>Toggle marker</value>
+    <value>切换标记</value>
   </data>
   <data name="ToggleMarker_Description" xml:space="preserve">
-    <value>Toggle a marker at the current playhead. Removes the existing marker if one already exists at this position.</value>
+    <value>在当前播放头处切换标记。如果此位置已存在标记，则将其移除。</value>
   </data>
   <data name="NextMarker" xml:space="preserve">
-    <value>Next marker</value>
+    <value>下一个标记</value>
   </data>
   <data name="NextMarker_Description" xml:space="preserve">
-    <value>Seek to the next marker.</value>
+    <value>跳转到下一个标记。</value>
   </data>
   <data name="PreviousMarker" xml:space="preserve">
-    <value>Previous marker</value>
+    <value>上一个标记</value>
   </data>
   <data name="PreviousMarker_Description" xml:space="preserve">
-    <value>Seek to the previous marker.</value>
+    <value>跳转到上一个标记。</value>
   </data>
   <data name="NextKeyFrame" xml:space="preserve">
-    <value>Next keyframe</value>
+    <value>下一个关键帧</value>
   </data>
   <data name="NextKeyFrame_Description" xml:space="preserve">
-    <value>Seek to the next keyframe within the selected element (or scene-wide if none).</value>
+    <value>跳转到所选元素中的下一个关键帧（如果没有，则跳转到场景范围）。</value>
   </data>
   <data name="PreviousKeyFrame" xml:space="preserve">
-    <value>Previous keyframe</value>
+    <value>上一个关键帧</value>
   </data>
   <data name="PreviousKeyFrame_Description" xml:space="preserve">
-    <value>Seek to the previous keyframe within the selected element (or scene-wide if none).</value>
+    <value>跳转到所选元素中的上一个关键帧（如果没有，则跳转到场景范围）。</value>
   </data>
   <data name="NoKeyFrameToSeek" xml:space="preserve">
-    <value>No keyframe to seek.</value>
+    <value>没有要跳转的关键帧。</value>
   </data>
   <data name="ShuttleForward" xml:space="preserve">
-    <value>Shuttle forward</value>
+    <value>快进</value>
   </data>
   <data name="ShuttleForward_Description" xml:space="preserve">
-    <value>Shuttle forward (L). Press repeatedly to accelerate.</value>
+    <value>快进 (L)。重复按以加速。</value>
   </data>
   <data name="ShuttleForwardFine" xml:space="preserve">
-    <value>Shuttle forward (fine)</value>
+    <value>快进（精细）</value>
   </data>
   <data name="ShuttleForwardFine_Description" xml:space="preserve">
-    <value>Shuttle forward at half speed.</value>
+    <value>以半速快进。</value>
   </data>
   <data name="ShuttleBackward" xml:space="preserve">
-    <value>Shuttle backward</value>
+    <value>快退</value>
   </data>
   <data name="ShuttleBackward_Description" xml:space="preserve">
-    <value>Shuttle backward (J). Press repeatedly to accelerate.</value>
+    <value>快退 (J)。重复按以加速。</value>
   </data>
   <data name="ShuttleBackwardFine" xml:space="preserve">
-    <value>Shuttle backward (fine)</value>
+    <value>快退（精细）</value>
   </data>
   <data name="ShuttleBackwardFine_Description" xml:space="preserve">
-    <value>Shuttle backward at half speed.</value>
+    <value>以半速快退。</value>
   </data>
   <data name="ShuttleStop" xml:space="preserve">
-    <value>Shuttle stop</value>
+    <value>停止穿梭</value>
   </data>
   <data name="ShuttleStop_Description" xml:space="preserve">
-    <value>Stop shuttle playback.</value>
+    <value>停止穿梭播放。</value>
   </data>
   <data name="ToggleLoop" xml:space="preserve">
-    <value>Toggle loop</value>
+    <value>切换循环</value>
   </data>
   <data name="ToggleLoop_Description" xml:space="preserve">
-    <value>Toggle loop playback.</value>
+    <value>切换循环播放。</value>
   </data>
   <data name="GotoTimecode" xml:space="preserve">
-    <value>Goto timecode</value>
+    <value>转到时间码</value>
   </data>
   <data name="GotoTimecode_Description" xml:space="preserve">
-    <value>Edit the current timecode to seek. Accepts absolute (00:01:23.45), frame (60f or #60), relative (+5s/-10f/+1m) or marker name (@Intro).</value>
+    <value>编辑当前时间码以跳转。接受绝对 (00:01:23.45)、帧 (60f 或 #60)、相对 (+5s/-10f/+1m) 或标记名称 (@Intro)。</value>
   </data>
   <data name="GotoTimecode_InputHint" xml:space="preserve">
     <value>00:01:23 / 60f / +5s / @marker</value>
   </data>
   <data name="GotoTimecode_InvalidFormat" xml:space="preserve">
-    <value>Invalid timecode format.</value>
+    <value>无效的时间码格式。</value>
   </data>
   <data name="GotoTimecode_MarkerNotFound" xml:space="preserve">
-    <value>Marker not found.</value>
+    <value>未找到标记。</value>
   </data>
   <data name="GotoTimecode_NoScene" xml:space="preserve">
-    <value>No scene is loaded.</value>
+    <value>未加载场景。</value>
   </data>
   <data name="GotoTimecode_OutOfRange" xml:space="preserve">
-    <value>Timecode is out of range.</value>
+    <value>时间码超出范围。</value>
   </data>
   <data name="Paste_Description" xml:space="preserve">
-    <value>Paste the copied data.</value>
+    <value>粘贴复制的数据。</value>
   </data>
   <data name="Rename_Description" xml:space="preserve">
-    <value>Rename the selected item.</value>
+    <value>重命名所选项目。</value>
   </data>
   <data name="Exclude_Description" xml:space="preserve">
-    <value>Exclude the selected item.</value>
+    <value>排除所选项目。</value>
   </data>
   <data name="Delete_Description" xml:space="preserve">
-    <value>Delete the selected item.</value>
+    <value>删除所选项目。</value>
   </data>
   <data name="Copy_Description" xml:space="preserve">
-    <value>Copy the selected item.</value>
+    <value>复制所选项目。</value>
   </data>
   <data name="Cut_Description" xml:space="preserve">
-    <value>Cut the selected item.</value>
+    <value>剪切所选项目。</value>
   </data>
   <data name="Duplicate_Description" xml:space="preserve">
-    <value>Duplicate the selected item.</value>
+    <value>创建所选项目的副本。</value>
   </data>
   <data name="Duplicate_Failed" xml:space="preserve">
-    <value>Failed to duplicate</value>
+    <value>复制失败</value>
   </data>
   <data name="Duplicate_ProjectNotSaved" xml:space="preserve">
-    <value>Save the project before duplicating clips.</value>
+    <value>复制剪辑之前请先保存项目。</value>
   </data>
   <data name="Duplicate_IOFailed" xml:space="preserve">
-    <value>Could not write the duplicated element to disk.</value>
+    <value>无法将复制的元素写入磁盘。</value>
   </data>
   <data name="Duplicate_NoEmptySlot" xml:space="preserve">
-    <value>Could not find an empty slot on the timeline; the duplicate was placed where it may overlap an existing clip.</value>
+    <value>在时间轴上找不到空位；副本被放置在可能重叠现有剪辑的位置。</value>
   </data>
   <data name="Duplicate_FallbackToMove" xml:space="preserve">
-    <value>Duplicate failed; falling back to a plain move of the original clips.</value>
+    <value>复制失败；回退为对原始剪辑的简单移动。</value>
   </data>
   <data name="Duplicate_FallbackFailed" xml:space="preserve">
-    <value>The move fallback also failed; the timeline state may not match what you see.</value>
+    <value>移动回退也失败了；时间轴状态可能与您看到的不一致。</value>
   </data>
   <data name="AboutBeutl" xml:space="preserve">
-    <value>About Beutl</value>
+    <value>关于 Beutl</value>
   </data>
   <data name="Update" xml:space="preserve">
-    <value>Update</value>
+    <value>更新</value>
   </data>
   <data name="EditDrawable" xml:space="preserve">
-    <value>Edit drawable</value>
+    <value>编辑可绘制对象</value>
   </data>
   <data name="Item" xml:space="preserve">
-    <value>Item</value>
+    <value>项目</value>
   </data>
   <data name="Profiles" xml:space="preserve">
-    <value>Profiles</value>
+    <value>配置文件</value>
   </data>
   <data name="Presets" xml:space="preserve">
-    <value>Presets</value>
+    <value>预设</value>
   </data>
   <data name="Convert_to_preset" xml:space="preserve">
-    <value>Convert to preset</value>
+    <value>转换为预设</value>
   </data>
   <data name="Expression_Input" xml:space="preserve">
-    <value>Input</value>
+    <value>输入</value>
   </data>
   <data name="Expression_Help" xml:space="preserve">
-    <value>Help</value>
+    <value>帮助</value>
   </data>
   <data name="Expression_Variables" xml:space="preserve">
-    <value>Variables</value>
+    <value>变量</value>
   </data>
   <data name="Expression_Functions" xml:space="preserve">
-    <value>Functions</value>
+    <value>函数</value>
   </data>
   <data name="Expression_Variables_Description" xml:space="preserve">
-    <value>Time: Current time relative to the element start (seconds)
-Start: Element start time (seconds)
-Duration: Element duration (seconds)
-Progress: Normalized progress (0.0 to 1.0)
-PI: Mathematical constant π (3.14159...)</value>
+    <value>Time：相对于元素开始的当前时间（秒）
+Start：元素开始时间（秒）
+Duration：元素时长（秒）
+Progress：归一化进度（0.0 到 1.0）
+PI：数学常数 π (3.14159...)</value>
   </data>
   <data name="Expression_Functions_Trigonometric" xml:space="preserve">
-    <value>Trigonometric: Sin, Cos, Tan, Asin, Acos, Atan, Atan2
-Hyperbolic: Sinh, Cosh, Tanh</value>
+    <value>三角函数：Sin、Cos、Tan、Asin、Acos、Atan、Atan2
+双曲函数：Sinh、Cosh、Tanh</value>
   </data>
   <data name="Expression_Functions_Math" xml:space="preserve">
-    <value>Math: Sqrt, Pow, Exp, Log, Log10, Log2
-Rounding: Abs, Floor, Ceil, Round, Truncate, Sign
-Range: Min, Max, Clamp</value>
+    <value>数学：Sqrt、Pow、Exp、Log、Log10、Log2
+舍入：Abs、Floor、Ceil、Round、Truncate、Sign
+范围：Min、Max、Clamp</value>
   </data>
   <data name="Expression_Functions_Interpolation" xml:space="preserve">
-    <value>Interpolation: Lerp, InverseLerp, Remap, Smoothstep</value>
+    <value>插值：Lerp、InverseLerp、Remap、Smoothstep</value>
   </data>
   <data name="Expression_Functions_Utility" xml:space="preserve">
-    <value>Utility: Radians, Degrees, Mod, Frac
-Random: Random(seed), Random(seed, min, max), FrameRandom(), FrameRandom(min, max)</value>
+    <value>实用工具：Radians、Degrees、Mod、Frac
+随机：Random(seed)、Random(seed, min, max)、FrameRandom()、FrameRandom(min, max)</value>
   </data>
   <data name="Expression_GetProperty_Description" xml:space="preserve">
-    <value>Reference other properties:
-GetProperty&lt;T&gt;("path") or GetProperty&lt;T&gt;(guid, "propertyName")
-Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
+    <value>引用其他属性：
+GetProperty&lt;T&gt;("path") 或 GetProperty&lt;T&gt;(guid, "propertyName")
+示例：GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
   </data>
   <data name="Histogram" xml:space="preserve">
-    <value>Histogram</value>
+    <value>直方图</value>
   </data>
   <data name="Vectorscope" xml:space="preserve">
-    <value>Vectorscope</value>
+    <value>矢量示波器</value>
   </data>
   <data name="Waveform" xml:space="preserve">
-    <value>Waveform</value>
+    <value>波形</value>
   </data>
   <data name="FalseColor" xml:space="preserve">
-    <value>False Color</value>
+    <value>假色</value>
   </data>
   <data name="Zebra" xml:space="preserve">
-    <value>Zebra</value>
+    <value>斑马纹</value>
   </data>
   <data name="Threshold" xml:space="preserve">
-    <value>Threshold</value>
+    <value>阈值</value>
   </data>
   <data name="ZebraHighThreshold" xml:space="preserve">
-    <value>High</value>
+    <value>高</value>
   </data>
   <data name="ZebraLowThreshold" xml:space="preserve">
-    <value>Low</value>
+    <value>低</value>
   </data>
   <data name="Spectrum" xml:space="preserve">
-    <value>Spectrum</value>
+    <value>频谱</value>
   </data>
   <data name="Meter" xml:space="preserve">
-    <value>Meter</value>
+    <value>电平表</value>
   </data>
   <data name="AudioVisualizer" xml:space="preserve">
-    <value>Audio Visualizer</value>
+    <value>音频可视化</value>
   </data>
   <data name="Spectrogram" xml:space="preserve">
-    <value>Spectrogram</value>
+    <value>声谱图</value>
   </data>
   <data name="PhaseScope" xml:space="preserve">
-    <value>Phase Scope</value>
+    <value>相位示波器</value>
   </data>
   <data name="AudioVisualizer_ResetTooltip" xml:space="preserve">
-    <value>Right-click to reset to default</value>
+    <value>右键单击以重置为默认值</value>
   </data>
   <data name="AudioVisualizer_Waveform_Description" xml:space="preserve">
-    <value>Time-domain L/R waveform of the most recent audio. The upper trace is the left channel, the lower trace is the right channel; both share a center axis line. Use this view to spot transients, clipping, asymmetric or DC-offset signals, and to confirm at a glance that audio is actually flowing.</value>
+    <value>最近音频的时域 L/R 波形。上方的轨迹是左声道，下方的轨迹是右声道；两者共享一条中心轴线。使用此视图可发现瞬态、削波、不对称或直流偏移信号，并一目了然地确认音频确实在流动。</value>
   </data>
   <data name="AudioVisualizer_Spectrum_Description" xml:space="preserve">
-    <value>Real-time FFT frequency spectrum on a logarithmic frequency axis (~20 Hz to Nyquist). Bar height represents energy in dB at each frequency band. The settings flyout exposes shape (Bar / Line / FilledArea / MirroredBars), FFT size, smoothing, and the noise floor (Min dB). Useful for EQ work, spotting hum or whistles, and confirming that the mix has the expected high-frequency content.</value>
+    <value>对数频率轴（约 20 Hz 到奈奎斯特频率）上的实时 FFT 频谱。条形高度表示每个频段的能量（dB）。设置浮出控件可调整形状（条形/线条/填充区域/镜像条形）、FFT 大小、平滑度和噪声下限（最小 dB）。适用于均衡器工作、发现嗡嗡声或啸叫，以及确认混音具有预期的高频内容。</value>
   </data>
   <data name="AudioVisualizer_Meter_Description" xml:space="preserve">
-    <value>Stereo level meter combining several broadcast-standard readouts. Bars show RMS with a peak-hold marker that decays at ~6 dB/sec. Red LEDs at the top latch on for 2 seconds when the channel reaches 0 dBFS. The M number is momentary LUFS (BS.1770-4 K-weighted, 400 ms window). TP L / TP R are true peak in dBTP, computed by 4× polyphase oversampling. Use this view to verify loudness against delivery targets (-14 LUFS for YouTube, -23 LUFS for EBU R128) and to catch inter-sample peaks before encoding.</value>
+    <value>结合多种广播标准读数的立体声电平表。条形显示 RMS，并带有以约 6 dB/秒衰减的峰值保持标记。当声道达到 0 dBFS 时，顶部的红色 LED 会锁定 2 秒。M 数字是瞬时 LUFS（BS.1770-4 K 加权，400 ms 窗口）。TP L / TP R 是以 dBTP 为单位的真实峰值，通过 4 倍多相过采样计算。使用此视图可根据交付目标验证响度（YouTube 为 -14 LUFS，EBU R128 为 -23 LUFS），并在编码前捕捉采样间峰值。</value>
   </data>
   <data name="AudioVisualizer_Spectrogram_Description" xml:space="preserve">
-    <value>Time-frequency heatmap of roughly the last 4 seconds. The vertical axis is logarithmic frequency (low at the bottom, high at the top); the horizontal axis is time (older on the left, newer on the right). Brightness represents energy in dB above the noise floor. Use this view to see how the spectrum evolves over time — identifying sweeping filters, vibrato, room modes, and the harmonic structure of sustained notes.</value>
+    <value>大约最近 4 秒的时间-频率热图。垂直轴是对数频率（底部低，顶部高）；水平轴是时间（左侧旧，右侧新）。亮度表示噪声下限以上的能量（dB）。使用此视图可查看频谱如何随时间演变——识别扫频滤波器、颤音、房间模式和持续音符的谐波结构。</value>
   </data>
   <data name="AudioVisualizer_PhaseScope_Description" xml:space="preserve">
-    <value>Stereo Lissajous (goniometer) rotated 45° — the broadcast-standard convention. Pure mono content traces a vertical line on the M (mono) axis; fully out-of-phase material spreads horizontally toward the S (anti-phase) axis; a single channel traces the L or R diagonal. The "corr" value at the top-left is the Pearson correlation between channels: +1 means perfectly mono, 0 uncorrelated, -1 fully anti-phase. Use this view to catch channel-flipped or phase-cancelling material that would collapse during mono playback.</value>
+    <value>旋转 45° 的立体声利萨如（测角仪）——广播标准惯例。纯单声道内容在 M（单声道）轴上绘制一条垂直线；完全反相的材料向 S（反相）轴水平扩展；单个声道绘制 L 或 R 对角线。左上角的 "corr" 值是声道之间的皮尔逊相关系数：+1 表示完全单声道，0 表示不相关，-1 表示完全反相。使用此视图可捕捉在单声道播放期间会崩溃的声道翻转或相位抵消材料。</value>
   </data>
   <data name="Luma" xml:space="preserve">
-    <value>Luma</value>
+    <value>亮度</value>
   </data>
   <data name="RgbOverlay" xml:space="preserve">
-    <value>RGB Overlay</value>
+    <value>RGB 叠加</value>
   </data>
   <data name="RgbParade" xml:space="preserve">
-    <value>RGB Parade</value>
+    <value>RGB 波形</value>
   </data>
   <data name="Gamma" xml:space="preserve">
-    <value>Gamma</value>
+    <value>伽马</value>
   </data>
   <data name="AVFoundationEncoder" xml:space="preserve">
-    <value>AVFoundation Encoder</value>
+    <value>AVFoundation 编码器</value>
   </data>
   <data name="AVFoundationDecoder" xml:space="preserve">
-    <value>AVFoundation Decoder</value>
+    <value>AVFoundation 解码器</value>
   </data>
   <data name="UniformValue" xml:space="preserve">
-    <value>Uniform value</value>
+    <value>统一值</value>
   </data>
   <data name="Null" xml:space="preserve">
-    <value>Null</value>
+    <value>空</value>
   </data>
   <data name="OpenInTab" xml:space="preserve">
-    <value>Open in tab</value>
+    <value>在选项卡中打开</value>
   </data>
   <data name="Previous" xml:space="preserve">
-    <value>Previous</value>
+    <value>上一个</value>
   </data>
   <data name="Current" xml:space="preserve">
-    <value>Current</value>
+    <value>当前</value>
   </data>
   <data name="Result" xml:space="preserve">
-    <value>Result</value>
+    <value>结果</value>
   </data>
   <data name="ElapsedTime" xml:space="preserve">
-    <value>Elapsed time</value>
+    <value>已用时间</value>
   </data>
   <data name="Difference" xml:space="preserve">
-    <value>Difference</value>
+    <value>差异</value>
   </data>
   <data name="Error" xml:space="preserve">
-    <value>Error</value>
+    <value>错误</value>
   </data>
   <data name="APIError" xml:space="preserve">
-    <value>API Error</value>
+    <value>API 错误</value>
   </data>
   <data name="Website" xml:space="preserve">
-    <value>Website</value>
+    <value>网站</value>
   </data>
   <data name="DisplayMode" xml:space="preserve">
-    <value>Display mode</value>
+    <value>显示模式</value>
   </data>
   <data name="Docked" xml:space="preserve">
-    <value>Docked</value>
+    <value>已停靠</value>
   </data>
   <data name="Floating" xml:space="preserve">
-    <value>Floating</value>
+    <value>浮动</value>
   </data>
   <data name="CropSelection" xml:space="preserve">
-    <value>Crop selection</value>
+    <value>裁剪选区</value>
   </data>
   <data name="Camera3DControl" xml:space="preserve">
-    <value>3D camera control</value>
+    <value>3D 相机控制</value>
   </data>
   <data name="Gizmo_Translate" xml:space="preserve">
-    <value>Translate</value>
+    <value>平移</value>
   </data>
   <data name="Gizmo_Rotate" xml:space="preserve">
-    <value>Rotate</value>
+    <value>旋转</value>
   </data>
   <data name="Gizmo_Scale" xml:space="preserve">
-    <value>Scale</value>
+    <value>缩放</value>
   </data>
   <data name="Portal" xml:space="preserve">
-    <value>Portal</value>
+    <value>传送门</value>
   </data>
   <data name="Portal_Count" xml:space="preserve">
-    <value>Count</value>
+    <value>数量</value>
   </data>
   <data name="Portal_Clear" xml:space="preserve">
-    <value>Clear</value>
+    <value>清除</value>
   </data>
   <data name="ExportProject" xml:space="preserve">
-    <value>Export Project...</value>
+    <value>导出项目...</value>
   </data>
   <data name="ImportProject" xml:space="preserve">
-    <value>Import Project...</value>
+    <value>导入项目...</value>
   </data>
   <data name="ExportingProject" xml:space="preserve">
-    <value>Exporting project...</value>
+    <value>正在导出项目...</value>
   </data>
   <data name="ImportingProject" xml:space="preserve">
-    <value>Importing project...</value>
+    <value>正在导入项目...</value>
   </data>
   <data name="ProjectPackage" xml:space="preserve">
-    <value>Project Package</value>
+    <value>项目包</value>
   </data>
   <data name="SelectDestinationFolder" xml:space="preserve">
-    <value>Select Destination Folder</value>
+    <value>选择目标文件夹</value>
   </data>
-  <!-- 3D Graphics -->
+  
   <data name="Experimental" xml:space="preserve">
-    <value>Experimental</value>
+    <value>实验性</value>
   </data>
   <data name="Home" xml:space="preserve">
-    <value>Home</value>
+    <value>主页</value>
   </data>
   <data name="ProjectDirectory" xml:space="preserve">
-    <value>Project Directory</value>
+    <value>项目目录</value>
   </data>
   <data name="MediaFiles" xml:space="preserve">
-    <value>Media Files</value>
+    <value>媒体文件</value>
   </data>
   <data name="SearchingMediaFiles" xml:space="preserve">
-    <value>Searching for media files...</value>
+    <value>正在搜索媒体文件...</value>
   </data>
   <data name="NoMediaFilesFound" xml:space="preserve">
-    <value>No media files found</value>
+    <value>未找到媒体文件</value>
   </data>
   <data name="Tutorials" xml:space="preserve">
-    <value>Tutorials</value>
+    <value>教程</value>
   </data>
   <data name="BpmGrid" xml:space="preserve">
-    <value>BPM Grid</value>
+    <value>BPM 网格</value>
   </data>
   <data name="ShowBpmGrid" xml:space="preserve">
-    <value>Show BPM Grid</value>
+    <value>显示 BPM 网格</value>
   </data>
   <data name="BpmValue" xml:space="preserve">
     <value>BPM</value>
   </data>
   <data name="BeatSubdivisions" xml:space="preserve">
-    <value>Subdivisions</value>
+    <value>细分</value>
   </data>
   <data name="BpmOffset" xml:space="preserve">
-    <value>Offset</value>
+    <value>偏移</value>
   </data>
   <data name="Preview" xml:space="preserve">
-    <value>Preview</value>
+    <value>预览</value>
   </data>
   <data name="PreviewSettings" xml:space="preserve">
-    <value>Preview Settings</value>
+    <value>预览设置</value>
   </data>
   <data name="Templates" xml:space="preserve">
-    <value>Templates</value>
+    <value>模板</value>
   </data>
   <data name="SaveAsTemplate" xml:space="preserve">
-    <value>Save as Template</value>
+    <value>另存为模板</value>
   </data>
   <data name="ApplyTemplate" xml:space="preserve">
-    <value>Apply Template</value>
+    <value>应用模板</value>
   </data>
   <data name="AddFromTemplate" xml:space="preserve">
-    <value>Add from Template</value>
+    <value>从模板添加</value>
   </data>
   <data name="TemplateSaved" xml:space="preserve">
-    <value>Template has been saved.</value>
+    <value>模板已保存。</value>
   </data>
   <data name="DeleteTemplateConfirm" xml:space="preserve">
-    <value>Are you sure you want to delete this template?</value>
+    <value>确定要删除此模板吗？</value>
   </data>
   <data name="EnterTemplateName" xml:space="preserve">
-    <value>Enter template name</value>
+    <value>输入模板名称</value>
   </data>
   <data name="Preset_YouTube_1080p60" xml:space="preserve">
     <value>YouTube 1080p 60fps</value>
@@ -1289,10 +1289,10 @@ Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
     <value>YouTube 4K 60fps</value>
   </data>
   <data name="Preset_Twitter_1080p" xml:space="preserve">
-    <value>Twitter (X) 1080p (max 2:20)</value>
+    <value>Twitter (X) 1080p（最长 2:20）</value>
   </data>
   <data name="Preset_Instagram_Reels" xml:space="preserve">
-    <value>Instagram Reels 9:16 (max 90s)</value>
+    <value>Instagram Reels 9:16（最长 90 秒）</value>
   </data>
   <data name="Preset_Instagram_Feed" xml:space="preserve">
     <value>Instagram Feed 1:1</value>
@@ -1301,273 +1301,273 @@ Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
     <value>TikTok 9:16</value>
   </data>
   <data name="Preset_Discord_8MB" xml:space="preserve">
-    <value>Discord 8MB (~1 min)</value>
+    <value>Discord 8MB（约 1 分钟）</value>
   </data>
   <data name="Encoding" xml:space="preserve">
-    <value>Encoding...</value>
+    <value>正在编码...</value>
   </data>
   <data name="RemainingTime" xml:space="preserve">
-    <value>Remaining</value>
+    <value>剩余</value>
   </data>
   <data name="Frames" xml:space="preserve">
-    <value>Frames</value>
+    <value>帧</value>
   </data>
   <data name="FileSize" xml:space="preserve">
-    <value>Size</value>
+    <value>大小</value>
   </data>
   <data name="EstimatedSize" xml:space="preserve">
-    <value>Estimated</value>
+    <value>估计</value>
   </data>
   <data name="ShowCommandPalette" xml:space="preserve">
-    <value>Show command palette</value>
+    <value>显示命令面板</value>
   </data>
   <data name="ShowCommandPalette_Description" xml:space="preserve">
-    <value>Open the searchable command list</value>
+    <value>打开可搜索的命令列表</value>
   </data>
   <data name="CommandPalette_Placeholder" xml:space="preserve">
-    <value>Type a command name…</value>
+    <value>输入命令名称…</value>
   </data>
   <data name="CommandPalette_NoResults" xml:space="preserve">
-    <value>No matching commands</value>
+    <value>没有匹配的命令</value>
   </data>
   <data name="CommandPalette_MenuCategory" xml:space="preserve">
-    <value>Menu</value>
+    <value>菜单</value>
   </data>
   <data name="OnionSkin" xml:space="preserve">
-    <value>Onion skin</value>
+    <value>洋葱皮</value>
   </data>
   <data name="OnionSkin_Description" xml:space="preserve">
-    <value>Show semi-transparent previous and next frames overlaid on the current frame.</value>
+    <value>在当前帧上叠加显示半透明的前一帧和下一帧。</value>
   </data>
   <data name="ToggleOnionSkin" xml:space="preserve">
-    <value>Toggle onion skin</value>
+    <value>切换洋葱皮</value>
   </data>
   <data name="ToggleOnionSkin_Description" xml:space="preserve">
-    <value>Toggle the onion skin overlay in the preview.</value>
+    <value>在预览中切换洋葱皮叠加。</value>
   </data>
   <data name="OnionSkinPrevCount" xml:space="preserve">
-    <value>Previous frames</value>
+    <value>上一帧数</value>
   </data>
   <data name="OnionSkinNextCount" xml:space="preserve">
-    <value>Next frames</value>
+    <value>下一帧数</value>
   </data>
   <data name="OnionSkinPrevOpacity" xml:space="preserve">
-    <value>Previous opacity</value>
+    <value>上一帧不透明度</value>
   </data>
   <data name="OnionSkinNextOpacity" xml:space="preserve">
-    <value>Next opacity</value>
+    <value>下一帧不透明度</value>
   </data>
   <data name="Supersampling" xml:space="preserve">
-    <value>Supersampling</value>
+    <value>超采样</value>
   </data>
   <data name="Supersampling_Tip" xml:space="preserve">
-    <value>Render at the selected multiple of the output resolution, then downscale to the output size for smoother edges</value>
+    <value>以输出分辨率的所选倍数渲染，然后缩小到输出大小以获得更平滑的边缘</value>
   </data>
   <data name="PreviewRenderQuality" xml:space="preserve">
-    <value>Preview render quality</value>
+    <value>预览渲染质量</value>
   </data>
   <data name="PreviewRenderQuality_Tip" xml:space="preserve">
-    <value>Preview render quality. Cannot be changed during playback.</value>
+    <value>预览渲染质量。播放期间无法更改。</value>
   </data>
   <data name="RenderScale_Full" xml:space="preserve">
-    <value>Full</value>
+    <value>完整</value>
   </data>
   <data name="RenderScale_Half" xml:space="preserve">
-    <value>Half (1/2)</value>
+    <value>一半 (1/2)</value>
   </data>
   <data name="RenderScale_Quarter" xml:space="preserve">
-    <value>Quarter (1/4)</value>
+    <value>四分之一 (1/4)</value>
   </data>
   <data name="RenderScale_FitToPreviewer" xml:space="preserve">
-    <value>Fit to previewer</value>
+    <value>适应预览器</value>
   </data>
   <data name="Terminal" xml:space="preserve">
-    <value>Terminal</value>
+    <value>终端</value>
   </data>
   <data name="TerminalSessionEnded" xml:space="preserve">
-    <value>The terminal session has ended.</value>
+    <value>终端会话已结束。</value>
   </data>
   <data name="Restart" xml:space="preserve">
-    <value>Restart</value>
+    <value>重新启动</value>
   </data>
   <data name="Proxies" xml:space="preserve">
-    <value>Proxies</value>
+    <value>代理</value>
   </data>
   <data name="ProxyPresetHalf" xml:space="preserve">
-    <value>Half proxy (1/2)</value>
+    <value>半代理 (1/2)</value>
   </data>
   <data name="ProxyQuality" xml:space="preserve">
-    <value>Proxy quality</value>
+    <value>代理质量</value>
   </data>
   <data name="PreviewSource" xml:space="preserve">
-    <value>Preview source</value>
+    <value>预览源</value>
   </data>
   <data name="PreviewSourcePreferProxy" xml:space="preserve">
-    <value>Prefer proxy</value>
+    <value>优先使用代理</value>
   </data>
   <data name="PreviewSourceForceOriginal" xml:space="preserve">
-    <value>Force original</value>
+    <value>强制使用原始</value>
   </data>
   <data name="ProxyPresetQuarter" xml:space="preserve">
-    <value>Quarter proxy (1/4)</value>
+    <value>四分之一代理 (1/4)</value>
   </data>
   <data name="ProxyPresetEighth" xml:space="preserve">
-    <value>Eighth proxy (1/8)</value>
+    <value>八分之一代理 (1/8)</value>
   </data>
   <data name="ProxyStoreUsage" xml:space="preserve">
-    <value>Store</value>
+    <value>存储</value>
   </data>
   <data name="ProxyStoreCap" xml:space="preserve">
-    <value>Cap</value>
+    <value>上限</value>
   </data>
   <data name="ProxyClips" xml:space="preserve">
-    <value>Clips</value>
+    <value>剪辑</value>
   </data>
   <data name="ProxyQueue" xml:space="preserve">
-    <value>Queue</value>
+    <value>队列</value>
   </data>
   <data name="ProxyGenerate" xml:space="preserve">
-    <value>Generate</value>
+    <value>生成</value>
   </data>
   <data name="ProxyGenerateSelected" xml:space="preserve">
-    <value>Generate selected</value>
+    <value>生成所选</value>
   </data>
   <data name="ProxyGenerateAll" xml:space="preserve">
-    <value>Generate all</value>
+    <value>全部生成</value>
   </data>
   <data name="ProxyRegenerate" xml:space="preserve">
-    <value>Regenerate</value>
+    <value>重新生成</value>
   </data>
   <data name="ProxyRegenerateSelected" xml:space="preserve">
-    <value>Regenerate selected</value>
+    <value>重新生成所选</value>
   </data>
   <data name="ProxyDeleteSelected" xml:space="preserve">
-    <value>Delete selected</value>
+    <value>删除所选</value>
   </data>
   <data name="ProxyDeleteProjectProxies" xml:space="preserve">
-    <value>Delete project proxies</value>
+    <value>删除项目代理</value>
   </data>
   <data name="ProxyDeleteProjectProxiesConfirmationFormat" xml:space="preserve">
-    <value>Proxies are stored in a machine-wide shared cache. Deleting the {0} proxy file(s) used by this project also removes them for every other project that references the same source files, and they will have to be regenerated. Continue?</value>
+    <value>代理存储在整个机器的共享缓存中。删除此项目使用的 {0} 个代理文件也会将它们从引用相同源文件的每个其他项目中移除，并且必须重新生成。继续吗？</value>
   </data>
   <data name="ProxyReady" xml:space="preserve">
-    <value>Ready</value>
+    <value>就绪</value>
   </data>
   <data name="ProxyGenerating" xml:space="preserve">
-    <value>Generating</value>
+    <value>正在生成</value>
   </data>
   <data name="ProxyStale" xml:space="preserve">
-    <value>Stale</value>
+    <value>过期</value>
   </data>
   <data name="ProxyFailed" xml:space="preserve">
-    <value>Failed</value>
+    <value>失败</value>
   </data>
   <data name="ProxyMissing" xml:space="preserve">
-    <value>Missing</value>
+    <value>缺失</value>
   </data>
   <data name="ProxyPartial" xml:space="preserve">
-    <value>Partial</value>
+    <value>部分</value>
   </data>
   <data name="ProxyUnavailable" xml:space="preserve">
-    <value>Unavailable</value>
+    <value>不可用</value>
   </data>
   <data name="ProxyStoreUnavailable" xml:space="preserve">
-    <value>Proxy store is not available.</value>
+    <value>代理存储不可用。</value>
   </data>
   <data name="ProxyQueueUnavailable" xml:space="preserve">
-    <value>Proxy queue is not available.</value>
+    <value>代理队列不可用。</value>
   </data>
   <data name="ProxyBulkNoEligibleClips" xml:space="preserve">
-    <value>No clips met the bulk-generation threshold; use per-clip generate.</value>
+    <value>没有剪辑达到批量生成阈值；请使用逐剪辑生成。</value>
   </data>
   <data name="ProxyQueueIdle" xml:space="preserve">
-    <value>Queue idle</value>
+    <value>队列空闲</value>
   </data>
   <data name="ProxyQueuedJobSingular" xml:space="preserve">
-    <value>1 queued job</value>
+    <value>1 个排队任务</value>
   </data>
   <data name="ProxyQueuedJobPlural" xml:space="preserve">
-    <value>{0} queued jobs</value>
+    <value>{0} 个排队任务</value>
   </data>
   <data name="ProxyDeleteFailedSingular" xml:space="preserve">
-    <value>1 proxy could not be deleted because its file is in use.</value>
+    <value>1 个代理无法删除，因为其文件正在使用中。</value>
   </data>
   <data name="ProxyDeleteFailedPluralFormat" xml:space="preserve">
-    <value>{0} proxies could not be deleted because their files are in use.</value>
+    <value>{0} 个代理无法删除，因为其文件正在使用中。</value>
   </data>
   <data name="ProxyClipSummaryFormat" xml:space="preserve">
-    <value>{0} clips / {1} ready / {2} stale / {3} failed / {4} missing</value>
+    <value>{0} 个剪辑 / {1} 就绪 / {2} 过期 / {3} 失败 / {4} 缺失</value>
   </data>
   <data name="ProxySelectedSingular" xml:space="preserve">
-    <value>1 selected</value>
+    <value>已选择 1 个</value>
   </data>
   <data name="ProxySelectedPlural" xml:space="preserve">
-    <value>{0} selected</value>
+    <value>已选择 {0} 个</value>
   </data>
   <data name="ProxyStoreSummaryFormat" xml:space="preserve">
-    <value>Project {0} / Store {1} / Cap {2}</value>
+    <value>项目 {0} / 存储 {1} / 上限 {2}</value>
   </data>
   <data name="ProxySourceInfoFormat" xml:space="preserve">
-    <value>Source {0} / {1}</value>
+    <value>源 {0} / {1}</value>
   </data>
   <data name="ProxyInfoFormat" xml:space="preserve">
-    <value>Proxy {0} -> {1} / {2}</value>
+    <value>代理 {0} -&gt; {1} / {2}</value>
   </data>
   <data name="ProxyMissingForSelectedPreset" xml:space="preserve">
-    <value>Proxy missing for selected preset</value>
+    <value>所选预设缺少代理</value>
   </data>
   <data name="ProxyLastUsedFormat" xml:space="preserve">
-    <value>Used {0}</value>
+    <value>使用于 {0}</value>
   </data>
   <data name="ProxyJobStatusQueued" xml:space="preserve">
-    <value>Queued</value>
+    <value>已排队</value>
   </data>
   <data name="ProxyJobStatusRunning" xml:space="preserve">
-    <value>Running</value>
+    <value>正在运行</value>
   </data>
   <data name="ProxyJobStatusSucceeded" xml:space="preserve">
-    <value>Succeeded</value>
+    <value>成功</value>
   </data>
   <data name="ProxyJobStatusFailed" xml:space="preserve">
-    <value>Failed</value>
+    <value>失败</value>
   </data>
   <data name="ProxyJobStatusCanceled" xml:space="preserve">
-    <value>Canceled</value>
+    <value>已取消</value>
   </data>
   <data name="ProxyJobStatusSkipped" xml:space="preserve">
-    <value>Skipped</value>
+    <value>已跳过</value>
   </data>
   <data name="ProxyJobStatusWithMessageFormat" xml:space="preserve">
     <value>{0}: {1}</value>
   </data>
   <data name="Start" xml:space="preserve">
-    <value>Start</value>
+    <value>开始</value>
   </data>
   <data name="Debug" xml:space="preserve">
-    <value>Debug</value>
+    <value>调试</value>
   </data>
   <data name="AudioVisualizer_Display" xml:space="preserve">
-    <value>Display</value>
+    <value>显示</value>
   </data>
   <data name="WindowCapture" xml:space="preserve">
-    <value>Window Capture</value>
+    <value>窗口捕获</value>
   </data>
   <data name="AudioVisualizer_MinDecibels" xml:space="preserve">
-    <value>Min dB</value>
+    <value>最小 dB</value>
   </data>
   <data name="WindowCapture_RenderScale" xml:space="preserve">
-    <value>Render scale</value>
+    <value>渲染缩放</value>
   </data>
   <data name="WindowCapture_FrameRate" xml:space="preserve">
-    <value>Frame rate (fps)</value>
+    <value>帧率 (fps)</value>
   </data>
   <data name="WindowCapture_OutputFile" xml:space="preserve">
-    <value>Output file (.mp4)</value>
+    <value>输出文件 (.mp4)</value>
   </data>
   <data name="Browse" xml:space="preserve">
-    <value>Browse...</value>
+    <value>浏览...</value>
   </data>
   <data name="ClickBrowse" xml:space="preserve">
-    <value>Click Browse...</value>
+    <value>单击浏览...</value>
   </data>
 </root>

--- a/src/Beutl.Language/TutorialStrings.es.resx
+++ b/src/Beutl.Language/TutorialStrings.es.resx
@@ -1,0 +1,200 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="StartTutorial" xml:space="preserve">
+    <value>Iniciar tutorial</value>
+  </data>
+  <data name="TutorialStep" xml:space="preserve">
+    <value>Paso {0} de {1}</value>
+  </data>
+  <data name="TutorialNext" xml:space="preserve">
+    <value>Siguiente</value>
+  </data>
+  <data name="TutorialPrevious" xml:space="preserve">
+    <value>Anterior</value>
+  </data>
+  <data name="TutorialFinish" xml:space="preserve">
+    <value>Finalizar</value>
+  </data>
+  <data name="TutorialSkip" xml:space="preserve">
+    <value>Omitir tutorial</value>
+  </data>
+  <data name="LearnBeutlBasics" xml:space="preserve">
+    <value>Aprende los conceptos básicos de Beutl</value>
+  </data>
+  <data name="NoTutorialsAvailable" xml:space="preserve">
+    <value>No hay tutoriales disponibles</value>
+  </data>
+  <data name="Tutorial_Welcome_Title" xml:space="preserve">
+    <value>Bienvenido a Beutl</value>
+  </data>
+  <data name="Tutorial_Welcome_Content" xml:space="preserve">
+    <value>Beutl es un editor de video multiplataforma. Este tutorial te guiará a través de los conceptos básicos.</value>
+  </data>
+  <data name="Tutorial_Welcome_MenuBar_Title" xml:space="preserve">
+    <value>Barra de menú</value>
+  </data>
+  <data name="Tutorial_Welcome_MenuBar_Content" xml:space="preserve">
+    <value>La barra de menú contiene opciones para la gestión de archivos, edición y más.</value>
+  </data>
+  <data name="Tutorial_Welcome_Create_Title" xml:space="preserve">
+    <value>Crear nuevo</value>
+  </data>
+  <data name="Tutorial_Welcome_Create_Content" xml:space="preserve">
+    <value>Haz clic aquí para crear un nuevo proyecto o escena y comenzar a editar.</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Title" xml:space="preserve">
+    <value>Conceptos básicos de edición de escenas</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Description" xml:space="preserve">
+    <value>Aprende a agregar elementos, editar propiedades y crear animaciones</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step1_Title" xml:space="preserve">
+    <value>Agregar una elipse</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step1_Content" xml:space="preserve">
+    <value>Haz clic derecho en la línea de tiempo y agrega un elemento de elipse. También puedes arrastrarlo y soltarlo desde la biblioteca.</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step2_Title" xml:space="preserve">
+    <value>Seleccionar el elemento</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step2_Content" xml:space="preserve">
+    <value>Haz clic en el elemento que acabas de agregar en la línea de tiempo para seleccionarlo.</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step3_Title" xml:space="preserve">
+    <value>Propiedades</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step3_Content" xml:space="preserve">
+    <value>Esta es la pestaña de propiedades. Puedes ver y editar las propiedades del elemento seleccionado aquí.</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step4_Title" xml:space="preserve">
+    <value>Habilitar animación</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step4_Content" xml:space="preserve">
+    <value>Busca la propiedad Width y haz clic en el icono de menú junto a ella para habilitar la animación. Puedes habilitarla con "Editar animación" o "Editar animación en vista en línea".</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step5_Title" xml:space="preserve">
+    <value>Agregar un fotograma clave</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step5_Content" xml:space="preserve">
+    <value>La posición de reproducción se ha movido hacia adelante. Haz clic en el icono de diamante para agregar un fotograma clave en esta posición.</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step6_Title" xml:space="preserve">
+    <value>Cambiar el valor</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step6_Content" xml:space="preserve">
+    <value>El valor de Width se ha cambiado a 300. Esto crea una animación de 100 a 300 con el tiempo.</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step7_Title" xml:space="preserve">
+    <value>Vista previa de la animación</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step7_Content" xml:space="preserve">
+    <value>Pulsa el botón Reproducir en el reproductor para previsualizar tu animación.</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step8_Title" xml:space="preserve">
+    <value>¡Tutorial completado!</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step8_Content" xml:space="preserve">
+    <value>¡Felicidades! Has aprendido a agregar elementos, editar propiedades y crear animaciones. ¡Explora más funciones por tu cuenta!</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Title" xml:space="preserve">
+    <value>Edición de animaciones</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Description" xml:space="preserve">
+    <value>Aprende edición avanzada de animaciones con el editor de gráficos</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step1_Title" xml:space="preserve">
+    <value>Seleccionar un objeto</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step1_Content" xml:space="preserve">
+    <value>Selecciona el elemento que quieres animar en la línea de tiempo.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step2_Title" xml:space="preserve">
+    <value>Agregar traslación</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step2_Content" xml:space="preserve">
+    <value>Haz clic en el botón + de la propiedad Transform y agrega "Translate".</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step3_Title" xml:space="preserve">
+    <value>Habilitar animación X</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step3_Content" xml:space="preserve">
+    <value>Haz clic en el icono de menú de la propiedad X y selecciona "Editar animación".</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step4_Title" xml:space="preserve">
+    <value>Agregar un fotograma clave</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step4_Content" xml:space="preserve">
+    <value>La posición de reproducción se ha movido hacia adelante. Haz clic en el icono de diamante para agregar un fotograma clave en esta posición.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step5_Title" xml:space="preserve">
+    <value>Aplicar suavizado</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step5_Content" xml:space="preserve">
+    <value>Arrastrar una función de suavizado desde el panel Biblioteca (pestaña Suavizado) y soltarla en el editor de gráficos agrega fotogramas clave con esa función. Soltarla en la misma posición que un fotograma clave existente cambia la función de suavizado de ese fotograma.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step6_Title" xml:space="preserve">
+    <value>Descripción general del editor de gráficos</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step6_Content" xml:space="preserve">
+    <value>En el editor de gráficos, los iconos redondos representan puntos de control de suavizado. Muévelos a la izquierda o derecha para revelar los iconos de diamante (fotogramas clave) debajo.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step7_Title" xml:space="preserve">
+    <value>Mover fotogramas clave</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step7_Content" xml:space="preserve">
+    <value>Puedes arrastrar los iconos de diamante para cambiar el tiempo y el valor de los fotogramas clave.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step8_Title" xml:space="preserve">
+    <value>Vista previa de la animación</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step8_Content" xml:space="preserve">
+    <value>Pulsa el botón Reproducir para previsualizar tu animación.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step9_Title" xml:space="preserve">
+    <value>Copiar animación</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step9_Content" xml:space="preserve">
+    <value>Haz clic derecho en el fondo del editor de gráficos y selecciona "Copiar todo" para copiar todos los fotogramas clave.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step10_Title" xml:space="preserve">
+    <value>Habilitar animación Y</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step10_Content" xml:space="preserve">
+    <value>Haz clic en el icono de menú de la propiedad Y y selecciona "Editar animación".</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step11_Title" xml:space="preserve">
+    <value>Pegar animación</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step11_Content" xml:space="preserve">
+    <value>Haz clic derecho en el editor de gráficos de la propiedad Y y selecciona "Pegar" para aplicar la animación copiada.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step12_Title" xml:space="preserve">
+    <value>Vista previa final</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step12_Content" xml:space="preserve">
+    <value>Pulsa el botón Reproducir de nuevo para verificar que las animaciones X e Y funcionan juntas.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step13_Title" xml:space="preserve">
+    <value>¡Tutorial completado!</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step13_Content" xml:space="preserve">
+    <value>Has aprendido edición avanzada de animaciones con el editor de gráficos, aplicar funciones de suavizado y copiar/pegar animaciones. ¡Explora más funciones por tu cuenta!</value>
+  </data>
+</root>

--- a/src/Beutl.Language/TutorialStrings.ko-KR.resx
+++ b/src/Beutl.Language/TutorialStrings.ko-KR.resx
@@ -1,0 +1,200 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="StartTutorial" xml:space="preserve">
+    <value>튜토리얼 시작</value>
+  </data>
+  <data name="TutorialStep" xml:space="preserve">
+    <value>{1}단계 중 {0}단계</value>
+  </data>
+  <data name="TutorialNext" xml:space="preserve">
+    <value>다음</value>
+  </data>
+  <data name="TutorialPrevious" xml:space="preserve">
+    <value>이전</value>
+  </data>
+  <data name="TutorialFinish" xml:space="preserve">
+    <value>완료</value>
+  </data>
+  <data name="TutorialSkip" xml:space="preserve">
+    <value>튜토리얼 건너뛰기</value>
+  </data>
+  <data name="LearnBeutlBasics" xml:space="preserve">
+    <value>Beutl의 기본 사항 배우기</value>
+  </data>
+  <data name="NoTutorialsAvailable" xml:space="preserve">
+    <value>사용 가능한 튜토리얼이 없습니다</value>
+  </data>
+  <data name="Tutorial_Welcome_Title" xml:space="preserve">
+    <value>Beutl에 오신 것을 환영합니다</value>
+  </data>
+  <data name="Tutorial_Welcome_Content" xml:space="preserve">
+    <value>Beutl은 크로스 플랫폼 비디오 편집기입니다. 이 튜토리얼은 기본 사항을 안내합니다.</value>
+  </data>
+  <data name="Tutorial_Welcome_MenuBar_Title" xml:space="preserve">
+    <value>메뉴 모음</value>
+  </data>
+  <data name="Tutorial_Welcome_MenuBar_Content" xml:space="preserve">
+    <value>메뉴 모음에는 파일 관리, 편집 등의 옵션이 있습니다.</value>
+  </data>
+  <data name="Tutorial_Welcome_Create_Title" xml:space="preserve">
+    <value>새로 만들기</value>
+  </data>
+  <data name="Tutorial_Welcome_Create_Content" xml:space="preserve">
+    <value>여기를 클릭하여 새 프로젝트나 장면을 만들어 편집을 시작하세요.</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Title" xml:space="preserve">
+    <value>장면 편집 기본</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Description" xml:space="preserve">
+    <value>요소 추가, 속성 편집, 애니메이션 만들기 배우기</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step1_Title" xml:space="preserve">
+    <value>타원 추가</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step1_Content" xml:space="preserve">
+    <value>타임라인을 마우스 오른쪽 버튼으로 클릭하고 타원 요소를 추가하세요. 라이브러리에서 끌어다 놓을 수도 있습니다.</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step2_Title" xml:space="preserve">
+    <value>요소 선택</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step2_Content" xml:space="preserve">
+    <value>타임라인에서 방금 추가한 요소를 클릭하여 선택하세요.</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step3_Title" xml:space="preserve">
+    <value>속성</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step3_Content" xml:space="preserve">
+    <value>이것은 속성 탭입니다. 여기에서 선택한 요소의 속성을 보고 편집할 수 있습니다.</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step4_Title" xml:space="preserve">
+    <value>애니메이션 활성화</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step4_Content" xml:space="preserve">
+    <value>Width 속성을 찾아 옆에 있는 메뉴 아이콘을 클릭하여 애니메이션을 활성화하세요. "애니메이션 편집" 또는 "인라인 보기에서 애니메이션 편집"으로 활성화할 수 있습니다.</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step5_Title" xml:space="preserve">
+    <value>키프레임 추가</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step5_Content" xml:space="preserve">
+    <value>재생 위치가 앞으로 이동했습니다. 다이아몬드 아이콘을 클릭하여 이 위치에 키프레임을 추가하세요.</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step6_Title" xml:space="preserve">
+    <value>값 변경</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step6_Content" xml:space="preserve">
+    <value>Width 값이 300으로 변경되었습니다. 이렇게 하면 시간에 따라 100에서 300으로 애니메이션이 만들어집니다.</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step7_Title" xml:space="preserve">
+    <value>애니메이션 미리 보기</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step7_Content" xml:space="preserve">
+    <value>플레이어에서 재생 버튼을 눌러 애니메이션을 미리 보세요.</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step8_Title" xml:space="preserve">
+    <value>튜토리얼 완료!</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step8_Content" xml:space="preserve">
+    <value>축하합니다! 요소 추가, 속성 편집, 애니메이션 만들기를 배웠습니다. 더 많은 기능을 직접 탐색해 보세요!</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Title" xml:space="preserve">
+    <value>애니메이션 편집</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Description" xml:space="preserve">
+    <value>그래프 편집기를 사용하여 고급 애니메이션 편집 배우기</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step1_Title" xml:space="preserve">
+    <value>개체 선택</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step1_Content" xml:space="preserve">
+    <value>타임라인에서 애니메이션을 적용할 요소를 선택하세요.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step2_Title" xml:space="preserve">
+    <value>이동 추가</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step2_Content" xml:space="preserve">
+    <value>Transform 속성의 + 버튼을 클릭하고 "Translate"를 추가하세요.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step3_Title" xml:space="preserve">
+    <value>X 애니메이션 활성화</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step3_Content" xml:space="preserve">
+    <value>X 속성의 메뉴 아이콘을 클릭하고 "애니메이션 편집"을 선택하세요.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step4_Title" xml:space="preserve">
+    <value>키프레임 추가</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step4_Content" xml:space="preserve">
+    <value>재생 위치가 앞으로 이동했습니다. 다이아몬드 아이콘을 클릭하여 이 위치에 키프레임을 추가하세요.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step5_Title" xml:space="preserve">
+    <value>이징 적용</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step5_Content" xml:space="preserve">
+    <value>라이브러리 패널(이징 탭)에서 이징 함수를 끌어 그래프 편집기에 놓으면 해당 이징 함수를 사용하여 키프레임이 추가됩니다. 기존 키프레임과 같은 위치에 놓으면 해당 키프레임의 이징 함수가 변경됩니다.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step6_Title" xml:space="preserve">
+    <value>그래프 편집기 개요</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step6_Content" xml:space="preserve">
+    <value>그래프 편집기에서 원형 아이콘은 이징 제어점을 나타냅니다. 왼쪽이나 오른쪽으로 이동하여 아래의 다이아몬드 아이콘(키프레임)을 표시하세요.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step7_Title" xml:space="preserve">
+    <value>키프레임 이동</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step7_Content" xml:space="preserve">
+    <value>다이아몬드 아이콘을 끌어 키프레임의 시간과 값을 변경할 수 있습니다.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step8_Title" xml:space="preserve">
+    <value>애니메이션 미리 보기</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step8_Content" xml:space="preserve">
+    <value>재생 버튼을 눌러 애니메이션을 미리 보세요.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step9_Title" xml:space="preserve">
+    <value>애니메이션 복사</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step9_Content" xml:space="preserve">
+    <value>그래프 편집기 배경을 마우스 오른쪽 버튼으로 클릭하고 "모두 복사"를 선택하여 모든 키프레임을 복사하세요.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step10_Title" xml:space="preserve">
+    <value>Y 애니메이션 활성화</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step10_Content" xml:space="preserve">
+    <value>Y 속성의 메뉴 아이콘을 클릭하고 "애니메이션 편집"을 선택하세요.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step11_Title" xml:space="preserve">
+    <value>애니메이션 붙여넣기</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step11_Content" xml:space="preserve">
+    <value>Y 속성의 그래프 편집기를 마우스 오른쪽 버튼으로 클릭하고 "붙여넣기"를 선택하여 복사한 애니메이션을 적용하세요.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step12_Title" xml:space="preserve">
+    <value>최종 미리 보기</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step12_Content" xml:space="preserve">
+    <value>재생 버튼을 다시 눌러 X와 Y 애니메이션이 함께 작동하는지 확인하세요.</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step13_Title" xml:space="preserve">
+    <value>튜토리얼 완료!</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step13_Content" xml:space="preserve">
+    <value>그래프 편집기를 사용한 고급 애니메이션 편집, 이징 함수 적용, 애니메이션 복사/붙여넣기를 배웠습니다. 더 많은 기능을 직접 탐색해 보세요!</value>
+  </data>
+</root>

--- a/src/Beutl.Language/TutorialStrings.zh-CN.resx
+++ b/src/Beutl.Language/TutorialStrings.zh-CN.resx
@@ -1,0 +1,200 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="StartTutorial" xml:space="preserve">
+    <value>开始教程</value>
+  </data>
+  <data name="TutorialStep" xml:space="preserve">
+    <value>第 {0} 步，共 {1} 步</value>
+  </data>
+  <data name="TutorialNext" xml:space="preserve">
+    <value>下一步</value>
+  </data>
+  <data name="TutorialPrevious" xml:space="preserve">
+    <value>上一步</value>
+  </data>
+  <data name="TutorialFinish" xml:space="preserve">
+    <value>完成</value>
+  </data>
+  <data name="TutorialSkip" xml:space="preserve">
+    <value>跳过教程</value>
+  </data>
+  <data name="LearnBeutlBasics" xml:space="preserve">
+    <value>学习 Beutl 的基础知识</value>
+  </data>
+  <data name="NoTutorialsAvailable" xml:space="preserve">
+    <value>没有可用的教程</value>
+  </data>
+  <data name="Tutorial_Welcome_Title" xml:space="preserve">
+    <value>欢迎使用 Beutl</value>
+  </data>
+  <data name="Tutorial_Welcome_Content" xml:space="preserve">
+    <value>Beutl 是一款跨平台视频编辑器。本教程将引导您了解基础知识。</value>
+  </data>
+  <data name="Tutorial_Welcome_MenuBar_Title" xml:space="preserve">
+    <value>菜单栏</value>
+  </data>
+  <data name="Tutorial_Welcome_MenuBar_Content" xml:space="preserve">
+    <value>菜单栏包含文件管理、编辑等选项。</value>
+  </data>
+  <data name="Tutorial_Welcome_Create_Title" xml:space="preserve">
+    <value>新建</value>
+  </data>
+  <data name="Tutorial_Welcome_Create_Content" xml:space="preserve">
+    <value>单击此处创建新项目或场景以开始编辑。</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Title" xml:space="preserve">
+    <value>场景编辑基础</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Description" xml:space="preserve">
+    <value>学习添加元素、编辑属性和创建动画</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step1_Title" xml:space="preserve">
+    <value>添加椭圆</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step1_Content" xml:space="preserve">
+    <value>在时间轴上右键单击并添加椭圆元素。您也可以从库中拖放。</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step2_Title" xml:space="preserve">
+    <value>选择元素</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step2_Content" xml:space="preserve">
+    <value>单击时间轴中刚添加的元素以将其选中。</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step3_Title" xml:space="preserve">
+    <value>属性</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step3_Content" xml:space="preserve">
+    <value>这是属性选项卡。您可以在此查看和编辑所选元素的属性。</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step4_Title" xml:space="preserve">
+    <value>启用动画</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step4_Content" xml:space="preserve">
+    <value>找到 Width 属性，单击其旁边的菜单图标以启用动画。您可以使用“编辑动画”或“在内联视图中编辑动画”启用它。</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step5_Title" xml:space="preserve">
+    <value>添加关键帧</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step5_Content" xml:space="preserve">
+    <value>播放位置已向前移动。单击菱形图标在此位置添加关键帧。</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step6_Title" xml:space="preserve">
+    <value>更改值</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step6_Content" xml:space="preserve">
+    <value>Width 值已更改为 300。这将随时间创建从 100 到 300 的动画。</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step7_Title" xml:space="preserve">
+    <value>预览动画</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step7_Content" xml:space="preserve">
+    <value>按播放器中的“播放”按钮预览您的动画。</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step8_Title" xml:space="preserve">
+    <value>教程完成！</value>
+  </data>
+  <data name="Tutorial_SceneEdit_Step8_Content" xml:space="preserve">
+    <value>恭喜！您已经学会了如何添加元素、编辑属性和创建动画。自己探索更多功能吧！</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Title" xml:space="preserve">
+    <value>动画编辑</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Description" xml:space="preserve">
+    <value>使用图形编辑器学习高级动画编辑</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step1_Title" xml:space="preserve">
+    <value>选择对象</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step1_Content" xml:space="preserve">
+    <value>在时间轴中选择要设置动画的元素。</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step2_Title" xml:space="preserve">
+    <value>添加平移</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step2_Content" xml:space="preserve">
+    <value>单击 Transform 属性上的 + 按钮并添加“Translate”。</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step3_Title" xml:space="preserve">
+    <value>启用 X 动画</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step3_Content" xml:space="preserve">
+    <value>单击 X 属性上的菜单图标并选择“编辑动画”。</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step4_Title" xml:space="preserve">
+    <value>添加关键帧</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step4_Content" xml:space="preserve">
+    <value>播放位置已向前移动。单击菱形图标在此位置添加关键帧。</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step5_Title" xml:space="preserve">
+    <value>应用缓动</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step5_Content" xml:space="preserve">
+    <value>从库面板（缓动选项卡）拖动缓动函数并将其放到图形编辑器上，即可使用该缓动函数添加关键帧。将其放到现有关键帧的相同位置会更改该关键帧的缓动函数。</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step6_Title" xml:space="preserve">
+    <value>图形编辑器概览</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step6_Content" xml:space="preserve">
+    <value>在图形编辑器中，圆形图标表示缓动控制点。左右移动它们以显示下方的菱形图标（关键帧）。</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step7_Title" xml:space="preserve">
+    <value>移动关键帧</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step7_Content" xml:space="preserve">
+    <value>您可以拖动菱形图标来更改关键帧的时间和值。</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step8_Title" xml:space="preserve">
+    <value>预览动画</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step8_Content" xml:space="preserve">
+    <value>按“播放”按钮预览您的动画。</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step9_Title" xml:space="preserve">
+    <value>复制动画</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step9_Content" xml:space="preserve">
+    <value>右键单击图形编辑器背景并选择“全部复制”以复制所有关键帧。</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step10_Title" xml:space="preserve">
+    <value>启用 Y 动画</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step10_Content" xml:space="preserve">
+    <value>单击 Y 属性上的菜单图标并选择“编辑动画”。</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step11_Title" xml:space="preserve">
+    <value>粘贴动画</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step11_Content" xml:space="preserve">
+    <value>右键单击 Y 属性的图形编辑器并选择“粘贴”以应用复制的动画。</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step12_Title" xml:space="preserve">
+    <value>最终预览</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step12_Content" xml:space="preserve">
+    <value>再次按“播放”按钮以验证 X 和 Y 动画是否协同工作。</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step13_Title" xml:space="preserve">
+    <value>教程完成！</value>
+  </data>
+  <data name="Tutorial_AnimationEdit_Step13_Content" xml:space="preserve">
+    <value>您已经学会了使用图形编辑器进行高级动画编辑、应用缓动函数以及复制/粘贴动画。自己探索更多功能吧！</value>
+  </data>
+</root>

--- a/src/Beutl.PackageTools.UI/Resources/Strings.es.resx
+++ b/src/Beutl.PackageTools.UI/Resources/Strings.es.resx
@@ -1,0 +1,185 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+      <xs:complexType>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element name="data">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+                <xs:element name="comment" type="xsd:string" minOccurs="0" ns1:Ordinal="2" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" ns1:Ordinal="1" />
+              <xs:attribute name="type" type="xsd:string" ns1:Ordinal="3" />
+              <xs:attribute name="mimetype" type="xsd:string" ns1:Ordinal="4" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="resheader">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" />
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Cancel" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="Back" xml:space="preserve">
+    <value>Atrás</value>
+  </data>
+  <data name="Verify" xml:space="preserve">
+    <value>Verificar</value>
+  </data>
+  <data name="Hash_code_verification_failed" xml:space="preserve">
+    <value>La verificación del código hash falló.
+Este archivo de paquete puede haber sido manipulado.</value>
+  </data>
+  <data name="Do_you_really_want_to_continue_with_the_installation" xml:space="preserve">
+    <value>¿De verdad quieres continuar con la instalación?</value>
+  </data>
+  <data name="No" xml:space="preserve">
+    <value>No</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Sí</value>
+  </data>
+  <data name="Skipped_verification_because_local_source_is_used" xml:space="preserve">
+    <value>Se omitió la verificación porque se usa una fuente local.</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Cerrar</value>
+  </data>
+  <data name="ShowDetails" xml:space="preserve">
+    <value>Mostrar detalles</value>
+  </data>
+  <data name="Result" xml:space="preserve">
+    <value>Resultado</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>Instalar</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>Actualizar</value>
+  </data>
+  <data name="Uninstall" xml:space="preserve">
+    <value>Desinstalar</value>
+  </data>
+  <data name="ResolveDependencies" xml:space="preserve">
+    <value>Resolver dependencias</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Descargar</value>
+  </data>
+  <data name="Package_with_same_ID_found_in_local_source" xml:space="preserve">
+    <value>Se encontró un paquete con el mismo ID en la fuente local.</value>
+  </data>
+  <data name="Do_you_want_to_use_this_package" xml:space="preserve">
+    <value>¿Quieres usar este paquete?</value>
+  </data>
+  <data name="Skipped_downloading_to_use_local_source" xml:space="preserve">
+    <value>Se omitió la descarga para usar la fuente local.</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+    <value>Iniciar</value>
+  </data>
+  <data name="Changes" xml:space="preserve">
+    <value>Cambios</value>
+  </data>
+  <data name="This_package_has_already_been_uninstalled" xml:space="preserve">
+    <value>Este paquete ya ha sido desinstalado.</value>
+  </data>
+  <data name="Deleting_files" xml:space="preserve">
+    <value>Eliminando archivos...</value>
+  </data>
+  <data name="Uninstalled_XXX" xml:space="preserve">
+    <value>Se desinstaló '{0}'.</value>
+  </data>
+  <data name="Acceptance_of_License" xml:space="preserve">
+    <value>Aceptación de la licencia</value>
+  </data>
+  <data name="Please_accept_the_following_license" xml:space="preserve">
+    <value>Acepta la siguiente licencia.</value>
+  </data>
+  <data name="AcceptAll" xml:space="preserve">
+    <value>Aceptar todo</value>
+  </data>
+  <data name="There_are_no_licenses_that_require_acceptance" xml:space="preserve">
+    <value>No hay licencias que requieran aceptación.</value>
+  </data>
+  <data name="These_packages_were_not_deleted_successfully" xml:space="preserve">
+    <value>Estos paquetes no se eliminaron correctamente.</value>
+  </data>
+  <data name="VerifyingHashCode" xml:space="preserve">
+    <value>Verificando código hash...</value>
+  </data>
+  <data name="Verified" xml:space="preserve">
+    <value>Verificado</value>
+  </data>
+  <data name="Downloading_XXX" xml:space="preserve">
+    <value>Descargando '{0}'...</value>
+  </data>
+  <data name="Downloaded_XXX" xml:space="preserve">
+    <value>Se descargó '{0}'.</value>
+  </data>
+  <data name="Operation_canceled" xml:space="preserve">
+    <value>Operación cancelada.</value>
+  </data>
+  <data name="Close_this_window_because_other_Beutl_PackageTools_processes_are_running" xml:space="preserve">
+    <value>Cierra esta ventana porque hay otros procesos de Beutl.PackageTools en ejecución.</value>
+  </data>
+  <data name="Waiting_for_all_Beutl_processes_to_terminate" xml:space="preserve">
+    <value>Esperando a que terminen todos los procesos de Beutl...</value>
+  </data>
+  <data name="Deleted_unnecessary_packages" xml:space="preserve">
+    <value>Se eliminaron los paquetes innecesarios.</value>
+  </data>
+  <data name="Deleting_unnecessary_packages" xml:space="preserve">
+    <value>Eliminando paquetes innecesarios...</value>
+  </data>
+  <data name="Delete_unnecessary_packages" xml:space="preserve">
+    <value>Eliminar paquetes innecesarios</value>
+  </data>
+  <data name="Select_the_packages_to_be_deleted" xml:space="preserve">
+    <value>Selecciona los paquetes que se eliminarán.</value>
+  </data>
+  <data name="XXX_will_be_released" xml:space="preserve">
+    <value>{0} será liberado.</value>
+  </data>
+  <data name="Clean" xml:space="preserve">
+    <value>Limpiar</value>
+  </data>
+  <data name="XXX_has_been_released" xml:space="preserve">
+    <value>{0} ha sido liberado.</value>
+  </data>
+  <data name="Canceled" xml:space="preserve">
+    <value>Cancelado</value>
+  </data>
+  <data name="Succeeded" xml:space="preserve">
+    <value>Correcto</value>
+  </data>
+  <data name="Failed" xml:space="preserve">
+    <value>Fallido</value>
+  </data>
+  <data name="Unknown" xml:space="preserve">
+    <value>Desconocido</value>
+  </data>
+</root>

--- a/src/Beutl.PackageTools.UI/Resources/Strings.es.resx
+++ b/src/Beutl.PackageTools.UI/Resources/Strings.es.resx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   
   <xs:schema id="root">
     <xs:element name="root" ns1:IsDataSet="true">

--- a/src/Beutl.PackageTools.UI/Resources/Strings.ko-KR.resx
+++ b/src/Beutl.PackageTools.UI/Resources/Strings.ko-KR.resx
@@ -1,0 +1,185 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+      <xs:complexType>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element name="data">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+                <xs:element name="comment" type="xsd:string" minOccurs="0" ns1:Ordinal="2" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" ns1:Ordinal="1" />
+              <xs:attribute name="type" type="xsd:string" ns1:Ordinal="3" />
+              <xs:attribute name="mimetype" type="xsd:string" ns1:Ordinal="4" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="resheader">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" />
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Cancel" xml:space="preserve">
+    <value>취소</value>
+  </data>
+  <data name="Back" xml:space="preserve">
+    <value>뒤로</value>
+  </data>
+  <data name="Verify" xml:space="preserve">
+    <value>확인</value>
+  </data>
+  <data name="Hash_code_verification_failed" xml:space="preserve">
+    <value>해시 코드 확인에 실패했습니다.
+이 패키지 파일이 변조되었을 수 있습니다.</value>
+  </data>
+  <data name="Do_you_really_want_to_continue_with_the_installation" xml:space="preserve">
+    <value>설치를 계속하시겠습니까?</value>
+  </data>
+  <data name="No" xml:space="preserve">
+    <value>아니요</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>예</value>
+  </data>
+  <data name="Skipped_verification_because_local_source_is_used" xml:space="preserve">
+    <value>로컬 소스를 사용하므로 확인을 건너뛰었습니다.</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>닫기</value>
+  </data>
+  <data name="ShowDetails" xml:space="preserve">
+    <value>자세한 정보 표시</value>
+  </data>
+  <data name="Result" xml:space="preserve">
+    <value>결과</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>설치</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>업데이트</value>
+  </data>
+  <data name="Uninstall" xml:space="preserve">
+    <value>제거</value>
+  </data>
+  <data name="ResolveDependencies" xml:space="preserve">
+    <value>종속성 확인</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>다운로드</value>
+  </data>
+  <data name="Package_with_same_ID_found_in_local_source" xml:space="preserve">
+    <value>로컬 소스에서 동일한 ID의 패키지를 찾았습니다.</value>
+  </data>
+  <data name="Do_you_want_to_use_this_package" xml:space="preserve">
+    <value>이 패키지를 사용하시겠습니까?</value>
+  </data>
+  <data name="Skipped_downloading_to_use_local_source" xml:space="preserve">
+    <value>로컬 소스를 사용하기 위해 다운로드를 건너뛰었습니다.</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+    <value>시작</value>
+  </data>
+  <data name="Changes" xml:space="preserve">
+    <value>변경 사항</value>
+  </data>
+  <data name="This_package_has_already_been_uninstalled" xml:space="preserve">
+    <value>이 패키지는 이미 제거되었습니다.</value>
+  </data>
+  <data name="Deleting_files" xml:space="preserve">
+    <value>파일 삭제 중...</value>
+  </data>
+  <data name="Uninstalled_XXX" xml:space="preserve">
+    <value>'{0}'을(를) 제거했습니다.</value>
+  </data>
+  <data name="Acceptance_of_License" xml:space="preserve">
+    <value>라이선스 동의</value>
+  </data>
+  <data name="Please_accept_the_following_license" xml:space="preserve">
+    <value>다음 라이선스에 동의해 주세요.</value>
+  </data>
+  <data name="AcceptAll" xml:space="preserve">
+    <value>모두 동의</value>
+  </data>
+  <data name="There_are_no_licenses_that_require_acceptance" xml:space="preserve">
+    <value>동의가 필요한 라이선스가 없습니다.</value>
+  </data>
+  <data name="These_packages_were_not_deleted_successfully" xml:space="preserve">
+    <value>이 패키지들은 성공적으로 삭제되지 않았습니다.</value>
+  </data>
+  <data name="VerifyingHashCode" xml:space="preserve">
+    <value>해시 코드 확인 중...</value>
+  </data>
+  <data name="Verified" xml:space="preserve">
+    <value>확인됨</value>
+  </data>
+  <data name="Downloading_XXX" xml:space="preserve">
+    <value>'{0}'을(를) 다운로드하는 중...</value>
+  </data>
+  <data name="Downloaded_XXX" xml:space="preserve">
+    <value>'{0}'을(를) 다운로드했습니다.</value>
+  </data>
+  <data name="Operation_canceled" xml:space="preserve">
+    <value>작업이 취소되었습니다.</value>
+  </data>
+  <data name="Close_this_window_because_other_Beutl_PackageTools_processes_are_running" xml:space="preserve">
+    <value>다른 Beutl.PackageTools 프로세스가 실행 중이므로 이 창을 닫으세요.</value>
+  </data>
+  <data name="Waiting_for_all_Beutl_processes_to_terminate" xml:space="preserve">
+    <value>모든 Beutl 프로세스가 종료될 때까지 기다리는 중...</value>
+  </data>
+  <data name="Deleted_unnecessary_packages" xml:space="preserve">
+    <value>불필요한 패키지를 삭제했습니다.</value>
+  </data>
+  <data name="Deleting_unnecessary_packages" xml:space="preserve">
+    <value>불필요한 패키지를 삭제하는 중...</value>
+  </data>
+  <data name="Delete_unnecessary_packages" xml:space="preserve">
+    <value>불필요한 패키지 삭제</value>
+  </data>
+  <data name="Select_the_packages_to_be_deleted" xml:space="preserve">
+    <value>삭제할 패키지를 선택하세요.</value>
+  </data>
+  <data name="XXX_will_be_released" xml:space="preserve">
+    <value>{0}이(가) 해제됩니다.</value>
+  </data>
+  <data name="Clean" xml:space="preserve">
+    <value>정리</value>
+  </data>
+  <data name="XXX_has_been_released" xml:space="preserve">
+    <value>{0}이(가) 해제되었습니다.</value>
+  </data>
+  <data name="Canceled" xml:space="preserve">
+    <value>취소됨</value>
+  </data>
+  <data name="Succeeded" xml:space="preserve">
+    <value>성공</value>
+  </data>
+  <data name="Failed" xml:space="preserve">
+    <value>실패</value>
+  </data>
+  <data name="Unknown" xml:space="preserve">
+    <value>알 수 없음</value>
+  </data>
+</root>

--- a/src/Beutl.PackageTools.UI/Resources/Strings.ko-KR.resx
+++ b/src/Beutl.PackageTools.UI/Resources/Strings.ko-KR.resx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   
   <xs:schema id="root">
     <xs:element name="root" ns1:IsDataSet="true">

--- a/src/Beutl.PackageTools.UI/Resources/Strings.zh-CN.resx
+++ b/src/Beutl.PackageTools.UI/Resources/Strings.zh-CN.resx
@@ -1,0 +1,185 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  
+  <xs:schema id="root">
+    <xs:element name="root" ns1:IsDataSet="true">
+      <xs:complexType>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element name="data">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+                <xs:element name="comment" type="xsd:string" minOccurs="0" ns1:Ordinal="2" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" ns1:Ordinal="1" />
+              <xs:attribute name="type" type="xsd:string" ns1:Ordinal="3" />
+              <xs:attribute name="mimetype" type="xsd:string" ns1:Ordinal="4" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="resheader">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" />
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Cancel" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="Back" xml:space="preserve">
+    <value>返回</value>
+  </data>
+  <data name="Verify" xml:space="preserve">
+    <value>验证</value>
+  </data>
+  <data name="Hash_code_verification_failed" xml:space="preserve">
+    <value>哈希码验证失败。
+此包文件可能已被篡改。</value>
+  </data>
+  <data name="Do_you_really_want_to_continue_with_the_installation" xml:space="preserve">
+    <value>您确定要继续安装吗？</value>
+  </data>
+  <data name="No" xml:space="preserve">
+    <value>否</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>是</value>
+  </data>
+  <data name="Skipped_verification_because_local_source_is_used" xml:space="preserve">
+    <value>由于使用本地源，已跳过验证。</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="ShowDetails" xml:space="preserve">
+    <value>显示详细信息</value>
+  </data>
+  <data name="Result" xml:space="preserve">
+    <value>结果</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>安装</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>更新</value>
+  </data>
+  <data name="Uninstall" xml:space="preserve">
+    <value>卸载</value>
+  </data>
+  <data name="ResolveDependencies" xml:space="preserve">
+    <value>解析依赖项</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>下载</value>
+  </data>
+  <data name="Package_with_same_ID_found_in_local_source" xml:space="preserve">
+    <value>在本地源中找到了相同 ID 的包。</value>
+  </data>
+  <data name="Do_you_want_to_use_this_package" xml:space="preserve">
+    <value>是否要使用此包？</value>
+  </data>
+  <data name="Skipped_downloading_to_use_local_source" xml:space="preserve">
+    <value>已跳过下载以使用本地源。</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+    <value>开始</value>
+  </data>
+  <data name="Changes" xml:space="preserve">
+    <value>更改</value>
+  </data>
+  <data name="This_package_has_already_been_uninstalled" xml:space="preserve">
+    <value>此包已被卸载。</value>
+  </data>
+  <data name="Deleting_files" xml:space="preserve">
+    <value>正在删除文件...</value>
+  </data>
+  <data name="Uninstalled_XXX" xml:space="preserve">
+    <value>已卸载 '{0}'。</value>
+  </data>
+  <data name="Acceptance_of_License" xml:space="preserve">
+    <value>接受许可协议</value>
+  </data>
+  <data name="Please_accept_the_following_license" xml:space="preserve">
+    <value>请接受以下许可协议。</value>
+  </data>
+  <data name="AcceptAll" xml:space="preserve">
+    <value>全部接受</value>
+  </data>
+  <data name="There_are_no_licenses_that_require_acceptance" xml:space="preserve">
+    <value>没有需要接受的许可协议。</value>
+  </data>
+  <data name="These_packages_were_not_deleted_successfully" xml:space="preserve">
+    <value>这些包未能成功删除。</value>
+  </data>
+  <data name="VerifyingHashCode" xml:space="preserve">
+    <value>正在验证哈希码...</value>
+  </data>
+  <data name="Verified" xml:space="preserve">
+    <value>已验证</value>
+  </data>
+  <data name="Downloading_XXX" xml:space="preserve">
+    <value>正在下载 '{0}'...</value>
+  </data>
+  <data name="Downloaded_XXX" xml:space="preserve">
+    <value>已下载 '{0}'。</value>
+  </data>
+  <data name="Operation_canceled" xml:space="preserve">
+    <value>操作已取消。</value>
+  </data>
+  <data name="Close_this_window_because_other_Beutl_PackageTools_processes_are_running" xml:space="preserve">
+    <value>请关闭此窗口，因为有其他 Beutl.PackageTools 进程正在运行。</value>
+  </data>
+  <data name="Waiting_for_all_Beutl_processes_to_terminate" xml:space="preserve">
+    <value>正在等待所有 Beutl 进程终止...</value>
+  </data>
+  <data name="Deleted_unnecessary_packages" xml:space="preserve">
+    <value>已删除不必要的包。</value>
+  </data>
+  <data name="Deleting_unnecessary_packages" xml:space="preserve">
+    <value>正在删除不必要的包...</value>
+  </data>
+  <data name="Delete_unnecessary_packages" xml:space="preserve">
+    <value>删除不必要的包</value>
+  </data>
+  <data name="Select_the_packages_to_be_deleted" xml:space="preserve">
+    <value>选择要删除的包。</value>
+  </data>
+  <data name="XXX_will_be_released" xml:space="preserve">
+    <value>{0} 将被释放。</value>
+  </data>
+  <data name="Clean" xml:space="preserve">
+    <value>清理</value>
+  </data>
+  <data name="XXX_has_been_released" xml:space="preserve">
+    <value>{0} 已被释放。</value>
+  </data>
+  <data name="Canceled" xml:space="preserve">
+    <value>已取消</value>
+  </data>
+  <data name="Succeeded" xml:space="preserve">
+    <value>成功</value>
+  </data>
+  <data name="Failed" xml:space="preserve">
+    <value>失败</value>
+  </data>
+  <data name="Unknown" xml:space="preserve">
+    <value>未知</value>
+  </data>
+</root>

--- a/src/Beutl.PackageTools.UI/Resources/Strings.zh-CN.resx
+++ b/src/Beutl.PackageTools.UI/Resources/Strings.zh-CN.resx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   
   <xs:schema id="root">
     <xs:element name="root" ns1:IsDataSet="true">

--- a/src/Beutl/Pages/SettingsPages/ViewSettingsPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/ViewSettingsPage.axaml
@@ -55,7 +55,7 @@
                                   SelectedItem="{CompiledBinding SelectedLanguage.Value}">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate x:DataType="glob:CultureInfo">
-                                    <TextBlock Text="{CompiledBinding DisplayName}" />
+                                    <TextBlock Text="{CompiledBinding NativeName}" />
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>

--- a/src/Beutl/ViewModels/SettingsPages/ViewSettingsPageViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsPages/ViewSettingsPageViewModel.cs
@@ -3,7 +3,6 @@ using Avalonia.Media;
 using Avalonia.Threading;
 using Beutl.Configuration;
 using Beutl.Controls.Navigation;
-using Beutl.Extensibility;
 using FluentAvalonia.Styling;
 using Reactive.Bindings;
 
@@ -50,11 +49,16 @@ public sealed class ViewSettingsPageViewModel : PageContext, IDisposable
             })
             .DisposeWith(_disposables);
 
+        // The combo box matches items by CultureInfo equality, so a stored es-MX has to be mapped
+        // onto the neutral "es" entry or the box renders with nothing selected. Skip(1) keeps that
+        // display-only mapping from being written back as if the user had chosen it.
         SelectedLanguage = _config.GetObservable(ViewConfig.UICultureProperty)
+            .Select(x => LocalizeService.Instance.ResolveSupportedCulture(x) ?? x)
             .ToReactiveProperty()
             .DisposeWith(_disposables)!;
 
-        SelectedLanguage.Subscribe(ci => _config.UICulture = ci)
+        SelectedLanguage.Skip(1)
+            .Subscribe(ci => _config.UICulture = ci)
             .DisposeWith(_disposables);
 
         GetPredefColors();

--- a/src/Beutl/Views/Dialogs/WindowCaptureDialog.axaml
+++ b/src/Beutl/Views/Dialogs/WindowCaptureDialog.axaml
@@ -2,18 +2,19 @@
                   xmlns="https://github.com/avaloniaui"
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                  xmlns:lang="using:Beutl.Language"
                   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                   xmlns:sys="using:System"
                   xmlns:ui="using:FluentAvalonia.UI.Controls"
                   xmlns:vm="using:Beutl.ViewModels.Dialogs"
-                  Title="Window Capture (Debug)"
+                  Title="{x:Static lang:Strings.WindowCapture}"
                   d:DesignHeight="320"
                   d:DesignWidth="480"
                   x:CompileBindings="True"
                   x:DataType="vm:WindowCaptureDialogViewModel"
-                  CloseButtonText="Cancel"
+                  CloseButtonText="{x:Static lang:Strings.Cancel}"
                   IsPrimaryButtonEnabled="{Binding CanStart.Value}"
-                  PrimaryButtonText="Start"
+                  PrimaryButtonText="{x:Static lang:Strings.Start}"
                   mc:Ignorable="d">
     <ui:ContentDialog.Resources>
         <StaticResource x:Key="ContentDialogMaxWidth" ResourceKey="ContentDialogMinWidth" />
@@ -21,7 +22,7 @@
 
     <StackPanel Spacing="12">
         <StackPanel Spacing="4">
-            <TextBlock Text="Render scale" />
+            <TextBlock Text="{x:Static lang:Strings.WindowCapture_RenderScale}" />
             <ComboBox HorizontalAlignment="Stretch" SelectedItem="{Binding Scale.Value}">
                 <sys:Double>0.5</sys:Double>
                 <sys:Double>1.0</sys:Double>
@@ -33,7 +34,7 @@
         </StackPanel>
 
         <StackPanel Spacing="4">
-            <TextBlock Text="Frame rate (fps)" />
+            <TextBlock Text="{x:Static lang:Strings.WindowCapture_FrameRate}" />
             <ComboBox HorizontalAlignment="Stretch" SelectedItem="{Binding FrameRate.Value}">
                 <sys:Int32>15</sys:Int32>
                 <sys:Int32>30</sys:Int32>
@@ -42,15 +43,15 @@
         </StackPanel>
 
         <StackPanel Spacing="4">
-            <TextBlock Text="Output file (.mp4)" />
+            <TextBlock Text="{x:Static lang:Strings.WindowCapture_OutputFile}" />
             <Grid ColumnDefinitions="*,8,Auto">
                 <TextBox Grid.Column="0"
                          IsReadOnly="True"
                          Text="{Binding OutputPath.Value}"
-                         Watermark="Click Browse..." />
+                         Watermark="{x:Static lang:Strings.ClickBrowse}" />
                 <Button Grid.Column="2"
                         Click="OnBrowseClick"
-                        Content="Browse..." />
+                        Content="{x:Static lang:Strings.Browse}" />
             </Grid>
         </StackPanel>
     </StackPanel>

--- a/src/Beutl/Views/MainView.axaml
+++ b/src/Beutl/Views/MainView.axaml
@@ -233,7 +233,7 @@
                 <TextBlock VerticalAlignment="Center"
                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                            IsVisible="{CompiledBinding IsDebuggerAttached}"
-                           Text="Debug" />
+                           Text="{x:Static lang:Strings.Debug}" />
 
                 <Border Margin="4,0,0,0"
                         wnd:AppWindow.AllowInteractionInTitleBar="True"

--- a/src/Beutl/Views/MainView.axaml.cs
+++ b/src/Beutl/Views/MainView.axaml.cs
@@ -456,8 +456,8 @@ public sealed partial class MainView : UserControl
         if (_captureSession is not null)
         {
             NotificationService.ShowWarning(
-                "Window Capture",
-                "A capture session is already running. Stop it before starting a new one.");
+                Strings.WindowCapture,
+                MessageStrings.WindowCapture_AlreadyRunning);
             return;
         }
 
@@ -470,8 +470,8 @@ public sealed partial class MainView : UserControl
         if (ffmpegPath is null)
         {
             NotificationService.ShowError(
-                "Window Capture",
-                "ffmpeg executable was not found. Install ffmpeg and ensure it is on PATH.");
+                Strings.WindowCapture,
+                MessageStrings.WindowCapture_FfmpegNotFound);
             return;
         }
 
@@ -494,18 +494,20 @@ public sealed partial class MainView : UserControl
             _captureSession = session;
 
             NotificationService.ShowInformation(
-                "Window Capture",
-                $"Recording started: {session.Width}x{session.Height} @ {session.FrameRate}fps");
+                Strings.WindowCapture,
+                string.Format(MessageStrings.WindowCapture_RecordingStarted, session.Width, session.Height, session.FrameRate));
         }
         catch (Exception ex)
         {
+            // The throw can occur after _captureSession was published, which would wedge every later Start.
+            _captureSession = null;
             _logger.LogError(ex, "Failed to start window capture.");
             if (session is not null)
             {
                 try { await session.DisposeAsync(); }
                 catch (Exception disposeEx) { _logger.LogWarning(disposeEx, "Failed to dispose capture session after start failure."); }
             }
-            NotificationService.ShowError("Window Capture", ex.Message);
+            NotificationService.ShowError(Strings.WindowCapture, ex.Message);
         }
     }
 
@@ -520,7 +522,7 @@ public sealed partial class MainView : UserControl
             WindowCaptureSession? session = _captureSession;
             if (session is null)
             {
-                NotificationService.ShowWarning("Window Capture", "No active capture session.");
+                NotificationService.ShowWarning(Strings.WindowCapture, MessageStrings.WindowCapture_NoActiveSession);
                 return;
             }
 
@@ -529,14 +531,14 @@ public sealed partial class MainView : UserControl
                 await session.StopAsync();
                 _captureSession = null;
                 NotificationService.ShowSuccess(
-                    "Window Capture",
-                    $"Saved: {session.OutputPath}\nCaptured {session.CapturedFrameCount} frames (dropped {session.DroppedFrameCount}).");
+                    Strings.WindowCapture,
+                    string.Format(MessageStrings.WindowCapture_Saved, session.OutputPath, session.CapturedFrameCount, session.DroppedFrameCount));
             }
             catch (Exception ex)
             {
                 _captureSession = null;
                 _logger.LogError(ex, "Failed to stop window capture.");
-                NotificationService.ShowError("Window Capture", ex.Message);
+                NotificationService.ShowError(Strings.WindowCapture, ex.Message);
             }
         });
     }

--- a/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
+++ b/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
@@ -39,6 +39,7 @@
     <ProjectReference Include="..\..\src\Beutl.Editor.Components\Beutl.Editor.Components.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Extensions.FFmpeg\Beutl.Extensions.FFmpeg.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Configuration\Beutl.Configuration.csproj" />
+    <ProjectReference Include="..\..\src\Beutl.Language\Beutl.Language.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Api\Beutl.Api.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Engine.SourceGenerators\Beutl.Engine.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/tests/Beutl.UnitTests/Language/LocalizeServiceTests.cs
+++ b/tests/Beutl.UnitTests/Language/LocalizeServiceTests.cs
@@ -1,0 +1,59 @@
+﻿using System.Globalization;
+using Beutl.Language;
+
+namespace Beutl.UnitTests.Language;
+
+[TestFixture]
+public class LocalizeServiceTests
+{
+    [TestCase("en-US", true)]
+    [TestCase("ja-JP", true)]
+    [TestCase("zh-CN", true)]
+    [TestCase("ko-KR", true)]
+    [TestCase("es", true)]
+    [TestCase("es-ES", true)]
+    [TestCase("es-MX", true)]
+    [TestCase("fr-FR", false)]
+    [TestCase("de-DE", false)]
+    [TestCase("en-GB", false)]
+    public void IsSupportedCulture_matches_exact_and_parent_cultures(string name, bool expected)
+    {
+        var ci = CultureInfo.GetCultureInfo(name);
+
+        Assert.That(LocalizeService.Instance.IsSupportedCulture(ci), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void IsSupportedCulture_rejects_invariant_culture()
+    {
+        Assert.That(LocalizeService.Instance.IsSupportedCulture(CultureInfo.InvariantCulture), Is.False);
+    }
+
+    [Test]
+    public void SupportedCultures_returns_all_supported_cultures()
+    {
+        string[] names = LocalizeService.Instance.SupportedCultures().Select(x => x.Name).ToArray();
+
+        Assert.That(names, Is.EquivalentTo(new[] { "en-US", "ja-JP", "zh-CN", "ko-KR", "es" }));
+    }
+
+    [TestCase("es-MX", "es")]
+    [TestCase("es-ES", "es")]
+    [TestCase("es", "es")]
+    [TestCase("ja-JP", "ja-JP")]
+    [TestCase("zh-CN", "zh-CN")]
+    public void ResolveSupportedCulture_maps_a_culture_onto_the_entry_the_picker_holds(string name, string expected)
+    {
+        CultureInfo? resolved = LocalizeService.Instance.ResolveSupportedCulture(CultureInfo.GetCultureInfo(name));
+
+        Assert.That(resolved?.Name, Is.EqualTo(expected));
+        Assert.That(LocalizeService.Instance.SupportedCultures(), Does.Contain(resolved));
+    }
+
+    [TestCase("fr-FR")]
+    [TestCase("en-GB")]
+    public void ResolveSupportedCulture_returns_null_for_an_unsupported_culture(string name)
+    {
+        Assert.That(LocalizeService.Instance.ResolveSupportedCulture(CultureInfo.GetCultureInfo(name)), Is.Null);
+    }
+}


### PR DESCRIPTION
## Description
- Add zh-CN, ko-KR, and es translations (~16k keys across 39 new resx files) for the Beutl.Language string tables and the extension/package-tools resources, so the app can be localized into three more languages.
- Extend `LocalizeService` to five cultures (en-US, ja-JP, zh-CN, ko-KR, es) with parent-culture resolution, so a specific culture such as es-MX maps onto the neutral "es" entry.
- Localize hardcoded strings in the Window Capture dialog, the Audio Visualizer tab, and the MainView debug label.
- Fix two bugs surfaced while localizing: `_captureSession` is now reset when a capture start fails (previously a later Start was wedged), and the view-settings language picker no longer writes back the display-only culture mapping.

## Affected areas
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None

## Test plan
- Added `tests/Beutl.UnitTests/Language/LocalizeServiceTests.cs` covering exact/parent culture matching, invariant-culture rejection, the supported-culture list, and `ResolveSupportedCulture` mapping (es-MX → es, unsupported → null).
- Full suite: `dotnet test Beutl.slnx -f net10.0` passes (4974 tests).

## Fixed issues / References
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Spanish, Korean, and Simplified Chinese localization across the editor, settings, tutorials, audio/graphics tools, package management, media features, and exception handling.
  * Added support for selecting and resolving these languages, with native language names shown in the selector.
  * Localized window-capture controls and notifications, debugger status, exception dialogs, and audio visualizer labels.
  * Added Japanese window-capture and visualizer messages.

* **Bug Fixes**
  * Improved window-capture failure handling and cleanup.
  * Prevented language settings from being rewritten during initial loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->