### PR TITLE
fix(api): report flatpak installs as zip in the update check

### DIFF
--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -109,14 +109,15 @@ public class BeutlApiApplication
     {
         var metadata = await LoadMetadata();
         if (metadata == null) return (await App.CheckForUpdates(version), null);
-        // The server's /api/v3/app/updates endpoint only accepts zip/debian/installer/app.
-        // Flatpak bundles are built from the standalone zip, so report them as zip.
-        string type = metadata.Type == "flatpak" ? "zip" : metadata.Type;
         var update = await App.GetUpdate(
-            version, type, metadata.OS, metadata.Arch,
+            version, ToServerType(metadata.Type), metadata.OS, metadata.Arch,
             metadata.Standalone, "false");
         return (null, update);
     }
+
+    // The server's /api/v3/app/updates endpoint only accepts zip/debian/installer/app.
+    // Flatpak bundles are built from the standalone zip, so report them as zip.
+    internal static string ToServerType(string type) => type == "flatpak" ? "zip" : type;
 
     public static async Task<AssetMetadataJson?> LoadMetadata()
     {
@@ -451,6 +452,7 @@ public sealed class AssetMetadataJson
 
     [JsonPropertyName("standalone")] public required string Standalone { get; init; }
 
-    // zip,debian,installer,app
+    // Metadata values: zip,debian,installer,app,flatpak.
+    // Server query values (see ToServerType): zip,debian,installer,app.
     [JsonPropertyName("type")] public required string Type { get; init; }
 }

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -109,8 +109,11 @@ public class BeutlApiApplication
     {
         var metadata = await LoadMetadata();
         if (metadata == null) return (await App.CheckForUpdates(version), null);
+        // The server's /api/v3/app/updates endpoint only accepts zip/debian/installer/app.
+        // Flatpak bundles are built from the standalone zip, so report them as zip.
+        string type = metadata.Type == "flatpak" ? "zip" : metadata.Type;
         var update = await App.GetUpdate(
-            version, metadata.Type, metadata.OS, metadata.Arch,
+            version, type, metadata.OS, metadata.Arch,
             metadata.Standalone, "false");
         return (null, update);
     }

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -6,6 +6,7 @@ using Beutl.Api.Services;
 namespace Beutl.UnitTests.Api;
 
 [TestFixture]
+[NonParallelizable]
 public sealed class BeutlApiApplicationTests
 {
     [Test]
@@ -39,24 +40,37 @@ public sealed class BeutlApiApplicationTests
     }
 
     [Test]
+    public void ToServerType_Flatpak_MapsToZip()
+    {
+        Assert.That(BeutlApiApplication.ToServerType("flatpak"), Is.EqualTo("zip"));
+    }
+
+    [TestCase("zip")]
+    [TestCase("debian")]
+    [TestCase("installer")]
+    [TestCase("app")]
+    public void ToServerType_KnownType_PassesThrough(string type)
+    {
+        Assert.That(BeutlApiApplication.ToServerType(type), Is.EqualTo(type));
+    }
+
+    [Test]
     public async Task CheckForUpdatesAsync_WithFlatpakMetadata_SendsZipType()
     {
-        // The server's /api/v3/app/updates endpoint only accepts zip/debian/installer/app.
-        // Flatpak bundles are built from the standalone zip, so report them as zip.
-        // (s_metadata is a per-process static cache, so this must be the only test exercising the metadata path.)
+        // LoadMetadata reads asset_metadata.json from AppContext.BaseDirectory (cached per process).
         string metadataPath = Path.Combine(AppContext.BaseDirectory, "asset_metadata.json");
-        File.WriteAllText(metadataPath, """
-            {
-              "id": "test-id",
-              "os": "linux",
-              "arch": "x64",
-              "version": "2.0.0-preview.6",
-              "standalone": "true",
-              "type": "flatpak"
-            }
-            """);
         try
         {
+            File.WriteAllText(metadataPath, """
+                {
+                  "id": "test-id",
+                  "os": "linux",
+                  "arch": "x64",
+                  "version": "2.0.0-preview.6",
+                  "standalone": "true",
+                  "type": "flatpak"
+                }
+                """);
             var handler = new CapturingHandler();
             using var httpClient = new HttpClient(handler);
             var app = new BeutlApiApplication(httpClient, new ExtensionProvider());

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -1,4 +1,6 @@
-﻿using Beutl.Api;
+﻿using System.Net;
+using System.Text;
+using Beutl.Api;
 using Beutl.Api.Services;
 
 namespace Beutl.UnitTests.Api;
@@ -34,5 +36,63 @@ public sealed class BeutlApiApplicationTests
         using var httpClient = new HttpClient();
 
         Assert.Throws<ArgumentNullException>(() => _ = new BeutlApiApplication(httpClient, null!));
+    }
+
+    [Test]
+    public async Task CheckForUpdatesAsync_WithFlatpakMetadata_SendsZipType()
+    {
+        // The server's /api/v3/app/updates endpoint only accepts zip/debian/installer/app.
+        // Flatpak bundles are built from the standalone zip, so report them as zip.
+        // (s_metadata is a per-process static cache, so this must be the only test exercising the metadata path.)
+        string metadataPath = Path.Combine(AppContext.BaseDirectory, "asset_metadata.json");
+        File.WriteAllText(metadataPath, """
+            {
+              "id": "test-id",
+              "os": "linux",
+              "arch": "x64",
+              "version": "2.0.0-preview.6",
+              "standalone": "true",
+              "type": "flatpak"
+            }
+            """);
+        try
+        {
+            var handler = new CapturingHandler();
+            using var httpClient = new HttpClient(handler);
+            var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+
+            var (v1, v3) = await app.CheckForUpdatesAsync("2.0.0-preview.6");
+
+            Assert.That(handler.LastRequestUri, Is.Not.Null);
+            Assert.That(handler.LastRequestUri!.Query, Does.Contain("type=zip"));
+            Assert.That(handler.LastRequestUri!.Query, Does.Not.Contain("type=flatpak"));
+            Assert.That(v3, Is.Not.Null);
+            Assert.That(v1, Is.Null);
+        }
+        finally
+        {
+            File.Delete(metadataPath);
+        }
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public Uri? LastRequestUri { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequestUri = request.RequestUri;
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    {"latestVersion":"2.0.0-preview.7","url":"https://github.com/b-editor/beutl/releases/tag/v2.0.0-preview.7","downloadUrl":null,"isLatest":false,"mustLatest":false}
+                    """,
+                    Encoding.UTF8,
+                    "application/json")
+            };
+            return Task.FromResult(response);
+        }
     }
 }

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -59,6 +59,7 @@ public sealed class BeutlApiApplicationTests
     {
         // LoadMetadata reads asset_metadata.json from AppContext.BaseDirectory (cached per process).
         string metadataPath = Path.Combine(AppContext.BaseDirectory, "asset_metadata.json");
+        string? originalContent = File.Exists(metadataPath) ? File.ReadAllText(metadataPath) : null;
         try
         {
             File.WriteAllText(metadataPath, """
@@ -85,7 +86,14 @@ public sealed class BeutlApiApplicationTests
         }
         finally
         {
-            File.Delete(metadataPath);
+            if (originalContent != null)
+            {
+                File.WriteAllText(metadataPath, originalContent);
+            }
+            else
+            {
+                File.Delete(metadataPath);
+            }
         }
     }
 


### PR DESCRIPTION
## Description
- The startup update check failed with HTTP 400 for every Flatpak install: the Flatpak build writes `type=flatpak` into `asset_metadata.json`, but the server's `/api/v3/app/updates` endpoint only accepts `zip`/`debian`/`installer`/`app` (Zod whitelist, verified against the server source in b-editor/beutl-web `packages/api/src/v3/app.ts`) and rejects the request with 400. This was the most frequent error in telemetry (Refit.ApiException, 30 records/week).
- Fix: translate the metadata type at the API boundary via the new `BeutlApiApplication.ToServerType` — Flatpak bundles are built from the standalone zip, so they are reported as `zip`. The Flatpak branch of `CheckForUpdatesTask` only consumes the release URL from the response (never the download URL), so the zip response is exactly what it needs.
- The Windows installer (`type=installer`, `os=win`) and macOS app (`type=app`, `os=osx`) builds already send contract-valid values and are unaffected.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [x] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None.

## Test plan
- `tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs`:
  - `ToServerType_Flatpak_MapsToZip` + `ToServerType_KnownType_PassesThrough` (4 cases) — direct unit tests of the new pure translation.
  - `CheckForUpdatesAsync_WithFlatpakMetadata_SendsZipType` — integration test pinning the Refit wiring: with flatpak metadata, the request query carries `type=zip` and not `type=flatpak`. Baseline against the unmodified code was red (request carried `type=flatpak`), confirming the test captures the bug; green after the fix. Fixture is `[NonParallelizable]` because `LoadMetadata` caches `asset_metadata.json` per process.
- Api-area suite: 58/58 green. `dotnet format Beutl.slnx --verify-no-changes`: green.

## Fixed issues / References
- Project board: b-editor/projects/9 ("[Bug] 更新チェック(CheckForUpdatesTask)が 400 Bad Request で失敗（最頻出）")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved update checks for Flatpak installations by sending the correct format to the update service.
  - Known update formats continue to be handled correctly.
  - Flatpak users now receive more reliable update results without changing their installation format.

- **Documentation**
  - Clarified supported metadata formats and server query values used during update checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->