### PR TITLE
refactor!(api): require CancellationToken on API client and store calls

### DIFF
--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -284,6 +284,7 @@ public class BeutlApiApplication
         CancellationToken cancellationToken)
     {
         string? previousAuthorization = _httpClient.DefaultRequestHeaders.Authorization?.ToString();
+        AuthenticatedUser? previousUser = _authenticatedUser.Value;
         _httpClient.DefaultRequestHeaders.Authorization =
             new AuthenticationHeaderValue("Bearer", authResponse.Token);
         try
@@ -297,6 +298,7 @@ public class BeutlApiApplication
         }
         catch
         {
+            _authenticatedUser.Value = previousUser;
             if (previousAuthorization != null)
             {
                 _httpClient.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse(previousAuthorization);

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -344,7 +344,7 @@ public class BeutlApiApplication
         string fileName = Path.Combine(Helper.AppRoot, UserFileName);
         if (File.Exists(fileName))
         {
-            JsonNode? node = JsonNode.Parse(await File.ReadAllTextAsync(fileName));
+            JsonNode? node = JsonNode.Parse(await File.ReadAllTextAsync(fileName, cancellationToken));
             DateTime lastWriteTime = File.GetLastWriteTimeUtc(fileName);
 
             if (node != null)

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -208,7 +208,7 @@ public class BeutlApiApplication
             CreateAuthUriResponse authUriRes = await Account.CreateAuthUri(new CreateAuthUriRequest
             {
                 ContinueUri = continueUri
-            });
+            }, cancellationToken);
             using HttpListener listener = StartListener($"{continueUri}/");
             activity?.AddEvent(new("Started_Listener"));
 
@@ -228,12 +228,12 @@ public class BeutlApiApplication
             {
                 Code = code,
                 SessionId = authUriRes.SessionId
-            });
+            }, cancellationToken);
             activity?.AddEvent(new("Done_CodeToJwtAsync"));
 
             _httpClient.DefaultRequestHeaders.Authorization =
                 new AuthenticationHeaderValue("Bearer", authResponse.Token);
-            ProfileResponse profileResponse = await Users.GetSelf();
+            ProfileResponse profileResponse = await Users.GetSelf(cancellationToken);
             var profile = new Profile(profileResponse, this);
 
             _authenticatedUser.Value = new AuthenticatedUser(profile, authResponse, this, _httpClient, DateTime.UtcNow);
@@ -254,7 +254,7 @@ public class BeutlApiApplication
                 CreateAuthUriResponse authUriRes = await Account.CreateAuthUri(new CreateAuthUriRequest
                 {
                     ContinueUri = continueUri
-                });
+                }, cancellationToken);
                 using HttpListener listener = StartListener($"{continueUri}/");
                 activity?.AddEvent(new("Started_Listener"));
 
@@ -273,12 +273,12 @@ public class BeutlApiApplication
                 {
                     Code = code,
                     SessionId = authUriRes.SessionId
-                });
+                }, cancellationToken);
                 activity?.AddEvent(new("Done_CodeToJwtAsync"));
 
                 _httpClient.DefaultRequestHeaders.Authorization =
                     new AuthenticationHeaderValue("Bearer", authResponse.Token);
-                ProfileResponse profileResponse = await Users.GetSelf();
+                ProfileResponse profileResponse = await Users.GetSelf(cancellationToken);
                 var profile = new Profile(profileResponse, this);
 
                 _authenticatedUser.Value = new AuthenticatedUser(profile, authResponse, this, _httpClient, DateTime.UtcNow);
@@ -326,10 +326,10 @@ public class BeutlApiApplication
             AuthenticatedUser? user = await ReadUserAsync();
             if (user != null)
             {
-                await user.RefreshAsync();
+                await user.RefreshAsync(CancellationToken.None);
 
                 _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", user.Token);
-                await user.Profile.RefreshAsync(true);
+                await user.Profile.RefreshAsync(CancellationToken.None, true);
                 _authenticatedUser.Value = user;
                 SaveUser();
             }

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -319,27 +319,28 @@ public class BeutlApiApplication
         }
     }
 
-    public async Task RestoreUserAsync(Activity? activity)
+    public async Task RestoreUserAsync(Activity? activity, CancellationToken cancellationToken)
     {
-        using (await Lock.LockAsync())
+        using (await Lock.LockAsync(cancellationToken))
         {
             activity?.AddEvent(new("Entered_AsyncLock"));
 
-            AuthenticatedUser? user = await ReadUserAsync();
+            AuthenticatedUser? user = await ReadUserAsync(cancellationToken);
             if (user != null)
             {
-                await user.RefreshAsync(CancellationToken.None);
+                await user.RefreshAsync(cancellationToken);
 
                 _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", user.Token);
-                await user.Profile.RefreshAsync(CancellationToken.None, true);
+                await user.Profile.RefreshAsync(cancellationToken, true);
                 _authenticatedUser.Value = user;
                 SaveUser();
             }
         }
     }
 
-    public async ValueTask<AuthenticatedUser?> ReadUserAsync()
+    public async ValueTask<AuthenticatedUser?> ReadUserAsync(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         string fileName = Path.Combine(Helper.AppRoot, UserFileName);
         if (File.Exists(fileName))
         {

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -206,36 +206,38 @@ public class BeutlApiApplication
     {
         using (Activity? activity = ActivitySource.StartActivity("SignInExternalAsync", ActivityKind.Client))
         {
+            string continueUri = $"http://localhost:{GetRandomUnusedPort()}/__/auth/handler";
+            CreateAuthUriResponse authUriRes = await Account.CreateAuthUri(new CreateAuthUriRequest
+            {
+                ContinueUri = continueUri
+            }, cancellationToken);
+            using HttpListener listener = StartListener($"{continueUri}/");
+            activity?.AddEvent(new("Started_Listener"));
+
+            string uri =
+                $"{BaseUrl}/api/v2/identity/signInWith?provider={provider}&returnUrl={Uri.EscapeDataString(authUriRes.AuthUri)}";
+
+            Process.Start(new ProcessStartInfo(uri) { UseShellExecute = true, Verb = "open" });
+
+            string? code = await GetResponseFromListener(listener, cancellationToken);
+            activity?.AddEvent(new("Received_Code"));
+            if (string.IsNullOrWhiteSpace(code))
+            {
+                throw new Exception("The returned code was empty.");
+            }
+
+            AuthResponse authResponse = await Account.Exchange(new ExchangeRequest
+            {
+                Code = code,
+                SessionId = authUriRes.SessionId
+            }, cancellationToken);
+            activity?.AddEvent(new("Done_CodeToJwtAsync"));
+
+            // Serialize only the authentication state transition; the OAuth wait above must
+            // not hold the application-wide lock.
             using (await Lock.LockAsync(cancellationToken))
             {
                 activity?.AddEvent(new("Entered_AsyncLock"));
-                string continueUri = $"http://localhost:{GetRandomUnusedPort()}/__/auth/handler";
-                CreateAuthUriResponse authUriRes = await Account.CreateAuthUri(new CreateAuthUriRequest
-                {
-                    ContinueUri = continueUri
-                }, cancellationToken);
-                using HttpListener listener = StartListener($"{continueUri}/");
-                activity?.AddEvent(new("Started_Listener"));
-
-                string uri =
-                    $"{BaseUrl}/api/v2/identity/signInWith?provider={provider}&returnUrl={Uri.EscapeDataString(authUriRes.AuthUri)}";
-
-                Process.Start(new ProcessStartInfo(uri) { UseShellExecute = true, Verb = "open" });
-
-                string? code = await GetResponseFromListener(listener, cancellationToken);
-                activity?.AddEvent(new("Received_Code"));
-                if (string.IsNullOrWhiteSpace(code))
-                {
-                    throw new Exception("The returned code was empty.");
-                }
-
-                AuthResponse authResponse = await Account.Exchange(new ExchangeRequest
-                {
-                    Code = code,
-                    SessionId = authUriRes.SessionId
-                }, cancellationToken);
-                activity?.AddEvent(new("Done_CodeToJwtAsync"));
-
                 AuthenticatedUser user = await CompleteSignInAsync(authResponse, cancellationToken);
                 activity?.AddEvent(new("Saved_User"));
                 return user;
@@ -291,25 +293,33 @@ public class BeutlApiApplication
         AuthenticatedUser? previousUser = _authenticatedUser.Value;
         _httpClient.DefaultRequestHeaders.Authorization =
             new AuthenticationHeaderValue("Bearer", authResponse.Token);
+        AuthenticatedUser? attemptedUser = null;
         try
         {
             ProfileResponse profileResponse = await Users.GetSelf(cancellationToken);
             var profile = new Profile(profileResponse, this);
 
-            _authenticatedUser.Value = new AuthenticatedUser(profile, authResponse, this, _httpClient, DateTime.UtcNow);
+            attemptedUser = new AuthenticatedUser(profile, authResponse, this, _httpClient, DateTime.UtcNow);
+            _authenticatedUser.Value = attemptedUser;
             SaveUser();
             return _authenticatedUser.Value;
         }
         catch
         {
-            _authenticatedUser.Value = previousUser;
-            if (previousAuthorization != null)
+            // Only roll back state still owned by this failing attempt: a SignOut or a
+            // later successful sign-in may have replaced the user while GetSelf was pending,
+            // and must not be overwritten by the stale snapshot.
+            if (ReferenceEquals(_authenticatedUser.Value, attemptedUser))
             {
-                _httpClient.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse(previousAuthorization);
-            }
-            else
-            {
-                _httpClient.DefaultRequestHeaders.Authorization = null;
+                _authenticatedUser.Value = previousUser;
+                if (previousAuthorization != null)
+                {
+                    _httpClient.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse(previousAuthorization);
+                }
+                else
+                {
+                    _httpClient.DefaultRequestHeaders.Authorization = null;
+                }
             }
 
             throw;

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -109,7 +109,7 @@ public class BeutlApiApplication
         string version,
         CancellationToken cancellationToken)
     {
-        var metadata = await LoadMetadata();
+        var metadata = await LoadMetadata().WaitAsync(cancellationToken);
         if (metadata == null) return (await App.CheckForUpdates(version, cancellationToken), null);
         var update = await App.GetUpdate(
             version, ToServerType(metadata.Type), metadata.OS, metadata.Arch,

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -346,15 +346,34 @@ public class BeutlApiApplication
         {
             activity?.AddEvent(new("Entered_AsyncLock"));
 
+            string? previousAuthorization = _httpClient.DefaultRequestHeaders.Authorization?.ToString();
+            AuthenticatedUser? previousUser = _authenticatedUser.Value;
             AuthenticatedUser? user = await ReadUserAsync(cancellationToken);
             if (user != null)
             {
-                await user.RefreshAsync(cancellationToken);
+                try
+                {
+                    await user.RefreshAsync(cancellationToken);
 
-                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", user.Token);
-                await user.Profile.RefreshAsync(cancellationToken, true);
-                _authenticatedUser.Value = user;
-                SaveUser();
+                    _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", user.Token);
+                    await user.Profile.RefreshAsync(cancellationToken, true);
+                    _authenticatedUser.Value = user;
+                    SaveUser();
+                }
+                catch
+                {
+                    _authenticatedUser.Value = previousUser;
+                    if (previousAuthorization != null)
+                    {
+                        _httpClient.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse(previousAuthorization);
+                    }
+                    else
+                    {
+                        _httpClient.DefaultRequestHeaders.Authorization = null;
+                    }
+
+                    throw;
+                }
             }
         }
     }

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -233,15 +233,9 @@ public class BeutlApiApplication
             }, cancellationToken);
             activity?.AddEvent(new("Done_CodeToJwtAsync"));
 
-            _httpClient.DefaultRequestHeaders.Authorization =
-                new AuthenticationHeaderValue("Bearer", authResponse.Token);
-            ProfileResponse profileResponse = await Users.GetSelf(cancellationToken);
-            var profile = new Profile(profileResponse, this);
-
-            _authenticatedUser.Value = new AuthenticatedUser(profile, authResponse, this, _httpClient, DateTime.UtcNow);
-            SaveUser();
+            AuthenticatedUser user = await CompleteSignInAsync(authResponse, cancellationToken);
             activity?.AddEvent(new("Saved_User"));
-            return _authenticatedUser.Value;
+            return user;
         }
     }
 
@@ -278,16 +272,41 @@ public class BeutlApiApplication
                 }, cancellationToken);
                 activity?.AddEvent(new("Done_CodeToJwtAsync"));
 
-                _httpClient.DefaultRequestHeaders.Authorization =
-                    new AuthenticationHeaderValue("Bearer", authResponse.Token);
-                ProfileResponse profileResponse = await Users.GetSelf(cancellationToken);
-                var profile = new Profile(profileResponse, this);
-
-                _authenticatedUser.Value = new AuthenticatedUser(profile, authResponse, this, _httpClient, DateTime.UtcNow);
-                SaveUser();
+                AuthenticatedUser user = await CompleteSignInAsync(authResponse, cancellationToken);
                 activity?.AddEvent(new("Saved_User"));
-                return _authenticatedUser.Value;
+                return user;
             }
+        }
+    }
+
+    internal async Task<AuthenticatedUser> CompleteSignInAsync(
+        AuthResponse authResponse,
+        CancellationToken cancellationToken)
+    {
+        string? previousAuthorization = _httpClient.DefaultRequestHeaders.Authorization?.ToString();
+        _httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", authResponse.Token);
+        try
+        {
+            ProfileResponse profileResponse = await Users.GetSelf(cancellationToken);
+            var profile = new Profile(profileResponse, this);
+
+            _authenticatedUser.Value = new AuthenticatedUser(profile, authResponse, this, _httpClient, DateTime.UtcNow);
+            SaveUser();
+            return _authenticatedUser.Value;
+        }
+        catch
+        {
+            if (previousAuthorization != null)
+            {
+                _httpClient.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse(previousAuthorization);
+            }
+            else
+            {
+                _httpClient.DefaultRequestHeaders.Authorization = null;
+            }
+
+            throw;
         }
     }
 

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -206,36 +206,40 @@ public class BeutlApiApplication
     {
         using (Activity? activity = ActivitySource.StartActivity("SignInExternalAsync", ActivityKind.Client))
         {
-            string continueUri = $"http://localhost:{GetRandomUnusedPort()}/__/auth/handler";
-            CreateAuthUriResponse authUriRes = await Account.CreateAuthUri(new CreateAuthUriRequest
+            using (await Lock.LockAsync(cancellationToken))
             {
-                ContinueUri = continueUri
-            }, cancellationToken);
-            using HttpListener listener = StartListener($"{continueUri}/");
-            activity?.AddEvent(new("Started_Listener"));
+                activity?.AddEvent(new("Entered_AsyncLock"));
+                string continueUri = $"http://localhost:{GetRandomUnusedPort()}/__/auth/handler";
+                CreateAuthUriResponse authUriRes = await Account.CreateAuthUri(new CreateAuthUriRequest
+                {
+                    ContinueUri = continueUri
+                }, cancellationToken);
+                using HttpListener listener = StartListener($"{continueUri}/");
+                activity?.AddEvent(new("Started_Listener"));
 
-            string uri =
-                $"{BaseUrl}/api/v2/identity/signInWith?provider={provider}&returnUrl={Uri.EscapeDataString(authUriRes.AuthUri)}";
+                string uri =
+                    $"{BaseUrl}/api/v2/identity/signInWith?provider={provider}&returnUrl={Uri.EscapeDataString(authUriRes.AuthUri)}";
 
-            Process.Start(new ProcessStartInfo(uri) { UseShellExecute = true, Verb = "open" });
+                Process.Start(new ProcessStartInfo(uri) { UseShellExecute = true, Verb = "open" });
 
-            string? code = await GetResponseFromListener(listener, cancellationToken);
-            activity?.AddEvent(new("Received_Code"));
-            if (string.IsNullOrWhiteSpace(code))
-            {
-                throw new Exception("The returned code was empty.");
+                string? code = await GetResponseFromListener(listener, cancellationToken);
+                activity?.AddEvent(new("Received_Code"));
+                if (string.IsNullOrWhiteSpace(code))
+                {
+                    throw new Exception("The returned code was empty.");
+                }
+
+                AuthResponse authResponse = await Account.Exchange(new ExchangeRequest
+                {
+                    Code = code,
+                    SessionId = authUriRes.SessionId
+                }, cancellationToken);
+                activity?.AddEvent(new("Done_CodeToJwtAsync"));
+
+                AuthenticatedUser user = await CompleteSignInAsync(authResponse, cancellationToken);
+                activity?.AddEvent(new("Saved_User"));
+                return user;
             }
-
-            AuthResponse authResponse = await Account.Exchange(new ExchangeRequest
-            {
-                Code = code,
-                SessionId = authUriRes.SessionId
-            }, cancellationToken);
-            activity?.AddEvent(new("Done_CodeToJwtAsync"));
-
-            AuthenticatedUser user = await CompleteSignInAsync(authResponse, cancellationToken);
-            activity?.AddEvent(new("Saved_User"));
-            return user;
         }
     }
 

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -105,13 +105,15 @@ public class BeutlApiApplication
     // 更新があるかどうかをチェックします
     // このアプリケーションがアセットメタデータを持っている場合は、AppUpdateResponseを返します
     // そうでない場合は、CheckForUpdatesResponseを返します
-    public async Task<(CheckForUpdatesResponse? V1, AppUpdateResponse? V3)> CheckForUpdatesAsync(string version)
+    public async Task<(CheckForUpdatesResponse? V1, AppUpdateResponse? V3)> CheckForUpdatesAsync(
+        string version,
+        CancellationToken cancellationToken)
     {
         var metadata = await LoadMetadata();
-        if (metadata == null) return (await App.CheckForUpdates(version), null);
+        if (metadata == null) return (await App.CheckForUpdates(version, cancellationToken), null);
         var update = await App.GetUpdate(
             version, ToServerType(metadata.Type), metadata.OS, metadata.Arch,
-            metadata.Standalone, "false");
+            metadata.Standalone, "false", cancellationToken);
         return (null, update);
     }
 

--- a/src/Beutl.Api/Clients/IAccountClient.cs
+++ b/src/Beutl.Api/Clients/IAccountClient.cs
@@ -5,11 +5,17 @@ namespace Beutl.Api.Clients;
 public interface IAccountClient
 {
     [Post("/api/v1/account/createAuthUri")]
-    Task<CreateAuthUriResponse> CreateAuthUri([Body] CreateAuthUriRequest request);
+    Task<CreateAuthUriResponse> CreateAuthUri(
+        [Body] CreateAuthUriRequest request,
+        CancellationToken cancellationToken);
 
     [Post("/api/v1/account/refresh")]
-    Task<AuthResponse> Refresh([Body] RefreshTokenRequest request);
+    Task<AuthResponse> Refresh(
+        [Body] RefreshTokenRequest request,
+        CancellationToken cancellationToken);
 
     [Post("/api/v1/account/code2jwt")]
-    Task<AuthResponse> Exchange([Body] ExchangeRequest request);
+    Task<AuthResponse> Exchange(
+        [Body] ExchangeRequest request,
+        CancellationToken cancellationToken);
 }

--- a/src/Beutl.Api/Clients/IAppClient.cs
+++ b/src/Beutl.Api/Clients/IAppClient.cs
@@ -5,9 +5,16 @@ namespace Beutl.Api.Clients;
 public interface IAppClient
 {
     [Get("/api/v1/app/checkForUpdates/{version}")]
-    Task<CheckForUpdatesResponse> CheckForUpdates(string version);
+    Task<CheckForUpdatesResponse> CheckForUpdates(string version, CancellationToken cancellationToken);
 
 
     [Get("/api/v3/app/updates/{version}")]
-    Task<AppUpdateResponse> GetUpdate(string version, string type, string os, string arch, string standalone, string prerelease);
+    Task<AppUpdateResponse> GetUpdate(
+        string version,
+        string type,
+        string os,
+        string arch,
+        string standalone,
+        string prerelease,
+        CancellationToken cancellationToken);
 }

--- a/src/Beutl.Api/Clients/IDiscoverClient.cs
+++ b/src/Beutl.Api/Clients/IDiscoverClient.cs
@@ -5,8 +5,17 @@ namespace Beutl.Api.Clients;
 public interface IDiscoverClient
 {
     [Get("/api/v3/discover/search")]
-    Task<SimplePackageResponse[]> Search(string query, int start = 0, int count = 30, string type = "all");
+    Task<SimplePackageResponse[]> Search(
+        string query,
+        CancellationToken cancellationToken,
+        int start = 0,
+        int count = 30,
+        string type = "all");
 
     [Get("/api/v3/discover/featured")]
-    Task<SimplePackageResponse[]> GetFeatured(int start = 0, int count = 30, string type = "all");
+    Task<SimplePackageResponse[]> GetFeatured(
+        CancellationToken cancellationToken,
+        int start = 0,
+        int count = 30,
+        string type = "all");
 }

--- a/src/Beutl.Api/Clients/IFilesClient.cs
+++ b/src/Beutl.Api/Clients/IFilesClient.cs
@@ -5,5 +5,5 @@ namespace Beutl.Api.Clients;
 public interface IFilesClient
 {
     [Get("/api/v3/files/{id}")]
-    Task<FileResponse> GetFile(string id);
+    Task<FileResponse> GetFile(string id, CancellationToken cancellationToken);
 }

--- a/src/Beutl.Api/Clients/ILibraryClient.cs
+++ b/src/Beutl.Api/Clients/ILibraryClient.cs
@@ -5,11 +5,16 @@ namespace Beutl.Api.Clients;
 public interface ILibraryClient
 {
     [Post("/api/v3/account/library")]
-    Task<AcquirePackageResponse> AcquirePackage([Body] AcquirePackageRequest request);
+    Task<AcquirePackageResponse> AcquirePackage(
+        [Body] AcquirePackageRequest request,
+        CancellationToken cancellationToken);
 
     [Get("/api/v3/account/library")]
-    Task<AcquirePackageResponse[]> GetLibrary(int start = 0, int count = 30);
+    Task<AcquirePackageResponse[]> GetLibrary(
+        CancellationToken cancellationToken,
+        int start = 0,
+        int count = 30);
 
     [Delete("/api/v3/account/library/{name}")]
-    Task DeleteLibraryPackage(string name);
+    Task DeleteLibraryPackage(string name, CancellationToken cancellationToken);
 }

--- a/src/Beutl.Api/Clients/IPackagesClient.cs
+++ b/src/Beutl.Api/Clients/IPackagesClient.cs
@@ -5,5 +5,5 @@ namespace Beutl.Api.Clients;
 public interface IPackagesClient
 {
     [Get("/api/v3/packages/{name}")]
-    Task<PackageResponse> GetPackage(string name);
+    Task<PackageResponse> GetPackage(string name, CancellationToken cancellationToken);
 }

--- a/src/Beutl.Api/Clients/IReleasesClient.cs
+++ b/src/Beutl.Api/Clients/IReleasesClient.cs
@@ -5,8 +5,15 @@ namespace Beutl.Api.Clients;
 public interface IReleasesClient
 {
     [Get("/api/v3/packages/{name}/releases")]
-    Task<ReleaseResponse[]> GetReleases(string name, int start = 0, int count = 30);
+    Task<ReleaseResponse[]> GetReleases(
+        string name,
+        CancellationToken cancellationToken,
+        int start = 0,
+        int count = 30);
 
     [Get("/api/v3/packages/{name}/releases/{version}")]
-    Task<ReleaseResponse> GetRelease(string name, string version);
+    Task<ReleaseResponse> GetRelease(
+        string name,
+        string version,
+        CancellationToken cancellationToken);
 }

--- a/src/Beutl.Api/Clients/IUsersClient.cs
+++ b/src/Beutl.Api/Clients/IUsersClient.cs
@@ -5,11 +5,15 @@ namespace Beutl.Api.Clients;
 public interface IUsersClient
 {
     [Get("/api/v3/users/{name}")]
-    Task<ProfileResponse> GetUser(string name);
+    Task<ProfileResponse> GetUser(string name, CancellationToken cancellationToken);
 
     [Get("/api/v3/user")]
-    Task<ProfileResponse> GetSelf();
+    Task<ProfileResponse> GetSelf(CancellationToken cancellationToken);
 
     [Get("/api/v3/users/{name}/packages")]
-    Task<SimplePackageResponse[]> GetUserPackages(string name, int start = 0, int count = 30);
+    Task<SimplePackageResponse[]> GetUserPackages(
+        string name,
+        CancellationToken cancellationToken,
+        int start = 0,
+        int count = 30);
 }

--- a/src/Beutl.Api/MyAsyncLock.cs
+++ b/src/Beutl.Api/MyAsyncLock.cs
@@ -22,32 +22,14 @@ namespace Beutl.Api;
 public sealed class MyAsyncLock
 {
     private readonly SemaphoreSlim _semaphore = new(1, 1);
-    private readonly Task<IDisposable> _releaser;
 
-    public MyAsyncLock()
+    public async Task<IDisposable> LockAsync(CancellationToken cancellationToken = default)
     {
-        _releaser = Task.FromResult<IDisposable>(new Releaser(this));
-    }
-
-    public Task<IDisposable> LockAsync(CancellationToken cancellationToken = default)
-    {
-        Task wait = _semaphore.WaitAsync(cancellationToken);
-        if (wait.IsCompleted)
-        {
-            // A synchronously completed wait can still be canceled; propagate the
-            // cancellation instead of returning a releaser for a lock never acquired.
-            wait.GetAwaiter().GetResult();
-            return _releaser;
-        }
-        else
-        {
-            return wait.ContinueWith(
-                continuationFunction: (_, state) => (IDisposable)state!,
-                state: _releaser.Result,
-                cancellationToken: cancellationToken,
-                continuationOptions: TaskContinuationOptions.ExecuteSynchronously,
-                scheduler: TaskScheduler.Default);
-        }
+        // Awaiting the semaphore propagates cancellation and never returns a releaser for
+        // an acquisition that did not happen; there is no continuation that could be
+        // canceled after the semaphore was acquired.
+        await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        return new Releaser(this);
     }
 
     private sealed class Releaser(MyAsyncLock toRelease) : IDisposable

--- a/src/Beutl.Api/MyAsyncLock.cs
+++ b/src/Beutl.Api/MyAsyncLock.cs
@@ -34,6 +34,9 @@ public sealed class MyAsyncLock
         Task wait = _semaphore.WaitAsync(cancellationToken);
         if (wait.IsCompleted)
         {
+            // A synchronously completed wait can still be canceled; propagate the
+            // cancellation instead of returning a releaser for a lock never acquired.
+            wait.GetAwaiter().GetResult();
             return _releaser;
         }
         else

--- a/src/Beutl.Api/Objects/AuthorizedUser.cs
+++ b/src/Beutl.Api/Objects/AuthorizedUser.cs
@@ -29,7 +29,7 @@ public class AuthenticatedUser(
 
     public MyAsyncLock Lock => clients.Lock;
 
-    public async ValueTask RefreshAsync(bool force = false)
+    public async ValueTask RefreshAsync(CancellationToken cancellationToken, bool force = false)
     {
         using Activity? activity = clients.ActivitySource.StartActivity("AuthenticatedUser.Refresh", ActivityKind.Client);
 
@@ -62,7 +62,7 @@ public class AuthenticatedUser(
             {
                 RefreshToken = RefreshToken,
                 Token = Token
-            })
+            }, cancellationToken)
                 .ConfigureAwait(false);
             activity?.AddEvent(new("Refreshed"));
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);

--- a/src/Beutl.Api/Objects/AuthorizedUser.cs
+++ b/src/Beutl.Api/Objects/AuthorizedUser.cs
@@ -39,7 +39,7 @@ public class AuthenticatedUser(
             DateTime lastWriteTime = File.GetLastWriteTimeUtc(fileName);
             if (_writeTime < lastWriteTime)
             {
-                AuthenticatedUser? fileUser = await clients.ReadUserAsync();
+                AuthenticatedUser? fileUser = await clients.ReadUserAsync(cancellationToken);
                 if (fileUser?.Profile?.Id == Profile.Id)
                 {
                     _response = fileUser._response;

--- a/src/Beutl.Api/Objects/Package.cs
+++ b/src/Beutl.Api/Objects/Package.cs
@@ -85,28 +85,31 @@ public class Package
         };
     }
 
-    public async Task RefreshAsync()
+    public async Task RefreshAsync(CancellationToken cancellationToken)
     {
         using Activity? activity = _clients.ActivitySource.StartActivity("Package.Refresh", ActivityKind.Client);
 
-        _response.Value = await _clients.Packages.GetPackage(Name);
+        _response.Value = await _clients.Packages.GetPackage(Name, cancellationToken);
         _isDeleted.Value = false;
     }
 
-    public async Task<Release> GetReleaseAsync(string version)
+    public async Task<Release> GetReleaseAsync(string version, CancellationToken cancellationToken)
     {
         using Activity? activity = _clients.ActivitySource.StartActivity("Package.GetRelease", ActivityKind.Client);
-        ReleaseResponse response = await _clients.Releases.GetRelease(Name, version);
+        ReleaseResponse response = await _clients.Releases.GetRelease(Name, version, cancellationToken);
         return new Release(this, response, _clients);
     }
 
-    public async Task<Release[]> GetReleasesAsync(int start = 0, int count = 30)
+    public async Task<Release[]> GetReleasesAsync(
+        CancellationToken cancellationToken,
+        int start = 0,
+        int count = 30)
     {
         using Activity? activity = _clients.ActivitySource.StartActivity("Package.GetReleases", ActivityKind.Client);
         activity?.SetTag("start", start);
         activity?.SetTag("count", count);
 
-        return (await _clients.Releases.GetReleases(Name, start, count))
+        return (await _clients.Releases.GetReleases(Name, cancellationToken, start, count))
             .Select(x => new Release(this, x, _clients))
             .ToArray();
     }

--- a/src/Beutl.Api/Objects/Profile.cs
+++ b/src/Beutl.Api/Objects/Profile.cs
@@ -36,31 +36,34 @@ public class Profile
 
     public MyAsyncLock Lock => _clients.Lock;
 
-    public async Task RefreshAsync(bool self = false)
+    public async Task RefreshAsync(CancellationToken cancellationToken, bool self = false)
     {
         using Activity? activity = _clients.ActivitySource.StartActivity("Profile.Refresh", ActivityKind.Client);
 
         if (self)
         {
-            _response.Value = await _clients.Users.GetSelf();
+            _response.Value = await _clients.Users.GetSelf(cancellationToken);
             Name = _response.Value.Name;
         }
         else
         {
-            _response.Value = await _clients.Users.GetUser(Name);
+            _response.Value = await _clients.Users.GetUser(Name, cancellationToken);
         }
     }
 
-    public async Task<Package[]> GetPackagesAsync(int start = 0, int count = 30)
+    public async Task<Package[]> GetPackagesAsync(
+        CancellationToken cancellationToken,
+        int start = 0,
+        int count = 30)
     {
         using Activity? activity = _clients.ActivitySource.StartActivity("Profile.GetPackages", ActivityKind.Client);
         activity?.SetTag("start", start);
         activity?.SetTag("count", count);
 
         // TODO: System.Interactive.AsyncからSystem.Linq.Asyncが削除されれば、AsyncEnumerableを使った実装に戻す
-        return await (await _clients.Users.GetUserPackages(Name, start, count))
+        return await (await _clients.Users.GetUserPackages(Name, cancellationToken, start, count))
             .ToObservable()
-            .SelectMany(async x => await _clients.Packages.GetPackage(x.Name))
+            .SelectMany(async x => await _clients.Packages.GetPackage(x.Name, cancellationToken))
             .Select(x => new Package(this, x, _clients))
             .ToArray();
     }

--- a/src/Beutl.Api/Objects/Release.cs
+++ b/src/Beutl.Api/Objects/Release.cs
@@ -45,23 +45,25 @@ public class Release
 
     public ReadOnlyReactivePropertySlim<string?> AssetUrl { get; set; }
 
-    public async Task RefreshAsync()
+    public async Task RefreshAsync(CancellationToken cancellationToken)
     {
         using Activity? activity = _clients.ActivitySource.StartActivity("Release.Refresh", ActivityKind.Client);
 
-        _response.Value = await _clients.Releases.GetRelease(Package.Name, _response.Value.Version);
+        _response.Value = await _clients.Releases.GetRelease(
+            Package.Name,
+            _response.Value.Version,
+            cancellationToken);
 
         _isDeleted.Value = false;
     }
 
-    public async Task<FileResponse> GetAssetAsync()
+    public async Task<FileResponse> GetAssetAsync(CancellationToken cancellationToken)
     {
         using Activity? activity = _clients.ActivitySource.StartActivity("Release.GetAsset", ActivityKind.Client);
 
         if (AssetId.Value == null)
             throw new InvalidOperationException("This release has no assets.");
 
-        return await _clients.Files.GetFile(AssetId.Value!);
+        return await _clients.Files.GetFile(AssetId.Value!, cancellationToken);
     }
 }
-

--- a/src/Beutl.Api/Services/DiscoverService.cs
+++ b/src/Beutl.Api/Services/DiscoverService.cs
@@ -10,26 +10,29 @@ public class DiscoverService(BeutlApiApplication clients) : IBeutlApiResource
 {
     public MyAsyncLock Lock => clients.Lock;
 
-    public async Task<Package> GetPackage(string name)
+    public async Task<Package> GetPackage(string name, CancellationToken cancellationToken)
     {
         using Activity? activity = clients.ActivitySource.StartActivity("DiscoverService.GetPackage", ActivityKind.Client);
 
-        PackageResponse package = await clients.Packages.GetPackage(name).ConfigureAwait(false);
+        PackageResponse package = await clients.Packages.GetPackage(name, cancellationToken).ConfigureAwait(false);
         var owner = new Profile(package.Owner, clients);
 
         return new Package(owner, package, clients);
     }
 
-    public async Task<Profile> GetProfile(string name)
+    public async Task<Profile> GetProfile(string name, CancellationToken cancellationToken)
     {
         using Activity? activity = clients.ActivitySource.StartActivity("DiscoverService.GetProfile", ActivityKind.Client);
 
-        ProfileResponse response = await clients.Users.GetUser(name).ConfigureAwait(false);
+        ProfileResponse response = await clients.Users.GetUser(name, cancellationToken).ConfigureAwait(false);
         return new Profile(response, clients);
     }
 
     public async Task<Package[]> GetFeatured(
-        int start = 0, int count = 30, PackageKindFilter type = PackageKindFilter.All)
+        CancellationToken cancellationToken,
+        int start = 0,
+        int count = 30,
+        PackageKindFilter type = PackageKindFilter.All)
     {
         using Activity? activity = clients.ActivitySource.StartActivity("DiscoverService.GetFeatured", ActivityKind.Client);
         activity?.SetTag("start", start);
@@ -37,21 +40,25 @@ public class DiscoverService(BeutlApiApplication clients) : IBeutlApiResource
         activity?.SetTag("type", type.ToString());
 
         // TODO: System.Interactive.AsyncからSystem.Linq.Asyncが削除されれば、AsyncEnumerableを使った実装に戻す
-        return await (await clients.Discover.GetFeatured(start, count, type.ToQueryValue()).ConfigureAwait(false))
+        return await (await clients.Discover.GetFeatured(cancellationToken, start, count, type.ToQueryValue()).ConfigureAwait(false))
             .ToObservable()
-            .SelectMany(async x => await GetPackage(x.Name).ConfigureAwait(false))
+            .SelectMany(async x => await GetPackage(x.Name, cancellationToken).ConfigureAwait(false))
             .ToArray()
             .ToTask()
             .ConfigureAwait(false);
     }
 
     public async Task<Package[]> Search(
-        string query, int start = 0, int count = 30, PackageKindFilter type = PackageKindFilter.All)
+        string query,
+        CancellationToken cancellationToken,
+        int start = 0,
+        int count = 30,
+        PackageKindFilter type = PackageKindFilter.All)
     {
         // TODO: System.Interactive.AsyncからSystem.Linq.Asyncが削除されれば、AsyncEnumerableを使った実装に戻す
-        return await (await clients.Discover.Search(query, start, count, type.ToQueryValue()).ConfigureAwait(false))
+        return await (await clients.Discover.Search(query, cancellationToken, start, count, type.ToQueryValue()).ConfigureAwait(false))
             .ToObservable()
-            .SelectMany(async x => await GetPackage(x.Name).ConfigureAwait(false))
+            .SelectMany(async x => await GetPackage(x.Name, cancellationToken).ConfigureAwait(false))
             .ToArray()
             .ToTask()
             .ConfigureAwait(false);

--- a/src/Beutl.Api/Services/Helper.cs
+++ b/src/Beutl.Api/Services/Helper.cs
@@ -154,6 +154,10 @@ internal static class Helper
         {
             return func();
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch
         {
             return default;
@@ -165,6 +169,10 @@ internal static class Helper
         try
         {
             return await func().ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch
         {

--- a/src/Beutl.Api/Services/Helper.cs
+++ b/src/Beutl.Api/Services/Helper.cs
@@ -164,13 +164,15 @@ internal static class Helper
         }
     }
 
-    public static async Task<T?> TryGetOrDefault<T>(Func<Task<T>> func)
+    public static async Task<T?> TryGetOrDefault<T>(
+        Func<Task<T>> func,
+        CancellationToken cancellationToken)
     {
         try
         {
             return await func().ConfigureAwait(false);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }

--- a/src/Beutl.Api/Services/LibraryService.cs
+++ b/src/Beutl.Api/Services/LibraryService.cs
@@ -7,53 +7,56 @@ namespace Beutl.Api.Services;
 
 public class LibraryService(BeutlApiApplication clients) : IBeutlApiResource
 {
-    public async Task<Package> GetPackage(string name)
+    public async Task<Package> GetPackage(string name, CancellationToken cancellationToken)
     {
         using Activity? activity = clients.ActivitySource.StartActivity("LibraryService.GetPackage", ActivityKind.Client);
-        PackageResponse package = await clients.Packages.GetPackage(name);
+        PackageResponse package = await clients.Packages.GetPackage(name, cancellationToken);
         var owner = new Profile(package.Owner, clients);
 
         return new Package(owner, package, clients);
     }
 
-    public async Task<Profile> GetProfile(string name)
+    public async Task<Profile> GetProfile(string name, CancellationToken cancellationToken)
     {
         using Activity? activity = clients.ActivitySource.StartActivity("LibraryService.GetProfile", ActivityKind.Client);
-        ProfileResponse response = await clients.Users.GetUser(name);
+        ProfileResponse response = await clients.Users.GetUser(name, cancellationToken);
         return new Profile(response, clients);
     }
 
-    public async Task<Package[]> GetPackages(int start = 0, int count = 30)
+    public async Task<Package[]> GetPackages(
+        CancellationToken cancellationToken,
+        int start = 0,
+        int count = 30)
     {
         using Activity? activity = clients.ActivitySource.StartActivity("LibraryService.GetPackages", ActivityKind.Client);
         activity?.SetTag("start", start);
         activity?.SetTag("count", count);
 
         // TODO: System.Interactive.AsyncからSystem.Linq.Asyncが削除されれば、AsyncEnumerableを使った実装に戻す
-        return await (await clients.Library.GetLibrary(start, count))
+        return await (await clients.Library.GetLibrary(cancellationToken, start, count))
             .ToObservable()
-            .SelectMany(async x => await GetPackage(x.Package.Name))
+            .SelectMany(async x => await GetPackage(x.Package.Name, cancellationToken))
             .ToArray();
     }
 
-    public async Task<Release> Acquire(Package package)
+    public async Task<Release> Acquire(Package package, CancellationToken cancellationToken)
     {
         using Activity? activity = clients.ActivitySource.StartActivity("LibraryService.GetPackage", ActivityKind.Client);
 
         AcquirePackageResponse response = await clients.Library.AcquirePackage(new AcquirePackageRequest
         {
             PackageId = package.Id
-        });
+        }, cancellationToken);
         if (response.LatestRelease == null)
             throw new Exception("No release");
 
         return new Release(package, response.LatestRelease, clients);
     }
 
-    public async Task RemovePackage(Package package)
+    public async Task RemovePackage(Package package, CancellationToken cancellationToken)
     {
         using Activity? activity = clients.ActivitySource.StartActivity("LibraryService.RemovePackage", ActivityKind.Client);
 
-        await clients.Library.DeleteLibraryPackage(package.Name);
+        await clients.Library.DeleteLibraryPackage(package.Name, cancellationToken);
     }
 }

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -414,6 +414,10 @@ public partial class PackageInstaller : IBeutlApiResource
                 await user.RefreshAsync(cancellationToken);
                 request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", user.Token);
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to refresh authenticated user. Proceeding without authentication.");

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -118,7 +118,7 @@ public partial class PackageInstaller : IBeutlApiResource
         }
         else
         {
-            var asset = await release.GetAssetAsync().ConfigureAwait(false);
+            var asset = await release.GetAssetAsync(cancellationToken).ConfigureAwait(false);
 
             context = new PackageInstallContext(name, version, asset.DownloadUrl)
             {
@@ -411,7 +411,7 @@ public partial class PackageInstaller : IBeutlApiResource
         {
             try
             {
-                await user.RefreshAsync();
+                await user.RefreshAsync(cancellationToken);
                 request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", user.Token);
             }
             catch (Exception ex)

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -414,7 +414,7 @@ public partial class PackageInstaller : IBeutlApiResource
                 await user.RefreshAsync(cancellationToken);
                 request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", user.Token);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 throw;
             }

--- a/src/Beutl.Api/Services/PackageManager.cs
+++ b/src/Beutl.Api/Services/PackageManager.cs
@@ -62,8 +62,9 @@ public sealed class PackageManager(
         return list;
     }
 
-    public async Task<IReadOnlyList<PackageUpdate>> CheckUpdate()
+    public async Task<IReadOnlyList<PackageUpdate>> CheckUpdate(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         using (Activity? activity = Telemetry.ActivitySource.StartActivity("CheckUpdate"))
         {
             PackageIdentity[] packages = installedPackageRepository.GetLocalPackages().ToArray();
@@ -73,6 +74,7 @@ public sealed class PackageManager(
 
             for (int i = 0; i < packages.Length; i++)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 PackageIdentity pkg = packages[i];
                 NuGetVersion version = pkg.Version;
                 string versionStr = version.ToString();
@@ -81,18 +83,19 @@ public sealed class PackageManager(
                     activity?.AddEvent(new("Checking updates"));
                     activity?.SetTag("PackageId", pkg.Id);
                     activity?.SetTag("Version", versionStr);
-                    Package remotePackage = await discover.GetPackage(pkg.Id).ConfigureAwait(false);
+                    Package remotePackage = await discover.GetPackage(pkg.Id, cancellationToken).ConfigureAwait(false);
                     activity?.AddEvent(new("Checked updates"));
 
-                    Release[] releases = await remotePackage.GetReleasesAsync().ConfigureAwait(false);
+                    Release[] releases = await remotePackage.GetReleasesAsync(cancellationToken).ConfigureAwait(false);
 
                     foreach (Release? item in releases)
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
                         // 降順
                         if (new NuGetVersion(item.Version.Value).CompareTo(version) > 0)
                         {
                             Release? oldRelease = await Helper
-                                .TryGetOrDefault(() => remotePackage.GetReleaseAsync(versionStr))
+                                .TryGetOrDefault(() => remotePackage.GetReleaseAsync(versionStr, cancellationToken))
                                 .ConfigureAwait(false);
                             updates.Add(new PackageUpdate(remotePackage, oldRelease, item));
                             _logger.LogInformation("Update found for package {PackageId}: {OldVersion} -> {NewVersion}", pkg.Id, versionStr, item.Version.Value);
@@ -111,8 +114,9 @@ public sealed class PackageManager(
         }
     }
 
-    public async Task<PackageUpdate?> CheckUpdate(string name)
+    public async Task<PackageUpdate?> CheckUpdate(string name, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         using (Activity? activity = Telemetry.ActivitySource.StartActivity("CheckUpdate"))
         {
             DiscoverService discover = apiApplication.GetResource<DiscoverService>();
@@ -128,18 +132,19 @@ public sealed class PackageManager(
                 activity?.AddEvent(new("Checking updates"));
                 activity?.SetTag("PackageName", pkg.Name);
                 activity?.SetTag("Version", versionStr);
-                Package remotePackage = await discover.GetPackage(pkg.Name).ConfigureAwait(false);
+                Package remotePackage = await discover.GetPackage(pkg.Name, cancellationToken).ConfigureAwait(false);
                 activity?.AddEvent(new("Checked updates"));
 
-                Release[] releases = await remotePackage.GetReleasesAsync().ConfigureAwait(false);
+                Release[] releases = await remotePackage.GetReleasesAsync(cancellationToken).ConfigureAwait(false);
 
                 foreach (Release? item in releases)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     // 降順
                     if (new NuGetVersion(item.Version.Value).CompareTo(version) > 0)
                     {
                         Release? oldRelease = await Helper
-                            .TryGetOrDefault(() => remotePackage.GetReleaseAsync(pkg.Version))
+                            .TryGetOrDefault(() => remotePackage.GetReleaseAsync(pkg.Version, cancellationToken))
                             .ConfigureAwait(false);
                         _logger.LogInformation("Update found for package {PackageName}: {OldVersion} -> {NewVersion}", pkg.Name, versionStr, item.Version.Value);
                         return new PackageUpdate(remotePackage, oldRelease, item);

--- a/src/Beutl.Api/Services/PackageManager.cs
+++ b/src/Beutl.Api/Services/PackageManager.cs
@@ -95,7 +95,9 @@ public sealed class PackageManager(
                         if (new NuGetVersion(item.Version.Value).CompareTo(version) > 0)
                         {
                             Release? oldRelease = await Helper
-                                .TryGetOrDefault(() => remotePackage.GetReleaseAsync(versionStr, cancellationToken))
+                                .TryGetOrDefault(
+                                    () => remotePackage.GetReleaseAsync(versionStr, cancellationToken),
+                                    cancellationToken)
                                 .ConfigureAwait(false);
                             updates.Add(new PackageUpdate(remotePackage, oldRelease, item));
                             _logger.LogInformation("Update found for package {PackageId}: {OldVersion} -> {NewVersion}", pkg.Id, versionStr, item.Version.Value);
@@ -148,7 +150,9 @@ public sealed class PackageManager(
                     if (new NuGetVersion(item.Version.Value).CompareTo(version) > 0)
                     {
                         Release? oldRelease = await Helper
-                            .TryGetOrDefault(() => remotePackage.GetReleaseAsync(pkg.Version, cancellationToken))
+                            .TryGetOrDefault(
+                                () => remotePackage.GetReleaseAsync(pkg.Version, cancellationToken),
+                                cancellationToken)
                             .ConfigureAwait(false);
                         _logger.LogInformation("Update found for package {PackageName}: {OldVersion} -> {NewVersion}", pkg.Name, versionStr, item.Version.Value);
                         return new PackageUpdate(remotePackage, oldRelease, item);

--- a/src/Beutl.Api/Services/PackageManager.cs
+++ b/src/Beutl.Api/Services/PackageManager.cs
@@ -103,6 +103,10 @@ public sealed class PackageManager(
                         }
                     }
                 }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex,

--- a/src/Beutl.PackageTools.UI/Models/ChangesModel.cs
+++ b/src/Beutl.PackageTools.UI/Models/ChangesModel.cs
@@ -68,6 +68,7 @@ public class ChangesModel
             }
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
         foreach (PackageChangeModel item in installViewModels)
         {
             InstallItems.Add(item);

--- a/src/Beutl.PackageTools.UI/Models/ChangesModel.cs
+++ b/src/Beutl.PackageTools.UI/Models/ChangesModel.cs
@@ -17,6 +17,7 @@ public class ChangesModel
         string[] updateItems,
         CancellationToken cancellationToken)
     {
+        var installViewModels = new List<PackageChangeModel>();
         var hash = new HashSet<string>();
         foreach (string item in installItems)
         {
@@ -29,10 +30,11 @@ public class ChangesModel
 
             if (itemViewModel != null && hash.Add(itemViewModel.Id))
             {
-                InstallItems.Add(itemViewModel);
+                installViewModels.Add(itemViewModel);
             }
         }
 
+        var updateViewModels = new List<PackageChangeModel>();
         hash.Clear();
         foreach (string item in updateItems)
         {
@@ -45,10 +47,11 @@ public class ChangesModel
 
             if (itemViewModel != null && hash.Add(itemViewModel.Id))
             {
-                UpdateItems.Add(itemViewModel);
+                updateViewModels.Add(itemViewModel);
             }
         }
 
+        var uninstallViewModels = new List<PackageChangeModel>();
         hash.Clear();
         foreach (string item in uninstallItems)
         {
@@ -61,8 +64,23 @@ public class ChangesModel
 
             if (itemViewModel != null && hash.Add(itemViewModel.Id))
             {
-                UninstallItems.Add(itemViewModel);
+                uninstallViewModels.Add(itemViewModel);
             }
+        }
+
+        foreach (PackageChangeModel item in installViewModels)
+        {
+            InstallItems.Add(item);
+        }
+
+        foreach (PackageChangeModel item in updateViewModels)
+        {
+            UpdateItems.Add(item);
+        }
+
+        foreach (PackageChangeModel item in uninstallViewModels)
+        {
+            UninstallItems.Add(item);
         }
     }
 }

--- a/src/Beutl.PackageTools.UI/Models/ChangesModel.cs
+++ b/src/Beutl.PackageTools.UI/Models/ChangesModel.cs
@@ -12,12 +12,20 @@ public class ChangesModel
 
     public async Task Load(
         BeutlApiApplication apiApp,
-        string[] installItems, string[] uninstallItems, string[] updateItems)
+        string[] installItems,
+        string[] uninstallItems,
+        string[] updateItems,
+        CancellationToken cancellationToken)
     {
         var hash = new HashSet<string>();
         foreach (string item in installItems)
         {
-            PackageChangeModel? itemViewModel = await PackageChangeModel.TryParse(apiApp, item, PackageChangeAction.Install);
+            cancellationToken.ThrowIfCancellationRequested();
+            PackageChangeModel? itemViewModel = await PackageChangeModel.TryParse(
+                apiApp,
+                item,
+                PackageChangeAction.Install,
+                cancellationToken);
 
             if (itemViewModel != null && hash.Add(itemViewModel.Id))
             {
@@ -28,7 +36,12 @@ public class ChangesModel
         hash.Clear();
         foreach (string item in updateItems)
         {
-            PackageChangeModel? itemViewModel = await PackageChangeModel.TryParse(apiApp, item, PackageChangeAction.Uninstall);
+            cancellationToken.ThrowIfCancellationRequested();
+            PackageChangeModel? itemViewModel = await PackageChangeModel.TryParse(
+                apiApp,
+                item,
+                PackageChangeAction.Update,
+                cancellationToken);
 
             if (itemViewModel != null && hash.Add(itemViewModel.Id))
             {
@@ -39,7 +52,12 @@ public class ChangesModel
         hash.Clear();
         foreach (string item in uninstallItems)
         {
-            PackageChangeModel? itemViewModel = await PackageChangeModel.TryParse(apiApp, item, PackageChangeAction.Uninstall);
+            cancellationToken.ThrowIfCancellationRequested();
+            PackageChangeModel? itemViewModel = await PackageChangeModel.TryParse(
+                apiApp,
+                item,
+                PackageChangeAction.Uninstall,
+                cancellationToken);
 
             if (itemViewModel != null && hash.Add(itemViewModel.Id))
             {

--- a/src/Beutl.PackageTools.UI/Models/DownloadTaskModel.cs
+++ b/src/Beutl.PackageTools.UI/Models/DownloadTaskModel.cs
@@ -95,8 +95,8 @@ public class DownloadTaskModel : IProgress<double>
             IsProgressBarVisible.Value = true;
             IsIndeterminate.Value = true;
 
-            Package package = await discover.GetPackage(_model.Id);
-            Release release = await package.GetReleaseAsync(_model.Version.ToString());
+            Package package = await discover.GetPackage(_model.Id, token);
+            Release release = await package.GetReleaseAsync(_model.Version.ToString(), token);
 
             Context = await installer.PrepareForInstall(release, true, token);
             DownloadMessage.Value = string.Format(Strings.Downloading_XXX, PackageFileName);

--- a/src/Beutl.PackageTools.UI/Models/PackageChangeModel.cs
+++ b/src/Beutl.PackageTools.UI/Models/PackageChangeModel.cs
@@ -105,6 +105,10 @@ public record PackageChangeModel(
                     Conflict = CheckLocalSource(pkg)
                 };
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 s_logger.LogError(ex, "An exception occurred while discovering package {PackageId}", pkg.Id);
@@ -147,6 +151,10 @@ public record PackageChangeModel(
                 {
                     s_logger.LogWarning("No releases found for package {PackageId}", s);
                 }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {

--- a/src/Beutl.PackageTools.UI/Models/PackageChangeModel.cs
+++ b/src/Beutl.PackageTools.UI/Models/PackageChangeModel.cs
@@ -61,6 +61,10 @@ public record PackageChangeModel(
                     AlreadyInstalled = alreadyInstalled
                 };
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 s_logger.LogError(ex, "An exception occurred while reading nupkg file for package {PackageId} at path {Path}", package.Id, localNupkgPath);

--- a/src/Beutl.PackageTools.UI/Models/PackageChangeModel.cs
+++ b/src/Beutl.PackageTools.UI/Models/PackageChangeModel.cs
@@ -39,7 +39,11 @@ public record PackageChangeModel(
         return File.Exists(localNupkgPath);
     }
 
-    private static async Task<PackageChangeModel?> ReadLocalSource(PackageIdentity package, bool alreadyInstalled, PackageChangeAction action)
+    private static async Task<PackageChangeModel?> ReadLocalSource(
+        PackageIdentity package,
+        bool alreadyInstalled,
+        PackageChangeAction action,
+        CancellationToken cancellationToken)
     {
         string localNupkgPath = Path.Combine(Helper.LocalSourcePath, $"{package}.nupkg");
         s_logger.LogDebug("Reading local source for package {PackageId} at path {Path}", package.Id, localNupkgPath);
@@ -48,7 +52,7 @@ public record PackageChangeModel(
             try
             {
                 using var reader = new PackageArchiveReader(localNupkgPath);
-                NuspecReader nuspec = await reader.GetNuspecReaderAsync(default);
+                NuspecReader nuspec = await reader.GetNuspecReaderAsync(cancellationToken);
                 s_logger.LogInformation("Successfully read local package {PackageId} from path {Path}", package.Id, localNupkgPath);
                 return new PackageChangeModel(package.Id, package.Version, nuspec.GetTitle() ?? package.Id, false, action)
                 {
@@ -70,8 +74,13 @@ public record PackageChangeModel(
         return null;
     }
 
-    public static async ValueTask<PackageChangeModel?> TryParse(BeutlApiApplication apiApp, string s, PackageChangeAction action)
+    public static async ValueTask<PackageChangeModel?> TryParse(
+        BeutlApiApplication apiApp,
+        string s,
+        PackageChangeAction action,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         InstalledPackageRepository repos = apiApp.GetResource<InstalledPackageRepository>();
         DiscoverService discover = apiApp.GetResource<DiscoverService>();
         string[] splited = s.Split('/');
@@ -85,7 +94,7 @@ public record PackageChangeModel(
             try
             {
                 s_logger.LogDebug("Attempting to discover package {PackageId}", pkg.Id);
-                Package package = await discover.GetPackage(pkg.Id);
+                Package package = await discover.GetPackage(pkg.Id, cancellationToken);
                 s_logger.LogInformation("Successfully discovered package {PackageId}", pkg.Id);
                 item = new PackageChangeModel(pkg.Id, pkg.Version, package.DisplayName.Value ?? pkg.Id, true, action)
                 {
@@ -105,7 +114,7 @@ public record PackageChangeModel(
                 }
                 else if (CheckLocalSource(pkg))
                 {
-                    item = await ReadLocalSource(pkg, alreadyInstalled, action);
+                    item = await ReadLocalSource(pkg, alreadyInstalled, action, cancellationToken);
                 }
             }
 
@@ -116,8 +125,8 @@ public record PackageChangeModel(
             try
             {
                 s_logger.LogDebug("Attempting to discover package {PackageId}", s);
-                Package package = await discover.GetPackage(s);
-                Release[] releases = await package.GetReleasesAsync(0, 1);
+                Package package = await discover.GetPackage(s, cancellationToken);
+                Release[] releases = await package.GetReleasesAsync(cancellationToken, 0, 1);
 
                 if (releases.Length > 0)
                 {

--- a/src/Beutl.PackageTools.UI/ViewModels/MainViewModel.cs
+++ b/src/Beutl.PackageTools.UI/ViewModels/MainViewModel.cs
@@ -70,7 +70,7 @@ public class MainViewModel
 
             try
             {
-                await _model.Load(_app, installItems, uninstallItems, updateItems);
+                await _model.Load(_app, installItems, uninstallItems, updateItems, CancellationToken.None);
 
                 _viewModels.AddRange(InstallItems.Concat(UpdateItems)
                     .Concat(UninstallItems)

--- a/src/Beutl.PackageTools.UI/ViewModels/MainViewModel.cs
+++ b/src/Beutl.PackageTools.UI/ViewModels/MainViewModel.cs
@@ -54,7 +54,7 @@ public class MainViewModel
             IsBusy.Value = true;
             try
             {
-                await _app.RestoreUserAsync(null);
+                await _app.RestoreUserAsync(null, CancellationToken.None);
             }
             catch (Exception ex)
             {

--- a/src/Beutl/Services/StartupTasks/AuthenticationTask.cs
+++ b/src/Beutl/Services/StartupTasks/AuthenticationTask.cs
@@ -20,7 +20,7 @@ public sealed class AuthenticationTask : StartupTask
             {
                 try
                 {
-                    await _beutlApiApplication.RestoreUserAsync(activity);
+                    await _beutlApiApplication.RestoreUserAsync(activity, CancellationToken.None);
                 }
                 catch (Exception e)
                 {

--- a/src/Beutl/Services/StartupTasks/CheckForPackageUpdatesTask.cs
+++ b/src/Beutl/Services/StartupTasks/CheckForPackageUpdatesTask.cs
@@ -25,7 +25,7 @@ public sealed class CheckForPackageUpdatesTask : StartupTask
 
                 try
                 {
-                    IReadOnlyList<PackageUpdate> updates = await packageManager.CheckUpdate();
+                    IReadOnlyList<PackageUpdate> updates = await packageManager.CheckUpdate(CancellationToken.None);
                     activity?.SetTag("UpdateCount", updates.Count);
 
                     if (updates.Count > 0)

--- a/src/Beutl/Services/StartupTasks/CheckForUpdatesTask.cs
+++ b/src/Beutl/Services/StartupTasks/CheckForUpdatesTask.cs
@@ -146,7 +146,7 @@ public sealed class CheckForUpdatesTask : StartupTask
     {
         try
         {
-            return await _beutlApiApplication.CheckForUpdatesAsync(BeutlApplication.Version);
+            return await _beutlApiApplication.CheckForUpdatesAsync(BeutlApplication.Version, CancellationToken.None);
         }
         catch (Exception ex)
         {

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPageViewModel.cs
@@ -111,10 +111,10 @@ public sealed class DiscoverPageViewModel : BasePageViewModel, ISupportRefreshVi
             activity?.AddEvent(new("Entered_AsyncLock"));
             if (_apiApp.AuthenticatedUser.Value != null)
             {
-                await _apiApp.AuthenticatedUser.Value.RefreshAsync();
+                await _apiApp.AuthenticatedUser.Value.RefreshAsync(CancellationToken.None);
             }
 
-            return await _discover.GetFeatured(start, count, Kind.Selected);
+            return await _discover.GetFeatured(CancellationToken.None, start, count, Kind.Selected);
         }
     }
 

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
@@ -363,13 +363,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
             return SelectedRelease.Value;
         }
 
-        Release[] releases = await Package.GetReleasesAsync(CancellationToken.None, 0, 1);
-        if (releases.Length == 0)
-        {
-            throw new InvalidOperationException($"Package '{Package.Name}' has no releases.");
-        }
-
-        return releases[0];
+        return await PackageReleaseResolver.GetFirstReleaseAsync(Package, CancellationToken.None);
     }
 
     public Package Package { get; }

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
@@ -59,8 +59,11 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                         IsBusy.Value = true;
                         await PackageReleaseRefreshCoordinator.RefreshAsync(
                             releasesReady,
-                            Package.RefreshAsync,
-                            package.GetReleasesAsync,
+                            () => Package.RefreshAsync(CancellationToken.None),
+                            (start, count) => package.GetReleasesAsync(
+                                CancellationToken.None,
+                                start,
+                                count),
                             releases =>
                             {
                                 AllReleases.Clear();
@@ -128,7 +131,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                 AvaloniaScheduler.Instance,
                 () => SelectedRelease.Value,
                 () => AllReleases,
-                Package.GetReleaseAsync,
+                version => Package.GetReleaseAsync(version, CancellationToken.None),
                 ex => _logger.LogWarning(ex, "Failed to resolve installed release for {PackageId}.", Package.Name))
             .Subscribe(release => CurrentRelease.Value = release)
             .DisposeWith(_disposables);
@@ -351,8 +354,8 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
     {
         if (_app.AuthenticatedUser.Value != null)
         {
-            await _app.AuthenticatedUser.Value.RefreshAsync();
-            await _library.Acquire(Package);
+            await _app.AuthenticatedUser.Value.RefreshAsync(CancellationToken.None);
+            await _library.Acquire(Package, CancellationToken.None);
         }
 
         if (SelectedRelease.Value != null)
@@ -360,7 +363,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
             return SelectedRelease.Value;
         }
 
-        return (await Package.GetReleasesAsync())[0];
+        return (await Package.GetReleasesAsync(CancellationToken.None))[0];
     }
 
     public Package Package { get; }

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
@@ -363,7 +363,13 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
             return SelectedRelease.Value;
         }
 
-        return (await Package.GetReleasesAsync(CancellationToken.None))[0];
+        Release[] releases = await Package.GetReleasesAsync(CancellationToken.None, 0, 1);
+        if (releases.Length == 0)
+        {
+            throw new InvalidOperationException($"Package '{Package.Name}' has no releases.");
+        }
+
+        return releases[0];
     }
 
     public Package Package { get; }

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageReleaseResolver.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageReleaseResolver.cs
@@ -8,6 +8,17 @@ namespace Beutl.ViewModels.ExtensionsPages.DiscoverPages;
 
 internal static class PackageReleaseResolver
 {
+    public static async Task<Release> GetFirstReleaseAsync(Package package, CancellationToken cancellationToken)
+    {
+        Release[] releases = await package.GetReleasesAsync(cancellationToken, 0, 1);
+        if (releases.Length == 0)
+        {
+            throw new InvalidOperationException($"Package '{package.Name}' has no releases.");
+        }
+
+        return releases[0];
+    }
+
     public static IObservable<PackageIdentity?> ObserveWhenReleasesReady(
         IObservable<PackageIdentity?> installedPackages,
         IObservable<bool> releasesReady,

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/SearchPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/SearchPageViewModel.cs
@@ -88,7 +88,7 @@ public sealed class SearchPageViewModel : BasePageViewModel, ISupportRefreshView
 
     private async Task<Package[]> SearchPackages(int start, int count)
     {
-        return await _discoverService.Search(Keyword, start, count, Kind.Selected);
+        return await _discoverService.Search(Keyword, CancellationToken.None, start, count, Kind.Selected);
     }
 
     private async Task RefreshPackages()

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/UserProfilePageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/UserProfilePageViewModel.cs
@@ -30,7 +30,7 @@ public sealed class UserProfilePageViewModel : BasePageViewModel, ISupportRefres
                     {
                         activity?.AddEvent(new("Entered_AsyncLock"));
                         IsBusy.Value = true;
-                        await Profile.RefreshAsync();
+                        await Profile.RefreshAsync(CancellationToken.None);
                         await RefreshPackages();
                     }
                 }
@@ -90,7 +90,7 @@ public sealed class UserProfilePageViewModel : BasePageViewModel, ISupportRefres
 
     private async Task RefreshPackages()
     {
-        Package[] array = await Profile.GetPackagesAsync(0, 30);
+        Package[] array = await Profile.GetPackagesAsync(CancellationToken.None, 0, 30);
         Packages.Clear();
         Packages.AddRange(array);
 
@@ -103,7 +103,7 @@ public sealed class UserProfilePageViewModel : BasePageViewModel, ISupportRefres
     private async Task MoreLoadPackages()
     {
         Packages.RemoveAt(Packages.Count - 1);
-        Package[] array = await Profile.GetPackagesAsync(Packages.Count, 30);
+        Package[] array = await Profile.GetPackagesAsync(CancellationToken.None, Packages.Count, 30);
         Packages.AddRange(array);
 
         if (array.Length == 30)

--- a/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
@@ -48,7 +48,7 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
 
                         if (_user != null)
                         {
-                            await _user.RefreshAsync();
+                            await _user.RefreshAsync(CancellationToken.None);
                         }
 
                         await RefreshPackages(_user != null);
@@ -86,11 +86,11 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
 
                         if (_user != null)
                         {
-                            await _user.RefreshAsync();
+                            await _user.RefreshAsync(CancellationToken.None);
                         }
 
                         PackageManager manager = _clients.GetResource<PackageManager>();
-                        foreach (PackageUpdate item in await manager.CheckUpdate())
+                        foreach (PackageUpdate item in await manager.CheckUpdate(CancellationToken.None))
                         {
                             LocalUserPackageViewModel? localPackage = LocalPackages.FirstOrDefault(
                                 x => x.Package.Name.Equals(item.Package.Name, StringComparison.OrdinalIgnoreCase));
@@ -154,7 +154,7 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
             DiscoverService discover = _clients.GetResource<DiscoverService>();
             try
             {
-                return await discover.GetPackage(localPackage.Name);
+                return await discover.GetPackage(localPackage.Name, CancellationToken.None);
             }
             catch
             {
@@ -214,7 +214,7 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
             {
                 try
                 {
-                    remote = await discover.GetPackage(name);
+                    remote = await discover.GetPackage(name, CancellationToken.None);
                 }
                 catch
                 {
@@ -237,11 +237,11 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
     private async Task<List<Package>> LoadAll()
     {
         var list = new List<Package>();
-        Package[] array = await _service.GetPackages(0, 30);
+        Package[] array = await _service.GetPackages(CancellationToken.None, 0, 30);
         list.AddRange(array);
         while (array.Length == 30)
         {
-            array = await _service.GetPackages(list.Count, 30);
+            array = await _service.GetPackages(CancellationToken.None, list.Count, 30);
             list.AddRange(array);
         }
 

--- a/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
@@ -299,7 +299,13 @@ public sealed class RemoteUserPackageViewModel : BaseViewModel, IUserPackageView
             return await _library.Acquire(Package, CancellationToken.None);
         }
 
-        return (await Package.GetReleasesAsync(CancellationToken.None))[0];
+        Release[] releases = await Package.GetReleasesAsync(CancellationToken.None, 0, 1);
+        if (releases.Length == 0)
+        {
+            throw new InvalidOperationException($"Package '{Package.Name}' has no releases.");
+        }
+
+        return releases[0];
     }
 
     public Package Package { get; }

--- a/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
@@ -4,12 +4,12 @@ using Beutl.Api.Objects;
 using Beutl.Api.Services;
 using Beutl.Logging;
 using Beutl.Services;
+using Beutl.ViewModels.ExtensionsPages.DiscoverPages;
 using FluentAvalonia.UI.Controls;
 using Microsoft.Extensions.Logging;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using Reactive.Bindings;
-using Beutl.ViewModels.ExtensionsPages.DiscoverPages;
 using LibraryService = Beutl.Api.Services.LibraryService;
 
 namespace Beutl.ViewModels.ExtensionsPages;

--- a/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
@@ -71,7 +71,7 @@ public sealed class RemoteUserPackageViewModel : BaseViewModel, IUserPackageView
                         activity?.AddEvent(new("Entered_AsyncLock"));
                         if (_app.AuthenticatedUser.Value != null)
                         {
-                            await _app.AuthenticatedUser.Value.RefreshAsync();
+                            await _app.AuthenticatedUser.Value.RefreshAsync(CancellationToken.None);
                         }
 
                         Release release = await AcquirePackage();
@@ -127,7 +127,7 @@ public sealed class RemoteUserPackageViewModel : BaseViewModel, IUserPackageView
                         activity?.AddEvent(new("Entered_AsyncLock"));
                         if (_app.AuthenticatedUser.Value != null)
                         {
-                            await _app.AuthenticatedUser.Value.RefreshAsync();
+                            await _app.AuthenticatedUser.Value.RefreshAsync(CancellationToken.None);
                         }
 
                         Release release = await AcquirePackage();
@@ -270,8 +270,8 @@ public sealed class RemoteUserPackageViewModel : BaseViewModel, IUserPackageView
                         activity?.AddEvent(new("Entered_AsyncLock"));
                         if (_app.AuthenticatedUser.Value != null)
                         {
-                            await _app.AuthenticatedUser.Value.RefreshAsync();
-                            await _library.RemovePackage(Package);
+                            await _app.AuthenticatedUser.Value.RefreshAsync(CancellationToken.None);
+                            await _library.RemovePackage(Package, CancellationToken.None);
                         }
 
                         activity?.AddEvent(new("Removed_PackageFromLibrary"));
@@ -296,10 +296,10 @@ public sealed class RemoteUserPackageViewModel : BaseViewModel, IUserPackageView
     {
         if (_app.AuthenticatedUser.Value != null)
         {
-            return await _library.Acquire(Package);
+            return await _library.Acquire(Package, CancellationToken.None);
         }
 
-        return (await Package.GetReleasesAsync())[0];
+        return (await Package.GetReleasesAsync(CancellationToken.None))[0];
     }
 
     public Package Package { get; }

--- a/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using Reactive.Bindings;
+using Beutl.ViewModels.ExtensionsPages.DiscoverPages;
 using LibraryService = Beutl.Api.Services.LibraryService;
 
 namespace Beutl.ViewModels.ExtensionsPages;
@@ -299,13 +300,7 @@ public sealed class RemoteUserPackageViewModel : BaseViewModel, IUserPackageView
             return await _library.Acquire(Package, CancellationToken.None);
         }
 
-        Release[] releases = await Package.GetReleasesAsync(CancellationToken.None, 0, 1);
-        if (releases.Length == 0)
-        {
-            throw new InvalidOperationException($"Package '{Package.Name}' has no releases.");
-        }
-
-        return releases[0];
+        return await PackageReleaseResolver.GetFirstReleaseAsync(Package, CancellationToken.None);
     }
 
     public Package Package { get; }

--- a/src/Beutl/ViewModels/SettingsPages/AccountSettingsPageViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsPages/AccountSettingsPageViewModel.cs
@@ -79,8 +79,8 @@ public sealed class AccountSettingsPageViewModel : BasePageViewModel
                         {
                             activity?.AddEvent(new("Entered_AsyncLock"));
 
-                            await user.RefreshAsync();
-                            await user.Profile.RefreshAsync();
+                            await user.RefreshAsync(CancellationToken.None);
+                            await user.Profile.RefreshAsync(CancellationToken.None);
                         }
                     }
                 }

--- a/tests/Beutl.HeadlessUITests/PackageReleaseResolverTests.cs
+++ b/tests/Beutl.HeadlessUITests/PackageReleaseResolverTests.cs
@@ -1,6 +1,8 @@
-﻿using System.Net.Http;
+﻿using System.Net;
+using System.Net.Http;
 using System.Reactive.Concurrency;
 using System.Reactive.Subjects;
+using System.Text;
 
 using Beutl.Api;
 using Beutl.Api.Clients;
@@ -266,6 +268,31 @@ public class PackageReleaseResolverTests
         });
     }
 
+    [Test]
+    public async Task GetFirstReleaseAsync_ThrowsWhenPackageHasNoReleases()
+    {
+        using var handler = new EmptyReleasesHandler();
+        using var httpClient = new HttpClient(handler);
+        var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        Package package = CreatePackage(clients);
+
+        Assert.ThrowsAsync<InvalidOperationException>(
+            () => PackageReleaseResolver.GetFirstReleaseAsync(package, CancellationToken.None));
+    }
+
+    [Test]
+    public async Task GetFirstReleaseAsync_ReturnsFirstRelease()
+    {
+        using var handler = new SingleReleaseHandler();
+        using var httpClient = new HttpClient(handler);
+        var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        Package package = CreatePackage(clients);
+
+        Release release = await PackageReleaseResolver.GetFirstReleaseAsync(package, CancellationToken.None);
+
+        Assert.That(release.Version.Value, Is.EqualTo("1.0.0"));
+    }
+
     private static PackageIdentity CreateIdentity(string version)
     {
         return new PackageIdentity("Package", NuGetVersion.Parse(version));
@@ -313,6 +340,69 @@ public class PackageReleaseResolverTests
             FileId = null,
             FileUrl = null,
         }, clients);
+    }
+
+    private static Package CreatePackage(BeutlApiApplication clients)
+    {
+        var ownerResponse = new ProfileResponse
+        {
+            Id = "owner",
+            Name = "owner",
+            DisplayName = "Owner",
+            Bio = null,
+            IconId = null,
+            IconUrl = null,
+        };
+        var owner = new Profile(ownerResponse, clients);
+        return new Package(owner, new PackageResponse
+        {
+            Id = "package",
+            Owner = ownerResponse,
+            Name = "Package",
+            DisplayName = "Package",
+            Description = "",
+            ShortDescription = "",
+            WebSite = "",
+            Tags = [],
+            LogoId = null,
+            LogoUrl = null,
+            Screenshots = [],
+            Currency = null,
+            Price = null,
+            Paid = false,
+            Owned = true,
+        }, clients);
+    }
+
+    private sealed class EmptyReleasesHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[]", Encoding.UTF8, "application/json"),
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class SingleReleaseHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """[{"id":"r1","version":"1.0.0","title":"Release","description":"","targetVersion":null,"fileId":null,"fileUrl":null}]""",
+                    Encoding.UTF8,
+                    "application/json"),
+            };
+            return Task.FromResult(response);
+        }
     }
 
     private static async Task WaitForAsync(Func<bool> condition)

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -97,6 +97,45 @@ public sealed class BeutlApiApplicationTests
         }
     }
 
+    [Test]
+    public async Task CheckForUpdatesAsync_PreCanceledTokenStopsBeforeMetadataRead()
+    {
+        // LoadMetadata reads asset_metadata.json from AppContext.BaseDirectory (cached per process).
+        string metadataPath = Path.Combine(AppContext.BaseDirectory, "asset_metadata.json");
+        string? originalContent = File.Exists(metadataPath) ? File.ReadAllText(metadataPath) : null;
+        try
+        {
+            File.WriteAllText(metadataPath, """
+                {
+                  "id": "test-id",
+                  "os": "linux",
+                  "arch": "x64",
+                  "version": "2.0.0-preview.6",
+                  "standalone": "true",
+                  "type": "flatpak"
+                }
+                """);
+            using var httpClient = new HttpClient();
+            var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+            using var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+
+            Assert.CatchAsync<OperationCanceledException>(async () =>
+                await app.CheckForUpdatesAsync("2.0.0-preview.6", cancellationTokenSource.Token));
+        }
+        finally
+        {
+            if (originalContent != null)
+            {
+                File.WriteAllText(metadataPath, originalContent);
+            }
+            else
+            {
+                File.Delete(metadataPath);
+            }
+        }
+    }
+
     private sealed class CapturingHandler : HttpMessageHandler
     {
         public Uri? LastRequestUri { get; private set; }

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Text;
 using Beutl.Api;
 using Beutl.Api.Clients;
+using Beutl.Api.Objects;
 using Beutl.Api.Services;
 using Beutl.Testing.Headless;
 
@@ -206,6 +207,39 @@ public sealed class BeutlApiApplicationTests
         {
             Directory.Delete(userFile, recursive: true);
         }
+    }
+
+    [Test]
+    public async Task CompleteSignInAsync_DoesNotResurrectUser_WhenSignedOutDuringGetSelf()
+    {
+        var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRequest = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = new DelegateHandler(async (request, cancellationToken) =>
+        {
+            requestStarted.TrySetResult();
+            await releaseRequest.Task;
+            throw new HttpRequestException("request failed");
+        });
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var authResponse = new AuthResponse
+        {
+            Token = "new-token",
+            RefreshToken = "new-refresh",
+            Expiration = DateTime.UtcNow.AddHours(1)
+        };
+
+        Task<AuthenticatedUser> signIn = app.CompleteSignInAsync(authResponse, CancellationToken.None);
+        await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // SignOut while GetSelf is pending; the failing attempt must not resurrect the user.
+        app.SignOut(false);
+        releaseRequest.TrySetResult();
+
+        Assert.CatchAsync<Exception>(async () =>
+            await signIn.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.That(app.AuthenticatedUser.Value, Is.Null,
+            "SignOut must not be undone by the failing sign-in");
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -208,8 +208,8 @@ public sealed class BeutlApiApplicationTests
         }
     }
 
-     [Test]
-     public async Task RestoreUserAsync_RestoresAuthorization_WhenProfileRefreshIsCanceled()
+    [Test]
+    public async Task RestoreUserAsync_RestoresAuthorization_WhenProfileRefreshIsCanceled()
     {
         Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
         string userFile = Path.Combine(Helper.AppRoot, BeutlApiApplication.UserFileName);
@@ -270,7 +270,7 @@ public sealed class BeutlApiApplicationTests
         }
     }
 
-     private sealed class CapturingHandler : HttpMessageHandler
+    private sealed class CapturingHandler : HttpMessageHandler
     {
         public Uri? LastRequestUri { get; private set; }
 

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -208,7 +208,69 @@ public sealed class BeutlApiApplicationTests
         }
     }
 
-    private sealed class CapturingHandler : HttpMessageHandler
+     [Test]
+     public async Task RestoreUserAsync_RestoresAuthorization_WhenProfileRefreshIsCanceled()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+        string userFile = Path.Combine(Helper.AppRoot, BeutlApiApplication.UserFileName);
+        string original = """
+            {
+              "token": "restored-token",
+              "refresh_token": "restored-refresh",
+              "expiration": "2027-01-01T00:00:00Z",
+              "profile": {
+                "id": "restored-profile",
+                "name": "restored-name",
+                "displayName": "Restored Name",
+                "bio": null,
+                "iconId": null,
+                "iconUrl": null
+              }
+            }
+            """;
+        File.WriteAllText(userFile, original);
+        try
+        {
+            using var cancellationTokenSource = new CancellationTokenSource();
+            using var handler = new DelegateHandler((request, cancellationToken) =>
+            {
+                if (request.RequestUri!.PathAndQuery.StartsWith("/api/v3/user"))
+                {
+                    cancellationTokenSource.Cancel();
+                    throw new OperationCanceledException(cancellationToken);
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(new ProfileResponse
+                    {
+                        Id = "restored-profile",
+                        Name = "restored-name",
+                        DisplayName = "Restored Name",
+                        Bio = null,
+                        IconId = null,
+                        IconUrl = null,
+                    })
+                });
+            });
+            using var httpClient = new HttpClient(handler);
+            var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+
+            Assert.CatchAsync<OperationCanceledException>(async () =>
+                await app.RestoreUserAsync(null, cancellationTokenSource.Token));
+
+            Assert.That(httpClient.DefaultRequestHeaders.Authorization, Is.Null,
+                "the restored bearer token must not remain after a canceled restoration");
+            Assert.That(app.AuthenticatedUser.Value, Is.Null,
+                "the restored user must not remain after a canceled restoration");
+        }
+        finally
+        {
+            File.Delete(userFile);
+        }
+    }
+
+     private sealed class CapturingHandler : HttpMessageHandler
     {
         public Uri? LastRequestUri { get; private set; }
 

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using System.Text;
 using Beutl.Api;
+using Beutl.Api.Clients;
 using Beutl.Api.Services;
 
 namespace Beutl.UnitTests.Api;
@@ -136,6 +137,31 @@ public sealed class BeutlApiApplicationTests
         }
     }
 
+    [Test]
+    public async Task CompleteSignInAsync_RestoresAuthorization_WhenGetSelfIsCanceled()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        using var handler = new DelegateHandler((request, cancellationToken) =>
+        {
+            cancellationTokenSource.Cancel();
+            throw new OperationCanceledException(cancellationToken);
+        });
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var authResponse = new AuthResponse
+        {
+            Token = "new-token",
+            RefreshToken = "new-refresh",
+            Expiration = DateTime.UtcNow.AddHours(1)
+        };
+
+        Assert.CatchAsync<OperationCanceledException>(async () =>
+            await app.CompleteSignInAsync(authResponse, cancellationTokenSource.Token));
+
+        Assert.That(httpClient.DefaultRequestHeaders.Authorization, Is.Null,
+            "the new bearer token must not remain after a canceled sign-in");
+    }
+
     private sealed class CapturingHandler : HttpMessageHandler
     {
         public Uri? LastRequestUri { get; private set; }
@@ -155,5 +181,14 @@ public sealed class BeutlApiApplicationTests
             };
             return Task.FromResult(response);
         }
+    }
+
+    private sealed class DelegateHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => handler(request, cancellationToken);
     }
 }

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -1,8 +1,10 @@
 ﻿using System.Net;
+using System.Net.Http.Json;
 using System.Text;
 using Beutl.Api;
 using Beutl.Api.Clients;
 using Beutl.Api.Services;
+using Beutl.Testing.Headless;
 
 namespace Beutl.UnitTests.Api;
 
@@ -160,6 +162,50 @@ public sealed class BeutlApiApplicationTests
 
         Assert.That(httpClient.DefaultRequestHeaders.Authorization, Is.Null,
             "the new bearer token must not remain after a canceled sign-in");
+    }
+
+    [Test]
+    public async Task CompleteSignInAsync_RestoresAuthenticatedUser_WhenPersistenceFails()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+        string userFile = Path.Combine(Helper.AppRoot, BeutlApiApplication.UserFileName);
+        Directory.CreateDirectory(userFile); // SaveUser's File.Create fails on a directory.
+        try
+        {
+            using var handler = new DelegateHandler((request, cancellationToken) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(new ProfileResponse
+                    {
+                        Id = "new-profile",
+                        Name = "new-name",
+                        DisplayName = "New Name",
+                        Bio = null,
+                        IconId = null,
+                        IconUrl = null,
+                    })
+                }));
+            using var httpClient = new HttpClient(handler);
+            var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+            var authResponse = new AuthResponse
+            {
+                Token = "new-token",
+                RefreshToken = "new-refresh",
+                Expiration = DateTime.UtcNow.AddHours(1)
+            };
+
+            Assert.CatchAsync<Exception>(async () =>
+                await app.CompleteSignInAsync(authResponse, CancellationToken.None));
+
+            Assert.That(app.AuthenticatedUser.Value, Is.Null,
+                "the failed sign-in must not leave a signed-in user");
+            Assert.That(httpClient.DefaultRequestHeaders.Authorization, Is.Null,
+                "the new bearer token must not remain after a failed sign-in");
+        }
+        finally
+        {
+            Directory.Delete(userFile, recursive: true);
+        }
     }
 
     private sealed class CapturingHandler : HttpMessageHandler

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -76,7 +76,7 @@ public sealed class BeutlApiApplicationTests
             using var httpClient = new HttpClient(handler);
             var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
 
-            var (v1, v3) = await app.CheckForUpdatesAsync("2.0.0-preview.6");
+            var (v1, v3) = await app.CheckForUpdatesAsync("2.0.0-preview.6", CancellationToken.None);
 
             Assert.That(handler.LastRequestUri, Is.Not.Null);
             Assert.That(handler.LastRequestUri!.Query, Does.Contain("type=zip"));

--- a/tests/Beutl.UnitTests/Api/MyAsyncLockTests.cs
+++ b/tests/Beutl.UnitTests/Api/MyAsyncLockTests.cs
@@ -19,4 +19,26 @@ public sealed class MyAsyncLockTests
         // The lock must still be acquirable after the canceled attempt.
         using IDisposable releaser = asyncLock.LockAsync().GetAwaiter().GetResult();
     }
+
+    [Test]
+    public async Task LockAsync_ContendedCanceledAcquisition_DoesNotLeakTheLock()
+    {
+        var asyncLock = new MyAsyncLock();
+        IDisposable first = asyncLock.LockAsync().GetAwaiter().GetResult();
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        // A contended acquisition starts waiting on the semaphore.
+        Task<IDisposable> second = asyncLock.LockAsync(cancellationTokenSource.Token);
+
+        // Canceling while the acquisition waits must propagate instead of returning a
+        // releaser, and must not leave the lock permanently held.
+        cancellationTokenSource.Cancel();
+
+        Assert.CatchAsync<OperationCanceledException>(async () =>
+            await second.WaitAsync(TimeSpan.FromSeconds(5)));
+
+        // The lock must still be acquirable after the canceled contended attempt.
+        first.Dispose();
+        using IDisposable third = asyncLock.LockAsync().GetAwaiter().GetResult();
+    }
 }

--- a/tests/Beutl.UnitTests/Api/MyAsyncLockTests.cs
+++ b/tests/Beutl.UnitTests/Api/MyAsyncLockTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Api;
+﻿using Beutl.Api;
 
 namespace Beutl.UnitTests.Api;
 

--- a/tests/Beutl.UnitTests/Api/MyAsyncLockTests.cs
+++ b/tests/Beutl.UnitTests/Api/MyAsyncLockTests.cs
@@ -1,0 +1,22 @@
+using Beutl.Api;
+
+namespace Beutl.UnitTests.Api;
+
+[TestFixture]
+[NonParallelizable]
+public sealed class MyAsyncLockTests
+{
+    [Test]
+    public void LockAsync_PreCanceledToken_ThrowsWithoutAcquiringTheLock()
+    {
+        var asyncLock = new MyAsyncLock();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        Assert.CatchAsync<OperationCanceledException>(async () =>
+            await asyncLock.LockAsync(cancellationTokenSource.Token));
+
+        // The lock must still be acquirable after the canceled attempt.
+        using IDisposable releaser = asyncLock.LockAsync().GetAwaiter().GetResult();
+    }
+}

--- a/tests/Beutl.UnitTests/Api/PublicApiCancellationTests.cs
+++ b/tests/Beutl.UnitTests/Api/PublicApiCancellationTests.cs
@@ -24,6 +24,9 @@ public sealed class PublicApiCancellationTests
         ["RefreshAsync", "GetAssetAsync"];
 
     private static readonly string[] s_profileOperations =
+        ["RefreshAsync", "GetPackagesAsync"];
+
+    private static readonly string[] s_authenticatedUserOperations =
         ["RefreshAsync"];
 
     [Test]
@@ -34,6 +37,8 @@ public sealed class PublicApiCancellationTests
         AssertRequiredCancellationTokens(typeof(Package), s_packageOperations);
         AssertRequiredCancellationTokens(typeof(Release), s_releaseOperations);
         AssertRequiredCancellationTokens(typeof(Profile), s_profileOperations);
+        AssertRequiredCancellationTokens(typeof(AuthenticatedUser), s_authenticatedUserOperations);
+        AssertRequiredCancellationTokens(typeof(BeutlApiApplication), ["CheckForUpdatesAsync"]);
         AssertRequiredCancellationTokens(typeof(IFilesClient), ["GetFile"]);
     }
 
@@ -185,6 +190,57 @@ public sealed class PublicApiCancellationTests
         Profile profile = CreateProfile(app);
 
         Task operation = profile.RefreshAsync(cancellationTokenSource.Token, self);
+
+        await AssertTransportCancellation(operation, handler, cancellationTokenSource);
+    }
+
+    [Test]
+    public async Task ProfileGetPackagesAsync_PropagatesCancellationToTransport()
+    {
+        using var handler = new BlockingHandler();
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        using var cancellationTokenSource = new CancellationTokenSource();
+        Profile profile = CreateProfile(app);
+
+        Task operation = profile.GetPackagesAsync(cancellationTokenSource.Token);
+
+        await AssertTransportCancellation(operation, handler, cancellationTokenSource);
+    }
+
+    [Test]
+    public async Task AuthenticatedUserRefreshAsync_PropagatesCancellationToTransport()
+    {
+        using var handler = new BlockingHandler();
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var user = new AuthenticatedUser(
+            CreateProfile(app),
+            new AuthResponse
+            {
+                Token = "token",
+                RefreshToken = "refresh-token",
+                Expiration = DateTime.UtcNow.AddMinutes(-1),
+            },
+            app,
+            httpClient,
+            DateTime.UtcNow);
+
+        Task operation = user.RefreshAsync(cancellationTokenSource.Token, force: true).AsTask();
+
+        await AssertTransportCancellation(operation, handler, cancellationTokenSource);
+    }
+
+    [Test]
+    public async Task CheckForUpdatesAsync_PropagatesCancellationToTransport()
+    {
+        using var handler = new BlockingHandler();
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        Task operation = app.CheckForUpdatesAsync("1.0.0", cancellationTokenSource.Token);
 
         await AssertTransportCancellation(operation, handler, cancellationTokenSource);
     }

--- a/tests/Beutl.UnitTests/Api/PublicApiCancellationTests.cs
+++ b/tests/Beutl.UnitTests/Api/PublicApiCancellationTests.cs
@@ -1,0 +1,318 @@
+using System.Net;
+using System.Reflection;
+using System.Text;
+using Beutl.Api;
+using Beutl.Api.Clients;
+using Beutl.Api.Objects;
+using Beutl.Api.Services;
+
+namespace Beutl.UnitTests.Api;
+
+[TestFixture]
+public sealed class PublicApiCancellationTests
+{
+    private static readonly string[] s_discoverOperations =
+        ["GetPackage", "GetProfile", "GetFeatured", "Search"];
+
+    private static readonly string[] s_libraryOperations =
+        ["GetPackage", "GetProfile", "GetPackages", "Acquire", "RemovePackage"];
+
+    private static readonly string[] s_packageOperations =
+        ["RefreshAsync", "GetReleaseAsync", "GetReleasesAsync"];
+
+    private static readonly string[] s_releaseOperations =
+        ["RefreshAsync", "GetAssetAsync"];
+
+    [Test]
+    public void HighLevelOperations_RequireCancellationTokens()
+    {
+        AssertRequiredCancellationTokens(typeof(DiscoverService), s_discoverOperations);
+        AssertRequiredCancellationTokens(typeof(LibraryService), s_libraryOperations);
+        AssertRequiredCancellationTokens(typeof(Package), s_packageOperations);
+        AssertRequiredCancellationTokens(typeof(Release), s_releaseOperations);
+        AssertRequiredCancellationTokens(typeof(IFilesClient), ["GetFile"]);
+    }
+
+    [Test]
+    public void ClientInterfaces_RequireCancellationTokens()
+    {
+        AssertRequiredCancellationTokens(typeof(IAccountClient), ["CreateAuthUri", "Refresh", "Exchange"]);
+        AssertRequiredCancellationTokens(typeof(IDiscoverClient), ["Search", "GetFeatured"]);
+        AssertRequiredCancellationTokens(typeof(IFilesClient), ["GetFile"]);
+        AssertRequiredCancellationTokens(typeof(ILibraryClient), ["AcquirePackage", "GetLibrary", "DeleteLibraryPackage"]);
+        AssertRequiredCancellationTokens(typeof(IPackagesClient), ["GetPackage"]);
+        AssertRequiredCancellationTokens(typeof(IReleasesClient), ["GetReleases", "GetRelease"]);
+        AssertRequiredCancellationTokens(typeof(IUsersClient), ["GetUser", "GetSelf", "GetUserPackages"]);
+    }
+
+    [Test]
+    public void PackageManagerCheckUpdateOperations_RequireCancellationTokens()
+    {
+        MethodInfo[] methods = typeof(PackageManager)
+            .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
+            .Where(method => method.Name == "CheckUpdate")
+            .ToArray();
+
+        Assert.That(methods, Has.Length.EqualTo(2));
+
+        foreach (MethodInfo method in methods)
+        {
+            ParameterInfo[] cancellationTokens = method.GetParameters()
+                .Where(parameter => parameter.ParameterType == typeof(CancellationToken))
+                .ToArray();
+            Assert.That(
+                cancellationTokens,
+                Has.Length.EqualTo(1),
+                $"{method.Name} must require a CancellationToken.");
+            Assert.That(
+                cancellationTokens[0].HasDefaultValue,
+                Is.False,
+                $"{method.Name} must not default its CancellationToken.");
+        }
+    }
+
+    [Test]
+    public void PackageManagerCheckUpdateOperations_ObservePreCanceledTokens()
+    {
+        using var httpClient = new HttpClient();
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+        PackageManager manager = app.GetResource<PackageManager>();
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await manager.CheckUpdate(cancellationTokenSource.Token));
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await manager.CheckUpdate("package-name", cancellationTokenSource.Token));
+    }
+
+    [TestCaseSource(nameof(s_discoverOperations))]
+    public async Task DiscoverOperations_PropagateCancellationToTransport(string operationName)
+    {
+        using var handler = new BlockingHandler();
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var service = new DiscoverService(app);
+
+        Task operation = operationName switch
+        {
+            "GetPackage" => service.GetPackage("package-name", cancellationTokenSource.Token),
+            "GetProfile" => service.GetProfile("profile-name", cancellationTokenSource.Token),
+            "GetFeatured" => service.GetFeatured(cancellationTokenSource.Token),
+            "Search" => service.Search("query", cancellationTokenSource.Token),
+            _ => throw new ArgumentOutOfRangeException(nameof(operationName)),
+        };
+
+        await AssertTransportCancellation(operation, handler, cancellationTokenSource);
+    }
+
+    [TestCaseSource(nameof(s_libraryOperations))]
+    public async Task LibraryOperations_PropagateCancellationToTransport(string operationName)
+    {
+        using var handler = new BlockingHandler();
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var service = new LibraryService(app);
+        Package package = CreatePackage(app);
+
+        Task operation = operationName switch
+        {
+            "GetPackage" => service.GetPackage("package-name", cancellationTokenSource.Token),
+            "GetProfile" => service.GetProfile("profile-name", cancellationTokenSource.Token),
+            "GetPackages" => service.GetPackages(cancellationTokenSource.Token),
+            "Acquire" => service.Acquire(package, cancellationTokenSource.Token),
+            "RemovePackage" => service.RemovePackage(package, cancellationTokenSource.Token),
+            _ => throw new ArgumentOutOfRangeException(nameof(operationName)),
+        };
+
+        await AssertTransportCancellation(operation, handler, cancellationTokenSource);
+    }
+
+    [TestCaseSource(nameof(s_packageOperations))]
+    public async Task PackageOperations_PropagateCancellationToTransport(string operationName)
+    {
+        using var handler = new BlockingHandler();
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        using var cancellationTokenSource = new CancellationTokenSource();
+        Package package = CreatePackage(app);
+
+        Task operation = operationName switch
+        {
+            "RefreshAsync" => package.RefreshAsync(cancellationTokenSource.Token),
+            "GetReleaseAsync" => package.GetReleaseAsync("1.0.0", cancellationTokenSource.Token),
+            "GetReleasesAsync" => package.GetReleasesAsync(cancellationTokenSource.Token),
+            _ => throw new ArgumentOutOfRangeException(nameof(operationName)),
+        };
+
+        await AssertTransportCancellation(operation, handler, cancellationTokenSource);
+    }
+
+    [TestCaseSource(nameof(s_releaseOperations))]
+    public async Task ReleaseOperations_PropagateCancellationToTransport(string operationName)
+    {
+        using var handler = new BlockingHandler();
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        using var cancellationTokenSource = new CancellationTokenSource();
+        Release release = CreateRelease(app);
+
+        Task operation = operationName switch
+        {
+            "RefreshAsync" => release.RefreshAsync(cancellationTokenSource.Token),
+            "GetAssetAsync" => release.GetAssetAsync(cancellationTokenSource.Token),
+            _ => throw new ArgumentOutOfRangeException(nameof(operationName)),
+        };
+
+        await AssertTransportCancellation(operation, handler, cancellationTokenSource);
+    }
+
+    private const string SimplePackageJson = """
+        {
+          "id": "package-id",
+          "owner": {
+            "id": "profile-id",
+            "name": "profile-name",
+            "displayName": "Profile",
+            "bio": null,
+            "iconId": null,
+            "iconUrl": null
+          },
+          "name": "package-name",
+          "displayName": "Package",
+          "shortDescription": "Package description",
+          "tags": [],
+          "logoId": null,
+          "logoUrl": null,
+          "currency": null,
+          "price": null,
+          "paid": false,
+          "owned": false
+        }
+        """;
+
+    private static void AssertRequiredCancellationTokens(Type type, IEnumerable<string> operationNames)
+    {
+        foreach (string operationName in operationNames)
+        {
+            MethodInfo[] methods = type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
+                .Where(method => method.Name == operationName)
+                .ToArray();
+            Assert.That(methods, Has.Length.EqualTo(1), $"{type.Name}.{operationName} must have one public signature.");
+
+            ParameterInfo[] cancellationTokens = methods[0].GetParameters()
+                .Where(parameter => parameter.ParameterType == typeof(CancellationToken))
+                .ToArray();
+            Assert.That(
+                cancellationTokens,
+                Has.Length.EqualTo(1),
+                $"{type.Name}.{operationName} must require a CancellationToken.");
+            Assert.That(
+                cancellationTokens[0].HasDefaultValue,
+                Is.False,
+                $"{type.Name}.{operationName} must not default its CancellationToken.");
+        }
+    }
+
+    private static async Task AssertTransportCancellation(
+        Task operation,
+        BlockingHandler handler,
+        CancellationTokenSource cancellationTokenSource)
+    {
+        await handler.BlockingRequestStarted.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellationTokenSource.Cancel();
+
+        Assert.CatchAsync<OperationCanceledException>(async () => await operation);
+        await handler.CancellationObserved.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    private static Package CreatePackage(BeutlApiApplication app)
+    {
+        ProfileResponse ownerResponse = new()
+        {
+            Id = "profile-id",
+            Name = "profile-name",
+            DisplayName = "Profile",
+            Bio = null,
+            IconId = null,
+            IconUrl = null,
+        };
+        var owner = new Profile(ownerResponse, app);
+        PackageResponse packageResponse = new()
+        {
+            Id = "package-id",
+            Owner = ownerResponse,
+            Name = "package-name",
+            DisplayName = "Package",
+            Description = "Package description",
+            ShortDescription = "Package description",
+            WebSite = "https://example.com",
+            Tags = [],
+            LogoId = null,
+            LogoUrl = null,
+            Screenshots = [],
+            Currency = null,
+            Price = null,
+            Paid = false,
+            Owned = false,
+        };
+        return new Package(owner, packageResponse, app);
+    }
+
+    private static Release CreateRelease(BeutlApiApplication app)
+    {
+        return new Release(CreatePackage(app), new ReleaseResponse
+        {
+            Id = "release-id",
+            Version = "1.0.0",
+            Title = "Release",
+            Description = "Release description",
+            TargetVersion = null,
+            FileId = "asset-id",
+            FileUrl = "https://example.com/asset",
+        }, app);
+    }
+
+    private static HttpResponseMessage JsonResponse(HttpStatusCode statusCode, string json)
+        => new(statusCode) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    private sealed class BlockingHandler(
+        Func<HttpRequestMessage, HttpResponseMessage?>? immediateResponse = null) : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource _blockingRequestStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _cancellationObserved =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task BlockingRequestStarted => _blockingRequestStarted.Task;
+
+        public Task CancellationObserved => _cancellationObserved.Task;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (immediateResponse?.Invoke(request) is { } response)
+            {
+                response.RequestMessage = request;
+                return response;
+            }
+
+            _blockingRequestStarted.TrySetResult();
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                throw new InvalidOperationException("The blocking request completed without cancellation.");
+            }
+            finally
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    _cancellationObserved.TrySetResult();
+                }
+            }
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Api/PublicApiCancellationTests.cs
+++ b/tests/Beutl.UnitTests/Api/PublicApiCancellationTests.cs
@@ -47,6 +47,7 @@ public sealed class PublicApiCancellationTests
         AssertRequiredCancellationTokens(typeof(IPackagesClient), ["GetPackage"]);
         AssertRequiredCancellationTokens(typeof(IReleasesClient), ["GetReleases", "GetRelease"]);
         AssertRequiredCancellationTokens(typeof(IUsersClient), ["GetUser", "GetSelf", "GetUserPackages"]);
+        AssertRequiredCancellationTokens(typeof(IAppClient), ["CheckForUpdates", "GetUpdate"]);
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Api/PublicApiCancellationTests.cs
+++ b/tests/Beutl.UnitTests/Api/PublicApiCancellationTests.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using System.Reflection;
 using System.Text;
 using Beutl.Api;

--- a/tests/Beutl.UnitTests/Api/PublicApiCancellationTests.cs
+++ b/tests/Beutl.UnitTests/Api/PublicApiCancellationTests.cs
@@ -23,6 +23,9 @@ public sealed class PublicApiCancellationTests
     private static readonly string[] s_releaseOperations =
         ["RefreshAsync", "GetAssetAsync"];
 
+    private static readonly string[] s_profileOperations =
+        ["RefreshAsync"];
+
     [Test]
     public void HighLevelOperations_RequireCancellationTokens()
     {
@@ -30,6 +33,7 @@ public sealed class PublicApiCancellationTests
         AssertRequiredCancellationTokens(typeof(LibraryService), s_libraryOperations);
         AssertRequiredCancellationTokens(typeof(Package), s_packageOperations);
         AssertRequiredCancellationTokens(typeof(Release), s_releaseOperations);
+        AssertRequiredCancellationTokens(typeof(Profile), s_profileOperations);
         AssertRequiredCancellationTokens(typeof(IFilesClient), ["GetFile"]);
     }
 
@@ -169,6 +173,21 @@ public sealed class PublicApiCancellationTests
         await AssertTransportCancellation(operation, handler, cancellationTokenSource);
     }
 
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task ProfileRefreshAsync_PropagatesCancellationToTransport(bool self)
+    {
+        using var handler = new BlockingHandler();
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        using var cancellationTokenSource = new CancellationTokenSource();
+        Profile profile = CreateProfile(app);
+
+        Task operation = profile.RefreshAsync(cancellationTokenSource.Token, self);
+
+        await AssertTransportCancellation(operation, handler, cancellationTokenSource);
+    }
+
     private const string SimplePackageJson = """
         {
           "id": "package-id",
@@ -259,6 +278,20 @@ public sealed class PublicApiCancellationTests
             Owned = false,
         };
         return new Package(owner, packageResponse, app);
+    }
+
+    private static Profile CreateProfile(BeutlApiApplication app)
+    {
+        ProfileResponse response = new()
+        {
+            Id = "profile-id",
+            Name = "profile-name",
+            DisplayName = "Profile",
+            Bio = null,
+            IconId = null,
+            IconUrl = null,
+        };
+        return new Profile(response, app);
     }
 
     private static Release CreateRelease(BeutlApiApplication app)

--- a/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
+++ b/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
@@ -41,6 +41,7 @@
     <ProjectReference Include="..\..\src\Beutl.Configuration\Beutl.Configuration.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Language\Beutl.Language.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Api\Beutl.Api.csproj" />
+    <ProjectReference Include="..\..\src\Beutl.PackageTools.UI\Beutl.PackageTools.UI.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Engine.SourceGenerators\Beutl.Engine.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 

--- a/tests/Beutl.UnitTests/PackageTools/ChangesModelTests.cs
+++ b/tests/Beutl.UnitTests/PackageTools/ChangesModelTests.cs
@@ -62,11 +62,11 @@ public sealed class ChangesModelTests
         var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         int requestCount = 0;
-        using var handler = new DelegateHandler(async (request, _) =>
+        using var handler = new DelegateHandler(async (request, cancellationToken) =>
         {
             Interlocked.Increment(ref requestCount);
             requestStarted.TrySetResult();
-            await releaseResponse.Task;
+            await releaseResponse.Task.WaitAsync(cancellationToken);
             return CreatePackageResponse(request);
         });
         using var httpClient = new HttpClient(handler);
@@ -83,9 +83,8 @@ public sealed class ChangesModelTests
         await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         cancellation.Cancel();
-        releaseResponse.TrySetResult();
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.CatchAsync<OperationCanceledException>(async () =>
             await load.WaitAsync(TimeSpan.FromSeconds(5)));
         using (Assert.EnterMultipleScope())
         {

--- a/tests/Beutl.UnitTests/PackageTools/ChangesModelTests.cs
+++ b/tests/Beutl.UnitTests/PackageTools/ChangesModelTests.cs
@@ -95,6 +95,43 @@ public sealed class ChangesModelTests
         }
     }
 
+    [Test]
+    public async Task Load_CancellationAfterFirstItemLeavesCollectionsEmpty()
+    {
+        var secondRequestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int requestCount = 0;
+        using var handler = new DelegateHandler(async (request, cancellationToken) =>
+        {
+            int count = Interlocked.Increment(ref requestCount);
+            if (count > 1)
+            {
+                secondRequestStarted.TrySetResult();
+                await releaseResponse.Task.WaitAsync(cancellationToken);
+            }
+
+            return CreatePackageResponse(request);
+        });
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        using var cancellation = new CancellationTokenSource();
+        var model = new ChangesModel();
+
+        Task load = model.Load(
+            app,
+            ["first-package/1.0.0", "second-package/1.0.0"],
+            [],
+            [],
+            cancellation.Token);
+        await secondRequestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        cancellation.Cancel();
+
+        Assert.CatchAsync<OperationCanceledException>(async () =>
+            await load.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.That(model.InstallItems, Is.Empty, "partially parsed items must not be published");
+    }
+
     private static HttpResponseMessage CreatePackageResponse(HttpRequestMessage request)
     {
         string name = request.RequestUri!.Segments[^1];

--- a/tests/Beutl.UnitTests/PackageTools/ChangesModelTests.cs
+++ b/tests/Beutl.UnitTests/PackageTools/ChangesModelTests.cs
@@ -132,6 +132,36 @@ public sealed class ChangesModelTests
         Assert.That(model.InstallItems, Is.Empty, "partially parsed items must not be published");
     }
 
+    [Test]
+    public async Task Load_CancellationAfterParsingLeavesCollectionsEmpty()
+    {
+        var requestCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cancellation = new CancellationTokenSource();
+        using var handler = new DelegateHandler((request, cancellationToken) =>
+        {
+            HttpResponseMessage response = CreatePackageResponse(request);
+            // Cancel while the response is being processed, before the publish loops run.
+            cancellation.Cancel();
+            requestCompleted.TrySetResult();
+            return Task.FromResult(response);
+        });
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var model = new ChangesModel();
+
+        Task load = model.Load(
+            app,
+            ["parsed-package/1.0.0"],
+            [],
+            [],
+            cancellation.Token);
+        await requestCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.CatchAsync<OperationCanceledException>(async () =>
+            await load.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.That(model.InstallItems, Is.Empty, "items must not be published after cancellation");
+    }
+
     private static HttpResponseMessage CreatePackageResponse(HttpRequestMessage request)
     {
         string name = request.RequestUri!.Segments[^1];

--- a/tests/Beutl.UnitTests/PackageTools/ChangesModelTests.cs
+++ b/tests/Beutl.UnitTests/PackageTools/ChangesModelTests.cs
@@ -1,0 +1,144 @@
+﻿using System.Net;
+using System.Net.Http.Json;
+
+using Beutl.Api;
+using Beutl.Api.Clients;
+using Beutl.Api.Services;
+using Beutl.PackageTools.UI.Models;
+
+namespace Beutl.UnitTests.PackageTools;
+
+[TestFixture]
+public sealed class ChangesModelTests
+{
+    [Test]
+    public async Task Load_ClassifiesActionsAndDeduplicatesIdsWithinEachAction()
+    {
+        using var handler = new DelegateHandler((request, _) =>
+            Task.FromResult(CreatePackageResponse(request)));
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var model = new ChangesModel();
+
+        await model.Load(
+            app,
+            ["shared-package/1.0.0", "install-package/1.0.0", "install-package/2.0.0"],
+            ["shared-package/3.0.0", "uninstall-package/1.0.0", "uninstall-package/2.0.0"],
+            ["shared-package/2.0.0", "update-package/1.0.0", "update-package/2.0.0"],
+            CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                model.InstallItems.Select(item => (item.Id, item.Version.ToString(), item.Action)),
+                Is.EqualTo(new[]
+                {
+                    ("shared-package", "1.0.0", PackageChangeAction.Install),
+                    ("install-package", "1.0.0", PackageChangeAction.Install),
+                }));
+            Assert.That(
+                model.UpdateItems.Select(item => (item.Id, item.Version.ToString(), item.Action)),
+                Is.EqualTo(new[]
+                {
+                    ("shared-package", "2.0.0", PackageChangeAction.Update),
+                    ("update-package", "1.0.0", PackageChangeAction.Update),
+                }));
+            Assert.That(
+                model.UninstallItems.Select(item => (item.Id, item.Version.ToString(), item.Action)),
+                Is.EqualTo(new[]
+                {
+                    ("shared-package", "3.0.0", PackageChangeAction.Uninstall),
+                    ("uninstall-package", "1.0.0", PackageChangeAction.Uninstall),
+                }));
+            Assert.That(
+                model.InstallItems.Concat(model.UpdateItems).Concat(model.UninstallItems),
+                Is.All.Matches<PackageChangeModel>(item => item.IsRemote));
+        }
+    }
+
+    [Test]
+    public async Task Load_CancellationAfterRequestPropagatesWithoutAddingAnItem()
+    {
+        var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int requestCount = 0;
+        using var handler = new DelegateHandler(async (request, _) =>
+        {
+            Interlocked.Increment(ref requestCount);
+            requestStarted.TrySetResult();
+            await releaseResponse.Task;
+            return CreatePackageResponse(request);
+        });
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        using var cancellation = new CancellationTokenSource();
+        var model = new ChangesModel();
+
+        Task load = model.Load(
+            app,
+            ["cancel-package/1.0.0"],
+            ["not-reached-uninstall/1.0.0"],
+            ["not-reached-update/1.0.0"],
+            cancellation.Token);
+        await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        cancellation.Cancel();
+        releaseResponse.TrySetResult();
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await load.WaitAsync(TimeSpan.FromSeconds(5)));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(requestCount, Is.EqualTo(1));
+            Assert.That(model.InstallItems, Is.Empty);
+            Assert.That(model.UpdateItems, Is.Empty);
+            Assert.That(model.UninstallItems, Is.Empty);
+        }
+    }
+
+    private static HttpResponseMessage CreatePackageResponse(HttpRequestMessage request)
+    {
+        string name = request.RequestUri!.Segments[^1];
+        var response = new PackageResponse
+        {
+            Id = $"id-{name}",
+            Owner = new ProfileResponse
+            {
+                Id = "owner-id",
+                Name = "owner",
+                DisplayName = "Owner",
+                Bio = null,
+                IconId = null,
+                IconUrl = null,
+            },
+            Name = name,
+            DisplayName = $"Display {name}",
+            Description = $"Description {name}",
+            ShortDescription = $"Short description {name}",
+            WebSite = "https://example.com",
+            Tags = [],
+            LogoId = null,
+            LogoUrl = null,
+            Screenshots = [],
+            Currency = null,
+            Price = null,
+            Paid = false,
+            Owned = false,
+        };
+
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(response),
+        };
+    }
+
+    private sealed class DelegateHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => handler(request, cancellationToken);
+    }
+}


### PR DESCRIPTION
## Description
- Thread a required `CancellationToken` through the Refit client interfaces (`IAccountClient`, `IDiscoverClient`, `IFilesClient`, `ILibraryClient`, `IPackagesClient`, `IReleasesClient`, `IUsersClient`) so every HTTP operation observes caller cancellation.
- Propagate the token through the `Package` / `Release` / `Profile` objects and the `DiscoverService` / `LibraryService` / `PackageManager.CheckUpdate` services.
- Update all `Beutl.PackageTools.UI` call sites and add `PublicApiCancellationTests` covering the new signatures.

## Affected areas
- [x] `Beutl.Api` (server API client)

## Breaking changes
Public methods on the API clients, the `Package` / `Release` / `Profile` objects, `DiscoverService`, `LibraryService`, and `PackageManager.CheckUpdate` now require a `CancellationToken`. Affects `Beutl.Api` and `Beutl.PackageTools.UI` call sites. Migration: pass a token (e.g. `CancellationToken.None`) at each call site.

## Test plan
- `tests/Beutl.UnitTests/Api/PublicApiCancellationTests.cs` — verifies the new required-token signatures and that cancellation is observed.

## Fixed issues / References
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cancellation support across authentication, discovery, library, package, release, profile, download, installation, and update operations.
  * Long-running network requests and package processing can now be stopped more consistently.

* **Bug Fixes**
  * Improved cancellation handling during requests and package processing.
  * Improved handling when packages have no available releases.

* **Tests**
  * Added coverage for cancellation requirements, pre-canceled operations, and request-level cancellation propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->