### PR TITLE
refactor!(api): harden API application and package-tools lifecycles

### DIFF
--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -290,13 +290,15 @@ public class BeutlApiApplication : IAsyncDisposable
 
     private async Task<AuthenticatedUser> SignInExternalAsync(string provider, CancellationToken cancellationToken)
     {
+        using CancellationTokenSource lifetimeCts = CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
         using (Activity? activity = ActivitySource.StartActivity("SignInExternalAsync", ActivityKind.Client))
         {
             string continueUri = $"http://localhost:{GetRandomUnusedPort()}/__/auth/handler";
             CreateAuthUriResponse authUriRes = await Account.CreateAuthUri(new CreateAuthUriRequest
             {
                 ContinueUri = continueUri
-            }, cancellationToken);
+            }, token);
             using HttpListener listener = StartListener($"{continueUri}/");
             activity?.AddEvent(new("Started_Listener"));
 
@@ -305,7 +307,7 @@ public class BeutlApiApplication : IAsyncDisposable
 
             Process.Start(new ProcessStartInfo(uri) { UseShellExecute = true, Verb = "open" });
 
-            string? code = await GetResponseFromListener(listener, cancellationToken);
+            string? code = await GetResponseFromListener(listener, token);
             activity?.AddEvent(new("Received_Code"));
             if (string.IsNullOrWhiteSpace(code))
             {
@@ -316,15 +318,15 @@ public class BeutlApiApplication : IAsyncDisposable
             {
                 Code = code,
                 SessionId = authUriRes.SessionId
-            }, cancellationToken);
+            }, token);
             activity?.AddEvent(new("Done_CodeToJwtAsync"));
 
             // Serialize only the authentication state transition; the OAuth wait above must
             // not hold the application-wide lock.
-            using (await Lock.LockAsync(cancellationToken))
+            using (await Lock.LockAsync(token))
             {
                 activity?.AddEvent(new("Entered_AsyncLock"));
-                AuthenticatedUser user = await CompleteSignInAsync(authResponse, cancellationToken);
+                AuthenticatedUser user = await CompleteSignInAsync(authResponse, token);
                 activity?.AddEvent(new("Saved_User"));
                 return user;
             }
@@ -333,16 +335,18 @@ public class BeutlApiApplication : IAsyncDisposable
 
     public async Task<AuthenticatedUser> SignInAsync(CancellationToken cancellationToken)
     {
+        using CancellationTokenSource lifetimeCts = CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
         using (Activity? activity = ActivitySource.StartActivity("SignInAsync", ActivityKind.Client))
         {
-            using (await Lock.LockAsync(cancellationToken))
+            using (await Lock.LockAsync(token))
             {
                 activity?.AddEvent(new("Entered_AsyncLock"));
                 string continueUri = $"http://localhost:{GetRandomUnusedPort()}/__/auth/handler";
                 CreateAuthUriResponse authUriRes = await Account.CreateAuthUri(new CreateAuthUriRequest
                 {
                     ContinueUri = continueUri
-                }, cancellationToken);
+                }, token);
                 using HttpListener listener = StartListener($"{continueUri}/");
                 activity?.AddEvent(new("Started_Listener"));
 
@@ -350,7 +354,7 @@ public class BeutlApiApplication : IAsyncDisposable
 
                 Process.Start(new ProcessStartInfo(uri) { UseShellExecute = true, Verb = "open" });
 
-                string? code = await GetResponseFromListener(listener, cancellationToken);
+                string? code = await GetResponseFromListener(listener, token);
                 activity?.AddEvent(new("Received_Code"));
                 if (string.IsNullOrWhiteSpace(code))
                 {
@@ -361,10 +365,10 @@ public class BeutlApiApplication : IAsyncDisposable
                 {
                     Code = code,
                     SessionId = authUriRes.SessionId
-                }, cancellationToken);
+                }, token);
                 activity?.AddEvent(new("Done_CodeToJwtAsync"));
 
-                AuthenticatedUser user = await CompleteSignInAsync(authResponse, cancellationToken);
+                AuthenticatedUser user = await CompleteSignInAsync(authResponse, token);
                 activity?.AddEvent(new("Saved_User"));
                 return user;
             }

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -117,10 +117,17 @@ public class BeutlApiApplication : IAsyncDisposable
         using CancellationTokenSource lifetimeCts = CreateLifetimeLinkedTokenSource(cancellationToken);
         CancellationToken token = lifetimeCts.Token;
         var metadata = await LoadMetadata().WaitAsync(token);
-        if (metadata == null) return (await App.CheckForUpdates(version, token), null);
+        if (metadata == null)
+        {
+            var updateResponse = await App.CheckForUpdates(version, token);
+            token.ThrowIfCancellationRequested();
+            return (updateResponse, null);
+        }
+
         var update = await App.GetUpdate(
             version, ToServerType(metadata.Type), metadata.OS, metadata.Arch,
             metadata.Standalone, "false", token);
+        token.ThrowIfCancellationRequested();
         return (null, update);
     }
 

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -188,7 +188,11 @@ public class BeutlApiApplication : IAsyncDisposable
         throw new Exception("Resource not found");
     }
 
-    public T? TryGetResource<T>()
+    // Returns only resources another caller has already materialized; a registered-but-
+    // uncreated resource is not available yet, so the resolver-style name would conflate
+    // that state with unavailable. The sole production use is a shutdown-time probe for
+    // resources that must have been created by then.
+    public T? TryGetCreatedResource<T>()
         where T : class, IBeutlApiResource
     {
         lock (_disposeGate)

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -111,7 +111,7 @@ public class BeutlApiApplication : IAsyncDisposable
     // 更新があるかどうかをチェックします
     // このアプリケーションがアセットメタデータを持っている場合は、AppUpdateResponseを返します
     // そうでない場合は、CheckForUpdatesResponseを返します
-    // (戻り値はタプルで、該当する方の値がセットされます)
+    // The return value is a tuple; the applicable side is set and the other is null.
     public async Task<(CheckForUpdatesResponse? V1, AppUpdateResponse? V3)> CheckForUpdatesAsync(
         string version,
         CancellationToken cancellationToken)
@@ -230,7 +230,7 @@ public class BeutlApiApplication : IAsyncDisposable
         }
     }
 
-    private async Task DisposeCoreAsync()
+    protected virtual async Task DisposeCoreAsync()
     {
         List<object> disposableResources;
         lock (_disposeGate)
@@ -324,6 +324,10 @@ public class BeutlApiApplication : IAsyncDisposable
     {
         lock (_disposeGate)
         {
+            // A canceled caller token must surface as cancellation, not as an
+            // ObjectDisposedException, so nested calls started during disposal can
+            // observe the shutdown as normal cancellation.
+            cancellationToken.ThrowIfCancellationRequested();
             ObjectDisposedException.ThrowIf(_disposed, this);
             return CancellationTokenSource.CreateLinkedTokenSource(
                 cancellationToken,

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -147,21 +147,45 @@ public class BeutlApiApplication : IAsyncDisposable
         lock (_disposeGate)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            if (_services.TryGetValue(typeof(T), out Lazy<object>? lazy))
-            {
-                return (T)lazy.Value;
-            }
-
-            foreach (KeyValuePair<Type, Lazy<object>> item in _services)
-            {
-                if (item.Key.IsAssignableTo(typeof(T)))
-                {
-                    return (T)item.Value.Value;
-                }
-            }
-
-            throw new Exception("Resource not found");
+            return GetResourceCore<T>();
         }
+    }
+
+    // Resolves the resource and links the lifetime token under one dispose-gate hold, so a
+    // concurrent DisposeAsync cannot invalidate the resource between admission and use.
+    internal T GetResourceWithLifetime<T>(CancellationToken cancellationToken, out CancellationTokenSource lifetimeCts)
+        where T : IBeutlApiResource
+    {
+        lock (_disposeGate)
+        {
+            // A canceled caller token must surface as cancellation, not ObjectDisposedException.
+            cancellationToken.ThrowIfCancellationRequested();
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            T resource = GetResourceCore<T>();
+            lifetimeCts = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                _lifetimeCts.Token);
+            return resource;
+        }
+    }
+
+    private T GetResourceCore<T>()
+        where T : IBeutlApiResource
+    {
+        if (_services.TryGetValue(typeof(T), out Lazy<object>? lazy))
+        {
+            return (T)lazy.Value;
+        }
+
+        foreach (KeyValuePair<Type, Lazy<object>> item in _services)
+        {
+            if (item.Key.IsAssignableTo(typeof(T)))
+            {
+                return (T)item.Value.Value;
+            }
+        }
+
+        throw new Exception("Resource not found");
     }
 
     public T? TryGetResource<T>()

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -114,11 +114,13 @@ public class BeutlApiApplication : IAsyncDisposable
         string version,
         CancellationToken cancellationToken)
     {
-        var metadata = await LoadMetadata().WaitAsync(cancellationToken);
-        if (metadata == null) return (await App.CheckForUpdates(version, cancellationToken), null);
+        using CancellationTokenSource lifetimeCts = CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
+        var metadata = await LoadMetadata().WaitAsync(token);
+        if (metadata == null) return (await App.CheckForUpdates(version, token), null);
         var update = await App.GetUpdate(
             version, ToServerType(metadata.Type), metadata.OS, metadata.Arch,
-            metadata.Standalone, "false", cancellationToken);
+            metadata.Standalone, "false", token);
         return (null, update);
     }
 
@@ -177,7 +179,15 @@ public class BeutlApiApplication : IAsyncDisposable
                 .ToList();
         }
 
-        _lifetimeCts.Cancel();
+        Exception? cancellationFailure = null;
+        try
+        {
+            _lifetimeCts.Cancel();
+        }
+        catch (Exception ex)
+        {
+            cancellationFailure = ex;
+        }
 
         foreach (object resource in disposableResources)
         {
@@ -199,6 +209,11 @@ public class BeutlApiApplication : IAsyncDisposable
 
         _lifetimeCts.Dispose();
         ActivitySource.Dispose();
+
+        if (cancellationFailure != null)
+        {
+            throw cancellationFailure;
+        }
     }
 
     private void RegisterAll()

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -165,6 +165,8 @@ public class BeutlApiApplication : IAsyncDisposable
 
     public ValueTask DisposeAsync()
     {
+        TaskCompletionSource? proxy = null;
+        Task disposeTask;
         lock (_disposeGate)
         {
             // Publish a completion proxy before cancellation fires: DisposeCoreAsync runs
@@ -172,12 +174,20 @@ public class BeutlApiApplication : IAsyncDisposable
             // observe the original teardown instead of starting a second pipeline.
             if (_disposeTask == null)
             {
-                TaskCompletionSource proxy = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                proxy = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 _disposeTask = proxy.Task;
-                _ = RunDisposeCoreAsync(proxy);
             }
-            return new ValueTask(_disposeTask);
+            disposeTask = _disposeTask;
         }
+
+        // Start the teardown after releasing the lock so cancellation callbacks that
+        // re-enter disposal or other resource operations do not deadlock against it.
+        if (proxy != null)
+        {
+            _ = RunDisposeCoreAsync(proxy);
+        }
+
+        return new ValueTask(disposeTask);
     }
 
     private async Task RunDisposeCoreAsync(TaskCompletionSource proxy)

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -398,6 +398,7 @@ public class BeutlApiApplication : IAsyncDisposable
         try
         {
             ProfileResponse profileResponse = await Users.GetSelf(cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
             var profile = new Profile(profileResponse, this);
 
             attemptedUser = new AuthenticatedUser(profile, authResponse, this, _httpClient, DateTime.UtcNow);

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -475,6 +475,7 @@ public class BeutlApiApplication : IAsyncDisposable
 
                     _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", user.Token);
                     await user.Profile.RefreshAsync(token, true);
+                    token.ThrowIfCancellationRequested();
                     _authenticatedUser.Value = user;
                     SaveUser();
                 }

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -229,7 +229,11 @@ public class BeutlApiApplication : IAsyncDisposable
         Register(() => new AcceptedLicenseManager());
         Register(() => new PackageChangesQueue());
         Register(() => new LibraryService(this));
-        Register(() => new PackageInstaller(new HttpClient(), GetResource<InstalledPackageRepository>(), this));
+        Register(() => new PackageInstaller(
+            new HttpClient(),
+            ownsHttpClient: true,
+            GetResource<InstalledPackageRepository>(),
+            this));
         Register(() =>
         {
             // Unload diagnostics take a heavy ClrMD self-snapshot and write a dump; they are a development-only aid,

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -109,6 +109,7 @@ public class BeutlApiApplication : IAsyncDisposable
     // 更新があるかどうかをチェックします
     // このアプリケーションがアセットメタデータを持っている場合は、AppUpdateResponseを返します
     // そうでない場合は、CheckForUpdatesResponseを返します
+    // (戻り値はタプルで、該当する方の値がセットされます)
     public async Task<(CheckForUpdatesResponse? V1, AppUpdateResponse? V3)> CheckForUpdatesAsync(
         string version,
         CancellationToken cancellationToken)

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -345,7 +345,7 @@ public class BeutlApiApplication : IAsyncDisposable
         _services.Add(typeof(T), new Lazy<object>(() => factory()));
     }
 
-    internal CancellationTokenSource CreateLifetimeLinkedTokenSource(CancellationToken cancellationToken)
+    protected internal CancellationTokenSource CreateLifetimeLinkedTokenSource(CancellationToken cancellationToken)
     {
         lock (_disposeGate)
         {

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -22,7 +22,7 @@ using IUsersClient = Beutl.Api.Clients.IUsersClient;
 
 namespace Beutl.Api;
 
-public class BeutlApiApplication
+public class BeutlApiApplication : IAsyncDisposable
 {
 #if false
     private const string BaseUrl = "http://localhost:3001";
@@ -35,7 +35,11 @@ public class BeutlApiApplication
     private readonly ExtensionProvider _extensionProvider;
     private readonly ReactivePropertySlim<AuthenticatedUser?> _authenticatedUser = new();
     private readonly Dictionary<Type, Lazy<object>> _services = [];
+    private readonly object _disposeGate = new();
+    private readonly CancellationTokenSource _lifetimeCts = new();
     private static readonly ILogger s_logger = Log.CreateLogger<BeutlApiApplication>();
+    private volatile bool _disposed;
+    private Task? _disposeTask;
     private static readonly AsyncLazy<AssetMetadataJson?> s_metadata = new(async () =>
     {
         s_logger.LogInformation("Loading asset metadata");
@@ -129,20 +133,71 @@ public class BeutlApiApplication
     public T GetResource<T>()
         where T : IBeutlApiResource
     {
-        if (_services.TryGetValue(typeof(T), out Lazy<object>? lazy))
+        lock (_disposeGate)
         {
-            return (T)lazy.Value;
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_services.TryGetValue(typeof(T), out Lazy<object>? lazy))
+            {
+                return (T)lazy.Value;
+            }
+
+            foreach (KeyValuePair<Type, Lazy<object>> item in _services)
+            {
+                if (item.Key.IsAssignableTo(typeof(T)))
+                {
+                    return (T)item.Value.Value;
+                }
+            }
+
+            throw new Exception("Resource not found");
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        lock (_disposeGate)
+        {
+            return new ValueTask(_disposeTask ??= DisposeCoreAsync());
+        }
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        List<object> disposableResources;
+        lock (_disposeGate)
+        {
+            _disposed = true;
+            disposableResources = _services.Values
+                .Where(lazy => lazy.IsValueCreated)
+                .Select(lazy => lazy.Value)
+                .Where(resource => resource is IDisposable or IAsyncDisposable)
+                .Distinct(ReferenceEqualityComparer.Instance)
+                .Reverse()
+                .ToList();
         }
 
-        foreach (KeyValuePair<Type, Lazy<object>> item in _services)
+        _lifetimeCts.Cancel();
+
+        foreach (object resource in disposableResources)
         {
-            if (item.Key.IsAssignableTo(typeof(T)))
+            try
             {
-                return (T)item.Value.Value;
+                if (resource is IAsyncDisposable asyncDisposable)
+                    await asyncDisposable.DisposeAsync();
+                else
+                    ((IDisposable)resource).Dispose();
+            }
+            catch (Exception ex)
+            {
+                s_logger.LogWarning(
+                    ex,
+                    "Failed to dispose API resource {ResourceType}.",
+                    resource.GetType());
             }
         }
 
-        throw new Exception("Resource not found");
+        _lifetimeCts.Dispose();
+        ActivitySource.Dispose();
     }
 
     private void RegisterAll()
@@ -177,6 +232,17 @@ public class BeutlApiApplication
         where T : IBeutlApiResource
     {
         _services.Add(typeof(T), new Lazy<object>(() => factory()));
+    }
+
+    internal CancellationTokenSource CreateLifetimeLinkedTokenSource(CancellationToken cancellationToken)
+    {
+        lock (_disposeGate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                _lifetimeCts.Token);
+        }
     }
 
     public void SignOut(bool deleteFile = true)
@@ -356,21 +422,23 @@ public class BeutlApiApplication
 
     public async Task RestoreUserAsync(Activity? activity, CancellationToken cancellationToken)
     {
-        using (await Lock.LockAsync(cancellationToken))
+        using CancellationTokenSource lifetimeCts = CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
+        using (await Lock.LockAsync(token))
         {
             activity?.AddEvent(new("Entered_AsyncLock"));
 
             string? previousAuthorization = _httpClient.DefaultRequestHeaders.Authorization?.ToString();
             AuthenticatedUser? previousUser = _authenticatedUser.Value;
-            AuthenticatedUser? user = await ReadUserAsync(cancellationToken);
+            AuthenticatedUser? user = await ReadUserAsync(token);
             if (user != null)
             {
                 try
                 {
-                    await user.RefreshAsync(cancellationToken);
+                    await user.RefreshAsync(token);
 
                     _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", user.Token);
-                    await user.Profile.RefreshAsync(cancellationToken, true);
+                    await user.Profile.RefreshAsync(token, true);
                     _authenticatedUser.Value = user;
                     SaveUser();
                 }
@@ -394,28 +462,31 @@ public class BeutlApiApplication
 
     public async ValueTask<AuthenticatedUser?> ReadUserAsync(CancellationToken cancellationToken)
     {
-        cancellationToken.ThrowIfCancellationRequested();
+        using CancellationTokenSource lifetimeCts = CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
+        token.ThrowIfCancellationRequested();
         string fileName = Path.Combine(Helper.AppRoot, UserFileName);
         if (File.Exists(fileName))
         {
-            JsonNode? node = JsonNode.Parse(await File.ReadAllTextAsync(fileName, cancellationToken));
+            JsonNode? node = JsonNode.Parse(await File.ReadAllTextAsync(fileName, token));
+            token.ThrowIfCancellationRequested();
             DateTime lastWriteTime = File.GetLastWriteTimeUtc(fileName);
 
             if (node != null)
             {
                 ProfileResponse? profile = JsonSerializer.Deserialize<ProfileResponse>(node["profile"]);
-                string? token = (string?)node["token"];
+                string? persistedToken = (string?)node["token"];
                 string? refreshToken = (string?)node["refresh_token"];
                 var expiration = (DateTime?)node["expiration"];
 
                 if (profile != null
-                    && token != null
+                    && persistedToken != null
                     && refreshToken != null
                     && expiration.HasValue)
                 {
                     return new AuthenticatedUser(
                         new Profile(profile, this),
-                        new AuthResponse { Expiration = expiration.Value, RefreshToken = refreshToken, Token = token },
+                        new AuthResponse { Expiration = expiration.Value, RefreshToken = refreshToken, Token = persistedToken },
                         this,
                         _httpClient,
                         lastWriteTime);

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -192,7 +192,7 @@ public class BeutlApiApplication : IAsyncDisposable
     // uncreated resource is not available yet, so the resolver-style name would conflate
     // that state with unavailable. The sole production use is a shutdown-time probe for
     // resources that must have been created by then.
-    public T? TryGetCreatedResource<T>()
+    internal T? TryGetCreatedResource<T>()
         where T : class, IBeutlApiResource
     {
         lock (_disposeGate)

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -106,6 +106,8 @@ public class BeutlApiApplication : IAsyncDisposable
 
     public IReadOnlyReactiveProperty<AuthenticatedUser?> AuthenticatedUser => _authenticatedUser;
 
+    public bool IsDisposed => _disposed;
+
     // 更新があるかどうかをチェックします
     // このアプリケーションがアセットメタデータを持っている場合は、AppUpdateResponseを返します
     // そうでない場合は、CheckForUpdatesResponseを返します
@@ -160,6 +162,31 @@ public class BeutlApiApplication : IAsyncDisposable
             }
 
             throw new Exception("Resource not found");
+        }
+    }
+
+    public T? TryGetResource<T>()
+        where T : class, IBeutlApiResource
+    {
+        lock (_disposeGate)
+        {
+            if (_disposed)
+                return null;
+
+            if (_services.TryGetValue(typeof(T), out Lazy<object>? lazy) && lazy.IsValueCreated)
+            {
+                return (T)lazy.Value;
+            }
+
+            foreach (KeyValuePair<Type, Lazy<object>> item in _services)
+            {
+                if (item.Key.IsAssignableTo(typeof(T)) && item.Value.IsValueCreated)
+                {
+                    return (T)item.Value.Value;
+                }
+            }
+
+            return null;
         }
     }
 

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -328,6 +328,7 @@ public class BeutlApiApplication : IAsyncDisposable
             {
                 ContinueUri = continueUri
             }, token);
+            token.ThrowIfCancellationRequested();
             using HttpListener listener = StartListener($"{continueUri}/");
             activity?.AddEvent(new("Started_Listener"));
 
@@ -376,6 +377,7 @@ public class BeutlApiApplication : IAsyncDisposable
                 {
                     ContinueUri = continueUri
                 }, token);
+                token.ThrowIfCancellationRequested();
                 using HttpListener listener = StartListener($"{continueUri}/");
                 activity?.AddEvent(new("Started_Listener"));
 
@@ -429,7 +431,8 @@ public class BeutlApiApplication : IAsyncDisposable
             // Only roll back state still owned by this failing attempt: a SignOut or a
             // later successful sign-in may have replaced the user while GetSelf was pending,
             // and must not be overwritten by the stale snapshot.
-            if (ReferenceEquals(_authenticatedUser.Value, attemptedUser))
+            if (ReferenceEquals(_authenticatedUser.Value, attemptedUser)
+                || (attemptedUser == null && ReferenceEquals(_authenticatedUser.Value, previousUser)))
             {
                 _authenticatedUser.Value = previousUser;
                 if (previousAuthorization != null)

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -111,7 +111,6 @@ public class BeutlApiApplication : IAsyncDisposable
     // 更新があるかどうかをチェックします
     // このアプリケーションがアセットメタデータを持っている場合は、AppUpdateResponseを返します
     // そうでない場合は、CheckForUpdatesResponseを返します
-    // The return value is a tuple; the applicable side is set and the other is null.
     public async Task<(CheckForUpdatesResponse? V1, AppUpdateResponse? V3)> CheckForUpdatesAsync(
         string version,
         CancellationToken cancellationToken)
@@ -196,9 +195,8 @@ public class BeutlApiApplication : IAsyncDisposable
         Task disposeTask;
         lock (_disposeGate)
         {
-            // Publish a completion proxy before cancellation fires: DisposeCoreAsync runs
-            // synchronously through _lifetimeCts.Cancel(), and a re-entrant callback must
-            // observe the original teardown instead of starting a second pipeline.
+            // Publish the disposal task before cancellation so re-entrant callbacks
+            // observe the original teardown.
             if (_disposeTask == null)
             {
                 proxy = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -207,8 +205,7 @@ public class BeutlApiApplication : IAsyncDisposable
             disposeTask = _disposeTask;
         }
 
-        // Start the teardown after releasing the lock so cancellation callbacks that
-        // re-enter disposal or other resource operations do not deadlock against it.
+        // Start teardown after releasing the lock so re-entrant callbacks do not deadlock.
         if (proxy != null)
         {
             _ = RunDisposeCoreAsync(proxy);
@@ -324,9 +321,7 @@ public class BeutlApiApplication : IAsyncDisposable
     {
         lock (_disposeGate)
         {
-            // A canceled caller token must surface as cancellation, not as an
-            // ObjectDisposedException, so nested calls started during disposal can
-            // observe the shutdown as normal cancellation.
+            // A canceled caller token must surface as cancellation, not ObjectDisposedException.
             cancellationToken.ThrowIfCancellationRequested();
             ObjectDisposedException.ThrowIf(_disposed, this);
             return CancellationTokenSource.CreateLinkedTokenSource(

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -167,7 +167,11 @@ public class BeutlApiApplication : IAsyncDisposable
     {
         lock (_disposeGate)
         {
-            return new ValueTask(_disposeTask ??= DisposeCoreAsync());
+            // Publish the shared disposal task before cancellation fires, so a cancellation
+            // callback that re-enters DisposeAsync observes the original teardown instead of
+            // starting a second disposal pipeline over the same resource snapshot.
+            _disposeTask ??= DisposeCoreAsync();
+            return new ValueTask(_disposeTask);
         }
     }
 

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -167,11 +167,29 @@ public class BeutlApiApplication : IAsyncDisposable
     {
         lock (_disposeGate)
         {
-            // Publish the shared disposal task before cancellation fires, so a cancellation
-            // callback that re-enters DisposeAsync observes the original teardown instead of
-            // starting a second disposal pipeline over the same resource snapshot.
-            _disposeTask ??= DisposeCoreAsync();
+            // Publish a completion proxy before cancellation fires: DisposeCoreAsync runs
+            // synchronously through _lifetimeCts.Cancel(), and a re-entrant callback must
+            // observe the original teardown instead of starting a second pipeline.
+            if (_disposeTask == null)
+            {
+                TaskCompletionSource proxy = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                _disposeTask = proxy.Task;
+                _ = RunDisposeCoreAsync(proxy);
+            }
             return new ValueTask(_disposeTask);
+        }
+    }
+
+    private async Task RunDisposeCoreAsync(TaskCompletionSource proxy)
+    {
+        try
+        {
+            await DisposeCoreAsync().ConfigureAwait(false);
+            proxy.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            proxy.TrySetException(ex);
         }
     }
 

--- a/src/Beutl.Api/Objects/AuthorizedUser.cs
+++ b/src/Beutl.Api/Objects/AuthorizedUser.cs
@@ -42,6 +42,7 @@ public class AuthenticatedUser(
             if (_writeTime < lastWriteTime)
             {
                 AuthenticatedUser? fileUser = await clients.ReadUserAsync(token);
+                token.ThrowIfCancellationRequested();
                 if (fileUser?.Profile?.Id == Profile.Id)
                 {
                     _response = fileUser._response;

--- a/src/Beutl.Api/Objects/AuthorizedUser.cs
+++ b/src/Beutl.Api/Objects/AuthorizedUser.cs
@@ -31,6 +31,8 @@ public class AuthenticatedUser(
 
     public async ValueTask RefreshAsync(CancellationToken cancellationToken, bool force = false)
     {
+        using CancellationTokenSource lifetimeCts = clients.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
         using Activity? activity = clients.ActivitySource.StartActivity("AuthenticatedUser.Refresh", ActivityKind.Client);
 
         string fileName = Path.Combine(Helper.AppRoot, BeutlApiApplication.UserFileName);
@@ -39,7 +41,7 @@ public class AuthenticatedUser(
             DateTime lastWriteTime = File.GetLastWriteTimeUtc(fileName);
             if (_writeTime < lastWriteTime)
             {
-                AuthenticatedUser? fileUser = await clients.ReadUserAsync(cancellationToken);
+                AuthenticatedUser? fileUser = await clients.ReadUserAsync(token);
                 if (fileUser?.Profile?.Id == Profile.Id)
                 {
                     _response = fileUser._response;
@@ -62,7 +64,7 @@ public class AuthenticatedUser(
             {
                 RefreshToken = RefreshToken,
                 Token = Token
-            }, cancellationToken)
+            }, token)
                 .ConfigureAwait(false);
             activity?.AddEvent(new("Refreshed"));
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);

--- a/src/Beutl.Api/Objects/AuthorizedUser.cs
+++ b/src/Beutl.Api/Objects/AuthorizedUser.cs
@@ -60,12 +60,14 @@ public class AuthenticatedUser(
 
         if (force || IsExpired)
         {
-            _response = await clients.Account.Refresh(new RefreshTokenRequest
+            AuthResponse response = await clients.Account.Refresh(new RefreshTokenRequest
             {
                 RefreshToken = RefreshToken,
                 Token = Token
             }, token)
                 .ConfigureAwait(false);
+            token.ThrowIfCancellationRequested();
+            _response = response;
             activity?.AddEvent(new("Refreshed"));
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
 

--- a/src/Beutl.Api/Objects/Package.cs
+++ b/src/Beutl.Api/Objects/Package.cs
@@ -87,16 +87,25 @@ public class Package
 
     public async Task RefreshAsync(CancellationToken cancellationToken)
     {
+        using CancellationTokenSource lifetimeCts = _clients.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
+        token.ThrowIfCancellationRequested();
         using Activity? activity = _clients.ActivitySource.StartActivity("Package.Refresh", ActivityKind.Client);
 
-        _response.Value = await _clients.Packages.GetPackage(Name, cancellationToken);
+        PackageResponse response = await _clients.Packages.GetPackage(Name, token);
+        token.ThrowIfCancellationRequested();
+        _response.Value = response;
         _isDeleted.Value = false;
     }
 
     public async Task<Release> GetReleaseAsync(string version, CancellationToken cancellationToken)
     {
+        using CancellationTokenSource lifetimeCts = _clients.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
+        token.ThrowIfCancellationRequested();
         using Activity? activity = _clients.ActivitySource.StartActivity("Package.GetRelease", ActivityKind.Client);
-        ReleaseResponse response = await _clients.Releases.GetRelease(Name, version, cancellationToken);
+        ReleaseResponse response = await _clients.Releases.GetRelease(Name, version, token);
+        token.ThrowIfCancellationRequested();
         return new Release(this, response, _clients);
     }
 
@@ -105,11 +114,16 @@ public class Package
         int start = 0,
         int count = 30)
     {
+        using CancellationTokenSource lifetimeCts = _clients.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
+        token.ThrowIfCancellationRequested();
         using Activity? activity = _clients.ActivitySource.StartActivity("Package.GetReleases", ActivityKind.Client);
         activity?.SetTag("start", start);
         activity?.SetTag("count", count);
 
-        return (await _clients.Releases.GetReleases(Name, cancellationToken, start, count))
+        ReleaseResponse[] responses = await _clients.Releases.GetReleases(Name, token, start, count);
+        token.ThrowIfCancellationRequested();
+        return responses
             .Select(x => new Release(this, x, _clients))
             .ToArray();
     }

--- a/src/Beutl.Api/Objects/Profile.cs
+++ b/src/Beutl.Api/Objects/Profile.cs
@@ -44,12 +44,16 @@ public class Profile
 
         if (self)
         {
-            _response.Value = await _clients.Users.GetSelf(token);
+            ProfileResponse response = await _clients.Users.GetSelf(token);
+            token.ThrowIfCancellationRequested();
+            _response.Value = response;
             Name = _response.Value.Name;
         }
         else
         {
-            _response.Value = await _clients.Users.GetUser(Name, token);
+            ProfileResponse response = await _clients.Users.GetUser(Name, token);
+            token.ThrowIfCancellationRequested();
+            _response.Value = response;
         }
     }
 

--- a/src/Beutl.Api/Objects/Profile.cs
+++ b/src/Beutl.Api/Objects/Profile.cs
@@ -71,11 +71,15 @@ public class Profile
         // TODO: System.Interactive.AsyncからSystem.Linq.Asyncが削除されれば、AsyncEnumerableを使った実装に戻す
         SimplePackageResponse[] packages = await _clients.Users.GetUserPackages(Name, token, start, count);
         token.ThrowIfCancellationRequested();
-        Package[] result = await packages
-            .ToObservable()
-            .SelectMany(async x => await _clients.Packages.GetPackage(x.Name, token))
-            .Select(x => new Package(this, x, _clients))
-            .ToArray();
+        // Await every spawned request so a fault in one does not sever the others from
+        // the lifetime token; SelectMany would terminate the sequence on the first fault
+        // and leave the remaining requests running unlinked.
+        Package[] result = await Task.WhenAll(
+            packages.Select(async x =>
+            {
+                PackageResponse response = await _clients.Packages.GetPackage(x.Name, token);
+                return new Package(this, response, _clients);
+            }));
         token.ThrowIfCancellationRequested();
         return result;
     }

--- a/src/Beutl.Api/Objects/Profile.cs
+++ b/src/Beutl.Api/Objects/Profile.cs
@@ -38,16 +38,18 @@ public class Profile
 
     public async Task RefreshAsync(CancellationToken cancellationToken, bool self = false)
     {
+        using CancellationTokenSource lifetimeCts = _clients.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
         using Activity? activity = _clients.ActivitySource.StartActivity("Profile.Refresh", ActivityKind.Client);
 
         if (self)
         {
-            _response.Value = await _clients.Users.GetSelf(cancellationToken);
+            _response.Value = await _clients.Users.GetSelf(token);
             Name = _response.Value.Name;
         }
         else
         {
-            _response.Value = await _clients.Users.GetUser(Name, cancellationToken);
+            _response.Value = await _clients.Users.GetUser(Name, token);
         }
     }
 
@@ -56,14 +58,16 @@ public class Profile
         int start = 0,
         int count = 30)
     {
+        using CancellationTokenSource lifetimeCts = _clients.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
         using Activity? activity = _clients.ActivitySource.StartActivity("Profile.GetPackages", ActivityKind.Client);
         activity?.SetTag("start", start);
         activity?.SetTag("count", count);
 
         // TODO: System.Interactive.AsyncからSystem.Linq.Asyncが削除されれば、AsyncEnumerableを使った実装に戻す
-        return await (await _clients.Users.GetUserPackages(Name, cancellationToken, start, count))
+        return await (await _clients.Users.GetUserPackages(Name, token, start, count))
             .ToObservable()
-            .SelectMany(async x => await _clients.Packages.GetPackage(x.Name, cancellationToken))
+            .SelectMany(async x => await _clients.Packages.GetPackage(x.Name, token))
             .Select(x => new Package(this, x, _clients))
             .ToArray();
     }

--- a/src/Beutl.Api/Objects/Profile.cs
+++ b/src/Beutl.Api/Objects/Profile.cs
@@ -71,9 +71,7 @@ public class Profile
         // TODO: System.Interactive.AsyncからSystem.Linq.Asyncが削除されれば、AsyncEnumerableを使った実装に戻す
         SimplePackageResponse[] packages = await _clients.Users.GetUserPackages(Name, token, start, count);
         token.ThrowIfCancellationRequested();
-        // Await every spawned request so a fault in one does not sever the others from
-        // the lifetime token; SelectMany would terminate the sequence on the first fault
-        // and leave the remaining requests running unlinked.
+        // Await all requests so a fault in one does not sever the others from the lifetime token.
         Package[] result = await Task.WhenAll(
             packages.Select(async x =>
             {

--- a/src/Beutl.Api/Objects/Profile.cs
+++ b/src/Beutl.Api/Objects/Profile.cs
@@ -69,10 +69,14 @@ public class Profile
         activity?.SetTag("count", count);
 
         // TODO: System.Interactive.AsyncからSystem.Linq.Asyncが削除されれば、AsyncEnumerableを使った実装に戻す
-        return await (await _clients.Users.GetUserPackages(Name, token, start, count))
+        SimplePackageResponse[] packages = await _clients.Users.GetUserPackages(Name, token, start, count);
+        token.ThrowIfCancellationRequested();
+        Package[] result = await packages
             .ToObservable()
             .SelectMany(async x => await _clients.Packages.GetPackage(x.Name, token))
             .Select(x => new Package(this, x, _clients))
             .ToArray();
+        token.ThrowIfCancellationRequested();
+        return result;
     }
 }

--- a/src/Beutl.Api/Objects/Release.cs
+++ b/src/Beutl.Api/Objects/Release.cs
@@ -47,23 +47,33 @@ public class Release
 
     public async Task RefreshAsync(CancellationToken cancellationToken)
     {
+        using CancellationTokenSource lifetimeCts = _clients.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
+        token.ThrowIfCancellationRequested();
         using Activity? activity = _clients.ActivitySource.StartActivity("Release.Refresh", ActivityKind.Client);
 
-        _response.Value = await _clients.Releases.GetRelease(
+        ReleaseResponse response = await _clients.Releases.GetRelease(
             Package.Name,
             _response.Value.Version,
-            cancellationToken);
+            token);
 
+        token.ThrowIfCancellationRequested();
+        _response.Value = response;
         _isDeleted.Value = false;
     }
 
     public async Task<FileResponse> GetAssetAsync(CancellationToken cancellationToken)
     {
+        using CancellationTokenSource lifetimeCts = _clients.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
+        token.ThrowIfCancellationRequested();
         using Activity? activity = _clients.ActivitySource.StartActivity("Release.GetAsset", ActivityKind.Client);
 
         if (AssetId.Value == null)
             throw new InvalidOperationException("This release has no assets.");
 
-        return await _clients.Files.GetFile(AssetId.Value!, cancellationToken);
+        FileResponse response = await _clients.Files.GetFile(AssetId.Value!, token);
+        token.ThrowIfCancellationRequested();
+        return response;
     }
 }

--- a/src/Beutl.Api/Services/DiscoverService.cs
+++ b/src/Beutl.Api/Services/DiscoverService.cs
@@ -43,7 +43,7 @@ public class DiscoverService(BeutlApiApplication clients) : IBeutlApiResource
         using CancellationTokenSource lifetimeCts = clients.CreateLifetimeLinkedTokenSource(cancellationToken);
         CancellationToken token = lifetimeCts.Token;
         token.ThrowIfCancellationRequested();
-        using Activity? activity = clients.ActivitySource.StartActivity("DiscoverService.GetDailyRanking", ActivityKind.Client);
+        using Activity? activity = clients.ActivitySource.StartActivity("DiscoverService.GetFeatured", ActivityKind.Client);
         activity?.SetTag("start", start);
         activity?.SetTag("count", count);
         activity?.SetTag("type", type.ToString());

--- a/src/Beutl.Api/Services/DiscoverService.cs
+++ b/src/Beutl.Api/Services/DiscoverService.cs
@@ -51,6 +51,7 @@ public class DiscoverService(BeutlApiApplication clients) : IBeutlApiResource
         SimplePackageResponse[] packages = await clients.Discover
             .GetFeatured(token, start, count, type.ToQueryValue())
             .ConfigureAwait(false);
+        token.ThrowIfCancellationRequested();
         Package[] result = await Task.WhenAll(
                 packages.Select(package => GetPackage(package.Name, token)))
             .ConfigureAwait(false);
@@ -72,6 +73,7 @@ public class DiscoverService(BeutlApiApplication clients) : IBeutlApiResource
         SimplePackageResponse[] packages = await clients.Discover
             .Search(query, token, start, count, type.ToQueryValue())
             .ConfigureAwait(false);
+        token.ThrowIfCancellationRequested();
         Package[] result = await Task.WhenAll(
                 packages.Select(package => GetPackage(package.Name, token)))
             .ConfigureAwait(false);

--- a/src/Beutl.Api/Services/DiscoverService.cs
+++ b/src/Beutl.Api/Services/DiscoverService.cs
@@ -1,6 +1,4 @@
 ﻿using System.Diagnostics;
-using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using Beutl.Api.Clients;
 using Beutl.Api.Objects;
 
@@ -12,9 +10,13 @@ public class DiscoverService(BeutlApiApplication clients) : IBeutlApiResource
 
     public async Task<Package> GetPackage(string name, CancellationToken cancellationToken)
     {
+        using CancellationTokenSource lifetimeCts = clients.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
+        token.ThrowIfCancellationRequested();
         using Activity? activity = clients.ActivitySource.StartActivity("DiscoverService.GetPackage", ActivityKind.Client);
 
-        PackageResponse package = await clients.Packages.GetPackage(name, cancellationToken).ConfigureAwait(false);
+        PackageResponse package = await clients.Packages.GetPackage(name, token).ConfigureAwait(false);
+        token.ThrowIfCancellationRequested();
         var owner = new Profile(package.Owner, clients);
 
         return new Package(owner, package, clients);
@@ -22,9 +24,13 @@ public class DiscoverService(BeutlApiApplication clients) : IBeutlApiResource
 
     public async Task<Profile> GetProfile(string name, CancellationToken cancellationToken)
     {
+        using CancellationTokenSource lifetimeCts = clients.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
+        token.ThrowIfCancellationRequested();
         using Activity? activity = clients.ActivitySource.StartActivity("DiscoverService.GetProfile", ActivityKind.Client);
 
-        ProfileResponse response = await clients.Users.GetUser(name, cancellationToken).ConfigureAwait(false);
+        ProfileResponse response = await clients.Users.GetUser(name, token).ConfigureAwait(false);
+        token.ThrowIfCancellationRequested();
         return new Profile(response, clients);
     }
 
@@ -34,18 +40,22 @@ public class DiscoverService(BeutlApiApplication clients) : IBeutlApiResource
         int count = 30,
         PackageKindFilter type = PackageKindFilter.All)
     {
-        using Activity? activity = clients.ActivitySource.StartActivity("DiscoverService.GetFeatured", ActivityKind.Client);
+        using CancellationTokenSource lifetimeCts = clients.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
+        token.ThrowIfCancellationRequested();
+        using Activity? activity = clients.ActivitySource.StartActivity("DiscoverService.GetDailyRanking", ActivityKind.Client);
         activity?.SetTag("start", start);
         activity?.SetTag("count", count);
         activity?.SetTag("type", type.ToString());
 
-        // TODO: System.Interactive.AsyncからSystem.Linq.Asyncが削除されれば、AsyncEnumerableを使った実装に戻す
-        return await (await clients.Discover.GetFeatured(cancellationToken, start, count, type.ToQueryValue()).ConfigureAwait(false))
-            .ToObservable()
-            .SelectMany(async x => await GetPackage(x.Name, cancellationToken).ConfigureAwait(false))
-            .ToArray()
-            .ToTask()
+        SimplePackageResponse[] packages = await clients.Discover
+            .GetFeatured(token, start, count, type.ToQueryValue())
             .ConfigureAwait(false);
+        Package[] result = await Task.WhenAll(
+                packages.Select(package => GetPackage(package.Name, token)))
+            .ConfigureAwait(false);
+        token.ThrowIfCancellationRequested();
+        return result;
     }
 
     public async Task<Package[]> Search(
@@ -55,12 +65,17 @@ public class DiscoverService(BeutlApiApplication clients) : IBeutlApiResource
         int count = 30,
         PackageKindFilter type = PackageKindFilter.All)
     {
-        // TODO: System.Interactive.AsyncからSystem.Linq.Asyncが削除されれば、AsyncEnumerableを使った実装に戻す
-        return await (await clients.Discover.Search(query, cancellationToken, start, count, type.ToQueryValue()).ConfigureAwait(false))
-            .ToObservable()
-            .SelectMany(async x => await GetPackage(x.Name, cancellationToken).ConfigureAwait(false))
-            .ToArray()
-            .ToTask()
+        using CancellationTokenSource lifetimeCts = clients.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
+        token.ThrowIfCancellationRequested();
+
+        SimplePackageResponse[] packages = await clients.Discover
+            .Search(query, token, start, count, type.ToQueryValue())
             .ConfigureAwait(false);
+        Package[] result = await Task.WhenAll(
+                packages.Select(package => GetPackage(package.Name, token)))
+            .ConfigureAwait(false);
+        token.ThrowIfCancellationRequested();
+        return result;
     }
 }

--- a/src/Beutl.Api/Services/LibraryService.cs
+++ b/src/Beutl.Api/Services/LibraryService.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using System.Reactive.Linq;
 using Beutl.Api.Clients;
 using Beutl.Api.Objects;
 
@@ -9,8 +8,12 @@ public class LibraryService(BeutlApiApplication clients) : IBeutlApiResource
 {
     public async Task<Package> GetPackage(string name, CancellationToken cancellationToken)
     {
+        using CancellationTokenSource lifetimeCts = clients.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
+        token.ThrowIfCancellationRequested();
         using Activity? activity = clients.ActivitySource.StartActivity("LibraryService.GetPackage", ActivityKind.Client);
-        PackageResponse package = await clients.Packages.GetPackage(name, cancellationToken);
+        PackageResponse package = await clients.Packages.GetPackage(name, token);
+        token.ThrowIfCancellationRequested();
         var owner = new Profile(package.Owner, clients);
 
         return new Package(owner, package, clients);
@@ -18,8 +21,12 @@ public class LibraryService(BeutlApiApplication clients) : IBeutlApiResource
 
     public async Task<Profile> GetProfile(string name, CancellationToken cancellationToken)
     {
+        using CancellationTokenSource lifetimeCts = clients.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
+        token.ThrowIfCancellationRequested();
         using Activity? activity = clients.ActivitySource.StartActivity("LibraryService.GetProfile", ActivityKind.Client);
-        ProfileResponse response = await clients.Users.GetUser(name, cancellationToken);
+        ProfileResponse response = await clients.Users.GetUser(name, token);
+        token.ThrowIfCancellationRequested();
         return new Profile(response, clients);
     }
 
@@ -28,25 +35,32 @@ public class LibraryService(BeutlApiApplication clients) : IBeutlApiResource
         int start = 0,
         int count = 30)
     {
+        using CancellationTokenSource lifetimeCts = clients.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
+        token.ThrowIfCancellationRequested();
         using Activity? activity = clients.ActivitySource.StartActivity("LibraryService.GetPackages", ActivityKind.Client);
         activity?.SetTag("start", start);
         activity?.SetTag("count", count);
 
-        // TODO: System.Interactive.AsyncからSystem.Linq.Asyncが削除されれば、AsyncEnumerableを使った実装に戻す
-        return await (await clients.Library.GetLibrary(cancellationToken, start, count))
-            .ToObservable()
-            .SelectMany(async x => await GetPackage(x.Package.Name, cancellationToken))
-            .ToArray();
+        AcquirePackageResponse[] packages = await clients.Library.GetLibrary(token, start, count);
+        Package[] result = await Task.WhenAll(
+            packages.Select(package => GetPackage(package.Package.Name, token)));
+        token.ThrowIfCancellationRequested();
+        return result;
     }
 
     public async Task<Release> Acquire(Package package, CancellationToken cancellationToken)
     {
+        using CancellationTokenSource lifetimeCts = clients.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
+        token.ThrowIfCancellationRequested();
         using Activity? activity = clients.ActivitySource.StartActivity("LibraryService.GetPackage", ActivityKind.Client);
 
         AcquirePackageResponse response = await clients.Library.AcquirePackage(new AcquirePackageRequest
         {
             PackageId = package.Id
-        }, cancellationToken);
+        }, token);
+        token.ThrowIfCancellationRequested();
         if (response.LatestRelease == null)
             throw new Exception("No release");
 
@@ -55,8 +69,11 @@ public class LibraryService(BeutlApiApplication clients) : IBeutlApiResource
 
     public async Task RemovePackage(Package package, CancellationToken cancellationToken)
     {
+        using CancellationTokenSource lifetimeCts = clients.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
+        token.ThrowIfCancellationRequested();
         using Activity? activity = clients.ActivitySource.StartActivity("LibraryService.RemovePackage", ActivityKind.Client);
 
-        await clients.Library.DeleteLibraryPackage(package.Name, cancellationToken);
+        await clients.Library.DeleteLibraryPackage(package.Name, token);
     }
 }

--- a/src/Beutl.Api/Services/LibraryService.cs
+++ b/src/Beutl.Api/Services/LibraryService.cs
@@ -76,5 +76,6 @@ public class LibraryService(BeutlApiApplication clients) : IBeutlApiResource
         using Activity? activity = clients.ActivitySource.StartActivity("LibraryService.RemovePackage", ActivityKind.Client);
 
         await clients.Library.DeleteLibraryPackage(package.Name, token);
+        token.ThrowIfCancellationRequested();
     }
 }

--- a/src/Beutl.Api/Services/LibraryService.cs
+++ b/src/Beutl.Api/Services/LibraryService.cs
@@ -43,6 +43,7 @@ public class LibraryService(BeutlApiApplication clients) : IBeutlApiResource
         activity?.SetTag("count", count);
 
         AcquirePackageResponse[] packages = await clients.Library.GetLibrary(token, start, count);
+        token.ThrowIfCancellationRequested();
         Package[] result = await Task.WhenAll(
             packages.Select(package => GetPackage(package.Package.Name, token)));
         token.ThrowIfCancellationRequested();

--- a/src/Beutl.Api/Services/PackageInstaller.Clean.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.Clean.cs
@@ -54,6 +54,7 @@ public partial class PackageInstaller
 
     public PackageCleanContext PrepareForClean(IEnumerable<PackageIdentity>? excludedPackages = null, CancellationToken cancellationToken = default)
     {
+        EnsureNotDisposed();
         cancellationToken.ThrowIfCancellationRequested();
         excludedPackages ??= [];
 
@@ -87,6 +88,7 @@ public partial class PackageInstaller
         IProgress<double> progress,
         CancellationToken cancellationToken = default)
     {
+        EnsureNotDisposed();
         cancellationToken.ThrowIfCancellationRequested();
 
         var failedPackages = new List<string>();

--- a/src/Beutl.Api/Services/PackageInstaller.Clean.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.Clean.cs
@@ -54,33 +54,35 @@ public partial class PackageInstaller
 
     public PackageCleanContext PrepareForClean(IEnumerable<PackageIdentity>? excludedPackages = null, CancellationToken cancellationToken = default)
     {
-        EnsureNotDisposed();
-        cancellationToken.ThrowIfCancellationRequested();
-        excludedPackages ??= [];
-
-        PackageIdentity[] unnecessaryPackages = UnnecessaryPackages()
-            .Except(excludedPackages, PackageIdentityComparer.Default)
-            .ToArray();
-
-        long size = 0;
-        foreach (PackageIdentity package in unnecessaryPackages)
+        return TrackSyncOperation(() =>
         {
-            string directory = Helper.ResolveInstalledDirectory(package);
-            if (!Directory.Exists(directory))
+            cancellationToken.ThrowIfCancellationRequested();
+            excludedPackages ??= [];
+
+            PackageIdentity[] unnecessaryPackages = UnnecessaryPackages()
+                .Except(excludedPackages, PackageIdentityComparer.Default)
+                .ToArray();
+
+            long size = 0;
+            foreach (PackageIdentity package in unnecessaryPackages)
             {
-                _logger.LogWarning("Installed directory not found for package: {PackageId}", package.Id);
-                continue;
+                string directory = Helper.ResolveInstalledDirectory(package);
+                if (!Directory.Exists(directory))
+                {
+                    _logger.LogWarning("Installed directory not found for package: {PackageId}", package.Id);
+                    continue;
+                }
+
+                foreach (string file in Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories))
+                {
+                    size += new FileInfo(file).Length;
+                }
             }
 
-            foreach (string file in Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories))
-            {
-                size += new FileInfo(file).Length;
-            }
-        }
+            _logger.LogInformation("Prepared for clean. Unnecessary packages: {PackageCount}, Total size: {TotalSize} bytes", unnecessaryPackages.Length, size);
 
-        _logger.LogInformation("Prepared for clean. Unnecessary packages: {PackageCount}, Total size: {TotalSize} bytes", unnecessaryPackages.Length, size);
-
-        return new PackageCleanContext(unnecessaryPackages, size);
+            return new PackageCleanContext(unnecessaryPackages, size);
+        });
     }
 
     public void Clean(
@@ -88,85 +90,87 @@ public partial class PackageInstaller
         IProgress<double> progress,
         CancellationToken cancellationToken = default)
     {
-        EnsureNotDisposed();
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var failedPackages = new List<string>();
-        long totalSize = 0;
-        foreach (PackageIdentity package in context.UnnecessaryPackages)
+        TrackSyncOperation(() =>
         {
-            // A data package's payload lives outside the install directory, and it has to
-            // go even when the extracted package itself is already missing. The payload
-            // directory is keyed by id alone, so an update that leaves a newer identity
-            // installed still owns it — removing it here would strip the live version.
-            bool dataRemoved = KeepsAnotherInstalledIdentity(context, package)
-                               || UninstallDataPackage(package.Id);
+            cancellationToken.ThrowIfCancellationRequested();
 
-            string directory = Helper.ResolveInstalledDirectory(package);
-            if (!dataRemoved)
+            var failedPackages = new List<string>();
+            long totalSize = 0;
+            foreach (PackageIdentity package in context.UnnecessaryPackages)
             {
-                // PrepareForClean rediscovers candidates from extracted package directories,
-                // so dropping this one would strand the payload with nothing left to retry
-                // from. Keep both the directory and the repository entry for the next run.
-                _logger.LogError("Failed to delete the data payload of package: {PackageId}", package.Id);
-                failedPackages.Add(directory);
-                continue;
-            }
+                // A data package's payload lives outside the install directory, and it has to
+                // go even when the extracted package itself is already missing. The payload
+                // directory is keyed by id alone, so an update that leaves a newer identity
+                // installed still owns it — removing it here would strip the live version.
+                bool dataRemoved = KeepsAnotherInstalledIdentity(context, package)
+                                   || UninstallDataPackage(package.Id);
 
-            if (!Directory.Exists(directory))
-            {
-                // The files are already gone, so the repository entry would outlive them.
-                _logger.LogWarning("Installed directory not found for package: {PackageId}", package.Id);
-                _installedPackageRepository.RemovePackage(package);
-                continue;
-            }
+                string directory = Helper.ResolveInstalledDirectory(package);
+                if (!dataRemoved)
+                {
+                    // PrepareForClean rediscovers candidates from extracted package directories,
+                    // so dropping this one would strand the payload with nothing left to retry
+                    // from. Keep both the directory and the repository entry for the next run.
+                    _logger.LogError("Failed to delete the data payload of package: {PackageId}", package.Id);
+                    failedPackages.Add(directory);
+                    continue;
+                }
 
-            bool hasAnyFailures = false;
-            foreach (string file in Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories))
-            {
+                if (!Directory.Exists(directory))
+                {
+                    // The files are already gone, so the repository entry would outlive them.
+                    _logger.LogWarning("Installed directory not found for package: {PackageId}", package.Id);
+                    _installedPackageRepository.RemovePackage(package);
+                    continue;
+                }
+
+                bool hasAnyFailures = false;
+                foreach (string file in Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories))
+                {
+                    try
+                    {
+                        var fi = new FileInfo(file);
+                        totalSize += fi.Length;
+                        fi.Delete();
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to delete file: {FileName} in package: {PackageId}", Path.GetFileName(file), package.Id);
+                        hasAnyFailures = true;
+                    }
+
+                    progress.Report(totalSize / (double)context.SizeToBeReleased);
+                }
+
                 try
                 {
-                    var fi = new FileInfo(file);
-                    totalSize += fi.Length;
-                    fi.Delete();
+                    Directory.Delete(directory, true);
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Failed to delete file: {FileName} in package: {PackageId}", Path.GetFileName(file), package.Id);
+                    _logger.LogError(ex, "Failed to delete package directory: {Directory} for package: {PackageId}", directory, package.Id);
                     hasAnyFailures = true;
                 }
 
-                progress.Report(totalSize / (double)context.SizeToBeReleased);
+                if (hasAnyFailures)
+                {
+                    failedPackages.Add(directory);
+                }
+
+                _installedPackageRepository.RemovePackage(package);
             }
 
-            try
+            context.FailedPackages = failedPackages;
+
+            if (failedPackages.Count > 0)
             {
-                Directory.Delete(directory, true);
+                _logger.LogWarning("Clean completed with failures. Failed packages: {FailedPackageCount}", failedPackages.Count);
             }
-            catch (Exception ex)
+            else
             {
-                _logger.LogError(ex, "Failed to delete package directory: {Directory} for package: {PackageId}", directory, package.Id);
-                hasAnyFailures = true;
+                _logger.LogInformation("Clean completed successfully. Total size released: {TotalSize} bytes", totalSize);
             }
-
-            if (hasAnyFailures)
-            {
-                failedPackages.Add(directory);
-            }
-
-            _installedPackageRepository.RemovePackage(package);
-        }
-
-        context.FailedPackages = failedPackages;
-
-        if (failedPackages.Count > 0)
-        {
-            _logger.LogWarning("Clean completed with failures. Failed packages: {FailedPackageCount}", failedPackages.Count);
-        }
-        else
-        {
-            _logger.LogInformation("Clean completed successfully. Total size released: {TotalSize} bytes", totalSize);
-        }
+        });
     }
 
     // True when an installed identity sharing this package's id survives the clean, and

--- a/src/Beutl.Api/Services/PackageInstaller.Data.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.Data.cs
@@ -15,6 +15,7 @@ public partial class PackageInstaller
     /// </summary>
     public void InstallDataPackage(LocalPackage package)
     {
+        EnsureNotDisposed();
         if (string.IsNullOrEmpty(package.InstalledPath))
         {
             throw new ArgumentException(
@@ -81,6 +82,7 @@ public partial class PackageInstaller
     /// </remarks>
     public bool UninstallDataPackage(string packageName)
     {
+        EnsureNotDisposed();
         string name = ValidatePackageName(packageName);
         bool templates = DeleteIfExists(Path.Combine(BeutlEnvironment.GetTemplatesDirectoryPath(), name));
         bool materials = DeleteIfExists(Path.Combine(BeutlEnvironment.GetMaterialsDirectoryPath(), name));

--- a/src/Beutl.Api/Services/PackageInstaller.Data.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.Data.cs
@@ -15,41 +15,43 @@ public partial class PackageInstaller
     /// </summary>
     public void InstallDataPackage(LocalPackage package)
     {
-        EnsureNotDisposed();
-        if (string.IsNullOrEmpty(package.InstalledPath))
+        TrackSyncOperation(() =>
         {
-            throw new ArgumentException(
-                $"'{package.Name}' has not been extracted yet.",
-                nameof(package));
-        }
+            if (string.IsNullOrEmpty(package.InstalledPath))
+            {
+                throw new ArgumentException(
+                    $"'{package.Name}' has not been extracted yet.",
+                    nameof(package));
+            }
 
-        string name = ValidatePackageName(package.Name);
-        bool hasMaterial = package.Tags.Contains(PackageKinds.MaterialTag);
-        bool hasTemplate = package.Tags.Contains(PackageKinds.TemplateTag);
-        if (!hasMaterial && !hasTemplate)
-        {
-            throw new ArgumentException(
-                $"'{package.Name}' is an extension package and has no data payload.",
-                nameof(package));
-        }
+            string name = ValidatePackageName(package.Name);
+            bool hasMaterial = package.Tags.Contains(PackageKinds.MaterialTag);
+            bool hasTemplate = package.Tags.Contains(PackageKinds.TemplateTag);
+            if (!hasMaterial && !hasTemplate)
+            {
+                throw new ArgumentException(
+                    $"'{package.Name}' is an extension package and has no data payload.",
+                    nameof(package));
+            }
 
-        // An update may have dropped a kind, so clear both payload directories; the
-        // removed kind's payload would otherwise stay registered.
-        if (!DeleteIfExists(Path.Combine(BeutlEnvironment.GetMaterialsDirectoryPath(), name))
-            || !DeleteIfExists(Path.Combine(BeutlEnvironment.GetTemplatesDirectoryPath(), name)))
-        {
-            throw new IOException($"Could not clear the existing package data directories for '{name}'.");
-        }
+            // An update may have dropped a kind, so clear both payload directories; the
+            // removed kind's payload would otherwise stay registered.
+            if (!DeleteIfExists(Path.Combine(BeutlEnvironment.GetMaterialsDirectoryPath(), name))
+                || !DeleteIfExists(Path.Combine(BeutlEnvironment.GetTemplatesDirectoryPath(), name)))
+            {
+                throw new IOException($"Could not clear the existing package data directories for '{name}'.");
+            }
 
-        if (hasMaterial)
-        {
-            InstallPayload(package, name, MaterialsContentDirectory, BeutlEnvironment.GetMaterialsDirectoryPath());
-        }
+            if (hasMaterial)
+            {
+                InstallPayload(package, name, MaterialsContentDirectory, BeutlEnvironment.GetMaterialsDirectoryPath());
+            }
 
-        if (hasTemplate)
-        {
-            InstallPayload(package, name, TemplatesContentDirectory, BeutlEnvironment.GetTemplatesDirectoryPath());
-        }
+            if (hasTemplate)
+            {
+                InstallPayload(package, name, TemplatesContentDirectory, BeutlEnvironment.GetTemplatesDirectoryPath());
+            }
+        });
     }
 
     private void InstallPayload(LocalPackage package, string name, string contentDirectory, string root)
@@ -82,11 +84,13 @@ public partial class PackageInstaller
     /// </remarks>
     public bool UninstallDataPackage(string packageName)
     {
-        EnsureNotDisposed();
-        string name = ValidatePackageName(packageName);
-        bool templates = DeleteIfExists(Path.Combine(BeutlEnvironment.GetTemplatesDirectoryPath(), name));
-        bool materials = DeleteIfExists(Path.Combine(BeutlEnvironment.GetMaterialsDirectoryPath(), name));
-        return templates && materials;
+        return TrackSyncOperation(() =>
+        {
+            string name = ValidatePackageName(packageName);
+            bool templates = DeleteIfExists(Path.Combine(BeutlEnvironment.GetTemplatesDirectoryPath(), name));
+            bool materials = DeleteIfExists(Path.Combine(BeutlEnvironment.GetMaterialsDirectoryPath(), name));
+            return templates && materials;
+        });
     }
 
     // The name is a NuGet id read out of a downloaded nuspec, and it becomes a directory

--- a/src/Beutl.Api/Services/PackageInstaller.Uninstall.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.Uninstall.cs
@@ -12,6 +12,7 @@ public partial class PackageInstaller
         bool clean = true,
         CancellationToken cancellationToken = default)
     {
+        EnsureNotDisposed();
         cancellationToken.ThrowIfCancellationRequested();
 
         _logger.LogInformation("Preparing for uninstall. Installed path: {InstalledPath}, Clean: {Clean}", installedPath, clean);
@@ -60,6 +61,7 @@ public partial class PackageInstaller
         IProgress<double> progress,
         CancellationToken cancellationToken = default)
     {
+        EnsureNotDisposed();
         cancellationToken.ThrowIfCancellationRequested();
 
         var failedPackages = new List<string>();

--- a/src/Beutl.Api/Services/PackageInstaller.Uninstall.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.Uninstall.cs
@@ -12,48 +12,50 @@ public partial class PackageInstaller
         bool clean = true,
         CancellationToken cancellationToken = default)
     {
-        EnsureNotDisposed();
-        cancellationToken.ThrowIfCancellationRequested();
-
-        _logger.LogInformation("Preparing for uninstall. Installed path: {InstalledPath}, Clean: {Clean}", installedPath, clean);
-
-        PackageIdentity uninstallPackage = new PackageFolderReader(installedPath).GetIdentity();
-        PackageIdentity[] unnecessaryPackages = [uninstallPackage];
-
-        if (clean)
+        return TrackSyncOperation(() =>
         {
-            _logger.LogInformation("Cleaning unnecessary packages.");
+            cancellationToken.ThrowIfCancellationRequested();
 
-            PackageIdentity[] installedPackages = _installedPackageRepository.GetLocalPackages()
-                .Except(unnecessaryPackages, PackageIdentityComparer.Default)
-                .ToArray();
+            _logger.LogInformation("Preparing for uninstall. Installed path: {InstalledPath}, Clean: {Clean}", installedPath, clean);
 
-            unnecessaryPackages = UnnecessaryPackages(installedPackages);
-        }
+            PackageIdentity uninstallPackage = new PackageFolderReader(installedPath).GetIdentity();
+            PackageIdentity[] unnecessaryPackages = [uninstallPackage];
 
-        long size = 0;
-        foreach (PackageIdentity package in unnecessaryPackages)
-        {
-            string directory = Helper.ResolveInstalledDirectory(package);
-            if (!Directory.Exists(directory))
+            if (clean)
             {
-                _logger.LogWarning("Installed directory not found for package: {PackageId}", package.Id);
-                continue;
+                _logger.LogInformation("Cleaning unnecessary packages.");
+
+                PackageIdentity[] installedPackages = _installedPackageRepository.GetLocalPackages()
+                    .Except(unnecessaryPackages, PackageIdentityComparer.Default)
+                    .ToArray();
+
+                unnecessaryPackages = UnnecessaryPackages(installedPackages);
             }
 
-            foreach (string file in Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories))
+            long size = 0;
+            foreach (PackageIdentity package in unnecessaryPackages)
             {
-                size += new FileInfo(file).Length;
+                string directory = Helper.ResolveInstalledDirectory(package);
+                if (!Directory.Exists(directory))
+                {
+                    _logger.LogWarning("Installed directory not found for package: {PackageId}", package.Id);
+                    continue;
+                }
+
+                foreach (string file in Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories))
+                {
+                    size += new FileInfo(file).Length;
+                }
             }
-        }
 
-        _logger.LogInformation("Prepared uninstall context. Uninstall package: {UninstallPackage}, Size to be released: {SizeToBeReleased}", uninstallPackage, size);
+            _logger.LogInformation("Prepared uninstall context. Uninstall package: {UninstallPackage}, Size to be released: {SizeToBeReleased}", uninstallPackage, size);
 
-        return new PackageUninstallContext(uninstallPackage, installedPath)
-        {
-            UnnecessaryPackages = unnecessaryPackages,
-            SizeToBeReleased = size
-        };
+            return new PackageUninstallContext(uninstallPackage, installedPath)
+            {
+                UnnecessaryPackages = unnecessaryPackages,
+                SizeToBeReleased = size
+            };
+        });
     }
 
     public void Uninstall(
@@ -61,74 +63,76 @@ public partial class PackageInstaller
         IProgress<double> progress,
         CancellationToken cancellationToken = default)
     {
-        EnsureNotDisposed();
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var failedPackages = new List<string>();
-        long totalSize = 0;
-        foreach (PackageIdentity package in context.UnnecessaryPackages)
+        TrackSyncOperation(() =>
         {
-            // A data package's payload lives outside the install directory, and it has to
-            // go even when the extracted package itself is already missing.
-            bool dataRemoved = UninstallDataPackage(package.Id);
+            cancellationToken.ThrowIfCancellationRequested();
 
-            string directory = Helper.ResolveInstalledDirectory(package);
-            if (!Directory.Exists(directory))
+            var failedPackages = new List<string>();
+            long totalSize = 0;
+            foreach (PackageIdentity package in context.UnnecessaryPackages)
             {
-                // The files are already gone, so the repository entry would outlive them.
-                _logger.LogWarning("Installed directory not found for package: {PackageId}", package.Id);
-                _installedPackageRepository.RemovePackage(package);
-                if (!dataRemoved)
+                // A data package's payload lives outside the install directory, and it has to
+                // go even when the extracted package itself is already missing.
+                bool dataRemoved = UninstallDataPackage(package.Id);
+
+                string directory = Helper.ResolveInstalledDirectory(package);
+                if (!Directory.Exists(directory))
                 {
-                    failedPackages.Add(directory);
+                    // The files are already gone, so the repository entry would outlive them.
+                    _logger.LogWarning("Installed directory not found for package: {PackageId}", package.Id);
+                    _installedPackageRepository.RemovePackage(package);
+                    if (!dataRemoved)
+                    {
+                        failedPackages.Add(directory);
+                    }
+
+                    continue;
                 }
 
-                continue;
-            }
+                bool hasAnyFailures = !dataRemoved;
+                foreach (string file in Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories))
+                {
+                    try
+                    {
+                        var fi = new FileInfo(file);
+                        totalSize += fi.Length;
+                        fi.Delete();
+                        _logger.LogInformation("Deleted file: {FileName}", file);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to delete file: {FileName}", file);
+                        hasAnyFailures = true;
+                    }
 
-            bool hasAnyFailures = !dataRemoved;
-            foreach (string file in Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories))
-            {
+                    progress.Report(totalSize / (double)context.SizeToBeReleased);
+                }
+
                 try
                 {
-                    var fi = new FileInfo(file);
-                    totalSize += fi.Length;
-                    fi.Delete();
-                    _logger.LogInformation("Deleted file: {FileName}", file);
+                    Directory.Delete(directory, true);
+                    _logger.LogInformation("Deleted directory: {Directory}", directory);
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Failed to delete file: {FileName}", file);
+                    _logger.LogError(ex, "Failed to delete directory: {Directory}", directory);
                     hasAnyFailures = true;
                 }
 
-                progress.Report(totalSize / (double)context.SizeToBeReleased);
+                if (hasAnyFailures)
+                {
+                    failedPackages.Add(directory);
+                    _logger.LogWarning("Package uninstallation had failures: {PackageId}", package.Id);
+                }
+                else
+                {
+                    _logger.LogInformation("Successfully uninstalled package: {PackageId}", package.Id);
+                }
+
+                _installedPackageRepository.RemovePackage(package);
             }
 
-            try
-            {
-                Directory.Delete(directory, true);
-                _logger.LogInformation("Deleted directory: {Directory}", directory);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to delete directory: {Directory}", directory);
-                hasAnyFailures = true;
-            }
-
-            if (hasAnyFailures)
-            {
-                failedPackages.Add(directory);
-                _logger.LogWarning("Package uninstallation had failures: {PackageId}", package.Id);
-            }
-            else
-            {
-                _logger.LogInformation("Successfully uninstalled package: {PackageId}", package.Id);
-            }
-
-            _installedPackageRepository.RemovePackage(package);
-        }
-
-        context.FailedPackages = failedPackages;
+            context.FailedPackages = failedPackages;
+        });
     }
 }

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -32,6 +32,10 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
     private readonly PackageResolver _resolver;
 
     private readonly Dictionary<PackageIdentity, PackageInstallContext> _installingContexts = [];
+    private readonly object _gate = new();
+    private readonly HashSet<Task> _operations = [];
+    private Task? _disposeTask;
+    private bool _disposed;
 
     private const string DefaultNuGetConfigContentTemplate = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
@@ -102,13 +106,81 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
 
     public ValueTask DisposeAsync()
     {
+        lock (_gate)
+        {
+            _disposed = true;
+            return new ValueTask(_disposeTask ??= DisposeCoreAsync());
+        }
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        while (true)
+        {
+            Task[] operations;
+            lock (_gate)
+            {
+                operations = _operations.ToArray();
+            }
+
+            if (operations.Length == 0)
+                break;
+
+            try
+            {
+                await Task.WhenAll(operations).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Awaiting observes operation failures. Each caller reports its own operation error;
+                // resource teardown must still run after every task has drained.
+            }
+
+            lock (_gate)
+            {
+                _operations.RemoveWhere(task => task.IsCompleted);
+            }
+        }
+
         _cacheContext.Dispose();
         if (_ownsHttpClient)
         {
             _httpClient.Dispose();
         }
+    }
 
-        return ValueTask.CompletedTask;
+    private Task TrackAsync(Func<Task> operation)
+        => TrackAsyncCore(operation);
+
+    private Task<T> TrackAsync<T>(Func<Task<T>> operation)
+        => TrackAsyncCore(operation);
+
+    private Task TrackAsyncCore(Func<Task> operation)
+    {
+        Task task;
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            _operations.RemoveWhere(task => task.IsCompleted);
+            task = operation();
+            _operations.Add(task);
+        }
+
+        return task;
+    }
+
+    private Task<T> TrackAsyncCore<T>(Func<Task<T>> operation)
+    {
+        Task<T> task;
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            _operations.RemoveWhere(task => task.IsCompleted);
+            task = operation();
+            _operations.Add(task);
+        }
+
+        return task;
     }
 
     private static void CreateLocalSourceDirectory()
@@ -119,10 +191,16 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         }
     }
 
-    public async Task<PackageInstallContext> PrepareForInstall(
+    public Task<PackageInstallContext> PrepareForInstall(
         Release release,
         bool force = false,
         CancellationToken cancellationToken = default)
+        => TrackAsync(() => PrepareForInstallCoreAsync(release, force, cancellationToken));
+
+    private async Task<PackageInstallContext> PrepareForInstallCoreAsync(
+        Release release,
+        bool force,
+        CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -181,10 +259,16 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         }
     }
 
-    public async Task DownloadPackageFile(
+    public Task DownloadPackageFile(
         PackageInstallContext context,
         IProgress<double>? progress = null,
         CancellationToken cancellationToken = default)
+        => TrackAsync(() => DownloadPackageFileCoreAsync(context, progress, cancellationToken));
+
+    private async Task DownloadPackageFileCoreAsync(
+        PackageInstallContext context,
+        IProgress<double>? progress,
+        CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         if ((int)context.Phase <= (int)PackageInstallPhase.Downloading)
@@ -205,10 +289,16 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         }
     }
 
-    public async Task VerifyPackageFile(
+    public Task VerifyPackageFile(
         PackageInstallContext context,
         IProgress<double>? progress = null,
         CancellationToken cancellationToken = default)
+        => TrackAsync(() => VerifyPackageFileCoreAsync(context, progress, cancellationToken));
+
+    private async Task VerifyPackageFileCoreAsync(
+        PackageInstallContext context,
+        IProgress<double>? progress,
+        CancellationToken cancellationToken)
     {
         async Task<bool> Varify(HashAlgorithm algorithm, Stream stream, long totalLength, string hashValue)
         {
@@ -296,20 +386,32 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         }
     }
 
-    public async Task ReResolveDependencies(
+    public Task ReResolveDependencies(
         PackageIdentity package,
         ILogger? logger,
         CancellationToken cancellationToken = default)
+        => TrackAsync(() => ReResolveDependenciesCoreAsync(package, logger, cancellationToken));
+
+    private async Task ReResolveDependenciesCoreAsync(
+        PackageIdentity package,
+        ILogger? logger,
+        CancellationToken cancellationToken)
     {
         var context = PrepareForInstall(
             package.Id, package.Version.ToString(), force: true, cancellationToken);
         await ResolveDependencies(context, logger, cancellationToken);
     }
 
-    public async Task ResolveDependencies(
+    public Task ResolveDependencies(
         PackageInstallContext context,
         ILogger? logger,
         CancellationToken cancellationToken = default)
+        => TrackAsync(() => ResolveDependenciesCoreAsync(context, logger, cancellationToken));
+
+    private async Task ResolveDependenciesCoreAsync(
+        PackageInstallContext context,
+        ILogger? logger,
+        CancellationToken cancellationToken)
     {
         PackageIdentity? package = null;
         try

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -220,11 +220,20 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
     // Waits until every admitted operation has actually stopped, without the drain
     // deadline: when Disposal ended at its deadline with operations still running,
     // their fallback queueing must be observable before the shutdown snapshot of
-    // PackageChangesQueue is taken.
-    internal async Task WaitUntilIdleAsync()
+    // PackageChangesQueue is taken. The timeout keeps the wait bounded even when a
+    // tracked operation never completes, so shutdown cannot hang behind it.
+    internal async Task WaitUntilIdleAsync(TimeSpan timeout)
     {
+        long deadline = Environment.TickCount64 + (long)timeout.TotalMilliseconds;
         while (true)
         {
+            long remaining = deadline - Environment.TickCount64;
+            if (remaining <= 0)
+            {
+                _logger.LogWarning("Package installer did not become idle within the shutdown deadline.");
+                return;
+            }
+
             Task[] operations;
             lock (_gate)
             {
@@ -237,7 +246,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
 
             try
             {
-                await Task.WhenAll(operations).ConfigureAwait(false);
+                await Task.WhenAll(operations).WaitAsync(TimeSpan.FromMilliseconds(remaining)).ConfigureAwait(false);
             }
             catch
             {

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -268,6 +268,10 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
             await operation().ConfigureAwait(false);
             proxy.TrySetResult();
         }
+        catch (OperationCanceledException ex)
+        {
+            proxy.TrySetCanceled(ex.CancellationToken);
+        }
         catch (Exception ex)
         {
             proxy.TrySetException(ex);
@@ -282,10 +286,15 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
             proxy.TrySetResult(result);
             return result;
         }
+        catch (OperationCanceledException ex)
+        {
+            proxy.TrySetCanceled(ex.CancellationToken);
+            return default!;
+        }
         catch (Exception ex)
         {
             proxy.TrySetException(ex);
-            throw;
+            return default!;
         }
     }
 
@@ -505,7 +514,9 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
     {
         var context = PrepareForInstall(
             package.Id, package.Version.ToString(), force: true, cancellationToken);
-        await ResolveDependencies(context, logger, cancellationToken);
+        // Call the core method directly: the outer operation is already admitted and
+        // tracked, so the nested phase must not re-enter the admission guard.
+        await ResolveDependenciesCoreAsync(context, logger, cancellationToken);
     }
 
     public Task ResolveDependencies(

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -185,11 +185,17 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         try
         {
             await operation().ConfigureAwait(false);
+            proxy.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            // Propagate the operation's failure to the caller so DownloadAndLoadPackage
+            // reports the fault and its fallback queueing runs.
+            proxy.TrySetException(ex);
         }
         finally
         {
             s_transactionOwner.Value = previous;
-            proxy.TrySetResult();
         }
     }
 

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -36,7 +36,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
     private readonly HashSet<Task> _operations = [];
     private Task? _disposeTask;
     private bool _disposed;
-    private int _admittedTransactions;
+    private static readonly AsyncLocal<bool> s_inTransaction = new();
 
     private const string DefaultNuGetConfigContentTemplate = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
@@ -164,10 +164,10 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
             _operations.RemoveWhere(task => task.IsCompleted);
-            _admittedTransactions++;
-            // Run on the thread pool so the transaction never captures a UI synchronization
-            // context; shutdown can then block on DisposeAsync without deadlocking it.
-            task = Task.Run(() => RunTransactionAsync(operation));
+            // Run in the caller's context so plugin activation inside the operation keeps its
+            // original synchronization context; the operation's awaits use ConfigureAwait(false)
+            // so shutdown can block on DisposeAsync without deadlocking the UI thread.
+            task = RunTransactionAsync(operation);
             _operations.Add(task);
         }
 
@@ -176,16 +176,15 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
 
     private async Task RunTransactionAsync(Func<Task> operation)
     {
+        bool previous = s_inTransaction.Value;
+        s_inTransaction.Value = true;
         try
         {
             await operation().ConfigureAwait(false);
         }
         finally
         {
-            lock (_gate)
-            {
-                _admittedTransactions--;
-            }
+            s_inTransaction.Value = previous;
         }
     }
 
@@ -196,7 +195,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         {
             // Nested phases of an already admitted transaction must still be tracked while
             // disposal drains it; only brand-new work is rejected after disposal.
-            if (_disposed && _admittedTransactions == 0)
+            if (_disposed && !s_inTransaction.Value)
             {
                 throw new ObjectDisposedException(nameof(PackageInstaller));
             }
@@ -213,7 +212,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         Task<T> task;
         lock (_gate)
         {
-            if (_disposed && _admittedTransactions == 0)
+            if (_disposed && !s_inTransaction.Value)
             {
                 throw new ObjectDisposedException(nameof(PackageInstaller));
             }

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -188,11 +188,13 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
             _operations.RemoveWhere(task => task.IsCompleted);
             // Register before invoking so a re-entrant DisposeAsync drains this transaction.
             _operations.Add(task);
-            // Run in the caller context; the operation's awaits use ConfigureAwait(false)
-            // so shutdown can block without deadlocking.
-            _ = RunTransactionAsync(operation, proxy);
         }
 
+        // Invoke outside the lock: a delegate that blocks before its first incomplete await
+        // must not hold the gate, or a concurrent DisposeAsync could not even start its
+        // drain deadline. The operation's awaits use ConfigureAwait(false) so shutdown can
+        // block without deadlocking.
+        _ = RunTransactionAsync(operation, proxy);
         return task;
     }
 
@@ -398,6 +400,15 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         bool force = false,
         CancellationToken cancellationToken = default)
     {
+        return TrackSyncOperation(() => PrepareForInstallCore(name, version, force, cancellationToken));
+    }
+
+    private PackageInstallContext PrepareForInstallCore(
+        string name,
+        string version,
+        bool force,
+        CancellationToken cancellationToken)
+    {
         cancellationToken.ThrowIfCancellationRequested();
         var packageId = new PackageIdentity(name, new NuGetVersion(version));
 
@@ -559,9 +570,9 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         ILogger? logger,
         CancellationToken cancellationToken)
     {
-        var context = PrepareForInstall(
-            package.Id, package.Version.ToString(), force: true, cancellationToken);
         // Call the core directly; the outer operation is already admitted.
+        var context = PrepareForInstallCore(
+            package.Id, package.Version.ToString(), force: true, cancellationToken);
         await ResolveDependenciesCoreAsync(context, logger, cancellationToken);
     }
 

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -36,6 +36,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
     private readonly HashSet<Task> _operations = [];
     private Task? _disposeTask;
     private bool _disposed;
+    private bool _drained;
     private static readonly AsyncLocal<PackageInstaller?> s_transactionOwner = new();
 
     private const string DefaultNuGetConfigContentTemplate = @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -116,7 +117,9 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
 
     private async Task DisposeCoreAsync()
     {
-        while (true)
+        long deadline = Environment.TickCount64 + 30_000;
+        bool drained = false;
+        while (Environment.TickCount64 < deadline)
         {
             Task[] operations;
             lock (_gate)
@@ -125,7 +128,10 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
             }
 
             if (operations.Length == 0)
+            {
+                drained = true;
                 break;
+            }
 
             try
             {
@@ -141,6 +147,16 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
             {
                 _operations.RemoveWhere(task => task.IsCompleted);
             }
+        }
+
+        if (!drained)
+        {
+            _logger.LogWarning("Package installer did not drain within the shutdown deadline.");
+        }
+
+        lock (_gate)
+        {
+            _drained = true;
         }
 
         _cacheContext.Dispose();
@@ -204,10 +220,9 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         Task task;
         lock (_gate)
         {
-            // Nested phases of an already admitted transaction must still be tracked while
-            // disposal drains it; only brand-new work from other owners is rejected after
-            // disposal.
-            if (_disposed && !ReferenceEquals(s_transactionOwner.Value, this))
+            // Once draining has finished and the resources are disposed, reject all work
+            // including nested phases of an admitted transaction.
+            if (_drained || (_disposed && !ReferenceEquals(s_transactionOwner.Value, this)))
             {
                 throw new ObjectDisposedException(nameof(PackageInstaller));
             }
@@ -224,7 +239,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         Task<T> task;
         lock (_gate)
         {
-            if (_disposed && !ReferenceEquals(s_transactionOwner.Value, this))
+            if (_drained || (_disposed && !ReferenceEquals(s_transactionOwner.Value, this)))
             {
                 throw new ObjectDisposedException(nameof(PackageInstaller));
             }

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -159,22 +159,26 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
     public Task TrackInstallOperationAsync(Func<Task> operation)
     {
         ArgumentNullException.ThrowIfNull(operation);
-        Task task;
+        TaskCompletionSource proxy = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task task = proxy.Task;
         lock (_gate)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
             _operations.RemoveWhere(task => task.IsCompleted);
+            // Register the proxy before invoking the callback so a synchronous re-entrant
+            // DisposeAsync from inside the callback observes this transaction as in-flight
+            // and drains it instead of tearing down resources underneath it.
+            _operations.Add(task);
             // Run in the caller's context so plugin activation inside the operation keeps its
             // original synchronization context; the operation's awaits use ConfigureAwait(false)
             // so shutdown can block on DisposeAsync without deadlocking the UI thread.
-            task = RunTransactionAsync(operation);
-            _operations.Add(task);
+            _ = RunTransactionAsync(operation, proxy);
         }
 
         return task;
     }
 
-    private async Task RunTransactionAsync(Func<Task> operation)
+    private async Task RunTransactionAsync(Func<Task> operation, TaskCompletionSource proxy)
     {
         PackageInstaller? previous = s_transactionOwner.Value;
         s_transactionOwner.Value = this;
@@ -185,6 +189,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         finally
         {
             s_transactionOwner.Value = previous;
+            proxy.TrySetResult();
         }
     }
 

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -36,7 +36,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
     private readonly HashSet<Task> _operations = [];
     private Task? _disposeTask;
     private bool _disposed;
-    private static readonly AsyncLocal<bool> s_inTransaction = new();
+    private static readonly AsyncLocal<PackageInstaller?> s_transactionOwner = new();
 
     private const string DefaultNuGetConfigContentTemplate = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
@@ -176,15 +176,15 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
 
     private async Task RunTransactionAsync(Func<Task> operation)
     {
-        bool previous = s_inTransaction.Value;
-        s_inTransaction.Value = true;
+        PackageInstaller? previous = s_transactionOwner.Value;
+        s_transactionOwner.Value = this;
         try
         {
             await operation().ConfigureAwait(false);
         }
         finally
         {
-            s_inTransaction.Value = previous;
+            s_transactionOwner.Value = previous;
         }
     }
 
@@ -194,8 +194,9 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         lock (_gate)
         {
             // Nested phases of an already admitted transaction must still be tracked while
-            // disposal drains it; only brand-new work is rejected after disposal.
-            if (_disposed && !s_inTransaction.Value)
+            // disposal drains it; only brand-new work from other owners is rejected after
+            // disposal.
+            if (_disposed && !ReferenceEquals(s_transactionOwner.Value, this))
             {
                 throw new ObjectDisposedException(nameof(PackageInstaller));
             }
@@ -212,7 +213,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         Task<T> task;
         lock (_gate)
         {
-            if (_disposed && !s_inTransaction.Value)
+            if (_disposed && !ReferenceEquals(s_transactionOwner.Value, this))
             {
                 throw new ObjectDisposedException(nameof(PackageInstaller));
             }

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -115,7 +115,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         }
     }
 
-    private async Task DisposeCoreAsync()
+    protected virtual async Task DisposeCoreAsync()
     {
         long deadline = Environment.TickCount64 + 30_000;
         bool drained = false;
@@ -189,6 +189,14 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         return task;
     }
 
+    private void EnsureNotDisposed()
+    {
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_drained || _disposed, this);
+        }
+    }
+
     private async Task RunTransactionAsync(Func<Task> operation, TaskCompletionSource proxy)
     {
         PackageInstaller? previous = s_transactionOwner.Value;
@@ -197,6 +205,10 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         {
             await operation().ConfigureAwait(false);
             proxy.TrySetResult();
+        }
+        catch (OperationCanceledException ex)
+        {
+            proxy.TrySetCanceled(ex.CancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -218,6 +218,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
     private Task TrackAsyncCore(Func<Task> operation)
     {
         Task task;
+        bool admitted = false;
         lock (_gate)
         {
             // Once draining has finished and the resources are disposed, reject all work
@@ -227,8 +228,18 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
                 throw new ObjectDisposedException(nameof(PackageInstaller));
             }
             _operations.RemoveWhere(task => task.IsCompleted);
-            task = operation();
-            _operations.Add(task);
+            admitted = true;
+        }
+
+        // Invoke the delegate outside the lock so a synchronously executing delegate that
+        // re-enters a tracked method cannot deadlock on _gate.
+        task = operation();
+        lock (_gate)
+        {
+            if (admitted)
+            {
+                _operations.Add(task);
+            }
         }
 
         return task;
@@ -237,6 +248,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
     private Task<T> TrackAsyncCore<T>(Func<Task<T>> operation)
     {
         Task<T> task;
+        bool admitted = false;
         lock (_gate)
         {
             if (_drained || (_disposed && !ReferenceEquals(s_transactionOwner.Value, this)))
@@ -244,8 +256,18 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
                 throw new ObjectDisposedException(nameof(PackageInstaller));
             }
             _operations.RemoveWhere(task => task.IsCompleted);
-            task = operation();
-            _operations.Add(task);
+            admitted = true;
+        }
+
+        // Invoke the delegate outside the lock so a synchronously executing delegate that
+        // re-enters a tracked method cannot deadlock on _gate.
+        task = operation();
+        lock (_gate)
+        {
+            if (admitted)
+            {
+                _operations.Add(task);
+            }
         }
 
         return task;

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -135,7 +135,11 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
 
             try
             {
-                await Task.WhenAll(operations).ConfigureAwait(false);
+                long remaining = deadline - Environment.TickCount64;
+                if (remaining <= 0)
+                    break;
+
+                await Task.WhenAll(operations).WaitAsync(TimeSpan.FromMilliseconds(remaining)).ConfigureAwait(false);
             }
             catch
             {
@@ -189,11 +193,46 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         return task;
     }
 
-    private void EnsureNotDisposed()
+    private void TrackSyncOperation(Action operation)
     {
+        TaskCompletionSource proxy = new(TaskCreationOptions.RunContinuationsAsynchronously);
         lock (_gate)
         {
             ObjectDisposedException.ThrowIf(_drained || _disposed, this);
+            _operations.Add(proxy.Task);
+        }
+
+        try
+        {
+            operation();
+            proxy.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            proxy.TrySetException(ex);
+            throw;
+        }
+    }
+
+    private T TrackSyncOperation<T>(Func<T> operation)
+    {
+        TaskCompletionSource proxy = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_drained || _disposed, this);
+            _operations.Add(proxy.Task);
+        }
+
+        try
+        {
+            T result = operation();
+            proxy.TrySetResult();
+            return result;
+        }
+        catch (Exception ex)
+        {
+            proxy.TrySetException(ex);
+            throw;
         }
     }
 

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -155,6 +155,12 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
     private Task<T> TrackAsync<T>(Func<Task<T>> operation)
         => TrackAsyncCore(operation);
 
+    public Task TrackInstallOperationAsync(Func<Task> operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        return TrackAsync(operation);
+    }
+
     private Task TrackAsyncCore(Func<Task> operation)
     {
         Task task;

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -17,10 +17,11 @@ using ILogger = NuGet.Common.ILogger;
 
 namespace Beutl.Api.Services;
 
-public partial class PackageInstaller : IBeutlApiResource
+public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
 {
     private readonly Microsoft.Extensions.Logging.ILogger _logger = Log.CreateLogger<PackageInstaller>();
     private readonly HttpClient _httpClient;
+    private readonly bool _ownsHttpClient;
     private readonly InstalledPackageRepository _installedPackageRepository;
     private readonly BeutlApiApplication _apiApplication;
 
@@ -45,6 +46,7 @@ public partial class PackageInstaller : IBeutlApiResource
     public PackageInstaller(HttpClient httpClient, InstalledPackageRepository installedPackageRepository, BeutlApiApplication apiApplication)
     {
         _httpClient = httpClient;
+        _ownsHttpClient = false;
         _installedPackageRepository = installedPackageRepository;
         _apiApplication = apiApplication;
 
@@ -86,6 +88,27 @@ public partial class PackageInstaller : IBeutlApiResource
         };
 
         _resolver = new PackageResolver();
+    }
+
+    internal PackageInstaller(
+        HttpClient httpClient,
+        bool ownsHttpClient,
+        InstalledPackageRepository installedPackageRepository,
+        BeutlApiApplication apiApplication)
+        : this(httpClient, installedPackageRepository, apiApplication)
+    {
+        _ownsHttpClient = ownsHttpClient;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _cacheContext.Dispose();
+        if (_ownsHttpClient)
+        {
+            _httpClient.Dispose();
+        }
+
+        return ValueTask.CompletedTask;
     }
 
     private static void CreateLocalSourceDirectory()

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -117,7 +117,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
 
     protected virtual async Task DisposeCoreAsync()
     {
-        long deadline = Environment.TickCount64 + 30_000;
+        long deadline = Environment.TickCount64 + DrainDeadlineMilliseconds;
         bool drained = false;
         while (Environment.TickCount64 < deadline)
         {
@@ -168,6 +168,9 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         }
     }
 
+    // Virtual so tests can shorten the drain window; production keeps the 30-second budget.
+    protected virtual long DrainDeadlineMilliseconds => 30_000;
+
     private Task TrackAsync(Func<Task> operation)
         => TrackAsyncCore(operation);
 
@@ -193,15 +196,17 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         return task;
     }
 
-    private void TrackSyncOperation(Action operation)
+    internal void TrackSyncOperation(Action operation)
     {
         TaskCompletionSource proxy = new(TaskCreationOptions.RunContinuationsAsynchronously);
         lock (_gate)
         {
-            ObjectDisposedException.ThrowIf(_drained || _disposed, this);
+            ObjectDisposedException.ThrowIf(_drained || (_disposed && !ReferenceEquals(s_transactionOwner.Value, this)), this);
             _operations.Add(proxy.Task);
         }
 
+        PackageInstaller? previous = s_transactionOwner.Value;
+        s_transactionOwner.Value = this;
         try
         {
             operation();
@@ -212,17 +217,23 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
             proxy.TrySetException(ex);
             throw;
         }
+        finally
+        {
+            s_transactionOwner.Value = previous;
+        }
     }
 
-    private T TrackSyncOperation<T>(Func<T> operation)
+    internal T TrackSyncOperation<T>(Func<T> operation)
     {
         TaskCompletionSource proxy = new(TaskCreationOptions.RunContinuationsAsynchronously);
         lock (_gate)
         {
-            ObjectDisposedException.ThrowIf(_drained || _disposed, this);
+            ObjectDisposedException.ThrowIf(_drained || (_disposed && !ReferenceEquals(s_transactionOwner.Value, this)), this);
             _operations.Add(proxy.Task);
         }
 
+        PackageInstaller? previous = s_transactionOwner.Value;
+        s_transactionOwner.Value = this;
         try
         {
             T result = operation();
@@ -233,6 +244,10 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         {
             proxy.TrySetException(ex);
             throw;
+        }
+        finally
+        {
+            s_transactionOwner.Value = previous;
         }
     }
 

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -119,19 +119,21 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
     {
         long deadline = Environment.TickCount64 + DrainDeadlineMilliseconds;
         bool drained = false;
-        while (Environment.TickCount64 < deadline)
+        while (!drained && Environment.TickCount64 < deadline)
         {
             Task[] operations;
             lock (_gate)
             {
+                _operations.RemoveWhere(task => task.IsCompleted);
+                if (_operations.Count == 0)
+                {
+                    drained = true;
+                }
                 operations = _operations.ToArray();
             }
 
-            if (operations.Length == 0)
-            {
-                drained = true;
+            if (drained)
                 break;
-            }
 
             try
             {
@@ -151,16 +153,63 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
             }
         }
 
-        if (!drained)
-        {
-            _logger.LogWarning("Package installer did not drain within the shutdown deadline.");
-        }
-
         lock (_gate)
         {
             _drained = true;
         }
 
+        if (drained)
+        {
+            DisposeResources();
+        }
+        else
+        {
+            _logger.LogWarning(
+                "Package installer did not drain within the shutdown deadline; "
+                + "keeping resources alive until tracked work stops.");
+            _ = DisposeResourcesWhenIdleAsync();
+        }
+    }
+
+    // Waits until every admitted operation has actually stopped before releasing the
+    // installer resources, so a slow download or NuGet phase that outlived the drain
+    // deadline never sees its cache context or HttpClient disposed underneath it.
+    private async Task DisposeResourcesWhenIdleAsync()
+    {
+        try
+        {
+            while (true)
+            {
+                Task[] operations;
+                lock (_gate)
+                {
+                    _operations.RemoveWhere(task => task.IsCompleted);
+                    operations = _operations.ToArray();
+                }
+
+                if (operations.Length == 0)
+                    break;
+
+                try
+                {
+                    await Task.WhenAll(operations).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Awaiting observes operation faults; resource disposal must still run.
+                }
+            }
+
+            DisposeResources();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to dispose package installer resources after tracked work stopped.");
+        }
+    }
+
+    private void DisposeResources()
+    {
         _cacheContext.Dispose();
         if (_ownsHttpClient)
         {

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -36,6 +36,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
     private readonly HashSet<Task> _operations = [];
     private Task? _disposeTask;
     private bool _disposed;
+    private int _admittedTransactions;
 
     private const string DefaultNuGetConfigContentTemplate = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
@@ -158,7 +159,34 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
     public Task TrackInstallOperationAsync(Func<Task> operation)
     {
         ArgumentNullException.ThrowIfNull(operation);
-        return TrackAsync(operation);
+        Task task;
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            _operations.RemoveWhere(task => task.IsCompleted);
+            _admittedTransactions++;
+            // Run on the thread pool so the transaction never captures a UI synchronization
+            // context; shutdown can then block on DisposeAsync without deadlocking it.
+            task = Task.Run(() => RunTransactionAsync(operation));
+            _operations.Add(task);
+        }
+
+        return task;
+    }
+
+    private async Task RunTransactionAsync(Func<Task> operation)
+    {
+        try
+        {
+            await operation().ConfigureAwait(false);
+        }
+        finally
+        {
+            lock (_gate)
+            {
+                _admittedTransactions--;
+            }
+        }
     }
 
     private Task TrackAsyncCore(Func<Task> operation)
@@ -166,7 +194,12 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         Task task;
         lock (_gate)
         {
-            ObjectDisposedException.ThrowIf(_disposed, this);
+            // Nested phases of an already admitted transaction must still be tracked while
+            // disposal drains it; only brand-new work is rejected after disposal.
+            if (_disposed && _admittedTransactions == 0)
+            {
+                throw new ObjectDisposedException(nameof(PackageInstaller));
+            }
             _operations.RemoveWhere(task => task.IsCompleted);
             task = operation();
             _operations.Add(task);
@@ -180,7 +213,10 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         Task<T> task;
         lock (_gate)
         {
-            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_disposed && _admittedTransactions == 0)
+            {
+                throw new ObjectDisposedException(nameof(PackageInstaller));
+            }
             _operations.RemoveWhere(task => task.IsCompleted);
             task = operation();
             _operations.Add(task);

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -217,8 +217,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
 
     private Task TrackAsyncCore(Func<Task> operation)
     {
-        Task task;
-        bool admitted = false;
+        TaskCompletionSource proxy = new(TaskCreationOptions.RunContinuationsAsynchronously);
         lock (_gate)
         {
             // Once draining has finished and the resources are disposed, reject all work
@@ -228,27 +227,21 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
                 throw new ObjectDisposedException(nameof(PackageInstaller));
             }
             _operations.RemoveWhere(task => task.IsCompleted);
-            admitted = true;
+            // Register the proxy before invoking the delegate so a concurrent DisposeAsync
+            // observes this phase as in-flight and drains it instead of disposing resources
+            // underneath it.
+            _operations.Add(proxy.Task);
         }
 
         // Invoke the delegate outside the lock so a synchronously executing delegate that
         // re-enters a tracked method cannot deadlock on _gate.
-        task = operation();
-        lock (_gate)
-        {
-            if (admitted)
-            {
-                _operations.Add(task);
-            }
-        }
-
-        return task;
+        _ = RunTrackedAsync(operation, proxy);
+        return proxy.Task;
     }
 
     private Task<T> TrackAsyncCore<T>(Func<Task<T>> operation)
     {
-        Task<T> task;
-        bool admitted = false;
+        TaskCompletionSource<T> proxy = new(TaskCreationOptions.RunContinuationsAsynchronously);
         lock (_gate)
         {
             if (_drained || (_disposed && !ReferenceEquals(s_transactionOwner.Value, this)))
@@ -256,21 +249,44 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
                 throw new ObjectDisposedException(nameof(PackageInstaller));
             }
             _operations.RemoveWhere(task => task.IsCompleted);
-            admitted = true;
+            // Register the proxy before invoking the delegate so a concurrent DisposeAsync
+            // observes this phase as in-flight and drains it instead of disposing resources
+            // underneath it.
+            _operations.Add(proxy.Task);
         }
 
         // Invoke the delegate outside the lock so a synchronously executing delegate that
         // re-enters a tracked method cannot deadlock on _gate.
-        task = operation();
-        lock (_gate)
-        {
-            if (admitted)
-            {
-                _operations.Add(task);
-            }
-        }
+        _ = RunTrackedAsync(operation, proxy);
+        return proxy.Task;
+    }
 
-        return task;
+    private async Task RunTrackedAsync(Func<Task> operation, TaskCompletionSource proxy)
+    {
+        try
+        {
+            await operation().ConfigureAwait(false);
+            proxy.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            proxy.TrySetException(ex);
+        }
+    }
+
+    private async Task<T> RunTrackedAsync<T>(Func<Task<T>> operation, TaskCompletionSource<T> proxy)
+    {
+        try
+        {
+            T result = await operation().ConfigureAwait(false);
+            proxy.TrySetResult(result);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            proxy.TrySetException(ex);
+            throw;
+        }
     }
 
     private static void CreateLocalSourceDirectory()

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -139,8 +139,6 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
             }
             catch
             {
-                // Awaiting observes operation failures. Each caller reports its own operation error;
-                // resource teardown must still run after every task has drained.
             }
 
             lock (_gate)
@@ -181,13 +179,10 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
             _operations.RemoveWhere(task => task.IsCompleted);
-            // Register the proxy before invoking the callback so a synchronous re-entrant
-            // DisposeAsync from inside the callback observes this transaction as in-flight
-            // and drains it instead of tearing down resources underneath it.
+            // Register before invoking so a re-entrant DisposeAsync drains this transaction.
             _operations.Add(task);
-            // Run in the caller's context so plugin activation inside the operation keeps its
-            // original synchronization context; the operation's awaits use ConfigureAwait(false)
-            // so shutdown can block on DisposeAsync without deadlocking the UI thread.
+            // Run in the caller context; the operation's awaits use ConfigureAwait(false)
+            // so shutdown can block without deadlocking.
             _ = RunTransactionAsync(operation, proxy);
         }
 
@@ -205,8 +200,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         }
         catch (Exception ex)
         {
-            // Propagate the operation's failure to the caller so DownloadAndLoadPackage
-            // reports the fault and its fallback queueing runs.
+            // Propagate the failure so the caller reports it and queues fallback.
             proxy.TrySetException(ex);
         }
         finally
@@ -220,21 +214,17 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         TaskCompletionSource proxy = new(TaskCreationOptions.RunContinuationsAsynchronously);
         lock (_gate)
         {
-            // Once draining has finished and the resources are disposed, reject all work
-            // including nested phases of an admitted transaction.
+            // After draining, reject all work including nested phases.
             if (_drained || (_disposed && !ReferenceEquals(s_transactionOwner.Value, this)))
             {
                 throw new ObjectDisposedException(nameof(PackageInstaller));
             }
             _operations.RemoveWhere(task => task.IsCompleted);
-            // Register the proxy before invoking the delegate so a concurrent DisposeAsync
-            // observes this phase as in-flight and drains it instead of disposing resources
-            // underneath it.
+            // Register before invoking so a concurrent DisposeAsync drains this phase.
             _operations.Add(proxy.Task);
         }
 
-        // Invoke the delegate outside the lock so a synchronously executing delegate that
-        // re-enters a tracked method cannot deadlock on _gate.
+        // Invoke outside the lock so a re-entrant delegate cannot deadlock on _gate.
         _ = RunTrackedAsync(operation, proxy);
         return proxy.Task;
     }
@@ -249,14 +239,11 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
                 throw new ObjectDisposedException(nameof(PackageInstaller));
             }
             _operations.RemoveWhere(task => task.IsCompleted);
-            // Register the proxy before invoking the delegate so a concurrent DisposeAsync
-            // observes this phase as in-flight and drains it instead of disposing resources
-            // underneath it.
+            // Register before invoking so a concurrent DisposeAsync drains this phase.
             _operations.Add(proxy.Task);
         }
 
-        // Invoke the delegate outside the lock so a synchronously executing delegate that
-        // re-enters a tracked method cannot deadlock on _gate.
+        // Invoke outside the lock so a re-entrant delegate cannot deadlock on _gate.
         _ = RunTrackedAsync(operation, proxy);
         return proxy.Task;
     }
@@ -514,8 +501,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
     {
         var context = PrepareForInstall(
             package.Id, package.Version.ToString(), force: true, cancellationToken);
-        // Call the core method directly: the outer operation is already admitted and
-        // tracked, so the nested phase must not re-enter the admission guard.
+        // Call the core directly; the outer operation is already admitted.
         await ResolveDependenciesCoreAsync(context, logger, cancellationToken);
     }
 

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -536,7 +536,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         {
             try
             {
-                await user.RefreshAsync(cancellationToken);
+                await user.RefreshAsync(cancellationToken).ConfigureAwait(false);
                 request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", user.Token);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -217,6 +217,36 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         }
     }
 
+    // Waits until every admitted operation has actually stopped, without the drain
+    // deadline: when Disposal ended at its deadline with operations still running,
+    // their fallback queueing must be observable before the shutdown snapshot of
+    // PackageChangesQueue is taken.
+    internal async Task WaitUntilIdleAsync()
+    {
+        while (true)
+        {
+            Task[] operations;
+            lock (_gate)
+            {
+                _operations.RemoveWhere(task => task.IsCompleted);
+                operations = _operations.ToArray();
+            }
+
+            if (operations.Length == 0)
+                return;
+
+            try
+            {
+                await Task.WhenAll(operations).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Awaiting observes operation faults; the loop must keep waiting for
+                // every admitted operation to stop before the queue snapshot.
+            }
+        }
+    }
+
     // Virtual so tests can shorten the drain window; production keeps the 30-second budget.
     protected virtual long DrainDeadlineMilliseconds => 30_000;
 

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -210,15 +210,13 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         try
         {
             operation();
-            proxy.TrySetResult();
-        }
-        catch (Exception ex)
-        {
-            proxy.TrySetException(ex);
-            throw;
         }
         finally
         {
+            // The proxy exists only to keep disposal draining until the operation finishes;
+            // the caller observes the exception directly, so complete it normally to avoid
+            // an unobserved fault when the drain loop removes the completed task.
+            proxy.TrySetResult();
             s_transactionOwner.Value = previous;
         }
     }
@@ -236,17 +234,13 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         s_transactionOwner.Value = this;
         try
         {
-            T result = operation();
-            proxy.TrySetResult();
-            return result;
-        }
-        catch (Exception ex)
-        {
-            proxy.TrySetException(ex);
-            throw;
+            return operation();
         }
         finally
         {
+            // See TrackSyncOperation(Action): the proxy is lifetime-only, so complete it
+            // normally even when the operation throws.
+            proxy.TrySetResult();
             s_transactionOwner.Value = previous;
         }
     }

--- a/src/Beutl.Api/Services/PackageManager.cs
+++ b/src/Beutl.Api/Services/PackageManager.cs
@@ -65,31 +65,93 @@ public sealed class PackageManager(
     public async Task<IReadOnlyList<PackageUpdate>> CheckUpdate(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        // Resolve the resource before the lifetime token source is created: GetResource
-        // and CreateLifetimeLinkedTokenSource both take the dispose gate, and resolving
-        // after admission would let a concurrent DisposeAsync invalidate the resource
-        // between the two calls.
-        DiscoverService discover = apiApplication.GetResource<DiscoverService>();
-        using CancellationTokenSource operationCts = apiApplication.CreateLifetimeLinkedTokenSource(cancellationToken);
-        CancellationToken operationToken = operationCts.Token;
-        using (Activity? activity = Telemetry.ActivitySource.StartActivity("CheckUpdate"))
+        // Resolve the resource and link the lifetime token under one dispose-gate hold so a
+        // concurrent DisposeAsync cannot invalidate the resource between admission and use.
+        DiscoverService discover = apiApplication.GetResourceWithLifetime<DiscoverService>(
+            cancellationToken, out CancellationTokenSource operationCts);
+        using (operationCts)
         {
-            PackageIdentity[] packages = installedPackageRepository.GetLocalPackages().ToArray();
-
-            var updates = new List<PackageUpdate>(packages.Length);
-
-            for (int i = 0; i < packages.Length; i++)
+            CancellationToken operationToken = operationCts.Token;
+            using (Activity? activity = Telemetry.ActivitySource.StartActivity("CheckUpdate"))
             {
-                operationToken.ThrowIfCancellationRequested();
-                PackageIdentity pkg = packages[i];
-                NuGetVersion version = pkg.Version;
-                string versionStr = version.ToString();
-                try
+                PackageIdentity[] packages = installedPackageRepository.GetLocalPackages().ToArray();
+
+                var updates = new List<PackageUpdate>(packages.Length);
+
+                for (int i = 0; i < packages.Length; i++)
                 {
+                    operationToken.ThrowIfCancellationRequested();
+                    PackageIdentity pkg = packages[i];
+                    NuGetVersion version = pkg.Version;
+                    string versionStr = version.ToString();
+                    try
+                    {
+                        activity?.AddEvent(new("Checking updates"));
+                        activity?.SetTag("PackageId", pkg.Id);
+                        activity?.SetTag("Version", versionStr);
+                        Package remotePackage = await discover.GetPackage(pkg.Id, operationToken).ConfigureAwait(false);
+                        activity?.AddEvent(new("Checked updates"));
+
+                        Release[] releases = await remotePackage.GetReleasesAsync(operationToken).ConfigureAwait(false);
+
+                        foreach (Release? item in releases)
+                        {
+                            operationToken.ThrowIfCancellationRequested();
+                            // 降順
+                            if (new NuGetVersion(item.Version.Value).CompareTo(version) > 0)
+                            {
+                                Release? oldRelease = await Helper
+                                    .TryGetOrDefault(
+                                        () => remotePackage.GetReleaseAsync(versionStr, operationToken),
+                                        operationToken)
+                                    .ConfigureAwait(false);
+                                updates.Add(new PackageUpdate(remotePackage, oldRelease, item));
+                                _logger.LogInformation("Update found for package {PackageId}: {OldVersion} -> {NewVersion}", pkg.Id, versionStr, item.Version.Value);
+                                break;
+                            }
+                        }
+                    }
+                    catch (OperationCanceledException) when (operationToken.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex,
+                            "An exception occurred while checking for package updates. (PackageId: {PackageId})", pkg.Id);
+                    }
+                }
+
+                operationToken.ThrowIfCancellationRequested();
+                return updates;
+            }
+        }
+    }
+
+    public async Task<PackageUpdate?> CheckUpdate(string name, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        // See the other CheckUpdate overload: resolve the resource and link the lifetime
+        // token under one dispose-gate hold.
+        DiscoverService discover = apiApplication.GetResourceWithLifetime<DiscoverService>(
+            cancellationToken, out CancellationTokenSource operationCts);
+        using (operationCts)
+        {
+            CancellationToken operationToken = operationCts.Token;
+            using (Activity? activity = Telemetry.ActivitySource.StartActivity("CheckUpdate"))
+            {
+                LocalPackage? pkg = _loadedPackages.Values
+                    .Select(x => x.Package)
+                    .FirstOrDefault(v =>
+                        !v.SideLoad && StringComparer.OrdinalIgnoreCase.Equals(v.Name, name));
+                if (pkg != null)
+                {
+                    string versionStr = pkg.Version;
+                    var version = new NuGetVersion(versionStr);
                     activity?.AddEvent(new("Checking updates"));
-                    activity?.SetTag("PackageId", pkg.Id);
+                    activity?.SetTag("PackageName", pkg.Name);
                     activity?.SetTag("Version", versionStr);
-                    Package remotePackage = await discover.GetPackage(pkg.Id, operationToken).ConfigureAwait(false);
+                    Package remotePackage = await discover.GetPackage(pkg.Name, operationToken).ConfigureAwait(false);
                     activity?.AddEvent(new("Checked updates"));
 
                     Release[] releases = await remotePackage.GetReleasesAsync(operationToken).ConfigureAwait(false);
@@ -102,77 +164,19 @@ public sealed class PackageManager(
                         {
                             Release? oldRelease = await Helper
                                 .TryGetOrDefault(
-                                    () => remotePackage.GetReleaseAsync(versionStr, operationToken),
+                                    () => remotePackage.GetReleaseAsync(pkg.Version, operationToken),
                                     operationToken)
                                 .ConfigureAwait(false);
-                            updates.Add(new PackageUpdate(remotePackage, oldRelease, item));
-                            _logger.LogInformation("Update found for package {PackageId}: {OldVersion} -> {NewVersion}", pkg.Id, versionStr, item.Version.Value);
-                            break;
+                            operationToken.ThrowIfCancellationRequested();
+                            _logger.LogInformation("Update found for package {PackageName}: {OldVersion} -> {NewVersion}", pkg.Name, versionStr, item.Version.Value);
+                            return new PackageUpdate(remotePackage, oldRelease, item);
                         }
                     }
                 }
-                catch (OperationCanceledException) when (operationToken.IsCancellationRequested)
-                {
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex,
-                        "An exception occurred while checking for package updates. (PackageId: {PackageId})", pkg.Id);
-                }
+
+                operationToken.ThrowIfCancellationRequested();
+                return null;
             }
-
-            operationToken.ThrowIfCancellationRequested();
-            return updates;
-        }
-    }
-
-    public async Task<PackageUpdate?> CheckUpdate(string name, CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        // See the other CheckUpdate overload: resolve before admission so a concurrent
-        // DisposeAsync cannot invalidate the resource after the lifetime token is linked.
-        DiscoverService discover = apiApplication.GetResource<DiscoverService>();
-        using CancellationTokenSource operationCts = apiApplication.CreateLifetimeLinkedTokenSource(cancellationToken);
-        CancellationToken operationToken = operationCts.Token;
-        using (Activity? activity = Telemetry.ActivitySource.StartActivity("CheckUpdate"))
-        {
-            LocalPackage? pkg = _loadedPackages.Values
-                .Select(x => x.Package)
-                .FirstOrDefault(v =>
-                    !v.SideLoad && StringComparer.OrdinalIgnoreCase.Equals(v.Name, name));
-            if (pkg != null)
-            {
-                string versionStr = pkg.Version;
-                var version = new NuGetVersion(versionStr);
-                activity?.AddEvent(new("Checking updates"));
-                activity?.SetTag("PackageName", pkg.Name);
-                activity?.SetTag("Version", versionStr);
-                Package remotePackage = await discover.GetPackage(pkg.Name, operationToken).ConfigureAwait(false);
-                activity?.AddEvent(new("Checked updates"));
-
-                Release[] releases = await remotePackage.GetReleasesAsync(operationToken).ConfigureAwait(false);
-
-                foreach (Release? item in releases)
-                {
-                    operationToken.ThrowIfCancellationRequested();
-                    // 降順
-                    if (new NuGetVersion(item.Version.Value).CompareTo(version) > 0)
-                    {
-                        Release? oldRelease = await Helper
-                            .TryGetOrDefault(
-                                () => remotePackage.GetReleaseAsync(pkg.Version, operationToken),
-                                operationToken)
-                            .ConfigureAwait(false);
-                        operationToken.ThrowIfCancellationRequested();
-                        _logger.LogInformation("Update found for package {PackageName}: {OldVersion} -> {NewVersion}", pkg.Name, versionStr, item.Version.Value);
-                        return new PackageUpdate(remotePackage, oldRelease, item);
-                    }
-                }
-            }
-
-            operationToken.ThrowIfCancellationRequested();
-            return null;
         }
     }
 

--- a/src/Beutl.Api/Services/PackageManager.cs
+++ b/src/Beutl.Api/Services/PackageManager.cs
@@ -159,6 +159,7 @@ public sealed class PackageManager(
                                 () => remotePackage.GetReleaseAsync(pkg.Version, operationToken),
                                 operationToken)
                             .ConfigureAwait(false);
+                        operationToken.ThrowIfCancellationRequested();
                         _logger.LogInformation("Update found for package {PackageName}: {OldVersion} -> {NewVersion}", pkg.Name, versionStr, item.Version.Value);
                         return new PackageUpdate(remotePackage, oldRelease, item);
                     }

--- a/src/Beutl.Api/Services/PackageManager.cs
+++ b/src/Beutl.Api/Services/PackageManager.cs
@@ -65,6 +65,11 @@ public sealed class PackageManager(
     public async Task<IReadOnlyList<PackageUpdate>> CheckUpdate(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        // Resolve the resource before the lifetime token source is created: GetResource
+        // and CreateLifetimeLinkedTokenSource both take the dispose gate, and resolving
+        // after admission would let a concurrent DisposeAsync invalidate the resource
+        // between the two calls.
+        DiscoverService discover = apiApplication.GetResource<DiscoverService>();
         using CancellationTokenSource operationCts = apiApplication.CreateLifetimeLinkedTokenSource(cancellationToken);
         CancellationToken operationToken = operationCts.Token;
         using (Activity? activity = Telemetry.ActivitySource.StartActivity("CheckUpdate"))
@@ -72,7 +77,6 @@ public sealed class PackageManager(
             PackageIdentity[] packages = installedPackageRepository.GetLocalPackages().ToArray();
 
             var updates = new List<PackageUpdate>(packages.Length);
-            DiscoverService discover = apiApplication.GetResource<DiscoverService>();
 
             for (int i = 0; i < packages.Length; i++)
             {
@@ -126,12 +130,13 @@ public sealed class PackageManager(
     public async Task<PackageUpdate?> CheckUpdate(string name, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        // See the other CheckUpdate overload: resolve before admission so a concurrent
+        // DisposeAsync cannot invalidate the resource after the lifetime token is linked.
+        DiscoverService discover = apiApplication.GetResource<DiscoverService>();
         using CancellationTokenSource operationCts = apiApplication.CreateLifetimeLinkedTokenSource(cancellationToken);
         CancellationToken operationToken = operationCts.Token;
         using (Activity? activity = Telemetry.ActivitySource.StartActivity("CheckUpdate"))
         {
-            DiscoverService discover = apiApplication.GetResource<DiscoverService>();
-
             LocalPackage? pkg = _loadedPackages.Values
                 .Select(x => x.Package)
                 .FirstOrDefault(v =>

--- a/src/Beutl.Api/Services/PackageManager.cs
+++ b/src/Beutl.Api/Services/PackageManager.cs
@@ -65,6 +65,8 @@ public sealed class PackageManager(
     public async Task<IReadOnlyList<PackageUpdate>> CheckUpdate(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        using CancellationTokenSource operationCts = apiApplication.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken operationToken = operationCts.Token;
         using (Activity? activity = Telemetry.ActivitySource.StartActivity("CheckUpdate"))
         {
             PackageIdentity[] packages = installedPackageRepository.GetLocalPackages().ToArray();
@@ -74,7 +76,7 @@ public sealed class PackageManager(
 
             for (int i = 0; i < packages.Length; i++)
             {
-                cancellationToken.ThrowIfCancellationRequested();
+                operationToken.ThrowIfCancellationRequested();
                 PackageIdentity pkg = packages[i];
                 NuGetVersion version = pkg.Version;
                 string versionStr = version.ToString();
@@ -83,21 +85,21 @@ public sealed class PackageManager(
                     activity?.AddEvent(new("Checking updates"));
                     activity?.SetTag("PackageId", pkg.Id);
                     activity?.SetTag("Version", versionStr);
-                    Package remotePackage = await discover.GetPackage(pkg.Id, cancellationToken).ConfigureAwait(false);
+                    Package remotePackage = await discover.GetPackage(pkg.Id, operationToken).ConfigureAwait(false);
                     activity?.AddEvent(new("Checked updates"));
 
-                    Release[] releases = await remotePackage.GetReleasesAsync(cancellationToken).ConfigureAwait(false);
+                    Release[] releases = await remotePackage.GetReleasesAsync(operationToken).ConfigureAwait(false);
 
                     foreach (Release? item in releases)
                     {
-                        cancellationToken.ThrowIfCancellationRequested();
+                        operationToken.ThrowIfCancellationRequested();
                         // 降順
                         if (new NuGetVersion(item.Version.Value).CompareTo(version) > 0)
                         {
                             Release? oldRelease = await Helper
                                 .TryGetOrDefault(
-                                    () => remotePackage.GetReleaseAsync(versionStr, cancellationToken),
-                                    cancellationToken)
+                                    () => remotePackage.GetReleaseAsync(versionStr, operationToken),
+                                    operationToken)
                                 .ConfigureAwait(false);
                             updates.Add(new PackageUpdate(remotePackage, oldRelease, item));
                             _logger.LogInformation("Update found for package {PackageId}: {OldVersion} -> {NewVersion}", pkg.Id, versionStr, item.Version.Value);
@@ -105,7 +107,7 @@ public sealed class PackageManager(
                         }
                     }
                 }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                catch (OperationCanceledException) when (operationToken.IsCancellationRequested)
                 {
                     throw;
                 }
@@ -116,6 +118,7 @@ public sealed class PackageManager(
                 }
             }
 
+            operationToken.ThrowIfCancellationRequested();
             return updates;
         }
     }
@@ -123,6 +126,8 @@ public sealed class PackageManager(
     public async Task<PackageUpdate?> CheckUpdate(string name, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        using CancellationTokenSource operationCts = apiApplication.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken operationToken = operationCts.Token;
         using (Activity? activity = Telemetry.ActivitySource.StartActivity("CheckUpdate"))
         {
             DiscoverService discover = apiApplication.GetResource<DiscoverService>();
@@ -138,21 +143,21 @@ public sealed class PackageManager(
                 activity?.AddEvent(new("Checking updates"));
                 activity?.SetTag("PackageName", pkg.Name);
                 activity?.SetTag("Version", versionStr);
-                Package remotePackage = await discover.GetPackage(pkg.Name, cancellationToken).ConfigureAwait(false);
+                Package remotePackage = await discover.GetPackage(pkg.Name, operationToken).ConfigureAwait(false);
                 activity?.AddEvent(new("Checked updates"));
 
-                Release[] releases = await remotePackage.GetReleasesAsync(cancellationToken).ConfigureAwait(false);
+                Release[] releases = await remotePackage.GetReleasesAsync(operationToken).ConfigureAwait(false);
 
                 foreach (Release? item in releases)
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
+                    operationToken.ThrowIfCancellationRequested();
                     // 降順
                     if (new NuGetVersion(item.Version.Value).CompareTo(version) > 0)
                     {
                         Release? oldRelease = await Helper
                             .TryGetOrDefault(
-                                () => remotePackage.GetReleaseAsync(pkg.Version, cancellationToken),
-                                cancellationToken)
+                                () => remotePackage.GetReleaseAsync(pkg.Version, operationToken),
+                                operationToken)
                             .ConfigureAwait(false);
                         _logger.LogInformation("Update found for package {PackageName}: {OldVersion} -> {NewVersion}", pkg.Name, versionStr, item.Version.Value);
                         return new PackageUpdate(remotePackage, oldRelease, item);
@@ -160,6 +165,7 @@ public sealed class PackageManager(
                 }
             }
 
+            operationToken.ThrowIfCancellationRequested();
             return null;
         }
     }

--- a/src/Beutl.PackageTools.UI/Beutl.PackageTools.UI.csproj
+++ b/src/Beutl.PackageTools.UI/Beutl.PackageTools.UI.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Beutl.UnitTests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Themes.Fluent" />

--- a/src/Beutl.PackageTools.UI/Services/AsyncOperationLifetime.cs
+++ b/src/Beutl.PackageTools.UI/Services/AsyncOperationLifetime.cs
@@ -54,7 +54,11 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
         lock (_gate)
         {
             _stopping = true;
-            return new ValueTask(_disposeTask ??= DisposeCoreAsync());
+            // Publish the shared disposal task before cancellation fires, so a cancellation
+            // callback that re-enters DisposeAsync observes the original teardown instead of
+            // starting a second pipeline over the same resource snapshot.
+            _disposeTask ??= DisposeCoreAsync();
+            return new ValueTask(_disposeTask);
         }
     }
 

--- a/src/Beutl.PackageTools.UI/Services/AsyncOperationLifetime.cs
+++ b/src/Beutl.PackageTools.UI/Services/AsyncOperationLifetime.cs
@@ -51,14 +51,40 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
 
     public ValueTask DisposeAsync()
     {
+        TaskCompletionSource? proxy = null;
+        Task disposeTask;
         lock (_gate)
         {
             _stopping = true;
             // Publish the shared disposal task before cancellation fires, so a cancellation
             // callback that re-enters DisposeAsync observes the original teardown instead of
             // starting a second pipeline over the same resource snapshot.
-            _disposeTask ??= DisposeCoreAsync();
-            return new ValueTask(_disposeTask);
+            if (_disposeTask == null)
+            {
+                proxy = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                _disposeTask = proxy.Task;
+            }
+            disposeTask = _disposeTask;
+        }
+
+        if (proxy != null)
+        {
+            _ = RunDisposeCoreAsync(proxy);
+        }
+
+        return new ValueTask(disposeTask);
+    }
+
+    private async Task RunDisposeCoreAsync(TaskCompletionSource proxy)
+    {
+        try
+        {
+            await DisposeCoreAsync().ConfigureAwait(false);
+            proxy.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            proxy.TrySetException(ex);
         }
     }
 

--- a/src/Beutl.PackageTools.UI/Services/AsyncOperationLifetime.cs
+++ b/src/Beutl.PackageTools.UI/Services/AsyncOperationLifetime.cs
@@ -56,9 +56,8 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
         lock (_gate)
         {
             _stopping = true;
-            // Publish the shared disposal task before cancellation fires, so a cancellation
-            // callback that re-enters DisposeAsync observes the original teardown instead of
-            // starting a second pipeline over the same resource snapshot.
+            // Publish the disposal task before cancellation so re-entrant callbacks
+            // observe the original teardown.
             if (_disposeTask == null)
             {
                 proxy = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -93,7 +92,6 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
         Action? completion,
         CancellationTokenSource linkedCancellation)
     {
-        // Ensure the task is registered before a synchronously completing operation can remove it.
         await Task.Yield();
         try
         {
@@ -129,8 +127,7 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
 
         try
         {
-            // Run independently so a throwing token callback cannot skip cancelling
-            // pending HTTP requests; the first failure is preserved for rethrow.
+            // Run independently so a throwing callback cannot skip cancelling pending requests.
             _cancelPendingRequests();
         }
         catch (Exception ex)

--- a/src/Beutl.PackageTools.UI/Services/AsyncOperationLifetime.cs
+++ b/src/Beutl.PackageTools.UI/Services/AsyncOperationLifetime.cs
@@ -91,11 +91,21 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
         try
         {
             _lifetimeCancellation.Cancel();
-            _cancelPendingRequests();
         }
         catch (Exception ex)
         {
             cancellationFailure = ex;
+        }
+
+        try
+        {
+            // Run independently so a throwing token callback cannot skip cancelling
+            // pending HTTP requests; both failures are preserved below.
+            _cancelPendingRequests();
+        }
+        catch (Exception ex)
+        {
+            cancellationFailure ??= ex;
         }
 
         try

--- a/src/Beutl.PackageTools.UI/Services/AsyncOperationLifetime.cs
+++ b/src/Beutl.PackageTools.UI/Services/AsyncOperationLifetime.cs
@@ -1,0 +1,134 @@
+﻿namespace Beutl.PackageTools.UI.Services;
+
+/// <summary>
+/// Owns asynchronous work that must finish before its backing resources are disposed.
+/// </summary>
+internal sealed class AsyncOperationLifetime : IAsyncDisposable
+{
+    private readonly object _gate = new();
+    private readonly CancellationTokenSource _lifetimeCancellation = new();
+    private readonly Action _cancelPendingRequests;
+    private readonly Func<ValueTask> _disposeResources;
+    private readonly HashSet<Task> _operations = [];
+    private Task? _disposeTask;
+    private bool _stopping;
+
+    public AsyncOperationLifetime(Action cancelPendingRequests, Func<ValueTask> disposeResources)
+    {
+        _cancelPendingRequests = cancelPendingRequests
+            ?? throw new ArgumentNullException(nameof(cancelPendingRequests));
+        _disposeResources = disposeResources
+            ?? throw new ArgumentNullException(nameof(disposeResources));
+    }
+
+    public Task RunAsync(
+        Func<CancellationToken, Task> operation,
+        CancellationToken cancellationToken = default)
+        => RunAsync(operation, completion: null, cancellationToken);
+
+    public Task RunAsync(
+        Func<CancellationToken, Task> operation,
+        Action? completion,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        CancellationTokenSource linkedCancellation;
+        Task task;
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_stopping, this);
+            _operations.RemoveWhere(task => task.IsCompleted);
+            linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                _lifetimeCancellation.Token,
+                cancellationToken);
+            task = RunCoreAsync(operation, completion, linkedCancellation);
+            _operations.Add(task);
+        }
+
+        return task;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        lock (_gate)
+        {
+            _stopping = true;
+            return new ValueTask(_disposeTask ??= DisposeCoreAsync());
+        }
+    }
+
+    private async Task RunCoreAsync(
+        Func<CancellationToken, Task> operation,
+        Action? completion,
+        CancellationTokenSource linkedCancellation)
+    {
+        // Ensure the task is registered before a synchronously completing operation can remove it.
+        await Task.Yield();
+        try
+        {
+            await operation(linkedCancellation.Token);
+            if (completion != null)
+            {
+                lock (_gate)
+                {
+                    if (!_stopping && !linkedCancellation.IsCancellationRequested)
+                    {
+                        completion();
+                    }
+                }
+            }
+        }
+        finally
+        {
+            linkedCancellation.Dispose();
+        }
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        _lifetimeCancellation.Cancel();
+        _cancelPendingRequests();
+
+        try
+        {
+            while (true)
+            {
+                Task[] operations;
+                lock (_gate)
+                {
+                    operations = _operations.ToArray();
+                }
+
+                if (operations.Length == 0)
+                    break;
+
+                try
+                {
+                    await Task.WhenAll(operations).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Awaiting observes operation failures. Each owner reports its own operation error;
+                    // resource teardown must still run after every task has drained.
+                }
+
+                lock (_gate)
+                {
+                    _operations.RemoveWhere(task => task.IsCompleted);
+                }
+            }
+        }
+        finally
+        {
+            try
+            {
+                await _disposeResources();
+            }
+            finally
+            {
+                _lifetimeCancellation.Dispose();
+            }
+        }
+    }
+}

--- a/src/Beutl.PackageTools.UI/Services/AsyncOperationLifetime.cs
+++ b/src/Beutl.PackageTools.UI/Services/AsyncOperationLifetime.cs
@@ -9,16 +9,21 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
     private readonly CancellationTokenSource _lifetimeCancellation = new();
     private readonly Action _cancelPendingRequests;
     private readonly Func<ValueTask> _disposeResources;
+    private readonly long _drainDeadlineMilliseconds;
     private readonly HashSet<Task> _operations = [];
     private Task? _disposeTask;
     private bool _stopping;
 
-    public AsyncOperationLifetime(Action cancelPendingRequests, Func<ValueTask> disposeResources)
+    public AsyncOperationLifetime(
+        Action cancelPendingRequests,
+        Func<ValueTask> disposeResources,
+        long drainDeadlineMilliseconds = 30_000)
     {
         _cancelPendingRequests = cancelPendingRequests
             ?? throw new ArgumentNullException(nameof(cancelPendingRequests));
         _disposeResources = disposeResources
             ?? throw new ArgumentNullException(nameof(disposeResources));
+        _drainDeadlineMilliseconds = drainDeadlineMilliseconds;
     }
 
     public Task RunAsync(
@@ -115,6 +120,7 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
 
     private async Task DisposeCoreAsync()
     {
+        long deadline = Environment.TickCount64 + _drainDeadlineMilliseconds;
         Exception? cancellationFailure = null;
         try
         {
@@ -137,7 +143,7 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
 
         try
         {
-            while (true)
+            while (Environment.TickCount64 < deadline)
             {
                 Task[] operations;
                 lock (_gate)
@@ -150,7 +156,11 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
 
                 try
                 {
-                    await Task.WhenAll(operations).ConfigureAwait(false);
+                    long remaining = deadline - Environment.TickCount64;
+                    if (remaining <= 0)
+                        break;
+
+                    await Task.WhenAll(operations).WaitAsync(TimeSpan.FromMilliseconds(remaining)).ConfigureAwait(false);
                 }
                 catch
                 {
@@ -181,4 +191,5 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
             throw cancellationFailure;
         }
     }
+
 }

--- a/src/Beutl.PackageTools.UI/Services/AsyncOperationLifetime.cs
+++ b/src/Beutl.PackageTools.UI/Services/AsyncOperationLifetime.cs
@@ -130,7 +130,7 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
         try
         {
             // Run independently so a throwing token callback cannot skip cancelling
-            // pending HTTP requests; both failures are preserved below.
+            // pending HTTP requests; the first failure is preserved for rethrow.
             _cancelPendingRequests();
         }
         catch (Exception ex)

--- a/src/Beutl.PackageTools.UI/Services/AsyncOperationLifetime.cs
+++ b/src/Beutl.PackageTools.UI/Services/AsyncOperationLifetime.cs
@@ -72,7 +72,7 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
             {
                 lock (_gate)
                 {
-                    if (!_stopping && !linkedCancellation.IsCancellationRequested)
+                    if (!_stopping)
                     {
                         completion();
                     }
@@ -87,8 +87,16 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
 
     private async Task DisposeCoreAsync()
     {
-        _lifetimeCancellation.Cancel();
-        _cancelPendingRequests();
+        Exception? cancellationFailure = null;
+        try
+        {
+            _lifetimeCancellation.Cancel();
+            _cancelPendingRequests();
+        }
+        catch (Exception ex)
+        {
+            cancellationFailure = ex;
+        }
 
         try
         {
@@ -129,6 +137,11 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
             {
                 _lifetimeCancellation.Dispose();
             }
+        }
+
+        if (cancellationFailure != null)
+        {
+            throw cancellationFailure;
         }
     }
 }

--- a/src/Beutl.PackageTools.UI/ViewModels/MainViewModel.cs
+++ b/src/Beutl.PackageTools.UI/ViewModels/MainViewModel.cs
@@ -123,7 +123,9 @@ public class MainViewModel : IAsyncDisposable
 
             if (!Debugger.IsAttached && launchDebugger)
             {
-                AttachDebugger();
+                // The attach loop blocks until a debugger connects; keep it off the UI
+                // thread so the window can still paint and close while waiting.
+                await Task.Run(() => AttachDebugger(), cancellationToken);
             }
 
             await _model.Load(
@@ -268,7 +270,7 @@ public class MainViewModel : IAsyncDisposable
     public ValueTask DisposeAsync()
         => _operationLifetime.DisposeAsync();
 
-    private async ValueTask DisposeOwnedResources()
+    protected virtual async ValueTask DisposeOwnedResources()
     {
         foreach (Process process in _beutlProcesses.Concat(_pkgProcesses))
         {

--- a/src/Beutl.PackageTools.UI/ViewModels/MainViewModel.cs
+++ b/src/Beutl.PackageTools.UI/ViewModels/MainViewModel.cs
@@ -125,7 +125,7 @@ public class MainViewModel : IAsyncDisposable
             {
                 // The attach loop blocks until a debugger connects; keep it off the UI
                 // thread so the window can still paint and close while waiting.
-                await Task.Run(() => AttachDebugger(), cancellationToken);
+                await Task.Run(() => AttachDebugger(cancellationToken), cancellationToken);
             }
 
             await _model.Load(
@@ -179,10 +179,11 @@ public class MainViewModel : IAsyncDisposable
     }
 
     [Conditional("DEBUG")]
-    private static void AttachDebugger()
+    private static void AttachDebugger(CancellationToken cancellationToken)
     {
         while (true)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             Thread.Sleep(100);
 
             if (Debugger.Launch())

--- a/src/Beutl.PackageTools.UI/ViewModels/MainViewModel.cs
+++ b/src/Beutl.PackageTools.UI/ViewModels/MainViewModel.cs
@@ -3,16 +3,20 @@ using System.CommandLine.Parsing;
 
 using Beutl.Logging;
 using Beutl.PackageTools.UI.Models;
+using Beutl.PackageTools.UI.Services;
 
 using Reactive.Bindings;
 
 namespace Beutl.PackageTools.UI.ViewModels;
 
-public class MainViewModel
+public class MainViewModel : IAsyncDisposable
 {
     private readonly ILogger _logger = Log.CreateLogger<MainViewModel>();
     private readonly ChangesModel _model;
     private readonly BeutlApiApplication _app;
+    private readonly HttpClient _httpClient;
+    private readonly AsyncOperationLifetime _operationLifetime;
+    private readonly Task _initializationTask;
 
     private readonly List<ActionViewModel> _viewModels = [];
 
@@ -22,66 +26,49 @@ public class MainViewModel
     private readonly Process[] _pkgProcesses;
 
     public MainViewModel()
+        : this(new HttpClient())
     {
-        // This standalone package-tools process owns its own extension provider; it never
-        // loads editor extensions, so a fresh instance is sufficient for the API resource graph.
-        _app = new BeutlApiApplication(new HttpClient(), new ExtensionProvider());
-        _model = new ChangesModel();
+    }
 
-        _beutlProcesses =
-        [
-            .. Process.GetProcessesByName("Beutl"),
-            .. Process.GetProcessesByName("beutl")
-        ];
+    // This standalone package-tools process owns its own extension provider; it never
+    // loads editor extensions, so a fresh instance is sufficient for the API resource graph.
+    private MainViewModel(HttpClient httpClient)
+        : this(
+            httpClient,
+            new BeutlApiApplication(httpClient, new ExtensionProvider()),
+            new ChangesModel(),
+            [
+                .. Process.GetProcessesByName("Beutl"),
+                .. Process.GetProcessesByName("beutl")
+            ],
+            [
+                .. Process.GetProcessesByName("Beutl.PackageTools"),
+                .. Process.GetProcessesByName("Beutl.PackageTools.UI"),
+                .. Process.GetProcessesByName("beutl-pkg"),
+            ])
+    {
+    }
 
-        _pkgProcesses =
-        [
-            .. Process.GetProcessesByName("Beutl.PackageTools"),
-            .. Process.GetProcessesByName("Beutl.PackageTools.UI"),
-            .. Process.GetProcessesByName("beutl-pkg"),
-        ];
+    internal MainViewModel(
+        HttpClient httpClient,
+        BeutlApiApplication app,
+        ChangesModel model,
+        Process[] beutlProcesses,
+        Process[] pkgProcesses,
+        Func<CancellationToken, Task>? initialize = null,
+        Action? cancelPendingRequests = null,
+        Func<ValueTask>? disposeResources = null)
+    {
+        _httpClient = httpClient;
+        _app = app;
+        _model = model;
+        _beutlProcesses = beutlProcesses;
+        _pkgProcesses = pkgProcesses;
 
-        Task.Run(async () =>
-        {
-            AreOthersRunning.Value = _pkgProcesses.Length > 1;
-            if (AreOthersRunning.Value)
-            {
-                return;
-            }
-
-            await WaitForTermination();
-
-            IsBusy.Value = true;
-            try
-            {
-                await _app.RestoreUserAsync(null, CancellationToken.None);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "An error occurred during authentication");
-            }
-
-            (string[] installItems, string[] uninstallItems, string[] updateItems, bool launchDebugger) = ParseArgs();
-
-            if (!Debugger.IsAttached && launchDebugger)
-            {
-                AttachDebugger();
-            }
-
-            try
-            {
-                await _model.Load(_app, installItems, uninstallItems, updateItems, CancellationToken.None);
-
-                _viewModels.AddRange(InstallItems.Concat(UpdateItems)
-                    .Concat(UninstallItems)
-                    .Select(i => i.CreateViewModel(_app, _model))
-                    .Where(i => i != null)!);
-            }
-            finally
-            {
-                IsBusy.Value = false;
-            }
-        });
+        _operationLifetime = new AsyncOperationLifetime(
+            cancelPendingRequests ?? _httpClient.CancelPendingRequests,
+            disposeResources ?? DisposeOwnedResources);
+        _initializationTask = _operationLifetime.RunAsync(initialize ?? InitializeAsync);
     }
 
     public ReactiveCollection<PackageChangeModel> InstallItems => _model.InstallItems;
@@ -98,7 +85,74 @@ public class MainViewModel
 
     public ReactiveProperty<PackageChangeModel> SelectedItem { get; } = new();
 
-    private async ValueTask WaitForTermination()
+    internal Task InitializationTask => _initializationTask;
+
+    internal Task RunOperationAsync(
+        Func<CancellationToken, Task> operation,
+        Action completion,
+        CancellationToken cancellationToken)
+        => _operationLifetime.RunAsync(operation, completion, cancellationToken);
+
+    private async Task InitializeAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            AreOthersRunning.Value = _pkgProcesses.Length > 1;
+            if (AreOthersRunning.Value)
+                return;
+
+            await WaitForTermination(cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            IsBusy.Value = true;
+            try
+            {
+                await _app.RestoreUserAsync(null, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An error occurred during authentication");
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            (string[] installItems, string[] uninstallItems, string[] updateItems, bool launchDebugger) = ParseArgs();
+
+            if (!Debugger.IsAttached && launchDebugger)
+            {
+                AttachDebugger();
+            }
+
+            await _model.Load(
+                _app,
+                installItems,
+                uninstallItems,
+                updateItems,
+                cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            _viewModels.AddRange(InstallItems.Concat(UpdateItems)
+                .Concat(UninstallItems)
+                .Select(i => i.CreateViewModel(_app, _model))
+                .Where(i => i != null)!);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to initialize package tools");
+        }
+        finally
+        {
+            IsBusy.Value = false;
+        }
+    }
+
+    private async ValueTask WaitForTermination(CancellationToken cancellationToken)
     {
         if (_beutlProcesses.Length == 0)
         {
@@ -112,7 +166,7 @@ public class MainViewModel
             {
                 if (!item.HasExited)
                 {
-                    await item.WaitForExitAsync();
+                    await item.WaitForExitAsync(cancellationToken);
                 }
             }
         }
@@ -209,5 +263,40 @@ public class MainViewModel
             uninstall: [.. _viewModels.Where(x => x is { Model.Action: PackageChangeAction.Uninstall })],
             update: [.. _viewModels.Where(x => x is { Model.Action: PackageChangeAction.Update })],
             clean: _cleanViewModel?.Items?.Length > 0 ? _cleanViewModel : null);
+    }
+
+    public ValueTask DisposeAsync()
+        => _operationLifetime.DisposeAsync();
+
+    private async ValueTask DisposeOwnedResources()
+    {
+        foreach (Process process in _beutlProcesses.Concat(_pkgProcesses))
+        {
+            try
+            {
+                process.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to dispose a tracked process handle");
+            }
+        }
+
+        try
+        {
+            await _app.DisposeAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to dispose the package-tools API application");
+        }
+        finally
+        {
+            _httpClient.Dispose();
+            IsBusy.Dispose();
+            IsWaitingForTermination.Dispose();
+            AreOthersRunning.Dispose();
+            SelectedItem.Dispose();
+        }
     }
 }

--- a/src/Beutl.PackageTools.UI/Views/CleanPage.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/CleanPage.axaml.cs
@@ -82,7 +82,7 @@ public partial class CleanPage : PackageToolPage
                         try
                         {
                             await main.RunOperationAsync(
-                                operationToken => Task.Run(() => viewModel.Run(operationToken), operationToken),
+                                operationToken => Task.Run(() => viewModel.Run(operationToken)),
                                 () =>
                                 {
                                     object? nextViewModel = main.Result();

--- a/src/Beutl.PackageTools.UI/Views/CleanPage.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/CleanPage.axaml.cs
@@ -75,12 +75,28 @@ public partial class CleanPage : PackageToolPage
                     {
                         cancelButton.IsEnabled = true;
                         runButton.IsEnabled = false;
-                        await Task.Run(() => viewModel.Run(token));
                         Frame? frame = this.FindAncestorOfType<Frame>();
-                        if (frame is { DataContext: MainViewModel main })
+                        if (frame is not { DataContext: MainViewModel main })
+                            return;
+
+                        try
                         {
-                            object? nextViewModel = main.Result();
-                            frame.NavigateFromObject(nextViewModel);
+                            await main.RunOperationAsync(
+                                operationToken => Task.Run(() => viewModel.Run(operationToken), operationToken),
+                                () =>
+                                {
+                                    object? nextViewModel = main.Result();
+                                    frame.NavigateFromObject(nextViewModel);
+                                },
+                                token);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            return;
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            return;
                         }
                     }
                     finally

--- a/src/Beutl.PackageTools.UI/Views/InstallPage.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/InstallPage.axaml.cs
@@ -142,7 +142,7 @@ public partial class InstallPage : PackageToolPage
                         {
                             // Navigation must run on the UI thread; the completion callback
                             // may be invoked from a thread-pool thread after Task.Run.
-                            Dispatcher.UIThread.Post(() =>
+                            Dispatcher.UIThread.Invoke(() =>
                             {
                                 object? nextViewModel = main.Next(viewModel, token);
                                 frame.NavigateFromObject(nextViewModel);

--- a/src/Beutl.PackageTools.UI/Views/InstallPage.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/InstallPage.axaml.cs
@@ -140,8 +140,7 @@ public partial class InstallPage : PackageToolPage
                         operationToken => Task.Run(() => viewModel.Run(operationToken)),
                         () =>
                         {
-                            // Navigation must run on the UI thread; the completion callback
-                            // may be invoked from a thread-pool thread after Task.Run.
+                            // Navigation must run on the UI thread.
                             Dispatcher.UIThread.Invoke(() =>
                             {
                                 object? nextViewModel = main.Next(viewModel, token);

--- a/src/Beutl.PackageTools.UI/Views/InstallPage.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/InstallPage.axaml.cs
@@ -137,7 +137,7 @@ public partial class InstallPage : PackageToolPage
                 try
                 {
                     await main.RunOperationAsync(
-                        operationToken => Task.Run(() => viewModel.Run(operationToken), operationToken),
+                        operationToken => Task.Run(() => viewModel.Run(operationToken)),
                         () =>
                         {
                             object? nextViewModel = main.Next(viewModel, token);

--- a/src/Beutl.PackageTools.UI/Views/InstallPage.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/InstallPage.axaml.cs
@@ -130,12 +130,28 @@ public partial class InstallPage : PackageToolPage
                 _cts?.Cancel();
                 _cts = new CancellationTokenSource();
                 CancellationToken token = _cts.Token;
-                await Task.Run(async () => await viewModel.Run(token));
                 Frame? frame = this.FindAncestorOfType<Frame>();
-                if (frame is { DataContext: MainViewModel main })
+                if (frame is not { DataContext: MainViewModel main })
+                    return;
+
+                try
                 {
-                    object? nextViewModel = main.Next(viewModel, token);
-                    frame.NavigateFromObject(nextViewModel);
+                    await main.RunOperationAsync(
+                        operationToken => Task.Run(() => viewModel.Run(operationToken), operationToken),
+                        () =>
+                        {
+                            object? nextViewModel = main.Next(viewModel, token);
+                            frame.NavigateFromObject(nextViewModel);
+                        },
+                        token);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+                catch (ObjectDisposedException)
+                {
+                    return;
                 }
             }
         }

--- a/src/Beutl.PackageTools.UI/Views/InstallPage.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/InstallPage.axaml.cs
@@ -140,8 +140,13 @@ public partial class InstallPage : PackageToolPage
                         operationToken => Task.Run(() => viewModel.Run(operationToken)),
                         () =>
                         {
-                            object? nextViewModel = main.Next(viewModel, token);
-                            frame.NavigateFromObject(nextViewModel);
+                            // Navigation must run on the UI thread; the completion callback
+                            // may be invoked from a thread-pool thread after Task.Run.
+                            Dispatcher.UIThread.Post(() =>
+                            {
+                                object? nextViewModel = main.Next(viewModel, token);
+                                frame.NavigateFromObject(nextViewModel);
+                            });
                         },
                         token);
                 }

--- a/src/Beutl.PackageTools.UI/Views/MainWindow.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/MainWindow.axaml.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia.Controls;
 
+using Beutl.Logging;
 using Beutl.PackageTools.UI.ViewModels;
 
 using FluentAvalonia.UI.Controls;
@@ -33,6 +34,10 @@ public partial class MainWindow : Window
             try
             {
                 await viewmodel.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                Log.CreateLogger<MainWindow>().LogWarning(ex, "Failed to dispose the main view model during shutdown.");
             }
             finally
             {

--- a/src/Beutl.PackageTools.UI/Views/MainWindow.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/MainWindow.axaml.cs
@@ -18,6 +18,22 @@ public partial class MainWindow : Window
         InitializeComponent();
 
         var viewmodel = new MainViewModel();
+        bool disposeStarted = false;
+        bool disposeCompleted = false;
+        Closing += async (_, e) =>
+        {
+            if (disposeCompleted)
+                return;
+
+            e.Cancel = true;
+            if (disposeStarted)
+                return;
+
+            disposeStarted = true;
+            await viewmodel.DisposeAsync();
+            disposeCompleted = true;
+            Close();
+        };
 
         DataContext = viewmodel;
         frame.NavigationPageFactory = new MyNavigationPageFactory();

--- a/src/Beutl.PackageTools.UI/Views/MainWindow.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/MainWindow.axaml.cs
@@ -30,9 +30,15 @@ public partial class MainWindow : Window
                 return;
 
             disposeStarted = true;
-            await viewmodel.DisposeAsync();
-            disposeCompleted = true;
-            Close();
+            try
+            {
+                await viewmodel.DisposeAsync();
+            }
+            finally
+            {
+                disposeCompleted = true;
+                Close();
+            }
         };
 
         DataContext = viewmodel;

--- a/src/Beutl.PackageTools.UI/Views/UninstallPage.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/UninstallPage.axaml.cs
@@ -100,7 +100,7 @@ public partial class UninstallPage : PackageToolPage
                         {
                             // Navigation must run on the UI thread; the completion callback
                             // may be invoked from a thread-pool thread after Task.Run.
-                            Dispatcher.UIThread.Post(() =>
+                            Dispatcher.UIThread.Invoke(() =>
                             {
                                 object? nextViewModel = main.Next(viewModel, token);
                                 frame.NavigateFromObject(nextViewModel);

--- a/src/Beutl.PackageTools.UI/Views/UninstallPage.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/UninstallPage.axaml.cs
@@ -98,8 +98,7 @@ public partial class UninstallPage : PackageToolPage
                         operationToken => Task.Run(() => viewModel.Run(operationToken)),
                         () =>
                         {
-                            // Navigation must run on the UI thread; the completion callback
-                            // may be invoked from a thread-pool thread after Task.Run.
+                            // Navigation must run on the UI thread.
                             Dispatcher.UIThread.Invoke(() =>
                             {
                                 object? nextViewModel = main.Next(viewModel, token);

--- a/src/Beutl.PackageTools.UI/Views/UninstallPage.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/UninstallPage.axaml.cs
@@ -2,6 +2,7 @@
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Beutl.PackageTools.UI.ViewModels;
 
@@ -97,8 +98,13 @@ public partial class UninstallPage : PackageToolPage
                         operationToken => Task.Run(() => viewModel.Run(operationToken)),
                         () =>
                         {
-                            object? nextViewModel = main.Next(viewModel, token);
-                            frame.NavigateFromObject(nextViewModel);
+                            // Navigation must run on the UI thread; the completion callback
+                            // may be invoked from a thread-pool thread after Task.Run.
+                            Dispatcher.UIThread.Post(() =>
+                            {
+                                object? nextViewModel = main.Next(viewModel, token);
+                                frame.NavigateFromObject(nextViewModel);
+                            });
                         },
                         token);
                 }

--- a/src/Beutl.PackageTools.UI/Views/UninstallPage.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/UninstallPage.axaml.cs
@@ -94,7 +94,7 @@ public partial class UninstallPage : PackageToolPage
                 try
                 {
                     await main.RunOperationAsync(
-                        operationToken => Task.Run(() => viewModel.Run(operationToken), operationToken),
+                        operationToken => Task.Run(() => viewModel.Run(operationToken)),
                         () =>
                         {
                             object? nextViewModel = main.Next(viewModel, token);

--- a/src/Beutl.PackageTools.UI/Views/UninstallPage.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/UninstallPage.axaml.cs
@@ -87,12 +87,28 @@ public partial class UninstallPage : PackageToolPage
                 _cts?.Cancel();
                 _cts = new CancellationTokenSource();
                 CancellationToken token = _cts.Token;
-                await Task.Run(() => viewModel.Run(token));
                 Frame? frame = this.FindAncestorOfType<Frame>();
-                if (frame is { DataContext: MainViewModel main })
+                if (frame is not { DataContext: MainViewModel main })
+                    return;
+
+                try
                 {
-                    object? nextViewModel = main.Next(viewModel, token);
-                    frame.NavigateFromObject(nextViewModel);
+                    await main.RunOperationAsync(
+                        operationToken => Task.Run(() => viewModel.Run(operationToken), operationToken),
+                        () =>
+                        {
+                            object? nextViewModel = main.Next(viewModel, token);
+                            frame.NavigateFromObject(nextViewModel);
+                        },
+                        token);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+                catch (ObjectDisposedException)
+                {
+                    return;
                 }
             }
         }

--- a/src/Beutl/Pages/ExtensionsPages/LibraryPage.axaml.cs
+++ b/src/Beutl/Pages/ExtensionsPages/LibraryPage.axaml.cs
@@ -50,27 +50,35 @@ public sealed partial class LibraryPage : UserControl
         Frame frame)
     {
         button.IsEnabled = false;
-        var package = await viewModel.TryFindPackage(localPackage.Package);
-        button.IsEnabled = true;
-        if (package != null)
+        try
         {
-            frame.Navigate(typeof(PackageDetailsPage), package);
-        }
-        else
-        {
-            var dialog = new ContentDialog
+            var package = await viewModel.TryFindPackage(localPackage.Package);
+            button.IsEnabled = true;
+            if (package != null)
             {
-                Title = ExtensionsStrings.LocalPackage,
-                Content = $"{string.Format(ExtensionsStrings.Could_not_find_a_package_from_remote, localPackage.Name)}\n" +
-                $"Name: {localPackage.Name}\n" +
-                $"DisplayName: {localPackage.DisplayName}\n" +
-                $"Publisher: {localPackage.Publisher}\n" +
-                $"Description: {localPackage.Package.Description}\n" +
-                $"Version: {localPackage.Package.Version}\n" +
-                $"WebSite: {localPackage.Package.WebSite}",
-                CloseButtonText = Strings.Close
-            };
-            await dialog.ShowAsync();
+                frame.Navigate(typeof(PackageDetailsPage), package);
+            }
+            else
+            {
+                var dialog = new ContentDialog
+                {
+                    Title = ExtensionsStrings.LocalPackage,
+                    Content = $"{string.Format(ExtensionsStrings.Could_not_find_a_package_from_remote, localPackage.Name)}\n" +
+                    $"Name: {localPackage.Name}\n" +
+                    $"DisplayName: {localPackage.DisplayName}\n" +
+                    $"Publisher: {localPackage.Publisher}\n" +
+                    $"Description: {localPackage.Package.Description}\n" +
+                    $"Version: {localPackage.Package.Version}\n" +
+                    $"WebSite: {localPackage.Package.WebSite}",
+                    CloseButtonText = Strings.Close
+                };
+                await dialog.ShowAsync();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // The page was disposed while the remote lookup was pending; end navigation
+            // normally instead of letting the cancellation escape the async void handler.
         }
     }
 

--- a/src/Beutl/Services/LifetimeCancellationSource.cs
+++ b/src/Beutl/Services/LifetimeCancellationSource.cs
@@ -16,22 +16,53 @@ internal sealed class LifetimeCancellationSource : IDisposable
 
     public void Cancel()
     {
+        Exception? failure = null;
         lock (_gate)
         {
-            _source?.Cancel();
+            try
+            {
+                _source?.Cancel();
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+        }
+
+        if (failure != null)
+        {
+            throw failure;
         }
     }
 
     public void Dispose()
     {
         CancellationTokenSource? source;
+        Exception? failure = null;
         lock (_gate)
         {
             source = _source;
             _source = null;
-            source?.Cancel();
+            try
+            {
+                source?.Cancel();
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
         }
 
-        source?.Dispose();
+        try
+        {
+            source?.Dispose();
+        }
+        finally
+        {
+            if (failure != null)
+            {
+                throw failure;
+            }
+        }
     }
 }

--- a/src/Beutl/Services/LifetimeCancellationSource.cs
+++ b/src/Beutl/Services/LifetimeCancellationSource.cs
@@ -1,0 +1,37 @@
+﻿namespace Beutl.Services;
+
+internal sealed class LifetimeCancellationSource : IDisposable
+{
+    private readonly object _gate = new();
+    private CancellationTokenSource? _source = new();
+
+    public LifetimeCancellationSource()
+    {
+        Token = _source.Token;
+    }
+
+    public CancellationToken Token { get; }
+
+    public bool IsCancellationRequested => Token.IsCancellationRequested;
+
+    public void Cancel()
+    {
+        lock (_gate)
+        {
+            _source?.Cancel();
+        }
+    }
+
+    public void Dispose()
+    {
+        CancellationTokenSource? source;
+        lock (_gate)
+        {
+            source = _source;
+            _source = null;
+            source?.Cancel();
+        }
+
+        source?.Dispose();
+    }
+}

--- a/src/Beutl/Services/StartupTasks/AuthenticationTask.cs
+++ b/src/Beutl/Services/StartupTasks/AuthenticationTask.cs
@@ -22,6 +22,13 @@ public sealed class AuthenticationTask : StartupTask
                 {
                     await _beutlApiApplication.RestoreUserAsync(activity, CancellationToken.None);
                 }
+                catch (Exception ex) when (_beutlApiApplication.IsDisposed
+                    && ex is OperationCanceledException or ObjectDisposedException)
+                {
+                    // Shutdown cancellation is a normal exit, not a failed authentication:
+                    // the lifetime token is canceled when the application is disposed, so
+                    // skip the error telemetry and the sign-in prompts.
+                }
                 catch (Exception e)
                 {
                     activity?.SetStatus(ActivityStatusCode.Error);

--- a/src/Beutl/Services/StartupTasks/CheckForPackageUpdatesTask.cs
+++ b/src/Beutl/Services/StartupTasks/CheckForPackageUpdatesTask.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Threading;
+using Beutl.Api;
 using Beutl.Api.Services;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Logging;
@@ -12,9 +13,11 @@ namespace Beutl.Services.StartupTasks;
 public sealed class CheckForPackageUpdatesTask : StartupTask
 {
     private readonly ILogger<CheckForPackageUpdatesTask> _logger = Log.CreateLogger<CheckForPackageUpdatesTask>();
+    private readonly BeutlApiApplication _beutlApiApplication;
 
-    public CheckForPackageUpdatesTask(Startup startup, PackageManager packageManager)
+    public CheckForPackageUpdatesTask(Startup startup, PackageManager packageManager, BeutlApiApplication beutlApiApplication)
     {
+        _beutlApiApplication = beutlApiApplication;
         Task = Task.Run(async () =>
         {
             using (Activity? activity = Telemetry.StartActivity("CheckForPackageUpdatesTask"))
@@ -40,6 +43,12 @@ public sealed class CheckForPackageUpdatesTask : StartupTask
                     {
                         _logger.LogInformation("All packages are up to date.");
                     }
+                }
+                catch (Exception ex) when (_beutlApiApplication.IsDisposed
+                    && ex is OperationCanceledException or ObjectDisposedException)
+                {
+                    // Shutdown cancellation is a normal exit, not a failed update check:
+                    // skip the error telemetry and the error log.
                 }
                 catch (Exception ex)
                 {

--- a/src/Beutl/Services/StartupTasks/CheckForUpdatesTask.cs
+++ b/src/Beutl/Services/StartupTasks/CheckForUpdatesTask.cs
@@ -154,6 +154,13 @@ public sealed class CheckForUpdatesTask : StartupTask
             _logger.LogError(ex, "An error occurred while checking for updates");
             if (ex is OperationCanceledException)
             {
+                if (_beutlApiApplication.IsDisposed)
+                {
+                    // Shutdown cancelled the update request through the application
+                    // lifetime; that is not a network timeout and must not show a message.
+                    return default;
+                }
+
                 // HttpClient timeouts surface as TaskCanceledException or, on modern .NET,
                 // sometimes as plain OperationCanceledException. No external CancellationToken
                 // is passed here, so any OCE is effectively a network timeout — show a

--- a/src/Beutl/Services/StartupTasks/CheckForUpdatesTask.cs
+++ b/src/Beutl/Services/StartupTasks/CheckForUpdatesTask.cs
@@ -156,8 +156,7 @@ public sealed class CheckForUpdatesTask : StartupTask
             {
                 if (_beutlApiApplication.IsDisposed)
                 {
-                    // Shutdown cancelled the update request through the application
-                    // lifetime; that is not a network timeout and must not show a message.
+                    // Shutdown cancellation is not a network timeout.
                     return default;
                 }
 

--- a/src/Beutl/Services/StartupTasks/CheckForUpdatesTask.cs
+++ b/src/Beutl/Services/StartupTasks/CheckForUpdatesTask.cs
@@ -150,16 +150,18 @@ public sealed class CheckForUpdatesTask : StartupTask
         }
         catch (Exception ex)
         {
+            if (_beutlApiApplication.IsDisposed
+                && ex is OperationCanceledException or ObjectDisposedException)
+            {
+                // Shutdown cancellation is a normal exit, not a failed update check:
+                // skip the error telemetry and the timeout notification.
+                return default;
+            }
+
             activity?.SetStatus(ActivityStatusCode.Error);
             _logger.LogError(ex, "An error occurred while checking for updates");
             if (ex is OperationCanceledException)
             {
-                if (_beutlApiApplication.IsDisposed)
-                {
-                    // Shutdown cancellation is not a network timeout.
-                    return default;
-                }
-
                 // HttpClient timeouts surface as TaskCanceledException or, on modern .NET,
                 // sometimes as plain OperationCanceledException. No external CancellationToken
                 // is passed here, so any OCE is effectively a network timeout — show a

--- a/src/Beutl/Services/StartupTasks/Startup.cs
+++ b/src/Beutl/Services/StartupTasks/Startup.cs
@@ -77,7 +77,7 @@ public sealed class Startup
         Register(() => new AfterLoadingExtensionsTask(this));
         Register(() => new RestoreLastProjectTask(this, _projectService));
         Register(() => new CheckForUpdatesTask(_apiApp));
-        Register(() => new CheckForPackageUpdatesTask(this, _apiApp.GetResource<PackageManager>()));
+        Register(() => new CheckForPackageUpdatesTask(this, _apiApp.GetResource<PackageManager>(), _apiApp));
     }
 
     private void Register<T>(Func<T> factory)

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPageViewModel.cs
@@ -131,8 +131,14 @@ public sealed class DiscoverPageViewModel : BasePageViewModel, ISupportRefreshVi
 
     public override void Dispose()
     {
-        _lifetimeCts.Cancel();
-        _disposables.Dispose();
-        _lifetimeCts.Dispose();
+        try
+        {
+            _lifetimeCts.Cancel();
+        }
+        finally
+        {
+            _disposables.Dispose();
+            _lifetimeCts.Dispose();
+        }
     }
 }

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPageViewModel.cs
@@ -14,6 +14,7 @@ public sealed class DiscoverPageViewModel : BasePageViewModel, ISupportRefreshVi
 {
     private readonly ILogger _logger = Log.CreateLogger<DiscoverPageViewModel>();
     private readonly CompositeDisposable _disposables = [];
+    private readonly LifetimeCancellationSource _lifetimeCts = new();
     private readonly DiscoverService _discover;
     private readonly BeutlApiApplication _apiApp;
 
@@ -34,7 +35,7 @@ public sealed class DiscoverPageViewModel : BasePageViewModel, ISupportRefreshVi
                     Items.Clear();
                     Items.AddRange(Enumerable.Repeat(new DummyItem(), 10));
 
-                    Package[] array = await LoadItems(0, 30, activity);
+                    Package[] array = await LoadItems(0, 30, activity, _lifetimeCts.Token);
                     Items.Clear();
                     Items.AddRange(array);
 
@@ -42,6 +43,9 @@ public sealed class DiscoverPageViewModel : BasePageViewModel, ISupportRefreshVi
                     {
                         Items.Add(new LoadMoreItem());
                     }
+                }
+                catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+                {
                 }
                 catch (Exception e)
                 {
@@ -65,13 +69,16 @@ public sealed class DiscoverPageViewModel : BasePageViewModel, ISupportRefreshVi
                 {
                     IsBusy.Value = true;
                     Items.RemoveAt(Items.Count - 1);
-                    Package[] array = await LoadItems(Items.Count, 30, activity);
+                    Package[] array = await LoadItems(Items.Count, 30, activity, _lifetimeCts.Token);
                     Items.AddRange(array);
 
                     if (array.Length == 30)
                     {
                         Items.Add(new LoadMoreItem());
                     }
+                }
+                catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+                {
                 }
                 catch (Exception e)
                 {
@@ -104,22 +111,28 @@ public sealed class DiscoverPageViewModel : BasePageViewModel, ISupportRefreshVi
 
     public DataContextFactory DataContextFactory { get; }
 
-    private async Task<Package[]> LoadItems(int start, int count, Activity? activity)
+    private async Task<Package[]> LoadItems(
+        int start,
+        int count,
+        Activity? activity,
+        CancellationToken cancellationToken)
     {
-        using (await _discover.Lock.LockAsync())
+        using (await _discover.Lock.LockAsync(cancellationToken))
         {
             activity?.AddEvent(new("Entered_AsyncLock"));
             if (_apiApp.AuthenticatedUser.Value != null)
             {
-                await _apiApp.AuthenticatedUser.Value.RefreshAsync(CancellationToken.None);
+                await _apiApp.AuthenticatedUser.Value.RefreshAsync(cancellationToken);
             }
 
-            return await _discover.GetFeatured(CancellationToken.None, start, count, Kind.Selected);
+            return await _discover.GetFeatured(cancellationToken, start, count, Kind.Selected);
         }
     }
 
     public override void Dispose()
     {
+        _lifetimeCts.Cancel();
         _disposables.Dispose();
+        _lifetimeCts.Dispose();
     }
 }

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPageViewModel.cs
@@ -135,6 +135,10 @@ public sealed class DiscoverPageViewModel : BasePageViewModel, ISupportRefreshVi
         {
             _lifetimeCts.Cancel();
         }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to cancel the lifetime token during disposal.");
+        }
         finally
         {
             _disposables.Dispose();

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
@@ -258,6 +258,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                         Release release = await AcquireRelease(_lifetimeCts.Token);
                         var packageId = new PackageIdentity(Package.Name, new NuGetVersion(release.Version.Value));
 
+                        bool oldVersionRemoved = false;
                         try
                         {
                             if (!await _handler.UnloadPackages(Package.Name))
@@ -267,6 +268,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                             }
 
                             _handler.DeleteOldVersionFiles(Package.Name);
+                            oldVersionRemoved = true;
 
                             await _handler.DownloadAndLoadPackage(release, packageId, _lifetimeCts.Token);
                             NotificationService.ShowInformation(
@@ -275,6 +277,13 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                         }
                         catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
                         {
+                            if (oldVersionRemoved)
+                            {
+                                // The old version was already unloaded and deleted; queue the update so
+                                // PackageTools restores the package on the next launch.
+                                _handler.Queue.InstallQueue(packageId);
+                            }
+
                             throw;
                         }
                         catch (Exception ex)

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
@@ -279,8 +279,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                         {
                             if (oldVersionRemoved)
                             {
-                                // The old version was already unloaded and deleted; queue the update so
-                                // PackageTools restores the package on the next launch.
+                                // The old version is gone; queue the update for the next launch.
                                 _handler.Queue.InstallQueue(packageId);
                             }
 

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
@@ -449,6 +449,10 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
         {
             _lifetimeCts.Cancel();
         }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to cancel the lifetime token during disposal.");
+        }
         finally
         {
             _disposables.Dispose();

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
@@ -202,7 +202,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
 
                         try
                         {
-                            await _handler.DownloadAndLoadPackage(release, packageId);
+                            await _handler.DownloadAndLoadPackage(release, packageId, _lifetimeCts.Token);
                             NotificationService.ShowInformation(
                                 title: ExtensionsStrings.PackageInstaller,
                                 message: string.Format(ExtensionsStrings.PackageInstaller_Installed,
@@ -268,7 +268,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
 
                             _handler.DeleteOldVersionFiles(Package.Name);
 
-                            await _handler.DownloadAndLoadPackage(release, packageId);
+                            await _handler.DownloadAndLoadPackage(release, packageId, _lifetimeCts.Token);
                             NotificationService.ShowInformation(
                                 title: ExtensionsStrings.PackageInstaller,
                                 message: string.Format(ExtensionsStrings.PackageInstaller_Updated, packageId.Id));

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
@@ -17,6 +17,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
 {
     private readonly ILogger _logger = Log.CreateLogger<PackageDetailsPageViewModel>();
     private readonly CompositeDisposable _disposables = [];
+    private readonly LifetimeCancellationSource _lifetimeCts = new();
     private readonly PackageOperationHandler _handler;
     private readonly LibraryService _library;
     private readonly BeutlApiApplication _app;
@@ -53,15 +54,15 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
 
                 try
                 {
-                    using (await _app.Lock.LockAsync())
+                    using (await _app.Lock.LockAsync(_lifetimeCts.Token))
                     {
                         activity?.AddEvent(new("Entered_AsyncLock"));
                         IsBusy.Value = true;
                         await PackageReleaseRefreshCoordinator.RefreshAsync(
                             releasesReady,
-                            () => Package.RefreshAsync(CancellationToken.None),
+                            () => Package.RefreshAsync(_lifetimeCts.Token),
                             (start, count) => package.GetReleasesAsync(
-                                CancellationToken.None,
+                                _lifetimeCts.Token,
                                 start,
                                 count),
                             releases =>
@@ -76,6 +77,9 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                                 }
                             });
                     }
+                }
+                catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+                {
                 }
                 catch (Exception e)
                 {
@@ -131,7 +135,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                 AvaloniaScheduler.Instance,
                 () => SelectedRelease.Value,
                 () => AllReleases,
-                version => Package.GetReleaseAsync(version, CancellationToken.None),
+                version => Package.GetReleaseAsync(version, _lifetimeCts.Token),
                 ex => _logger.LogWarning(ex, "Failed to resolve installed release for {PackageId}.", Package.Name))
             .Subscribe(release => CurrentRelease.Value = release)
             .DisposeWith(_disposables);
@@ -190,10 +194,10 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
 
                     IsBusy.Value = true;
                     StatusText.Value = ExtensionsStrings.Installing;
-                    using (await _app.Lock.LockAsync())
+                    using (await _app.Lock.LockAsync(_lifetimeCts.Token))
                     {
                         activity?.AddEvent(new("Entered_AsyncLock"));
-                        Release release = await AcquireRelease();
+                        Release release = await AcquireRelease(_lifetimeCts.Token);
                         var packageId = new PackageIdentity(Package.Name, new NuGetVersion(release.Version.Value));
 
                         try
@@ -203,6 +207,10 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                                 title: ExtensionsStrings.PackageInstaller,
                                 message: string.Format(ExtensionsStrings.PackageInstaller_Installed,
                                     packageId.Id));
+                        }
+                        catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+                        {
+                            throw;
                         }
                         catch (Exception ex)
                         {
@@ -214,6 +222,9 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                                     packageId.Id));
                         }
                     }
+                }
+                catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+                {
                 }
                 catch (Exception e)
                 {
@@ -241,15 +252,19 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                         return;
 
                     StatusText.Value = ExtensionsStrings.Updating;
-                    using (await _app.Lock.LockAsync())
+                    using (await _app.Lock.LockAsync(_lifetimeCts.Token))
                     {
                         activity?.AddEvent(new("Entered_AsyncLock"));
-                        Release release = await AcquireRelease();
+                        Release release = await AcquireRelease(_lifetimeCts.Token);
                         var packageId = new PackageIdentity(Package.Name, new NuGetVersion(release.Version.Value));
 
                         try
                         {
-                            await _handler.UnloadPackages(Package.Name);
+                            if (!await _handler.UnloadPackages(Package.Name))
+                            {
+                                throw new InvalidOperationException(
+                                    $"Package '{Package.Name}' could not be unloaded safely.");
+                            }
 
                             _handler.DeleteOldVersionFiles(Package.Name);
 
@@ -257,6 +272,10 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                             NotificationService.ShowInformation(
                                 title: ExtensionsStrings.PackageInstaller,
                                 message: string.Format(ExtensionsStrings.PackageInstaller_Updated, packageId.Id));
+                        }
+                        catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+                        {
+                            throw;
                         }
                         catch (Exception ex)
                         {
@@ -267,6 +286,9 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                                 message: string.Format(ExtensionsStrings.PackageInstaller_ScheduledUpdate, packageId.Id));
                         }
                     }
+                }
+                catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+                {
                 }
                 catch (Exception e)
                 {
@@ -350,12 +372,12 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
         Refresh.Execute();
     }
 
-    private async Task<Release> AcquireRelease()
+    private async Task<Release> AcquireRelease(CancellationToken cancellationToken)
     {
         if (_app.AuthenticatedUser.Value != null)
         {
-            await _app.AuthenticatedUser.Value.RefreshAsync(CancellationToken.None);
-            await _library.Acquire(Package, CancellationToken.None);
+            await _app.AuthenticatedUser.Value.RefreshAsync(cancellationToken);
+            await _library.Acquire(Package, cancellationToken);
         }
 
         if (SelectedRelease.Value != null)
@@ -363,7 +385,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
             return SelectedRelease.Value;
         }
 
-        return await PackageReleaseResolver.GetFirstReleaseAsync(Package, CancellationToken.None);
+        return await PackageReleaseResolver.GetFirstReleaseAsync(Package, cancellationToken);
     }
 
     public Package Package { get; }
@@ -414,7 +436,9 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
 
     public override void Dispose()
     {
+        _lifetimeCts.Cancel();
         _disposables.Dispose();
+        _lifetimeCts.Dispose();
     }
 
     private static string KindToText(PackageKind kind)

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
@@ -445,9 +445,15 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
 
     public override void Dispose()
     {
-        _lifetimeCts.Cancel();
-        _disposables.Dispose();
-        _lifetimeCts.Dispose();
+        try
+        {
+            _lifetimeCts.Cancel();
+        }
+        finally
+        {
+            _disposables.Dispose();
+            _lifetimeCts.Dispose();
+        }
     }
 
     private static string KindToText(PackageKind kind)

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/SearchPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/SearchPageViewModel.cs
@@ -90,9 +90,15 @@ public sealed class SearchPageViewModel : BasePageViewModel, ISupportRefreshView
 
     public override void Dispose()
     {
-        _lifetimeCts.Cancel();
-        _disposables.Dispose();
-        _lifetimeCts.Dispose();
+        try
+        {
+            _lifetimeCts.Cancel();
+        }
+        finally
+        {
+            _disposables.Dispose();
+            _lifetimeCts.Dispose();
+        }
     }
 
     private async Task<Package[]> SearchPackages(int start, int count, CancellationToken cancellationToken)

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/SearchPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/SearchPageViewModel.cs
@@ -94,6 +94,10 @@ public sealed class SearchPageViewModel : BasePageViewModel, ISupportRefreshView
         {
             _lifetimeCts.Cancel();
         }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to cancel the lifetime token during disposal.");
+        }
         finally
         {
             _disposables.Dispose();

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/SearchPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/SearchPageViewModel.cs
@@ -12,6 +12,7 @@ public sealed class SearchPageViewModel : BasePageViewModel, ISupportRefreshView
 {
     private readonly ILogger _logger = Log.CreateLogger<SearchPageViewModel>();
     private readonly CompositeDisposable _disposables = [];
+    private readonly LifetimeCancellationSource _lifetimeCts = new();
     private readonly DiscoverService _discoverService;
 
     public SearchPageViewModel(DiscoverService discoverService, string keyword)
@@ -27,7 +28,10 @@ public sealed class SearchPageViewModel : BasePageViewModel, ISupportRefreshView
                 try
                 {
                     IsBusy.Value = true;
-                    await RefreshPackages();
+                    await RefreshPackages(_lifetimeCts.Token);
+                }
+                catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+                {
                 }
                 catch (Exception e)
                 {
@@ -50,7 +54,10 @@ public sealed class SearchPageViewModel : BasePageViewModel, ISupportRefreshView
                 try
                 {
                     IsBusy.Value = true;
-                    await MoreLoadPackages();
+                    await MoreLoadPackages(_lifetimeCts.Token);
+                }
+                catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+                {
                 }
                 catch (Exception e)
                 {
@@ -83,22 +90,24 @@ public sealed class SearchPageViewModel : BasePageViewModel, ISupportRefreshView
 
     public override void Dispose()
     {
+        _lifetimeCts.Cancel();
         _disposables.Dispose();
+        _lifetimeCts.Dispose();
     }
 
-    private async Task<Package[]> SearchPackages(int start, int count)
+    private async Task<Package[]> SearchPackages(int start, int count, CancellationToken cancellationToken)
     {
-        return await _discoverService.Search(Keyword, CancellationToken.None, start, count, Kind.Selected);
+        return await _discoverService.Search(Keyword, cancellationToken, start, count, Kind.Selected);
     }
 
-    private async Task RefreshPackages()
+    private async Task RefreshPackages(CancellationToken cancellationToken)
     {
         Packages.Clear();
         Packages.AddRange(Enumerable.Repeat(new DummyItem(), 6));
 
-        using (await _discoverService.Lock.LockAsync())
+        using (await _discoverService.Lock.LockAsync(cancellationToken))
         {
-            Package[] array = await SearchPackages(0, 30);
+            Package[] array = await SearchPackages(0, 30, cancellationToken);
             Packages.Clear();
             Packages.AddRange(array);
 
@@ -109,12 +118,12 @@ public sealed class SearchPageViewModel : BasePageViewModel, ISupportRefreshView
         }
     }
 
-    private async Task MoreLoadPackages()
+    private async Task MoreLoadPackages(CancellationToken cancellationToken)
     {
-        using (await _discoverService.Lock.LockAsync())
+        using (await _discoverService.Lock.LockAsync(cancellationToken))
         {
             Packages.RemoveAt(Packages.Count - 1);
-            Package[] array = await SearchPackages(Packages.Count, 30);
+            Package[] array = await SearchPackages(Packages.Count, 30, cancellationToken);
             Packages.AddRange(array);
 
             if (array.Length == 30)

--- a/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
@@ -247,6 +247,7 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
                 }
                 catch
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     var item = installed.FirstOrDefault(i => i.Name == name);
                     if (item != null)
                         Packages.Add(new LocalUserPackageViewModel(item, _clients, _editorService, _projectService));
@@ -255,6 +256,7 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
 
             if (remote != null)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 Packages.Add(new RemoteUserPackageViewModel(remote, _clients, _editorService, _projectService)
                 {
                     OnRemoveFromLibrary = OnPackageRemoveFromLibrary

--- a/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
@@ -222,6 +222,7 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
 
         foreach (KeyValuePair<string, LocalPackage> item in dict)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             LocalPackages.Add(new LocalUserPackageViewModel(item.Value, _clients, _editorService, _projectService));
         }
     }

--- a/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
@@ -43,20 +43,23 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
                     Packages.Clear();
                     Packages.AddRange(Enumerable.Repeat(new DummyItem(), 6));
 
-                    using (await _clients.Lock.LockAsync())
+                    using (await _clients.Lock.LockAsync(_lifetimeCts.Token))
                     {
                         activity?.AddEvent(new("Entered_AsyncLock"));
 
                         if (_user != null)
                         {
-                            await _user.RefreshAsync(CancellationToken.None);
+                            await _user.RefreshAsync(_lifetimeCts.Token);
                         }
 
-                        await RefreshPackages(_user != null);
+                        await RefreshPackages(_user != null, _lifetimeCts.Token);
                         activity?.AddEvent(new("Refreshed_Packages"));
                     }
 
                     await task;
+                }
+                catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+                {
                 }
                 catch (Exception e)
                 {
@@ -205,22 +208,27 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
         }
     }
 
-    private async Task RefreshPackages(bool auth)
+    private async Task RefreshPackages(bool auth, CancellationToken cancellationToken)
     {
         PackageManager manager = _clients.GetResource<PackageManager>();
         DiscoverService discover = _clients.GetResource<DiscoverService>();
-        List<Package> own = auth ? await LoadAll() : [];
+        List<Package> own = auth ? await LoadAll(cancellationToken) : [];
         Packages.Clear();
         var installed = await manager.GetPackages();
 
         foreach (var name in own.Select(i => i.Name).Union(installed.Select(i => i.Name)))
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var remote = own.FirstOrDefault(i => i.Name == name);
             if (remote == null)
             {
                 try
                 {
-                    remote = await discover.GetPackage(name, CancellationToken.None);
+                    remote = await discover.GetPackage(name, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
                 }
                 catch
                 {
@@ -240,14 +248,15 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
         }
     }
 
-    private async Task<List<Package>> LoadAll()
+    private async Task<List<Package>> LoadAll(CancellationToken cancellationToken)
     {
         var list = new List<Package>();
-        Package[] array = await _service.GetPackages(CancellationToken.None, 0, 30);
+        Package[] array = await _service.GetPackages(cancellationToken, 0, 30);
         list.AddRange(array);
         while (array.Length == 30)
         {
-            array = await _service.GetPackages(CancellationToken.None, list.Count, 30);
+            cancellationToken.ThrowIfCancellationRequested();
+            array = await _service.GetPackages(cancellationToken, list.Count, 30);
             list.AddRange(array);
         }
 

--- a/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
@@ -151,9 +151,15 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
 
     public override void Dispose()
     {
-        _lifetimeCts.Cancel();
-        _disposables.Dispose();
-        _lifetimeCts.Dispose();
+        try
+        {
+            _lifetimeCts.Cancel();
+        }
+        finally
+        {
+            _disposables.Dispose();
+            _lifetimeCts.Dispose();
+        }
     }
 
     public async Task<Package?> TryFindPackage(LocalPackage localPackage)

--- a/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
@@ -155,6 +155,10 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
         {
             _lifetimeCts.Cancel();
         }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to cancel the lifetime token during disposal.");
+        }
         finally
         {
             _disposables.Dispose();

--- a/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
@@ -38,7 +38,7 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
                 try
                 {
                     IsBusy.Value = true;
-                    Task task = RefreshLocalPackages();
+                    Task task = RefreshLocalPackages(_lifetimeCts.Token);
                     DisposeAll(Packages.OfType<IDisposable>());
                     Packages.Clear();
                     Packages.AddRange(Enumerable.Repeat(new DummyItem(), 6));
@@ -178,7 +178,7 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
         obj.Dispose();
     }
 
-    private async Task RefreshLocalPackages()
+    private async Task RefreshLocalPackages(CancellationToken cancellationToken)
     {
         PackageManager manager = _clients.GetResource<PackageManager>();
         DisposeAll(LocalPackages);
@@ -188,6 +188,7 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
         foreach (LocalPackage item in manager.GetLocalSourcePackages()
                      .Concat(await manager.GetPackages()))
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (dict.TryGetValue(item.Name, out LocalPackage? localPackage))
             {
                 // itemのほうが新しいバージョン

--- a/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
@@ -17,6 +17,7 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
     private readonly AuthenticatedUser? _user;
     private readonly BeutlApiApplication _clients;
     private readonly CompositeDisposable _disposables = [];
+    private readonly LifetimeCancellationSource _lifetimeCts = new();
     private readonly LibraryService _service;
     private readonly EditorService _editorService;
     private readonly ProjectService _projectService;
@@ -80,17 +81,17 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
                 try
                 {
                     IsBusy.Value = true;
-                    using (await _clients.Lock.LockAsync())
+                    using (await _clients.Lock.LockAsync(_lifetimeCts.Token))
                     {
                         activity?.AddEvent(new("Entered_AsyncLock"));
 
                         if (_user != null)
                         {
-                            await _user.RefreshAsync(CancellationToken.None);
+                            await _user.RefreshAsync(_lifetimeCts.Token);
                         }
 
                         PackageManager manager = _clients.GetResource<PackageManager>();
-                        foreach (PackageUpdate item in await manager.CheckUpdate(CancellationToken.None))
+                        foreach (PackageUpdate item in await manager.CheckUpdate(_lifetimeCts.Token))
                         {
                             LocalUserPackageViewModel? localPackage = LocalPackages.FirstOrDefault(
                                 x => x.Package.Name.Equals(item.Package.Name, StringComparison.OrdinalIgnoreCase));
@@ -118,6 +119,9 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
                         }
                     }
                 }
+                catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+                {
+                }
                 catch (Exception e)
                 {
                     activity?.SetStatus(ActivityStatusCode.Error);
@@ -144,7 +148,9 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
 
     public override void Dispose()
     {
+        _lifetimeCts.Cancel();
         _disposables.Dispose();
+        _lifetimeCts.Dispose();
     }
 
     public async Task<Package?> TryFindPackage(LocalPackage localPackage)

--- a/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
@@ -158,12 +158,16 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
 
     public async Task<Package?> TryFindPackage(LocalPackage localPackage)
     {
-        using (await _clients.Lock.LockAsync())
+        using (await _clients.Lock.LockAsync(_lifetimeCts.Token))
         {
             DiscoverService discover = _clients.GetResource<DiscoverService>();
             try
             {
-                return await discover.GetPackage(localPackage.Name, CancellationToken.None);
+                return await discover.GetPackage(localPackage.Name, _lifetimeCts.Token);
+            }
+            catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+            {
+                throw;
             }
             catch
             {

--- a/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
@@ -94,8 +94,11 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
                         }
 
                         PackageManager manager = _clients.GetResource<PackageManager>();
-                        foreach (PackageUpdate item in await manager.CheckUpdate(_lifetimeCts.Token))
+                        IReadOnlyList<PackageUpdate> updates = await manager.CheckUpdate(_lifetimeCts.Token);
+                        _lifetimeCts.Token.ThrowIfCancellationRequested();
+                        foreach (PackageUpdate item in updates)
                         {
+                            _lifetimeCts.Token.ThrowIfCancellationRequested();
                             LocalUserPackageViewModel? localPackage = LocalPackages.FirstOrDefault(
                                 x => x.Package.Name.Equals(item.Package.Name, StringComparison.OrdinalIgnoreCase));
 

--- a/src/Beutl/ViewModels/ExtensionsPages/LocalUserPackageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/LocalUserPackageViewModel.cs
@@ -65,7 +65,7 @@ public sealed class LocalUserPackageViewModel : BaseViewModel, IUserPackageViewM
 
                     try
                     {
-                        await _handler.DownloadAndLoadPackage(_packageIdentity);
+                        await _handler.DownloadAndLoadPackage(_packageIdentity, CancellationToken.None);
                         NotificationService.ShowInformation(
                             title: ExtensionsStrings.PackageInstaller,
                             message: string.Format(ExtensionsStrings.PackageInstaller_Installed,
@@ -120,7 +120,7 @@ public sealed class LocalUserPackageViewModel : BaseViewModel, IUserPackageViewM
                                     $"Package '{Package.Name}' could not be unloaded safely.");
                             }
                             _handler.DeleteOldVersionFiles(Package.Name);
-                            await _handler.DownloadAndLoadPackage(LatestRelease.Value, packageId);
+                            await _handler.DownloadAndLoadPackage(LatestRelease.Value, packageId, CancellationToken.None);
                             NotificationService.ShowInformation(
                                 title: ExtensionsStrings.PackageInstaller,
                                 message: string.Format(ExtensionsStrings.PackageInstaller_Updated, packageId.Id));

--- a/src/Beutl/ViewModels/ExtensionsPages/LocalUserPackageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/LocalUserPackageViewModel.cs
@@ -114,7 +114,11 @@ public sealed class LocalUserPackageViewModel : BaseViewModel, IUserPackageViewM
 
                         try
                         {
-                            await _handler.UnloadPackages(Package.Name);
+                            if (!await _handler.UnloadPackages(Package.Name))
+                            {
+                                throw new InvalidOperationException(
+                                    $"Package '{Package.Name}' could not be unloaded safely.");
+                            }
                             _handler.DeleteOldVersionFiles(Package.Name);
                             await _handler.DownloadAndLoadPackage(LatestRelease.Value, packageId);
                             NotificationService.ShowInformation(

--- a/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
@@ -52,9 +52,13 @@ internal class PackageOperationHandler
             await _packageInstaller.VerifyPackageFile(context, cancellationToken: cancellationToken).ConfigureAwait(false);
             await _packageInstaller.ResolveDependencies(context, null, cancellationToken).ConfigureAwait(false);
 
-            _installedPackageRepository.UpgradePackages(packageId);
-
-            ActivateInstalledPackage(packageId);
+            // Plugin activation (Extension.Load) may perform Avalonia-bound initialization,
+            // so run it on the UI thread even though the install phases ran off-context.
+            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                _installedPackageRepository.UpgradePackages(packageId);
+                ActivateInstalledPackage(packageId);
+            });
         }).ConfigureAwait(false);
     }
 
@@ -73,9 +77,13 @@ internal class PackageOperationHandler
             await _packageInstaller.VerifyPackageFile(context, cancellationToken: cancellationToken).ConfigureAwait(false);
             await _packageInstaller.ResolveDependencies(context, null, cancellationToken).ConfigureAwait(false);
 
-            _installedPackageRepository.UpgradePackages(packageId);
-
-            ActivateInstalledPackage(packageId);
+            // Plugin activation (Extension.Load) may perform Avalonia-bound initialization,
+            // so run it on the UI thread even though the install phases ran off-context.
+            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                _installedPackageRepository.UpgradePackages(packageId);
+                ActivateInstalledPackage(packageId);
+            });
         }).ConfigureAwait(false);
     }
 

--- a/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
@@ -37,24 +37,36 @@ internal class PackageOperationHandler
 
     public PackageChangesQueue Queue => _queue;
 
-    public async Task DownloadAndLoadPackage(Release release, PackageIdentity packageId)
+    public async Task DownloadAndLoadPackage(
+        Release release,
+        PackageIdentity packageId,
+        CancellationToken cancellationToken)
     {
-        PackageInstallContext context = await _packageInstaller.PrepareForInstall(release, force: true);
-        await _packageInstaller.DownloadPackageFile(context);
-        await _packageInstaller.VerifyPackageFile(context);
-        await _packageInstaller.ResolveDependencies(context, null);
+        PackageInstallContext context = await _packageInstaller.PrepareForInstall(
+            release,
+            force: true,
+            cancellationToken);
+        await _packageInstaller.DownloadPackageFile(context, cancellationToken: cancellationToken);
+        await _packageInstaller.VerifyPackageFile(context, cancellationToken: cancellationToken);
+        await _packageInstaller.ResolveDependencies(context, null, cancellationToken);
 
         _installedPackageRepository.UpgradePackages(packageId);
 
         ActivateInstalledPackage(packageId);
     }
 
-    public async Task DownloadAndLoadPackage(PackageIdentity packageId)
+    public async Task DownloadAndLoadPackage(
+        PackageIdentity packageId,
+        CancellationToken cancellationToken)
     {
-        PackageInstallContext context = _packageInstaller.PrepareForInstall(packageId.Id, packageId.Version.ToString(), force: true);
-        await _packageInstaller.DownloadPackageFile(context);
-        await _packageInstaller.VerifyPackageFile(context);
-        await _packageInstaller.ResolveDependencies(context, null);
+        PackageInstallContext context = _packageInstaller.PrepareForInstall(
+            packageId.Id,
+            packageId.Version.ToString(),
+            force: true,
+            cancellationToken);
+        await _packageInstaller.DownloadPackageFile(context, cancellationToken: cancellationToken);
+        await _packageInstaller.VerifyPackageFile(context, cancellationToken: cancellationToken);
+        await _packageInstaller.ResolveDependencies(context, null, cancellationToken);
 
         _installedPackageRepository.UpgradePackages(packageId);
 

--- a/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
@@ -52,10 +52,12 @@ internal class PackageOperationHandler
             await _packageInstaller.VerifyPackageFile(context, cancellationToken: cancellationToken).ConfigureAwait(false);
             await _packageInstaller.ResolveDependencies(context, null, cancellationToken).ConfigureAwait(false);
 
+            cancellationToken.ThrowIfCancellationRequested();
             // Plugin activation (Extension.Load) may perform Avalonia-bound initialization,
             // so run it on the UI thread even though the install phases ran off-context.
             await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 _installedPackageRepository.UpgradePackages(packageId);
                 ActivateInstalledPackage(packageId);
             });
@@ -77,10 +79,12 @@ internal class PackageOperationHandler
             await _packageInstaller.VerifyPackageFile(context, cancellationToken: cancellationToken).ConfigureAwait(false);
             await _packageInstaller.ResolveDependencies(context, null, cancellationToken).ConfigureAwait(false);
 
+            cancellationToken.ThrowIfCancellationRequested();
             // Plugin activation (Extension.Load) may perform Avalonia-bound initialization,
             // so run it on the UI thread even though the install phases ran off-context.
             await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 _installedPackageRepository.UpgradePackages(packageId);
                 ActivateInstalledPackage(packageId);
             });

--- a/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
@@ -47,15 +47,15 @@ internal class PackageOperationHandler
             PackageInstallContext context = await _packageInstaller.PrepareForInstall(
                 release,
                 force: true,
-                cancellationToken);
-            await _packageInstaller.DownloadPackageFile(context, cancellationToken: cancellationToken);
-            await _packageInstaller.VerifyPackageFile(context, cancellationToken: cancellationToken);
-            await _packageInstaller.ResolveDependencies(context, null, cancellationToken);
+                cancellationToken).ConfigureAwait(false);
+            await _packageInstaller.DownloadPackageFile(context, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await _packageInstaller.VerifyPackageFile(context, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await _packageInstaller.ResolveDependencies(context, null, cancellationToken).ConfigureAwait(false);
 
             _installedPackageRepository.UpgradePackages(packageId);
 
             ActivateInstalledPackage(packageId);
-        });
+        }).ConfigureAwait(false);
     }
 
     public async Task DownloadAndLoadPackage(
@@ -69,14 +69,14 @@ internal class PackageOperationHandler
                 packageId.Version.ToString(),
                 force: true,
                 cancellationToken);
-            await _packageInstaller.DownloadPackageFile(context, cancellationToken: cancellationToken);
-            await _packageInstaller.VerifyPackageFile(context, cancellationToken: cancellationToken);
-            await _packageInstaller.ResolveDependencies(context, null, cancellationToken);
+            await _packageInstaller.DownloadPackageFile(context, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await _packageInstaller.VerifyPackageFile(context, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await _packageInstaller.ResolveDependencies(context, null, cancellationToken).ConfigureAwait(false);
 
             _installedPackageRepository.UpgradePackages(packageId);
 
             ActivateInstalledPackage(packageId);
-        });
+        }).ConfigureAwait(false);
     }
 
     private void ActivateInstalledPackage(PackageIdentity packageId)

--- a/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
@@ -42,35 +42,41 @@ internal class PackageOperationHandler
         PackageIdentity packageId,
         CancellationToken cancellationToken)
     {
-        PackageInstallContext context = await _packageInstaller.PrepareForInstall(
-            release,
-            force: true,
-            cancellationToken);
-        await _packageInstaller.DownloadPackageFile(context, cancellationToken: cancellationToken);
-        await _packageInstaller.VerifyPackageFile(context, cancellationToken: cancellationToken);
-        await _packageInstaller.ResolveDependencies(context, null, cancellationToken);
+        await _packageInstaller.TrackInstallOperationAsync(async () =>
+        {
+            PackageInstallContext context = await _packageInstaller.PrepareForInstall(
+                release,
+                force: true,
+                cancellationToken);
+            await _packageInstaller.DownloadPackageFile(context, cancellationToken: cancellationToken);
+            await _packageInstaller.VerifyPackageFile(context, cancellationToken: cancellationToken);
+            await _packageInstaller.ResolveDependencies(context, null, cancellationToken);
 
-        _installedPackageRepository.UpgradePackages(packageId);
+            _installedPackageRepository.UpgradePackages(packageId);
 
-        ActivateInstalledPackage(packageId);
+            ActivateInstalledPackage(packageId);
+        });
     }
 
     public async Task DownloadAndLoadPackage(
         PackageIdentity packageId,
         CancellationToken cancellationToken)
     {
-        PackageInstallContext context = _packageInstaller.PrepareForInstall(
-            packageId.Id,
-            packageId.Version.ToString(),
-            force: true,
-            cancellationToken);
-        await _packageInstaller.DownloadPackageFile(context, cancellationToken: cancellationToken);
-        await _packageInstaller.VerifyPackageFile(context, cancellationToken: cancellationToken);
-        await _packageInstaller.ResolveDependencies(context, null, cancellationToken);
+        await _packageInstaller.TrackInstallOperationAsync(async () =>
+        {
+            PackageInstallContext context = _packageInstaller.PrepareForInstall(
+                packageId.Id,
+                packageId.Version.ToString(),
+                force: true,
+                cancellationToken);
+            await _packageInstaller.DownloadPackageFile(context, cancellationToken: cancellationToken);
+            await _packageInstaller.VerifyPackageFile(context, cancellationToken: cancellationToken);
+            await _packageInstaller.ResolveDependencies(context, null, cancellationToken);
 
-        _installedPackageRepository.UpgradePackages(packageId);
+            _installedPackageRepository.UpgradePackages(packageId);
 
-        ActivateInstalledPackage(packageId);
+            ActivateInstalledPackage(packageId);
+        });
     }
 
     private void ActivateInstalledPackage(PackageIdentity packageId)

--- a/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
@@ -53,8 +53,7 @@ internal class PackageOperationHandler
             await _packageInstaller.ResolveDependencies(context, null, cancellationToken).ConfigureAwait(false);
 
             cancellationToken.ThrowIfCancellationRequested();
-            // Plugin activation (Extension.Load) may perform Avalonia-bound initialization,
-            // so run it on the UI thread even though the install phases ran off-context.
+            // Plugin activation may touch the UI; run it on the UI thread.
             await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -80,8 +79,7 @@ internal class PackageOperationHandler
             await _packageInstaller.ResolveDependencies(context, null, cancellationToken).ConfigureAwait(false);
 
             cancellationToken.ThrowIfCancellationRequested();
-            // Plugin activation (Extension.Load) may perform Avalonia-bound initialization,
-            // so run it on the UI thread even though the install phases ran off-context.
+            // Plugin activation may touch the UI; run it on the UI thread.
             await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
             {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
@@ -136,7 +136,11 @@ public sealed class RemoteUserPackageViewModel : BaseViewModel, IUserPackageView
 
                         try
                         {
-                            await _handler.UnloadPackages(Package.Name);
+                            if (!await _handler.UnloadPackages(Package.Name))
+                            {
+                                throw new InvalidOperationException(
+                                    $"Package '{Package.Name}' could not be unloaded safely.");
+                            }
 
                             _handler.DeleteOldVersionFiles(Package.Name);
 

--- a/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
@@ -80,7 +80,7 @@ public sealed class RemoteUserPackageViewModel : BaseViewModel, IUserPackageView
 
                         try
                         {
-                            await _handler.DownloadAndLoadPackage(release, packageId);
+                            await _handler.DownloadAndLoadPackage(release, packageId, CancellationToken.None);
                             NotificationService.ShowInformation(
                                 title: ExtensionsStrings.PackageInstaller,
                                 message: string.Format(ExtensionsStrings.PackageInstaller_Installed,
@@ -144,7 +144,7 @@ public sealed class RemoteUserPackageViewModel : BaseViewModel, IUserPackageView
 
                             _handler.DeleteOldVersionFiles(Package.Name);
 
-                            await _handler.DownloadAndLoadPackage(release, packageId);
+                            await _handler.DownloadAndLoadPackage(release, packageId, CancellationToken.None);
                             NotificationService.ShowInformation(
                                 title: ExtensionsStrings.PackageInstaller,
                                 message: string.Format(ExtensionsStrings.PackageInstaller_Updated, packageId.Id));

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -187,6 +187,11 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
                 else
                 {
                     _logger.LogWarning("Package installer did not drain within the shutdown deadline.");
+                    // Disposal keeps installer resources alive until the tracked work
+                    // stops, so fallback queueing for a still-running install/update can
+                    // still happen after the deadline. Wait for actual idleness so the
+                    // snapshot below reflects every queued recovery.
+                    installer.WaitUntilIdleAsync().GetAwaiter().GetResult();
                 }
             }
         }

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -171,7 +171,17 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
         // below; otherwise PackageTools is launched without the queued recovery.
         try
         {
-            _beutlClients.GetResource<PackageInstaller>().DisposeAsync().AsTask().GetAwaiter().GetResult();
+            Task drain = _beutlClients.GetResource<PackageInstaller>().DisposeAsync().AsTask();
+            // The transaction's activation callback is queued on the UI dispatcher; pump
+            // jobs while draining so it can complete instead of deadlocking the blocked
+            // UI thread.
+            while (!drain.IsCompleted)
+            {
+                Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+                Thread.Sleep(10);
+            }
+
+            drain.GetAwaiter().GetResult();
         }
         catch (Exception ex)
         {

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -166,17 +166,13 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
             _logger.LogWarning(ex, "Proxy media services failed to dispose during shutdown.");
         }
 
-        // Drain in-flight install transactions first so their fallback queueing (which
-        // resumes on the UI context after cancellation) is reflected in the snapshot
-        // below; otherwise PackageTools is launched without the queued recovery.
+        // Drain installs first so fallback queueing is reflected in the snapshot below.
         try
         {
             if (_beutlClients.TryGetResource<PackageInstaller>() is { } installer)
             {
                 Task drain = installer.DisposeAsync().AsTask();
-                // The transaction's activation callback is queued on the UI dispatcher; pump
-                // jobs while draining so it can complete instead of deadlocking the blocked
-                // UI thread.
+                // Pump UI jobs while draining so the queued activation can complete.
                 long deadline = Environment.TickCount64 + 30_000;
                 while (!drain.IsCompleted && Environment.TickCount64 < deadline)
                 {

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -175,13 +175,21 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
             // The transaction's activation callback is queued on the UI dispatcher; pump
             // jobs while draining so it can complete instead of deadlocking the blocked
             // UI thread.
-            while (!drain.IsCompleted)
+            long deadline = Environment.TickCount64 + 30_000;
+            while (!drain.IsCompleted && Environment.TickCount64 < deadline)
             {
                 Avalonia.Threading.Dispatcher.UIThread.RunJobs();
                 Thread.Sleep(10);
             }
 
-            drain.GetAwaiter().GetResult();
+            if (drain.IsCompleted)
+            {
+                drain.GetAwaiter().GetResult();
+            }
+            else
+            {
+                _logger.LogWarning("Package installer did not drain within the shutdown deadline.");
+            }
         }
         catch (Exception ex)
         {

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -169,7 +169,7 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
         // Drain installs first so fallback queueing is reflected in the snapshot below.
         try
         {
-            if (_beutlClients.TryGetResource<PackageInstaller>() is { } installer)
+            if (_beutlClients.TryGetCreatedResource<PackageInstaller>() is { } installer)
             {
                 Task drain = installer.DisposeAsync().AsTask();
                 // Pump UI jobs while draining so the queued activation can complete.

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -190,8 +190,21 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
                     // Disposal keeps installer resources alive until the tracked work
                     // stops, so fallback queueing for a still-running install/update can
                     // still happen after the deadline. Wait for actual idleness so the
-                    // snapshot below reflects every queued recovery.
-                    installer.WaitUntilIdleAsync().GetAwaiter().GetResult();
+                    // snapshot below reflects every queued recovery, while continuing to
+                    // pump UI jobs so queued activations keep progressing. The extra wait
+                    // is bounded so shutdown never hangs behind a non-cooperative install.
+                    Task idle = installer.WaitUntilIdleAsync(TimeSpan.FromSeconds(30));
+                    long idleDeadline = Environment.TickCount64 + 30_000;
+                    while (!idle.IsCompleted && Environment.TickCount64 < idleDeadline)
+                    {
+                        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+                        Thread.Sleep(10);
+                    }
+
+                    if (!idle.IsCompleted)
+                    {
+                        _logger.LogWarning("Package installer did not become idle within the shutdown deadline.");
+                    }
                 }
             }
         }

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -200,6 +200,15 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
 
             Process.Start(startInfo);
         }
+
+        try
+        {
+            _beutlClients.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Beutl API application failed to dispose during shutdown.");
+        }
     }
 
     public void Execute(ContextCommandExecution execution)

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -166,6 +166,18 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
             _logger.LogWarning(ex, "Proxy media services failed to dispose during shutdown.");
         }
 
+        // Drain in-flight install transactions first so their fallback queueing (which
+        // resumes on the UI context after cancellation) is reflected in the snapshot
+        // below; otherwise PackageTools is launched without the queued recovery.
+        try
+        {
+            _beutlClients.GetResource<PackageInstaller>().DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Package installer failed to drain during shutdown.");
+        }
+
         PackageChangesQueue queue = _beutlClients.GetResource<PackageChangesQueue>();
         PackageIdentity[] installs = queue.GetInstalls().ToArray();
         PackageIdentity[] uninstalls = queue.GetUninstalls().ToArray();

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -171,24 +171,27 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
         // below; otherwise PackageTools is launched without the queued recovery.
         try
         {
-            Task drain = _beutlClients.GetResource<PackageInstaller>().DisposeAsync().AsTask();
-            // The transaction's activation callback is queued on the UI dispatcher; pump
-            // jobs while draining so it can complete instead of deadlocking the blocked
-            // UI thread.
-            long deadline = Environment.TickCount64 + 30_000;
-            while (!drain.IsCompleted && Environment.TickCount64 < deadline)
+            if (_beutlClients.TryGetResource<PackageInstaller>() is { } installer)
             {
-                Avalonia.Threading.Dispatcher.UIThread.RunJobs();
-                Thread.Sleep(10);
-            }
+                Task drain = installer.DisposeAsync().AsTask();
+                // The transaction's activation callback is queued on the UI dispatcher; pump
+                // jobs while draining so it can complete instead of deadlocking the blocked
+                // UI thread.
+                long deadline = Environment.TickCount64 + 30_000;
+                while (!drain.IsCompleted && Environment.TickCount64 < deadline)
+                {
+                    Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+                    Thread.Sleep(10);
+                }
 
-            if (drain.IsCompleted)
-            {
-                drain.GetAwaiter().GetResult();
-            }
-            else
-            {
-                _logger.LogWarning("Package installer did not drain within the shutdown deadline.");
+                if (drain.IsCompleted)
+                {
+                    drain.GetAwaiter().GetResult();
+                }
+                else
+                {
+                    _logger.LogWarning("Package installer did not drain within the shutdown deadline.");
+                }
             }
         }
         catch (Exception ex)

--- a/tests/Beutl.HeadlessUITests/ExtensionsPageInitialNavigationTests.cs
+++ b/tests/Beutl.HeadlessUITests/ExtensionsPageInitialNavigationTests.cs
@@ -27,8 +27,8 @@ public class ExtensionsPageInitialNavigationTests
         MainViewModel mainViewModel = TestShell.MainViewModel;
 
         using var httpClient = new HttpClient(new EmptyJsonArrayHandler());
-        var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
-        var vm = new ExtensionsPageViewModel(
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        using var vm = new ExtensionsPageViewModel(
             clients,
             mainViewModel.EditorService,
             mainViewModel.ProjectService);

--- a/tests/Beutl.HeadlessUITests/LibraryPageDisposalTests.cs
+++ b/tests/Beutl.HeadlessUITests/LibraryPageDisposalTests.cs
@@ -1,0 +1,32 @@
+﻿using Avalonia.Headless.NUnit;
+using Beutl.Api;
+using Beutl.Api.Services;
+using Beutl.Services;
+using Beutl.ViewModels.ExtensionsPages;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class LibraryPageDisposalTests
+{
+    [AvaloniaTest]
+    public async Task Refresh_AfterDisposal_DoesNotRepopulateLocalPackages()
+    {
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var editorService = new EditorService(new ExtensionProvider());
+        var projectService = new ProjectService();
+        var viewModel = new LibraryPageViewModel(null, app, editorService, projectService);
+
+        // Let the constructor-triggered refresh settle before disposing.
+        await Task.Delay(200);
+
+        viewModel.Dispose();
+        viewModel.Refresh.Execute();
+        await Task.Delay(200);
+
+        // The lifetime token is canceled on disposal, so a refresh admitted afterwards must
+        // not repopulate the list with children that would never be disposed.
+        Assert.That(viewModel.LocalPackages, Is.Empty);
+    }
+}

--- a/tests/Beutl.HeadlessUITests/LifetimeCancellationSourceTests.cs
+++ b/tests/Beutl.HeadlessUITests/LifetimeCancellationSourceTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Services;
+﻿using Beutl.Services;
 
 namespace Beutl.HeadlessUITests;
 

--- a/tests/Beutl.HeadlessUITests/LifetimeCancellationSourceTests.cs
+++ b/tests/Beutl.HeadlessUITests/LifetimeCancellationSourceTests.cs
@@ -14,7 +14,6 @@ public sealed class LifetimeCancellationSourceTests
 
         Assert.Throws<AggregateException>(source.Cancel);
 
-        // Dispose must still run even though Cancel rethrows.
         Assert.DoesNotThrow(source.Dispose);
     }
 }

--- a/tests/Beutl.HeadlessUITests/LifetimeCancellationSourceTests.cs
+++ b/tests/Beutl.HeadlessUITests/LifetimeCancellationSourceTests.cs
@@ -1,4 +1,7 @@
-﻿using Beutl.Services;
+﻿using Beutl.Api;
+using Beutl.Api.Services;
+using Beutl.Services;
+using Beutl.Services.StartupTasks;
 
 namespace Beutl.HeadlessUITests;
 
@@ -15,5 +18,20 @@ public sealed class LifetimeCancellationSourceTests
         Assert.Throws<AggregateException>(source.Cancel);
 
         Assert.DoesNotThrow(source.Dispose);
+    }
+
+    [Test]
+    public async Task AuthenticationTask_ShutdownCancellation_IsNotReportedAsAnError()
+    {
+        using var httpClient = new HttpClient();
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        await app.DisposeAsync();
+
+        // RestoreUserAsync links the application lifetime, so after disposal it throws
+        // ObjectDisposedException; the task must treat that as a normal shutdown and
+        // complete without error telemetry.
+        var task = new AuthenticationTask(app);
+
+        await task.Task.WaitAsync(TimeSpan.FromSeconds(5));
     }
 }

--- a/tests/Beutl.HeadlessUITests/LifetimeCancellationSourceTests.cs
+++ b/tests/Beutl.HeadlessUITests/LifetimeCancellationSourceTests.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.Api;
+﻿using Avalonia.Headless.NUnit;
+using Beutl.Api;
 using Beutl.Api.Services;
 using Beutl.Services;
 using Beutl.Services.StartupTasks;
@@ -46,6 +47,28 @@ public sealed class LifetimeCancellationSourceTests
         // ObjectDisposedException; the task must treat that as a normal shutdown and
         // complete without error telemetry or a timeout notification.
         var task = new CheckForUpdatesTask(app);
+
+        await task.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [AvaloniaTest]
+    public async Task CheckForPackageUpdatesTask_ShutdownCancellation_IsNotReportedAsAnError()
+    {
+        using var httpClient = new HttpClient();
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var editorService = new EditorService(new ExtensionProvider());
+        var projectService = new ProjectService();
+
+        // Startup must be constructed before disposal: its constructor registers all
+        // startup tasks, which lazily resolve their resources through the app.
+        var startup = new Startup(app, projectService, editorService);
+        var packageManager = app.GetResource<PackageManager>();
+        await app.DisposeAsync();
+
+        // CheckUpdate links the application lifetime, so after disposal it throws
+        // ObjectDisposedException; the task must treat that as a normal shutdown and
+        // complete without error telemetry or a notification.
+        var task = new CheckForPackageUpdatesTask(startup, packageManager, app);
 
         await task.Task.WaitAsync(TimeSpan.FromSeconds(5));
     }

--- a/tests/Beutl.HeadlessUITests/LifetimeCancellationSourceTests.cs
+++ b/tests/Beutl.HeadlessUITests/LifetimeCancellationSourceTests.cs
@@ -1,0 +1,20 @@
+using Beutl.Services;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public sealed class LifetimeCancellationSourceTests
+{
+    [Test]
+    public void Cancel_ThrowingCallback_StillAllowsDispose()
+    {
+        var source = new LifetimeCancellationSource();
+        using var registration = source.Token.Register(static () =>
+            throw new InvalidOperationException("callback failed"));
+
+        Assert.Throws<AggregateException>(source.Cancel);
+
+        // Dispose must still run even though Cancel rethrows.
+        Assert.DoesNotThrow(source.Dispose);
+    }
+}

--- a/tests/Beutl.HeadlessUITests/LifetimeCancellationSourceTests.cs
+++ b/tests/Beutl.HeadlessUITests/LifetimeCancellationSourceTests.cs
@@ -34,4 +34,19 @@ public sealed class LifetimeCancellationSourceTests
 
         await task.Task.WaitAsync(TimeSpan.FromSeconds(5));
     }
+
+    [Test]
+    public async Task CheckForUpdatesTask_ShutdownCancellation_IsNotReportedAsAnError()
+    {
+        using var httpClient = new HttpClient();
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        await app.DisposeAsync();
+
+        // CheckForUpdatesAsync links the application lifetime, so after disposal it throws
+        // ObjectDisposedException; the task must treat that as a normal shutdown and
+        // complete without error telemetry or a timeout notification.
+        var task = new CheckForUpdatesTask(app);
+
+        await task.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
 }

--- a/tests/Beutl.HeadlessUITests/PackageReleaseRefreshCoordinatorTests.cs
+++ b/tests/Beutl.HeadlessUITests/PackageReleaseRefreshCoordinatorTests.cs
@@ -24,8 +24,14 @@ public class PackageReleaseRefreshCoordinatorTests
     [OneTimeTearDown]
     public async Task OneTimeTearDown()
     {
-        await _clients.DisposeAsync();
-        _httpClient.Dispose();
+        try
+        {
+            await _clients.DisposeAsync();
+        }
+        finally
+        {
+            _httpClient.Dispose();
+        }
     }
 
     [TestCase(true)]

--- a/tests/Beutl.HeadlessUITests/PackageReleaseRefreshCoordinatorTests.cs
+++ b/tests/Beutl.HeadlessUITests/PackageReleaseRefreshCoordinatorTests.cs
@@ -22,8 +22,9 @@ public class PackageReleaseRefreshCoordinatorTests
     }
 
     [OneTimeTearDown]
-    public void OneTimeTearDown()
+    public async Task OneTimeTearDown()
     {
+        await _clients.DisposeAsync();
         _httpClient.Dispose();
     }
 

--- a/tests/Beutl.HeadlessUITests/PackageReleaseResolverTests.cs
+++ b/tests/Beutl.HeadlessUITests/PackageReleaseResolverTests.cs
@@ -30,8 +30,14 @@ public class PackageReleaseResolverTests
     [OneTimeTearDown]
     public async Task OneTimeTearDown()
     {
-        await _clients.DisposeAsync();
-        _httpClient.Dispose();
+        try
+        {
+            await _clients.DisposeAsync();
+        }
+        finally
+        {
+            _httpClient.Dispose();
+        }
     }
 
     [Test]

--- a/tests/Beutl.HeadlessUITests/PackageReleaseResolverTests.cs
+++ b/tests/Beutl.HeadlessUITests/PackageReleaseResolverTests.cs
@@ -18,6 +18,22 @@ namespace Beutl.HeadlessUITests;
 [TestFixture]
 public class PackageReleaseResolverTests
 {
+    private readonly HttpClient _httpClient;
+    private readonly BeutlApiApplication _clients;
+
+    public PackageReleaseResolverTests()
+    {
+        _httpClient = new HttpClient();
+        _clients = new BeutlApiApplication(_httpClient, new ExtensionProvider());
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        await _clients.DisposeAsync();
+        _httpClient.Dispose();
+    }
+
     [Test]
     public async Task ObserveLatest_IgnoresCompletionFromSupersededRequest()
     {
@@ -298,9 +314,8 @@ public class PackageReleaseResolverTests
         return new PackageIdentity("Package", NuGetVersion.Parse(version));
     }
 
-    private static Release CreateRelease(string version)
+    private Release CreateRelease(string version)
     {
-        var clients = new BeutlApiApplication(new HttpClient(), new ExtensionProvider());
         var ownerResponse = new ProfileResponse
         {
             Id = "owner",
@@ -310,7 +325,7 @@ public class PackageReleaseResolverTests
             IconId = null,
             IconUrl = null,
         };
-        var owner = new Profile(ownerResponse, clients);
+        var owner = new Profile(ownerResponse, _clients);
         var package = new Package(owner, new PackageResponse
         {
             Id = "package",
@@ -328,7 +343,7 @@ public class PackageReleaseResolverTests
             Price = null,
             Paid = false,
             Owned = true,
-        }, clients);
+        }, _clients);
 
         return new Release(package, new ReleaseResponse
         {
@@ -339,7 +354,7 @@ public class PackageReleaseResolverTests
             TargetVersion = null,
             FileId = null,
             FileUrl = null,
-        }, clients);
+        }, _clients);
     }
 
     private static Package CreatePackage(BeutlApiApplication clients)

--- a/tests/Beutl.HeadlessUITests/SearchPageCardLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/SearchPageCardLayoutTests.cs
@@ -31,8 +31,6 @@ public class SearchPageCardLayoutTests
         + "ellipsized rather than expanding the card height without bound, going on and on and on and on.";
     private const string LongOwner = "AnExtremelyLongAuthorAccountNameThatShouldNotPushTheCardWider";
 
-    private static BeutlApiApplication CreateClients() => new(new HttpClient(), new ExtensionProvider());
-
     private static Package CreatePackage(BeutlApiApplication clients)
     {
         var ownerResponse = new ProfileResponse
@@ -67,9 +65,10 @@ public class SearchPageCardLayoutTests
     }
 
     [AvaloniaTest]
-    public void Long_card_text_ellipsizes_wraps_and_stays_bounded()
+    public async Task Long_card_text_ellipsizes_wraps_and_stays_bounded()
     {
-        BeutlApiApplication clients = CreateClients();
+        using var httpClient = new HttpClient();
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
         var viewModel = new SearchPageViewModel(new DiscoverService(clients), "search");
         viewModel.Packages.Add(CreatePackage(clients));
 

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -305,6 +305,65 @@ public sealed class BeutlApiApplicationTests
     }
 
     [Test]
+    public async Task RestoreUserAsync_Rethrows_WhenCancelledAfterProfileRefresh()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+        string userFile = Path.Combine(Helper.AppRoot, BeutlApiApplication.UserFileName);
+        File.WriteAllText(userFile, """
+            {
+              "token": "restored-token",
+              "refresh_token": "restored-refresh",
+              "expiration": "2027-01-01T00:00:00Z",
+              "profile": {
+                "id": "restored-profile",
+                "name": "restored-name",
+                "displayName": "Restored Name",
+                "bio": null,
+                "iconId": null,
+                "iconUrl": null
+              }
+            }
+            """);
+        try
+        {
+            var requestCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            BeutlApiApplication? appRef = null;
+            using var handler = new DelegateHandler((request, cancellationToken) =>
+            {
+                requestCompleted.TrySetResult();
+                // Dispose while the profile response is being processed, so the lifetime
+                // token is cancelled before RestoreUserAsync publishes the restored state.
+                appRef?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(new ProfileResponse
+                    {
+                        Id = "restored-profile",
+                        Name = "restored-name",
+                        DisplayName = "Restored Name",
+                        Bio = null,
+                        IconId = null,
+                        IconUrl = null,
+                    })
+                });
+            });
+            using var httpClient = new HttpClient(handler);
+            var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+            appRef = app;
+
+            Task restore = app.RestoreUserAsync(null, CancellationToken.None);
+            await requestCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.CatchAsync<OperationCanceledException>(async () =>
+                await restore.WaitAsync(TimeSpan.FromSeconds(5)));
+        }
+        finally
+        {
+            File.Delete(userFile);
+        }
+    }
+
+    [Test]
     public async Task CompleteSignInAsync_Rethrows_WhenCancelledAfterProfileResponse()
     {
         var requestCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -243,6 +243,48 @@ public sealed class BeutlApiApplicationTests
     }
 
     [Test]
+    public async Task CompleteSignInAsync_RestoresAuthorization_WhenCancelledAfterGetSelf()
+    {
+        var requestCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cancellation = new CancellationTokenSource();
+        using var handler = new DelegateHandler((request, cancellationToken) =>
+        {
+            requestCompleted.TrySetResult();
+            // Cancel while the response is being processed, so the recheck after GetSelf
+            // throws before the new token is committed.
+            cancellation.Cancel();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new ProfileResponse
+                {
+                    Id = "new-profile",
+                    Name = "new-name",
+                    DisplayName = "New Name",
+                    Bio = null,
+                    IconId = null,
+                    IconUrl = null,
+                })
+            });
+        });
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var authResponse = new AuthResponse
+        {
+            Token = "new-token",
+            RefreshToken = "new-refresh",
+            Expiration = DateTime.UtcNow.AddHours(1)
+        };
+
+        Task<AuthenticatedUser> signIn = app.CompleteSignInAsync(authResponse, cancellation.Token);
+        await requestCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.CatchAsync<OperationCanceledException>(async () =>
+            await signIn.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.That(httpClient.DefaultRequestHeaders.Authorization, Is.Null,
+            "the uncommitted new token must not remain after a canceled re-sign-in");
+    }
+
+    [Test]
     public async Task RestoreUserAsync_RestoresAuthorization_WhenProfileRefreshIsCanceled()
     {
         Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -301,11 +301,35 @@ public sealed class BeutlApiApplicationTests
         finally
         {
             File.Delete(userFile);
-        }
+         }
+    }
+
+    [Test]
+    public async Task ReadUserAsync_PreCanceledRequestStopsBeforeFileAccess()
+    {
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await app.ReadUserAsync(cancellationTokenSource.Token));
+    }
+
+    [Test]
+    public async Task Dispose_IsIdempotentAndRejectsFurtherResourceResolution()
+    {
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        _ = app.GetResource<PackageManager>();
+
+        Assert.DoesNotThrowAsync(async () => await app.DisposeAsync());
+        Assert.DoesNotThrowAsync(async () => await app.DisposeAsync());
+        Assert.Throws<ObjectDisposedException>(() => app.GetResource<DiscoverService>());
     }
 
     private sealed class CapturingHandler : HttpMessageHandler
-    {
+     {
         public Uri? LastRequestUri { get; private set; }
 
         protected override Task<HttpResponseMessage> SendAsync(

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -580,19 +580,21 @@ public sealed class BeutlApiApplicationTests
         var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
         _ = app.GetResource<PackageManager>();
 
-        int reentrantDisposeCount = 0;
+        Task? reentrantTask = null;
         using CancellationTokenSource linked = app.CreateLifetimeLinkedTokenSource(CancellationToken.None);
         using var registration = linked.Token.Register(() =>
         {
             // A cancellation callback that re-enters DisposeAsync must observe the
             // original disposal task instead of starting a second pipeline.
-            Interlocked.Increment(ref reentrantDisposeCount);
-            app.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            reentrantTask = app.DisposeAsync().AsTask();
         });
 
-        await app.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        Task outer = app.DisposeAsync().AsTask();
+        await outer.WaitAsync(TimeSpan.FromSeconds(5));
 
-        Assert.That(reentrantDisposeCount, Is.EqualTo(1));
+        Assert.That(reentrantTask, Is.Not.Null);
+        Assert.That(reentrantTask, Is.SameAs(outer),
+            "the reentrant call must observe the original disposal task");
     }
 
     private sealed class DelegateHandler(

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -605,6 +605,19 @@ public sealed class BeutlApiApplicationTests
             "the reentrant call must observe the original disposal task");
     }
 
+    [Test]
+    public void Subclass_CanAdmitWorkThroughTheLifetimePrimitive()
+    {
+        using var httpClient = new HttpClient();
+        var app = new LifetimeAdmissionSubclass(httpClient, new ExtensionProvider());
+
+        using CancellationTokenSource linked = app.AdmitOperation();
+        Assert.That(app.IsDisposed, Is.False);
+
+        app.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        Assert.That(app.IsDisposed, Is.True);
+    }
+
     private sealed class DelegateHandler(
         Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
         : HttpMessageHandler
@@ -612,6 +625,17 @@ public sealed class BeutlApiApplicationTests
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
             => handler(request, cancellationToken);
+    }
+
+    private sealed class LifetimeAdmissionSubclass : BeutlApiApplication
+    {
+        public LifetimeAdmissionSubclass(HttpClient httpClient, ExtensionProvider extensionProvider)
+            : base(httpClient, extensionProvider)
+        {
+        }
+
+        public CancellationTokenSource AdmitOperation()
+            => CreateLifetimeLinkedTokenSource(CancellationToken.None);
     }
 
     private static ProfileResponse CreateProfileResponse()

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -301,7 +301,49 @@ public sealed class BeutlApiApplicationTests
         finally
         {
             File.Delete(userFile);
-         }
+        }
+    }
+
+    [Test]
+    public async Task CompleteSignInAsync_Rethrows_WhenCancelledAfterProfileResponse()
+    {
+        var requestCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        BeutlApiApplication? appRef = null;
+        using var handler = new DelegateHandler((request, cancellationToken) =>
+        {
+            requestCompleted.TrySetResult();
+            // Dispose while the profile response is being processed, so the lifetime token
+            // is cancelled before CompleteSignInAsync publishes the signed-in state.
+            appRef?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new ProfileResponse
+                {
+                    Id = "new-profile",
+                    Name = "new-name",
+                    DisplayName = "New Name",
+                    Bio = null,
+                    IconId = null,
+                    IconUrl = null,
+                })
+            });
+        });
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        appRef = app;
+        var authResponse = new AuthResponse
+        {
+            Token = "new-token",
+            RefreshToken = "new-refresh",
+            Expiration = DateTime.UtcNow.AddHours(1)
+        };
+
+        using CancellationTokenSource lifetimeCts = app.CreateLifetimeLinkedTokenSource(CancellationToken.None);
+        Task<AuthenticatedUser> signIn = app.CompleteSignInAsync(authResponse, lifetimeCts.Token);
+        await requestCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.CatchAsync<OperationCanceledException>(async () =>
+            await signIn.WaitAsync(TimeSpan.FromSeconds(5)));
     }
 
     [Test]
@@ -380,7 +422,7 @@ public sealed class BeutlApiApplicationTests
     }
 
     private sealed class CapturingHandler : HttpMessageHandler
-     {
+    {
         public Uri? LastRequestUri { get; private set; }
 
         protected override Task<HttpResponseMessage> SendAsync(
@@ -400,6 +442,58 @@ public sealed class BeutlApiApplicationTests
         }
     }
 
+    [Test]
+    public async Task RemovePackage_Rethrows_WhenCancelledAfterDelete()
+    {
+        var requestCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        BeutlApiApplication? appRef = null;
+        using var handler = new DelegateHandler((request, cancellationToken) =>
+        {
+            requestCompleted.TrySetResult();
+            // Dispose while the delete response is being processed, so the lifetime token
+            // is cancelled before RemovePackage returns.
+            appRef?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}")
+            });
+        });
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        appRef = app;
+        var library = app.GetResource<LibraryService>();
+        var owner = new Profile(CreateProfileResponse(), app);
+        var package = new Package(owner, CreatePackageResponse(), app);
+
+        Task remove = library.RemovePackage(package, CancellationToken.None);
+        await requestCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.CatchAsync<OperationCanceledException>(async () =>
+            await remove.WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    [Test]
+    public async Task DisposeAsync_ReentrantCallback_ObservesTheOriginalTeardown()
+    {
+        using var httpClient = new HttpClient();
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        _ = app.GetResource<PackageManager>();
+
+        int reentrantDisposeCount = 0;
+        using CancellationTokenSource linked = app.CreateLifetimeLinkedTokenSource(CancellationToken.None);
+        using var registration = linked.Token.Register(() =>
+        {
+            // A cancellation callback that re-enters DisposeAsync must observe the
+            // original disposal task instead of starting a second pipeline.
+            Interlocked.Increment(ref reentrantDisposeCount);
+            app.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        });
+
+        await app.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(reentrantDisposeCount, Is.EqualTo(1));
+    }
+
     private sealed class DelegateHandler(
         Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
         : HttpMessageHandler
@@ -407,5 +501,40 @@ public sealed class BeutlApiApplicationTests
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
             => handler(request, cancellationToken);
+    }
+
+    private static ProfileResponse CreateProfileResponse()
+    {
+        return new ProfileResponse
+        {
+            Id = "profile-id",
+            Name = "profile-name",
+            DisplayName = "Profile Name",
+            Bio = null,
+            IconId = null,
+            IconUrl = null,
+        };
+    }
+
+    private static PackageResponse CreatePackageResponse()
+    {
+        return new PackageResponse
+        {
+            Id = "package-id",
+            Owner = CreateProfileResponse(),
+            Name = "package-name",
+            DisplayName = "Package Name",
+            Description = "Description",
+            ShortDescription = "Short description",
+            WebSite = null,
+            Tags = [],
+            LogoId = null,
+            LogoUrl = null,
+            Screenshots = [],
+            Currency = null,
+            Price = null,
+            Paid = false,
+            Owned = false,
+        };
     }
 }

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -489,14 +489,20 @@ public sealed class BeutlApiApplicationTests
                   "type": "zip"
                 }
                 """);
-            var handler = new DelegateHandler((request, cancellationToken) =>
-                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var handler = new DelegateHandler(async (request, cancellationToken) =>
+            {
+                requestStarted.TrySetResult();
+                await releaseResponse.Task.WaitAsync(cancellationToken);
+                return new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new StringContent(
                         """{"latestVersion":"2.0.0-preview.7","url":"https://example.com","downloadUrl":null,"isLatest":false,"mustLatest":false}""",
                         Encoding.UTF8,
                         "application/json")
-                }));
+                };
+            });
             using var httpClient = new HttpClient(handler);
             var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
 
@@ -504,7 +510,9 @@ public sealed class BeutlApiApplicationTests
             // lifetime token is cancelled, so the method must recheck it before returning.
             Task<(CheckForUpdatesResponse? V1, AppUpdateResponse? V3)> check
                 = app.CheckForUpdatesAsync("2.0.0-preview.6", CancellationToken.None);
+            await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
             await app.DisposeAsync().AsTask();
+            releaseResponse.TrySetResult();
 
             Assert.CatchAsync<OperationCanceledException>(async () =>
                 await check.WaitAsync(TimeSpan.FromSeconds(5)));

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -328,6 +328,57 @@ public sealed class BeutlApiApplicationTests
         Assert.Throws<ObjectDisposedException>(() => app.GetResource<DiscoverService>());
     }
 
+    [Test]
+    public async Task CheckForUpdatesAsync_Rethrows_WhenCancelledAfterResponse()
+    {
+        // LoadMetadata reads asset_metadata.json from AppContext.BaseDirectory (cached per process).
+        string metadataPath = Path.Combine(AppContext.BaseDirectory, "asset_metadata.json");
+        string? originalContent = File.Exists(metadataPath) ? File.ReadAllText(metadataPath) : null;
+        try
+        {
+            File.WriteAllText(metadataPath, """
+                {
+                  "id": "test-id",
+                  "os": "linux",
+                  "arch": "x64",
+                  "version": "2.0.0-preview.6",
+                  "standalone": "true",
+                  "type": "zip"
+                }
+                """);
+            var handler = new DelegateHandler((request, cancellationToken) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """{"latestVersion":"2.0.0-preview.7","url":"https://example.com","downloadUrl":null,"isLatest":false,"mustLatest":false}""",
+                        Encoding.UTF8,
+                        "application/json")
+                }));
+            using var httpClient = new HttpClient(handler);
+            var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+
+            // Dispose after the response completes but before the continuation runs: the
+            // lifetime token is cancelled, so the method must recheck it before returning.
+            Task<(CheckForUpdatesResponse? V1, AppUpdateResponse? V3)> check
+                = app.CheckForUpdatesAsync("2.0.0-preview.6", CancellationToken.None);
+            await app.DisposeAsync().AsTask();
+
+            Assert.CatchAsync<OperationCanceledException>(async () =>
+                await check.WaitAsync(TimeSpan.FromSeconds(5)));
+        }
+        finally
+        {
+            if (originalContent != null)
+            {
+                File.WriteAllText(metadataPath, originalContent);
+            }
+            else
+            {
+                File.Delete(metadataPath);
+            }
+        }
+    }
+
     private sealed class CapturingHandler : HttpMessageHandler
      {
         public Uri? LastRequestUri { get; private set; }

--- a/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Diagnostics;
+using System.Net;
 using Beutl.Api;
 using Beutl.Api.Clients;
 using Beutl.Api.Objects;
@@ -224,6 +225,84 @@ public sealed class PackageInstallerDisposeTests
 
         Assert.That(phase.IsCanceled, Is.True,
             "a canceled tracked phase must surface as a canceled task, not a faulted one");
+    }
+
+    [Test]
+    public async Task DisposeAsync_StopsWaitingAtTheDrainDeadline_WhenAnOperationNeverCompletes()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new ShortDeadlinePackageInstaller(
+            httpClient,
+            ownsHttpClient: true,
+            new InstalledPackageRepository(),
+            app);
+
+        // A tracked operation that never completes must not outlive the drain deadline.
+        Task operation = installer.TrackInstallOperationAsync(async () =>
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan);
+        });
+
+        var stopwatch = Stopwatch.StartNew();
+        await installer.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        stopwatch.Stop();
+
+        Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(5)),
+            "disposal must stop waiting at the drain deadline even when an operation never completes");
+    }
+
+    [Test]
+    public async Task DisposeAsync_DrainsSynchronousOperations_UntilCompletion()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new PackageInstaller(
+            httpClient,
+            ownsHttpClient: true,
+            new InstalledPackageRepository(),
+            app);
+
+        var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseOperation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        bool operationCompleted = false;
+
+        Task syncOperation = Task.Run(() =>
+            installer.TrackSyncOperation(() =>
+            {
+                operationStarted.TrySetResult();
+                releaseOperation.Task.Wait();
+                operationCompleted = true;
+            }));
+
+        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Task dispose = installer.DisposeAsync().AsTask();
+        await Task.Delay(300);
+        Assert.That(dispose.IsCompleted, Is.False,
+            "disposal must wait for the admitted synchronous operation");
+
+        releaseOperation.TrySetResult();
+        await Task.WhenAll(syncOperation, dispose).WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(operationCompleted, Is.True);
+    }
+
+    private sealed class ShortDeadlinePackageInstaller : PackageInstaller
+    {
+        public ShortDeadlinePackageInstaller(
+            HttpClient httpClient,
+            bool ownsHttpClient,
+            InstalledPackageRepository installedPackageRepository,
+            BeutlApiApplication apiApplication)
+            : base(httpClient, ownsHttpClient, installedPackageRepository, apiApplication)
+        {
+        }
+
+        protected override long DrainDeadlineMilliseconds => 500;
     }
 
     private sealed class BlockingHandler : HttpMessageHandler

--- a/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
@@ -346,6 +346,65 @@ public sealed class PackageInstallerDisposeTests
         await installer.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
     }
 
+    [Test]
+    public async Task PrepareForInstall_StringOverload_RejectsAdmissionAfterDisposal()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new PackageInstaller(
+            httpClient,
+            ownsHttpClient: true,
+            new InstalledPackageRepository(),
+            app);
+        await installer.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        // The string-based overload must be admitted like every other synchronous entry
+        // point, so a cached installer cannot mint a context after disposal completed.
+        Assert.Throws<ObjectDisposedException>(() =>
+            installer.PrepareForInstall("Beutl.Package.PostDisposal", "1.0.0"));
+    }
+
+    [Test]
+    public async Task DisposeAsync_StartsDraining_WhenTheTransactionBlocksBeforeItsFirstAwait()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new ShortDeadlinePackageInstaller(
+            httpClient,
+            ownsHttpClient: true,
+            new InstalledPackageRepository(),
+            app);
+
+        var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseOperation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        // The delegate blocks synchronously before its first incomplete await, so the
+        // admission call itself blocks; run it on a worker so disposal can be observed.
+        Task operation = Task.Run(() =>
+            installer.TrackInstallOperationAsync(async () =>
+            {
+                // Block synchronously before the first incomplete await: the transaction
+                // runner must not hold the gate, or disposal could not even start draining.
+                operationStarted.TrySetResult();
+                releaseOperation.Task.Wait();
+                await Task.CompletedTask;
+            }));
+        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Disposal must be able to acquire the gate and start its drain deadline even
+        // though the transaction is still blocked in its synchronous prefix.
+        Task dispose = installer.DisposeAsync().AsTask();
+        await Task.Delay(300);
+        Assert.That(dispose.IsCompleted, Is.False,
+            "disposal must start draining while the transaction blocks before its first await");
+
+        releaseOperation.TrySetResult();
+        await Task.WhenAll(operation, dispose).WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
     private sealed class ShortDeadlinePackageInstaller : PackageInstaller
     {
         public ShortDeadlinePackageInstaller(

--- a/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
@@ -463,13 +463,39 @@ public sealed class PackageInstallerDisposeTests
 
         // WaitUntilIdleAsync must keep waiting for the operation that outlived the
         // drain deadline; it must not return while the operation is still running.
-        Task idle = installer.WaitUntilIdleAsync();
+        Task idle = installer.WaitUntilIdleAsync(TimeSpan.FromSeconds(10));
         await Task.Delay(300);
         Assert.That(idle.IsCompleted, Is.False,
             "waiting for idleness must not complete while an operation is still running");
 
         release.TrySetResult();
         await Task.WhenAll(idle, operation).WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task WaitUntilIdleAsync_StopsAtTheTimeout_WhenAnOperationNeverCompletes()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new PackageInstaller(
+            httpClient,
+            ownsHttpClient: true,
+            new InstalledPackageRepository(),
+            app);
+
+        // An operation that never completes; the idle wait must still be bounded.
+        Task operation = installer.TrackInstallOperationAsync(async () =>
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan);
+        });
+
+        var stopwatch = Stopwatch.StartNew();
+        await installer.WaitUntilIdleAsync(TimeSpan.FromMilliseconds(300)).WaitAsync(TimeSpan.FromSeconds(5));
+        stopwatch.Stop();
+
+        Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(3)));
     }
 
     private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)

--- a/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
@@ -405,6 +405,54 @@ public sealed class PackageInstallerDisposeTests
         await Task.WhenAll(operation, dispose).WaitAsync(TimeSpan.FromSeconds(10));
     }
 
+    [Test]
+    public async Task DisposeAsync_KeepsInstallerResourcesAlive_UntilTrackedWorkStops()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        using var handler = new BlockingHandler();
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new ShortDeadlinePackageInstaller(
+            httpClient,
+            ownsHttpClient: true,
+            new InstalledPackageRepository(),
+            app);
+
+        Task operation = installer.DownloadPackageFile(
+            new PackageInstallContext(
+                "Beutl.Package.KeepAlive", "1.0.0", "https://example.com/package.nupkg"),
+            cancellationToken: CancellationToken.None);
+
+        await handler.Entered.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Disposal stops waiting at its deadline, but the installer resources must
+        // not be released while the tracked operation is still running.
+        Task dispose = installer.DisposeAsync().AsTask();
+        await dispose.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.That(handler.Disposed, Is.False,
+            "the installer must keep its HttpClient alive while a tracked operation is still running");
+
+        // Once the tracked work stops, the resource teardown must run to completion.
+        handler.Release();
+        await operation.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await WaitUntilAsync(() => handler.Disposed, TimeSpan.FromSeconds(10));
+        Assert.That(handler.Disposed, Is.True,
+            "the installer must dispose its HttpClient after the tracked operation stopped");
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        long deadline = Environment.TickCount64 + (long)timeout.TotalMilliseconds;
+        while (!condition() && Environment.TickCount64 < deadline)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.That(condition(), Is.True, "condition did not become true within the timeout");
+    }
+
     private sealed class ShortDeadlinePackageInstaller : PackageInstaller
     {
         public ShortDeadlinePackageInstaller(

--- a/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
@@ -158,6 +158,36 @@ public sealed class PackageInstallerDisposeTests
             await operation.WaitAsync(TimeSpan.FromSeconds(5)));
     }
 
+    [Test]
+    public async Task DisposeAsync_DrainsPhaseRegisteredWhileDisposalIsRunning()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        var handler = new BlockingHandler();
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new PackageInstaller(
+            httpClient,
+            ownsHttpClient: true,
+            new InstalledPackageRepository(),
+            app);
+
+        var phaseStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePhase = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task phase = installer.DownloadPackageFile(
+            new PackageInstallContext("Beutl.Package.RacePhase", "1.0.0", "https://example.com/package.nupkg"),
+            cancellationToken: CancellationToken.None);
+        // The phase is admitted and its proxy registered before it reaches the network
+        // handler; disposal must drain it instead of disposing the client underneath it.
+        Task dispose = installer.DisposeAsync().AsTask();
+        await handler.Entered.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(dispose.IsCompleted, Is.False,
+            "disposal must wait for the phase that was admitted while disposal started");
+
+        handler.Release();
+        await Task.WhenAll(phase, dispose).WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
     private sealed class BlockingHandler : HttpMessageHandler
     {
         private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
@@ -442,6 +442,36 @@ public sealed class PackageInstallerDisposeTests
             "the installer must dispose its HttpClient after the tracked operation stopped");
     }
 
+    [Test]
+    public async Task WaitUntilIdleAsync_WaitsForOperationsThatOutlivedTheDrainDeadline()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new ShortDeadlinePackageInstaller(
+            httpClient,
+            ownsHttpClient: true,
+            new InstalledPackageRepository(),
+            app);
+
+        // An operation that never completes, so disposal ends at its deadline.
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task operation = installer.TrackInstallOperationAsync(async () => await release.Task);
+
+        await installer.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+
+        // WaitUntilIdleAsync must keep waiting for the operation that outlived the
+        // drain deadline; it must not return while the operation is still running.
+        Task idle = installer.WaitUntilIdleAsync();
+        await Task.Delay(300);
+        Assert.That(idle.IsCompleted, Is.False,
+            "waiting for idleness must not complete while an operation is still running");
+
+        release.TrySetResult();
+        await Task.WhenAll(idle, operation).WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
     private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
     {
         long deadline = Environment.TickCount64 + (long)timeout.TotalMilliseconds;

--- a/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using Beutl.Api;
+using Beutl.Api.Services;
+using Beutl.Testing.Headless;
+
+namespace Beutl.UnitTests.Api;
+
+[TestFixture]
+[NonParallelizable]
+public sealed class PackageInstallerDisposeTests
+{
+    [Test]
+    public async Task DisposeAsync_DrainsInFlightOperations_BeforeDisposingResources()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        var handler = new BlockingHandler();
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new PackageInstaller(
+            httpClient,
+            ownsHttpClient: true,
+            new InstalledPackageRepository(),
+            app);
+
+        var context = new PackageInstallContext(
+            "Beutl.Package.DisposeTest", "1.0.0", "https://example.com/package.nupkg");
+        Task download = installer.DownloadPackageFile(context, cancellationToken: CancellationToken.None);
+
+        await handler.Entered.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Task dispose = installer.DisposeAsync().AsTask();
+        await Task.Delay(500);
+        Assert.That(dispose.IsCompleted, Is.False, "disposal must wait for the in-flight download");
+
+        handler.Release();
+        await dispose.WaitAsync(TimeSpan.FromSeconds(10));
+        await download.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.That(handler.Disposed, Is.True, "the owned HttpClient must be disposed after draining");
+    }
+
+    private sealed class BlockingHandler : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task Entered => _entered.Task;
+
+        public bool Disposed { get; private set; }
+
+        public void Release() => _release.TrySetResult();
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            _entered.TrySetResult();
+            await _release.Task.WaitAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("package content")
+            };
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            Disposed = true;
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
@@ -126,9 +126,7 @@ public sealed class PackageInstallerDisposeTests
         Task? dispose = null;
         Task operation = installer.TrackInstallOperationAsync(async () =>
         {
-            // A re-entrant DisposeAsync from inside the callback must observe this
-            // transaction as in-flight and drain it instead of tearing down resources
-            // underneath it; it must not complete before the callback returns.
+            // A re-entrant DisposeAsync must drain this transaction.
             dispose = installer.DisposeAsync().AsTask();
             await Task.Delay(1).ConfigureAwait(false);
         });
@@ -179,8 +177,7 @@ public sealed class PackageInstallerDisposeTests
         Task phase = installer.DownloadPackageFile(
             new PackageInstallContext("Beutl.Package.RacePhase", "1.0.0", "https://example.com/package.nupkg"),
             cancellationToken: CancellationToken.None);
-        // The phase is admitted and its proxy registered before it reaches the network
-        // handler; disposal must drain it instead of disposing the client underneath it.
+        // The phase is registered before the network call; disposal must drain it.
         Task dispose = installer.DisposeAsync().AsTask();
         await handler.Entered.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.That(dispose.IsCompleted, Is.False,

--- a/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Net;
 using Beutl.Api;
+using Beutl.Api.Clients;
+using Beutl.Api.Objects;
 using Beutl.Api.Services;
 using Beutl.Testing.Headless;
 
@@ -188,6 +190,45 @@ public sealed class PackageInstallerDisposeTests
         await Task.WhenAll(phase, dispose).WaitAsync(TimeSpan.FromSeconds(10));
     }
 
+    [Test]
+    public async Task TrackedGenericPhase_PreservesCancellationState()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        using var handler = new BlockingHandler();
+        handler.Release();
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new PackageInstaller(
+            httpClient,
+            ownsHttpClient: true,
+            new InstalledPackageRepository(),
+            app);
+
+        var owner = new Profile(CreateProfileResponse(), app);
+        var package = new Package(owner, CreatePackageResponse(), app);
+        var release = new Release(
+            package,
+            new ReleaseResponse
+            {
+                Id = "release-id",
+                Version = "1.0.0",
+                Title = "Release",
+                Description = "Description",
+                TargetVersion = null,
+                FileId = null,
+                FileUrl = null,
+            },
+            app);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        Task<PackageInstallContext> phase = installer.PrepareForInstall(release, cancellationToken: cancellation.Token);
+
+        Assert.That(phase.IsCanceled, Is.True,
+            "a canceled tracked phase must surface as a canceled task, not a faulted one");
+    }
+
     private sealed class BlockingHandler : HttpMessageHandler
     {
         private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -215,5 +256,40 @@ public sealed class PackageInstallerDisposeTests
             base.Dispose(disposing);
             Disposed = true;
         }
+    }
+
+    private static ProfileResponse CreateProfileResponse()
+    {
+        return new ProfileResponse
+        {
+            Id = "profile-id",
+            Name = "profile-name",
+            DisplayName = "Profile Name",
+            Bio = null,
+            IconId = null,
+            IconUrl = null,
+        };
+    }
+
+    private static PackageResponse CreatePackageResponse()
+    {
+        return new PackageResponse
+        {
+            Id = "package-id",
+            Owner = CreateProfileResponse(),
+            Name = "package-name",
+            DisplayName = "Package Name",
+            Description = "Description",
+            ShortDescription = "Short description",
+            WebSite = null,
+            Tags = [],
+            LogoId = null,
+            LogoUrl = null,
+            Screenshots = [],
+            Currency = null,
+            Price = null,
+            Paid = false,
+            Owned = false,
+        };
     }
 }

--- a/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
@@ -45,7 +45,9 @@ public sealed class PackageInstallerDisposeTests
     {
         Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
 
-        using var httpClient = new HttpClient();
+        using var handler = new BlockingHandler();
+        handler.Release();
+        using var httpClient = new HttpClient(handler);
         await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
         var installer = new PackageInstaller(
             httpClient,

--- a/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
@@ -126,7 +126,7 @@ public sealed class PackageInstallerDisposeTests
             // transaction as in-flight and drain it instead of tearing down resources
             // underneath it; it must not complete before the callback returns.
             dispose = installer.DisposeAsync().AsTask();
-            await Task.Yield();
+            await Task.Delay(1).ConfigureAwait(false);
         });
 
         await operation.WaitAsync(TimeSpan.FromSeconds(5));

--- a/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
@@ -291,6 +291,61 @@ public sealed class PackageInstallerDisposeTests
         Assert.That(operationCompleted, Is.True);
     }
 
+    [Test]
+    public async Task DisposeAsync_AdmitsNestedSynchronousPhases_OfAnAdmittedTransaction()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new PackageInstaller(
+            httpClient,
+            ownsHttpClient: true,
+            new InstalledPackageRepository(),
+            app);
+
+        var phaseStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePhase = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        bool nestedPhaseRan = false;
+        Task operation = installer.TrackInstallOperationAsync(async () =>
+        {
+            phaseStarted.TrySetResult();
+            await releasePhase.Task;
+            // Disposal has started by now; a nested synchronous phase must still be admitted.
+            installer.TrackSyncOperation(() => nestedPhaseRan = true);
+        });
+        await phaseStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Task dispose = installer.DisposeAsync().AsTask();
+        releasePhase.TrySetResult();
+
+        await Task.WhenAll(operation, dispose).WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(nestedPhaseRan, Is.True,
+            "the nested synchronous phase must run while the transaction is drained");
+    }
+
+    [Test]
+    public async Task DisposeAsync_CompletesNormally_WhenASynchronousOperationThrows()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new PackageInstaller(
+            httpClient,
+            ownsHttpClient: true,
+            new InstalledPackageRepository(),
+            app);
+
+        // The lifetime proxy must not fault when the operation throws: the caller observes
+        // the exception directly, and a faulted proxy would surface later as an unobserved
+        // task exception when the drain loop removes it.
+        Assert.Throws<InvalidOperationException>(() =>
+            installer.TrackSyncOperation(() => throw new InvalidOperationException("sync phase failed")));
+
+        await installer.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
     private sealed class ShortDeadlinePackageInstaller : PackageInstaller
     {
         public ShortDeadlinePackageInstaller(

--- a/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
@@ -70,6 +70,42 @@ public sealed class PackageInstallerDisposeTests
         await Task.WhenAll(operation, dispose).WaitAsync(TimeSpan.FromSeconds(5));
     }
 
+    [Test]
+    public async Task DisposeAsync_AllowsNestedPhases_OfAnAdmittedTransaction()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new PackageInstaller(
+            httpClient,
+            ownsHttpClient: true,
+            new InstalledPackageRepository(),
+            app);
+
+        var phaseStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePhase = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        bool nestedPhaseRan = false;
+        Task operation = installer.TrackInstallOperationAsync(async () =>
+        {
+            phaseStarted.TrySetResult();
+            await releasePhase.Task;
+            // Disposal has started by now; a nested phase must still be admitted.
+            await installer.DownloadPackageFile(
+                new PackageInstallContext(
+                    "Beutl.Package.NestedPhase", "1.0.0", "https://example.com/package.nupkg"),
+                cancellationToken: CancellationToken.None);
+            nestedPhaseRan = true;
+        });
+        await phaseStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Task dispose = installer.DisposeAsync().AsTask();
+        releasePhase.TrySetResult();
+
+        await Task.WhenAll(operation, dispose).WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(nestedPhaseRan, Is.True, "the nested phase must run while the transaction is drained");
+    }
+
     private sealed class BlockingHandler : HttpMessageHandler
     {
         private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
@@ -106,6 +106,33 @@ public sealed class PackageInstallerDisposeTests
         Assert.That(nestedPhaseRan, Is.True, "the nested phase must run while the transaction is drained");
     }
 
+    [Test]
+    public async Task DisposeAsync_ReentrantFromCallback_DrainsTheTransaction()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new PackageInstaller(
+            httpClient,
+            ownsHttpClient: true,
+            new InstalledPackageRepository(),
+            app);
+
+        Task? dispose = null;
+        Task operation = installer.TrackInstallOperationAsync(async () =>
+        {
+            // A re-entrant DisposeAsync from inside the callback must observe this
+            // transaction as in-flight and drain it instead of tearing down resources
+            // underneath it; it must not complete before the callback returns.
+            dispose = installer.DisposeAsync().AsTask();
+            await Task.Yield();
+        });
+
+        await operation.WaitAsync(TimeSpan.FromSeconds(5));
+        await dispose!.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
     private sealed class BlockingHandler : HttpMessageHandler
     {
         private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
@@ -133,6 +133,29 @@ public sealed class PackageInstallerDisposeTests
         await dispose!.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
+    [Test]
+    public async Task TrackInstallOperationAsync_PropagatesFaultedTransaction()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new PackageInstaller(
+            httpClient,
+            ownsHttpClient: true,
+            new InstalledPackageRepository(),
+            app);
+
+        Task operation = installer.TrackInstallOperationAsync(async () =>
+        {
+            await Task.Delay(1).ConfigureAwait(false);
+            throw new InvalidOperationException("install failed");
+        });
+
+        Assert.CatchAsync<InvalidOperationException>(async () =>
+            await operation.WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
     private sealed class BlockingHandler : HttpMessageHandler
     {
         private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
@@ -40,6 +40,36 @@ public sealed class PackageInstallerDisposeTests
         Assert.That(handler.Disposed, Is.True, "the owned HttpClient must be disposed after draining");
     }
 
+    [Test]
+    public async Task DisposeAsync_DrainsCompositeInstallOperations()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new PackageInstaller(
+            httpClient,
+            ownsHttpClient: true,
+            new InstalledPackageRepository(),
+            app);
+
+        var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseOperation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task operation = installer.TrackInstallOperationAsync(async () =>
+        {
+            operationStarted.TrySetResult();
+            await releaseOperation.Task;
+        });
+        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Task dispose = installer.DisposeAsync().AsTask();
+        await Task.Delay(300);
+        Assert.That(dispose.IsCompleted, Is.False, "disposal must wait for the composite operation");
+
+        releaseOperation.TrySetResult();
+        await Task.WhenAll(operation, dispose).WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
     private sealed class BlockingHandler : HttpMessageHandler
     {
         private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using Beutl.Api;
 using Beutl.Api.Services;
 using Beutl.Testing.Headless;

--- a/tests/Beutl.UnitTests/Api/ProfileLifetimeTests.cs
+++ b/tests/Beutl.UnitTests/Api/ProfileLifetimeTests.cs
@@ -4,6 +4,7 @@ using Beutl.Api;
 using Beutl.Api.Clients;
 using Beutl.Api.Objects;
 using Beutl.Api.Services;
+using Beutl.Testing.Headless;
 
 namespace Beutl.UnitTests.Api;
 
@@ -104,6 +105,54 @@ public sealed class ProfileLifetimeTests
 
         Assert.CatchAsync<OperationCanceledException>(async () =>
             await getPackages.WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    [Test]
+    public async Task AuthenticatedUserRefresh_Rethrows_WhenCancelledAfterFileRead()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+        string userFile = Path.Combine(Helper.AppRoot, BeutlApiApplication.UserFileName);
+        File.WriteAllText(userFile, """
+            {
+              "token": "stale-token",
+              "refresh_token": "stale-refresh",
+              "expiration": "2027-01-01T00:00:00Z",
+              "profile": {
+                "id": "profile-id",
+                "name": "profile-name",
+                "displayName": "Profile Name",
+                "bio": null,
+                "iconId": null,
+                "iconUrl": null
+              }
+            }
+            """);
+        try
+        {
+            using var httpClient = new HttpClient();
+            var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+            var profile = new Profile(CreateProfileResponse(), app);
+            var authResponse = new AuthResponse
+            {
+                Token = "stale-token",
+                RefreshToken = "stale-refresh",
+                Expiration = DateTime.UtcNow.AddDays(1)
+            };
+            var user = new AuthenticatedUser(profile, authResponse, app, httpClient, DateTime.UtcNow.AddDays(-1));
+
+            // A stale write-time forces the persisted-file branch; cancel before the
+            // continuation resumes so the recheck throws instead of mutating state.
+            using var cancellation = new CancellationTokenSource();
+            Task refresh = user.RefreshAsync(cancellation.Token).AsTask();
+            cancellation.Cancel();
+
+            Assert.CatchAsync<OperationCanceledException>(async () =>
+                await refresh.WaitAsync(TimeSpan.FromSeconds(5)));
+        }
+        finally
+        {
+            File.Delete(userFile);
+        }
     }
 
     private static ProfileResponse CreateProfileResponse()

--- a/tests/Beutl.UnitTests/Api/ProfileLifetimeTests.cs
+++ b/tests/Beutl.UnitTests/Api/ProfileLifetimeTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Json;
 using Beutl.Api;
 using Beutl.Api.Clients;
 using Beutl.Api.Objects;
@@ -48,6 +49,35 @@ public sealed class ProfileLifetimeTests
             await getPackages.WaitAsync(TimeSpan.FromSeconds(5)));
     }
 
+    [Test]
+    public async Task RefreshAsync_DoesNotPublishState_WhenCancelledAfterResponse()
+    {
+        var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRequest = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = new DelegateHandler(async (request, cancellationToken) =>
+        {
+            requestStarted.TrySetResult();
+            await releaseRequest.Task;
+            // Return a valid response even though the token was cancelled; the method must
+            // recheck the lifetime token before publishing the refreshed state.
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(CreateProfileResponse())
+            };
+        });
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var profile = new Profile(CreateProfileResponse(), app);
+
+        Task refresh = profile.RefreshAsync(CancellationToken.None);
+        await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await app.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        releaseRequest.TrySetResult();
+
+        Assert.CatchAsync<OperationCanceledException>(async () =>
+            await refresh.WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
     private static ProfileResponse CreateProfileResponse()
     {
         return new ProfileResponse
@@ -75,5 +105,14 @@ public sealed class ProfileLifetimeTests
                 Content = new StringContent("{}")
             };
         }
+    }
+
+    private sealed class DelegateHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => handler(request, cancellationToken);
     }
 }

--- a/tests/Beutl.UnitTests/Api/ProfileLifetimeTests.cs
+++ b/tests/Beutl.UnitTests/Api/ProfileLifetimeTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using Beutl.Api;
+using Beutl.Api.Clients;
+using Beutl.Api.Objects;
+using Beutl.Api.Services;
+
+namespace Beutl.UnitTests.Api;
+
+[TestFixture]
+[NonParallelizable]
+public sealed class ProfileLifetimeTests
+{
+    [Test]
+    public async Task RefreshAsync_IsCancelledByApplicationDisposal()
+    {
+        var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRequest = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = new BlockingHandler(requestStarted, releaseRequest);
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var profile = new Profile(CreateProfileResponse(), app);
+
+        Task refresh = profile.RefreshAsync(CancellationToken.None);
+        await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await app.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.CatchAsync<OperationCanceledException>(async () =>
+            await refresh.WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    [Test]
+    public async Task GetPackagesAsync_IsCancelledByApplicationDisposal()
+    {
+        var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRequest = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = new BlockingHandler(requestStarted, releaseRequest);
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var profile = new Profile(CreateProfileResponse(), app);
+
+        Task getPackages = profile.GetPackagesAsync(CancellationToken.None);
+        await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await app.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.CatchAsync<OperationCanceledException>(async () =>
+            await getPackages.WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    private static ProfileResponse CreateProfileResponse()
+    {
+        return new ProfileResponse
+        {
+            Id = "profile-id",
+            Name = "profile-name",
+            DisplayName = "Profile Name",
+            Bio = null,
+            IconId = null,
+            IconUrl = null,
+        };
+    }
+
+    private sealed class BlockingHandler(
+        TaskCompletionSource requestStarted,
+        TaskCompletionSource releaseRequest) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            requestStarted.TrySetResult();
+            await releaseRequest.Task.WaitAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}")
+            };
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Api/ProfileLifetimeTests.cs
+++ b/tests/Beutl.UnitTests/Api/ProfileLifetimeTests.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using System.Net.Http.Json;
 using Beutl.Api;
 using Beutl.Api.Clients;

--- a/tests/Beutl.UnitTests/Api/ProfileLifetimeTests.cs
+++ b/tests/Beutl.UnitTests/Api/ProfileLifetimeTests.cs
@@ -78,6 +78,34 @@ public sealed class ProfileLifetimeTests
             await refresh.WaitAsync(TimeSpan.FromSeconds(5)));
     }
 
+    [Test]
+    public async Task GetPackagesAsync_Rethrows_WhenCancelledAfterEmptyResponse()
+    {
+        var requestCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        BeutlApiApplication? appRef = null;
+        using var handler = new DelegateHandler((request, cancellationToken) =>
+        {
+            requestCompleted.TrySetResult();
+            // Dispose the application while the empty response is being processed, so the
+            // lifetime token is cancelled before GetPackagesAsync returns its final array.
+            appRef?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[]")
+            });
+        });
+        using var httpClient = new HttpClient(handler);
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        appRef = app;
+        var profile = new Profile(CreateProfileResponse(), app);
+
+        Task<Package[]> getPackages = profile.GetPackagesAsync(CancellationToken.None);
+        await requestCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.CatchAsync<OperationCanceledException>(async () =>
+            await getPackages.WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
     private static ProfileResponse CreateProfileResponse()
     {
         return new ProfileResponse

--- a/tests/Beutl.UnitTests/Api/ProfileLifetimeTests.cs
+++ b/tests/Beutl.UnitTests/Api/ProfileLifetimeTests.cs
@@ -129,7 +129,12 @@ public sealed class ProfileLifetimeTests
             """);
         try
         {
-            using var httpClient = new HttpClient();
+            using var handler = new DelegateHandler((request, cancellationToken) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{}")
+                }));
+            using var httpClient = new HttpClient(handler);
             var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
             var profile = new Profile(CreateProfileResponse(), app);
             var authResponse = new AuthResponse
@@ -140,11 +145,11 @@ public sealed class ProfileLifetimeTests
             };
             var user = new AuthenticatedUser(profile, authResponse, app, httpClient, DateTime.UtcNow.AddDays(-1));
 
-            // A stale write-time forces the persisted-file branch; cancel before the
-            // continuation resumes so the recheck throws instead of mutating state.
+            // A stale write-time forces the persisted-file branch; a pre-canceled token
+            // makes the cancellation point deterministic instead of racing the file read.
             using var cancellation = new CancellationTokenSource();
-            Task refresh = user.RefreshAsync(cancellation.Token).AsTask();
             cancellation.Cancel();
+            Task refresh = user.RefreshAsync(cancellation.Token).AsTask();
 
             Assert.CatchAsync<OperationCanceledException>(async () =>
                 await refresh.WaitAsync(TimeSpan.FromSeconds(5)));

--- a/tests/Beutl.UnitTests/Api/PublicApiCancellationTests.cs
+++ b/tests/Beutl.UnitTests/Api/PublicApiCancellationTests.cs
@@ -82,10 +82,10 @@ public sealed class PublicApiCancellationTests
     }
 
     [Test]
-    public void PackageManagerCheckUpdateOperations_ObservePreCanceledTokens()
+    public async Task PackageManagerCheckUpdateOperations_ObservePreCanceledTokens()
     {
         using var httpClient = new HttpClient();
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
         using var cancellationTokenSource = new CancellationTokenSource();
         cancellationTokenSource.Cancel();
         PackageManager manager = app.GetResource<PackageManager>();
@@ -101,7 +101,7 @@ public sealed class PublicApiCancellationTests
     {
         using var handler = new BlockingHandler();
         using var httpClient = new HttpClient(handler);
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
         using var cancellationTokenSource = new CancellationTokenSource();
         var service = new DiscoverService(app);
 
@@ -122,7 +122,7 @@ public sealed class PublicApiCancellationTests
     {
         using var handler = new BlockingHandler();
         using var httpClient = new HttpClient(handler);
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
         using var cancellationTokenSource = new CancellationTokenSource();
         var service = new LibraryService(app);
         Package package = CreatePackage(app);
@@ -145,7 +145,7 @@ public sealed class PublicApiCancellationTests
     {
         using var handler = new BlockingHandler();
         using var httpClient = new HttpClient(handler);
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
         using var cancellationTokenSource = new CancellationTokenSource();
         Package package = CreatePackage(app);
 
@@ -165,7 +165,7 @@ public sealed class PublicApiCancellationTests
     {
         using var handler = new BlockingHandler();
         using var httpClient = new HttpClient(handler);
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
         using var cancellationTokenSource = new CancellationTokenSource();
         Release release = CreateRelease(app);
 
@@ -177,6 +177,28 @@ public sealed class PublicApiCancellationTests
         };
 
         await AssertTransportCancellation(operation, handler, cancellationTokenSource);
+    }
+
+    [TestCaseSource(nameof(s_releaseOperations))]
+    public async Task ReleaseOperations_LinkApplicationLifetimeToTransport(string operationName)
+    {
+        using var handler = new BlockingHandler();
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        Release release = CreateRelease(app);
+
+        Task operation = operationName switch
+        {
+            "RefreshAsync" => release.RefreshAsync(CancellationToken.None),
+            "GetAssetAsync" => release.GetAssetAsync(CancellationToken.None),
+            _ => throw new ArgumentOutOfRangeException(nameof(operationName)),
+        };
+
+        await handler.BlockingRequestStarted.WaitAsync(TimeSpan.FromSeconds(5));
+        await app.DisposeAsync();
+
+        Assert.CatchAsync<OperationCanceledException>(async () => await operation);
+        await handler.CancellationObserved.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
     [TestCase(false)]

--- a/tests/Beutl.UnitTests/Api/PublicApiCancellationTests.cs
+++ b/tests/Beutl.UnitTests/Api/PublicApiCancellationTests.cs
@@ -96,6 +96,23 @@ public sealed class PublicApiCancellationTests
             await manager.CheckUpdate("package-name", cancellationTokenSource.Token));
     }
 
+    [Test]
+    public async Task PackageManagerCheckUpdate_RejectsAdmissionAfterDisposal()
+    {
+        using var httpClient = new HttpClient();
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        PackageManager manager = app.GetResource<PackageManager>();
+        await app.DisposeAsync();
+
+        // The resource lookup and the lifetime lease both take the dispose gate, so a
+        // disposed application must reject the update check at admission instead of
+        // failing halfway through with an unexpected error.
+        Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            await manager.CheckUpdate(CancellationToken.None));
+        Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            await manager.CheckUpdate("package-name", CancellationToken.None));
+    }
+
     [TestCaseSource(nameof(s_discoverOperations))]
     public async Task DiscoverOperations_PropagateCancellationToTransport(string operationName)
     {

--- a/tests/Beutl.UnitTests/PackageTools/AsyncOperationLifetimeTests.cs
+++ b/tests/Beutl.UnitTests/PackageTools/AsyncOperationLifetimeTests.cs
@@ -158,4 +158,41 @@ public sealed class AsyncOperationLifetimeTests
 
         Assert.That(completionCount, Is.EqualTo(1));
     }
+
+    [Test]
+    public async Task DisposeAsync_RunsCancelPendingRequests_WhenTokenCallbackThrows()
+    {
+        var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowOperationToFinish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        bool requestsCanceled = false;
+        var lifetime = new AsyncOperationLifetime(
+            () => requestsCanceled = true,
+            static () => ValueTask.CompletedTask);
+
+        Task operation = lifetime.RunAsync(async cancellationToken =>
+        {
+            operationStarted.TrySetResult();
+            using var registration = cancellationToken.Register(static () =>
+                throw new InvalidOperationException("callback failed"));
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
+
+            await allowOperationToFinish.Task;
+        });
+        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Task dispose = lifetime.DisposeAsync().AsTask();
+        allowOperationToFinish.TrySetResult();
+
+        await operation.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.CatchAsync<Exception>(async () =>
+            await dispose.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.That(requestsCanceled, Is.True,
+            "CancelPendingRequests must run even when a token callback throws");
+    }
 }

--- a/tests/Beutl.UnitTests/PackageTools/AsyncOperationLifetimeTests.cs
+++ b/tests/Beutl.UnitTests/PackageTools/AsyncOperationLifetimeTests.cs
@@ -1,0 +1,78 @@
+﻿using Beutl.PackageTools.UI.Services;
+
+namespace Beutl.UnitTests.PackageTools;
+
+[TestFixture]
+public sealed class AsyncOperationLifetimeTests
+{
+    [Test]
+    public async Task DisposeAsync_CancelsAndDrainsOperationsBeforeDisposingResources()
+    {
+        var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowOperationToFinish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        bool requestsCanceled = false;
+        bool resourcesDisposed = false;
+        var lifetime = new AsyncOperationLifetime(
+            () => requestsCanceled = true,
+            () =>
+            {
+                resourcesDisposed = true;
+                return ValueTask.CompletedTask;
+            });
+        Task operation = lifetime.RunAsync(async cancellationToken =>
+        {
+            operationStarted.TrySetResult();
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                cancellationObserved.TrySetResult();
+            }
+
+            await allowOperationToFinish.Task;
+        });
+        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Task dispose = lifetime.DisposeAsync().AsTask();
+        await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(requestsCanceled, Is.True);
+            Assert.That(resourcesDisposed, Is.False);
+            Assert.That(dispose.IsCompleted, Is.False);
+        });
+
+        allowOperationToFinish.TrySetResult();
+        await Task.WhenAll(operation, dispose).WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(resourcesDisposed, Is.True);
+    }
+
+    [Test]
+    public async Task DisposeAsync_IsIdempotentAndRejectsNewOperations()
+    {
+        int disposeCount = 0;
+        var lifetime = new AsyncOperationLifetime(
+            static () => { },
+            () =>
+            {
+                disposeCount++;
+                return ValueTask.CompletedTask;
+            });
+
+        Task first = lifetime.DisposeAsync().AsTask();
+        Task second = lifetime.DisposeAsync().AsTask();
+        await Task.WhenAll(first, second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(disposeCount, Is.EqualTo(1));
+            Assert.That(
+                () => lifetime.RunAsync(static _ => Task.CompletedTask),
+                Throws.TypeOf<ObjectDisposedException>());
+        });
+    }
+}

--- a/tests/Beutl.UnitTests/PackageTools/AsyncOperationLifetimeTests.cs
+++ b/tests/Beutl.UnitTests/PackageTools/AsyncOperationLifetimeTests.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.PackageTools.UI.Services;
+﻿using System.Diagnostics;
+using Beutl.PackageTools.UI.Services;
 
 namespace Beutl.UnitTests.PackageTools;
 
@@ -195,4 +196,38 @@ public sealed class AsyncOperationLifetimeTests
         Assert.That(requestsCanceled, Is.True,
             "CancelPendingRequests must run even when a token callback throws");
     }
+
+    [Test]
+    public async Task DisposeAsync_StopsWaitingAtTheDrainDeadline_WhenAnOperationNeverCompletes()
+    {
+        var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        bool resourcesDisposed = false;
+        var lifetime = new AsyncOperationLifetime(
+            static () => { },
+            () =>
+            {
+                resourcesDisposed = true;
+                return ValueTask.CompletedTask;
+            },
+            drainDeadlineMilliseconds: 500);
+        Task operation = lifetime.RunAsync(async cancellationToken =>
+        {
+            operationStarted.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        });
+        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var stopwatch = Stopwatch.StartNew();
+        await lifetime.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        stopwatch.Stop();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(5)),
+                "disposal must stop waiting at the drain deadline even when an operation never completes");
+            Assert.That(resourcesDisposed, Is.True,
+                "resources must still be disposed after the drain deadline expires");
+        });
+    }
+
 }

--- a/tests/Beutl.UnitTests/PackageTools/AsyncOperationLifetimeTests.cs
+++ b/tests/Beutl.UnitTests/PackageTools/AsyncOperationLifetimeTests.cs
@@ -75,4 +75,87 @@ public sealed class AsyncOperationLifetimeTests
                 Throws.TypeOf<ObjectDisposedException>());
         });
     }
+
+    [Test]
+    public async Task DisposeAsync_StillDrainsAndDisposesWhenCancellationThrows()
+    {
+        var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowOperationToFinish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        bool resourcesDisposed = false;
+        var lifetime = new AsyncOperationLifetime(
+            static () => throw new InvalidOperationException("cancel failed"),
+            () =>
+            {
+                resourcesDisposed = true;
+                return ValueTask.CompletedTask;
+            });
+        Task operation = lifetime.RunAsync(async cancellationToken =>
+        {
+            operationStarted.TrySetResult();
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                cancellationObserved.TrySetResult();
+            }
+
+            await allowOperationToFinish.Task;
+        });
+        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Task dispose = lifetime.DisposeAsync().AsTask();
+        await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        allowOperationToFinish.TrySetResult();
+
+        await operation.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                async () => await dispose.WaitAsync(TimeSpan.FromSeconds(5)),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(resourcesDisposed, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task RunAsync_InvokesCompletionWhenCallerCancelsButLifetimeIsNotStopping()
+    {
+        var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowOperationToFinish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int completionCount = 0;
+        var lifetime = new AsyncOperationLifetime(
+            static () => { },
+            static () => ValueTask.CompletedTask);
+        using var callerCancellation = new CancellationTokenSource();
+
+        Task operation = lifetime.RunAsync(
+            async cancellationToken =>
+            {
+                operationStarted.TrySetResult();
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    cancellationObserved.TrySetResult();
+                }
+
+                await allowOperationToFinish.Task;
+            },
+            () => Interlocked.Increment(ref completionCount),
+            callerCancellation.Token);
+        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        callerCancellation.Cancel();
+        await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        allowOperationToFinish.TrySetResult();
+        await operation.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(completionCount, Is.EqualTo(1));
+    }
 }

--- a/tests/Beutl.UnitTests/PackageTools/AsyncOperationLifetimeTests.cs
+++ b/tests/Beutl.UnitTests/PackageTools/AsyncOperationLifetimeTests.cs
@@ -11,10 +11,10 @@ public sealed class AsyncOperationLifetimeTests
         var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var allowOperationToFinish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        bool requestsCanceled = false;
+        var requestsCanceled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         bool resourcesDisposed = false;
         var lifetime = new AsyncOperationLifetime(
-            () => requestsCanceled = true,
+            () => requestsCanceled.TrySetResult(),
             () =>
             {
                 resourcesDisposed = true;
@@ -41,7 +41,7 @@ public sealed class AsyncOperationLifetimeTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(requestsCanceled, Is.True);
+            Assert.That(requestsCanceled.Task.IsCompleted, Is.True);
             Assert.That(resourcesDisposed, Is.False);
             Assert.That(dispose.IsCompleted, Is.False);
         });

--- a/tests/Beutl.UnitTests/PackageTools/ChangesModelTests.cs
+++ b/tests/Beutl.UnitTests/PackageTools/ChangesModelTests.cs
@@ -17,7 +17,7 @@ public sealed class ChangesModelTests
         using var handler = new DelegateHandler((request, _) =>
             Task.FromResult(CreatePackageResponse(request)));
         using var httpClient = new HttpClient(handler);
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
         var model = new ChangesModel();
 
         await model.Load(
@@ -70,7 +70,7 @@ public sealed class ChangesModelTests
             return CreatePackageResponse(request);
         });
         using var httpClient = new HttpClient(handler);
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
         using var cancellation = new CancellationTokenSource();
         var model = new ChangesModel();
 

--- a/tests/Beutl.UnitTests/PackageTools/MainViewModelLifetimeTests.cs
+++ b/tests/Beutl.UnitTests/PackageTools/MainViewModelLifetimeTests.cs
@@ -1,0 +1,203 @@
+﻿using Beutl.Api;
+using Beutl.Api.Services;
+using Beutl.PackageTools.UI.Models;
+
+using PackageToolsMainViewModel = Beutl.PackageTools.UI.ViewModels.MainViewModel;
+
+namespace Beutl.UnitTests.PackageTools;
+
+[TestFixture]
+public sealed class MainViewModelLifetimeTests
+{
+    [Test]
+    public async Task DisposeAsync_CancelsAndDrainsBlockedInitializationBeforeDisposal()
+    {
+        var initializationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseInitialization = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int cancelRequestsCount = 0;
+        int disposeResourcesCount = 0;
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var viewModel = CreateViewModel(
+            httpClient,
+            app,
+            async cancellationToken =>
+            {
+                initializationStarted.TrySetResult();
+                await ObserveCancellationAndWaitToFinish(
+                    cancellationToken,
+                    cancellationObserved,
+                    releaseInitialization);
+            },
+            () => Interlocked.Increment(ref cancelRequestsCount),
+            () =>
+            {
+                Interlocked.Increment(ref disposeResourcesCount);
+                return ValueTask.CompletedTask;
+            });
+
+        try
+        {
+            await initializationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Task firstDispose = viewModel.DisposeAsync().AsTask();
+            Task secondDispose = viewModel.DisposeAsync().AsTask();
+            await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(cancelRequestsCount, Is.EqualTo(1));
+                Assert.That(disposeResourcesCount, Is.Zero);
+                Assert.That(firstDispose.IsCompleted, Is.False);
+                Assert.That(secondDispose.IsCompleted, Is.False);
+            }
+
+            releaseInitialization.TrySetResult();
+            await Task.WhenAll(firstDispose, secondDispose).WaitAsync(TimeSpan.FromSeconds(5));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.InitializationTask.IsCompletedSuccessfully, Is.True);
+                Assert.That(disposeResourcesCount, Is.EqualTo(1));
+            }
+        }
+        finally
+        {
+            releaseInitialization.TrySetResult();
+            await viewModel.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [Test]
+    public async Task DisposeAsync_DrainsActiveOperationsOnceAndSuppressesNavigationCompletions()
+    {
+        var firstStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstCancellation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondCancellation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirst = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSecond = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int cancelRequestsCount = 0;
+        int disposeResourcesCount = 0;
+        int navigationCount = 0;
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var viewModel = CreateViewModel(
+            httpClient,
+            app,
+            static _ => Task.CompletedTask,
+            () => Interlocked.Increment(ref cancelRequestsCount),
+            () =>
+            {
+                Interlocked.Increment(ref disposeResourcesCount);
+                return ValueTask.CompletedTask;
+            });
+
+        try
+        {
+            await viewModel.InitializationTask.WaitAsync(TimeSpan.FromSeconds(5));
+            Task firstOperation = viewModel.RunOperationAsync(
+                cancellationToken => BlockUntilCanceledThenReleased(
+                    cancellationToken,
+                    firstStarted,
+                    firstCancellation,
+                    releaseFirst),
+                () => Interlocked.Increment(ref navigationCount),
+                CancellationToken.None);
+            Task secondOperation = viewModel.RunOperationAsync(
+                cancellationToken => BlockUntilCanceledThenReleased(
+                    cancellationToken,
+                    secondStarted,
+                    secondCancellation,
+                    releaseSecond),
+                () => Interlocked.Increment(ref navigationCount),
+                CancellationToken.None);
+            await Task.WhenAll(firstStarted.Task, secondStarted.Task).WaitAsync(TimeSpan.FromSeconds(5));
+
+            Task firstDispose = viewModel.DisposeAsync().AsTask();
+            Task secondDispose = viewModel.DisposeAsync().AsTask();
+            await Task.WhenAll(firstCancellation.Task, secondCancellation.Task)
+                .WaitAsync(TimeSpan.FromSeconds(5));
+
+            releaseFirst.TrySetResult();
+            await firstOperation.WaitAsync(TimeSpan.FromSeconds(5));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(cancelRequestsCount, Is.EqualTo(1));
+                Assert.That(disposeResourcesCount, Is.Zero);
+                Assert.That(navigationCount, Is.Zero);
+                Assert.That(firstDispose.IsCompleted, Is.False);
+                Assert.That(secondDispose.IsCompleted, Is.False);
+            }
+
+            releaseSecond.TrySetResult();
+            await Task.WhenAll(secondOperation, firstDispose, secondDispose)
+                .WaitAsync(TimeSpan.FromSeconds(5));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(disposeResourcesCount, Is.EqualTo(1));
+                Assert.That(navigationCount, Is.Zero);
+                Assert.That(
+                    () => viewModel.RunOperationAsync(
+                        static _ => Task.CompletedTask,
+                        static () => { },
+                        CancellationToken.None),
+                    Throws.TypeOf<ObjectDisposedException>());
+            }
+        }
+        finally
+        {
+            releaseFirst.TrySetResult();
+            releaseSecond.TrySetResult();
+            await viewModel.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    private static PackageToolsMainViewModel CreateViewModel(
+        HttpClient httpClient,
+        BeutlApiApplication app,
+        Func<CancellationToken, Task> initialize,
+        Action cancelPendingRequests,
+        Func<ValueTask> disposeResources)
+    {
+        return new PackageToolsMainViewModel(
+            httpClient,
+            app,
+            new ChangesModel(),
+            [],
+            [],
+            initialize,
+            cancelPendingRequests,
+            disposeResources);
+    }
+
+    private static async Task BlockUntilCanceledThenReleased(
+        CancellationToken cancellationToken,
+        TaskCompletionSource started,
+        TaskCompletionSource cancellationObserved,
+        TaskCompletionSource release)
+    {
+        started.TrySetResult();
+        await ObserveCancellationAndWaitToFinish(cancellationToken, cancellationObserved, release);
+    }
+
+    private static async Task ObserveCancellationAndWaitToFinish(
+        CancellationToken cancellationToken,
+        TaskCompletionSource cancellationObserved,
+        TaskCompletionSource release)
+    {
+        try
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            cancellationObserved.TrySetResult();
+        }
+
+        await release.Task;
+    }
+}


### PR DESCRIPTION
## Description
- Make `BeutlApiApplication` implement `IAsyncDisposable` with a dispose gate and a lifetime `CancellationTokenSource` that cancels in-flight store operations on shutdown.
- Add `CreateLifetimeLinkedTokenSource` and link `Package` / `Release` / `DiscoverService` / `LibraryService` / `PackageManager` operations to the application lifetime.
- Give the package-tools UI an `AsyncOperationLifetime` that drains work before shutdown, and make `MainViewModel` `IAsyncDisposable`.
- Add `LifetimeCancellationSource` for the Extensions ViewModels and cover the new behavior with NUnit tests.

## Affected areas
- [x] `Beutl.Api` (server API client)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)

## Breaking changes
`BeutlApiApplication` now implements `IAsyncDisposable`; `RestoreUserAsync` and `ReadUserAsync` require a `CancellationToken`; `PackageManager.CheckUpdate` links its operation to the application lifetime. Affects `Beutl.Api` and `Beutl.PackageTools.UI` call sites. Migration: dispose the application when shutting down and pass a token at the affected call sites.

## Test plan
- `tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs` — dispose idempotency and lifetime cancellation.
- `tests/Beutl.UnitTests/PackageTools/AsyncOperationLifetimeTests.cs`, `ChangesModelTests.cs`, `MainViewModelLifetimeTests.cs` — operation lifetime draining and shutdown behavior.
- `tests/Beutl.UnitTests/Api/PublicApiCancellationTests.cs` — extended for the new token-required signatures.

## Fixed issues / References
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added coordinated asynchronous shutdown across API, package management, and application UI operations.
  * In-progress requests now cancel cleanly when closing or disposing.
  * Package installations and updates safely finish or cancel before resources are released.
  * Package updates verify successful unloading before replacing files.
* **Bug Fixes**
  * Prevented canceled operations from publishing incomplete state.
  * Improved shutdown reliability and prevented duplicate close or disposal actions.
  * Suppressed misleading update-timeout notifications during normal application shutdown.
* **Tests**
  * Added comprehensive coverage for cancellation, disposal, in-flight operations, and update safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->