### PR TITLE
fix(editor): complete the editor-clock bridge subject and guard the playback loop past PlayerViewModel disposal

### DIFF
--- a/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
@@ -48,7 +48,11 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
         Header = property.DisplayName;
         Description = new ReactivePropertySlim<string?>(property.Description).AddTo(Disposables);
 
-        _currentTime = new Subject<TimeSpan>().DisposeWith(Disposables);
+        // Do NOT register in Disposables: a completed subject tolerates straggler OnNext calls from
+        // the editor-clock bridge (the publisher may still be mid-iteration when disposal runs on
+        // another thread), whereas a disposed one throws ObjectDisposedException. We complete it in
+        // Dispose(bool) below instead.
+        _currentTime = new Subject<TimeSpan>();
         CurrentTime = _currentTime.Publish(TimeSpan.Zero).RefCount();
 
         IObservable<bool> hasAnimation = property is IAnimatablePropertyAdapter anm
@@ -299,11 +303,18 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
 
     protected virtual void Dispose(bool disposing)
     {
+        // Unsubscribe the editor-clock bridge first, then complete (not dispose) _currentTime.
+        // Completion is the race-safe teardown for a Subject that a publisher on another thread
+        // (playback timer) may still be feeding through a stale snapshot of the observer list:
+        // post-completion OnNext is swallowed instead of escaping as an unhandled
+        // ObjectDisposedException on the ThreadPool.
+        _currentFrameRevoker?.Dispose();
+        _currentFrameRevoker = null;
+        _currentTime.OnCompleted();
+
         Disposables.Dispose();
         _canPaste.Dispose();
         _extensionProvider.Dispose();
-        _currentFrameRevoker?.Dispose();
-        _currentFrameRevoker = null;
         _editViewModel = null!;
         _parentServices = null;
         _element = null;

--- a/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
@@ -48,10 +48,7 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
         Header = property.DisplayName;
         Description = new ReactivePropertySlim<string?>(property.Description).AddTo(Disposables);
 
-        // Do NOT register in Disposables: a completed subject tolerates straggler OnNext calls from
-        // the editor-clock bridge (the publisher may still be mid-iteration when disposal runs on
-        // another thread), whereas a disposed one throws ObjectDisposedException. We complete it in
-        // Dispose(bool) below instead.
+        // Complete during disposal so stale clock writes are ignored.
         _currentTime = new Subject<TimeSpan>();
         CurrentTime = _currentTime.Publish(TimeSpan.Zero).RefCount();
 
@@ -303,11 +300,7 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
 
     protected virtual void Dispose(bool disposing)
     {
-        // Unsubscribe the editor-clock bridge first, then complete (not dispose) _currentTime.
-        // Completion is the race-safe teardown for a Subject that a publisher on another thread
-        // (playback timer) may still be feeding through a stale snapshot of the observer list:
-        // post-completion OnNext is swallowed instead of escaping as an unhandled
-        // ObjectDisposedException on the ThreadPool.
+        // Stop new clock writes before completing the subject.
         _currentFrameRevoker?.Dispose();
         _currentFrameRevoker = null;
         _currentTime.OnCompleted();

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -368,8 +368,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     internal void PublishAudioSnapshot(Pcm<Stereo32BitFloat>? pcm, TimeSpan startTime)
     {
-        // Skip once disposal began: an audio backend task (or one abandoned by a Pause() timeout)
-        // can still reach this method while DisposeAsync is tearing the player down.
+        // An abandoned audio task may still publish after disposal begins.
         if (pcm == null || _isDisposing) return;
 
         // Always publish so the ReplaySubject retains the latest snapshot — a
@@ -378,10 +377,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         int channels = pcm.NumChannels;
         var interleaved = new float[samples * channels];
         MemoryMarshal.Cast<Stereo32BitFloat, float>(pcm.DataSpan).CopyTo(interleaved);
-        // The _isDisposing check above is only a snapshot: a publisher that read it as false
-        // (e.g. while still copying the PCM) can land here after disposal began. Teardown
-        // therefore completes the subject instead of disposing it, so a straggler OnNext is
-        // dropped silently by Rx instead of throwing ObjectDisposedException.
+        // Teardown completes the subject so a racing publish is ignored.
         _audioFramePushed.OnNext(new AudioFrameSnapshot(interleaved, pcm.SampleRate, channels, startTime));
     }
 
@@ -645,9 +641,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 if (Interlocked.Exchange(ref processing, 1) != 0) return;
                 try
                 {
-                    // Once disposal begins, DisposeAsync tears down the subjects and the editor
-                    // clock subscriptions this callback can reach; bail out before touching them.
-                    // (PlayInternal's own finally restore is separately gated on ownership.)
+                    // Do not let a timer callback touch state after disposal.
                     if (_isDisposing)
                     {
                         tcs.TrySetResult(true);
@@ -2059,9 +2053,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         _disposables.Dispose();
         _currentFrameSubscription?.Dispose();
         AfterRendered.Dispose();
-        // Complete (not dispose): an audio task abandoned by a Pause() timeout can still be
-        // publishing while we tear down here, and ReplaySubject.OnNext throws
-        // ObjectDisposedException on a disposed subject but is a no-op after OnCompleted.
+        // Complete so an abandoned audio task can finish without throwing.
         _audioFramePushed.OnCompleted();
         BeginEditTimecodeRequested.Dispose();
         PreviewInvalidated = null;

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -366,11 +366,10 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     IObservable<AudioFrameSnapshot> IPreviewPlayer.AudioFramePushed => _audioFramePushed;
 
-    private void PublishAudioSnapshot(Pcm<Stereo32BitFloat>? pcm, TimeSpan startTime)
+    internal void PublishAudioSnapshot(Pcm<Stereo32BitFloat>? pcm, TimeSpan startTime)
     {
-        // Skip once disposal began: the ReplaySubject is disposed in DisposeAsync while an audio
-        // backend task (or one abandoned by a Pause() timeout) can still be publishing from its
-        // own thread, which would otherwise escape as an unhandled ObjectDisposedException.
+        // Skip once disposal began: an audio backend task (or one abandoned by a Pause() timeout)
+        // can still reach this method while DisposeAsync is tearing the player down.
         if (pcm == null || _isDisposing) return;
 
         // Always publish so the ReplaySubject retains the latest snapshot — a
@@ -379,6 +378,10 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         int channels = pcm.NumChannels;
         var interleaved = new float[samples * channels];
         MemoryMarshal.Cast<Stereo32BitFloat, float>(pcm.DataSpan).CopyTo(interleaved);
+        // The _isDisposing check above is only a snapshot: a publisher that read it as false
+        // (e.g. while still copying the PCM) can land here after disposal began. Teardown
+        // therefore completes the subject instead of disposing it, so a straggler OnNext is
+        // dropped silently by Rx instead of throwing ObjectDisposedException.
         _audioFramePushed.OnNext(new AudioFrameSnapshot(interleaved, pcm.SampleRate, channels, startTime));
     }
 
@@ -2056,7 +2059,10 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         _disposables.Dispose();
         _currentFrameSubscription?.Dispose();
         AfterRendered.Dispose();
-        _audioFramePushed.Dispose();
+        // Complete (not dispose): an audio task abandoned by a Pause() timeout can still be
+        // publishing while we tear down here, and ReplaySubject.OnNext throws
+        // ObjectDisposedException on a disposed subject but is a no-op after OnCompleted.
+        _audioFramePushed.OnCompleted();
         BeginEditTimecodeRequested.Dispose();
         PreviewInvalidated = null;
         Scene = null!;

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -59,7 +59,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     private IDisposable? _currentFrameSubscription;
     private readonly object _renderRequestLock = new();
     private CancellationTokenSource? _cts;
-    private bool _isDisposing;
+    private volatile bool _isDisposing;
     private Size _maxFrameSize;
     private Task _playbackTask = Task.CompletedTask;
     private bool _isShuttling;
@@ -368,7 +368,10 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     private void PublishAudioSnapshot(Pcm<Stereo32BitFloat>? pcm, TimeSpan startTime)
     {
-        if (pcm == null) return;
+        // Skip once disposal began: the ReplaySubject is disposed in DisposeAsync while an audio
+        // backend task (or one abandoned by a Pause() timeout) can still be publishing from its
+        // own thread, which would otherwise escape as an unhandled ObjectDisposedException.
+        if (pcm == null || _isDisposing) return;
 
         // Always publish so the ReplaySubject retains the latest snapshot — a
         // visualizer tab opened after this point can replay it on subscribe.
@@ -639,6 +642,15 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 if (Interlocked.Exchange(ref processing, 1) != 0) return;
                 try
                 {
+                    // Once disposal begins, DisposeAsync tears down the subjects and the editor
+                    // clock subscriptions this callback can reach; bail out before touching them.
+                    // (PlayInternal's own finally restore is separately gated on ownership.)
+                    if (_isDisposing)
+                    {
+                        tcs.TrySetResult(true);
+                        return;
+                    }
+
                     // A Pause() timeout may have disowned this task while it is still blocked in the
                     // WhenAll below; once a newer session has claimed, stop the loop instead of
                     // dequeuing frames or writing shared preview state (PreviewImage / CurrentTime /

--- a/tests/Beutl.HeadlessUITests/AssemblySetUp.cs
+++ b/tests/Beutl.HeadlessUITests/AssemblySetUp.cs
@@ -6,7 +6,11 @@ namespace Beutl.HeadlessUITests;
 public sealed class AssemblySetUp
 {
     [OneTimeSetUp]
-    public void SetUp() => BeutlHomeIsolation.Begin("beutl-shell-e2e");
+    public void SetUp()
+    {
+        OpenALPreload.EnsureLoaded();
+        BeutlHomeIsolation.Begin("beutl-shell-e2e");
+    }
 
     [OneTimeTearDown]
     public void TearDown() => BeutlHomeIsolation.End();

--- a/tests/Beutl.HeadlessUITests/AssemblySetUp.cs
+++ b/tests/Beutl.HeadlessUITests/AssemblySetUp.cs
@@ -6,11 +6,7 @@ namespace Beutl.HeadlessUITests;
 public sealed class AssemblySetUp
 {
     [OneTimeSetUp]
-    public void SetUp()
-    {
-        OpenALPreload.EnsureLoaded();
-        BeutlHomeIsolation.Begin("beutl-shell-e2e");
-    }
+    public void SetUp() => BeutlHomeIsolation.Begin("beutl-shell-e2e");
 
     [OneTimeTearDown]
     public void TearDown() => BeutlHomeIsolation.End();

--- a/tests/Beutl.HeadlessUITests/EditorViewModelDisposeRaceTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorViewModelDisposeRaceTests.cs
@@ -107,17 +107,23 @@ public class EditorViewModelDisposeRaceTests
                 viewModel.Accept(new ServiceVisitor(editor, clock));
                 viewModel.Dispose();
             }
-
-            if (observedStack.Task.IsCompleted)
-            {
-                string stack = await observedStack.Task;
-                Assert.Fail($"a clock write landed on the disposed subject (dispose-order race):\n{stack}");
-            }
         }
         finally
         {
             await stop.CancelAsync();
-            await Task.WhenAny(writer, Task.Delay(TimeSpan.FromSeconds(5)));
+            // Await the writer so an unexpected fault fails this test deterministically, and a
+            // teardown that hangs fails with a timeout instead of leaking the writer into later
+            // tests.
+            await writer.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        // Assert only after the writer has fully drained: an ObjectDisposedException recorded by
+        // the very last Dispose() iteration — or while the writer was being cancelled — must
+        // still fail the test.
+        if (observedStack.Task.IsCompleted)
+        {
+            string stack = await observedStack.Task;
+            Assert.Fail($"a clock write landed on the disposed subject (dispose-order race):\n{stack}");
         }
     }
 }

--- a/tests/Beutl.HeadlessUITests/EditorViewModelDisposeRaceTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorViewModelDisposeRaceTests.cs
@@ -11,14 +11,7 @@ using Reactive.Bindings;
 
 namespace Beutl.HeadlessUITests;
 
-// Reproduces the telemetry crash: a playback-loop timer callback (ThreadPool) reached a disposed
-// System.Reactive.Subjects.Subject<T>.OnNext through the editor-clock subscription that
-// BaseEditorViewModel bridges onto its private Subject<TimeSpan> (_currentTime). Even with the
-// clock subscription disposed first, ReactivePropertySlim keeps iterating its observer list while a
-// writer thread is already inside the setter, so the bridge can still land on the subject after
-// teardown ran on another thread. BaseEditorViewModel therefore completes (not disposes) the
-// subject: post-completion OnNext is swallowed, whereas a disposed one escapes as an unhandled
-// ObjectDisposedException on the ThreadPool -> process crash.
+// Regression coverage for the editor-clock disposal race.
 [TestFixture]
 public class EditorViewModelDisposeRaceTests
 {
@@ -43,7 +36,7 @@ public class EditorViewModelDisposeRaceTests
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
     }
 
-    // Minimal visitor injecting the editor-session services Accept() resolves.
+    // Supplies the services accepted by the editor property context.
     private sealed class ServiceVisitor(EditViewModel editViewModel, IEditorClock clock)
         : IPropertyEditorContextVisitor, IServiceProvider
     {
@@ -73,7 +66,7 @@ public class EditorViewModelDisposeRaceTests
 
         var adapter = new CorePropertyAdapter<TimeSpan>(Scene.DurationProperty, editor.Scene);
 
-        // A background thread hammering the clock stands in for the playback-loop timer callback.
+        // Simulate a playback timer writing from a background thread.
         using var stop = new CancellationTokenSource();
         var observedDisposedWrite = new TaskCompletionSource<bool>(
             TaskCreationOptions.RunContinuationsAsynchronously);
@@ -88,8 +81,7 @@ public class EditorViewModelDisposeRaceTests
                 }
                 catch (ObjectDisposedException ex)
                 {
-                    // The window this test covers: the write landed after the subject was disposed
-                    // but before the clock subscription was torn down.
+                    // This is the race that caused the production crash.
                     observedStack.TrySetResult(ex.StackTrace ?? string.Empty);
                     observedDisposedWrite.TrySetResult(true);
                     return;
@@ -111,15 +103,11 @@ public class EditorViewModelDisposeRaceTests
         finally
         {
             await stop.CancelAsync();
-            // Await the writer so an unexpected fault fails this test deterministically, and a
-            // teardown that hangs fails with a timeout instead of leaking the writer into later
-            // tests.
+            // Drain the writer before the test ends.
             await writer.WaitAsync(TimeSpan.FromSeconds(5));
         }
 
-        // Assert only after the writer has fully drained: an ObjectDisposedException recorded by
-        // the very last Dispose() iteration — or while the writer was being cancelled — must
-        // still fail the test.
+        // Check after the writer has stopped.
         if (observedStack.Task.IsCompleted)
         {
             string stack = await observedStack.Task;

--- a/tests/Beutl.HeadlessUITests/EditorViewModelDisposeRaceTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorViewModelDisposeRaceTests.cs
@@ -1,0 +1,123 @@
+﻿using Avalonia.Headless.NUnit;
+using Beutl.Editor.Services;
+using Beutl.Extensibility;
+using Beutl.ProjectSystem;
+using Beutl.PropertyAdapters;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.ViewModels.Editors;
+using Microsoft.Extensions.DependencyInjection;
+using Reactive.Bindings;
+
+namespace Beutl.HeadlessUITests;
+
+// Reproduces the telemetry crash: a playback-loop timer callback (ThreadPool) reached a disposed
+// System.Reactive.Subjects.Subject<T>.OnNext through the editor-clock subscription that
+// BaseEditorViewModel bridges onto its private Subject<TimeSpan> (_currentTime). Even with the
+// clock subscription disposed first, ReactivePropertySlim keeps iterating its observer list while a
+// writer thread is already inside the setter, so the bridge can still land on the subject after
+// teardown ran on another thread. BaseEditorViewModel therefore completes (not disposes) the
+// subject: post-completion OnNext is swallowed, whereas a disposed one escapes as an unhandled
+// ObjectDisposedException on the ThreadPool -> process crash.
+[TestFixture]
+public class EditorViewModelDisposeRaceTests
+{
+    private static Task ResetProjectAsync() => TestReset.ResetShellAsync();
+
+    private static string NewWorkspace(string name)
+    {
+        string location = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(location);
+        return location;
+    }
+
+    private static async Task<EditViewModel> OpenEditorForNewScene(string name)
+    {
+        Project project = (await TestShell.Project.CreateProject(
+            640, 480, 30, 44100, name, NewWorkspace(name)))!;
+        HeadlessTestHelpers.Settle();
+        Scene scene = project.Items.OfType<Scene>().First();
+
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+    }
+
+    // Minimal visitor injecting the editor-session services Accept() resolves.
+    private sealed class ServiceVisitor(EditViewModel editViewModel, IEditorClock clock)
+        : IPropertyEditorContextVisitor, IServiceProvider
+    {
+        public void Visit(IPropertyEditorContext context)
+        {
+        }
+
+        public object? GetService(Type serviceType)
+        {
+            if (serviceType == typeof(EditViewModel))
+                return editViewModel;
+            if (serviceType == typeof(IEditorClock))
+                return clock;
+            return null;
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Dispose_completes_the_current_time_subject_before_the_clock_bridge_can_write_to_it()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("dispose-race");
+        IEditorClock clock = editor.GetRequiredService<IEditorClock>();
+        IReactiveProperty<TimeSpan> clockProperty = clock.CurrentTime;
+        var observedStack = new TaskCompletionSource<string>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var adapter = new CorePropertyAdapter<TimeSpan>(Scene.DurationProperty, editor.Scene);
+
+        // A background thread hammering the clock stands in for the playback-loop timer callback.
+        using var stop = new CancellationTokenSource();
+        var observedDisposedWrite = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        Task writer = Task.Run(async () =>
+        {
+            TimeSpan t = TimeSpan.Zero;
+            while (!stop.IsCancellationRequested)
+            {
+                try
+                {
+                    clockProperty.Value = (t += TimeSpan.FromMilliseconds(1));
+                }
+                catch (ObjectDisposedException ex)
+                {
+                    // The window this test covers: the write landed after the subject was disposed
+                    // but before the clock subscription was torn down.
+                    observedStack.TrySetResult(ex.StackTrace ?? string.Empty);
+                    observedDisposedWrite.TrySetResult(true);
+                    return;
+                }
+
+                await Task.Yield();
+            }
+        });
+
+        try
+        {
+            for (int i = 0; i < 2000 && !observedDisposedWrite.Task.IsCompleted; i++)
+            {
+                var viewModel = new ValueEditorViewModel<TimeSpan>(adapter);
+                viewModel.Accept(new ServiceVisitor(editor, clock));
+                viewModel.Dispose();
+            }
+
+            if (observedStack.Task.IsCompleted)
+            {
+                string stack = await observedStack.Task;
+                Assert.Fail($"a clock write landed on the disposed subject (dispose-order race):\n{stack}");
+            }
+        }
+        finally
+        {
+            await stop.CancelAsync();
+            await Task.WhenAny(writer, Task.Delay(TimeSpan.FromSeconds(5)));
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/PlayerViewModelDisposalTests.cs
+++ b/tests/Beutl.HeadlessUITests/PlayerViewModelDisposalTests.cs
@@ -1,0 +1,64 @@
+﻿using System.Reactive.Linq;
+using Avalonia.Headless.NUnit;
+using Beutl.Editor.Services;
+using Beutl.Media.Music;
+using Beutl.Media.Music.Samples;
+using Beutl.ProjectSystem;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+
+namespace Beutl.HeadlessUITests;
+
+// Regression tests for the abandoned-playback-task disposal race: a Pause() timeout can leave an
+// audio backend task running while the player is disposed, and that task can still publish audio
+// snapshots after teardown began.
+[TestFixture]
+public class PlayerViewModelDisposalTests
+{
+    private static Task ResetProjectAsync() => TestReset.ResetShellAsync();
+
+    private static string NewWorkspace(string name)
+    {
+        string location = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(location);
+        return location;
+    }
+
+    private static async Task<EditViewModel> OpenEditorForNewScene(string name)
+    {
+        Project project = (await TestShell.Project.CreateProject(
+            640, 480, 30, 44100, name, NewWorkspace(name)))!;
+        HeadlessTestHelpers.Settle();
+        Scene scene = project.Items.OfType<Scene>().First();
+
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+    }
+
+    [AvaloniaTest]
+    public async Task Publishing_audio_after_dispose_is_safe_for_abandoned_playback_tasks()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("player-dispose");
+        PlayerViewModel player = editor.Player;
+
+        // The normal editor-close path disposes the player (the same path ResetShellAsync uses).
+        await TestShell.Editor.CloseTabItem(TestShell.Editor.SelectedTabItem.Value!);
+        HeadlessTestHelpers.Settle();
+
+        // An audio backend task abandoned by a Pause() timeout can still reach
+        // PublishAudioSnapshot after disposal; it must not throw on the torn-down player.
+        using var pcm = new Pcm<Stereo32BitFloat>(44100, 64);
+        Assert.DoesNotThrow(() => player.PublishAudioSnapshot(pcm, TimeSpan.Zero));
+
+        // Teardown must complete (not dispose) the audio-frame subject: a straggler OnNext that
+        // slipped past the _isDisposing snapshot is dropped silently by Rx, whereas OnNext on a
+        // disposed ReplaySubject throws ObjectDisposedException. A fresh subscriber to a
+        // completed subject observes OnCompleted immediately; a disposed one would throw here.
+        bool completed = false;
+        ((IPreviewPlayer)player).AudioFramePushed.Subscribe(_ => { }, () => completed = true);
+        Assert.That(completed, Is.True,
+            "AudioFramePushed must be completed, not disposed, after DisposeAsync");
+    }
+}

--- a/tests/Beutl.HeadlessUITests/PlayerViewModelDisposalTests.cs
+++ b/tests/Beutl.HeadlessUITests/PlayerViewModelDisposalTests.cs
@@ -1,11 +1,16 @@
-﻿using System.Reactive.Linq;
+﻿using System.Diagnostics;
+using System.Reactive.Linq;
 using Avalonia.Headless.NUnit;
+using Beutl.Editor.Models;
 using Beutl.Editor.Services;
+using Beutl.Graphics.Shapes;
 using Beutl.Media.Music;
 using Beutl.Media.Music.Samples;
 using Beutl.ProjectSystem;
+using Beutl.Services;
 using Beutl.Testing.Headless;
 using Beutl.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Beutl.HeadlessUITests;
 
@@ -36,6 +41,18 @@ public class PlayerViewModelDisposalTests
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
     }
 
+    private static Element AddRectangle(EditViewModel editor)
+    {
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        adder.AddElement(new ElementDescription(
+            Start: TimeSpan.Zero,
+            Length: TimeSpan.FromSeconds(4),
+            Layer: 0,
+            EngineObjectFactory: () => new RectShape()));
+        HeadlessTestHelpers.Settle();
+        return editor.Scene.Children[^1];
+    }
+
     [AvaloniaTest]
     public async Task Publishing_audio_after_dispose_is_safe_for_abandoned_playback_tasks()
     {
@@ -60,5 +77,87 @@ public class PlayerViewModelDisposalTests
         ((IPreviewPlayer)player).AudioFramePushed.Subscribe(_ => { }, () => completed = true);
         Assert.That(completed, Is.True,
             "AudioFramePushed must be completed, not disposed, after DisposeAsync");
+    }
+
+    // GPU-gated: the playback loop renders preview frames through SceneRenderer.
+    [AvaloniaTest]
+    public async Task Disposing_the_editor_while_the_playback_timer_is_active_stops_cleanly()
+    {
+        GpuTestGate.EnsureAvailable();
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("player-timer-dispose");
+        PlayerViewModel player = editor.Player;
+        AddRectangle(editor);
+        IEditorClock clock = editor.GetRequiredService<IEditorClock>();
+
+        var frameApplied = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnPreviewInvalidated(object? sender, EventArgs e) => frameApplied.TrySetResult(true);
+        player.PreviewInvalidated += OnPreviewInvalidated;
+
+        // Capture notifications so an audio/render backend failure stopping playback early
+        // surfaces as a readable test failure rather than an opaque IsPlaying mismatch.
+        var notifications = new CaptureNotificationHandler();
+        INotificationServiceHandler previousHandler = NotificationService.Handler;
+        NotificationService.Handler = notifications;
+
+        try
+        {
+            player.Play();
+
+            // The playback timer ticks once the loop applies frames. Wait for the first preview
+            // frame and for the playhead to advance so the disposal below genuinely races an
+            // active timer callback.
+            await frameApplied.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            bool clockAdvanced = await WaitUntilAsync(
+                () => clock.CurrentTime.Value > TimeSpan.Zero, TimeSpan.FromSeconds(5));
+
+            Assert.That(clockAdvanced, Is.True,
+                $"the playback timer must advance the editor clock; {Diagnostics()}");
+            Assert.That(player.IsPlaying.Value, Is.True,
+                $"playback must still be running before the mid-playback disposal; {Diagnostics()}");
+
+            // Close the editor tab while the playback timer is active — the same teardown path
+            // ResetShellAsync uses. Without the disposal-aware shutdown, a timer/audio callback
+            // firing during teardown would hit a torn-down subject and crash the process with an
+            // unhandled ObjectDisposedException.
+            await TestShell.Editor.CloseTabItem(TestShell.Editor.SelectedTabItem.Value!);
+            HeadlessTestHelpers.Settle();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(player.IsPlaying.Value, Is.False);
+                Assert.That(player.PreviewImage.Value, Is.Null,
+                    "teardown must leave no preview frame behind");
+            });
+        }
+        finally
+        {
+            NotificationService.Handler = previousHandler;
+            player.PreviewInvalidated -= OnPreviewInvalidated;
+        }
+
+        string Diagnostics() =>
+            $"renderError={player.PreviewRenderError.Value}, clock={clock.CurrentTime.Value}, " +
+            $"notifications=[{string.Join(" | ", notifications.All.Select(static n => n.Message))}]";
+    }
+
+    private static async Task<bool> WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        long deadline = Stopwatch.GetTimestamp() + timeout.Ticks * Stopwatch.Frequency / TimeSpan.TicksPerSecond;
+        while (!condition())
+        {
+            if (Stopwatch.GetTimestamp() >= deadline) return false;
+            await Task.Delay(10);
+        }
+
+        return true;
+    }
+
+    private sealed class CaptureNotificationHandler : INotificationServiceHandler
+    {
+        public System.Collections.Concurrent.ConcurrentQueue<Notification> All { get; } = new();
+
+        public void Show(Notification notification) => All.Enqueue(notification);
     }
 }

--- a/tests/Beutl.HeadlessUITests/PlayerViewModelDisposalTests.cs
+++ b/tests/Beutl.HeadlessUITests/PlayerViewModelDisposalTests.cs
@@ -14,9 +14,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Beutl.HeadlessUITests;
 
-// Regression tests for the abandoned-playback-task disposal race: a Pause() timeout can leave an
-// audio backend task running while the player is disposed, and that task can still publish audio
-// snapshots after teardown began.
+// Regression coverage for abandoned playback tasks.
 [TestFixture]
 public class PlayerViewModelDisposalTests
 {
@@ -60,19 +58,15 @@ public class PlayerViewModelDisposalTests
         EditViewModel editor = await OpenEditorForNewScene("player-dispose");
         PlayerViewModel player = editor.Player;
 
-        // The normal editor-close path disposes the player (the same path ResetShellAsync uses).
+        // Use the normal editor-close path.
         await TestShell.Editor.CloseTabItem(TestShell.Editor.SelectedTabItem.Value!);
         HeadlessTestHelpers.Settle();
 
-        // An audio backend task abandoned by a Pause() timeout can still reach
-        // PublishAudioSnapshot after disposal; it must not throw on the torn-down player.
+        // A delayed audio task may still call this after disposal.
         using var pcm = new Pcm<Stereo32BitFloat>(44100, 64);
         Assert.DoesNotThrow(() => player.PublishAudioSnapshot(pcm, TimeSpan.Zero));
 
-        // Teardown must complete (not dispose) the audio-frame subject: a straggler OnNext that
-        // slipped past the _isDisposing snapshot is dropped silently by Rx, whereas OnNext on a
-        // disposed ReplaySubject throws ObjectDisposedException. A fresh subscriber to a
-        // completed subject observes OnCompleted immediately; a disposed one would throw here.
+        // A fresh subscriber should observe completion after disposal.
         bool completed = false;
         ((IPreviewPlayer)player).AudioFramePushed.Subscribe(_ => { }, () => completed = true);
         Assert.That(completed, Is.True,
@@ -95,8 +89,7 @@ public class PlayerViewModelDisposalTests
         void OnPreviewInvalidated(object? sender, EventArgs e) => frameApplied.TrySetResult(true);
         player.PreviewInvalidated += OnPreviewInvalidated;
 
-        // Capture notifications so an audio/render backend failure stopping playback early
-        // surfaces as a readable test failure rather than an opaque IsPlaying mismatch.
+        // Capture backend errors for diagnostics.
         var notifications = new CaptureNotificationHandler();
         INotificationServiceHandler previousHandler = NotificationService.Handler;
         NotificationService.Handler = notifications;
@@ -105,9 +98,7 @@ public class PlayerViewModelDisposalTests
         {
             player.Play();
 
-            // The playback timer ticks once the loop applies frames. Wait for the first preview
-            // frame and for the playhead to advance so the disposal below genuinely races an
-            // active timer callback.
+            // Wait until playback has advanced before disposing the editor.
             await frameApplied.Task.WaitAsync(TimeSpan.FromSeconds(10));
             bool clockAdvanced = await WaitUntilAsync(
                 () => clock.CurrentTime.Value > TimeSpan.Zero, TimeSpan.FromSeconds(5));
@@ -117,10 +108,7 @@ public class PlayerViewModelDisposalTests
             Assert.That(player.IsPlaying.Value, Is.True,
                 $"playback must still be running before the mid-playback disposal; {Diagnostics()}");
 
-            // Close the editor tab while the playback timer is active — the same teardown path
-            // ResetShellAsync uses. Without the disposal-aware shutdown, a timer/audio callback
-            // firing during teardown would hit a torn-down subject and crash the process with an
-            // unhandled ObjectDisposedException.
+            // Dispose while the playback timer is active.
             await TestShell.Editor.CloseTabItem(TestShell.Editor.SelectedTabItem.Value!);
             HeadlessTestHelpers.Settle();
 

--- a/tests/Beutl.HeadlessUITests/TestAppBuilder.cs
+++ b/tests/Beutl.HeadlessUITests/TestAppBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia;
 using Avalonia.Headless;
 using Beutl.HeadlessUITests;
+using Beutl.Testing.Headless;
 
 [assembly: AvaloniaTestApplication(typeof(TestAppBuilder))]
 
@@ -14,8 +15,11 @@ namespace Beutl.HeadlessUITests;
 
 public static class TestAppBuilder
 {
-    public static AppBuilder BuildAvaloniaApp() =>
-        AppBuilder.Configure<TestApp>()
+    public static AppBuilder BuildAvaloniaApp()
+    {
+        OpenALPreload.EnsureLoaded();
+        return AppBuilder.Configure<TestApp>()
             .UseSkia()
             .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false });
+    }
 }

--- a/tests/Beutl.Testing.Headless/OpenALPreload.cs
+++ b/tests/Beutl.Testing.Headless/OpenALPreload.cs
@@ -1,0 +1,36 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Beutl.Testing.Headless;
+
+// Silk.NET loads OpenAL with a plain dlopen that only probes the system paths, the app base
+// directory, and the main module directory — it cannot see the NuGet runtime-pack layout
+// (runtimes/<rid>/native) that the bundled Silk.NET.OpenAL.Soft.Native ships in. Without a
+// system-installed libopenal, audio playback therefore fails in test/dev environments even
+// though the native library sits right next to the test binaries. Preload it through
+// NativeLibrary (which performs deps.json probing and finds the runtime-pack layout) so
+// Silk.NET's dlopen reuses the already-loaded handle.
+public static class OpenALPreload
+{
+    public static void EnsureLoaded()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            // Playback uses XAudio2 on Windows.
+            return;
+        }
+
+        string[] candidates = OperatingSystem.IsMacOS()
+            ? ["libopenal.dylib", "openal.dylib"]
+            : ["libopenal.so", "libopenal.so.1", "openal.so"];
+
+        foreach (string candidate in candidates)
+        {
+            // Keep the handle loaded for the lifetime of the process: Silk.NET resolves it by
+            // name later, and freeing it here would undo the preload.
+            if (NativeLibrary.TryLoad(candidate, typeof(OpenALPreload).Assembly, null, out _))
+            {
+                return;
+            }
+        }
+    }
+}

--- a/tests/Beutl.Testing.Headless/OpenALPreload.cs
+++ b/tests/Beutl.Testing.Headless/OpenALPreload.cs
@@ -2,13 +2,7 @@
 
 namespace Beutl.Testing.Headless;
 
-// Silk.NET loads OpenAL with a plain dlopen that only probes the system paths, the app base
-// directory, and the main module directory — it cannot see the NuGet runtime-pack layout
-// (runtimes/<rid>/native) that the bundled Silk.NET.OpenAL.Soft.Native ships in. Without a
-// system-installed libopenal, audio playback therefore fails in test/dev environments even
-// though the native library sits right next to the test binaries. Preload it through
-// NativeLibrary (which performs deps.json probing and finds the runtime-pack layout) so
-// Silk.NET's dlopen reuses the already-loaded handle.
+// Preload the bundled OpenAL library for Silk.NET on non-Windows test hosts.
 public static class OpenALPreload
 {
     public static void EnsureLoaded()
@@ -19,10 +13,7 @@ public static class OpenALPreload
             return;
         }
 
-        // Headless environments (CI runners, machines without an audio server) have no audio
-        // device, so OpenAL Soft's default backend probing fails with InvalidDevice the moment
-        // the player opens a context. Route it to the software null backend instead: playback
-        // position still advances without hardware, which is all the tests need.
+        // Use the null backend when no audio device is available.
         Environment.SetEnvironmentVariable("ALSOFT_DRIVERS", "null");
 
         string[] candidates = OperatingSystem.IsMacOS()
@@ -31,8 +22,7 @@ public static class OpenALPreload
 
         foreach (string candidate in candidates)
         {
-            // Keep the handle loaded for the lifetime of the process: Silk.NET resolves it by
-            // name later, and freeing it here would undo the preload.
+            // Keep the handle loaded for Silk.NET.
             if (NativeLibrary.TryLoad(candidate, typeof(OpenALPreload).Assembly, null, out _))
             {
                 return;

--- a/tests/Beutl.Testing.Headless/OpenALPreload.cs
+++ b/tests/Beutl.Testing.Headless/OpenALPreload.cs
@@ -3,8 +3,11 @@
 namespace Beutl.Testing.Headless;
 
 // Preload the bundled OpenAL library for Silk.NET on non-Windows test hosts.
-public static class OpenALPreload
+public static partial class OpenALPreload
 {
+    [LibraryImport("libc", EntryPoint = "setenv", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial int SetEnvironmentVariable(string name, string value, int overwrite);
+
     public static void EnsureLoaded()
     {
         if (OperatingSystem.IsWindows())
@@ -13,8 +16,7 @@ public static class OpenALPreload
             return;
         }
 
-        // Use the null backend when no audio device is available.
-        Environment.SetEnvironmentVariable("ALSOFT_DRIVERS", "null");
+        SetEnvironmentVariable("ALSOFT_DRIVERS", "null", 1);
 
         string[] candidates = OperatingSystem.IsMacOS()
             ? ["libopenal.dylib", "openal.dylib"]

--- a/tests/Beutl.Testing.Headless/OpenALPreload.cs
+++ b/tests/Beutl.Testing.Headless/OpenALPreload.cs
@@ -19,6 +19,12 @@ public static class OpenALPreload
             return;
         }
 
+        // Headless environments (CI runners, machines without an audio server) have no audio
+        // device, so OpenAL Soft's default backend probing fails with InvalidDevice the moment
+        // the player opens a context. Route it to the software null backend instead: playback
+        // position still advances without hardware, which is all the tests need.
+        Environment.SetEnvironmentVariable("ALSOFT_DRIVERS", "null");
+
         string[] candidates = OperatingSystem.IsMacOS()
             ? ["libopenal.dylib", "openal.dylib"]
             : ["libopenal.so", "libopenal.so.1", "openal.so"];


### PR DESCRIPTION
## Summary

Fixes a Critical release crash first observed in `2.0.0-preview.3` and still reproducing in `2.0.0-preview.6`: an `ObjectDisposedException` (`Cannot access a disposed object.`) escapes `Beutl.Services.UnhandledExceptionHandler` from `PlayerViewModel.PlayInternal`'s timer callback on a ThreadPool thread:

```
System.ObjectDisposedException: Cannot access a disposed object.
   at System.Reactive.Subjects.Subject`1.ThrowDisposed()
   at System.Reactive.ObserverBase`1.OnNext(T value)
   at Beutl.ViewModels.PlayerViewModel.<>c__DisplayClass124_0.<PlayInternal>b__1(Object ...)
   ...
   at System.Threading.TimerQueue.FireNextTimers()
```

## Root cause

A write/teardown race between the editor clock and property-editor view models:

1. `BaseEditorViewModel` bridges `IEditorClock.CurrentTime` (a `ReactivePropertySlim`) onto its private `Subject<TimeSpan> _currentTime` via `Subscribe(_currentTime.OnNext)`.
2. The playback loop's `Timer` writes `CurrentTime` on a ThreadPool thread.
3. `ReactivePropertySlim` iterates its observer list lock-free per setter call, so even if disposal unsubscribes the bridge first, a writer already mid-iteration still reaches the bridge — and a **disposed** `Subject` turns that late `OnNext` into an `ObjectDisposedException` that crashes the process.

## Changes

- `BaseEditorViewModel`: unsubscribe the clock bridge first, then **complete** `_currentTime` instead of disposing it. Post-completion `OnNext` is silently dropped by Rx, while post-disposal `OnNext` throws — this is the race-safe teardown for a subject a publisher on another thread may still be feeding through a stale observer-list snapshot.
- `PlayerViewModel`: `_isDisposing` is now `volatile`; the timer callback bails out once disposal begins, and `PublishAudioSnapshot` no longer publishes to the disposed `_audioFramePushed` `ReplaySubject` from an audio task that outlives `DisposeAsync` (including a playback task abandoned by the `Pause()` timeout).

## Tests

- Added `EditorViewModelDisposeRaceTests` (`tests/Beutl.HeadlessUITests`): races a background clock writer against property-editor disposal to reproduce the disposed-subject `OnNext`. Reproduces the crash pattern on the old code (fails 5/5 and 3/3 runs when the fix is stashed) and stays green with the fix (8/8 runs).
- Full `Beutl.HeadlessUITests` suite: 251 passed. `Beutl.UnitTests`: 5411 passed (the single failure, `PixelSort_half_initialized_gpu_path_degrades_to_noop`, also fails on clean `main` without a GPU — unrelated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor and playback shutdown handling to prevent crashes from late clock and audio updates.
  * Prevented timers and background audio activity from accessing resources after disposal.
  * Ensured late audio updates are safely ignored after playback shuts down.

* **Tests**
  * Added regression coverage for editor disposal during background clock updates and active playback.
  * Improved headless test setup and cross-platform audio initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->