### PR TITLE
ci: cache .NET intermediate build outputs

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,29 +37,80 @@ jobs:
         with:
           global-json-file: global.json
 
-      - name: Restore MSBuild project cache
-        uses: actions/cache@v6
+      - name: Restore .NET build cache
+        id: build-cache
+        uses: actions/cache/restore@v6
         with:
-          path: ${{ runner.temp }}/msbuild-project-cache
-          key: msbuild-project-cache-v1-${{ runner.os }}-${{ hashFiles('global.json') }}-${{ github.sha }}
+          path: |
+            **/obj
+          key: dotnet-obj-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('global.json') }}-${{ github.event.pull_request.head.sha || github.sha }}
           restore-keys: |
-            msbuild-project-cache-v1-${{ runner.os }}-${{ hashFiles('global.json') }}-
+            dotnet-obj-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('global.json') }}-
+
+      # Git checks out every source file with a fresh mtime while actions/cache preserves
+      # the original mtimes of obj/. Without correcting this, MSBuild sees every source as
+      # newer than the restored intermediate outputs and recompiles the whole solution.
+      # Make unchanged tracked inputs old, then touch only files changed since the cache's
+      # source commit. Deletions and submodule changes conservatively force a full rebuild.
+      - name: Prepare incremental build timestamps
+        if: steps.build-cache.outputs.cache-matched-key != ''
+        shell: bash
+        env:
+          CACHE_KEY: ${{ steps.build-cache.outputs.cache-matched-key }}
+        run: |
+          set -euo pipefail
+
+          CACHED_SHA="${CACHE_KEY##*-}"
+          clear_cache() {
+            echo "Discarding restored obj cache; its source commit cannot be compared safely."
+            find . -type d -name obj -prune -exec rm -rf {} +
+          }
+
+          if [[ ! "$CACHED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            clear_cache
+            exit 0
+          fi
+
+          if ! git cat-file -e "${CACHED_SHA}^{commit}" 2>/dev/null; then
+            if ! git fetch --no-tags --depth=1 origin "$CACHED_SHA"; then
+              clear_cache
+              exit 0
+            fi
+          fi
+
+          OLD_TIMESTAMP='2000-01-01 00:00:00 UTC'
+          git ls-files -z | xargs -0 -r touch -h -d "$OLD_TIMESTAMP"
+          git submodule foreach --recursive \
+            'git ls-files -z | xargs -0 -r touch -h -d "2000-01-01 00:00:00 UTC"'
+
+          if ! git diff --quiet --diff-filter=D "$CACHED_SHA" HEAD -- \
+            || git diff --raw "$CACHED_SHA" HEAD -- | grep -q '160000'; then
+            echo "A tracked file was deleted or a submodule changed; forcing a full rebuild."
+            git ls-files -z | xargs -0 -r touch -h
+            git submodule foreach --recursive 'git ls-files -z | xargs -0 -r touch -h'
+          else
+            while IFS= read -r -d '' file; do
+              if [[ -e "$file" || -L "$file" ]]; then
+                touch -h "$file"
+              fi
+            done < <(git diff --name-only -z --diff-filter=ACMRTUXB "$CACHED_SHA" HEAD --)
+          fi
 
       - run: dotnet tool install -g dotnet-reportgenerator-globaltool
 
       - name: Restore dependencies
-        run: dotnet restore Beutl.slnx -p:MSBuildCacheEnabled=true
+        run: dotnet restore Beutl.slnx
 
       - name: Build
-        run: >
-          dotnet msbuild Beutl.slnx
-          /graph
-          /m
-          /reportfileaccesses
-          /p:MSBuildCacheEnabled=true
-          /p:MSBuildCacheLocalCacheRootPath=${{ runner.temp }}/msbuild-project-cache
-          /p:MSBuildCacheLocalCacheSizeInMegabytes=2048
-          /p:MSBuildCacheLogDirectory=${{ runner.temp }}/msbuild-cache-logs
+        run: dotnet build Beutl.slnx --no-restore
+
+      - name: Save .NET build cache
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            **/obj
+          key: dotnet-obj-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('global.json') }}-${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Test
         run: dotnet test Beutl.slnx --no-build --verbosity normal -f net10.0 --collect:"XPlat Code Coverage" --settings coverlet.runsettings

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,15 +37,19 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Resolve .NET SDK version
+        id: dotnet-sdk
+        run: echo "version=$(dotnet --version)" >> "$GITHUB_OUTPUT"
+
       - name: Restore .NET build cache
         id: build-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             **/obj
-          key: dotnet-obj-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('global.json') }}-${{ github.sha }}
+          key: dotnet-obj-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.dotnet-sdk.outputs.version }}-${{ hashFiles('global.json') }}-${{ github.sha }}
           restore-keys: |
-            dotnet-obj-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('global.json') }}-
+            dotnet-obj-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.dotnet-sdk.outputs.version }}-${{ hashFiles('global.json') }}-
 
       # Git checks out every source file with a fresh mtime while actions/cache preserves
       # the original mtimes of obj/. Without correcting this, MSBuild sees every source as
@@ -110,7 +114,7 @@ jobs:
         with:
           path: |
             **/obj
-          key: dotnet-obj-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('global.json') }}-${{ github.sha }}
+          key: dotnet-obj-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.dotnet-sdk.outputs.version }}-${{ hashFiles('global.json') }}-${{ github.sha }}
 
       - name: Test
         run: dotnet test Beutl.slnx --no-build --verbosity normal -f net10.0 --collect:"XPlat Code Coverage" --settings coverlet.runsettings

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -83,8 +83,8 @@ jobs:
           git submodule foreach --recursive \
             'git ls-files -z | xargs -0 -r touch -h -d "2000-01-01 00:00:00 UTC"'
 
-          if ! git diff --quiet --diff-filter=D "$CACHED_SHA" HEAD -- \
-            || git diff --raw "$CACHED_SHA" HEAD -- | awk '/160000/ { found = 1 } END { exit !found }'; then
+          if ! git diff --quiet --no-renames --diff-filter=D "$CACHED_SHA" HEAD -- \
+            || git diff --raw "$CACHED_SHA" HEAD -- | awk '$1 == ":160000" || $2 == "160000" { found = 1 } END { exit !found }'; then
             echo "A tracked file was deleted or a submodule changed; forcing a full rebuild."
             git ls-files -z | xargs -0 -r touch -h
             git submodule foreach --recursive 'git ls-files -z | xargs -0 -r touch -h'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,13 +37,29 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Restore MSBuild project cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/msbuild-project-cache
+          key: msbuild-project-cache-v1-${{ runner.os }}-${{ hashFiles('global.json') }}-${{ github.sha }}
+          restore-keys: |
+            msbuild-project-cache-v1-${{ runner.os }}-${{ hashFiles('global.json') }}-
+
       - run: dotnet tool install -g dotnet-reportgenerator-globaltool
 
       - name: Restore dependencies
-        run: dotnet restore Beutl.slnx
+        run: dotnet restore Beutl.slnx -p:MSBuildCacheEnabled=true
 
       - name: Build
-        run: dotnet build Beutl.slnx --no-restore
+        run: >
+          dotnet msbuild Beutl.slnx
+          /graph
+          /m
+          /reportfileaccesses
+          /p:MSBuildCacheEnabled=true
+          /p:MSBuildCacheLocalCacheRootPath=${{ runner.temp }}/msbuild-project-cache
+          /p:MSBuildCacheLocalCacheSizeInMegabytes=2048
+          /p:MSBuildCacheLogDirectory=${{ runner.temp }}/msbuild-cache-logs
 
       - name: Test
         run: dotnet test Beutl.slnx --no-build --verbosity normal -f net10.0 --collect:"XPlat Code Coverage" --settings coverlet.runsettings

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -84,7 +84,7 @@ jobs:
             'git ls-files -z | xargs -0 -r touch -h -d "2000-01-01 00:00:00 UTC"'
 
           if ! git diff --quiet --diff-filter=D "$CACHED_SHA" HEAD -- \
-            || git diff --raw "$CACHED_SHA" HEAD -- | grep -q '160000'; then
+            || git diff --raw "$CACHED_SHA" HEAD -- | awk '/160000/ { found = 1 } END { exit !found }'; then
             echo "A tracked file was deleted or a submodule changed; forcing a full rebuild."
             git ls-files -z | xargs -0 -r touch -h
             git submodule foreach --recursive 'git ls-files -z | xargs -0 -r touch -h'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -39,11 +39,11 @@ jobs:
 
       - name: Restore .NET build cache
         id: build-cache
-        uses: actions/cache/restore@v6
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             **/obj
-          key: dotnet-obj-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('global.json') }}-${{ github.event.pull_request.head.sha || github.sha }}
+          key: dotnet-obj-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('global.json') }}-${{ github.sha }}
           restore-keys: |
             dotnet-obj-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('global.json') }}-
 
@@ -106,11 +106,11 @@ jobs:
 
       - name: Save .NET build cache
         if: steps.build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             **/obj
-          key: dotnet-obj-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('global.json') }}-${{ github.event.pull_request.head.sha || github.sha }}
+          key: dotnet-obj-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('global.json') }}-${{ github.sha }}
 
       - name: Test
         run: dotnet test Beutl.slnx --no-build --verbosity normal -f net10.0 --collect:"XPlat Code Coverage" --settings coverlet.runsettings

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,12 +1,8 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <MSBuildCachePackageVersion>0.1.328-preview</MSBuildCachePackageVersion>
-    <MSBuildCacheEnabled Condition="'$(MSBuildCacheEnabled)' == ''">false</MSBuildCacheEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.MSBuildCache.Local" Version="$(MSBuildCachePackageVersion)" Condition="'$(MSBuildCacheEnabled)' == 'true'" />
-    <GlobalPackageReference Include="Microsoft.MSBuildCache.SharedCompilation" Version="$(MSBuildCachePackageVersion)" Condition="'$(MSBuildCacheEnabled)' == 'true'" />
     <PackageVersion Include="Aigamo.ResXGenerator" Version="4.4.0" />
     <PackageVersion Include="AsyncImageLoader.Avalonia" Version="3.7.0" />
     <PackageVersion Include="Avalonia" Version="11.3.17" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,12 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <MSBuildCachePackageVersion>0.1.328-preview</MSBuildCachePackageVersion>
+    <MSBuildCacheEnabled Condition="'$(MSBuildCacheEnabled)' == ''">false</MSBuildCacheEnabled>
   </PropertyGroup>
   <ItemGroup>
+    <GlobalPackageReference Include="Microsoft.MSBuildCache.Local" Version="$(MSBuildCachePackageVersion)" Condition="'$(MSBuildCacheEnabled)' == 'true'" />
+    <GlobalPackageReference Include="Microsoft.MSBuildCache.SharedCompilation" Version="$(MSBuildCachePackageVersion)" Condition="'$(MSBuildCacheEnabled)' == 'true'" />
     <PackageVersion Include="Aigamo.ResXGenerator" Version="4.4.0" />
     <PackageVersion Include="AsyncImageLoader.Avalonia" Version="3.7.0" />
     <PackageVersion Include="Avalonia" Version="11.3.17" />


### PR DESCRIPTION
## Summary
- cache `obj/` directories between GitHub Actions runs
- restore caches from earlier commits on the same branch or `main`
- preserve MSBuild incremental-build correctness across fresh checkouts by normalizing tracked source mtimes and touching only files changed since the restored cache commit
- conservatively fall back to a full rebuild when the cached commit cannot be resolved, a tracked file was deleted, or a submodule changed
- save a new cache snapshot after a successful build

## Why
GitHub-hosted runners start from a fresh checkout, so simply restoring `obj/` is not enough: Git gives source files fresh mtimes while the cache preserves older output mtimes, causing MSBuild to consider all sources newer and recompile everything.

This workflow restores the intermediate outputs, makes unchanged tracked inputs older than them, and restores current mtimes only for files changed since the cache was produced. That lets the normal MSBuild incremental checks skip unchanged projects while retaining correctness for changed inputs.

Only `obj/` is cached rather than `bin/` to keep cache size down. `dotnet build` materializes the final outputs into `bin/` from the restored intermediate assemblies before tests run.

## Safety
- SDK changes use a separate cache namespace via the `global.json` hash
- architecture and OS are part of the cache key
- cache reuse is abandoned if the source commit cannot be compared safely
- deletions and submodule updates force a full rebuild

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated build performance by caching intermediate build outputs.
  * Enhanced cache handling across operating systems, architectures, and project configurations.
  * Improved incremental build reliability when restoring cached build data.
  * Added safeguards to trigger clean builds when source deletions or linked component changes are detected.
  * Simplified continuous integration workflows for more consistent and reliable builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->