### PR TITLE
feat!: add paid AI editing workflows

### DIFF
--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -325,6 +325,7 @@ class Build : NukeBuild
             [
                 ("Beutl.Configuration", tfm),
                 ("Beutl.Core", tfm),
+                ("Beutl.Api", tfm),
                 ("Beutl.Extensibility", tfm),
                 ("Beutl.Engine", tfm),
                 ("Beutl.Engine.SourceGenerators", "netstandard2.0"),

--- a/sdk/Beutl.Extensibility.Sdk/Sdk/Sdk.targets
+++ b/sdk/Beutl.Extensibility.Sdk/Sdk/Sdk.targets
@@ -31,6 +31,7 @@
   <!-- Auto-reference opt-out properties -->
   <PropertyGroup>
     <BeutlAutoReferenceAll Condition="'$(BeutlAutoReferenceAll)' == ''">true</BeutlAutoReferenceAll>
+    <BeutlAutoReferenceApi Condition="'$(BeutlAutoReferenceApi)' == ''">$(BeutlAutoReferenceAll)</BeutlAutoReferenceApi>
     <BeutlAutoReferenceExtensibility Condition="'$(BeutlAutoReferenceExtensibility)' == ''">$(BeutlAutoReferenceAll)</BeutlAutoReferenceExtensibility>
     <BeutlAutoReferenceProjectSystem Condition="'$(BeutlAutoReferenceProjectSystem)' == ''">$(BeutlAutoReferenceAll)</BeutlAutoReferenceProjectSystem>
     <BeutlAutoReferenceNodeGraph Condition="'$(BeutlAutoReferenceNodeGraph)' == ''">$(BeutlAutoReferenceAll)</BeutlAutoReferenceNodeGraph>
@@ -39,6 +40,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(_PreventCopyInternalPackages)' == 'true'">
+    <PackageReference Include="Beutl.Api" Version="$(BeutlPackagesVersion)" ExcludeAssets="runtime;native" Condition="'$(BeutlAutoReferenceApi)' == 'true'" />
     <PackageReference Include="Beutl.Extensibility" Version="$(BeutlPackagesVersion)" ExcludeAssets="runtime;native" Condition="'$(BeutlAutoReferenceExtensibility)' == 'true'" />
     <PackageReference Include="Beutl.ProjectSystem" Version="$(BeutlPackagesVersion)" ExcludeAssets="runtime;native" Condition="'$(BeutlAutoReferenceProjectSystem)' == 'true'" />
     <PackageReference Include="Beutl.NodeGraph" Version="$(BeutlPackagesVersion)" ExcludeAssets="runtime;native" Condition="'$(BeutlAutoReferenceNodeGraph)' == 'true'" />
@@ -53,6 +55,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(_PreventCopyInternalPackages)' != 'true'">
+    <PackageReference Include="Beutl.Api" Version="$(BeutlPackagesVersion)" Condition="'$(BeutlAutoReferenceApi)' == 'true'" />
     <PackageReference Include="Beutl.Extensibility" Version="$(BeutlPackagesVersion)" Condition="'$(BeutlAutoReferenceExtensibility)' == 'true'" />
     <PackageReference Include="Beutl.ProjectSystem" Version="$(BeutlPackagesVersion)" Condition="'$(BeutlAutoReferenceProjectSystem)' == 'true'" />
     <PackageReference Include="Beutl.NodeGraph" Version="$(BeutlPackagesVersion)" Condition="'$(BeutlAutoReferenceNodeGraph)' == 'true'" />

--- a/src/Beutl.Api/Beutl.Api.csproj
+++ b/src/Beutl.Api/Beutl.Api.csproj
@@ -31,6 +31,7 @@
     <ProjectReference Include="..\Beutl.Core\Beutl.Core.csproj" />
     <ProjectReference Include="..\Beutl.Configuration\Beutl.Configuration.csproj" />
     <ProjectReference Include="..\Beutl.Extensibility\Beutl.Extensibility.csproj" />
+    <ProjectReference Include="..\Beutl.Language\Beutl.Language.csproj" />
     <ProjectReference Include="..\Beutl.ProjectSystem\Beutl.ProjectSystem.csproj" />
   </ItemGroup>
 
@@ -38,6 +39,9 @@
     <!-- Allow package lifecycle tests to exercise internal load/rollback seams without
          widening the extension API surface. -->
     <InternalsVisibleTo Include="Beutl.UnitTests" />
+    <InternalsVisibleTo Include="Beutl.Editor" />
+    <!-- Headless integration tests exercise the internal authenticated retry seam. -->
+    <InternalsVisibleTo Include="Beutl.HeadlessUITests" />
   </ItemGroup>
 
 </Project>

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -512,6 +512,16 @@ public class BeutlApiApplication : IAsyncDisposable
         }
     }
 
+    internal (T Resource, CancellationTokenSource Lifetime) GetResourceWithLifetime<T>(
+        CancellationToken cancellationToken) where T : IBeutlApiResource
+    {
+        lock (_disposeGate)
+        {
+            T resource = GetResource<T>();
+            return (resource, CreateLifetimeLinkedTokenSource(cancellationToken));
+        }
+    }
+
     internal async Task<AuthenticatedApiResult<T>> SendAuthenticatedAsync<T>(
         Func<string, CancellationToken, Task<T>> send,
         CancellationToken cancellationToken,

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -25,21 +25,30 @@ namespace Beutl.Api;
 public class BeutlApiApplication : IAsyncDisposable
 {
 #if false
-    private const string BaseUrl = "http://localhost:3001";
+    public const string BaseUrl = "http://localhost:3001";
     public const string UserFileName = "user.local.json";
 #else
-    private const string BaseUrl = "https://beutl.beditor.net";
+    public const string BaseUrl = "https://beutl.beditor.net";
     public const string UserFileName = "user.json";
 #endif
     private readonly HttpClient _httpClient;
     private readonly ExtensionProvider _extensionProvider;
+    private readonly Func<HttpClient> _packageInstallerHttpClientFactory;
+    private readonly Action<AuthenticatedUser> _persistAuthenticatedUser;
     private readonly ReactivePropertySlim<AuthenticatedUser?> _authenticatedUser = new();
+    private readonly ReadOnlyReactivePropertySlim<AuthenticatedUser?> _readOnlyAuthenticatedUser;
     private readonly Dictionary<Type, Lazy<object>> _services = [];
     private readonly object _disposeGate = new();
+    private readonly object _authenticationGate = new();
+    private readonly SemaphoreSlim _authenticationRefreshGate = new(1, 1);
     private readonly CancellationTokenSource _lifetimeCts = new();
+    private readonly IDisposable _authenticationSubscription;
     private static readonly ILogger s_logger = Log.CreateLogger<BeutlApiApplication>();
     private volatile bool _disposed;
     private Task? _disposeTask;
+    private CancellationTokenSource? _authenticationSessionCts;
+    private long _authenticationGeneration;
+    private long _authenticationAttemptVersion;
     private static readonly AsyncLazy<AssetMetadataJson?> s_metadata = new(async () =>
     {
         s_logger.LogInformation("Loading asset metadata");
@@ -57,28 +66,43 @@ public class BeutlApiApplication : IAsyncDisposable
     });
 
     public BeutlApiApplication(HttpClient httpClient, ExtensionProvider extensionProvider)
+        : this(httpClient, extensionProvider, static () => new HttpClient())
+    {
+    }
+
+    internal BeutlApiApplication(
+        HttpClient httpClient,
+        ExtensionProvider extensionProvider,
+        Func<HttpClient> packageInstallerHttpClientFactory,
+        Action<AuthenticatedUser>? persistAuthenticatedUser = null)
     {
         ArgumentNullException.ThrowIfNull(httpClient);
         ArgumentNullException.ThrowIfNull(extensionProvider);
+        ArgumentNullException.ThrowIfNull(packageInstallerHttpClientFactory);
 
         _httpClient = httpClient;
         _extensionProvider = extensionProvider;
-        httpClient.BaseAddress = new Uri(BaseUrl);
-        App = RestService.For<IAppClient>(httpClient);
-        Packages = RestService.For<IPackagesClient>(httpClient);
-        Releases = RestService.For<IReleasesClient>(httpClient);
-        Files = RestService.For<IFilesClient>(httpClient);
-        Users = RestService.For<IUsersClient>(httpClient);
-        Account = RestService.For<IAccountClient>(httpClient);
-        Discover = RestService.For<IDiscoverClient>(httpClient);
-        Library = RestService.For<ILibraryClient>(httpClient);
+        _packageInstallerHttpClientFactory = packageInstallerHttpClientFactory;
+        _persistAuthenticatedUser = persistAuthenticatedUser ?? PersistAuthenticatedUser;
+        _authenticationSubscription = _authenticatedUser.Subscribe(HandleAuthenticatedUserChanged);
+        _readOnlyAuthenticatedUser = _authenticatedUser.ToReadOnlyReactivePropertySlim();
+        _httpClient.BaseAddress = new Uri(BaseUrl);
+        App = RestService.For<IAppClient>(_httpClient);
+        Packages = RestService.For<IPackagesClient>(_httpClient);
+        Releases = RestService.For<IReleasesClient>(_httpClient);
+        Files = RestService.For<IFilesClient>(_httpClient);
+        Users = RestService.For<IUsersClient>(_httpClient);
+        Account = RestService.For<IAccountClient>(_httpClient);
+        Discover = RestService.For<IDiscoverClient>(_httpClient);
+        Library = RestService.For<ILibraryClient>(_httpClient);
+        Ai = RestService.For<IAiClient>(_httpClient);
 
         ViewConfig viewConfig = GlobalConfiguration.Instance.ViewConfig;
         string culture = viewConfig.UICulture.Name;
         if (!string.IsNullOrWhiteSpace(culture))
         {
-            httpClient.DefaultRequestHeaders.AcceptLanguage.Clear();
-            httpClient.DefaultRequestHeaders.AcceptLanguage.Add(new StringWithQualityHeaderValue(culture));
+            _httpClient.DefaultRequestHeaders.AcceptLanguage.Clear();
+            _httpClient.DefaultRequestHeaders.AcceptLanguage.Add(new StringWithQualityHeaderValue(culture));
         }
 
         RegisterAll();
@@ -100,17 +124,22 @@ public class BeutlApiApplication : IAsyncDisposable
 
     public ILibraryClient Library { get; }
 
+    internal IAiClient Ai { get; }
+
     public IAppClient App { get; }
+
+    internal HttpClient HttpClient => _httpClient;
 
     public MyAsyncLock Lock { get; } = new();
 
-    public IReadOnlyReactiveProperty<AuthenticatedUser?> AuthenticatedUser => _authenticatedUser;
+    public IReadOnlyReactiveProperty<AuthenticatedUser?> AuthenticatedUser => _readOnlyAuthenticatedUser;
 
     public bool IsDisposed => _disposed;
 
-    // 更新があるかどうかをチェックします
-    // このアプリケーションがアセットメタデータを持っている場合は、AppUpdateResponseを返します
-    // そうでない場合は、CheckForUpdatesResponseを返します
+    internal TimeSpan DisposalDeadline { get; set; } = TimeSpan.FromSeconds(30);
+
+    // Check for updates. Return AppUpdateResponse when this application has asset metadata;
+    // otherwise, return CheckForUpdatesResponse.
     public async Task<(CheckForUpdatesResponse? V1, AppUpdateResponse? V3)> CheckForUpdatesAsync(
         string version,
         CancellationToken cancellationToken)
@@ -132,8 +161,8 @@ public class BeutlApiApplication : IAsyncDisposable
         return (null, update);
     }
 
-    // The server's /api/v3/app/updates endpoint only accepts zip/debian/installer/app.
-    // Flatpak bundles are built from the standalone zip, so report them as zip.
+    // The server accepts archive types, while local metadata records the Flatpak package type.
+    // Flatpak releases are produced from the standalone zip archive used by the update endpoint.
     internal static string ToServerType(string type) => type == "flatpak" ? "zip" : type;
 
     public static async Task<AssetMetadataJson?> LoadMetadata()
@@ -147,73 +176,20 @@ public class BeutlApiApplication : IAsyncDisposable
         lock (_disposeGate)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            return GetResourceCore<T>();
-        }
-    }
-
-    // Resolves the resource and links the lifetime token under one dispose-gate hold, so a
-    // concurrent DisposeAsync cannot invalidate the resource between admission and use.
-    internal T GetResourceWithLifetime<T>(CancellationToken cancellationToken, out CancellationTokenSource lifetimeCts)
-        where T : IBeutlApiResource
-    {
-        lock (_disposeGate)
-        {
-            // A canceled caller token must surface as cancellation, not ObjectDisposedException.
-            cancellationToken.ThrowIfCancellationRequested();
-            ObjectDisposedException.ThrowIf(_disposed, this);
-            T resource = GetResourceCore<T>();
-            lifetimeCts = CancellationTokenSource.CreateLinkedTokenSource(
-                cancellationToken,
-                _lifetimeCts.Token);
-            return resource;
-        }
-    }
-
-    private T GetResourceCore<T>()
-        where T : IBeutlApiResource
-    {
-        if (_services.TryGetValue(typeof(T), out Lazy<object>? lazy))
-        {
-            return (T)lazy.Value;
-        }
-
-        foreach (KeyValuePair<Type, Lazy<object>> item in _services)
-        {
-            if (item.Key.IsAssignableTo(typeof(T)))
-            {
-                return (T)item.Value.Value;
-            }
-        }
-
-        throw new Exception("Resource not found");
-    }
-
-    // Returns only resources another caller has already materialized; a registered-but-
-    // uncreated resource is not available yet, so the resolver-style name would conflate
-    // that state with unavailable. The sole production use is a shutdown-time probe for
-    // resources that must have been created by then.
-    internal T? TryGetCreatedResource<T>()
-        where T : class, IBeutlApiResource
-    {
-        lock (_disposeGate)
-        {
-            if (_disposed)
-                return null;
-
-            if (_services.TryGetValue(typeof(T), out Lazy<object>? lazy) && lazy.IsValueCreated)
+            if (_services.TryGetValue(typeof(T), out Lazy<object>? lazy))
             {
                 return (T)lazy.Value;
             }
 
             foreach (KeyValuePair<Type, Lazy<object>> item in _services)
             {
-                if (item.Key.IsAssignableTo(typeof(T)) && item.Value.IsValueCreated)
+                if (item.Key.IsAssignableTo(typeof(T)))
                 {
                     return (T)item.Value.Value;
                 }
             }
 
-            return null;
+            throw new Exception("Resource not found");
         }
     }
 
@@ -223,31 +199,38 @@ public class BeutlApiApplication : IAsyncDisposable
         Task disposeTask;
         lock (_disposeGate)
         {
-            // Publish the disposal task before cancellation so re-entrant callbacks
-            // observe the original teardown.
-            if (_disposeTask == null)
+            if (_disposeTask is null)
             {
                 proxy = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 _disposeTask = proxy.Task;
+                _disposed = true;
             }
             disposeTask = _disposeTask;
         }
 
-        // Start teardown after releasing the lock so re-entrant callbacks do not deadlock.
-        if (proxy != null)
+        if (proxy is not null)
         {
-            _ = RunDisposeCoreAsync(proxy);
+            Task teardown = Task.Run(DisposeCoreAsync);
+            _ = CompleteDisposeAsync(proxy, teardown);
         }
 
         return new ValueTask(disposeTask);
     }
 
-    private async Task RunDisposeCoreAsync(TaskCompletionSource proxy)
+    private async Task CompleteDisposeAsync(TaskCompletionSource proxy, Task teardown)
     {
         try
         {
-            await DisposeCoreAsync().ConfigureAwait(false);
+            await teardown.WaitAsync(DisposalDeadline).ConfigureAwait(false);
             proxy.TrySetResult();
+        }
+        catch (TimeoutException)
+        {
+            s_logger.LogWarning(
+                "API application shutdown exceeded {Deadline}; cleanup will continue after callbacks and active leases drain.",
+                DisposalDeadline);
+            proxy.TrySetResult();
+            _ = ObserveDeferredTeardownAsync(teardown);
         }
         catch (Exception ex)
         {
@@ -255,12 +238,11 @@ public class BeutlApiApplication : IAsyncDisposable
         }
     }
 
-    protected virtual async Task DisposeCoreAsync()
+    private async Task DisposeCoreAsync()
     {
         List<object> disposableResources;
         lock (_disposeGate)
         {
-            _disposed = true;
             disposableResources = _services.Values
                 .Where(lazy => lazy.IsValueCreated)
                 .Select(lazy => lazy.Value)
@@ -280,12 +262,42 @@ public class BeutlApiApplication : IAsyncDisposable
             cancellationFailure = ex;
         }
 
+        CancellationTokenSource? authenticationSession;
+        lock (_authenticationGate)
+        {
+            authenticationSession = _authenticationSessionCts;
+            _authenticationSessionCts = null;
+            _authenticationGeneration++;
+            _authenticationAttemptVersion++;
+            _httpClient.DefaultRequestHeaders.Authorization = null;
+        }
+
+        try
+        {
+            authenticationSession?.Cancel();
+        }
+        catch (Exception ex)
+        {
+            cancellationFailure ??= ex;
+        }
+
+        await DisposeResourcesAndStateAsync(disposableResources, authenticationSession)
+            .ConfigureAwait(false);
+
+        if (cancellationFailure is not null)
+            throw cancellationFailure;
+    }
+
+    private async Task DisposeResourcesAndStateAsync(
+        IReadOnlyList<object> disposableResources,
+        CancellationTokenSource? authenticationSession)
+    {
         foreach (object resource in disposableResources)
         {
             try
             {
                 if (resource is IAsyncDisposable asyncDisposable)
-                    await asyncDisposable.DisposeAsync();
+                    await asyncDisposable.DisposeAsync().ConfigureAwait(false);
                 else
                     ((IDisposable)resource).Dispose();
             }
@@ -298,12 +310,35 @@ public class BeutlApiApplication : IAsyncDisposable
             }
         }
 
-        _lifetimeCts.Dispose();
-        ActivitySource.Dispose();
+        TryDispose(authenticationSession, "authentication session");
+        TryDispose(_authenticationSubscription, "authentication subscription");
+        TryDispose(_readOnlyAuthenticatedUser, "authenticated-user projection");
+        TryDispose(_authenticatedUser, "authenticated-user state");
+        TryDispose(_lifetimeCts, "application cancellation source");
+        TryDispose(ActivitySource, "activity source");
+    }
 
-        if (cancellationFailure != null)
+    private static void TryDispose(IDisposable? disposable, string name)
+    {
+        try
         {
-            throw cancellationFailure;
+            disposable?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            s_logger.LogWarning(ex, "Failed to dispose API application {ResourceName}.", name);
+        }
+    }
+
+    private static async Task ObserveDeferredTeardownAsync(Task teardown)
+    {
+        try
+        {
+            await teardown.ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            s_logger.LogWarning(ex, "Deferred API application cleanup failed.");
         }
     }
 
@@ -320,11 +355,56 @@ public class BeutlApiApplication : IAsyncDisposable
         Register(() => new AcceptedLicenseManager());
         Register(() => new PackageChangesQueue());
         Register(() => new LibraryService(this));
-        Register(() => new PackageInstaller(
-            new HttpClient(),
-            ownsHttpClient: true,
-            GetResource<InstalledPackageRepository>(),
-            this));
+        Register(() => new AiEntitlementStore(this));
+        Register(() => new AiJobChangeNotifier());
+        Register(() => new AiEntitlementService(
+            this,
+            GetResource<AiEntitlementStore>()));
+        Register<IAiOperationCapabilitySchemaProvider>(() =>
+            new AiOperationCapabilitySchemaRegistry(GetResource<IExtensionRegistry>()));
+        Register(() => new AiModelCatalogService(
+            this,
+            capabilitySchemas: GetResource<IAiOperationCapabilitySchemaProvider>()));
+        Register(() => new AiOperationAvailabilityService(this));
+        Register(() => new AiImageGenerationService(
+            this,
+            GetResource<AiJobChangeNotifier>()));
+        Register(() => new AiImageEditingService(
+            this,
+            GetResource<AiJobChangeNotifier>()));
+        Register(() => new AiTranscriptionService(
+            this,
+            GetResource<AiJobChangeNotifier>()));
+        Register(() => new AiCaptionTranslationService(
+            this,
+            GetResource<AiJobChangeNotifier>()));
+        Register(() => new AiVideoService(
+            this,
+            GetResource<AiJobChangeNotifier>()));
+        Register(() => new AuthenticatedContentService(this));
+        Register(() => new AiJobClient(this));
+        Register(() => new AiRetryAttemptContext(
+            new FileAiRetryKeyStore(Path.Combine(
+                BeutlEnvironment.GetHomeDirectoryPath(),
+                "ai")),
+            () => AuthenticatedUser.Value is { } user
+                ? new AiAuthenticatedRequestIdentity(user.Profile.Id, user)
+                : null));
+        Register<IAiJobKindRegistry>(() => AiJobKindRegistry.CreateBuiltIn(
+            GetResource<IAiImageGenerationService>(),
+            GetResource<IAiVideoService>(),
+            GetResource<IAiEntitlementService>(),
+            GetResource<IAiOperationAvailabilityService>(),
+            GetResource<IAiModelCatalogService>(),
+            GetResource<AiRetryAttemptContext>(),
+            GetResource<IExtensionRegistry>()));
+        Register(() => new AiJobMonitor(
+            this,
+            GetResource<IAiJobClient>(),
+            GetResource<IAiJobKindRegistry>(),
+            GetResource<AiJobChangeNotifier>().Changes,
+            TimeSpan.FromSeconds(5)));
+        Register(CreatePackageInstaller);
         Register(() =>
         {
             // Unload diagnostics take a heavy ClrMD self-snapshot and write a dump; they are a development-only aid,
@@ -345,12 +425,86 @@ public class BeutlApiApplication : IAsyncDisposable
         _services.Add(typeof(T), new Lazy<object>(() => factory()));
     }
 
-    protected internal CancellationTokenSource CreateLifetimeLinkedTokenSource(CancellationToken cancellationToken)
+    private PackageInstaller CreatePackageInstaller()
+    {
+        HttpClient httpClient = _packageInstallerHttpClientFactory()
+            ?? throw new InvalidOperationException("The package installer HTTP client factory returned null.");
+        try
+        {
+            return new PackageInstaller(
+                httpClient,
+                ownsHttpClient: true,
+                GetResource<InstalledPackageRepository>(),
+                this);
+        }
+        catch
+        {
+            httpClient.Dispose();
+            throw;
+        }
+    }
+
+    private void HandleAuthenticatedUserChanged(AuthenticatedUser? user)
+    {
+        CancellationTokenSource? previousSession;
+        lock (_authenticationGate)
+        {
+            previousSession = _authenticationSessionCts;
+            _authenticationSessionCts = user is null ? null : new CancellationTokenSource();
+            _authenticationGeneration++;
+            _authenticationAttemptVersion++;
+            if (user is null)
+            {
+                _httpClient.DefaultRequestHeaders.Authorization = null;
+            }
+            else
+            {
+                _httpClient.DefaultRequestHeaders.Authorization =
+                    new AuthenticationHeaderValue("Bearer", user.Token);
+            }
+        }
+
+        previousSession?.Cancel();
+        previousSession?.Dispose();
+    }
+
+    private long BeginAuthenticationAttempt()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        lock (_authenticationGate)
+            return ++_authenticationAttemptVersion;
+    }
+
+    private void CommitAuthenticatedUser(
+        AuthenticatedUser user,
+        long authenticationAttempt,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (_authenticationGate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_authenticationAttemptVersion != authenticationAttempt)
+                throw new AuthenticationRequiredException();
+
+            _authenticatedUser.Value = user;
+            _httpClient.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", user.Token);
+        }
+    }
+
+    private bool IsAuthenticationSessionCurrent(AuthenticatedUser user, long generation)
+    {
+        return !_disposed
+            && generation == _authenticationGeneration
+            && _authenticationSessionCts is not null
+            && ReferenceEquals(_authenticatedUser.Value, user);
+    }
+
+    internal CancellationTokenSource CreateLifetimeLinkedTokenSource(CancellationToken cancellationToken)
     {
         lock (_disposeGate)
         {
-            // A canceled caller token must surface as cancellation, not ObjectDisposedException.
-            cancellationToken.ThrowIfCancellationRequested();
             ObjectDisposedException.ThrowIf(_disposed, this);
             return CancellationTokenSource.CreateLinkedTokenSource(
                 cancellationToken,
@@ -358,9 +512,137 @@ public class BeutlApiApplication : IAsyncDisposable
         }
     }
 
+    internal async Task<AuthenticatedApiResult<T>> SendAuthenticatedAsync<T>(
+        Func<string, CancellationToken, Task<T>> send,
+        CancellationToken cancellationToken,
+        AuthenticatedUser? expectedUser = null)
+    {
+        ArgumentNullException.ThrowIfNull(send);
+        cancellationToken.ThrowIfCancellationRequested();
+        expectedUser ??= AiAuthenticatedRequestScope.Current;
+
+        using AuthenticatedSessionContext context = await CreateAuthenticatedSessionAsync(
+                expectedUser,
+                cancellationToken)
+            .ConfigureAwait(false);
+        try
+        {
+            T value = await send(context.Authorization, context.CancellationToken).ConfigureAwait(false);
+            try
+            {
+                EnsureAuthenticationSessionCurrent(context, cancellationToken);
+            }
+            catch (AuthenticationRequiredException ex)
+            {
+                // The endpoint already returned. Its job may have been reserved even though the
+                // authentication generation changed before the caller could observe the result.
+                throw new AuthenticationRequiredException(
+                    currentAttemptReservationIsKnownAbsent: false,
+                    ex);
+            }
+            return new AuthenticatedApiResult<T>(value, context.User);
+        }
+        catch (OperationCanceledException) when (
+            context.AuthenticationToken.IsCancellationRequested
+            && !context.ApplicationToken.IsCancellationRequested
+            && !cancellationToken.IsCancellationRequested)
+        {
+            // Cancellation can race with the server accepting the request. Keep any idempotency
+            // key until an authoritative endpoint response says that no job was reserved.
+            throw new AuthenticationRequiredException(
+                currentAttemptReservationIsKnownAbsent: false);
+        }
+    }
+
+    private async ValueTask<AuthenticatedSessionContext> CreateAuthenticatedSessionAsync(
+        AuthenticatedUser? expectedUser,
+        CancellationToken cancellationToken)
+    {
+        using CancellationTokenSource lifetimeCts = CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = lifetimeCts.Token;
+        AuthenticatedUser user;
+        lock (_authenticationGate)
+        {
+            user = _authenticatedUser.Value ?? throw new AuthenticationRequiredException();
+            if (expectedUser is not null && !ReferenceEquals(user, expectedUser))
+                throw new AuthenticationRequiredException();
+        }
+
+        await user.RefreshAsync(token).ConfigureAwait(false);
+        token.ThrowIfCancellationRequested();
+
+        lock (_disposeGate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            lock (_authenticationGate)
+            {
+                if (!ReferenceEquals(_authenticatedUser.Value, user)
+                    || _authenticationSessionCts is null)
+                {
+                    throw new AuthenticationRequiredException();
+                }
+
+                long generation = _authenticationGeneration;
+                CancellationToken authenticationToken = _authenticationSessionCts.Token;
+                CancellationToken applicationToken = _lifetimeCts.Token;
+                var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                    cancellationToken,
+                    applicationToken,
+                    authenticationToken);
+                return new AuthenticatedSessionContext(
+                    user,
+                    generation,
+                    $"Bearer {user.Token}",
+                    authenticationToken,
+                    applicationToken,
+                    linkedCancellation);
+            }
+        }
+    }
+
+    private void EnsureAuthenticationSessionCurrent(
+        AuthenticatedSessionContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        context.ApplicationToken.ThrowIfCancellationRequested();
+        lock (_authenticationGate)
+        {
+            if (!IsAuthenticationSessionCurrent(context.User, context.Generation))
+                throw new AuthenticationRequiredException();
+        }
+    }
+
+    internal void CommitForAuthenticatedUser(
+        AuthenticatedUser user,
+        Action commit,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+        ArgumentNullException.ThrowIfNull(commit);
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (_authenticationGate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (!ReferenceEquals(_authenticatedUser.Value, user)
+                || _authenticationSessionCts is null)
+            {
+                throw new AuthenticationRequiredException();
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            commit();
+        }
+    }
+
     public void SignOut(bool deleteFile = true)
     {
-        _authenticatedUser.Value = null;
+        lock (_authenticationGate)
+        {
+            _authenticationAttemptVersion++;
+            _authenticatedUser.Value = null;
+            _httpClient.DefaultRequestHeaders.Authorization = null;
+        }
         if (deleteFile)
         {
             string fileName = Path.Combine(Helper.AppRoot, UserFileName);
@@ -385,14 +667,13 @@ public class BeutlApiApplication : IAsyncDisposable
     {
         using CancellationTokenSource lifetimeCts = CreateLifetimeLinkedTokenSource(cancellationToken);
         CancellationToken token = lifetimeCts.Token;
-        using (Activity? activity = ActivitySource.StartActivity("SignInExternalAsync", ActivityKind.Client))
+        using Activity? activity = ActivitySource.StartActivity("SignInExternalAsync", ActivityKind.Client);
+        AuthenticatedUser user = await RunInteractiveAuthenticationAsync(async authenticationToken =>
         {
             string continueUri = $"http://localhost:{GetRandomUnusedPort()}/__/auth/handler";
-            CreateAuthUriResponse authUriRes = await Account.CreateAuthUri(new CreateAuthUriRequest
-            {
-                ContinueUri = continueUri
-            }, token);
-            token.ThrowIfCancellationRequested();
+            CreateAuthUriResponse authUriRes = await Account.CreateAuthUri(
+                new CreateAuthUriRequest { ContinueUri = continueUri },
+                authenticationToken);
             using HttpListener listener = StartListener($"{continueUri}/");
             activity?.AddEvent(new("Started_Listener"));
 
@@ -401,144 +682,313 @@ public class BeutlApiApplication : IAsyncDisposable
 
             Process.Start(new ProcessStartInfo(uri) { UseShellExecute = true, Verb = "open" });
 
-            string? code = await GetResponseFromListener(listener, token);
+            string? code = await GetResponseFromListener(listener, authenticationToken);
             activity?.AddEvent(new("Received_Code"));
             if (string.IsNullOrWhiteSpace(code))
             {
                 throw new Exception("The returned code was empty.");
             }
 
-            AuthResponse authResponse = await Account.Exchange(new ExchangeRequest
-            {
-                Code = code,
-                SessionId = authUriRes.SessionId
-            }, token);
+            AuthResponse authResponse = await Account.Exchange(
+                new ExchangeRequest { Code = code, SessionId = authUriRes.SessionId },
+                authenticationToken);
             activity?.AddEvent(new("Done_CodeToJwtAsync"));
 
-            // Serialize only the authentication state transition; the OAuth wait above must
-            // not hold the application-wide lock.
-            using (await Lock.LockAsync(token))
-            {
-                activity?.AddEvent(new("Entered_AsyncLock"));
-                AuthenticatedUser user = await CompleteSignInAsync(authResponse, token);
-                activity?.AddEvent(new("Saved_User"));
-                return user;
-            }
-        }
+            ProfileResponse profileResponse = await Users.GetSelf(
+                $"Bearer {authResponse.Token}",
+                authenticationToken);
+            var profile = new Profile(profileResponse, this);
+            return new AuthenticatedUser(profile, authResponse, this, DateTime.UtcNow);
+        }, token);
+        activity?.AddEvent(new("Saved_User"));
+        return user;
     }
 
     public async Task<AuthenticatedUser> SignInAsync(CancellationToken cancellationToken)
     {
         using CancellationTokenSource lifetimeCts = CreateLifetimeLinkedTokenSource(cancellationToken);
         CancellationToken token = lifetimeCts.Token;
-        using (Activity? activity = ActivitySource.StartActivity("SignInAsync", ActivityKind.Client))
+        using Activity? activity = ActivitySource.StartActivity("SignInAsync", ActivityKind.Client);
+        AuthenticatedUser user = await RunInteractiveAuthenticationAsync(async authenticationToken =>
         {
-            using (await Lock.LockAsync(token))
+            string continueUri = $"http://localhost:{GetRandomUnusedPort()}/__/auth/handler";
+            CreateAuthUriResponse authUriRes = await Account.CreateAuthUri(
+                new CreateAuthUriRequest { ContinueUri = continueUri },
+                authenticationToken);
+            using HttpListener listener = StartListener($"{continueUri}/");
+            activity?.AddEvent(new("Started_Listener"));
+
+            string uri = $"{BaseUrl}/account/signIn?returnUrl={Uri.EscapeDataString(authUriRes.AuthUri)}";
+
+            Process.Start(new ProcessStartInfo(uri) { UseShellExecute = true, Verb = "open" });
+
+            string? code = await GetResponseFromListener(listener, authenticationToken);
+            activity?.AddEvent(new("Received_Code"));
+            if (string.IsNullOrWhiteSpace(code))
             {
-                activity?.AddEvent(new("Entered_AsyncLock"));
-                string continueUri = $"http://localhost:{GetRandomUnusedPort()}/__/auth/handler";
-                CreateAuthUriResponse authUriRes = await Account.CreateAuthUri(new CreateAuthUriRequest
-                {
-                    ContinueUri = continueUri
-                }, token);
-                token.ThrowIfCancellationRequested();
-                using HttpListener listener = StartListener($"{continueUri}/");
-                activity?.AddEvent(new("Started_Listener"));
-
-                string uri = $"{BaseUrl}/account/signIn?returnUrl={Uri.EscapeDataString(authUriRes.AuthUri)}";
-
-                Process.Start(new ProcessStartInfo(uri) { UseShellExecute = true, Verb = "open" });
-
-                string? code = await GetResponseFromListener(listener, token);
-                activity?.AddEvent(new("Received_Code"));
-                if (string.IsNullOrWhiteSpace(code))
-                {
-                    throw new Exception("The returned code was empty.");
-                }
-
-                AuthResponse authResponse = await Account.Exchange(new ExchangeRequest
-                {
-                    Code = code,
-                    SessionId = authUriRes.SessionId
-                }, token);
-                activity?.AddEvent(new("Done_CodeToJwtAsync"));
-
-                AuthenticatedUser user = await CompleteSignInAsync(authResponse, token);
-                activity?.AddEvent(new("Saved_User"));
-                return user;
+                throw new Exception("The returned code was empty.");
             }
-        }
+
+            AuthResponse authResponse = await Account.Exchange(
+                new ExchangeRequest { Code = code, SessionId = authUriRes.SessionId },
+                authenticationToken);
+            activity?.AddEvent(new("Done_CodeToJwtAsync"));
+
+            ProfileResponse profileResponse = await Users.GetSelf(
+                $"Bearer {authResponse.Token}",
+                authenticationToken);
+            var profile = new Profile(profileResponse, this);
+            return new AuthenticatedUser(profile, authResponse, this, DateTime.UtcNow);
+        }, token);
+        activity?.AddEvent(new("Saved_User"));
+        return user;
     }
 
-    internal async Task<AuthenticatedUser> CompleteSignInAsync(
-        AuthResponse authResponse,
+    internal async Task<AuthenticatedUser> RunInteractiveAuthenticationAsync(
+        Func<CancellationToken, Task<AuthenticatedUser>> authenticate,
         CancellationToken cancellationToken)
     {
-        string? previousAuthorization = _httpClient.DefaultRequestHeaders.Authorization?.ToString();
-        AuthenticatedUser? previousUser = _authenticatedUser.Value;
-        _httpClient.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", authResponse.Token);
-        AuthenticatedUser? attemptedUser = null;
-        try
-        {
-            ProfileResponse profileResponse = await Users.GetSelf(cancellationToken);
-            cancellationToken.ThrowIfCancellationRequested();
-            var profile = new Profile(profileResponse, this);
+        ArgumentNullException.ThrowIfNull(authenticate);
+        cancellationToken.ThrowIfCancellationRequested();
+        long authenticationAttempt = BeginAuthenticationAttempt();
 
-            attemptedUser = new AuthenticatedUser(profile, authResponse, this, _httpClient, DateTime.UtcNow);
-            _authenticatedUser.Value = attemptedUser;
-            SaveUser();
-            return _authenticatedUser.Value;
+        AuthenticatedUser user = await authenticate(cancellationToken);
+        ArgumentNullException.ThrowIfNull(user);
+        using (await Lock.LockAsync(cancellationToken))
+        {
+            PersistAndCommitAuthenticatedUser(user, authenticationAttempt, cancellationToken);
         }
-        catch
-        {
-            // Only roll back state still owned by this failing attempt: a SignOut or a
-            // later successful sign-in may have replaced the user while GetSelf was pending,
-            // and must not be overwritten by the stale snapshot.
-            if (ReferenceEquals(_authenticatedUser.Value, attemptedUser)
-                || (attemptedUser == null && ReferenceEquals(_authenticatedUser.Value, previousUser)))
-            {
-                _authenticatedUser.Value = previousUser;
-                if (previousAuthorization != null)
-                {
-                    _httpClient.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse(previousAuthorization);
-                }
-                else
-                {
-                    _httpClient.DefaultRequestHeaders.Authorization = null;
-                }
-            }
+        return user;
+    }
 
-            throw;
+    private void PersistAndCommitAuthenticatedUser(
+        AuthenticatedUser user,
+        long authenticationAttempt,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (_authenticationGate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_authenticationAttemptVersion != authenticationAttempt)
+                throw new AuthenticationRequiredException();
+
+            _persistAuthenticatedUser(user);
+            _authenticatedUser.Value = user;
+            _httpClient.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", user.Token);
         }
     }
 
     public static void OpenAccountSettings()
     {
-        Process.Start(new ProcessStartInfo($"{BaseUrl}/account/manage") { UseShellExecute = true, Verb = "open" });
+        Process.Start(new ProcessStartInfo($"{BaseUrl}/account/manage")
+        {
+            UseShellExecute = true,
+            Verb = "open",
+        });
+    }
+
+    internal async ValueTask RefreshAuthenticatedUserAsync(
+        AuthenticatedUser user,
+        bool force,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+        cancellationToken.ThrowIfCancellationRequested();
+        using CancellationTokenSource lifetimeCts = CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken applicationToken = lifetimeCts.Token;
+        long authenticationGeneration;
+        CancellationToken sessionToken;
+        CancellationTokenSource linkedCts;
+        lock (_authenticationGate)
+        {
+            authenticationGeneration = _authenticationGeneration;
+            if (_disposed
+                || !ReferenceEquals(_authenticatedUser.Value, user)
+                || _authenticationSessionCts is null)
+            {
+                throw new AuthenticationRequiredException();
+            }
+
+            sessionToken = _authenticationSessionCts.Token;
+            linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+                applicationToken,
+                sessionToken);
+        }
+
+        using (linkedCts)
+        {
+            CancellationToken token = linkedCts.Token;
+            bool gateEntered = false;
+            try
+            {
+                await _authenticationRefreshGate.WaitAsync(token).ConfigureAwait(false);
+                gateEntered = true;
+                token.ThrowIfCancellationRequested();
+                lock (_authenticationGate)
+                {
+                    if (!IsAuthenticationSessionCurrent(user, authenticationGeneration))
+                        throw new AuthenticationRequiredException();
+                }
+
+                using Activity? activity = ActivitySource.StartActivity(
+                    "AuthenticatedUser.Refresh",
+                    ActivityKind.Client);
+                (AuthResponse response, DateTime writeTime) = user.GetAuthenticationState();
+                string fileName = Path.Combine(Helper.AppRoot, UserFileName);
+                if (File.Exists(fileName))
+                {
+                    DateTime lastWriteTime = File.GetLastWriteTimeUtc(fileName);
+                    if (writeTime < lastWriteTime)
+                    {
+                        AuthenticatedUser? fileUser = await ReadUserAsync(token).ConfigureAwait(false);
+                        token.ThrowIfCancellationRequested();
+                        if (fileUser?.Profile.Id == user.Profile.Id)
+                        {
+                            (response, writeTime) = fileUser.GetAuthenticationState();
+                        }
+                        else if (fileUser is not null)
+                        {
+                            SignOutIfCurrent(user);
+                            throw new InvalidOperationException(
+                                "The user may have been changed in another process.");
+                        }
+                    }
+                }
+
+                bool isExpired = response.Expiration < DateTime.UtcNow;
+                activity?.SetTag("force", force);
+                activity?.SetTag("is_expired", isExpired);
+                bool refreshed = false;
+                if (force || isExpired)
+                {
+                    response = await Account.Refresh(
+                            new RefreshTokenRequest
+                            {
+                                RefreshToken = response.RefreshToken,
+                                Token = response.Token,
+                            },
+                            token)
+                        .ConfigureAwait(false);
+                    token.ThrowIfCancellationRequested();
+                    refreshed = true;
+                    activity?.AddEvent(new("Refreshed"));
+                }
+
+                lock (_authenticationGate)
+                {
+                    token.ThrowIfCancellationRequested();
+                    if (!IsAuthenticationSessionCurrent(user, authenticationGeneration))
+                        throw new AuthenticationRequiredException();
+
+                    user.CommitAuthenticationState(response, writeTime);
+                    _httpClient.DefaultRequestHeaders.Authorization =
+                        new AuthenticationHeaderValue("Bearer", response.Token);
+                }
+
+                if (refreshed)
+                {
+                    SaveUser(user);
+                    activity?.AddEvent(new("Saved"));
+                }
+            }
+            catch (OperationCanceledException) when (
+                sessionToken.IsCancellationRequested
+                && !applicationToken.IsCancellationRequested
+                && !cancellationToken.IsCancellationRequested)
+            {
+                throw new AuthenticationRequiredException();
+            }
+            finally
+            {
+                if (gateEntered)
+                {
+                    _authenticationRefreshGate.Release();
+                }
+            }
+        }
+    }
+
+    private void SignOutIfCurrent(AuthenticatedUser user)
+    {
+        lock (_authenticationGate)
+        {
+            if (!ReferenceEquals(_authenticatedUser.Value, user))
+                return;
+
+            _authenticationAttemptVersion++;
+            _authenticatedUser.Value = null;
+            _httpClient.DefaultRequestHeaders.Authorization = null;
+        }
     }
 
     public void SaveUser()
     {
         if (_authenticatedUser.Value is { } user)
         {
-            string fileName = Path.Combine(Helper.AppRoot, UserFileName);
-            using (FileStream stream = File.Create(fileName))
-            {
-                var obj = new JsonObject
-                {
-                    ["token"] = user.Token,
-                    ["refresh_token"] = user.RefreshToken,
-                    ["expiration"] = user.Expiration,
-                    ["profile"] = JsonSerializer.SerializeToNode(user.Profile.Response.Value),
-                };
-
-                using var writer = new Utf8JsonWriter(stream);
-                obj.WriteTo(writer);
-            }
-
-            user._writeTime = File.GetLastWriteTimeUtc(fileName);
+            SaveUser(user);
         }
+    }
+
+    private void SaveUser(AuthenticatedUser user)
+    {
+        lock (_authenticationGate)
+        {
+            if (_disposed || !ReferenceEquals(_authenticatedUser.Value, user))
+                return;
+
+            _persistAuthenticatedUser(user);
+        }
+    }
+
+    private static void PersistAuthenticatedUser(AuthenticatedUser user)
+    {
+        (AuthResponse response, DateTime _) = user.GetAuthenticationState();
+        string fileName = Path.Combine(Helper.AppRoot, UserFileName);
+        string directory = Path.GetDirectoryName(fileName)!;
+        Directory.CreateDirectory(directory);
+        string temporaryPath = Path.Combine(
+            directory,
+            $".{Path.GetFileName(fileName)}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            var obj = new JsonObject
+            {
+                ["token"] = response.Token,
+                ["refresh_token"] = response.RefreshToken,
+                ["expiration"] = response.Expiration,
+                ["profile"] = JsonSerializer.SerializeToNode(user.Profile.Response.Value),
+            };
+            var streamOptions = new FileStreamOptions
+            {
+                Mode = FileMode.CreateNew,
+                Access = FileAccess.Write,
+                Share = FileShare.None,
+                BufferSize = 4096,
+                Options = FileOptions.WriteThrough,
+            };
+            if (!OperatingSystem.IsWindows())
+            {
+                streamOptions.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+            }
+            using (var stream = new FileStream(temporaryPath, streamOptions))
+            {
+                using (var writer = new Utf8JsonWriter(stream))
+                {
+                    obj.WriteTo(writer);
+                    writer.Flush();
+                }
+                stream.Flush(true);
+            }
+            File.Move(temporaryPath, fileName, true);
+        }
+        finally
+        {
+            File.Delete(temporaryPath);
+        }
+
+        user.SetWriteTime(File.GetLastWriteTimeUtc(fileName));
     }
 
     public async Task RestoreUserAsync(Activity? activity, CancellationToken cancellationToken)
@@ -547,35 +997,23 @@ public class BeutlApiApplication : IAsyncDisposable
         CancellationToken token = lifetimeCts.Token;
         using (await Lock.LockAsync(token))
         {
+            long authenticationAttempt = BeginAuthenticationAttempt();
             activity?.AddEvent(new("Entered_AsyncLock"));
 
-            string? previousAuthorization = _httpClient.DefaultRequestHeaders.Authorization?.ToString();
-            AuthenticatedUser? previousUser = _authenticatedUser.Value;
             AuthenticatedUser? user = await ReadUserAsync(token);
             if (user != null)
             {
+                CommitAuthenticatedUser(user, authenticationAttempt, token);
                 try
                 {
                     await user.RefreshAsync(token);
-
-                    _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", user.Token);
-                    await user.Profile.RefreshAsync(token, true);
+                    await user.Profile.RefreshAsync(token, self: true);
                     token.ThrowIfCancellationRequested();
-                    _authenticatedUser.Value = user;
-                    SaveUser();
+                    SaveUser(user);
                 }
                 catch
                 {
-                    _authenticatedUser.Value = previousUser;
-                    if (previousAuthorization != null)
-                    {
-                        _httpClient.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse(previousAuthorization);
-                    }
-                    else
-                    {
-                        _httpClient.DefaultRequestHeaders.Authorization = null;
-                    }
-
+                    SignOutIfCurrent(user);
                     throw;
                 }
             }
@@ -608,9 +1046,13 @@ public class BeutlApiApplication : IAsyncDisposable
                 {
                     return new AuthenticatedUser(
                         new Profile(profile, this),
-                        new AuthResponse { Expiration = expiration.Value, RefreshToken = refreshToken, Token = persistedToken },
+                        new AuthResponse
+                        {
+                            Expiration = expiration.Value,
+                            RefreshToken = refreshToken,
+                            Token = persistedToken,
+                        },
                         this,
-                        _httpClient,
                         lastWriteTime);
                 }
             }

--- a/src/Beutl.Api/Clients/AiBalanceResponse.cs
+++ b/src/Beutl.Api/Clients/AiBalanceResponse.cs
@@ -1,0 +1,43 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Beutl.Api.Clients;
+
+internal sealed record AiMonthlyUsageResponse
+{
+    [JsonPropertyName("usedPercent")]
+    public required int UsedPercent { get; init; }
+
+    [JsonPropertyName("remainingPercent")]
+    public required int RemainingPercent { get; init; }
+
+    [JsonPropertyName("isExhausted")]
+    public required bool IsExhausted { get; init; }
+}
+
+internal sealed record AiBalanceResponse
+{
+    [JsonPropertyName("monthlyUsage")]
+    public required AiMonthlyUsageResponse MonthlyUsage { get; init; }
+
+    // Exact purchased-credit balance is limited to the account entitlement snapshot.
+    [JsonPropertyName("additionalCredits")]
+    public required int AdditionalCredits { get; init; }
+
+    [JsonPropertyName("hasAdditionalCreditDebt")]
+    public bool HasAdditionalCreditDebt { get; init; }
+
+    internal bool TryNormalize(out AiBalanceResponse? normalized)
+    {
+        normalized = null;
+        if (MonthlyUsage is null
+            || MonthlyUsage.UsedPercent is < 0 or > 100
+            || MonthlyUsage.RemainingPercent is < 0 or > 100
+            || AdditionalCredits < 0)
+        {
+            return false;
+        }
+
+        normalized = this;
+        return true;
+    }
+}

--- a/src/Beutl.Api/Clients/AiCapabilitiesResponse.cs
+++ b/src/Beutl.Api/Clients/AiCapabilitiesResponse.cs
@@ -1,0 +1,114 @@
+﻿using System.Collections.Immutable;
+using System.Text.Json.Serialization;
+
+namespace Beutl.Api.Clients;
+
+// What each model offers, which this client cannot know without asking: an
+// administrator registers the models at runtime, and what a video request may
+// carry differs per model — one renders only at 2K, another takes any whole
+// second from 4 to 30. The operation-level shapes and limits published beside
+// them are the outer bounds, and this client keeps its own copies of those.
+internal sealed record AiModelDescriptionResponse
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; init; }
+
+    // "low" / "medium" / "high", or absent when the operation offers a single
+    // model. Never a price: the server does not publish one.
+    [JsonPropertyName("costTier")]
+    public string? CostTier { get; init; }
+
+    [JsonPropertyName("isDefault")]
+    public bool IsDefault { get; init; }
+
+    // Image models only, and absent for a server that predates them.
+    [JsonPropertyName("aspectRatios")]
+    public ImmutableArray<string>? AspectRatios { get; init; }
+
+    // The backgrounds the model publishes rather than a single "can it cut one
+    // out": GPT Image-1 offers auto, opaque and transparent while GPT Image-2
+    // offers auto and opaque, and a boolean could not tell the two apart.
+    [JsonPropertyName("backgrounds")]
+    public ImmutableArray<string>? Backgrounds { get; init; }
+
+    [JsonPropertyName("maxReferenceImages")]
+    public int? MaxReferenceImages { get; init; }
+
+    // Whether a size can be asked for, which is what upscaling is. Absent from
+    // a server that predates it, which reads as "no restriction published".
+    [JsonPropertyName("resolution")]
+    public bool? Resolution { get; init; }
+
+    // Video models only. Absent for every other operation, and absent from a
+    // server that predates them, which reads as "no restriction published".
+    [JsonPropertyName("durationsSeconds")]
+    public ImmutableArray<int>? DurationsSeconds { get; init; }
+
+    [JsonPropertyName("resolutions")]
+    public ImmutableArray<string>? Resolutions { get; init; }
+
+    [JsonPropertyName("audio")]
+    public bool? Audio { get; init; }
+
+    [JsonPropertyName("seed")]
+    public bool? Seed { get; init; }
+
+    // Video models only, and separately: a model that conditions on a first
+    // frame does not necessarily take a last one.
+    [JsonPropertyName("firstFrame")]
+    public bool? FirstFrame { get; init; }
+
+    [JsonPropertyName("lastFrame")]
+    public bool? LastFrame { get; init; }
+}
+
+internal sealed record AiOperationCapabilityResponse
+{
+    [JsonPropertyName("models")]
+    public ImmutableArray<AiModelDescriptionResponse>? Models { get; init; }
+
+    // Video only, and the outer bounds rather than a menu: what the server will
+    // accept at all, whatever model a request names. A model's own list is
+    // narrowed to these, so a shape the server would refuse is never offered.
+    [JsonPropertyName("resolutions")]
+    public ImmutableArray<string>? Resolutions { get; init; }
+
+    [JsonPropertyName("aspectRatios")]
+    public ImmutableArray<string>? AspectRatios { get; init; }
+
+    // Image only, and the outer bound in the same way: what the server takes at
+    // all, whatever model a request names.
+    [JsonPropertyName("backgrounds")]
+    public ImmutableArray<string>? Backgrounds { get; init; }
+
+    // Image generation only. What all the reference pictures of one request may
+    // come to together, which is not the per-picture limit multiplied by the
+    // count: the server holds every picture raw, again as base64 and again
+    // through JSON. Absent from a server that publishes no figure of its own.
+    [JsonPropertyName("maxReferenceImagesTotalBytes")]
+    public long? MaxReferenceImagesTotalBytes { get; init; }
+
+    [JsonPropertyName("maxSegments")]
+    public int? MaxSegments { get; init; }
+
+    [JsonPropertyName("maxCharacters")]
+    public int? MaxCharacters { get; init; }
+
+    [JsonPropertyName("maxRequestBytes")]
+    public int? MaxRequestBytes { get; init; }
+
+    [JsonPropertyName("minDurationSeconds")]
+    public int? MinDurationSeconds { get; init; }
+
+    [JsonPropertyName("maxDurationSeconds")]
+    public int? MaxDurationSeconds { get; init; }
+}
+
+internal sealed record AiCapabilitiesResponse
+{
+    [JsonPropertyName("operations")]
+    public required ImmutableDictionary<string, AiOperationCapabilityResponse> Operations { get; init; }
+}

--- a/src/Beutl.Api/Clients/AiImageResponse.cs
+++ b/src/Beutl.Api/Clients/AiImageResponse.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Beutl.Api.Clients;
+
+internal sealed record AiImageResponse
+{
+    [JsonPropertyName("jobId")] public string? JobId { get; init; }
+
+    [JsonPropertyName("fileId")] public required string FileId { get; init; }
+
+    [JsonPropertyName("url")] public required string Url { get; init; }
+
+    [JsonPropertyName("fileName")] public string? FileName { get; init; }
+
+    [JsonPropertyName("contentType")] public string? ContentType { get; init; }
+}

--- a/src/Beutl.Api/Clients/AiJobHistoryResponse.cs
+++ b/src/Beutl.Api/Clients/AiJobHistoryResponse.cs
@@ -1,0 +1,62 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Beutl.Api.Clients;
+
+internal sealed record AiJobHistoryResponse
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("inputParams")]
+    public JsonElement? InputParams { get; init; }
+
+    // Null for jobs created before an operation could offer more than one.
+    [JsonPropertyName("model")]
+    public string? Model { get; init; }
+
+    [JsonPropertyName("fileId")]
+    public string? FileId { get; init; }
+
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+
+    [JsonPropertyName("fileName")]
+    public string? FileName { get; init; }
+
+    [JsonPropertyName("contentType")]
+    public string? ContentType { get; init; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; init; }
+
+    [JsonPropertyName("canRetry")]
+    public required bool CanRetry { get; init; }
+
+    [JsonPropertyName("createdAt")]
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    [JsonPropertyName("updatedAt")]
+    public required DateTimeOffset UpdatedAt { get; init; }
+}
+
+internal sealed record AiJobHistoryPageResponse
+{
+    [JsonPropertyName("jobs")]
+    public required AiJobHistoryResponse[] Jobs { get; init; }
+
+    [JsonPropertyName("nextCursor")]
+    public string? NextCursor { get; init; }
+}
+
+internal sealed record DeleteAiJobResponse
+{
+    [JsonPropertyName("deleted")]
+    public required bool Deleted { get; init; }
+}

--- a/src/Beutl.Api/Clients/AiOperationAvailabilityResponse.cs
+++ b/src/Beutl.Api/Clients/AiOperationAvailabilityResponse.cs
@@ -1,0 +1,60 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Beutl.Api.Clients;
+
+internal sealed record AiFixedOperationAvailabilityRequestDto
+{
+    [JsonPropertyName("operation")]
+    public required string Operation { get; init; }
+
+    // Which model the question is about. Omitted asks about the default, which
+    // is what a client that offers no choice sends.
+    [JsonPropertyName("model")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Model { get; init; }
+}
+
+internal sealed record AiVideoOperationAvailabilityRequestDto
+{
+    [JsonPropertyName("operation")]
+    public required string Operation { get; init; }
+
+    [JsonPropertyName("durationSeconds")]
+    public required int DurationSeconds { get; init; }
+
+    [JsonPropertyName("model")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Model { get; init; }
+}
+
+internal sealed record AiTranscriptionOperationAvailabilityRequestDto
+{
+    [JsonPropertyName("operation")]
+    public required string Operation { get; init; }
+
+    [JsonPropertyName("durationSeconds")]
+    public required double DurationSeconds { get; init; }
+
+    [JsonPropertyName("model")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Model { get; init; }
+}
+
+internal sealed record AiTranslationOperationAvailabilityRequestDto
+{
+    [JsonPropertyName("operation")]
+    public required string Operation { get; init; }
+
+    [JsonPropertyName("characterCount")]
+    public required int CharacterCount { get; init; }
+
+    [JsonPropertyName("model")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Model { get; init; }
+}
+
+internal sealed record AiOperationAvailabilityResponse
+{
+    [JsonPropertyName("available")]
+    public required bool Available { get; init; }
+}

--- a/src/Beutl.Api/Clients/AiTranscriptionResponse.cs
+++ b/src/Beutl.Api/Clients/AiTranscriptionResponse.cs
@@ -1,0 +1,32 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Beutl.Api.Clients;
+
+internal sealed record AiTranscriptionResponseDto
+{
+    [JsonPropertyName("jobId")] public string? JobId { get; init; }
+
+    [JsonPropertyName("segments")] public required AiTranscriptionSegmentDto[] Segments { get; init; }
+
+    [JsonPropertyName("language")] public string? Language { get; init; }
+
+    [JsonPropertyName("words")] public AiTranscriptionWordDto[]? Words { get; init; }
+}
+
+internal sealed class AiTranscriptionWordDto
+{
+    [JsonPropertyName("start")] public required double Start { get; init; }
+
+    [JsonPropertyName("end")] public required double End { get; init; }
+
+    [JsonPropertyName("word")] public required string Word { get; init; }
+}
+
+internal sealed class AiTranscriptionSegmentDto
+{
+    [JsonPropertyName("start")] public required double Start { get; init; }
+
+    [JsonPropertyName("end")] public required double End { get; init; }
+
+    [JsonPropertyName("text")] public required string Text { get; init; }
+}

--- a/src/Beutl.Api/Clients/AiTranslationResponse.cs
+++ b/src/Beutl.Api/Clients/AiTranslationResponse.cs
@@ -1,0 +1,76 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Beutl.Api.Clients;
+
+internal sealed record AiCaptionTranslationSegmentContextDto
+{
+    [JsonPropertyName("groupId")]
+    public required string GroupId { get; init; }
+
+    [JsonPropertyName("partIndex")]
+    public required int PartIndex { get; init; }
+
+    [JsonPropertyName("start")]
+    public required double Start { get; init; }
+
+    [JsonPropertyName("end")]
+    public required double End { get; init; }
+}
+
+internal sealed record AiCaptionTranslationSegmentDto
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("text")]
+    public required string Text { get; init; }
+
+    [JsonPropertyName("context")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public AiCaptionTranslationSegmentContextDto? Context { get; init; }
+}
+
+internal sealed record AiCaptionTranslationStyleDto
+{
+    [JsonPropertyName("glossary")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Glossary { get; init; }
+
+    [JsonPropertyName("maxCharactersPerLine")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MaxCharactersPerLine { get; init; }
+
+    [JsonPropertyName("maxLines")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MaxLines { get; init; }
+}
+
+internal sealed record AiCaptionTranslationRequestDto
+{
+    [JsonPropertyName("sourceLanguage")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SourceLanguage { get; init; }
+
+    [JsonPropertyName("targetLanguage")]
+    public required string TargetLanguage { get; init; }
+
+    [JsonPropertyName("segments")]
+    public required AiCaptionTranslationSegmentDto[] Segments { get; init; }
+
+    [JsonPropertyName("style")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public AiCaptionTranslationStyleDto? Style { get; init; }
+
+    [JsonPropertyName("model")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Model { get; init; }
+}
+
+internal sealed record AiCaptionTranslationResponseDto
+{
+    [JsonPropertyName("jobId")]
+    public string? JobId { get; init; }
+
+    [JsonPropertyName("segments")]
+    public required AiCaptionTranslationSegmentDto[] Segments { get; init; }
+}

--- a/src/Beutl.Api/Clients/AiVideoJobResponse.cs
+++ b/src/Beutl.Api/Clients/AiVideoJobResponse.cs
@@ -1,0 +1,20 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Beutl.Api.Clients;
+
+internal sealed record AiVideoJobResponse
+{
+    [JsonPropertyName("jobId")] public required string JobId { get; init; }
+
+    [JsonPropertyName("status")] public required string Status { get; init; }
+
+    [JsonPropertyName("fileId")] public string? FileId { get; init; }
+
+    [JsonPropertyName("url")] public string? Url { get; init; }
+
+    [JsonPropertyName("fileName")] public string? FileName { get; init; }
+
+    [JsonPropertyName("contentType")] public string? ContentType { get; init; }
+
+    [JsonPropertyName("error")] public string? Error { get; init; }
+}

--- a/src/Beutl.Api/Clients/ApiErrorCode.cs
+++ b/src/Beutl.Api/Clients/ApiErrorCode.cs
@@ -61,4 +61,33 @@ public enum ApiErrorCode
     VirtualAssetCannotBeDownloaded,
 
     CannotDeleteReleaseAssets,
+
+    AiPlanRequired,
+
+    AiUsageLimitExceeded,
+
+    AiProviderError,
+
+    AiJobNotFound,
+
+    AiJobIsActive,
+
+    AiJobLimitReached,
+
+    AiRequestInProgress,
+
+    AiRequestWasDeleted,
+
+    /// <summary>
+    /// The name this request was sent under belongs to a different request.
+    /// Not a malformed body: putting the request back as it was collects what
+    /// that name already paid for, and leaving it changed is a new request.
+    /// </summary>
+    AiRequestChanged,
+
+    AiModelDoesNotSupportRequest,
+
+    AiModelUnavailable,
+
+    AiResultUnavailable,
 }

--- a/src/Beutl.Api/Clients/ApiErrorCodeConverter.cs
+++ b/src/Beutl.Api/Clients/ApiErrorCodeConverter.cs
@@ -1,0 +1,46 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Beutl.Api.Clients;
+
+/// <summary>
+/// Reads an error code the server names in camelCase, and reads one this
+/// client has never heard of as <see cref="ApiErrorCode.Unknown"/>.
+/// </summary>
+/// <remarks>
+/// A server is free to add codes; refusing to parse one would throw away the
+/// whole error body, turning a failure the client could still report — and its
+/// status, and its message — into an unexplained one. Unknown is what the enum
+/// already means by "a code with no handling of its own".
+/// </remarks>
+internal sealed class ApiErrorCodeConverter : JsonConverter<ApiErrorCode>
+{
+    public override ApiErrorCode Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String
+            && reader.GetString() is { Length: > 0 } name
+            && !char.IsAsciiDigit(name[0])
+            && Enum.TryParse(name, ignoreCase: true, out ApiErrorCode parsed))
+        {
+            return parsed;
+        }
+
+        if (reader.TokenType == JsonTokenType.Number
+            && reader.TryGetInt32(out int numeric)
+            && Enum.IsDefined((ApiErrorCode)numeric))
+        {
+            return (ApiErrorCode)numeric;
+        }
+
+        return ApiErrorCode.Unknown;
+    }
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        ApiErrorCode value,
+        JsonSerializerOptions options)
+        => writer.WriteStringValue(JsonNamingPolicy.CamelCase.ConvertName(value.ToString()));
+}

--- a/src/Beutl.Api/Clients/ApiErrorResponse.cs
+++ b/src/Beutl.Api/Clients/ApiErrorResponse.cs
@@ -4,7 +4,9 @@ namespace Beutl.Api.Clients;
 
 public class ApiErrorResponse
 {
-    [JsonPropertyName("error_code")] public required ApiErrorCode ErrorCode { get; init; }
+    [JsonPropertyName("error_code")]
+    [JsonConverter(typeof(ApiErrorCodeConverter))]
+    public required ApiErrorCode ErrorCode { get; init; }
 
     [JsonPropertyName("message")] public required string? Message { get; init; }
 

--- a/src/Beutl.Api/Clients/CreateAiImageRequest.cs
+++ b/src/Beutl.Api/Clients/CreateAiImageRequest.cs
@@ -1,0 +1,27 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Beutl.Api.Clients;
+
+internal sealed class CreateAiImageRequest
+{
+    [JsonPropertyName("prompt")] public required string Prompt { get; init; }
+
+    // The endpoint also accepts the fixed sizes it shipped with, but exactly one
+    // of the two may be sent. A ratio is what the provider actually speaks and
+    // the only way to ask for 16:9 or a vertical image.
+    [JsonPropertyName("aspectRatio")] public required string AspectRatio { get; init; }
+
+    [JsonPropertyName("background")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Background { get; init; }
+
+    [JsonPropertyName("seed")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? Seed { get; init; }
+
+    // Omitted rather than sent empty: the endpoint runs the operation's default
+    // model when no model is named, and refuses an id it does not know.
+    [JsonPropertyName("model")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Model { get; init; }
+}

--- a/src/Beutl.Api/Clients/CreateAiVideoResponse.cs
+++ b/src/Beutl.Api/Clients/CreateAiVideoResponse.cs
@@ -1,0 +1,31 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Beutl.Api.Clients;
+
+internal sealed record CreateAiVideoResponse
+{
+    [JsonPropertyName("jobId")] public required string JobId { get; init; }
+
+    [JsonPropertyName("status")] public required string Status { get; init; }
+}
+
+internal sealed record CreateAiVideoRequest
+{
+    [JsonPropertyName("prompt")] public required string Prompt { get; init; }
+
+    [JsonPropertyName("durationSeconds")] public required int DurationSeconds { get; init; }
+
+    [JsonPropertyName("resolution")] public string Resolution { get; init; } = "720p";
+
+    [JsonPropertyName("aspectRatio")] public string AspectRatio { get; init; } = "16:9";
+
+    [JsonPropertyName("generateAudio")] public bool GenerateAudio { get; init; } = true;
+
+    [JsonPropertyName("seed")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? Seed { get; init; }
+
+    [JsonPropertyName("model")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Model { get; init; }
+}

--- a/src/Beutl.Api/Clients/EntitlementsResponse.cs
+++ b/src/Beutl.Api/Clients/EntitlementsResponse.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Immutable;
+using System.Text.Json.Serialization;
+
+namespace Beutl.Api.Clients;
+
+internal sealed record EntitlementsResponse
+{
+    [JsonPropertyName("plan")] public required string? Plan { get; init; }
+
+    [JsonPropertyName("subscriptionStatus")] public required string? SubscriptionStatus { get; init; }
+
+    [JsonPropertyName("currentPeriodStart")] public required string? CurrentPeriodStart { get; init; }
+
+    [JsonPropertyName("currentPeriodEnd")] public required string? CurrentPeriodEnd { get; init; }
+
+    // A cancellation made in the Stripe customer portal keeps the subscription
+    // active until the period ends, so the status alone cannot report it.
+    [JsonPropertyName("cancelAtPeriodEnd")] public bool CancelAtPeriodEnd { get; init; }
+
+    [JsonPropertyName("canUseAi")] public required bool CanUseAi { get; init; }
+
+    [JsonPropertyName("balance")] public required AiBalanceResponse Balance { get; init; }
+
+    // The server decides what a client may start without sending its price catalog.
+    [JsonPropertyName("availability")]
+    public required ImmutableDictionary<string, bool> Availability { get; init; }
+
+    // Per model within each operation. An operation reads as available when any
+    // one of its models does, so this is what decides which entries a picker
+    // may offer.
+    [JsonPropertyName("modelAvailability")]
+    public ImmutableDictionary<string, ImmutableDictionary<string, bool>>? ModelAvailability { get; init; }
+
+    internal bool TryNormalize(out EntitlementsResponse? normalized)
+    {
+        normalized = null;
+        if (Balance is null
+            || !Balance.TryNormalize(out AiBalanceResponse? balance)
+            || Availability is null)
+        {
+            return false;
+        }
+
+        normalized = this with { Balance = balance! };
+        return true;
+    }
+}

--- a/src/Beutl.Api/Clients/IAiClient.cs
+++ b/src/Beutl.Api/Clients/IAiClient.cs
@@ -1,0 +1,133 @@
+﻿using Refit;
+
+namespace Beutl.Api.Clients;
+
+internal interface IAiClient
+{
+    [Get("/api/v3/ai/capabilities")]
+    Task<AiCapabilitiesResponse> GetCapabilities(
+        [Header("Authorization")] string authorization,
+        CancellationToken cancellationToken);
+
+    [Get("/api/v3/user/entitlements")]
+    Task<EntitlementsResponse> GetEntitlements(
+        [Header("Authorization")] string authorization,
+        CancellationToken cancellationToken);
+
+    [Post("/api/v3/ai/images")]
+    Task<AiImageResponse> CreateImage(
+        [Header("Authorization")] string authorization,
+        [Header("Idempotency-Key")] string idempotencyKey,
+        [Body] CreateAiImageRequest request,
+        CancellationToken cancellationToken);
+
+    // Guiding a generation with existing pictures makes it an upload, so the
+    // same endpoint is called as multipart. The JSON form above stays the path
+    // for a request that carries no reference.
+    [Multipart]
+    [Post("/api/v3/ai/images")]
+    Task<AiImageResponse> CreateImageFromReferences(
+        [Header("Authorization")] string authorization,
+        [Header("Idempotency-Key")] string idempotencyKey,
+        [AliasAs("reference[]")] IEnumerable<StreamPart> references,
+        [AliasAs("prompt")] string prompt,
+        [AliasAs("aspectRatio")] string aspectRatio,
+        [AliasAs("background")] string? background,
+        [AliasAs("seed")] string? seed,
+        [AliasAs("model")] string? model,
+        CancellationToken cancellationToken);
+
+    [Multipart]
+    [Post("/api/v3/ai/images/edit")]
+    Task<AiImageResponse> EditImage(
+        [Header("Authorization")] string authorization,
+        [Header("Idempotency-Key")] string idempotencyKey,
+        [AliasAs("file")] StreamPart file,
+        [AliasAs("task")] string task,
+        [AliasAs("prompt")] string? prompt,
+        [AliasAs("model")] string? model,
+        CancellationToken cancellationToken);
+
+    [Multipart]
+    [Post("/api/v3/ai/transcriptions")]
+    Task<AiTranscriptionResponseDto> Transcribe(
+        [Header("Authorization")] string authorization,
+        [Header("Idempotency-Key")] string idempotencyKey,
+        [AliasAs("file")] StreamPart file,
+        [AliasAs("language")] string? language,
+        [AliasAs("model")] string? model,
+        CancellationToken cancellationToken);
+
+    [Post("/api/v3/ai/videos")]
+    Task<CreateAiVideoResponse> CreateVideo(
+        [Header("Authorization")] string authorization,
+        [Header("Idempotency-Key")] string idempotencyKey,
+        [Body] CreateAiVideoRequest request,
+        CancellationToken cancellationToken);
+
+    [Multipart]
+    [Post("/api/v3/ai/videos/frames")]
+    Task<CreateAiVideoResponse> CreateVideoFromFrames(
+        [Header("Authorization")] string authorization,
+        [Header("Idempotency-Key")] string idempotencyKey,
+        [AliasAs("firstFrame")] StreamPart firstFrame,
+        [AliasAs("lastFrame")] StreamPart? lastFrame,
+        [AliasAs("prompt")] string prompt,
+        [AliasAs("durationSeconds")] int durationSeconds,
+        [AliasAs("resolution")] string resolution,
+        [AliasAs("aspectRatio")] string aspectRatio,
+        [AliasAs("generateAudio")] string generateAudio,
+        [AliasAs("seed")] string? seed,
+        [AliasAs("model")] string? model,
+        CancellationToken cancellationToken);
+
+    [Get("/api/v3/ai/videos/{id}")]
+    Task<AiVideoJobResponse> GetVideoJob(
+        [Header("Authorization")] string authorization,
+        string id,
+        CancellationToken cancellationToken);
+
+    [Get("/api/v3/ai/jobs")]
+    Task<AiJobHistoryPageResponse> GetJobs(
+        [Header("Authorization")] string authorization,
+        [AliasAs("cursor")] string? cursor,
+        [AliasAs("limit")] int limit,
+        CancellationToken cancellationToken);
+
+    [Delete("/api/v3/ai/jobs/{id}")]
+    Task<DeleteAiJobResponse> DeleteJob(
+        [Header("Authorization")] string authorization,
+        string id,
+        CancellationToken cancellationToken);
+
+    [Post("/api/v3/ai/translations")]
+    Task<AiCaptionTranslationResponseDto> Translate(
+        [Header("Authorization")] string authorization,
+        [Header("Idempotency-Key")] string idempotencyKey,
+        [Body] AiCaptionTranslationRequestDto request,
+        CancellationToken cancellationToken);
+
+    [Post("/api/v3/user/ai-availability")]
+    Task<AiOperationAvailabilityResponse> CheckFixedAvailability(
+        [Header("Authorization")] string authorization,
+        [Body] AiFixedOperationAvailabilityRequestDto request,
+        CancellationToken cancellationToken);
+
+    [Post("/api/v3/user/ai-availability")]
+    Task<AiOperationAvailabilityResponse> CheckVideoAvailability(
+        [Header("Authorization")] string authorization,
+        [Body] AiVideoOperationAvailabilityRequestDto request,
+        CancellationToken cancellationToken);
+
+    [Post("/api/v3/user/ai-availability")]
+    Task<AiOperationAvailabilityResponse> CheckTranscriptionAvailability(
+        [Header("Authorization")] string authorization,
+        [Body] AiTranscriptionOperationAvailabilityRequestDto request,
+        CancellationToken cancellationToken);
+
+    [Post("/api/v3/user/ai-availability")]
+    Task<AiOperationAvailabilityResponse> CheckTranslationAvailability(
+        [Header("Authorization")] string authorization,
+        [Body] AiTranslationOperationAvailabilityRequestDto request,
+        CancellationToken cancellationToken);
+}

--- a/src/Beutl.Api/Clients/IAiClient.cs
+++ b/src/Beutl.Api/Clients/IAiClient.cs
@@ -48,16 +48,6 @@ internal interface IAiClient
         [AliasAs("model")] string? model,
         CancellationToken cancellationToken);
 
-    [Multipart]
-    [Post("/api/v3/ai/transcriptions")]
-    Task<AiTranscriptionResponseDto> Transcribe(
-        [Header("Authorization")] string authorization,
-        [Header("Idempotency-Key")] string idempotencyKey,
-        [AliasAs("file")] StreamPart file,
-        [AliasAs("language")] string? language,
-        [AliasAs("model")] string? model,
-        CancellationToken cancellationToken);
-
     [Post("/api/v3/ai/videos")]
     Task<CreateAiVideoResponse> CreateVideo(
         [Header("Authorization")] string authorization,

--- a/src/Beutl.Api/Clients/IUsersClient.cs
+++ b/src/Beutl.Api/Clients/IUsersClient.cs
@@ -8,7 +8,9 @@ public interface IUsersClient
     Task<ProfileResponse> GetUser(string name, CancellationToken cancellationToken);
 
     [Get("/api/v3/user")]
-    Task<ProfileResponse> GetSelf(CancellationToken cancellationToken);
+    Task<ProfileResponse> GetSelf(
+        [Header("Authorization")] string authorization,
+        CancellationToken cancellationToken);
 
     [Get("/api/v3/users/{name}/packages")]
     Task<SimplePackageResponse[]> GetUserPackages(

--- a/src/Beutl.Api/Objects/AuthorizedUser.cs
+++ b/src/Beutl.Api/Objects/AuthorizedUser.cs
@@ -1,7 +1,4 @@
-﻿using System.Diagnostics;
-using System.Net.Http.Headers;
-using Beutl.Api.Clients;
-using Beutl.Api.Services;
+﻿using Beutl.Api.Clients;
 
 namespace Beutl.Api.Objects;
 
@@ -9,74 +6,69 @@ public class AuthenticatedUser(
     Profile profile,
     AuthResponse response,
     BeutlApiApplication clients,
-    HttpClient httpClient,
     DateTime writeTime)
 {
+    private readonly object _stateGate = new();
     private AuthResponse _response = response;
-
-    // user.jsonに書き込まれた時間
-    internal DateTime _writeTime = writeTime;
+    private DateTime _writeTime = writeTime;
 
     public Profile Profile { get; } = profile;
 
-    public string Token => _response.Token;
+    public string Token
+    {
+        get
+        {
+            lock (_stateGate)
+                return _response.Token;
+        }
+    }
 
-    public string RefreshToken => _response.RefreshToken;
+    public string RefreshToken
+    {
+        get
+        {
+            lock (_stateGate)
+                return _response.RefreshToken;
+        }
+    }
 
-    public DateTimeOffset Expiration => _response.Expiration;
+    public DateTimeOffset Expiration
+    {
+        get
+        {
+            lock (_stateGate)
+                return _response.Expiration;
+        }
+    }
 
     public bool IsExpired => Expiration < DateTimeOffset.UtcNow;
 
     public MyAsyncLock Lock => clients.Lock;
 
-    public async ValueTask RefreshAsync(CancellationToken cancellationToken, bool force = false)
+    public ValueTask RefreshAsync(
+        CancellationToken cancellationToken,
+        bool force = false)
+        => clients.RefreshAuthenticatedUserAsync(this, force, cancellationToken);
+
+    internal (AuthResponse Response, DateTime WriteTime) GetAuthenticationState()
     {
-        using CancellationTokenSource lifetimeCts = clients.CreateLifetimeLinkedTokenSource(cancellationToken);
-        CancellationToken token = lifetimeCts.Token;
-        using Activity? activity = clients.ActivitySource.StartActivity("AuthenticatedUser.Refresh", ActivityKind.Client);
+        lock (_stateGate)
+            return (_response, _writeTime);
+    }
 
-        string fileName = Path.Combine(Helper.AppRoot, BeutlApiApplication.UserFileName);
-        if (File.Exists(fileName))
+    internal void CommitAuthenticationState(AuthResponse nextResponse, DateTime nextWriteTime)
+    {
+        ArgumentNullException.ThrowIfNull(nextResponse);
+        lock (_stateGate)
         {
-            DateTime lastWriteTime = File.GetLastWriteTimeUtc(fileName);
-            if (_writeTime < lastWriteTime)
-            {
-                AuthenticatedUser? fileUser = await clients.ReadUserAsync(token);
-                token.ThrowIfCancellationRequested();
-                if (fileUser?.Profile?.Id == Profile.Id)
-                {
-                    _response = fileUser._response;
-                    _writeTime = lastWriteTime;
-                }
-                else if (fileUser != null)
-                {
-                    clients.SignOut(false);
-                    throw new InvalidOperationException("The user may have been changed in another process.");
-                }
-            }
+            _response = nextResponse;
+            _writeTime = nextWriteTime;
         }
+    }
 
-        activity?.SetTag("force", force);
-        activity?.SetTag("is_expired", IsExpired);
-
-        if (force || IsExpired)
-        {
-            AuthResponse response = await clients.Account.Refresh(new RefreshTokenRequest
-            {
-                RefreshToken = RefreshToken,
-                Token = Token
-            }, token)
-                .ConfigureAwait(false);
-            token.ThrowIfCancellationRequested();
-            _response = response;
-            activity?.AddEvent(new("Refreshed"));
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
-
-            if (clients.AuthenticatedUser.Value == this)
-            {
-                clients.SaveUser();
-                activity?.AddEvent(new("Saved"));
-            }
-        }
+    internal void SetWriteTime(DateTime value)
+    {
+        lock (_stateGate)
+            _writeTime = value;
     }
 }

--- a/src/Beutl.Api/Objects/Profile.cs
+++ b/src/Beutl.Api/Objects/Profile.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Reactive.Linq;
 using Beutl.Api.Clients;
+using Beutl.Api.Services;
 using Reactive.Bindings;
 
 namespace Beutl.Api.Objects;
@@ -9,24 +10,36 @@ public class Profile
 {
     private readonly BeutlApiApplication _clients;
     private readonly ReactivePropertySlim<ProfileResponse> _response;
+    private readonly ReadOnlyReactivePropertySlim<ProfileResponse> _readOnlyResponse;
+    private readonly object _stateGate = new();
+    private string _name;
+    private long _refreshVersion;
 
     public Profile(ProfileResponse response, BeutlApiApplication clients)
     {
         _clients = clients;
         _response = new ReactivePropertySlim<ProfileResponse>(response);
+        _readOnlyResponse = _response.ToReadOnlyReactivePropertySlim(response);
 
         Id = response.Id;
-        Name = response.Name;
+        _name = response.Name;
         Biography = Response.Select(x => x.Bio).ToReadOnlyReactivePropertySlim()!;
         DisplayName = Response.Select(x => x.DisplayName).ToReadOnlyReactivePropertySlim()!;
         AvatarUrl = Response.Select(x => x.IconUrl).ToReadOnlyReactivePropertySlim();
     }
 
-    public IReadOnlyReactiveProperty<ProfileResponse> Response => _response;
+    public IReadOnlyReactiveProperty<ProfileResponse> Response => _readOnlyResponse;
 
     public string Id { get; }
 
-    public string Name { get; private set; }
+    public string Name
+    {
+        get
+        {
+            lock (_stateGate)
+                return _name;
+        }
+    }
 
     public IReadOnlyReactiveProperty<string> Biography { get; }
 
@@ -40,20 +53,50 @@ public class Profile
     {
         using CancellationTokenSource lifetimeCts = _clients.CreateLifetimeLinkedTokenSource(cancellationToken);
         CancellationToken token = lifetimeCts.Token;
+        token.ThrowIfCancellationRequested();
+        long refreshVersion = Interlocked.Increment(ref _refreshVersion);
         using Activity? activity = _clients.ActivitySource.StartActivity("Profile.Refresh", ActivityKind.Client);
 
+        ProfileResponse response;
+        AuthenticatedUser? authenticatedUser = null;
         if (self)
         {
-            ProfileResponse response = await _clients.Users.GetSelf(token);
-            token.ThrowIfCancellationRequested();
-            _response.Value = response;
-            Name = _response.Value.Name;
+            authenticatedUser = _clients.AuthenticatedUser.Value
+                ?? throw new AuthenticationRequiredException();
+            if (!ReferenceEquals(authenticatedUser.Profile, this))
+                throw new AuthenticationRequiredException();
+            AuthenticatedApiResult<ProfileResponse> result = await _clients.SendAuthenticatedAsync(
+                (authorization, requestToken) => _clients.Users.GetSelf(authorization, requestToken),
+                token,
+                authenticatedUser);
+            response = result.Value;
         }
         else
         {
-            ProfileResponse response = await _clients.Users.GetUser(Name, token);
-            token.ThrowIfCancellationRequested();
-            _response.Value = response;
+            string name = Name;
+            response = await _clients.Users.GetUser(name, token);
+        }
+
+        token.ThrowIfCancellationRequested();
+        void CommitResponse()
+        {
+            lock (_stateGate)
+            {
+                if (refreshVersion != Volatile.Read(ref _refreshVersion))
+                    return;
+
+                _name = response.Name;
+                _response.Value = response;
+            }
+        }
+
+        if (authenticatedUser is null)
+        {
+            CommitResponse();
+        }
+        else
+        {
+            _clients.CommitForAuthenticatedUser(authenticatedUser, CommitResponse, token);
         }
     }
 
@@ -64,21 +107,20 @@ public class Profile
     {
         using CancellationTokenSource lifetimeCts = _clients.CreateLifetimeLinkedTokenSource(cancellationToken);
         CancellationToken token = lifetimeCts.Token;
+        token.ThrowIfCancellationRequested();
         using Activity? activity = _clients.ActivitySource.StartActivity("Profile.GetPackages", ActivityKind.Client);
         activity?.SetTag("start", start);
         activity?.SetTag("count", count);
 
-        // TODO: System.Interactive.AsyncからSystem.Linq.Asyncが削除されれば、AsyncEnumerableを使った実装に戻す
-        SimplePackageResponse[] packages = await _clients.Users.GetUserPackages(Name, token, start, count);
+        string name = Name;
+        SimplePackageResponse[] packages = await _clients.Users.GetUserPackages(
+            name,
+            token,
+            start,
+            count);
+        PackageResponse[] responses = await Task.WhenAll(
+            packages.Select(package => _clients.Packages.GetPackage(package.Name, token)));
         token.ThrowIfCancellationRequested();
-        // Await all requests so a fault in one does not sever the others from the lifetime token.
-        Package[] result = await Task.WhenAll(
-            packages.Select(async x =>
-            {
-                PackageResponse response = await _clients.Packages.GetPackage(x.Name, token);
-                return new Package(this, response, _clients);
-            }));
-        token.ThrowIfCancellationRequested();
-        return result;
+        return responses.Select(response => new Package(this, response, _clients)).ToArray();
     }
 }

--- a/src/Beutl.Api/Services/AiCapabilityServices.cs
+++ b/src/Beutl.Api/Services/AiCapabilityServices.cs
@@ -589,23 +589,50 @@ internal sealed class AiTranscriptionService(
             request.Audio,
             AiRequestLimits.MaxTranscriptionUploadBytes,
             cancellationToken);
-        var filePart = new StreamPart(
-            stream,
-            request.Audio.FileName,
-            request.Audio.MediaType);
-        return await ExecuteAsync(
+        return await ExecuteStreamingAsync(
             "AiTranscriptionService.Transcribe",
-            (authorization, token) => Application.Ai.Transcribe(
-                authorization,
-                idempotencyKey,
-                filePart,
-                request.Language,
-                request.Model?.Value,
-                token),
-            AiModelMapper.ToModel,
-            cancellationToken);
+            () =>
+            {
+                var body = new MultipartFormDataContent();
+                var file = new StreamContent(stream);
+                file.Headers.ContentType = MediaTypeHeaderValue.Parse(request.Audio.MediaType);
+                body.Add(file, "file", request.Audio.FileName);
+                if (request.Language is not null)
+                    body.Add(new StringContent(request.Language), "language");
+                if (request.Model is { } model)
+                    body.Add(new StringContent(model.Value), "model");
+                var message = new HttpRequestMessage(HttpMethod.Post, "/api/v3/ai/transcriptions") { Content = body };
+                message.Headers.TryAddWithoutValidation("Idempotency-Key", idempotencyKey);
+                return message;
+            },
+            _ => { },
+            ReadTranscriptionResult,
+            cancellationToken,
+            requestEventStream: false);
     }
 
+    internal static AiTranscriptionResponse ReadTranscriptionResult(string body)
+    {
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(body);
+            if (document.RootElement.ValueKind != JsonValueKind.Object
+                || !document.RootElement.TryGetProperty("segments", out JsonElement segments)
+                || segments.ValueKind != JsonValueKind.Array || segments.GetArrayLength() > 10000)
+                throw new AiProviderErrorException(new InvalidDataException("The transcription result has an invalid or excessive segment count."));
+            if (document.RootElement.TryGetProperty("words", out JsonElement words)
+                && words.ValueKind != JsonValueKind.Null
+                && (words.ValueKind != JsonValueKind.Array || words.GetArrayLength() > 100000))
+                throw new AiProviderErrorException(new InvalidDataException("The transcription result has an invalid or excessive word count."));
+            return AiModelMapper.ToModel(
+                JsonSerializer.Deserialize<AiTranscriptionResponseDto>(body, AiStreamJson.Options)
+                ?? throw new AiProviderErrorException(new InvalidDataException("The transcription result was empty.")));
+        }
+        catch (JsonException ex)
+        {
+            throw new AiProviderErrorException(ex);
+        }
+    }
 }
 
 internal sealed class AiCaptionTranslationService(

--- a/src/Beutl.Api/Services/AiCapabilityServices.cs
+++ b/src/Beutl.Api/Services/AiCapabilityServices.cs
@@ -1,0 +1,1248 @@
+﻿using System.Buffers;
+using System.Diagnostics;
+using System.Globalization;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Beutl.Api.Clients;
+using Beutl.Api.Objects;
+using Reactive.Bindings;
+using Refit;
+
+namespace Beutl.Api.Services;
+
+internal sealed class AiEntitlementService(
+    BeutlApiApplication application,
+    AiEntitlementStore entitlementStore) : IAiEntitlementService
+{
+    public IReadOnlyReactiveProperty<AiEntitlements?> Entitlements
+        => entitlementStore.Entitlements;
+
+    public async Task<AiEntitlements?> RefreshAsync(CancellationToken cancellationToken)
+    {
+        using CancellationTokenSource operationCts =
+            application.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = operationCts.Token;
+        token.ThrowIfCancellationRequested();
+        using Activity? activity = application.ActivitySource.StartActivity(
+            "AiEntitlementService.Refresh",
+            ActivityKind.Client);
+
+        AuthenticatedUser? authenticatedUser = application.AuthenticatedUser.Value;
+        if (authenticatedUser is null)
+            return null;
+
+        await entitlementStore.WaitForBalanceRequestAsync(token);
+        long snapshotRequest = entitlementStore.BeginSnapshotRequest();
+        try
+        {
+            AuthenticatedApiResult<EntitlementsResponse> response =
+                await application.SendAuthenticatedAsync(
+                    (authorization, requestToken) =>
+                        application.Ai.GetEntitlements(authorization, requestToken),
+                    token,
+                    authenticatedUser);
+            AiEntitlements result = AiModelMapper.ToModel(response.Value);
+            entitlementStore.ApplyEntitlements(result, response.User, snapshotRequest);
+            return result;
+        }
+        catch (ApiException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error);
+            entitlementStore.ApplyEntitlements(null, authenticatedUser, snapshotRequest);
+            return null;
+        }
+        finally
+        {
+            entitlementStore.ReleaseBalanceRequest();
+        }
+    }
+}
+
+internal sealed class AiModelCatalogService : IAiModelCatalogService, IDisposable
+{
+    // Long enough that opening a few dialogs in a row does not fetch the list
+    // again, short enough that a model the operator disables — or adds, or
+    // reorders — stops being offered without the editor being restarted.
+    private static readonly TimeSpan s_freshness = TimeSpan.FromMinutes(5);
+    private readonly BeutlApiApplication _application;
+    private readonly TimeProvider _timeProvider;
+    private readonly IAiOperationCapabilitySchemaProvider _capabilitySchemas;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly IDisposable _authenticationSubscription;
+    private readonly object _cacheGate = new();
+    private AiModelCatalog? _catalog;
+    private AuthenticatedUser? _catalogOwner;
+    private long _catalogSchemaRevision = -1;
+    private long _fetchedAt;
+    private int _disposed;
+
+    internal Action? BeforeCachePublication { get; set; }
+
+    public AiModelCatalogService(
+        BeutlApiApplication application,
+        TimeProvider? timeProvider = null,
+        IAiOperationCapabilitySchemaProvider? capabilitySchemas = null)
+    {
+        _application = application;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _capabilitySchemas = capabilitySchemas
+            ?? BuiltInAiOperationCapabilitySchemaProvider.Instance;
+        // The catalog is the list one account may pay for. Another account's is
+        // a different list, so signing in as someone else drops it rather than
+        // offering them models that were never theirs.
+        _authenticationSubscription = application.AuthenticatedUser.Subscribe(_ => Invalidate());
+        _capabilitySchemas.Changed += OnCapabilitySchemasChanged;
+    }
+
+    public async Task<AiModelCatalog> GetAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+        if (TryGetFresh(out AiModelCatalog? cached))
+            return cached!;
+
+        using CancellationTokenSource operationCts =
+            _application.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = operationCts.Token;
+        await _gate.WaitAsync(token);
+        try
+        {
+            ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+            if (TryGetFresh(out AiModelCatalog? raced))
+                return raced!;
+
+            using Activity? activity = _application.ActivitySource.StartActivity(
+                "AiModelCatalogService.Get",
+                ActivityKind.Client);
+            AuthenticatedUser? authenticatedUser = _application.AuthenticatedUser.Value;
+            if (authenticatedUser is null)
+                return AiModelCatalog.Empty;
+
+            try
+            {
+                AuthenticatedApiResult<AiCapabilitiesResponse> response =
+                    await _application.SendAuthenticatedAsync(
+                        (authorization, requestToken) =>
+                            _application.Ai.GetCapabilities(authorization, requestToken),
+                        token,
+                        authenticatedUser);
+                AiOperationCapabilitySchemaSnapshot schemaSnapshot =
+                    _capabilitySchemas.GetSnapshot();
+                AiModelCatalog catalog = AiModelMapper.ToModel(response.Value, schemaSnapshot);
+                BeforeCachePublication?.Invoke();
+                while (true)
+                {
+                    AiOperationCapabilitySchemaSnapshot latestSchemaSnapshot =
+                        _capabilitySchemas.GetSnapshot();
+                    if (latestSchemaSnapshot.Revision != schemaSnapshot.Revision)
+                    {
+                        schemaSnapshot = latestSchemaSnapshot;
+                        catalog = AiModelMapper.ToModel(response.Value, schemaSnapshot);
+                        continue;
+                    }
+
+                    bool published = false;
+                    lock (_cacheGate)
+                    {
+                        if (!ReferenceEquals(_application.AuthenticatedUser.Value, response.User))
+                            return AiModelCatalog.Empty;
+
+                        latestSchemaSnapshot = _capabilitySchemas.GetSnapshot();
+                        if (latestSchemaSnapshot.Revision == schemaSnapshot.Revision)
+                        {
+                            _catalog = catalog;
+                            _catalogOwner = response.User;
+                            _catalogSchemaRevision = schemaSnapshot.Revision;
+                            _fetchedAt = _timeProvider.GetTimestamp();
+                            published = true;
+                        }
+                    }
+
+                    if (!published)
+                    {
+                        schemaSnapshot = latestSchemaSnapshot;
+                        catalog = AiModelMapper.ToModel(response.Value, schemaSnapshot);
+                        continue;
+                    }
+
+                    latestSchemaSnapshot = _capabilitySchemas.GetSnapshot();
+                    if (latestSchemaSnapshot.Revision == schemaSnapshot.Revision)
+                        return catalog;
+
+                    Invalidate();
+                    schemaSnapshot = latestSchemaSnapshot;
+                    catalog = AiModelMapper.ToModel(response.Value, schemaSnapshot);
+                }
+            }
+            catch (ApiException ex)
+            {
+                // A dialog that cannot list the models still has to open. It
+                // then offers no choice and the server uses its default, which
+                // is exactly what this client did before it could choose.
+                activity?.SetStatus(ActivityStatusCode.Error);
+                activity?.SetTag("statusCode", (int)ex.StatusCode);
+                return AiModelCatalog.Empty;
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public void Invalidate()
+    {
+        lock (_cacheGate)
+        {
+            _catalog = null;
+            _catalogOwner = null;
+            _catalogSchemaRevision = -1;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        _authenticationSubscription.Dispose();
+        _capabilitySchemas.Changed -= OnCapabilitySchemasChanged;
+        // Dispose is synchronous, while an in-flight GetAsync may still own the
+        // semaphore and release it after application-lifetime cancellation. The
+        // gate never exposes its wait handle, so keeping it alive avoids turning
+        // that expected cancellation into ObjectDisposedException.
+    }
+
+    private bool TryGetFresh(out AiModelCatalog? catalog)
+    {
+        while (true)
+        {
+            AiOperationCapabilitySchemaSnapshot schemaSnapshot =
+                _capabilitySchemas.GetSnapshot();
+            lock (_cacheGate)
+            {
+                catalog = _catalog;
+                if (catalog is null
+                    || !ReferenceEquals(_catalogOwner, _application.AuthenticatedUser.Value)
+                    || _catalogSchemaRevision != schemaSnapshot.Revision
+                    || _timeProvider.GetElapsedTime(_fetchedAt) >= s_freshness)
+                {
+                    return false;
+                }
+            }
+
+            if (_capabilitySchemas.GetSnapshot().Revision == schemaSnapshot.Revision)
+                return true;
+        }
+    }
+
+    private void OnCapabilitySchemasChanged(object? sender, EventArgs e) => Invalidate();
+}
+
+internal sealed class AiOperationAvailabilityService(BeutlApiApplication application)
+    : IAiOperationAvailabilityService
+{
+    public async Task<bool> CheckAsync(
+        AiOperationAvailabilityRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        using CancellationTokenSource operationCts =
+            application.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = operationCts.Token;
+        token.ThrowIfCancellationRequested();
+        using Activity? activity = application.ActivitySource.StartActivity(
+            "AiOperationAvailabilityService.Check",
+            ActivityKind.Client);
+        activity?.SetTag("operation", request.Operation.Value);
+
+        Func<string, CancellationToken, Task<AiOperationAvailabilityResponse>> send = request switch
+        {
+            AiOperationAvailabilityRequest.Fixed fixedRequest =>
+                (authorization, requestToken) => application.Ai.CheckFixedAvailability(
+                    authorization,
+                    new AiFixedOperationAvailabilityRequestDto
+                    {
+                        Operation = fixedRequest.Operation.Value,
+                        Model = fixedRequest.Model?.Value,
+                    },
+                    requestToken),
+            AiOperationAvailabilityRequest.Video videoRequest =>
+                (authorization, requestToken) => application.Ai.CheckVideoAvailability(
+                    authorization,
+                    new AiVideoOperationAvailabilityRequestDto
+                    {
+                        Operation = videoRequest.Operation.Value,
+                        DurationSeconds = videoRequest.DurationSeconds,
+                        Model = videoRequest.Model?.Value,
+                    },
+                    requestToken),
+            AiOperationAvailabilityRequest.Transcription transcriptionRequest =>
+                (authorization, requestToken) => application.Ai.CheckTranscriptionAvailability(
+                    authorization,
+                    new AiTranscriptionOperationAvailabilityRequestDto
+                    {
+                        Operation = transcriptionRequest.Operation.Value,
+                        DurationSeconds = transcriptionRequest.DurationSeconds,
+                        Model = transcriptionRequest.Model?.Value,
+                    },
+                    requestToken),
+            AiOperationAvailabilityRequest.Translation translationRequest =>
+                (authorization, requestToken) => application.Ai.CheckTranslationAvailability(
+                    authorization,
+                    new AiTranslationOperationAvailabilityRequestDto
+                    {
+                        Operation = translationRequest.Operation.Value,
+                        CharacterCount = translationRequest.CharacterCount,
+                        Model = translationRequest.Model?.Value,
+                    },
+                    requestToken),
+            _ => throw new ArgumentOutOfRangeException(nameof(request)),
+        };
+
+        try
+        {
+            AuthenticatedApiResult<AiOperationAvailabilityResponse> response =
+                await application.SendAuthenticatedAsync(send, token);
+            return response.Value.Available;
+        }
+        catch (ApiException ex)
+        {
+            throw await AiErrorConverter.ConvertAsync(ex, activity);
+        }
+    }
+}
+
+internal sealed class AiImageGenerationService(
+    BeutlApiApplication application,
+    AiJobChangeNotifier jobChangeNotifier)
+    : AiMeteredCapabilityService(application, jobChangeNotifier),
+        IAiImageGenerationService
+{
+    private const int MaximumImagePreviewCount = 4;
+    private const long MaximumImagePreviewBytes = AiRequestLimits.MaxImageUploadBytes;
+
+    public Task<AiImageResult> GenerateAsync(
+        AiImageGenerationRequest request,
+        CancellationToken cancellationToken)
+        => GenerateAsync(request, null, cancellationToken);
+
+    public async Task<AiImageResult> GenerateAsync(
+        AiImageGenerationRequest request,
+        IProgress<AiImagePreview>? progress,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        // The caller's key when it has one: that is what lets a retry recover a
+        // picture already paid for instead of buying it again.
+        string idempotencyKey = request.IdempotencyKey ?? CreateIdempotencyKey();
+        // The endpoint reads "auto" and an absent background the same way, so
+        // leaving it to the model is sent as nothing at all.
+        string backgroundValue = request.Background.Value;
+        string? background =
+            backgroundValue.Length > 0 && backgroundValue != "auto" ? backgroundValue : null;
+
+        if (request.References.Count == 0)
+        {
+            var body = new CreateAiImageRequest
+            {
+                Prompt = request.Prompt,
+                AspectRatio = request.AspectRatio.Value,
+                Background = background,
+                Seed = request.Seed,
+                Model = request.Model?.Value,
+            };
+            if (progress is null)
+            {
+                return await ExecuteAsync(
+                    "AiImageGenerationService.Generate",
+                    (authorization, token) => Application.Ai.CreateImage(
+                        authorization,
+                        idempotencyKey,
+                        body,
+                        token),
+                    AiModelMapper.ToModel,
+                    cancellationToken,
+                    activity => SetImageTags(activity, request));
+            }
+
+            var previewBudget = new ImagePreviewBudget();
+            return await ExecuteStreamingAsync(
+                "AiImageGenerationService.Generate",
+                () => JsonRequest("/api/v3/ai/images", idempotencyKey, body),
+                item => ReportImagePreview(item, progress, previewBudget),
+                data => AiModelMapper.ToModel(
+                    JsonSerializer.Deserialize<AiImageResponse>(
+                        data,
+                        AiStreamJson.Options)
+                    ?? throw new AiException("The AI image result was empty.")),
+                cancellationToken,
+                activity => SetImageTags(activity, request));
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        // Every reference is held open for the whole upload, so they are opened
+        // together and closed together — one that failed to open must not leave
+        // the ones before it behind.
+        var streams = new List<Stream>(request.References.Count);
+        try
+        {
+            var referenceParts = new List<StreamPart>(request.References.Count);
+            foreach (AiUploadSource reference in request.References)
+            {
+                Stream stream = await AiUploadValidation.OpenAsync(
+                    reference,
+                    AiRequestLimits.MaxImageUploadBytes,
+                    cancellationToken);
+                streams.Add(stream);
+                if (streams.Sum(value => value.Length - value.Position)
+                    > request.ReferenceLimits.MaxTotalBytes)
+                {
+                    throw new AiFileTooLargeException();
+                }
+                referenceParts.Add(new StreamPart(
+                    stream,
+                    reference.FileName,
+                    reference.MediaType));
+            }
+
+            return await ExecuteAsync(
+                "AiImageGenerationService.GenerateFromReferences",
+                (authorization, token) => Application.Ai.CreateImageFromReferences(
+                    authorization,
+                    idempotencyKey,
+                    referenceParts,
+                    request.Prompt,
+                    request.AspectRatio.Value,
+                    background,
+                    request.Seed?.ToString(CultureInfo.InvariantCulture),
+                    request.Model?.Value,
+                    token),
+                AiModelMapper.ToModel,
+                cancellationToken,
+                activity => SetImageTags(activity, request));
+        }
+        finally
+        {
+            await DisposeReferenceStreamsAsync(streams);
+        }
+    }
+
+    private static async ValueTask DisposeReferenceStreamsAsync(IReadOnlyList<Stream> streams)
+    {
+        List<Exception>? failures = null;
+        foreach (Stream stream in streams)
+        {
+            try
+            {
+                await stream.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                (failures ??= []).Add(ex);
+            }
+        }
+
+        if (failures is not null)
+        {
+            throw new AggregateException(
+                "One or more AI image reference streams failed to close.",
+                failures);
+        }
+    }
+
+    // A picture midway through being worked out. Anything that cannot be read as
+    // one is passed over: it is a preview, and the finished picture is what the
+    // caller is really waiting for.
+    private static void ReportImagePreview(
+        AiServerSentEvent item,
+        IProgress<AiImagePreview> progress,
+        ImagePreviewBudget budget)
+    {
+        if (item.Event != "partial")
+            return;
+
+        AiImagePartialDto? partial;
+        try
+        {
+            partial = JsonSerializer.Deserialize<AiImagePartialDto>(
+                item.Data,
+                AiStreamJson.Options);
+        }
+        catch (JsonException)
+        {
+            return;
+        }
+
+        if (partial is null || partial.Index < 0 || string.IsNullOrEmpty(partial.Image))
+            return;
+
+        byte[] bytes;
+        try
+        {
+            bytes = System.Convert.FromBase64String(partial.Image);
+        }
+        catch (FormatException)
+        {
+            return;
+        }
+
+        if (bytes.Length > 0
+            && bytes.LongLength <= AiRequestLimits.MaxImageUploadBytes
+            && budget.TryReserve(bytes.LongLength))
+        {
+            progress.Report(new AiImagePreview(partial.Index, bytes));
+        }
+    }
+
+    internal sealed class ImagePreviewBudget
+    {
+        private int _count;
+        private long _bytes;
+
+        public bool TryReserve(long bytes)
+        {
+            if (_count >= MaximumImagePreviewCount
+                || _bytes > MaximumImagePreviewBytes - bytes)
+            {
+                return false;
+            }
+
+            _count++;
+            _bytes += bytes;
+            return true;
+        }
+    }
+
+    private sealed record AiImagePartialDto
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("index")]
+        public required int Index { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("image")]
+        public string? Image { get; init; }
+    }
+
+    private static void SetImageTags(Activity? activity, AiImageGenerationRequest request)
+    {
+        activity?.SetTag("aspectRatio", request.AspectRatio.Value);
+        activity?.SetTag("background", request.Background.Value);
+        activity?.SetTag("referenceCount", request.References.Count);
+    }
+}
+
+internal sealed class AiImageEditingService(
+    BeutlApiApplication application,
+    AiJobChangeNotifier jobChangeNotifier)
+    : AiMeteredCapabilityService(application, jobChangeNotifier),
+        IAiImageEditingService
+{
+    public async Task<AiImageResult> EditAsync(
+        AiImageEditRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        // The caller's key when it has one: that is what lets a retry recover an
+        // edit already paid for instead of buying it again.
+        string idempotencyKey = request.IdempotencyKey ?? CreateIdempotencyKey();
+        cancellationToken.ThrowIfCancellationRequested();
+        await using Stream stream = await AiUploadValidation.OpenAsync(
+            request.Image,
+            AiRequestLimits.MaxImageUploadBytes,
+            cancellationToken);
+        var filePart = new StreamPart(
+            stream,
+            request.Image.FileName,
+            request.Image.MediaType);
+        return await ExecuteAsync(
+            "AiImageEditingService.Edit",
+            (authorization, token) => Application.Ai.EditImage(
+                authorization,
+                idempotencyKey,
+                filePart,
+                request.Task.Value,
+                request.Prompt,
+                request.Model?.Value,
+                token),
+            AiModelMapper.ToModel,
+            cancellationToken,
+            activity => activity?.SetTag("task", request.Task.Value));
+    }
+}
+
+internal sealed class AiTranscriptionService(
+    BeutlApiApplication application,
+    AiJobChangeNotifier jobChangeNotifier)
+    : AiMeteredCapabilityService(application, jobChangeNotifier),
+        IAiTranscriptionService
+{
+    public async Task<AiTranscriptionResponse> TranscribeAsync(
+        AiTranscriptionRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        // The caller's key when it has one: that is what lets a retry recover a
+        // transcription already paid for instead of buying it again.
+        string idempotencyKey = request.IdempotencyKey ?? CreateIdempotencyKey();
+        cancellationToken.ThrowIfCancellationRequested();
+        await using Stream stream = await AiUploadValidation.OpenAsync(
+            request.Audio,
+            AiRequestLimits.MaxTranscriptionUploadBytes,
+            cancellationToken);
+        var filePart = new StreamPart(
+            stream,
+            request.Audio.FileName,
+            request.Audio.MediaType);
+        return await ExecuteAsync(
+            "AiTranscriptionService.Transcribe",
+            (authorization, token) => Application.Ai.Transcribe(
+                authorization,
+                idempotencyKey,
+                filePart,
+                request.Language,
+                request.Model?.Value,
+                token),
+            AiModelMapper.ToModel,
+            cancellationToken);
+    }
+
+}
+
+internal sealed class AiCaptionTranslationService(
+    BeutlApiApplication application,
+    AiJobChangeNotifier jobChangeNotifier)
+    : AiMeteredCapabilityService(application, jobChangeNotifier),
+        IAiCaptionTranslationService
+{
+    public Task<AiCaptionTranslationResponse> TranslateAsync(
+        AiCaptionTranslationRequest request,
+        CancellationToken cancellationToken)
+        => TranslateAsync(request, null, cancellationToken);
+
+    public Task<AiCaptionTranslationResponse> TranslateAsync(
+        AiCaptionTranslationRequest request,
+        IProgress<AiCaptionTranslationSegment>? progress,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        AiCaptionTranslationRequestPayload payload =
+            AiCaptionTranslationRequestTransport.CreatePayload(request);
+        // The caller's key when it has one: that is what lets a retry recover a
+        // translation already paid for instead of buying it again.
+        string idempotencyKey = request.IdempotencyKey ?? CreateIdempotencyKey();
+        void Describe(Activity? activity)
+        {
+            activity?.SetTag("segmentCount", request.Segments.Count);
+            activity?.SetTag("targetLanguage", request.TargetLanguage);
+            activity?.SetTag("streamed", progress is not null);
+        }
+
+        if (progress is null)
+        {
+            return ExecuteStreamingAsync(
+                "AiCaptionTranslationService.Translate",
+                () => JsonRequestBytes(
+                    "/api/v3/ai/translations",
+                    idempotencyKey,
+                    payload.Json),
+                _ => { },
+                data => AiModelMapper.ToModel(
+                    JsonSerializer.Deserialize<AiCaptionTranslationResponseDto>(
+                        data,
+                        AiStreamJson.Options)
+                    ?? throw new AiException("The AI translation result was empty.")),
+                cancellationToken,
+                Describe,
+                requestEventStream: false);
+        }
+
+        HashSet<string> requestedSegmentIds = request.Segments
+            .Select(static segment => segment.Id)
+            .ToHashSet(StringComparer.Ordinal);
+        var reportedSegmentIds = new HashSet<string>(StringComparer.Ordinal);
+        return ExecuteStreamingAsync(
+            "AiCaptionTranslationService.Translate",
+            () => JsonRequestBytes("/api/v3/ai/translations", idempotencyKey, payload.Json),
+            item => ReportTranslationSegment(
+                item,
+                progress,
+                requestedSegmentIds,
+                reportedSegmentIds),
+            data => AiModelMapper.ToModel(
+                JsonSerializer.Deserialize<AiCaptionTranslationResponseDto>(
+                    data,
+                    AiStreamJson.Options)
+                ?? throw new AiException("The AI translation result was empty.")),
+            cancellationToken,
+            Describe);
+    }
+
+    private static void ReportTranslationSegment(
+        AiServerSentEvent item,
+        IProgress<AiCaptionTranslationSegment> progress,
+        IReadOnlySet<string> requestedSegmentIds,
+        ISet<string> reportedSegmentIds)
+    {
+        if (item.Event != "segment")
+            return;
+
+        AiCaptionTranslationSegmentDto? segment;
+        try
+        {
+            segment = JsonSerializer.Deserialize<AiCaptionTranslationSegmentDto>(
+                item.Data,
+                AiStreamJson.Options);
+        }
+        catch (JsonException)
+        {
+            return;
+        }
+
+        if (segment is null
+            || !AiRequestLimits.IsSafeTranslationIdentifier(segment.Id)
+            || string.IsNullOrWhiteSpace(segment.Text)
+            || segment.Text.Length > AiRequestLimits.MaxTranslationCharacters
+            || !requestedSegmentIds.Contains(segment.Id)
+            || !reportedSegmentIds.Add(segment.Id))
+        {
+            return;
+        }
+
+        progress.Report(new AiCaptionTranslationSegment
+        {
+            Id = segment.Id,
+            Text = segment.Text,
+        });
+    }
+}
+
+internal sealed class AiVideoService(
+    BeutlApiApplication application,
+    AiJobChangeNotifier jobChangeNotifier)
+    : AiMeteredCapabilityService(application, jobChangeNotifier), IAiVideoService
+{
+    public async Task<AiVideoGenerationResult> CreateAsync(
+        AiVideoGenerationRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        // The caller's key when it has one: that is what lets a retry recover a
+        // clip already paid for instead of buying it again.
+        string idempotencyKey = request.IdempotencyKey ?? CreateIdempotencyKey();
+        if (request.FirstFrame is null)
+        {
+            return await ExecuteAsync(
+                "AiVideoService.Create",
+                (authorization, token) => Application.Ai.CreateVideo(
+                    authorization,
+                    idempotencyKey,
+                    new CreateAiVideoRequest
+                    {
+                        Prompt = request.Prompt,
+                        DurationSeconds = request.DurationSeconds,
+                        Resolution = request.Resolution.Value,
+                        AspectRatio = request.AspectRatio.Value,
+                        GenerateAudio = request.GenerateAudio,
+                        Seed = request.Seed,
+                        Model = request.Model?.Value,
+                    },
+                    token),
+                AiModelMapper.ToModel,
+                cancellationToken,
+                activity => SetVideoTags(activity, request));
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await using Stream firstStream = await OpenFrameStreamAsync(
+            request.FirstFrame,
+            cancellationToken);
+        await using Stream? lastStream = request.LastFrame is null
+            ? null
+            : await OpenFrameStreamAsync(request.LastFrame, cancellationToken);
+        var firstPart = new StreamPart(
+            firstStream,
+            request.FirstFrame.FileName,
+            request.FirstFrame.MediaType);
+        StreamPart? lastPart = request.LastFrame is null || lastStream is null
+            ? null
+            : new StreamPart(
+                lastStream,
+                request.LastFrame.FileName,
+                request.LastFrame.MediaType);
+        return await ExecuteAsync(
+            "AiVideoService.CreateFromFrames",
+            (authorization, token) => Application.Ai.CreateVideoFromFrames(
+                authorization,
+                idempotencyKey,
+                firstPart,
+                lastPart,
+                request.Prompt,
+                request.DurationSeconds,
+                request.Resolution.Value,
+                request.AspectRatio.Value,
+                request.GenerateAudio ? "true" : "false",
+                request.Seed?.ToString(CultureInfo.InvariantCulture),
+                request.Model?.Value,
+                token),
+            AiModelMapper.ToModel,
+            cancellationToken,
+            activity => SetVideoTags(activity, request));
+    }
+
+    public Task<AiVideoJob> GetAsync(
+        AiJobId jobId,
+        CancellationToken cancellationToken)
+    {
+        if (jobId.Value.Length == 0)
+            throw new ArgumentException("A job identifier is required.", nameof(jobId));
+        return ExecuteAsync(
+            "AiVideoService.Get",
+            (authorization, token) => Application.Ai.GetVideoJob(
+                authorization,
+                jobId.Value,
+                token),
+            AiModelMapper.ToModel,
+            cancellationToken,
+            activity => activity?.SetTag("jobId", jobId.Value),
+            notifyJobsChanged: false);
+    }
+
+    private static void SetVideoTags(Activity? activity, AiVideoGenerationRequest request)
+    {
+        activity?.SetTag("durationSeconds", request.DurationSeconds);
+        activity?.SetTag("resolution", request.Resolution.Value);
+        activity?.SetTag("aspectRatio", request.AspectRatio.Value);
+        activity?.SetTag("generateAudio", request.GenerateAudio);
+        activity?.SetTag("hasFirstFrame", request.FirstFrame is not null);
+        activity?.SetTag("hasLastFrame", request.LastFrame is not null);
+    }
+
+    private static async ValueTask<Stream> OpenFrameStreamAsync(
+        AiUploadSource source,
+        CancellationToken cancellationToken)
+    {
+        return await AiUploadValidation.OpenAsync(
+            source,
+            AiRequestLimits.MaxFrameUploadBytes,
+            cancellationToken);
+    }
+}
+
+internal sealed class AuthenticatedContentService(BeutlApiApplication application)
+    : IAuthenticatedContentService
+{
+    public async Task<AiContentDownload> CopyToAsync(
+        Uri contentUri,
+        Stream destination,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(contentUri);
+        ArgumentNullException.ThrowIfNull(destination);
+        if (!destination.CanWrite)
+            throw new ArgumentException("The destination stream must be writable.", nameof(destination));
+        Uri downloadUri = ValidateContentUri(contentUri);
+        using CancellationTokenSource operationCts =
+            application.CreateLifetimeLinkedTokenSource(cancellationToken);
+        AuthenticatedApiResult<AiContentDownload> result =
+            await application.SendAuthenticatedAsync(
+            async (authorization, requestToken) =>
+            {
+                using HttpRequestMessage request = new(HttpMethod.Get, downloadUri);
+                request.Headers.TryAddWithoutValidation("Authorization", authorization);
+                using HttpResponseMessage response =
+                    await application.HttpClient.SendAsync(
+                        request,
+                        HttpCompletionOption.ResponseHeadersRead,
+                        requestToken);
+                if (!response.IsSuccessStatusCode)
+                {
+                    // Said as its own failure rather than as a failed request:
+                    // by the time a result is fetched the job has run and been
+                    // charged for, and the caller has somewhere to send the
+                    // user for it.
+                    throw new AiContentUnavailableException((int)response.StatusCode);
+                }
+                string? fileName = NormalizeContentDispositionFileName(
+                    response.Content.Headers.ContentDisposition);
+                string? contentType = response.Content.Headers.ContentType?.MediaType;
+                AiContentMetadata? metadata = string.IsNullOrWhiteSpace(fileName)
+                    && string.IsNullOrWhiteSpace(contentType)
+                        ? null
+                        : new AiContentMetadata(fileName, contentType);
+                await using Stream source = await response.Content.ReadAsStreamAsync(requestToken);
+                await source.CopyToAsync(destination, requestToken);
+                return new AiContentDownload(metadata);
+            },
+            operationCts.Token);
+        return result.Value;
+    }
+
+    private Uri ValidateContentUri(Uri contentUri)
+    {
+        Uri? baseAddress = application.HttpClient.BaseAddress;
+        if (!contentUri.IsAbsoluteUri
+            || baseAddress is null
+            || !string.Equals(contentUri.Scheme, baseAddress.Scheme, StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(contentUri.IdnHost, baseAddress.IdnHost, StringComparison.OrdinalIgnoreCase)
+            || contentUri.Port != baseAddress.Port
+            || !contentUri.AbsolutePath.StartsWith("/api/contents/", StringComparison.Ordinal)
+            || contentUri.AbsolutePath.Length == "/api/contents/".Length)
+        {
+            throw new ArgumentException(
+                "The URI must identify Beutl content on the configured API origin.",
+                nameof(contentUri));
+        }
+
+        return contentUri;
+    }
+
+    private static string? NormalizeContentDispositionFileName(
+        System.Net.Http.Headers.ContentDispositionHeaderValue? disposition)
+    {
+        if (disposition is null)
+            return null;
+
+        string? encoded = disposition.FileNameStar;
+        if (!string.IsNullOrWhiteSpace(encoded))
+        {
+            try
+            {
+                string value = encoded.Trim().Trim('"');
+                int charsetEnd = value.IndexOf('\'');
+                int languageEnd = charsetEnd < 0 ? -1 : value.IndexOf('\'', charsetEnd + 1);
+                if (charsetEnd > 0 && languageEnd > charsetEnd)
+                {
+                    string charset = value[..charsetEnd];
+                    if (!charset.Equals("UTF-8", StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new AiException(
+                            "The AI response filename uses an unsupported character encoding.");
+                    }
+
+                    value = value[(languageEnd + 1)..];
+                }
+
+                encoded = Uri.UnescapeDataString(value);
+            }
+            catch (UriFormatException ex)
+            {
+                throw new AiException("The AI response contains an invalid content filename.", ex);
+            }
+        }
+
+        return (encoded ?? disposition.FileName)?.Trim().Trim('"');
+    }
+}
+
+internal abstract class AiMeteredCapabilityService(
+    BeutlApiApplication application,
+    AiJobChangeNotifier jobChangeNotifier)
+{
+    internal const int MaximumResponseBodyBytes = 32 * 1024 * 1024;
+
+    protected BeutlApiApplication Application { get; } = application;
+
+    protected static string CreateIdempotencyKey() => Guid.NewGuid().ToString("D");
+
+    /// <summary>
+    /// Runs a request that answers a piece at a time, handing each piece to the
+    /// caller and returning what the closing event carries.
+    /// </summary>
+    /// <remarks>
+    /// Everything the server can refuse before it starts working still comes
+    /// back as an ordinary status code, and is converted here exactly as a
+    /// Refit reply would be. Once the stream is open the answer is one of two
+    /// events; a stream that carries neither was cut off, and whatever it was
+    /// carrying may well have finished and been charged for, which is why that
+    /// is said in its own way rather than as a plain failure.
+    /// </remarks>
+    protected async Task<TResult> ExecuteStreamingAsync<TResult>(
+        string activityName,
+        Func<HttpRequestMessage> createRequest,
+        Action<AiServerSentEvent> onProgress,
+        Func<string, TResult> readResult,
+        CancellationToken cancellationToken,
+        Action<Activity?>? configureActivity = null,
+        bool notifyJobsChanged = true,
+        bool requestEventStream = true)
+    {
+        using CancellationTokenSource operationCts =
+            Application.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = operationCts.Token;
+        token.ThrowIfCancellationRequested();
+        using Activity? activity = Application.ActivitySource.StartActivity(
+            activityName,
+            ActivityKind.Client);
+        configureActivity?.Invoke(activity);
+
+        AuthenticatedApiResult<TResult> response = await Application.SendAuthenticatedAsync(
+            async (authorization, requestToken) =>
+            {
+                using HttpRequestMessage request = createRequest();
+                request.Headers.TryAddWithoutValidation("Authorization", authorization);
+                if (requestEventStream)
+                {
+                    request.Headers.Accept.Add(
+                        new MediaTypeWithQualityHeaderValue(AiEventStream.MediaType));
+                }
+                using HttpResponseMessage message = await Application.HttpClient.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    requestToken);
+                if (!message.IsSuccessStatusCode)
+                {
+                    throw await ToFailureAsync(message, activity, requestToken);
+                }
+
+                if (!AiEventStream.IsEventStream(message))
+                {
+                    // A server that does not stream answers the same request in
+                    // one piece, and that answer is the same shape the closing
+                    // event would have carried. There is simply nothing to show
+                    // on the way.
+                    return readResult(await ReadResponseBodyAsync(
+                        message.Content,
+                        requestToken));
+                }
+
+                await using Stream stream = await message.Content.ReadAsStreamAsync(requestToken);
+                await foreach (AiServerSentEvent item in
+                    AiEventStream.ReadAsync(stream, requestToken))
+                {
+                    switch (item.Event)
+                    {
+                        case AiEventStream.ResultEvent:
+                            return readResult(item.Data);
+                        case AiEventStream.ErrorEvent:
+                            activity?.SetStatus(ActivityStatusCode.Error);
+                            throw AiErrorConverter.Convert(
+                                500,
+                                DeserializeError(item.Data),
+                                null);
+                        default:
+                            onProgress(item);
+                            break;
+                    }
+                }
+
+                activity?.SetStatus(ActivityStatusCode.Error);
+                throw new AiRequestInterruptedException();
+            },
+            token);
+
+        if (notifyJobsChanged)
+        {
+            jobChangeNotifier.Notify();
+        }
+
+        return response.Value;
+    }
+
+    private static async Task<AiException> ToFailureAsync(
+        HttpResponseMessage message,
+        Activity? activity,
+        CancellationToken cancellationToken)
+    {
+        activity?.SetStatus(ActivityStatusCode.Error);
+        string body = string.Empty;
+        try
+        {
+            body = await ReadResponseBodyAsync(message.Content, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            // A body that cannot be read says nothing more than the status did.
+        }
+
+        return AiErrorConverter.Convert(
+            (int)message.StatusCode,
+            DeserializeError(body),
+            null,
+            $"The AI request failed ({(int)message.StatusCode}).");
+    }
+
+    private static async Task<string> ReadResponseBodyAsync(
+        HttpContent content,
+        CancellationToken cancellationToken)
+    {
+        if (content.Headers.ContentLength is > MaximumResponseBodyBytes)
+            throw new AiException("The AI response body exceeded the supported size.");
+
+        await using Stream stream = await content.ReadAsStreamAsync(cancellationToken);
+        int initialCapacity = content.Headers.ContentLength is > 0 and <= MaximumResponseBodyBytes
+            ? (int)content.Headers.ContentLength.Value
+            : 0;
+        using var body = new MemoryStream(initialCapacity);
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(81920);
+        try
+        {
+            int totalBytes = 0;
+            while (true)
+            {
+                int read = await stream.ReadAsync(buffer, cancellationToken);
+                if (read == 0)
+                    break;
+                if (totalBytes > MaximumResponseBodyBytes - read)
+                    throw new AiException("The AI response body exceeded the supported size.");
+
+                await body.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+                totalBytes += read;
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        body.Position = 0;
+        Encoding encoding = Encoding.UTF8;
+        if (content.Headers.ContentType?.CharSet is { Length: > 0 } charset)
+        {
+            encoding = Encoding.GetEncoding(charset.Trim().Trim('"'));
+        }
+
+        using var reader = new StreamReader(
+            body,
+            encoding,
+            detectEncodingFromByteOrderMarks: true,
+            leaveOpen: false);
+        return await reader.ReadToEndAsync(cancellationToken);
+    }
+
+    /// <summary>The same JSON body Refit would have sent, as a raw request.</summary>
+    protected HttpRequestMessage JsonRequest<TBody>(
+        string path,
+        string idempotencyKey,
+        TBody body)
+    {
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            new Uri(Application.HttpClient.BaseAddress!, path))
+        {
+            Content = new StringContent(
+                JsonSerializer.Serialize(body, AiStreamJson.Options),
+                Encoding.UTF8,
+                "application/json"),
+        };
+        request.Headers.TryAddWithoutValidation("Idempotency-Key", idempotencyKey);
+        return request;
+    }
+
+    protected HttpRequestMessage JsonRequestBytes(
+        string path,
+        string idempotencyKey,
+        ReadOnlyMemory<byte> body)
+    {
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            new Uri(Application.HttpClient.BaseAddress!, path))
+        {
+            Content = new ByteArrayContent(body.ToArray()),
+        };
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        request.Headers.TryAddWithoutValidation("Idempotency-Key", idempotencyKey);
+        return request;
+    }
+
+    // Read leniently: what matters is the code and the message, and a body that
+    // carries them but not every field the client's own record insists on is
+    // still the failure it says it is.
+    private sealed record ErrorBody
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("error_code")]
+        public ApiErrorCode? ErrorCode { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("message")]
+        public string? Message { get; init; }
+    }
+
+    private static ApiErrorResponse? DeserializeError(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+            return null;
+        try
+        {
+            ErrorBody? parsed = JsonSerializer.Deserialize<ErrorBody>(
+                body,
+                AiStreamJson.Options);
+            if (parsed is null)
+                return null;
+            return new ApiErrorResponse
+            {
+                ErrorCode = parsed.ErrorCode ?? ApiErrorCode.Unknown,
+                Message = parsed.Message,
+                DocumentationUrl = null,
+            };
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    protected async Task<TResult> ExecuteAsync<TResponse, TResult>(
+        string activityName,
+        Func<string, CancellationToken, Task<TResponse>> send,
+        Func<TResponse, TResult> map,
+        CancellationToken cancellationToken,
+        Action<Activity?>? configureActivity = null,
+        bool notifyJobsChanged = true)
+    {
+        using CancellationTokenSource operationCts =
+            Application.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken token = operationCts.Token;
+        token.ThrowIfCancellationRequested();
+        using Activity? activity = Application.ActivitySource.StartActivity(
+            activityName,
+            ActivityKind.Client);
+        configureActivity?.Invoke(activity);
+
+        try
+        {
+            AuthenticatedApiResult<TResponse> response =
+                await Application.SendAuthenticatedAsync(send, token);
+            TResult result = map(response.Value);
+            if (notifyJobsChanged)
+            {
+                jobChangeNotifier.Notify();
+            }
+            return result;
+        }
+        catch (ApiException ex)
+        {
+            throw await AiErrorConverter.ConvertAsync(ex, activity);
+        }
+    }
+}
+
+internal static class AiMediaTypes
+{
+    public static string Get(string filePath)
+    {
+        return Path.GetExtension(filePath).ToLowerInvariant() switch
+        {
+            ".png" => "image/png",
+            ".jpg" or ".jpeg" => "image/jpeg",
+            ".webp" => "image/webp",
+            ".gif" => "image/gif",
+            ".bmp" => "image/bmp",
+            ".avif" => "image/avif",
+            ".heif" or ".heic" => "image/heif",
+            ".wav" => "audio/wav",
+            ".mp3" => "audio/mpeg",
+            ".flac" => "audio/flac",
+            ".m4a" => "audio/mp4",
+            ".ogg" or ".oga" or ".opus" => "audio/ogg",
+            ".webm" => "audio/webm",
+            ".aac" => "audio/aac",
+            ".mp4" or ".m4v" => "video/mp4",
+            ".mov" => "video/quicktime",
+            ".mkv" => "video/x-matroska",
+            _ => "application/octet-stream",
+        };
+    }
+}

--- a/src/Beutl.Api/Services/AiCapabilityServices.cs
+++ b/src/Beutl.Api/Services/AiCapabilityServices.cs
@@ -477,19 +477,7 @@ internal sealed class AiImageGenerationService(
         if (partial is null || partial.Index < 0 || string.IsNullOrEmpty(partial.Image))
             return;
 
-        byte[] bytes;
-        try
-        {
-            bytes = System.Convert.FromBase64String(partial.Image);
-        }
-        catch (FormatException)
-        {
-            return;
-        }
-
-        if (bytes.Length > 0
-            && bytes.LongLength <= AiRequestLimits.MaxImageUploadBytes
-            && budget.TryReserve(bytes.LongLength))
+        if (budget.TryDecode(partial.Image, out byte[] bytes))
         {
             progress.Report(new AiImagePreview(partial.Index, bytes));
         }
@@ -500,10 +488,48 @@ internal sealed class AiImageGenerationService(
         private int _count;
         private long _bytes;
 
+        public bool TryDecode(string image, out byte[] bytes)
+        {
+            bytes = [];
+            int length = 0;
+            int padding = 0;
+            foreach (char character in image)
+            {
+                // Match the whitespace accepted by Convert.FromBase64String.
+                if (character is ' ' or '\t' or '\r' or '\n')
+                    continue;
+
+                length++;
+                padding = character == '=' ? padding + 1 : 0;
+            }
+
+            if (length == 0 || length % 4 != 0 || padding > 2)
+                return false;
+
+            long decodedLength = (long)(length / 4) * 3 - padding;
+            if (!CanReserve(decodedLength))
+                return false;
+
+            try
+            {
+                bytes = System.Convert.FromBase64String(image);
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+
+            return TryReserve(bytes.LongLength);
+        }
+
+        private bool CanReserve(long bytes)
+            => bytes > 0
+               && _count < MaximumImagePreviewCount
+               && bytes <= MaximumImagePreviewBytes - _bytes;
+
         public bool TryReserve(long bytes)
         {
-            if (_count >= MaximumImagePreviewCount
-                || _bytes > MaximumImagePreviewBytes - bytes)
+            if (!CanReserve(bytes))
             {
                 return false;
             }

--- a/src/Beutl.Api/Services/AiCaptionTranslationRequestTransport.cs
+++ b/src/Beutl.Api/Services/AiCaptionTranslationRequestTransport.cs
@@ -1,0 +1,59 @@
+﻿using System.Text.Json;
+using Beutl.Api.Clients;
+
+namespace Beutl.Api.Services;
+
+/// <summary>
+/// Builds the wire request once and enforces the exact serialized body limit
+/// before either the Refit or event-stream transport can send it.
+/// </summary>
+internal static class AiCaptionTranslationRequestTransport
+{
+    public static AiCaptionTranslationRequestPayload CreatePayload(
+        AiCaptionTranslationRequest request)
+    {
+        var dto = new AiCaptionTranslationRequestDto
+        {
+            SourceLanguage = request.SourceLanguage,
+            TargetLanguage = request.TargetLanguage,
+            Segments = request.Segments.Select(segment => new AiCaptionTranslationSegmentDto
+            {
+                Id = segment.Id,
+                Text = segment.Text,
+                Context = segment.Context is { } context
+                    ? new AiCaptionTranslationSegmentContextDto
+                    {
+                        GroupId = context.GroupId,
+                        PartIndex = context.PartIndex,
+                        Start = context.Start.TotalSeconds,
+                        End = context.End.TotalSeconds,
+                    }
+                    : null,
+            }).ToArray(),
+            Style = request.Style is { } style
+                ? new AiCaptionTranslationStyleDto
+                {
+                    Glossary = style.Glossary,
+                    MaxCharactersPerLine = style.MaxCharactersPerLine,
+                    MaxLines = style.MaxLines,
+                }
+                : null,
+            Model = request.Model?.Value,
+        };
+
+        byte[] serialized = JsonSerializer.SerializeToUtf8Bytes(
+            dto,
+            AiStreamJson.CanonicalOptions);
+        if (serialized.Length > request.Limits.MaxRequestBytes)
+        {
+            throw new ArgumentException(
+                $"The serialized translation request cannot exceed {request.Limits.MaxRequestBytes} bytes.",
+                nameof(request));
+        }
+
+        return new AiCaptionTranslationRequestPayload(serialized);
+    }
+}
+
+internal readonly record struct AiCaptionTranslationRequestPayload(
+    byte[] Json);

--- a/src/Beutl.Api/Services/AiEntitlementStore.cs
+++ b/src/Beutl.Api/Services/AiEntitlementStore.cs
@@ -1,0 +1,88 @@
+﻿using Beutl.Api.Clients;
+using Beutl.Api.Objects;
+using Reactive.Bindings;
+
+namespace Beutl.Api.Services;
+
+internal sealed class AiEntitlementStore : IBeutlApiResource, IDisposable
+{
+    private readonly ReactivePropertySlim<AiEntitlements?> _entitlements = new();
+    private readonly ReadOnlyReactivePropertySlim<AiEntitlements?> _readOnlyEntitlements;
+    private readonly IDisposable _authenticationSubscription;
+    private readonly object _gate = new();
+    private readonly SemaphoreSlim _balanceRequestGate = new(1, 1);
+    private AuthenticatedUser? _owner;
+    private long _lastAppliedSnapshotRequest;
+    private long _nextSnapshotRequest;
+    private bool _disposed;
+
+    public AiEntitlementStore(BeutlApiApplication application)
+    {
+        _readOnlyEntitlements = _entitlements.ToReadOnlyReactivePropertySlim();
+        _authenticationSubscription = application.AuthenticatedUser.Subscribe(HandleAuthenticatedUserChanged);
+    }
+
+    public IReadOnlyReactiveProperty<AiEntitlements?> Entitlements => _readOnlyEntitlements;
+
+    public long BeginSnapshotRequest()
+    {
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return ++_nextSnapshotRequest;
+        }
+    }
+
+    public Task WaitForBalanceRequestAsync(CancellationToken cancellationToken)
+        => _balanceRequestGate.WaitAsync(cancellationToken);
+
+    public void ReleaseBalanceRequest()
+        => _balanceRequestGate.Release();
+
+    public void ApplyEntitlements(
+        AiEntitlements? entitlements,
+        AuthenticatedUser owner,
+        long snapshotRequest)
+    {
+        lock (_gate)
+        {
+            if (_disposed
+                || !ReferenceEquals(_owner, owner)
+                || snapshotRequest < _lastAppliedSnapshotRequest)
+            {
+                return;
+            }
+
+            _lastAppliedSnapshotRequest = snapshotRequest;
+            _entitlements.Value = entitlements;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+        }
+
+        _authenticationSubscription.Dispose();
+        _readOnlyEntitlements.Dispose();
+        _entitlements.Dispose();
+    }
+
+    private void HandleAuthenticatedUserChanged(AuthenticatedUser? user)
+    {
+        lock (_gate)
+        {
+            if (_disposed || ReferenceEquals(_owner, user))
+                return;
+
+            _owner = user;
+            _lastAppliedSnapshotRequest = ++_nextSnapshotRequest;
+            _entitlements.Value = null;
+        }
+    }
+}

--- a/src/Beutl.Api/Services/AiErrorConverter.cs
+++ b/src/Beutl.Api/Services/AiErrorConverter.cs
@@ -1,0 +1,72 @@
+﻿using System.Diagnostics;
+using Beutl.Api.Clients;
+using Refit;
+
+namespace Beutl.Api.Services;
+
+internal static class AiErrorConverter
+{
+    public static async Task<AiException> ConvertAsync(ApiException exception, Activity? activity)
+    {
+        activity?.SetStatus(ActivityStatusCode.Error);
+
+        // The outer worker rejects an oversized streamed body before an endpoint can
+        // produce its JSON error envelope. The HTTP status is authoritative even when
+        // the response body is empty or malformed.
+        if ((int)exception.StatusCode == 413)
+            return new AiFileTooLargeException(exception);
+
+        try
+        {
+            ApiErrorResponse? error = await exception.GetContentAsAsync<ApiErrorResponse>();
+            return Convert(
+                (int)exception.StatusCode,
+                error,
+                exception,
+                exception.Message);
+        }
+        catch (Exception parseException)
+        {
+            var converted = new AiException(
+                exception.Message,
+                exception,
+                isTransient: (int)exception.StatusCode >= 500);
+            converted.Data[nameof(parseException)] = parseException;
+            return converted;
+        }
+    }
+
+    /// <summary>
+    /// The same failure, told apart the same way, for a reply that did not come
+    /// back through Refit — an event stream reads its own error body.
+    /// </summary>
+    public static AiException Convert(
+        int statusCode,
+        ApiErrorResponse? error,
+        Exception? innerException,
+        string? fallbackMessage = null)
+        => statusCode == 413
+            ? new AiFileTooLargeException(innerException)
+            : error?.ErrorCode switch
+            {
+                ApiErrorCode.AuthenticationIsRequired => new AuthenticationRequiredException(innerException),
+                ApiErrorCode.AiPlanRequired => new AiPlanRequiredException(innerException),
+                ApiErrorCode.AiUsageLimitExceeded => new AiUsageLimitExceededException(innerException),
+                ApiErrorCode.FileIsTooLarge => new AiFileTooLargeException(innerException),
+                ApiErrorCode.AiProviderError => new AiProviderErrorException(innerException),
+                ApiErrorCode.AiJobNotFound => new AiJobNotFoundException(innerException),
+                ApiErrorCode.AiJobIsActive => new AiJobIsActiveException(innerException),
+                ApiErrorCode.AiJobLimitReached => new AiJobLimitReachedException(innerException),
+                ApiErrorCode.AiRequestInProgress => new AiRequestInProgressException(innerException),
+                ApiErrorCode.AiRequestWasDeleted => new AiRequestWasDeletedException(innerException),
+                ApiErrorCode.AiRequestChanged => new AiRequestChangedException(innerException),
+                ApiErrorCode.AiModelDoesNotSupportRequest =>
+                    new AiModelDoesNotSupportRequestException(innerException),
+                ApiErrorCode.AiModelUnavailable => new AiModelUnavailableException(innerException),
+                ApiErrorCode.AiResultUnavailable => new AiResultUnavailableException(innerException),
+                _ => new AiException(
+                    error?.Message ?? fallbackMessage ?? "The AI request failed.",
+                    innerException,
+                    isTransient: statusCode >= 500),
+            };
+}

--- a/src/Beutl.Api/Services/AiEventStream.cs
+++ b/src/Beutl.Api/Services/AiEventStream.cs
@@ -1,0 +1,135 @@
+﻿using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Beutl.Api.Services;
+
+/// <summary>One event from a server-sent event stream.</summary>
+internal readonly record struct AiServerSentEvent(string Event, string Data);
+
+/// <summary>
+/// Reads an answer that arrives a piece at a time.
+/// </summary>
+/// <remarks>
+/// The AI endpoints stream when asked to: subtitles as they are translated, or
+/// the rough versions of a picture as it is worked out, and then always one
+/// closing event carrying the same answer a caller that did not ask would have
+/// waited for. Refit cannot read that, so these requests are made with the
+/// HttpClient directly.
+/// </remarks>
+internal static class AiEventStream
+{
+    public const string ResultEvent = "result";
+    public const string ErrorEvent = "error";
+    public const string MediaType = "text/event-stream";
+
+    // A single event of a translated subtitle or a rough picture; the largest of
+    // them carries a base64 image. Anything past this is not an event this
+    // client knows how to use, and reading it would only cost memory.
+    private const int MaximumEventLength = 32 * 1024 * 1024;
+
+    public static bool IsEventStream(HttpResponseMessage response)
+        => string.Equals(
+            response.Content.Headers.ContentType?.MediaType,
+            MediaType,
+            StringComparison.OrdinalIgnoreCase);
+
+    public static async IAsyncEnumerable<AiServerSentEvent> ReadAsync(
+        Stream stream,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        string? name = null;
+        var data = new StringBuilder();
+        char[] buffer = ArrayPool<char>.Shared.Rent(4096);
+        int bufferOffset = 0;
+        int buffered = 0;
+        bool swallowLineFeed = false;
+        try
+        {
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                string? line = await ReadLineBoundedAsync();
+                if (line is null)
+                    break;
+
+                // A blank line ends an event. One with no name or no data is a
+                // keep-alive comment or a field this client does not use.
+                if (line.Length == 0)
+                {
+                    if (name is not null && data.Length > 0)
+                        yield return new AiServerSentEvent(name, data.ToString());
+                    name = null;
+                    data.Clear();
+                    continue;
+                }
+
+                if (line.StartsWith(':'))
+                    continue;
+                if (line.StartsWith("event:", StringComparison.Ordinal))
+                {
+                    name = line["event:".Length..].Trim();
+                    continue;
+                }
+
+                if (!line.StartsWith("data:", StringComparison.Ordinal))
+                    continue;
+                if (data.Length > 0)
+                    data.Append('\n');
+                data.Append(line["data:".Length..].TrimStart());
+                if (data.Length > MaximumEventLength)
+                    throw new AiException("An AI event stream sent an oversized event.");
+            }
+
+            if (name is not null && data.Length > 0)
+                yield return new AiServerSentEvent(name, data.ToString());
+        }
+        finally
+        {
+            ArrayPool<char>.Shared.Return(buffer);
+        }
+
+        async ValueTask<string?> ReadLineBoundedAsync()
+        {
+            var line = new StringBuilder();
+            while (true)
+            {
+                if (bufferOffset >= buffered)
+                {
+                    buffered = await reader.ReadAsync(buffer.AsMemory(), cancellationToken);
+                    bufferOffset = 0;
+                    if (buffered == 0)
+                    {
+                        if (line.Length == 0)
+                            return null;
+                        if (line[^1] == '\r')
+                            line.Length--;
+                        return line.ToString();
+                    }
+                }
+
+                char next = buffer[bufferOffset++];
+                if (swallowLineFeed)
+                {
+                    swallowLineFeed = false;
+                    if (next == '\n')
+                        continue;
+                }
+
+                if (next == '\r')
+                {
+                    swallowLineFeed = true;
+                    return line.ToString();
+                }
+                if (next == '\n')
+                    return line.ToString();
+
+                line.Append(next);
+                if (line.Length > MaximumEventLength)
+                    throw new AiException("An AI event stream sent an oversized line.");
+            }
+        }
+    }
+}

--- a/src/Beutl.Api/Services/AiExceptions.cs
+++ b/src/Beutl.Api/Services/AiExceptions.cs
@@ -1,0 +1,248 @@
+﻿namespace Beutl.Api.Services;
+
+/// <summary>
+/// Base class for errors reported by the server-side AI endpoints.
+/// </summary>
+public class AiException : Exception
+{
+    public AiException(
+        string message,
+        Exception? innerException = null,
+        bool isTransient = false)
+        : base(message, innerException)
+    {
+        IsTransient = isTransient;
+    }
+
+    public bool IsTransient { get; }
+}
+
+/// <summary>
+/// The user is not signed in (401 authenticationIsRequired).
+/// </summary>
+public sealed class AuthenticationRequiredException : AiException
+{
+    public AuthenticationRequiredException(Exception? innerException = null)
+        : this(currentAttemptReservationIsKnownAbsent: true, innerException)
+    {
+    }
+
+    internal AuthenticationRequiredException(
+        bool currentAttemptReservationIsKnownAbsent,
+        Exception? innerException = null)
+        : base("Authentication is required.", innerException)
+    {
+        CurrentAttemptReservationIsKnownAbsent = currentAttemptReservationIsKnownAbsent;
+    }
+
+    internal bool CurrentAttemptReservationIsKnownAbsent { get; }
+}
+
+/// <summary>
+/// The user does not have an active Pro plan (402 aiPlanRequired).
+/// </summary>
+public sealed class AiPlanRequiredException : AiException
+{
+    public AiPlanRequiredException(Exception? innerException = null)
+        : base("A Pro plan is required to use AI features.", innerException)
+    {
+    }
+}
+
+/// <summary>
+/// The user's monthly AI allowance and additional credits cannot cover the request
+/// (402 aiUsageLimitExceeded).
+/// </summary>
+public sealed class AiUsageLimitExceededException : AiException
+{
+    public AiUsageLimitExceededException(Exception? innerException = null)
+        : base("The request exceeds the remaining monthly AI allowance and additional credits.", innerException)
+    {
+    }
+}
+
+/// <summary>
+/// The request names a model the server no longer offers for that operation.
+/// Reruns hit this; falling back to the operation's default would run something
+/// else and charge that model's price for it.
+/// </summary>
+public sealed class AiModelUnavailableException : AiException
+{
+    public AiModelUnavailableException(Exception? innerException = null)
+        : base("The requested AI model is no longer offered for this operation.", innerException)
+    {
+    }
+}
+
+/// <summary>
+/// The selected media exceeds the server upload limit (413 fileIsTooLarge).
+/// </summary>
+public sealed class AiFileTooLargeException : AiException
+{
+    public AiFileTooLargeException(Exception? innerException = null)
+        : base("The selected file exceeds the AI upload limit.", innerException)
+    {
+    }
+}
+
+/// <summary>
+/// The AI provider failed to process the request (500 aiProviderError).
+/// </summary>
+public sealed class AiProviderErrorException : AiException
+{
+    public AiProviderErrorException(Exception? innerException = null)
+        : base("The AI provider failed to process the request.", innerException, isTransient: true)
+    {
+    }
+}
+
+/// <summary>
+/// The user already has a video generation job in progress (429 aiJobLimitReached).
+/// </summary>
+public sealed class AiJobLimitReachedException : AiException
+{
+    public AiJobLimitReachedException(Exception? innerException = null)
+        : base("A video generation job is already in progress.", innerException)
+    {
+    }
+}
+
+/// <summary>
+/// A retry reused an idempotency key while the original request is still running
+/// (409 aiRequestInProgress).
+/// </summary>
+public sealed class AiRequestInProgressException : AiException
+{
+    public AiRequestInProgressException(Exception? innerException = null)
+        : base("The AI request is still in progress.", innerException, isTransient: true)
+    {
+    }
+}
+
+/// <summary>
+/// A retry reused an idempotency key whose original request was deleted
+/// (409 aiRequestWasDeleted).
+/// </summary>
+public sealed class AiRequestWasDeletedException : AiException
+{
+    public AiRequestWasDeletedException(Exception? innerException = null)
+        : base("The original AI request was deleted. Start a new request to run it again.", innerException)
+    {
+    }
+}
+
+/// <summary>
+/// The name this request was sent under belongs to a different request
+/// (409 aiRequestChanged).
+/// </summary>
+/// <remarks>
+/// The server fingerprints what a name was used for and refuses to answer it
+/// with anything else. Asking again for exactly what that name was sent with
+/// collects what it may already have paid for; anything else is a new request
+/// and needs a new name.
+/// </remarks>
+public sealed class AiRequestChangedException : AiException
+{
+    public AiRequestChangedException(Exception? innerException = null)
+        : base("The idempotency key belongs to a different request.", innerException)
+    {
+    }
+}
+
+/// <summary>
+/// A paid result the server holds could not be read just now
+/// (503 aiResultUnavailable).
+/// </summary>
+/// <remarks>
+/// The job succeeded and was charged for; only fetching what it produced
+/// failed. Nothing is settled by this, so asking again under the same
+/// idempotency key is what recovers it — which is why it is told apart from a
+/// failure the server owns and has refunded.
+/// </remarks>
+public sealed class AiResultUnavailableException : AiException
+{
+    public AiResultUnavailableException(Exception? innerException = null)
+        : base(
+            "The AI result could not be read. Ask for it again.",
+            innerException,
+            isTransient: true)
+    {
+    }
+}
+
+/// <summary>
+/// The chosen model does not take the request as it stands — an aspect ratio,
+/// a background, a seed or a reference picture it does not accept
+/// (400 aiModelDoesNotSupportRequest).
+/// </summary>
+/// <remarks>
+/// Refused before the operation is reserved, so nothing was charged. What the
+/// caller has to change is the model or the shape of the request; repeating it
+/// unchanged is refused the same way.
+/// </remarks>
+public sealed class AiModelDoesNotSupportRequestException : AiException
+{
+    public AiModelDoesNotSupportRequestException(Exception? innerException = null)
+        : base("The chosen AI model does not support this request.", innerException)
+    {
+    }
+}
+
+/// <summary>
+/// The connection carrying an answer ended before the answer did. The work may
+/// well have finished and been charged for, so this is not the same as a run
+/// that failed: asking again under the same idempotency key is what recovers it.
+/// </summary>
+public sealed class AiRequestInterruptedException : AiException
+{
+    public AiRequestInterruptedException(Exception? innerException = null)
+        : base(
+            "The AI answer was cut off before it finished.",
+            innerException,
+            isTransient: true)
+    {
+    }
+}
+
+/// <summary>
+/// The job produced a result, but the file it produced could not be fetched.
+/// The work is done and paid for either way, so it is worth saying so: the
+/// result is still in the job history.
+/// </summary>
+public sealed class AiContentUnavailableException : AiException
+{
+    public AiContentUnavailableException(
+        int statusCode,
+        Exception? innerException = null)
+        : base(
+            $"The AI result could not be downloaded (HTTP {statusCode}).",
+            innerException,
+            isTransient: statusCode >= 500)
+    {
+        StatusCode = statusCode;
+    }
+
+    public int StatusCode { get; }
+}
+
+/// <summary>
+/// The requested AI job is still active and cannot be deleted (409 aiJobIsActive).
+/// </summary>
+public sealed class AiJobIsActiveException : AiException
+{
+    public AiJobIsActiveException(Exception? innerException = null)
+        : base("An active AI job cannot be deleted.", innerException)
+    {
+    }
+}
+
+/// <summary>
+/// The requested AI job no longer exists (404 aiJobNotFound).
+/// </summary>
+public sealed class AiJobNotFoundException : AiException
+{
+    public AiJobNotFoundException(Exception? innerException = null)
+        : base("The requested AI job no longer exists.", innerException)
+    {
+    }
+}

--- a/src/Beutl.Api/Services/AiJobBehaviorExtensions.cs
+++ b/src/Beutl.Api/Services/AiJobBehaviorExtensions.cs
@@ -1,0 +1,21 @@
+﻿using Beutl.Extensibility;
+
+namespace Beutl.Api.Services;
+
+/// <summary>Contributes status resolution independently of refresh and retry behavior.</summary>
+public abstract class AiJobStatusResolverExtension : Extension, ILiveUnloadExtension
+{
+    public abstract IReadOnlyCollection<AiJobStatusResolverRegistration> Registrations { get; }
+}
+
+/// <summary>Contributes polling refresh independently of status and retry behavior.</summary>
+public abstract class AiJobRefreshHandlerExtension : Extension, ILiveUnloadExtension
+{
+    public abstract IReadOnlyCollection<AiJobRefreshHandlerRegistration> Registrations { get; }
+}
+
+/// <summary>Contributes retry behavior independently of status and refresh behavior.</summary>
+public abstract class AiJobRetryHandlerExtension : Extension, ILiveUnloadExtension
+{
+    public abstract IReadOnlyCollection<AiJobRetryHandlerRegistration> Registrations { get; }
+}

--- a/src/Beutl.Api/Services/AiJobChangeNotifier.cs
+++ b/src/Beutl.Api/Services/AiJobChangeNotifier.cs
@@ -1,0 +1,46 @@
+﻿using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace Beutl.Api.Services;
+
+internal sealed class AiJobChangeNotifier : IBeutlApiResource, IDisposable
+{
+    private readonly Subject<Unit> _source = new();
+    private readonly ISubject<Unit> _serialized;
+    private readonly IObservable<Unit> _changes;
+    private readonly object _gate = new();
+    private bool _disposed;
+
+    public AiJobChangeNotifier()
+    {
+        _serialized = Subject.Synchronize(_source);
+        _changes = _serialized.AsObservable();
+    }
+
+    public IObservable<Unit> Changes => _changes;
+
+    public void Notify()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+
+            _serialized.OnNext(Unit.Default);
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            _serialized.OnCompleted();
+            _source.Dispose();
+        }
+    }
+}

--- a/src/Beutl.Api/Services/AiJobClient.cs
+++ b/src/Beutl.Api/Services/AiJobClient.cs
@@ -1,0 +1,71 @@
+﻿using System.Diagnostics;
+using Beutl.Api.Clients;
+using Refit;
+
+namespace Beutl.Api.Services;
+
+internal sealed class AiJobClient(BeutlApiApplication application) : IAiJobClient
+{
+    public async Task<AiJobPage> GetPageAsync(
+        AiJobPageRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        using CancellationTokenSource operationCts =
+            application.CreateLifetimeLinkedTokenSource(cancellationToken);
+        using Activity? activity = application.ActivitySource.StartActivity(
+            "AiJobClient.GetPage",
+            ActivityKind.Client);
+        try
+        {
+            AuthenticatedApiResult<AiJobHistoryPageResponse> response =
+                await application.SendAuthenticatedAsync(
+                    (authorization, token) => application.Ai.GetJobs(
+                        authorization,
+                        request.Cursor,
+                        request.Limit,
+                        token),
+                    operationCts.Token);
+            AiJob[] jobs = (response.Value.Jobs ?? [])
+                .Select(AiModelMapper.ToModel)
+                .ToArray();
+            return new AiJobPage(
+                [.. jobs],
+                string.IsNullOrWhiteSpace(response.Value.NextCursor)
+                    ? null
+                    : response.Value.NextCursor);
+        }
+        catch (ApiException ex)
+        {
+            throw await AiErrorConverter.ConvertAsync(ex, activity);
+        }
+    }
+
+    public async Task DeleteAsync(AiJobId jobId, CancellationToken cancellationToken)
+    {
+        if (jobId.Value.Length == 0)
+            throw new ArgumentException("A job identifier is required.", nameof(jobId));
+        using CancellationTokenSource operationCts =
+            application.CreateLifetimeLinkedTokenSource(cancellationToken);
+        using Activity? activity = application.ActivitySource.StartActivity(
+            "AiJobClient.Delete",
+            ActivityKind.Client);
+        activity?.SetTag("jobId", jobId.Value);
+        try
+        {
+            AuthenticatedApiResult<DeleteAiJobResponse> response =
+                await application.SendAuthenticatedAsync(
+                    (authorization, token) => application.Ai.DeleteJob(
+                        authorization,
+                        jobId.Value,
+                        token),
+                    operationCts.Token);
+            if (!response.Value.Deleted)
+                throw new AiException("The AI job was not deleted.");
+        }
+        catch (ApiException ex)
+        {
+            throw await AiErrorConverter.ConvertAsync(ex, activity);
+        }
+    }
+}

--- a/src/Beutl.Api/Services/AiJobKindContracts.cs
+++ b/src/Beutl.Api/Services/AiJobKindContracts.cs
@@ -1,0 +1,347 @@
+﻿namespace Beutl.Api.Services;
+
+public readonly struct AiJobOutcomeId : IEquatable<AiJobOutcomeId>
+{
+    private readonly string? _value;
+
+    public AiJobOutcomeId(string value) => _value = AiIdentifier.Normalize(value, nameof(value));
+
+    public string Value => _value ?? string.Empty;
+
+    public bool Equals(AiJobOutcomeId other) => StringComparer.Ordinal.Equals(Value, other.Value);
+
+    public override bool Equals(object? obj) => obj is AiJobOutcomeId other && Equals(other);
+
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Value);
+
+    public override string ToString() => Value;
+
+    public static bool operator ==(AiJobOutcomeId left, AiJobOutcomeId right) => left.Equals(right);
+
+    public static bool operator !=(AiJobOutcomeId left, AiJobOutcomeId right) => !left.Equals(right);
+}
+
+public static class AiJobOutcomes
+{
+    public static AiJobOutcomeId Succeeded { get; } = new("succeeded");
+
+    public static AiJobOutcomeId Failed { get; } = new("failed");
+
+    public static AiJobOutcomeId Canceled { get; } = new("canceled");
+}
+
+public readonly record struct AiJobStatusSemantics
+{
+    public AiJobStatusSemantics(
+        bool isTerminal,
+        bool shouldPoll,
+        AiJobOutcomeId? outcome = null)
+    {
+        if (isTerminal && shouldPoll)
+            throw new ArgumentException("A terminal job cannot request polling.", nameof(shouldPoll));
+        if (outcome.HasValue && outcome.Value.Value.Length == 0)
+            throw new ArgumentException("A non-empty outcome identifier is required.", nameof(outcome));
+        if (!isTerminal && outcome is not null)
+            throw new ArgumentException("Only a terminal job can have an outcome.", nameof(outcome));
+
+        IsTerminal = isTerminal;
+        ShouldPoll = shouldPoll;
+        Outcome = outcome;
+    }
+
+    public static AiJobStatusSemantics Unknown { get; } = new(false, false);
+
+    public bool IsTerminal { get; }
+
+    public bool ShouldPoll { get; }
+
+    public AiJobOutcomeId? Outcome { get; }
+}
+
+public interface IAiJobStatusResolver
+{
+    AiJobStatusSemantics Resolve(AiJobStatusId status);
+}
+
+public sealed class AiJobStatusMap : IAiJobStatusResolver
+{
+    private readonly Dictionary<string, AiJobStatusSemantics> _statuses;
+
+    public AiJobStatusMap(IEnumerable<KeyValuePair<AiJobStatusId, AiJobStatusSemantics>> statuses)
+    {
+        ArgumentNullException.ThrowIfNull(statuses);
+        _statuses = new Dictionary<string, AiJobStatusSemantics>(StringComparer.OrdinalIgnoreCase);
+        foreach ((AiJobStatusId status, AiJobStatusSemantics semantics) in statuses)
+        {
+            if (!_statuses.TryAdd(status.Value, semantics))
+                throw new ArgumentException($"Job status '{status}' is registered more than once.", nameof(statuses));
+        }
+    }
+
+    public AiJobStatusSemantics Resolve(AiJobStatusId status)
+    {
+        return _statuses.TryGetValue(status.Value, out AiJobStatusSemantics semantics)
+            ? semantics
+            : AiJobStatusSemantics.Unknown;
+    }
+}
+
+public interface IAiJobRefreshHandler
+{
+    Task RefreshAsync(AiJob job, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// The resource-free result of checking whether a terminal AI job is eligible for retry.
+/// </summary>
+/// <remarks>
+/// A preflight is only an estimate for presentation. It must not reserve
+/// balance, create a durable idempotency key, or retain a lease. Call
+/// <see cref="IAiJobRetryHandler.PrepareAsync"/> immediately before asking the
+/// user to pay or dispatching a retry.
+/// </remarks>
+public sealed record AiJobRetryPreflight(
+    bool IsAvailable,
+    bool CanSubmit,
+    string Explanation);
+
+/// <summary>
+/// Owns a retry prepared by a concrete handler. A preparation captures the
+/// handler and durable request identity that produced it, so replacing an
+/// extension after preparation cannot redirect the request to a different
+/// implementation.
+/// </summary>
+/// <remarks>
+/// <see cref="ExecuteAsync"/> is single-use. Dispose is idempotent; disposing
+/// before execution abandons the unconsumed preparation, while disposing after
+/// execution is a no-op because the handler owns the terminal/ambiguous outcome.
+/// The host retains the originating retry-handler lease until
+/// <see cref="ExecuteAsync"/> completes, then always calls
+/// <see cref="IAsyncDisposable.DisposeAsync"/>. An implementation that keeps
+/// using extension-owned resources after cancellation must keep its returned
+/// task incomplete until that work has drained; returning earlier permits the
+/// extension to unload while its background work is still running.
+/// </remarks>
+public interface IAiJobRetryPreparation : IAsyncDisposable
+{
+    /// <summary>
+    /// Executes the prepared retry exactly once. Task completion is the
+    /// lifetime boundary after which the originating retry handler may unload.
+    /// </summary>
+    /// <param name="cancellationToken">
+    /// Stops the host's request to wait. Implementations may finish already
+    /// dispatched paid work, but must not complete this task until all use of
+    /// extension-owned resources has ended.
+    /// </param>
+    Task ExecuteAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// The outcome of preparing a retry. A blocked result has no owned resource;
+/// a ready result owns exactly one preparation until it is taken or disposed.
+/// </summary>
+public sealed class AiJobRetryPreparationResult : IAsyncDisposable
+{
+    private readonly bool _isReady;
+    private readonly string _explanation;
+    private IAiJobRetryPreparation? _preparation;
+    private int _disposed;
+
+    private AiJobRetryPreparationResult(
+        bool isReady,
+        string explanation,
+        IAiJobRetryPreparation? preparation)
+    {
+        _isReady = isReady;
+        _explanation = explanation;
+        _preparation = preparation;
+    }
+
+    public bool IsReady => _isReady;
+
+    /// <summary>
+    /// The user-facing reason when preparation is blocked. This is empty for a
+    /// ready result.
+    /// </summary>
+    public string Explanation => _explanation;
+
+    /// <summary>Creates a result that cannot be dispatched.</summary>
+    public static AiJobRetryPreparationResult Blocked(string explanation)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(explanation);
+        return new AiJobRetryPreparationResult(
+            isReady: false,
+            explanation,
+            preparation: null);
+    }
+
+    /// <summary>Creates a result owning the supplied preparation.</summary>
+    public static AiJobRetryPreparationResult Ready(IAiJobRetryPreparation preparation)
+    {
+        ArgumentNullException.ThrowIfNull(preparation);
+        return new AiJobRetryPreparationResult(
+            isReady: true,
+            explanation: string.Empty,
+            preparation);
+    }
+
+    /// <summary>
+    /// Transfers ownership of the preparation to the caller. This succeeds
+    /// once for a ready result and throws for blocked, disposed, or already
+    /// transferred results.
+    /// </summary>
+    public IAiJobRetryPreparation TakePreparation()
+    {
+        if (!_isReady)
+            throw new InvalidOperationException("A blocked retry has no preparation.");
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+        return Interlocked.Exchange(ref _preparation, null)
+            ?? throw new InvalidOperationException("The retry preparation was already taken.");
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        IAiJobRetryPreparation? preparation = Interlocked.Exchange(ref _preparation, null);
+        if (preparation is not null)
+            await preparation.DisposeAsync();
+    }
+}
+
+/// <summary>
+/// A prepared retry can no longer be executed because its durable identity,
+/// account, or generation changed before dispatch.
+/// </summary>
+public sealed class AiJobRetryPreparationRejectedException : AiException
+{
+    public AiJobRetryPreparationRejectedException(Exception? innerException = null)
+        : base(
+            "The prepared AI retry is no longer valid. Start a new confirmation.",
+            innerException)
+    {
+    }
+}
+
+/// <summary>
+/// The retry store could not be read or updated while preparing a request.
+/// </summary>
+public sealed class AiJobRetryPreparationUnavailableException : AiException
+{
+    public AiJobRetryPreparationUnavailableException(Exception? innerException = null)
+        : base(
+            "The AI retry could not be prepared right now. Try again later.",
+            innerException,
+            isTransient: true)
+    {
+    }
+}
+
+public interface IAiJobRetryHandler
+{
+    /// <summary>Determines whether this handler supports retrying the job.</summary>
+    bool CanRetry(AiJob job, AiJobStatusSemantics status);
+
+    /// <summary>
+    /// Returns a resource-free presentation estimate. This method must not
+    /// allocate an idempotency key or retain request ownership.
+    /// </summary>
+    ValueTask<AiJobRetryPreflight> GetPreflightAsync(
+        AiJob job,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Revalidates the request immediately before dispatch and returns either
+    /// a blocked reason or an owned, handler-bound preparation.
+    /// </summary>
+    /// <remarks>
+    /// The caller disposes the result on every path. A ready result retains
+    /// ownership until <see cref="AiJobRetryPreparationResult.TakePreparation"/>
+    /// transfers it exactly once.
+    /// </remarks>
+    ValueTask<AiJobRetryPreparationResult> PrepareAsync(
+        AiJob job,
+        CancellationToken cancellationToken);
+}
+
+public enum AiJobBehaviorRegistrationMode
+{
+    Add,
+    Replace,
+}
+
+/// <summary>Registers status semantics for one AI job kind.</summary>
+public sealed class AiJobStatusResolverRegistration
+{
+    public AiJobStatusResolverRegistration(
+        AiJobKindId kind,
+        IAiJobStatusResolver resolver,
+        AiJobBehaviorRegistrationMode mode = AiJobBehaviorRegistrationMode.Add)
+    {
+        AiJobBehaviorRegistrationValidation.Validate(kind, mode);
+        Kind = kind;
+        Resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+        Mode = mode;
+    }
+
+    public AiJobKindId Kind { get; }
+
+    public IAiJobStatusResolver Resolver { get; }
+
+    public AiJobBehaviorRegistrationMode Mode { get; }
+}
+
+/// <summary>Registers polling refresh behavior for one AI job kind.</summary>
+public sealed class AiJobRefreshHandlerRegistration
+{
+    public AiJobRefreshHandlerRegistration(
+        AiJobKindId kind,
+        IAiJobRefreshHandler handler,
+        AiJobBehaviorRegistrationMode mode = AiJobBehaviorRegistrationMode.Add)
+    {
+        AiJobBehaviorRegistrationValidation.Validate(kind, mode);
+        Kind = kind;
+        Handler = handler ?? throw new ArgumentNullException(nameof(handler));
+        Mode = mode;
+    }
+
+    public AiJobKindId Kind { get; }
+
+    public IAiJobRefreshHandler Handler { get; }
+
+    public AiJobBehaviorRegistrationMode Mode { get; }
+}
+
+/// <summary>Registers retry behavior for one AI job kind.</summary>
+public sealed class AiJobRetryHandlerRegistration
+{
+    public AiJobRetryHandlerRegistration(
+        AiJobKindId kind,
+        IAiJobRetryHandler handler,
+        AiJobBehaviorRegistrationMode mode = AiJobBehaviorRegistrationMode.Add)
+    {
+        AiJobBehaviorRegistrationValidation.Validate(kind, mode);
+        Kind = kind;
+        Handler = handler ?? throw new ArgumentNullException(nameof(handler));
+        Mode = mode;
+    }
+
+    public AiJobKindId Kind { get; }
+
+    public IAiJobRetryHandler Handler { get; }
+
+    public AiJobBehaviorRegistrationMode Mode { get; }
+}
+
+internal static class AiJobBehaviorRegistrationValidation
+{
+    public static void Validate(AiJobKindId kind, AiJobBehaviorRegistrationMode mode)
+    {
+        if (string.IsNullOrWhiteSpace(kind.Value))
+            throw new ArgumentException("An AI job kind identifier is required.", nameof(kind));
+        if (!Enum.IsDefined(mode))
+            throw new ArgumentOutOfRangeException(nameof(mode));
+    }
+}

--- a/src/Beutl.Api/Services/AiJobKindRegistry.cs
+++ b/src/Beutl.Api/Services/AiJobKindRegistry.cs
@@ -1,0 +1,309 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Beutl.Extensibility;
+using Beutl.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace Beutl.Api.Services;
+
+/// <summary>Owns one status-resolver registration and drains its active leases on disposal.</summary>
+public interface IAiJobStatusResolverRegistration : IAsyncDisposable
+{
+}
+
+/// <summary>Owns one refresh-handler registration and drains its active leases on disposal.</summary>
+public interface IAiJobRefreshHandlerRegistration : IAsyncDisposable
+{
+}
+
+/// <summary>Owns one retry-handler registration and drains its active leases on disposal.</summary>
+public interface IAiJobRetryHandlerRegistration : IAsyncDisposable
+{
+}
+
+/// <summary>Keeps one status resolver alive for an operation.</summary>
+public interface IAiJobStatusResolverLease : IDisposable
+{
+    IAiJobStatusResolver Resolver { get; }
+}
+
+/// <summary>Keeps one refresh handler alive through its asynchronous refresh.</summary>
+public interface IAiJobRefreshHandlerLease : IDisposable
+{
+    IAiJobRefreshHandler Handler { get; }
+}
+
+/// <summary>
+/// Keeps one retry handler alive through preflight, confirmation, preparation execution, and
+/// preparation disposal.
+/// </summary>
+public interface IAiJobRetryHandlerLease : IDisposable
+{
+    IAiJobRetryHandler Handler { get; }
+}
+
+public interface IAiJobKindRegistry : IBeutlApiResource
+{
+    IAiJobStatusResolverRegistration Register(AiJobStatusResolverRegistration registration);
+
+    IAiJobRefreshHandlerRegistration Register(AiJobRefreshHandlerRegistration registration);
+
+    IAiJobRetryHandlerRegistration Register(AiJobRetryHandlerRegistration registration);
+
+    bool TryAcquireStatusResolver(
+        AiJobKindId kind,
+        [NotNullWhen(true)] out IAiJobStatusResolverLease? lease);
+
+    bool TryAcquireRefreshHandler(
+        AiJobKindId kind,
+        [NotNullWhen(true)] out IAiJobRefreshHandlerLease? lease);
+
+    bool TryAcquireRetryHandler(
+        AiJobKindId kind,
+        [NotNullWhen(true)] out IAiJobRetryHandlerLease? lease);
+
+    AiJobStatusSemantics GetStatus(AiJob job);
+
+    AiJobStatusSemantics GetStatus(AiJobKindId kind, AiJobStatusId status);
+}
+
+/// <summary>
+/// Resolves status, refresh, and retry behavior through independent Add/Replace slots.
+/// </summary>
+public sealed class AiJobKindRegistry : IAiJobKindRegistry, IAsyncDisposable
+{
+    private static readonly ILogger s_logger = Log.CreateLogger<AiJobKindRegistry>();
+    private readonly AiJobSlotRegistry<
+        IAiJobStatusResolver,
+        AiJobStatusResolverRegistration,
+        AiJobStatusResolverExtension> _statusResolvers;
+    private readonly AiJobSlotRegistry<
+        IAiJobRefreshHandler,
+        AiJobRefreshHandlerRegistration,
+        AiJobRefreshHandlerExtension> _refreshHandlers;
+    private readonly AiJobSlotRegistry<
+        IAiJobRetryHandler,
+        AiJobRetryHandlerRegistration,
+        AiJobRetryHandlerExtension> _retryHandlers;
+
+    public AiJobKindRegistry()
+        : this([], [], [], null)
+    {
+    }
+
+    public AiJobKindRegistry(
+        IEnumerable<AiJobStatusResolverRegistration> statusResolvers,
+        IEnumerable<AiJobRefreshHandlerRegistration> refreshHandlers,
+        IEnumerable<AiJobRetryHandlerRegistration> retryHandlers)
+        : this(statusResolvers, refreshHandlers, retryHandlers, null)
+    {
+    }
+
+    internal AiJobKindRegistry(
+        IEnumerable<AiJobStatusResolverRegistration> statusResolvers,
+        IEnumerable<AiJobRefreshHandlerRegistration> refreshHandlers,
+        IEnumerable<AiJobRetryHandlerRegistration> retryHandlers,
+        IExtensionRegistry? extensionProvider)
+    {
+        _statusResolvers = new AiJobSlotRegistry<
+            IAiJobStatusResolver,
+            AiJobStatusResolverRegistration,
+            AiJobStatusResolverExtension>(
+                statusResolvers,
+                static registration => registration.Kind,
+                static registration => registration.Resolver,
+                static registration => ToSlotMode(registration.Mode),
+                static (kind, capability) => new AiJobStatusResolverRegistration(kind, capability),
+                static extension => extension.Registrations,
+                extensionProvider,
+                static (extension, exception) => ReportFailure(
+                    extension,
+                    "status resolver",
+                    exception));
+        _refreshHandlers = new AiJobSlotRegistry<
+            IAiJobRefreshHandler,
+            AiJobRefreshHandlerRegistration,
+            AiJobRefreshHandlerExtension>(
+                refreshHandlers,
+                static registration => registration.Kind,
+                static registration => registration.Handler,
+                static registration => ToSlotMode(registration.Mode),
+                static (kind, capability) => new AiJobRefreshHandlerRegistration(kind, capability),
+                static extension => extension.Registrations,
+                extensionProvider,
+                static (extension, exception) => ReportFailure(
+                    extension,
+                    "refresh handler",
+                    exception));
+        _retryHandlers = new AiJobSlotRegistry<
+            IAiJobRetryHandler,
+            AiJobRetryHandlerRegistration,
+            AiJobRetryHandlerExtension>(
+                retryHandlers,
+                static registration => registration.Kind,
+                static registration => registration.Handler,
+                static registration => ToSlotMode(registration.Mode),
+                static (kind, capability) => new AiJobRetryHandlerRegistration(kind, capability),
+                static extension => extension.Registrations,
+                extensionProvider,
+                static (extension, exception) => ReportFailure(
+                    extension,
+                    "retry handler",
+                    exception));
+    }
+
+    internal static AiJobKindRegistry CreateBuiltIn(
+        IAiImageGenerationService images,
+        IAiVideoService videos,
+        IAiEntitlementService entitlements,
+        IAiOperationAvailabilityService availability,
+        IAiModelCatalogService models,
+        AiRetryAttemptContext retryContext,
+        IExtensionRegistry? extensionProvider = null)
+    {
+        BuiltInAiJobBehaviorRegistrations registrations = BuiltInAiJobKinds.Create(
+            images,
+            videos,
+            entitlements,
+            availability,
+            models,
+            retryContext);
+        return new AiJobKindRegistry(
+            registrations.StatusResolvers,
+            registrations.RefreshHandlers,
+            registrations.RetryHandlers,
+            extensionProvider);
+    }
+
+    public IAiJobStatusResolverRegistration Register(AiJobStatusResolverRegistration registration)
+        => new StatusResolverRegistration(_statusResolvers.Register(registration));
+
+    public IAiJobRefreshHandlerRegistration Register(AiJobRefreshHandlerRegistration registration)
+        => new RefreshHandlerRegistration(_refreshHandlers.Register(registration));
+
+    public IAiJobRetryHandlerRegistration Register(AiJobRetryHandlerRegistration registration)
+        => new RetryHandlerRegistration(_retryHandlers.Register(registration));
+
+    public bool TryAcquireStatusResolver(
+        AiJobKindId kind,
+        [NotNullWhen(true)] out IAiJobStatusResolverLease? lease)
+    {
+        if (_statusResolvers.TryAcquire(kind, out AiJobSlotLease<IAiJobStatusResolver>? inner))
+        {
+            lease = new StatusResolverLease(inner);
+            return true;
+        }
+
+        lease = null;
+        return false;
+    }
+
+    public bool TryAcquireRefreshHandler(
+        AiJobKindId kind,
+        [NotNullWhen(true)] out IAiJobRefreshHandlerLease? lease)
+    {
+        if (_refreshHandlers.TryAcquire(kind, out AiJobSlotLease<IAiJobRefreshHandler>? inner))
+        {
+            lease = new RefreshHandlerLease(inner);
+            return true;
+        }
+
+        lease = null;
+        return false;
+    }
+
+    public bool TryAcquireRetryHandler(
+        AiJobKindId kind,
+        [NotNullWhen(true)] out IAiJobRetryHandlerLease? lease)
+    {
+        if (_retryHandlers.TryAcquire(kind, out AiJobSlotLease<IAiJobRetryHandler>? inner))
+        {
+            lease = new RetryHandlerLease(inner);
+            return true;
+        }
+
+        lease = null;
+        return false;
+    }
+
+    public AiJobStatusSemantics GetStatus(AiJob job)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        return GetStatus(job.Kind, job.Status);
+    }
+
+    public AiJobStatusSemantics GetStatus(AiJobKindId kind, AiJobStatusId status)
+    {
+        if (!TryAcquireStatusResolver(kind, out IAiJobStatusResolverLease? lease))
+            return AiJobStatusSemantics.Unknown;
+
+        using (lease)
+        {
+            return lease.Resolver.Resolve(status);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Task.WhenAll(
+            _statusResolvers.DisposeAsync().AsTask(),
+            _refreshHandlers.DisposeAsync().AsTask(),
+            _retryHandlers.DisposeAsync().AsTask());
+    }
+
+    private static AiJobSlotRegistrationMode ToSlotMode(AiJobBehaviorRegistrationMode mode)
+        => mode == AiJobBehaviorRegistrationMode.Replace
+            ? AiJobSlotRegistrationMode.Replace
+            : AiJobSlotRegistrationMode.Add;
+
+    private static void ReportFailure(
+        Extension extension,
+        string capability,
+        Exception exception)
+        => s_logger.LogWarning(
+            exception,
+            "Ignoring invalid AI job {Capability} contribution from {ExtensionType}.",
+            capability,
+            extension.GetType().FullName ?? extension.GetType().Name);
+
+    private sealed class StatusResolverRegistration(
+        IAiJobSlotRegistration inner) : IAiJobStatusResolverRegistration
+    {
+        public ValueTask DisposeAsync() => inner.DisposeAsync();
+    }
+
+    private sealed class RefreshHandlerRegistration(
+        IAiJobSlotRegistration inner) : IAiJobRefreshHandlerRegistration
+    {
+        public ValueTask DisposeAsync() => inner.DisposeAsync();
+    }
+
+    private sealed class RetryHandlerRegistration(
+        IAiJobSlotRegistration inner) : IAiJobRetryHandlerRegistration
+    {
+        public ValueTask DisposeAsync() => inner.DisposeAsync();
+    }
+
+    private sealed class StatusResolverLease(
+        AiJobSlotLease<IAiJobStatusResolver> inner) : IAiJobStatusResolverLease
+    {
+        public IAiJobStatusResolver Resolver => inner.Capability;
+
+        public void Dispose() => inner.Dispose();
+    }
+
+    private sealed class RefreshHandlerLease(
+        AiJobSlotLease<IAiJobRefreshHandler> inner) : IAiJobRefreshHandlerLease
+    {
+        public IAiJobRefreshHandler Handler => inner.Capability;
+
+        public void Dispose() => inner.Dispose();
+    }
+
+    private sealed class RetryHandlerLease(
+        AiJobSlotLease<IAiJobRetryHandler> inner) : IAiJobRetryHandlerLease
+    {
+        public IAiJobRetryHandler Handler => inner.Capability;
+
+        public void Dispose() => inner.Dispose();
+    }
+}

--- a/src/Beutl.Api/Services/AiJobModels.cs
+++ b/src/Beutl.Api/Services/AiJobModels.cs
@@ -1,0 +1,148 @@
+﻿using System.Text.Json;
+
+namespace Beutl.Api.Services;
+
+public readonly struct AiJobId : IEquatable<AiJobId>
+{
+    private readonly string? _value;
+
+    public AiJobId(string value) => _value = AiIdentifier.Normalize(value, nameof(value));
+
+    public string Value => _value ?? string.Empty;
+
+    public bool Equals(AiJobId other) => StringComparer.Ordinal.Equals(Value, other.Value);
+
+    public override bool Equals(object? obj) => obj is AiJobId other && Equals(other);
+
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Value);
+
+    public override string ToString() => Value;
+
+    public static bool operator ==(AiJobId left, AiJobId right) => left.Equals(right);
+
+    public static bool operator !=(AiJobId left, AiJobId right) => !left.Equals(right);
+}
+
+public readonly struct AiContentId : IEquatable<AiContentId>
+{
+    private readonly string? _value;
+
+    public AiContentId(string value) => _value = AiIdentifier.Normalize(value, nameof(value));
+
+    public string Value => _value ?? string.Empty;
+
+    public bool Equals(AiContentId other) => StringComparer.Ordinal.Equals(Value, other.Value);
+
+    public override bool Equals(object? obj) => obj is AiContentId other && Equals(other);
+
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Value);
+
+    public override string ToString() => Value;
+
+    public static bool operator ==(AiContentId left, AiContentId right) => left.Equals(right);
+
+    public static bool operator !=(AiContentId left, AiContentId right) => !left.Equals(right);
+}
+
+public readonly struct AiJobKindId : IEquatable<AiJobKindId>
+{
+    private readonly string? _value;
+
+    public AiJobKindId(string value) => _value = AiIdentifier.Normalize(value, nameof(value));
+
+    public string Value => _value ?? string.Empty;
+
+    public bool Equals(AiJobKindId other) => StringComparer.Ordinal.Equals(Value, other.Value);
+
+    public override bool Equals(object? obj) => obj is AiJobKindId other && Equals(other);
+
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Value);
+
+    public override string ToString() => Value;
+
+    public static bool operator ==(AiJobKindId left, AiJobKindId right) => left.Equals(right);
+
+    public static bool operator !=(AiJobKindId left, AiJobKindId right) => !left.Equals(right);
+}
+
+public static class AiJobKinds
+{
+    public static AiJobKindId Image { get; } = new("image");
+
+    public static AiJobKindId ImageEdit { get; } = new("image_edit");
+
+    public static AiJobKindId Transcription { get; } = new("stt");
+
+    public static AiJobKindId CaptionTranslation { get; } = new("translation");
+
+    public static AiJobKindId Video { get; } = new("video");
+}
+
+public readonly struct AiJobStatusId : IEquatable<AiJobStatusId>
+{
+    private readonly string? _value;
+
+    public AiJobStatusId(string value) => _value = AiIdentifier.Normalize(value, nameof(value));
+
+    public string Value => _value ?? string.Empty;
+
+    public bool Equals(AiJobStatusId other) => StringComparer.Ordinal.Equals(Value, other.Value);
+
+    public override bool Equals(object? obj) => obj is AiJobStatusId other && Equals(other);
+
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Value);
+
+    public override string ToString() => Value;
+
+    public static bool operator ==(AiJobStatusId left, AiJobStatusId right) => left.Equals(right);
+
+    public static bool operator !=(AiJobStatusId left, AiJobStatusId right) => !left.Equals(right);
+}
+
+public static class AiJobStatuses
+{
+    public static AiJobStatusId Queued { get; } = new("queued");
+
+    public static AiJobStatusId Running { get; } = new("running");
+
+    public static AiJobStatusId Finalizing { get; } = new("finalizing");
+
+    public static AiJobStatusId Succeeded { get; } = new("succeeded");
+
+    public static AiJobStatusId Failed { get; } = new("failed");
+
+    public static AiJobStatusId Canceled { get; } = new("canceled");
+}
+
+public sealed record AiJob(
+    AiJobId Id,
+    AiJobKindId Kind,
+    AiJobStatusId Status,
+    JsonElement? InputParameters,
+    AiContentId? FileId,
+    Uri? ContentUri,
+    string? Error,
+    bool CanRetry,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt,
+    AiContentMetadata? ContentMetadata = null)
+{
+    /// <summary>
+    /// The model the job ran on, or null for one created before an operation
+    /// could offer more than one. A rerun repeats it rather than falling back
+    /// to whatever the default is now.
+    /// </summary>
+    public AiModelId? Model { get; init; }
+}
+
+internal static class AiIdentifier
+{
+    public static string Normalize(string value, string parameterName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value, parameterName);
+        string normalized = value.Trim();
+        if (normalized.Length > 256)
+            throw new ArgumentException("The identifier is too long.", parameterName);
+        return normalized;
+    }
+}

--- a/src/Beutl.Api/Services/AiJobMonitor.cs
+++ b/src/Beutl.Api/Services/AiJobMonitor.cs
@@ -1,0 +1,629 @@
+﻿using System.Collections.Immutable;
+using System.Net;
+using System.Reactive;
+using System.Reactive.Disposables;
+using Beutl.Api.Objects;
+using Reactive.Bindings;
+using Refit;
+
+namespace Beutl.Api.Services;
+
+public sealed record AiJobMonitorSnapshot(
+    ImmutableArray<AiJob> Jobs,
+    string? NextCursor,
+    bool IsLoading,
+    Exception? Error)
+{
+    public static AiJobMonitorSnapshot Empty { get; } = new([], null, false, null);
+}
+
+internal sealed class AiJobMonitor : IAiJobMonitor, IDisposable
+{
+    private readonly IAiJobClient _client;
+    private readonly IAiJobKindRegistry _jobKinds;
+    private readonly BeutlApiApplication _application;
+    private readonly TimeSpan _pollInterval;
+    private readonly Func<TimeSpan, CancellationToken, Task> _retryDelay;
+    private readonly SemaphoreSlim _refreshGate = new(1, 1);
+    private readonly object _pollingGate = new();
+    private readonly object _stateGate = new();
+    private readonly ReactivePropertySlim<AiJobMonitorSnapshot> _snapshot =
+        new(AiJobMonitorSnapshot.Empty);
+    private readonly ReadOnlyReactivePropertySlim<AiJobMonitorSnapshot> _readOnlySnapshot;
+    private readonly CompositeDisposable _subscriptions = [];
+    private CancellationTokenSource? _authenticationCts;
+    private CancellationTokenSource? _pollingCts;
+    private long _authenticationVersion;
+    private int _loadedPageCount;
+    private int _pollingLeases;
+    private readonly HashSet<long> _scheduledRetryVersions = [];
+    private volatile bool _disposed;
+
+    public AiJobMonitor(BeutlApiApplication application)
+        : this(
+            application,
+            application.GetResource<IAiJobClient>(),
+            application.GetResource<IAiJobKindRegistry>(),
+            application.GetResource<AiJobChangeNotifier>().Changes,
+            TimeSpan.FromSeconds(5))
+    {
+    }
+
+    internal AiJobMonitor(
+        BeutlApiApplication application,
+        IAiJobClient client,
+        IAiJobKindRegistry jobKinds,
+        IObservable<Unit> jobChanges,
+        TimeSpan pollInterval,
+        Func<TimeSpan, CancellationToken, Task>? retryDelay = null)
+    {
+        ArgumentNullException.ThrowIfNull(application);
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNull(jobKinds);
+        ArgumentNullException.ThrowIfNull(jobChanges);
+        if (pollInterval <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(pollInterval));
+
+        _application = application;
+        _client = client;
+        _jobKinds = jobKinds;
+        _pollInterval = pollInterval;
+        _retryDelay = retryDelay ?? Task.Delay;
+        _readOnlySnapshot = _snapshot.ToReadOnlyReactivePropertySlim(AiJobMonitorSnapshot.Empty);
+        _subscriptions.Add(jobChanges.Subscribe(HandleJobsChanged));
+        _subscriptions.Add(application.AuthenticatedUser.Subscribe(HandleAuthenticatedUserChanged));
+    }
+
+    public IReadOnlyReactiveProperty<AiJobMonitorSnapshot> Snapshot => _readOnlySnapshot;
+
+    public IDisposable AcquirePolling()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        lock (_pollingGate)
+        {
+            _pollingLeases++;
+        }
+
+        EnsurePolling();
+        if (!GetSnapshot().IsLoading)
+        {
+            RequestRefreshForCurrentAuthentication();
+        }
+
+        return Disposable.Create(ReleasePolling);
+    }
+
+    public Task RefreshAsync(CancellationToken cancellationToken)
+        => RefreshCoreAsync(append: false, cancellationToken);
+
+    public Task LoadNextPageAsync(CancellationToken cancellationToken)
+        => RefreshCoreAsync(append: true, cancellationToken);
+
+    internal Task RefreshPollingAsync(CancellationToken cancellationToken)
+        => RefreshCoreAsync(append: false, cancellationToken, preserveLoadedTail: true);
+
+    public void Dispose()
+    {
+        CancellationTokenSource? authenticationCts;
+        CancellationTokenSource? pollingCts;
+        lock (_stateGate)
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            authenticationCts = _authenticationCts;
+            _authenticationCts = null;
+        }
+
+        lock (_pollingGate)
+        {
+            pollingCts = _pollingCts;
+        }
+
+        authenticationCts?.Cancel();
+        pollingCts?.Cancel();
+        _subscriptions.Dispose();
+        _readOnlySnapshot.Dispose();
+        _snapshot.Dispose();
+        authenticationCts?.Dispose();
+    }
+
+    private async Task RefreshCoreAsync(
+        bool append,
+        CancellationToken cancellationToken,
+        bool preserveLoadedTail = false)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!TryGetAuthenticationContext(
+                out AuthenticatedUser? expectedOwner,
+                out long expectedVersion,
+                out CancellationToken authenticationToken))
+        {
+            SetAuthenticationRequiredSnapshot();
+            return;
+        }
+
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            authenticationToken);
+        CancellationToken token = linkedCts.Token;
+        bool gateEntered = false;
+        try
+        {
+            await _refreshGate.WaitAsync(token);
+            gateEntered = true;
+            token.ThrowIfCancellationRequested();
+
+            AiJobMonitorSnapshot previous;
+            int previousLoadedPageCount;
+            string? cursor;
+            lock (_stateGate)
+            {
+                if (!IsCurrentAuthentication(expectedOwner!, expectedVersion))
+                    return;
+
+                previous = _snapshot.Value;
+                previousLoadedPageCount = _loadedPageCount;
+                cursor = append ? previous.NextCursor : null;
+                if (append && cursor is null)
+                    return;
+
+                _snapshot.Value = previous with { IsLoading = true, Error = null };
+            }
+
+            try
+            {
+                AiJobPage page = await _client.GetPageAsync(new AiJobPageRequest(cursor), token);
+                ImmutableArray<AiJob> jobs;
+                string? nextCursor;
+                int loadedPageCount;
+                if (preserveLoadedTail)
+                {
+                    (jobs, nextCursor, loadedPageCount) = await RefreshLoadedPagesAsync(
+                        page,
+                        Math.Max(1, previousLoadedPageCount),
+                        token);
+                }
+                else
+                {
+                    jobs = MergeJobs(append ? previous.Jobs : [], page.Jobs);
+                    nextCursor = page.NextCursor;
+                    loadedPageCount = append ? previousLoadedPageCount + 1 : 1;
+                }
+
+                lock (_stateGate)
+                {
+                    if (IsCurrentAuthentication(expectedOwner!, expectedVersion))
+                    {
+                        _loadedPageCount = loadedPageCount;
+                        _snapshot.Value = new AiJobMonitorSnapshot(
+                            jobs,
+                            nextCursor,
+                            false,
+                            null);
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
+            {
+                lock (_stateGate)
+                {
+                    if (IsCurrentAuthentication(expectedOwner!, expectedVersion))
+                    {
+                        _snapshot.Value = previous with { IsLoading = false };
+                    }
+                }
+
+                if (cancellationToken.IsCancellationRequested)
+                    throw;
+                return;
+            }
+            catch (Exception ex)
+            {
+                lock (_stateGate)
+                {
+                    if (IsCurrentAuthentication(expectedOwner!, expectedVersion))
+                    {
+                        _snapshot.Value = previous with { IsLoading = false, Error = ex };
+                    }
+                }
+                if (!append && previous.Jobs.IsEmpty && IsTransientRefreshFailure(ex))
+                    ScheduleRetry(expectedOwner!, expectedVersion, authenticationToken);
+            }
+
+            EnsurePolling();
+        }
+        catch (OperationCanceledException) when (
+            authenticationToken.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+        }
+        finally
+        {
+            if (gateEntered)
+            {
+                _refreshGate.Release();
+            }
+        }
+    }
+
+    private void ScheduleRetry(
+        AuthenticatedUser owner,
+        long authenticationVersion,
+        CancellationToken authenticationToken)
+    {
+        lock (_stateGate)
+        {
+            if (_disposed || !_scheduledRetryVersions.Add(authenticationVersion))
+                return;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            bool releasedSchedule = false;
+            try
+            {
+                await _retryDelay(_pollInterval, authenticationToken);
+                lock (_stateGate)
+                {
+                    _scheduledRetryVersions.Remove(authenticationVersion);
+                }
+                releasedSchedule = true;
+                if (IsCurrentAuthentication(owner, authenticationVersion))
+                    await RefreshCoreAsync(false, authenticationToken);
+            }
+            catch (OperationCanceledException) when (authenticationToken.IsCancellationRequested)
+            {
+            }
+            finally
+            {
+                if (!releasedSchedule)
+                {
+                    lock (_stateGate)
+                    {
+                        _scheduledRetryVersions.Remove(authenticationVersion);
+                    }
+                }
+            }
+        }, CancellationToken.None);
+    }
+
+    private static bool IsTransientRefreshFailure(Exception exception)
+        => exception switch
+        {
+            TaskCanceledException => true,
+            TimeoutException => true,
+            HttpRequestException { StatusCode: null } => true,
+            HttpRequestException { StatusCode: { } status } => IsRetryableStatus(status),
+            ApiException apiException => IsRetryableStatus(apiException.StatusCode),
+            _ => false,
+        };
+
+    private static bool IsRetryableStatus(HttpStatusCode status)
+        => status is HttpStatusCode.RequestTimeout
+            or HttpStatusCode.TooManyRequests
+            || (int)status >= 500;
+
+    private static ImmutableArray<AiJob> MergeJobs(
+        IEnumerable<AiJob> existing,
+        IEnumerable<AiJob> incoming)
+    {
+        var result = new List<AiJob>();
+        var indices = new Dictionary<AiJobId, int>();
+        foreach (AiJob job in existing.Concat(incoming))
+        {
+            if (indices.TryGetValue(job.Id, out int index))
+            {
+                result[index] = job;
+            }
+            else
+            {
+                indices.Add(job.Id, result.Count);
+                result.Add(job);
+            }
+        }
+
+        return result.ToImmutableArray();
+    }
+
+    private async Task<(ImmutableArray<AiJob> Jobs, string? NextCursor, int PageCount)>
+        RefreshLoadedPagesAsync(
+            AiJobPage firstPage,
+            int pageCount,
+            CancellationToken cancellationToken)
+    {
+        // Re-read exactly the depth the person loaded. A new leading job can push the
+        // previous oldest item behind that boundary; retaining every absent old item
+        // instead would also retain jobs the server deleted, with no way to distinguish them.
+        ImmutableArray<AiJob> jobs = MergeJobs([], firstPage.Jobs);
+        string? nextCursor = firstPage.NextCursor;
+        int refreshedPages = 1;
+        while (refreshedPages < pageCount && nextCursor is not null)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            AiJobPage page = await _client.GetPageAsync(
+                new AiJobPageRequest(nextCursor),
+                cancellationToken);
+            jobs = MergeJobs(jobs, page.Jobs);
+            nextCursor = page.NextCursor;
+            refreshedPages++;
+        }
+
+        return (jobs, nextCursor, refreshedPages);
+    }
+
+    private bool ShouldPoll(AiJob job)
+    {
+        try
+        {
+            return _jobKinds.GetStatus(job).ShouldPoll;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private AiJobMonitorSnapshot GetSnapshot()
+    {
+        lock (_stateGate)
+        {
+            return _snapshot.Value;
+        }
+    }
+
+    private void HandleJobsChanged(Unit value)
+        => RequestRefreshForCurrentAuthentication();
+
+    private void HandleAuthenticatedUserChanged(AuthenticatedUser? user)
+    {
+        CancellationTokenSource? previousCts;
+        CancellationTokenSource? nextCts = user is null ? null : new CancellationTokenSource();
+        lock (_stateGate)
+        {
+            if (_disposed)
+            {
+                nextCts?.Dispose();
+                return;
+            }
+
+            previousCts = _authenticationCts;
+            _authenticationCts = nextCts;
+            _authenticationVersion++;
+            _loadedPageCount = 0;
+            _snapshot.Value = user is null
+                ? CreateAuthenticationRequiredSnapshot()
+                : AiJobMonitorSnapshot.Empty with { IsLoading = true };
+        }
+
+        previousCts?.Cancel();
+        previousCts?.Dispose();
+        if (user is not null)
+        {
+            RequestRefreshForCurrentAuthentication();
+            EnsurePolling();
+        }
+        else
+        {
+            CancelPollingIfUnneeded();
+        }
+    }
+
+    private void RequestRefreshForCurrentAuthentication()
+    {
+        CancellationToken token;
+        lock (_stateGate)
+        {
+            if (_disposed || _authenticationCts is null)
+                return;
+            token = _authenticationCts.Token;
+        }
+
+        _ = RefreshFromNotificationAsync(token);
+    }
+
+    private async Task RefreshFromNotificationAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await RefreshPollingAsync(cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    private bool TryGetAuthenticationContext(
+        out AuthenticatedUser? owner,
+        out long authenticationVersion,
+        out CancellationToken authenticationToken)
+    {
+        lock (_stateGate)
+        {
+            owner = _application.AuthenticatedUser.Value;
+            authenticationVersion = _authenticationVersion;
+            if (_disposed || owner is null || _authenticationCts is null)
+            {
+                authenticationToken = new CancellationToken(canceled: true);
+                return false;
+            }
+
+            authenticationToken = _authenticationCts.Token;
+            return true;
+        }
+    }
+
+    private bool IsCurrentAuthentication(AuthenticatedUser owner, long authenticationVersion)
+        => !_disposed
+            && _authenticationCts is not null
+            && _authenticationVersion == authenticationVersion
+            && ReferenceEquals(_application.AuthenticatedUser.Value, owner);
+
+    private void SetAuthenticationRequiredSnapshot()
+    {
+        lock (_stateGate)
+        {
+            if (!_disposed)
+            {
+                _loadedPageCount = 0;
+                _snapshot.Value = CreateAuthenticationRequiredSnapshot();
+            }
+        }
+    }
+
+    private static AiJobMonitorSnapshot CreateAuthenticationRequiredSnapshot()
+        => AiJobMonitorSnapshot.Empty with { Error = new AuthenticationRequiredException() };
+
+    private void ReleasePolling()
+    {
+        lock (_pollingGate)
+        {
+            if (_pollingLeases == 0)
+                return;
+            _pollingLeases--;
+        }
+
+        CancelPollingIfUnneeded();
+    }
+
+    private void EnsurePolling()
+    {
+        CancellationToken authenticationToken;
+        lock (_stateGate)
+        {
+            if (_disposed || _authenticationCts is null)
+                return;
+            authenticationToken = _authenticationCts.Token;
+        }
+
+        lock (_pollingGate)
+        {
+            if (_pollingCts is not null
+                || (_pollingLeases == 0 && !GetSnapshot().Jobs.Any(ShouldPoll)))
+            {
+                return;
+            }
+
+            var cancellationTokenSource =
+                CancellationTokenSource.CreateLinkedTokenSource(authenticationToken);
+            _pollingCts = cancellationTokenSource;
+            _ = RunPollingAsync(cancellationTokenSource);
+        }
+    }
+
+    private void CancelPollingIfUnneeded()
+    {
+        CancellationTokenSource? cancellationTokenSource = null;
+        lock (_pollingGate)
+        {
+            if (_pollingLeases == 0 && !GetSnapshot().Jobs.Any(ShouldPoll))
+            {
+                cancellationTokenSource = _pollingCts;
+            }
+        }
+
+        cancellationTokenSource?.Cancel();
+    }
+
+    private async Task RunPollingAsync(CancellationTokenSource cancellationTokenSource)
+    {
+        try
+        {
+            await PollActiveJobsAsync(cancellationTokenSource.Token);
+        }
+        finally
+        {
+            lock (_pollingGate)
+            {
+                if (ReferenceEquals(_pollingCts, cancellationTokenSource))
+                {
+                    _pollingCts = null;
+                }
+            }
+
+            cancellationTokenSource.Dispose();
+            EnsurePolling();
+        }
+    }
+
+    private bool ShouldKeepPolling()
+    {
+        lock (_pollingGate)
+        {
+            return !_disposed && (_pollingLeases > 0 || GetSnapshot().Jobs.Any(ShouldPoll));
+        }
+    }
+
+    private bool HasPollingLease()
+    {
+        lock (_pollingGate)
+        {
+            return _pollingLeases > 0;
+        }
+    }
+
+    private async Task PollActiveJobsAsync(CancellationToken cancellationToken)
+    {
+        while (ShouldKeepPolling())
+        {
+            try
+            {
+                await Task.Delay(_pollInterval, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            AiJobMonitorSnapshot snapshot = GetSnapshot();
+            if (snapshot.Error is AuthenticationRequiredException)
+                continue;
+
+            ImmutableArray<AiJob> pollingJobs = snapshot.Jobs.Where(ShouldPoll).ToImmutableArray();
+            foreach (AiJob job in pollingJobs)
+            {
+                AiJobStatusSemantics status;
+                try
+                {
+                    status = _jobKinds.GetStatus(job);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (!status.ShouldPoll
+                    || !_jobKinds.TryAcquireRefreshHandler(
+                        job.Kind,
+                        out IAiJobRefreshHandlerLease? refreshLease))
+                {
+                    continue;
+                }
+
+                using (refreshLease)
+                {
+                    try
+                    {
+                        await refreshLease.Handler.RefreshAsync(job, cancellationToken);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+                    catch (AuthenticationRequiredException)
+                    {
+                        break;
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+
+            if (pollingJobs.Length > 0 || HasPollingLease() || snapshot.Error is not null)
+            {
+                await RefreshPollingAsync(cancellationToken);
+            }
+        }
+    }
+}

--- a/src/Beutl.Api/Services/AiJobSlotRegistry.cs
+++ b/src/Beutl.Api/Services/AiJobSlotRegistry.cs
@@ -1,0 +1,692 @@
+﻿using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
+using Beutl.Extensibility;
+
+namespace Beutl.Api.Services;
+
+internal enum AiJobSlotRegistrationMode
+{
+    Add,
+    Replace,
+}
+
+internal interface IAiJobSlotRegistration : IAsyncDisposable
+{
+}
+
+internal sealed class AiJobSlotRegistry<TCapability, TRegistration, TExtension>
+    : IAsyncDisposable
+    where TCapability : class
+    where TRegistration : class
+    where TExtension : Extension
+{
+    private readonly Dictionary<AiJobKindId, List<Registration>> _registrations = [];
+    private readonly HashSet<Task> _activeRegistrationRetirements = [];
+    private readonly Dictionary<TExtension, List<Registration>> _extensionRegistrations =
+        new(ReferenceEqualityComparer.Instance);
+    private readonly object _extensionCompositionGate = new();
+    private readonly object _gate = new();
+    private readonly Func<TRegistration, AiJobKindId> _getKind;
+    private readonly Func<TRegistration, TCapability> _getCapability;
+    private readonly Func<TRegistration, AiJobSlotRegistrationMode> _getMode;
+    private readonly Func<AiJobKindId, TCapability, TRegistration> _createRegistration;
+    private readonly Func<TExtension, IReadOnlyCollection<TRegistration>?> _getExtensionRegistrations;
+    private readonly Action<TExtension, Exception>? _reportFailure;
+    private IExtensionRegistry? _extensionProvider;
+    private Task? _disposeTask;
+    private bool _disposed;
+
+    public AiJobSlotRegistry(
+        IEnumerable<TRegistration> hostRegistrations,
+        Func<TRegistration, AiJobKindId> getKind,
+        Func<TRegistration, TCapability> getCapability,
+        Func<TRegistration, AiJobSlotRegistrationMode> getMode,
+        Func<AiJobKindId, TCapability, TRegistration> createRegistration,
+        Func<TExtension, IReadOnlyCollection<TRegistration>?> getExtensionRegistrations,
+        IExtensionRegistry? extensionProvider,
+        Action<TExtension, Exception>? reportFailure)
+    {
+        ArgumentNullException.ThrowIfNull(hostRegistrations);
+        _getKind = getKind ?? throw new ArgumentNullException(nameof(getKind));
+        _getCapability = getCapability ?? throw new ArgumentNullException(nameof(getCapability));
+        _getMode = getMode ?? throw new ArgumentNullException(nameof(getMode));
+        _createRegistration = createRegistration ?? throw new ArgumentNullException(nameof(createRegistration));
+        _getExtensionRegistrations = getExtensionRegistrations
+            ?? throw new ArgumentNullException(nameof(getExtensionRegistrations));
+        _reportFailure = reportFailure;
+
+        foreach (TRegistration registration in hostRegistrations)
+        {
+            Register(registration);
+        }
+
+        if (extensionProvider is not null)
+        {
+            AttachExtensionProvider(extensionProvider);
+        }
+    }
+
+    public IAiJobSlotRegistration Register(TRegistration registration)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+        AiJobKindId kind = _getKind(registration);
+        TCapability capability = _getCapability(registration)
+            ?? throw new ArgumentException("A capability registration requires a capability.", nameof(registration));
+        AiJobSlotRegistrationMode mode = _getMode(registration);
+        Validate(kind, mode);
+
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return RegisterCore_NoLock(registration, Normalize(kind), capability, mode);
+        }
+    }
+
+    public bool TryAcquire(
+        AiJobKindId kind,
+        [NotNullWhen(true)] out AiJobSlotLease<TCapability>? lease)
+    {
+        if (string.IsNullOrWhiteSpace(kind.Value))
+        {
+            lease = null;
+            return false;
+        }
+
+        AiJobKindId normalized = Normalize(kind);
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_registrations.TryGetValue(normalized, out List<Registration>? registrations))
+            {
+                for (int index = registrations.Count - 1; index >= 0; index--)
+                {
+                    if (registrations[index].TryAcquire(out AiJobSlotLease<TCapability>? result))
+                    {
+                        lease = result;
+                        return true;
+                    }
+
+                    registrations.RemoveAt(index);
+                }
+
+                if (registrations.Count == 0)
+                {
+                    _registrations.Remove(normalized);
+                }
+            }
+
+            lease = null;
+            return false;
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (_extensionProvider is IExtensionRegistry registry)
+        {
+            ValueTask result = default;
+            registry.SynchronizeMutation(() => result = StartDispose());
+            return result;
+        }
+
+        return StartDispose();
+    }
+
+    private Registration RegisterCore_NoLock(
+        TRegistration registration,
+        AiJobKindId kind,
+        TCapability capability,
+        AiJobSlotRegistrationMode mode)
+    {
+        if (!_registrations.TryGetValue(kind, out List<Registration>? registrations))
+        {
+            registrations = [];
+            _registrations.Add(kind, registrations);
+        }
+
+        bool exists = registrations.Count > 0;
+        if (mode == AiJobSlotRegistrationMode.Add && exists)
+        {
+            throw new ArgumentException(
+                $"An AI job capability for '{_getKind(registration)}' is already registered. Use Replace explicitly.",
+                nameof(registration));
+        }
+        if (mode == AiJobSlotRegistrationMode.Replace && !exists)
+        {
+            throw new ArgumentException(
+                $"An AI job capability for '{_getKind(registration)}' cannot be replaced because it is not registered.",
+                nameof(registration));
+        }
+
+        var result = new Registration(this, new RegistrationState(kind, capability));
+        registrations.Add(result);
+        return result;
+    }
+
+    private Registration RegisterCore_NoLock(TRegistration registration)
+        => RegisterCore_NoLock(
+            registration,
+            Normalize(_getKind(registration)),
+            _getCapability(registration),
+            _getMode(registration));
+
+    private ValueTask StartDispose()
+    {
+        lock (_extensionCompositionGate)
+        {
+            return new ValueTask(_disposeTask ??= DisposeCoreAsync());
+        }
+    }
+
+    private Task DisposeCoreAsync()
+    {
+        Registration[] registrations;
+        Task[] activeRetirements;
+        KeyValuePair<TExtension, List<Registration>>[] extensionRegistrations;
+        lock (_extensionCompositionGate)
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                    return Task.CompletedTask;
+
+                _disposed = true;
+                registrations = _registrations.Values.SelectMany(value => value).ToArray();
+                _registrations.Clear();
+                activeRetirements = _activeRegistrationRetirements.ToArray();
+                _activeRegistrationRetirements.Clear();
+            }
+
+            if (_extensionProvider is not null)
+            {
+                _extensionProvider.AllExtensions.CollectionChanged -= OnExtensionCollectionChanged;
+                _extensionProvider.ExtensionsChanged -= OnCommittedExtensionsChanged;
+                _extensionProvider = null;
+            }
+
+            extensionRegistrations = _extensionRegistrations.ToArray();
+            _extensionRegistrations.Clear();
+        }
+
+        foreach ((TExtension extension, List<Registration> owned) in extensionRegistrations)
+        {
+            ExtensionRegistrationLifetimes.Retire(
+                extension,
+                () => DisposeRegistrationsAsync(owned));
+        }
+
+        Task registrationsDisposed = DisposeRegistrationsAsync(registrations).AsTask();
+        return Task.WhenAll(activeRetirements.Append(registrationsDisposed));
+    }
+
+    private void AttachExtensionProvider(IExtensionRegistry extensionProvider)
+    {
+        extensionProvider.SynchronizeMutation(() =>
+        {
+            lock (_extensionCompositionGate)
+            {
+                ObjectDisposedException.ThrowIf(_disposed, this);
+                if (_extensionProvider is not null)
+                    throw new InvalidOperationException("An extension provider is already attached.");
+
+                _extensionProvider = extensionProvider;
+                extensionProvider.AllExtensions.CollectionChanged += OnExtensionCollectionChanged;
+                extensionProvider.ExtensionsChanged += OnCommittedExtensionsChanged;
+                try
+                {
+                    SynchronizeExtensionRegistrationsCore();
+                }
+                catch
+                {
+                    extensionProvider.AllExtensions.CollectionChanged -= OnExtensionCollectionChanged;
+                    extensionProvider.ExtensionsChanged -= OnCommittedExtensionsChanged;
+                    _extensionProvider = null;
+                    throw;
+                }
+            }
+        });
+    }
+
+    private void OnExtensionCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.Action == NotifyCollectionChangedAction.Add)
+            return;
+
+        SynchronizeExtensionRegistrations();
+    }
+
+    private void OnCommittedExtensionsChanged(object? sender, EventArgs e)
+        => SynchronizeExtensionRegistrations();
+
+    private void SynchronizeExtensionRegistrations()
+    {
+        lock (_extensionCompositionGate)
+        {
+            if (!_disposed)
+            {
+                SynchronizeExtensionRegistrationsCore();
+            }
+        }
+    }
+
+    private void SynchronizeExtensionRegistrationsCore()
+    {
+        IExtensionRegistry extensionProvider = _extensionProvider
+            ?? throw new InvalidOperationException("No extension provider is attached.");
+        TExtension[] currentExtensions = extensionProvider.GetExtensions<TExtension>();
+        var currentSet = new HashSet<TExtension>(
+            currentExtensions,
+            ReferenceEqualityComparer.Instance);
+
+        KeyValuePair<TExtension, List<Registration>>[] removedRegistrations =
+            _extensionRegistrations
+                .Where(pair => !currentSet.Contains(pair.Key))
+                .ToArray();
+
+        var candidates = new List<(TExtension Extension, TRegistration[] Registrations)>();
+        foreach (TExtension extension in currentExtensions)
+        {
+            if (_extensionRegistrations.ContainsKey(extension))
+                continue;
+
+            try
+            {
+                candidates.Add((extension, ValidateRegistrations(extension)));
+            }
+            catch (Exception ex)
+            {
+                ReportFailure(extension, ex);
+            }
+        }
+
+        var failures = new Dictionary<TExtension, Exception>(ReferenceEqualityComparer.Instance);
+        List<(TExtension Extension, List<Registration> Owned)> retired = [];
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            var removedRegistrationSet = new HashSet<Registration>(
+                removedRegistrations.SelectMany(pair => pair.Value),
+                ReferenceEqualityComparer.Instance);
+            TRegistration[] baseRegistrations = _registrations
+                .Select(pair => new
+                {
+                    pair.Key,
+                    Registration = pair.Value.LastOrDefault(
+                        registration => !removedRegistrationSet.Contains(registration)),
+                })
+                .Where(pair => pair.Registration is not null)
+                .OrderBy(pair => pair.Key.Value, StringComparer.Ordinal)
+                .Select(pair => pair.Registration!.ToSeedRegistration())
+                .ToArray();
+
+            while (true)
+            {
+                var newFailures = new Dictionary<TExtension, (Exception Exception, int Phase)>(
+                    ReferenceEqualityComparer.Instance);
+                var working = new List<TRegistration>(baseRegistrations);
+                AiJobSlotRegistrationMode[] phases =
+                [
+                    AiJobSlotRegistrationMode.Add,
+                    AiJobSlotRegistrationMode.Replace,
+                ];
+
+                for (int phaseIndex = 0; phaseIndex < phases.Length; phaseIndex++)
+                {
+                    AiJobSlotRegistrationMode mode = phases[phaseIndex];
+                    foreach ((TExtension extension, TRegistration[] registrations) in candidates)
+                    {
+                        if (failures.ContainsKey(extension) || newFailures.ContainsKey(extension))
+                            continue;
+
+                        TRegistration[] phase = registrations
+                            .Where(registration => _getMode(registration) == mode)
+                            .ToArray();
+                        if (phase.Length == 0)
+                            continue;
+
+                        try
+                        {
+                            _ = CreateScratchRegistry(working.Concat(phase));
+                            working.AddRange(phase);
+                        }
+                        catch (Exception ex)
+                        {
+                            newFailures.Add(extension, (ex, phaseIndex));
+                        }
+                    }
+                }
+
+                if (newFailures.Count > 0)
+                {
+                    int latestFailedPhase = newFailures.Values.Max(failure => failure.Phase);
+                    KeyValuePair<TExtension, (Exception Exception, int Phase)> rejected =
+                        newFailures.First(failure => failure.Value.Phase == latestFailedPhase);
+                    failures.TryAdd(rejected.Key, rejected.Value.Exception);
+                    continue;
+                }
+
+                foreach ((TExtension extension, List<Registration> registrations)
+                         in removedRegistrations)
+                {
+                    _extensionRegistrations.Remove(extension);
+                    foreach (Registration registration in registrations)
+                        RetireRegistration_NoLock(registration);
+                    retired.Add((extension, registrations));
+                }
+
+                var ownedByExtension = new Dictionary<TExtension, List<Registration>>(
+                    ReferenceEqualityComparer.Instance);
+                foreach ((TExtension extension, _) in candidates)
+                {
+                    if (!failures.ContainsKey(extension))
+                        ownedByExtension.Add(extension, []);
+                }
+
+                foreach (AiJobSlotRegistrationMode mode in phases)
+                {
+                    foreach ((TExtension extension, TRegistration[] registrations) in candidates)
+                    {
+                        if (failures.ContainsKey(extension))
+                            continue;
+
+                        List<Registration> owned = ownedByExtension[extension];
+                        foreach (TRegistration registration in registrations
+                                     .Where(registration => _getMode(registration) == mode))
+                        {
+                            owned.Add(RegisterCore_NoLock(registration));
+                        }
+                    }
+                }
+
+                foreach ((TExtension extension, List<Registration> owned) in ownedByExtension)
+                {
+                    _extensionRegistrations[extension] = owned;
+                }
+
+                break;
+            }
+        }
+
+        foreach ((TExtension extension, List<Registration> registrations) in retired)
+        {
+            ExtensionRegistrationLifetimes.Retire(
+                extension,
+                () => DisposeRegistrationsAsync(registrations));
+        }
+
+        foreach ((TExtension extension, Exception failure) in failures)
+            ReportFailure(extension, failure);
+    }
+
+    private AiJobSlotRegistry<TCapability, TRegistration, TExtension> CreateScratchRegistry(
+        IEnumerable<TRegistration> registrations)
+        => new(
+            registrations,
+            _getKind,
+            _getCapability,
+            _getMode,
+            _createRegistration,
+            _getExtensionRegistrations,
+            null,
+            null);
+
+    private TRegistration[] ValidateRegistrations(TExtension extension)
+    {
+        IReadOnlyCollection<TRegistration>? registrations = _getExtensionRegistrations(extension);
+        if (registrations is null)
+        {
+            throw new InvalidOperationException(
+                "An AI job capability extension returned a null registration collection.");
+        }
+
+        TRegistration[] snapshot = registrations.ToArray();
+        if (snapshot.Any(registration => registration is null))
+        {
+            throw new InvalidOperationException(
+                "An AI job capability extension returned a null registration.");
+        }
+
+        return snapshot;
+    }
+
+    private void ReportFailure(TExtension extension, Exception exception)
+    {
+        if (_reportFailure is null)
+            return;
+
+        try
+        {
+            _reportFailure(extension, exception);
+        }
+        catch
+        {
+            // Diagnostics must not interrupt extension removal before Extension.Unload().
+        }
+    }
+
+    private Task UnregisterAsync(Registration registration, RegistrationState state)
+    {
+        Task drain;
+        lock (_gate)
+        {
+            drain = state.RetireAsync();
+            if (!drain.IsCompleted)
+            {
+                _activeRegistrationRetirements.Add(drain);
+                _ = ForgetRetirementWhenCompleteAsync(drain);
+            }
+
+            if (_registrations.TryGetValue(state.Kind, out List<Registration>? registrations))
+            {
+                registrations.Remove(registration);
+                if (registrations.Count == 0)
+                {
+                    _registrations.Remove(state.Kind);
+                }
+            }
+        }
+
+        return drain;
+    }
+
+    private async Task ForgetRetirementWhenCompleteAsync(Task retirement)
+    {
+        try
+        {
+            await retirement.ConfigureAwait(false);
+        }
+        catch
+        {
+            // The registration owner and any concurrent registry disposal still observe the
+            // original task. This continuation only releases completed tracking state.
+        }
+        finally
+        {
+            lock (_gate)
+            {
+                _activeRegistrationRetirements.Remove(retirement);
+            }
+        }
+    }
+
+    private void RetireRegistration_NoLock(Registration registration)
+    {
+        (AiJobKindId Kind, Task Drain)? retired = registration.RetireNoLock();
+        if (retired is null)
+            return;
+
+        if (_registrations.TryGetValue(retired.Value.Kind, out List<Registration>? registrations))
+        {
+            registrations.Remove(registration);
+            if (registrations.Count == 0)
+                _registrations.Remove(retired.Value.Kind);
+        }
+    }
+
+    private static ValueTask DisposeRegistrationsAsync(IEnumerable<Registration> registrations)
+    {
+        Task[] drains = registrations
+            .Select(registration => registration.DisposeAsync().AsTask())
+            .ToArray();
+        return drains.Length == 0
+            ? ValueTask.CompletedTask
+            : new ValueTask(Task.WhenAll(drains));
+    }
+
+    private static AiJobKindId Normalize(AiJobKindId kind)
+        => new(kind.Value.ToLowerInvariant());
+
+    private static void Validate(AiJobKindId kind, AiJobSlotRegistrationMode mode)
+    {
+        if (string.IsNullOrWhiteSpace(kind.Value))
+            throw new ArgumentException("An AI job kind identifier is required.", nameof(kind));
+        if (!Enum.IsDefined(mode))
+            throw new ArgumentOutOfRangeException(nameof(mode));
+    }
+
+    private sealed class RegistrationState(AiJobKindId kind, TCapability capability)
+    {
+        private readonly object _gate = new();
+        private TaskCompletionSource? _drained;
+        private int _activeLeases;
+        private bool _retired;
+
+        public AiJobKindId Kind { get; } = kind;
+
+        public TCapability Capability { get; } = capability;
+
+        public bool TryAcquire([NotNullWhen(true)] out AiJobSlotLease<TCapability>? lease)
+        {
+            lock (_gate)
+            {
+                if (_retired)
+                {
+                    lease = null;
+                    return false;
+                }
+
+                _activeLeases++;
+                lease = new AiJobSlotLease<TCapability>(Capability, ReleaseLease);
+                return true;
+            }
+        }
+
+        public Task RetireAsync()
+        {
+            lock (_gate)
+            {
+                _retired = true;
+                return _activeLeases == 0
+                    ? Task.CompletedTask
+                    : (_drained ??= new TaskCompletionSource(
+                        TaskCreationOptions.RunContinuationsAsynchronously)).Task;
+            }
+        }
+
+        private void ReleaseLease()
+        {
+            TaskCompletionSource? drained = null;
+            lock (_gate)
+            {
+                _activeLeases--;
+                if (_activeLeases == 0 && _retired)
+                {
+                    drained = _drained;
+                }
+            }
+
+            drained?.TrySetResult();
+        }
+    }
+
+    private sealed class Registration : IAiJobSlotRegistration
+    {
+        private readonly Lazy<Task> _retirement;
+        private RegistrationOwner? _owner;
+
+        public Registration(
+            AiJobSlotRegistry<TCapability, TRegistration, TExtension> registry,
+            RegistrationState state)
+        {
+            _owner = new RegistrationOwner(registry, state);
+            _retirement = new Lazy<Task>(
+                RetireCoreAsync,
+                LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+
+        public bool TryAcquire([NotNullWhen(true)] out AiJobSlotLease<TCapability>? lease)
+        {
+            RegistrationOwner? owner = Volatile.Read(ref _owner);
+            if (_retirement.IsValueCreated || owner is null)
+            {
+                lease = null;
+                return false;
+            }
+
+            return owner.State.TryAcquire(out lease);
+        }
+
+        public ValueTask DisposeAsync() => new(_retirement.Value);
+
+        public (AiJobKindId Kind, Task Drain)? RetireNoLock()
+        {
+            RegistrationOwner? owner = Volatile.Read(ref _owner);
+            return owner is null
+                ? null
+                : (owner.State.Kind, owner.State.RetireAsync());
+        }
+
+        public TRegistration ToSeedRegistration()
+        {
+            RegistrationOwner? owner = Volatile.Read(ref _owner);
+            if (owner is null)
+                throw new ObjectDisposedException(nameof(AiJobSlotRegistry<TCapability, TRegistration, TExtension>));
+
+            return owner.Registry._createRegistration(
+                owner.State.Kind,
+                owner.State.Capability);
+        }
+
+        private async Task RetireCoreAsync()
+        {
+            RegistrationOwner? owner = Volatile.Read(ref _owner);
+            if (owner is null)
+                return;
+
+            try
+            {
+                await owner.Registry.UnregisterAsync(this, owner.State).ConfigureAwait(false);
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _owner, null);
+            }
+        }
+
+        private sealed record RegistrationOwner(
+            AiJobSlotRegistry<TCapability, TRegistration, TExtension> Registry,
+            RegistrationState State);
+    }
+}
+
+internal sealed class AiJobSlotLease<TCapability>(
+    TCapability capability,
+    Action release) : IDisposable
+    where TCapability : class
+{
+    private Action? _release = release;
+
+    public TCapability Capability
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(Volatile.Read(ref _release) is null, this);
+            return capability;
+        }
+    }
+
+    public void Dispose()
+    {
+        Interlocked.Exchange(ref _release, null)?.Invoke();
+    }
+}

--- a/src/Beutl.Api/Services/AiModels.cs
+++ b/src/Beutl.Api/Services/AiModels.cs
@@ -373,11 +373,21 @@ public sealed class AiModelCatalog
         {
             if (models.IsDefault)
                 return [];
-            if (models.Any(model => model is null || model.Id.Value.Length == 0))
+            var modelIds = new HashSet<AiModelId>();
+            foreach (AiModelOption? model in models)
             {
-                throw new ArgumentException(
-                    "Every catalog model must have a non-empty identifier.",
-                    nameof(operations));
+                if (model is null || model.Id.Value.Length == 0)
+                {
+                    throw new ArgumentException(
+                        "Every catalog model must have a non-empty identifier.",
+                        nameof(operations));
+                }
+                if (!modelIds.Add(model.Id))
+                {
+                    throw new ArgumentException(
+                        "Model identifiers must be unique within an operation.",
+                        nameof(operations));
+                }
             }
 
             return models;

--- a/src/Beutl.Api/Services/AiModels.cs
+++ b/src/Beutl.Api/Services/AiModels.cs
@@ -398,9 +398,58 @@ public sealed class AiModelCatalog
                         + $"{AiRequestLimits.MaxVideoDurationSeconds} seconds.",
                         nameof(operations));
                 }
+                if (model.Video is { } video)
+                {
+                    ValidateCapabilityIdentifiers(video.Resolutions, "video resolution");
+                    ValidateCapabilityIdentifiers(video.AspectRatios, "video aspect ratio");
+                }
+                if (model.Image is { } image)
+                {
+                    ValidateCapabilityIdentifiers(image.AspectRatios, "image aspect ratio");
+                    ValidateCapabilityIdentifiers(image.Backgrounds, "image background");
+                }
             }
 
             return models;
+
+            static void ValidateCapabilityIdentifiers(
+                AiCapabilityDimension<string> dimension,
+                string dimensionName)
+            {
+                if (!dimension.IsSpecified)
+                    return;
+
+                var normalizedValues = new HashSet<string>(StringComparer.Ordinal);
+                foreach (string? value in dimension.Values)
+                {
+                    string normalized;
+                    try
+                    {
+                        normalized = AiIdentifier.Normalize(value!, dimensionName);
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        throw new ArgumentException(
+                            $"Every {dimensionName} capability must be a valid identifier.",
+                            nameof(operations),
+                            ex);
+                    }
+
+                    if (!string.Equals(value, normalized, StringComparison.Ordinal))
+                    {
+                        throw new ArgumentException(
+                            $"Every {dimensionName} capability must use its canonical identifier.",
+                            nameof(operations));
+                    }
+
+                    if (!normalizedValues.Add(normalized))
+                    {
+                        throw new ArgumentException(
+                            $"{dimensionName} capabilities must be unique after normalization.",
+                            nameof(operations));
+                    }
+                }
+            }
         }
     }
 

--- a/src/Beutl.Api/Services/AiModels.cs
+++ b/src/Beutl.Api/Services/AiModels.cs
@@ -1,0 +1,2005 @@
+﻿using System.Collections.Immutable;
+using Beutl.Api.Clients;
+
+namespace Beutl.Api.Services;
+
+public readonly struct AiOperationId : IEquatable<AiOperationId>
+{
+    private readonly string? _value;
+
+    public AiOperationId(string value) => _value = AiIdentifier.Normalize(value, nameof(value));
+
+    public string Value => _value ?? string.Empty;
+
+    public bool Equals(AiOperationId other) => StringComparer.Ordinal.Equals(Value, other.Value);
+
+    public override bool Equals(object? obj) => obj is AiOperationId other && Equals(other);
+
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Value);
+
+    public override string ToString() => Value;
+
+    public static bool operator ==(AiOperationId left, AiOperationId right) => left.Equals(right);
+
+    public static bool operator !=(AiOperationId left, AiOperationId right) => !left.Equals(right);
+}
+
+/// <summary>
+/// One of the models an operation may run on, as registered on the server. The
+/// list is not known at build time, so it is never a fixed set here.
+/// </summary>
+public readonly struct AiModelId : IEquatable<AiModelId>
+{
+    private readonly string? _value;
+
+    public AiModelId(string value) => _value = AiIdentifier.Normalize(value, nameof(value));
+
+    public string Value => _value ?? string.Empty;
+
+    public bool Equals(AiModelId other) => StringComparer.Ordinal.Equals(Value, other.Value);
+
+    public override bool Equals(object? obj) => obj is AiModelId other && Equals(other);
+
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Value);
+
+    public override string ToString() => Value;
+
+    public static bool operator ==(AiModelId left, AiModelId right) => left.Equals(right);
+
+    public static bool operator !=(AiModelId left, AiModelId right) => !left.Equals(right);
+}
+
+/// <summary>
+/// How one model compares in cost with the others offered for the same
+/// operation. The server publishes an ordering rather than a price, so this is
+/// all a client can say about what a choice will spend.
+/// </summary>
+public enum AiModelCostTier
+{
+    Low,
+    Medium,
+    High,
+}
+
+/// <summary>
+/// One dimension of values a model accepts. Unspecified means the provider
+/// omitted the dimension, Unsupported means it explicitly accepts no value,
+/// and Supported carries the accepted values.
+/// </summary>
+/// <remarks>
+/// <see langword="default"/> is identical to <see cref="Unspecified"/>.
+/// Both unspecified and unsupported dimensions expose an empty <see cref="Values"/>
+/// array; use <see cref="IsSpecified"/> to distinguish them. Calling
+/// <see cref="Supported(IEnumerable{T})"/> with an empty sequence produces the
+/// same value as <see cref="Unsupported"/>. Equality compares the specified
+/// state and, for a specified dimension, the values in order.
+/// </remarks>
+public readonly struct AiCapabilityDimension<T> : IEquatable<AiCapabilityDimension<T>>
+    where T : notnull
+{
+    private readonly ImmutableArray<T> _values;
+
+    private AiCapabilityDimension(ImmutableArray<T> values, bool isSpecified)
+    {
+        _values = values;
+        IsSpecified = isSpecified;
+    }
+
+    /// <summary>Gets the accepted values. Unspecified and unsupported dimensions return an empty array.</summary>
+    public ImmutableArray<T> Values => _values.IsDefault ? [] : _values;
+
+    /// <summary>Gets whether the server explicitly described this dimension.</summary>
+    /// <remarks><see langword="false"/> means <see cref="Unspecified"/>; <see langword="true"/> with no values means <see cref="Unsupported"/>.</remarks>
+    public bool IsSpecified { get; }
+
+    /// <summary>Gets the default dimension, meaning that the server did not specify support.</summary>
+    public static AiCapabilityDimension<T> Unspecified => default;
+
+    /// <summary>Creates a dimension containing the values accepted by a model.</summary>
+    /// <param name="values">The accepted values, in provider order. An empty sequence means explicitly unsupported.</param>
+    /// <returns>A specified dimension whose <see cref="Values"/> are a defensive immutable copy.</returns>
+    public static AiCapabilityDimension<T> Supported(IEnumerable<T> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        return new(values.ToImmutableArray(), true);
+    }
+
+    /// <summary>Gets the explicitly unsupported dimension.</summary>
+    public static AiCapabilityDimension<T> Unsupported { get; } =
+        new([], true);
+
+    /// <summary>Compares two dimensions by specified state and, when specified, ordered values.</summary>
+    public bool Equals(AiCapabilityDimension<T> other)
+    {
+        if (IsSpecified != other.IsSpecified)
+            return false;
+        return !IsSpecified || Values.SequenceEqual(other.Values);
+    }
+
+    /// <summary>Determines whether this dimension equals another object.</summary>
+    public override bool Equals(object? obj)
+        => obj is AiCapabilityDimension<T> other && Equals(other);
+
+    /// <summary>Returns a hash code based on specified state and ordered values.</summary>
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(IsSpecified);
+        if (IsSpecified)
+        {
+            foreach (T value in Values)
+                hash.Add(value);
+        }
+        return hash.ToHashCode();
+    }
+
+    /// <summary>Determines whether two dimensions are equal.</summary>
+    public static bool operator ==(
+        AiCapabilityDimension<T> left,
+        AiCapabilityDimension<T> right)
+        => left.Equals(right);
+
+    /// <summary>Determines whether two dimensions differ.</summary>
+    public static bool operator !=(
+        AiCapabilityDimension<T> left,
+        AiCapabilityDimension<T> right)
+        => !left.Equals(right);
+}
+
+/// <summary>
+/// The aggregate byte budget for the reference pictures in one image request.
+/// A default value is the client fallback used when an older server publishes
+/// no limit.
+/// </summary>
+public readonly struct AiImageReferenceLimits : IEquatable<AiImageReferenceLimits>
+{
+    private readonly long _maxTotalBytes;
+
+    public AiImageReferenceLimits(long maxTotalBytes)
+    {
+        if (maxTotalBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxTotalBytes));
+        _maxTotalBytes = maxTotalBytes;
+    }
+
+    public long MaxTotalBytes => _maxTotalBytes == 0
+        ? AiRequestLimits.MaxImageReferencesTotalBytes
+        : _maxTotalBytes;
+
+    public static AiImageReferenceLimits Default => default;
+
+    public bool Equals(AiImageReferenceLimits other)
+        => MaxTotalBytes == other.MaxTotalBytes;
+
+    public override bool Equals(object? obj)
+        => obj is AiImageReferenceLimits other && Equals(other);
+
+    public override int GetHashCode() => MaxTotalBytes.GetHashCode();
+
+    public static bool operator ==(AiImageReferenceLimits left, AiImageReferenceLimits right)
+        => left.Equals(right);
+
+    public static bool operator !=(AiImageReferenceLimits left, AiImageReferenceLimits right)
+        => !left.Equals(right);
+}
+
+/// <summary>
+/// The server-published shape and serialized-body budget for one caption
+/// translation request. A default value carries the client fallback for an
+/// older server that publishes none of these fields.
+/// </summary>
+public readonly struct AiCaptionTranslationLimits : IEquatable<AiCaptionTranslationLimits>
+{
+    private readonly int _maxSegments;
+    private readonly int _maxCharacters;
+    private readonly int _maxRequestBytes;
+
+    public AiCaptionTranslationLimits(
+        int maxSegments,
+        int maxCharacters,
+        int maxRequestBytes)
+    {
+        if (maxSegments <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxSegments));
+        if (maxCharacters <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxCharacters));
+        if (maxRequestBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxRequestBytes));
+        _maxSegments = maxSegments;
+        _maxCharacters = maxCharacters;
+        _maxRequestBytes = maxRequestBytes;
+    }
+
+    public int MaxSegments => _maxSegments == 0
+        ? AiRequestLimits.MaxTranslationSegments
+        : _maxSegments;
+
+    public int MaxCharacters => _maxCharacters == 0
+        ? AiRequestLimits.MaxTranslationCharacters
+        : _maxCharacters;
+
+    public int MaxRequestBytes => _maxRequestBytes == 0
+        ? AiRequestLimits.MaxTranslationRequestBytes
+        : _maxRequestBytes;
+
+    public static AiCaptionTranslationLimits Default => default;
+
+    public bool Equals(AiCaptionTranslationLimits other)
+        => MaxSegments == other.MaxSegments
+            && MaxCharacters == other.MaxCharacters
+            && MaxRequestBytes == other.MaxRequestBytes;
+
+    public override bool Equals(object? obj)
+        => obj is AiCaptionTranslationLimits other && Equals(other);
+
+    public override int GetHashCode()
+        => HashCode.Combine(MaxSegments, MaxCharacters, MaxRequestBytes);
+
+    public static bool operator ==(
+        AiCaptionTranslationLimits left,
+        AiCaptionTranslationLimits right)
+        => left.Equals(right);
+
+    public static bool operator !=(
+        AiCaptionTranslationLimits left,
+        AiCaptionTranslationLimits right)
+        => !left.Equals(right);
+}
+
+public sealed record AiVideoModelCapabilities(
+    AiCapabilityDimension<int> DurationsSeconds,
+    AiCapabilityDimension<string> Resolutions,
+    AiCapabilityDimension<string> AspectRatios,
+    bool SupportsAudio,
+    bool SupportsSeed,
+    bool SupportsFirstFrame = true,
+    bool SupportsLastFrame = true)
+{
+    public static AiVideoModelCapabilities Unrestricted { get; } =
+        new(
+            AiCapabilityDimension<int>.Unspecified,
+            AiCapabilityDimension<string>.Unspecified,
+            AiCapabilityDimension<string>.Unspecified,
+            true,
+            true);
+
+    /// <summary>
+    /// False for a model that shares no resolution or shape with what the
+    /// server accepts. The lists are already narrowed to that when they are
+    /// read, so nothing left on one of them means every request naming this
+    /// model would be refused, and offering it is worse than hiding it.
+    /// </summary>
+    public bool CanServeAnything()
+        => (!DurationsSeconds.IsSpecified || !DurationsSeconds.Values.IsEmpty)
+            && (!Resolutions.IsSpecified || !Resolutions.Values.IsEmpty)
+            && (!AspectRatios.IsSpecified || !AspectRatios.Values.IsEmpty);
+}
+
+/// <summary>
+/// What one image model will take. GPT Image-1 renders 1:1, 3:2 and 2:3 and
+/// refuses everything else; the backgrounds differ per model as well, and only
+/// some take a seed or accept a picture to work from — which every edit
+/// depends on. Aspect ratios and backgrounds use <see cref="AiCapabilityDimension{T}"/>
+/// so omitted, explicitly empty and narrowed lists remain distinct.
+/// </summary>
+public sealed record AiImageModelCapabilities(
+    AiCapabilityDimension<string> AspectRatios,
+    AiCapabilityDimension<string> Backgrounds,
+    bool SupportsSeed,
+    int MaxReferenceImages,
+    bool SupportsResolution = true)
+{
+    public static AiImageModelCapabilities Unrestricted { get; } =
+        new(
+            AiCapabilityDimension<string>.Unspecified,
+            AiCapabilityDimension<string>.Unspecified,
+            true,
+            AiRequestLimits.MaxImageReferences);
+
+    /// <summary>
+    /// False for a model that shares no shape with what the server accepts, or
+    /// that cannot be handed the picture an edit is made of.
+    /// </summary>
+    /// <param name="requiresResolution">
+    /// The operation asks for a size, which is what an upscale is; a model that
+    /// publishes no sizes cannot serve it.
+    /// </param>
+    /// <param name="requiredBackground">
+    /// The background the operation always asks for. Removing a background is
+    /// asking for a transparent one, and a model offering only auto and opaque
+    /// would refuse every such request.
+    /// </param>
+    public bool CanServeAnything(
+        bool requiresReferenceImages,
+        bool requiresResolution = false,
+        string? requiredBackground = null)
+        => (!AspectRatios.IsSpecified || !AspectRatios.Values.IsEmpty)
+           && (!Backgrounds.IsSpecified || !Backgrounds.Values.IsEmpty)
+           && (!requiresReferenceImages || MaxReferenceImages > 0)
+           && (!requiresResolution || SupportsResolution)
+           && (requiredBackground is not { Length: > 0 } background
+               || !Backgrounds.IsSpecified
+               || Backgrounds.Values.Contains(background));
+}
+
+public sealed record AiModelOption(
+    AiModelId Id,
+    string DisplayName,
+    AiModelCostTier? CostTier,
+    bool IsDefault,
+    AiVideoModelCapabilities? Video = null,
+    AiImageModelCapabilities? Image = null);
+
+/// <summary>
+/// The models each operation offers. Empty for an operation the server did not
+/// report, which a request answers by naming no model at all and letting the
+/// server pick its default.
+/// </summary>
+public sealed class AiModelCatalog
+{
+    public static AiModelCatalog Empty { get; } =
+        new(ImmutableDictionary<AiOperationId, ImmutableArray<AiModelOption>>.Empty);
+
+    public AiModelCatalog(
+        IEnumerable<KeyValuePair<AiOperationId, ImmutableArray<AiModelOption>>> operations,
+        IEnumerable<AiOperationId>? withoutModels = null,
+        IEnumerable<KeyValuePair<AiOperationId, AiModelCapabilitySchema>>? capabilitySchemas = null,
+        IEnumerable<KeyValuePair<AiOperationId, AiImageReferenceLimits>>? imageReferenceLimits = null)
+    {
+        ArgumentNullException.ThrowIfNull(operations);
+        Operations = operations.ToImmutableDictionary(
+            pair => pair.Key,
+            pair => NormalizeModels(pair.Value));
+        WithoutModels = withoutModels?.ToImmutableHashSet() ?? [];
+        if (WithoutModels.Overlaps(Operations.Keys))
+        {
+            throw new ArgumentException(
+                "An operation cannot both offer models and explicitly offer no models.",
+                nameof(withoutModels));
+        }
+        ImmutableDictionary<AiOperationId, AiModelCapabilitySchema> schemas =
+            capabilitySchemas?.ToImmutableDictionary(pair => pair.Key, pair => pair.Value)
+            ?? ImmutableDictionary<AiOperationId, AiModelCapabilitySchema>.Empty;
+        if (schemas.Any(pair => !Enum.IsDefined(pair.Value)))
+            throw new ArgumentException("A model capability schema is unsupported.", nameof(capabilitySchemas));
+        CapabilitySchemas = schemas;
+        ImageReferenceLimitsByOperation = imageReferenceLimits?.ToImmutableDictionary(
+            pair => pair.Key,
+            pair => pair.Value)
+            ?? ImmutableDictionary<AiOperationId, AiImageReferenceLimits>.Empty;
+
+        static ImmutableArray<AiModelOption> NormalizeModels(
+            ImmutableArray<AiModelOption> models)
+        {
+            if (models.IsDefault)
+                return [];
+            if (models.Any(model => model is null || model.Id.Value.Length == 0))
+            {
+                throw new ArgumentException(
+                    "Every catalog model must have a non-empty identifier.",
+                    nameof(operations));
+            }
+
+            return models;
+        }
+    }
+
+    public ImmutableDictionary<AiOperationId, ImmutableArray<AiModelOption>> Operations { get; }
+
+    /// <summary>
+    /// Operations the server named and offered no model for.
+    /// </summary>
+    /// <remarks>
+    /// Told apart from an operation the server said nothing about, which is how
+    /// a server that predates per-operation models reads and which a request
+    /// answers by naming no model at all. Named with nothing behind it means the
+    /// operation has been stopped, and a request would be refused however it is
+    /// shaped.
+    /// </remarks>
+    public ImmutableHashSet<AiOperationId> WithoutModels { get; }
+
+    public ImmutableDictionary<AiOperationId, AiModelCapabilitySchema> CapabilitySchemas { get; }
+
+    public bool OffersNoModel(AiOperationId operation) => WithoutModels.Contains(operation);
+
+    public AiModelCapabilitySchema GetCapabilitySchema(AiOperationId operation)
+        => CapabilitySchemas.GetValueOrDefault(operation, AiModelCapabilitySchema.Generic);
+
+    /// <summary>
+    /// Resolved aggregate reference-picture budgets keyed by image operation.
+    /// </summary>
+    public ImmutableDictionary<AiOperationId, AiImageReferenceLimits>
+        ImageReferenceLimitsByOperation
+    { get; }
+
+    /// <summary>
+    /// Gets the reference-picture budget for one operation, using the client fallback when an
+    /// older server did not publish it.
+    /// </summary>
+    public AiImageReferenceLimits GetImageReferenceLimits(AiOperationId operation)
+        => ImageReferenceLimitsByOperation.GetValueOrDefault(
+            operation,
+            AiImageReferenceLimits.Default);
+
+    /// <summary>
+    /// The caption-translation request limits published by the server. A
+    /// default value carries the client fallback for an older server.
+    /// </summary>
+    public AiCaptionTranslationLimits CaptionTranslationLimits { get; init; }
+
+    public ImmutableArray<AiModelOption> ModelsFor(AiOperationId operation)
+        => Operations.TryGetValue(operation, out ImmutableArray<AiModelOption> models)
+            ? models
+            : [];
+
+    public AiModelOption? DefaultFor(AiOperationId operation)
+    {
+        ImmutableArray<AiModelOption> models = ModelsFor(operation);
+        if (models.IsDefaultOrEmpty)
+            return null;
+        foreach (AiModelOption model in models)
+        {
+            if (model.IsDefault)
+                return model;
+        }
+
+        return models[0];
+    }
+}
+
+public static class AiOperations
+{
+    public static AiOperationId ImageGeneration { get; } = new("image.generate");
+
+    public static AiOperationId VideoGeneration { get; } = new("video.generate");
+
+    public static AiOperationId Transcription { get; } = new("audio.transcribe");
+
+    public static AiOperationId CaptionTranslation { get; } = new("subtitle.translate");
+
+    public static AiOperationId ImageEdit(AiImageEditTaskId task)
+        => new($"image.edit.{task.Value}");
+}
+
+public abstract record AiOperationAvailabilityRequest
+{
+    private AiOperationAvailabilityRequest(AiOperationId operation, AiModelId? model)
+    {
+        if (operation.Value.Length == 0)
+            throw new ArgumentException("An AI operation is required.", nameof(operation));
+        Operation = operation;
+        Model = model is { Value.Length: > 0 } ? model : null;
+    }
+
+    public AiOperationId Operation { get; }
+
+    /// <summary>
+    /// The model the question is about. Null asks about the operation's
+    /// default, since that is what a request naming no model would run on.
+    /// </summary>
+    public AiModelId? Model { get; }
+
+    public sealed record Fixed : AiOperationAvailabilityRequest
+    {
+        /// <summary>
+        /// Creates an availability check for an operation whose cost has no variable quantity.
+        /// Custom operation identifiers are forwarded unchanged to the server.
+        /// </summary>
+        public Fixed(AiOperationId operation, AiModelId? model = null)
+            : base(operation, model)
+        {
+        }
+    }
+
+    public sealed record Video : AiOperationAvailabilityRequest
+    {
+        /// <summary>
+        /// Creates a duration-based video availability check for a built-in or custom operation.
+        /// </summary>
+        public Video(
+            AiOperationId operation,
+            int durationSeconds,
+            AiModelId? model = null)
+            : base(operation, model)
+        {
+            DurationSeconds = AiRequestLimits.ValidateVideoDurationSeconds(
+                durationSeconds,
+                nameof(durationSeconds));
+        }
+
+        public int DurationSeconds { get; }
+    }
+
+    public sealed record Transcription : AiOperationAvailabilityRequest
+    {
+        /// <summary>
+        /// Creates a duration-based transcription availability check for a built-in or custom operation.
+        /// </summary>
+        public Transcription(
+            AiOperationId operation,
+            double durationSeconds,
+            AiModelId? model = null)
+            : base(operation, model)
+        {
+            if (!double.IsFinite(durationSeconds) || durationSeconds <= 0)
+                throw new ArgumentOutOfRangeException(nameof(durationSeconds));
+            DurationSeconds = durationSeconds;
+        }
+
+        public double DurationSeconds { get; }
+    }
+
+    public sealed record Translation : AiOperationAvailabilityRequest
+    {
+        /// <summary>
+        /// Creates a character-count-based translation availability check for a built-in or custom operation.
+        /// </summary>
+        public Translation(
+            AiOperationId operation,
+            int characterCount,
+            AiModelId? model = null,
+            AiCaptionTranslationLimits? limits = null)
+            : base(operation, model)
+        {
+            AiCaptionTranslationLimits effectiveLimits =
+                limits ?? AiCaptionTranslationLimits.Default;
+            if (characterCount <= 0 || characterCount > effectiveLimits.MaxCharacters)
+                throw new ArgumentOutOfRangeException(nameof(characterCount));
+            CharacterCount = characterCount;
+        }
+
+        public int CharacterCount { get; }
+    }
+}
+
+public static class AiRequestLimits
+{
+    private static readonly ImmutableHashSet<string> s_iso6391LanguageCodes =
+        ("aa ab ae af ak am an ar as av ay az ba be bg bh bi bm bn bo br bs "
+        + "ca ce ch co cr cs cu cv cy da de dv dz ee el en eo es et eu fa ff "
+        + "fi fj fo fr fy ga gd gl gn gu gv ha he hi ho hr ht hu hy hz ia id "
+        + "ie ig ii ik io is it iu ja jv ka kg ki kj kk kl km kn ko kr ks ku "
+        + "kv kw ky la lb lg li ln lo lt lu lv mg mh mi mk ml mn mr ms mt my "
+        + "na nb nd ne ng nl nn no nr nv ny oc oj om or os pa pi pl ps pt qu "
+        + "rm rn ro ru rw sa sc sd se sg si sk sl sm sn so sq sr ss st su sv "
+        + "sw ta te tg th ti tk tl tn to tr ts tt tw ty ug uk ur uz ve vi vo "
+        + "wa wo xh yi yo za zh zu")
+        .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+        .ToImmutableHashSet(StringComparer.Ordinal);
+
+    public const int MaxPromptLength = 4_000;
+
+    public const int MaxTranslationSegments = 200;
+
+    public const int MaxTranslationCharacters = 20_000;
+
+    public const int MaxTranslationRequestBytes = 128 * 1024;
+
+    public const long MaxFrameUploadBytes = 5L * 1024 * 1024;
+
+    public const long MaxImageUploadBytes = 20L * 1024 * 1024;
+
+    // What the transcription endpoint takes in one upload. Speech is sent as
+    // 16 kHz mono 16-bit PCM, so this is a little under fourteen minutes of it:
+    // audio longer than that has to be split before it is sent, and a caller
+    // that sends it anyway is refused after the whole upload has gone out.
+    public const long MaxTranscriptionUploadBytes = 25L * 1024 * 1024;
+
+    // What the server is priced for. Each model publishes its own count and the
+    // smaller of the two is what may be sent; this is also what a server that
+    // publishes nothing is read as.
+    public const int MaxImageReferences = 4;
+
+    // What all the reference pictures of one request may come to together, for
+    // a server that publishes no figure of its own. The per-picture limit taken
+    // four times over is more than the server can hold: every picture is kept
+    // raw, again as base64 and again through JSON, so the fallback is what one
+    // picture was already allowed to be.
+    public const long MaxImageReferencesTotalBytes = MaxImageUploadBytes;
+
+    // The provider accepts a signed 32-bit seed. Bounding it here keeps the
+    // same number intact through every JSON encoder on the way.
+    public const int MinSeed = 0;
+
+    public const int MaxSeed = int.MaxValue;
+
+    // The span the server considers at all. Which whole seconds within it a
+    // given model takes is published per model: Veo 3.1 takes 4, 6 or 8 and
+    // Seedance 2.5 anything from 4 to 30, so a fixed three would offer lengths
+    // one model refuses and hide most of another's.
+    public const int MinVideoDurationSeconds = 1;
+
+    public const int MaxVideoDurationSeconds = 60;
+
+    internal static int ValidateVideoDurationSeconds(
+        int durationSeconds,
+        string parameterName)
+    {
+        if (!IsValidVideoDurationSeconds(durationSeconds))
+            throw new ArgumentOutOfRangeException(parameterName);
+        return durationSeconds;
+    }
+
+    internal static bool IsValidVideoDurationSeconds(int durationSeconds)
+        => durationSeconds is >= MinVideoDurationSeconds and <= MaxVideoDurationSeconds;
+
+    internal static string ValidatePrompt(string prompt, string parameterName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(prompt, parameterName);
+        string normalized = prompt.Trim();
+        if (normalized.Length > MaxPromptLength)
+        {
+            throw new ArgumentException(
+                $"The final prompt cannot exceed {MaxPromptLength} characters.",
+                parameterName);
+        }
+
+        return normalized;
+    }
+
+    internal static bool IsSafeTranslationIdentifier(string? value)
+    {
+        if (string.IsNullOrEmpty(value) || value.Length > 64)
+            return false;
+        for (int i = 0; i < value.Length; i++)
+        {
+            char c = value[i];
+            bool alphaNumeric = c is >= 'A' and <= 'Z'
+                or >= 'a' and <= 'z'
+                or >= '0' and <= '9';
+            if (i == 0 ? !alphaNumeric : !alphaNumeric && c is not ('_' or '-'))
+                return false;
+        }
+
+        return true;
+    }
+
+    internal static bool IsIso6391LanguageCode(string value)
+        => s_iso6391LanguageCodes.Contains(value);
+
+    internal static string? ValidateOptionalPrompt(string? prompt, string parameterName)
+        => string.IsNullOrWhiteSpace(prompt) ? null : ValidatePrompt(prompt, parameterName);
+
+    internal static int? ValidateOptionalSeed(int? seed, string parameterName)
+    {
+        if (seed is null) return null;
+        if (seed.Value is < MinSeed or > MaxSeed)
+            throw new ArgumentOutOfRangeException(parameterName);
+        return seed;
+    }
+
+    // The server holds an idempotency key to printable ASCII and refuses the
+    // request outright when it does not match, so a key that could never be
+    // accepted is caught here rather than after the whole upload has gone out.
+    internal static string? ValidateOptionalIdempotencyKey(string? key, string parameterName)
+    {
+        if (key is null)
+            return null;
+        if (key.Length is 0 or > 255)
+            throw new ArgumentException("The idempotency key length is invalid.", parameterName);
+        foreach (char character in key)
+        {
+            if (character is < '\u0021' or > '\u007e')
+            {
+                throw new ArgumentException(
+                    "An idempotency key may only contain printable ASCII.",
+                    parameterName);
+            }
+        }
+
+        return key;
+    }
+
+    // A default-constructed AiModelId carries no id, and sending an empty
+    // string would be refused as an unknown model. It means "no choice made",
+    // so it is normalized to null and the server picks its own default.
+    internal static AiModelId? ValidateOptionalModel(AiModelId? model, string parameterName)
+    {
+        _ = parameterName;
+        return model is { Value.Length: > 0 } ? model : null;
+    }
+}
+
+// The server is asked for a shape, not a pixel count: "16:9" and "9:16" are the
+// ones a video editor needs and no fixed size could express them.
+public readonly struct AiImageAspectRatioId : IEquatable<AiImageAspectRatioId>
+{
+    private readonly string? _value;
+
+    public AiImageAspectRatioId(string value) => _value = AiIdentifier.Normalize(value, nameof(value));
+
+    public string Value => _value ?? string.Empty;
+
+    public bool Equals(AiImageAspectRatioId other) => StringComparer.Ordinal.Equals(Value, other.Value);
+
+    public override bool Equals(object? obj) => obj is AiImageAspectRatioId other && Equals(other);
+
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Value);
+
+    public override string ToString() => Value;
+
+    public static bool operator ==(AiImageAspectRatioId left, AiImageAspectRatioId right) => left.Equals(right);
+
+    public static bool operator !=(AiImageAspectRatioId left, AiImageAspectRatioId right) => !left.Equals(right);
+}
+
+// Named rather than a flag: the server publishes which backgrounds each model
+// takes, and a model that fills a background in is not the same as one that
+// cuts it out.
+public readonly struct AiImageBackgroundId : IEquatable<AiImageBackgroundId>
+{
+    private readonly string? _value;
+
+    public AiImageBackgroundId(string value) => _value = AiIdentifier.Normalize(value, nameof(value));
+
+    public string Value => _value ?? string.Empty;
+
+    public bool Equals(AiImageBackgroundId other) => StringComparer.Ordinal.Equals(Value, other.Value);
+
+    public override bool Equals(object? obj) => obj is AiImageBackgroundId other && Equals(other);
+
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Value);
+
+    public override string ToString() => Value;
+
+    public static bool operator ==(AiImageBackgroundId left, AiImageBackgroundId right) => left.Equals(right);
+
+    public static bool operator !=(AiImageBackgroundId left, AiImageBackgroundId right) => !left.Equals(right);
+}
+
+public readonly struct AiVideoAspectRatioId : IEquatable<AiVideoAspectRatioId>
+{
+    private readonly string? _value;
+
+    public AiVideoAspectRatioId(string value) => _value = AiIdentifier.Normalize(value, nameof(value));
+
+    public string Value => _value ?? string.Empty;
+
+    public bool Equals(AiVideoAspectRatioId other) => StringComparer.Ordinal.Equals(Value, other.Value);
+
+    public override bool Equals(object? obj) => obj is AiVideoAspectRatioId other && Equals(other);
+
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Value);
+
+    public override string ToString() => Value;
+
+    public static bool operator ==(AiVideoAspectRatioId left, AiVideoAspectRatioId right) => left.Equals(right);
+
+    public static bool operator !=(AiVideoAspectRatioId left, AiVideoAspectRatioId right) => !left.Equals(right);
+}
+
+public readonly struct AiImageEditTaskId : IEquatable<AiImageEditTaskId>
+{
+    private readonly string? _value;
+
+    public AiImageEditTaskId(string value) => _value = AiIdentifier.Normalize(value, nameof(value));
+
+    public string Value => _value ?? string.Empty;
+
+    public bool Equals(AiImageEditTaskId other) => StringComparer.Ordinal.Equals(Value, other.Value);
+
+    public override bool Equals(object? obj) => obj is AiImageEditTaskId other && Equals(other);
+
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Value);
+
+    public override string ToString() => Value;
+
+    public static bool operator ==(AiImageEditTaskId left, AiImageEditTaskId right) => left.Equals(right);
+
+    public static bool operator !=(AiImageEditTaskId left, AiImageEditTaskId right) => !left.Equals(right);
+}
+
+public readonly struct AiVideoResolutionId : IEquatable<AiVideoResolutionId>
+{
+    private readonly string? _value;
+
+    public AiVideoResolutionId(string value) => _value = AiIdentifier.Normalize(value, nameof(value));
+
+    public string Value => _value ?? string.Empty;
+
+    public bool Equals(AiVideoResolutionId other) => StringComparer.Ordinal.Equals(Value, other.Value);
+
+    public override bool Equals(object? obj) => obj is AiVideoResolutionId other && Equals(other);
+
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Value);
+
+    public override string ToString() => Value;
+
+    public static bool operator ==(AiVideoResolutionId left, AiVideoResolutionId right) => left.Equals(right);
+
+    public static bool operator !=(AiVideoResolutionId left, AiVideoResolutionId right) => !left.Equals(right);
+}
+
+public sealed record AiImageGenerationRequest
+{
+    public AiImageGenerationRequest(
+        string prompt,
+        AiImageAspectRatioId aspectRatio,
+        AiImageBackgroundId background = default,
+        int? seed = null,
+        IReadOnlyList<AiUploadSource>? references = null,
+        AiModelId? model = null,
+        string? idempotencyKey = null,
+        AiImageReferenceLimits? referenceLimits = null)
+    {
+        if (aspectRatio.Value.Length == 0)
+            throw new ArgumentException("An image aspect ratio is required.", nameof(aspectRatio));
+        if (references is { Count: > AiRequestLimits.MaxImageReferences })
+        {
+            throw new ArgumentException(
+                $"At most {AiRequestLimits.MaxImageReferences} reference pictures may guide one generation.",
+                nameof(references));
+        }
+
+        if (references?.Any(reference => reference is null) == true)
+            throw new ArgumentException("Reference pictures cannot contain null.", nameof(references));
+        if (references?.Any(reference => reference.Length > AiRequestLimits.MaxImageUploadBytes) == true)
+            throw new AiFileTooLargeException();
+        AiImageReferenceLimits effectiveLimits =
+            referenceLimits ?? AiImageReferenceLimits.Default;
+        if (references is not null)
+        {
+            long total = 0;
+            foreach (AiUploadSource reference in references)
+            {
+                if (reference.Length > effectiveLimits.MaxTotalBytes - total)
+                    throw new AiFileTooLargeException();
+                total += reference.Length;
+            }
+        }
+
+        Prompt = AiRequestLimits.ValidatePrompt(prompt, nameof(prompt));
+        AspectRatio = aspectRatio;
+        Background = background;
+        Seed = AiRequestLimits.ValidateOptionalSeed(seed, nameof(seed));
+        References = references is null || references.Count == 0
+            ? []
+            : Array.AsReadOnly(references.ToArray());
+        ReferenceLimits = effectiveLimits;
+        Model = AiRequestLimits.ValidateOptionalModel(model, nameof(model));
+        IdempotencyKey = AiRequestLimits.ValidateOptionalIdempotencyKey(
+            idempotencyKey,
+            nameof(idempotencyKey));
+    }
+
+    public string Prompt { get; }
+
+    public AiImageAspectRatioId AspectRatio { get; }
+
+    /// <summary>
+    /// The background to render, named as the server names it: "transparent"
+    /// for a compositing asset, "opaque" for a filled one. Empty leaves the
+    /// choice to the model, which is what sending no background means. The
+    /// generated file stays PNG whichever is asked for.
+    /// </summary>
+    public AiImageBackgroundId Background { get; }
+
+    /// <summary>
+    /// Repeating a seed with the same prompt reproduces the same picture, which
+    /// is what makes iterating on a result possible.
+    /// </summary>
+    public int? Seed { get; }
+
+    /// <summary>
+    /// Existing pictures the generation is guided by, in the order the model
+    /// should read them. Up to <see cref="AiRequestLimits.MaxImageReferences"/>,
+    /// which is what the operation's price covers, and together no larger than
+    /// <see cref="ReferenceLimits"/>; a model that takes fewer says so through
+    /// <see cref="AiImageModelCapabilities.MaxReferenceImages"/>.
+    /// </summary>
+    public IReadOnlyList<AiUploadSource> References { get; }
+
+    /// <summary>
+    /// The immutable total byte budget used when this request was validated.
+    /// It is copied from the server capability snapshot so a later capability
+    /// refresh cannot change the request after construction.
+    /// </summary>
+    public AiImageReferenceLimits ReferenceLimits { get; }
+
+    /// <summary>
+    /// Which model to run on. Null asks for the operation's default; naming one
+    /// the server does not offer is refused rather than substituted.
+    /// </summary>
+    public AiModelId? Model { get; }
+
+    /// <summary>
+    /// Names this request, so that sending it again asks the server for the
+    /// same one rather than for another.
+    /// </summary>
+    /// <remarks>
+    /// The operation is charged when it is accepted, and the server answers a
+    /// repeat of a key it has already seen with the result that key produced —
+    /// free, and with a refusal while the first attempt is still running. A
+    /// caller retrying after a lost response must send the key it used the
+    /// first time or it pays twice for one piece of work; a caller asking for
+    /// something new must not, or it is handed the earlier result. Left unset,
+    /// each attempt is a new request.
+    /// </remarks>
+    public string? IdempotencyKey { get; }
+}
+
+public sealed record AiImageEditRequest
+{
+    public AiImageEditRequest(
+        AiUploadSource image,
+        AiImageEditTaskId task,
+        string? prompt = null,
+        AiModelId? model = null,
+        string? idempotencyKey = null)
+    {
+        ArgumentNullException.ThrowIfNull(image);
+        if (task.Value.Length == 0)
+            throw new ArgumentException("An image edit task is required.", nameof(task));
+        Image = image;
+        Task = task;
+        Prompt = AiRequestLimits.ValidateOptionalPrompt(prompt, nameof(prompt));
+        Model = AiRequestLimits.ValidateOptionalModel(model, nameof(model));
+        IdempotencyKey = AiRequestLimits.ValidateOptionalIdempotencyKey(
+            idempotencyKey,
+            nameof(idempotencyKey));
+    }
+
+    public AiUploadSource Image { get; }
+
+    public AiImageEditTaskId Task { get; }
+
+    public string? Prompt { get; }
+
+    public AiModelId? Model { get; }
+
+    /// <summary>
+    /// Names this request, so that sending it again asks the server for the
+    /// same one rather than for another.
+    /// </summary>
+    /// <remarks>
+    /// The operation is charged when it is accepted, and the server answers a
+    /// repeat of a key it has already seen with the result that key produced —
+    /// free, and with a refusal while the first attempt is still running. A
+    /// caller retrying after a lost response must send the key it used the
+    /// first time or it pays twice for one piece of work; a caller asking for
+    /// something new must not, or it is handed the earlier result. Left unset,
+    /// each attempt is a new request.
+    /// </remarks>
+    public string? IdempotencyKey { get; }
+}
+
+public sealed record AiTranscriptionRequest
+{
+    public AiTranscriptionRequest(
+        AiUploadSource audio,
+        string? language = null,
+        AiModelId? model = null,
+        string? idempotencyKey = null)
+    {
+        ArgumentNullException.ThrowIfNull(audio);
+        if (audio.Length > AiRequestLimits.MaxTranscriptionUploadBytes)
+            throw new AiFileTooLargeException();
+
+        Audio = audio;
+        Language = string.IsNullOrWhiteSpace(language) ? null : language.Trim();
+        Model = AiRequestLimits.ValidateOptionalModel(model, nameof(model));
+        IdempotencyKey = AiRequestLimits.ValidateOptionalIdempotencyKey(
+            idempotencyKey,
+            nameof(idempotencyKey));
+    }
+
+    public AiUploadSource Audio { get; }
+
+    public string? Language { get; }
+
+    public AiModelId? Model { get; }
+
+    /// <summary>
+    /// Names this request, so that sending it again asks the server for the
+    /// same one rather than for another.
+    /// </summary>
+    /// <remarks>
+    /// A transcription is charged when it is accepted, and the server answers a
+    /// repeat of a key it has already seen with the result that key produced —
+    /// free, and even while the first attempt is still running. A caller that
+    /// retries after a lost response, or resumes a run it split into chunks,
+    /// must send the key it used the first time or it pays twice for one piece
+    /// of audio. Left unset, each attempt is a new request.
+    /// </remarks>
+    public string? IdempotencyKey { get; }
+}
+
+/// <summary>
+/// Direction that applies to the whole translation rather than to one segment.
+/// A line that does not fit its cue is unreadable however good the wording is,
+/// and a series keeps its own names for things.
+/// </summary>
+public sealed record AiCaptionTranslationStyle
+{
+    public const int MaxGlossaryEntries = 100;
+
+    public AiCaptionTranslationStyle(
+        IReadOnlyDictionary<string, string>? glossary = null,
+        int? maxCharactersPerLine = null,
+        int? maxLines = null)
+    {
+        if (glossary is { Count: > MaxGlossaryEntries })
+        {
+            throw new ArgumentException(
+                $"A glossary cannot hold more than {MaxGlossaryEntries} terms.",
+                nameof(glossary));
+        }
+
+        if (glossary is not null)
+        {
+            foreach ((string term, string translation) in glossary)
+            {
+                if (string.IsNullOrEmpty(term) || term.Length > 100)
+                    throw new ArgumentException("Glossary terms must be 1 to 100 characters.", nameof(glossary));
+                if (string.IsNullOrEmpty(translation) || translation.Length > 200)
+                    throw new ArgumentException("Glossary translations must be 1 to 200 characters.", nameof(glossary));
+            }
+        }
+
+        if (maxCharactersPerLine is not null and (< 1 or > 200))
+            throw new ArgumentOutOfRangeException(nameof(maxCharactersPerLine));
+        if (maxLines is not null and (< 1 or > 10))
+            throw new ArgumentOutOfRangeException(nameof(maxLines));
+
+        Glossary = glossary is null
+            ? null
+            : new Dictionary<string, string>(glossary).AsReadOnly();
+        MaxCharactersPerLine = maxCharactersPerLine;
+        MaxLines = maxLines;
+    }
+
+    /// <summary>
+    /// Term to required translation. These characters count against the same
+    /// request budget and the same charge as the subtitle text, because they
+    /// reach the provider the same way.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Glossary { get; }
+
+    public int? MaxCharactersPerLine { get; }
+
+    public int? MaxLines { get; }
+
+    public bool IsEmpty
+        => (Glossary is null || Glossary.Count == 0)
+           && MaxCharactersPerLine is null
+           && MaxLines is null;
+}
+
+public sealed record AiCaptionTranslationRequest
+{
+    public AiCaptionTranslationRequest(
+        IReadOnlyList<AiCaptionTranslationSegment> segments,
+        string targetLanguage,
+        string? sourceLanguage = null,
+        AiCaptionTranslationStyle? style = null,
+        AiModelId? model = null,
+        string? idempotencyKey = null,
+        AiCaptionTranslationLimits? limits = null)
+    {
+        ArgumentNullException.ThrowIfNull(segments);
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetLanguage);
+        AiCaptionTranslationLimits effectiveLimits =
+            limits ?? AiCaptionTranslationLimits.Default;
+        if (segments.Count == 0)
+            throw new ArgumentException("At least one subtitle segment is required.", nameof(segments));
+        if (segments.Count > effectiveLimits.MaxSegments)
+            throw new ArgumentException(
+                $"At most {effectiveLimits.MaxSegments} subtitle segments may be translated.",
+                nameof(segments));
+        if (segments.Any(segment => segment is null))
+            throw new ArgumentException("Translation segments cannot contain null.", nameof(segments));
+
+        var ids = new HashSet<string>(StringComparer.Ordinal);
+        int characterCount = 0;
+        foreach (AiCaptionTranslationSegment segment in segments)
+        {
+            if (!AiRequestLimits.IsSafeTranslationIdentifier(segment.Id))
+                throw new ArgumentException("Translation segment IDs must be 1 to 64 ASCII letters, digits, '_' or '-'.", nameof(segments));
+            if (!ids.Add(segment.Id))
+                throw new ArgumentException("Translation segment IDs must be unique.", nameof(segments));
+            if (string.IsNullOrWhiteSpace(segment.Text)
+                || segment.Text.Length > effectiveLimits.MaxCharacters)
+            {
+                throw new ArgumentException(
+                    $"Translation segment text must be 1 to {effectiveLimits.MaxCharacters} characters.",
+                    nameof(segments));
+            }
+
+            characterCount = checked(characterCount + segment.Text.Length);
+            if (segment.Context is { } context
+                && !AiRequestLimits.IsSafeTranslationIdentifier(context.GroupId))
+            {
+                throw new ArgumentException("Translation context group IDs must be 1 to 64 safe ASCII characters.", nameof(segments));
+            }
+            if (segment.Context is { PartIndex: var partIndex }
+                && partIndex >= effectiveLimits.MaxSegments)
+            {
+                throw new ArgumentException(
+                    $"Translation context part indexes must be below {effectiveLimits.MaxSegments}.",
+                    nameof(segments));
+            }
+        }
+
+        Segments = Array.AsReadOnly(segments.ToArray());
+        TargetLanguage = targetLanguage.Trim().ToLowerInvariant();
+        if (!AiRequestLimits.IsIso6391LanguageCode(TargetLanguage))
+            throw new ArgumentException("Target language must be an ISO 639-1 language code.", nameof(targetLanguage));
+        if (sourceLanguage is not null && string.IsNullOrWhiteSpace(sourceLanguage))
+            throw new ArgumentException(
+                "Source language cannot be whitespace.",
+                nameof(sourceLanguage));
+        SourceLanguage = sourceLanguage?.Trim().ToLowerInvariant();
+        if (SourceLanguage is not null && !AiRequestLimits.IsIso6391LanguageCode(SourceLanguage))
+            throw new ArgumentException("Source language must be an ISO 639-1 language code.", nameof(sourceLanguage));
+        Style = style is null || style.IsEmpty ? null : style;
+        if (Style?.Glossary is { } glossary)
+        {
+            foreach ((string term, string translation) in glossary)
+                characterCount = checked(characterCount + term.Length + translation.Length);
+        }
+        if (characterCount > effectiveLimits.MaxCharacters)
+            throw new ArgumentException(
+                $"Translation text cannot exceed {effectiveLimits.MaxCharacters} characters.",
+                nameof(segments));
+        Model = AiRequestLimits.ValidateOptionalModel(model, nameof(model));
+        IdempotencyKey = AiRequestLimits.ValidateOptionalIdempotencyKey(
+            idempotencyKey,
+            nameof(idempotencyKey));
+        Limits = effectiveLimits;
+        _ = AiCaptionTranslationRequestTransport.CreatePayload(this);
+    }
+
+    public IReadOnlyList<AiCaptionTranslationSegment> Segments { get; }
+
+    public string TargetLanguage { get; }
+
+    public string? SourceLanguage { get; }
+
+    public AiCaptionTranslationStyle? Style { get; }
+
+    public AiModelId? Model { get; }
+
+    public AiCaptionTranslationLimits Limits { get; }
+
+    /// <summary>
+    /// Names this request, so that sending it again asks the server for the
+    /// same one rather than for another.
+    /// </summary>
+    /// <remarks>
+    /// The operation is charged when it is accepted, and the server answers a
+    /// repeat of a key it has already seen with the result that key produced —
+    /// free, and with a refusal while the first attempt is still running. A
+    /// caller retrying after a lost response must send the key it used the
+    /// first time or it pays twice for one piece of work; a caller asking for
+    /// something new must not, or it is handed the earlier result. Left unset,
+    /// each attempt is a new request.
+    /// </remarks>
+    public string? IdempotencyKey { get; }
+}
+
+public sealed record AiVideoGenerationRequest
+{
+    public AiVideoGenerationRequest(
+        string prompt,
+        int durationSeconds,
+        AiVideoResolutionId resolution,
+        AiVideoAspectRatioId aspectRatio,
+        bool generateAudio = true,
+        int? seed = null,
+        AiUploadSource? firstFrame = null,
+        AiUploadSource? lastFrame = null,
+        AiModelId? model = null,
+        string? idempotencyKey = null)
+    {
+        AiRequestLimits.ValidateVideoDurationSeconds(durationSeconds, nameof(durationSeconds));
+        if (resolution.Value.Length == 0)
+            throw new ArgumentException("A video resolution is required.", nameof(resolution));
+        if (aspectRatio.Value.Length == 0)
+            throw new ArgumentException("A video aspect ratio is required.", nameof(aspectRatio));
+        if (lastFrame is not null && firstFrame is null)
+            throw new ArgumentException("A last frame requires a first frame.", nameof(lastFrame));
+        if (firstFrame?.Length > AiRequestLimits.MaxFrameUploadBytes)
+            throw new AiFileTooLargeException();
+        if (lastFrame?.Length > AiRequestLimits.MaxFrameUploadBytes)
+            throw new AiFileTooLargeException();
+
+        Prompt = AiRequestLimits.ValidatePrompt(prompt, nameof(prompt));
+        DurationSeconds = durationSeconds;
+        Resolution = resolution;
+        AspectRatio = aspectRatio;
+        GenerateAudio = generateAudio;
+        Seed = AiRequestLimits.ValidateOptionalSeed(seed, nameof(seed));
+        FirstFrame = firstFrame;
+        LastFrame = lastFrame;
+        Model = AiRequestLimits.ValidateOptionalModel(model, nameof(model));
+        IdempotencyKey = AiRequestLimits.ValidateOptionalIdempotencyKey(
+            idempotencyKey,
+            nameof(idempotencyKey));
+    }
+
+    public string Prompt { get; }
+
+    public int DurationSeconds { get; }
+
+    /// <summary>How many pixels; <see cref="AspectRatio"/> says what shape they are in.</summary>
+    public AiVideoResolutionId Resolution { get; }
+
+    public AiVideoAspectRatioId AspectRatio { get; }
+
+    /// <summary>
+    /// The model generates sound. Leaving it on matches what the plan is priced
+    /// for; turning it off is for a clip that will carry its own audio.
+    /// </summary>
+    public bool GenerateAudio { get; }
+
+    public int? Seed { get; }
+
+    public AiUploadSource? FirstFrame { get; }
+
+    public AiUploadSource? LastFrame { get; }
+
+    public AiModelId? Model { get; }
+
+    /// <summary>
+    /// Names this request, so that sending it again asks the server for the
+    /// same one rather than for another.
+    /// </summary>
+    /// <remarks>
+    /// The operation is charged when it is accepted, and the server answers a
+    /// repeat of a key it has already seen with the result that key produced —
+    /// free, and with a refusal while the first attempt is still running. A
+    /// caller retrying after a lost response must send the key it used the
+    /// first time or it pays twice for one piece of work; a caller asking for
+    /// something new must not, or it is handed the earlier result. Left unset,
+    /// each attempt is a new request.
+    /// </remarks>
+    public string? IdempotencyKey { get; }
+}
+
+public sealed record AiJobPageRequest
+{
+    public AiJobPageRequest(string? cursor = null, int limit = 50)
+    {
+        if (limit is <= 0 or > 100)
+            throw new ArgumentOutOfRangeException(nameof(limit));
+        Cursor = string.IsNullOrWhiteSpace(cursor) ? null : cursor;
+        Limit = limit;
+    }
+
+    public string? Cursor { get; }
+
+    public int Limit { get; }
+}
+
+// Usage is expressed as a proportion. The server owns the unit accounting so the
+// per-operation cost never reaches the client.
+public sealed record AiMonthlyUsage(int UsedPercent, int RemainingPercent, bool IsExhausted);
+
+public sealed record AiBalance(
+    AiMonthlyUsage MonthlyUsage,
+    int AdditionalCredits,
+    bool HasAdditionalCreditDebt);
+
+/// <summary>
+/// What the server has said about starting an operation. "Not answered" is a
+/// state of its own: a server that never mentioned an operation has not refused
+/// it, and reporting that as a refusal sends the account to buy credits it
+/// already has.
+/// </summary>
+public enum AiOperationAvailabilityState
+{
+    Unknown,
+    Available,
+    Unavailable,
+}
+
+// Which operations the server will accept right now, keyed by operation id.
+public sealed class AiOperationAvailability
+{
+    public AiOperationAvailability(IEnumerable<KeyValuePair<AiOperationId, bool>> operations)
+    {
+        ArgumentNullException.ThrowIfNull(operations);
+        Operations = operations.ToImmutableDictionary(pair => pair.Key, pair => pair.Value);
+    }
+
+    public ImmutableDictionary<AiOperationId, bool> Operations { get; }
+
+    /// <summary>
+    /// An operation the server did not report reads as
+    /// <see cref="AiOperationAvailabilityState.Unknown"/>, mirroring
+    /// <see cref="AiModelAvailability.CanStart"/>: silence is not a refusal.
+    /// </summary>
+    public AiOperationAvailabilityState GetState(AiOperationId operation)
+    {
+        if (!Operations.TryGetValue(operation, out bool allowed))
+            return AiOperationAvailabilityState.Unknown;
+        return allowed
+            ? AiOperationAvailabilityState.Available
+            : AiOperationAvailabilityState.Unavailable;
+    }
+}
+
+/// <summary>
+/// Which of an operation's models the account can pay for right now. An
+/// operation reads as available when any one of them does, so a picker needs
+/// this to know which entries to offer.
+/// </summary>
+public sealed class AiModelAvailability
+{
+    public static AiModelAvailability Empty { get; } =
+        new(ImmutableDictionary<AiOperationId, ImmutableDictionary<AiModelId, bool>>.Empty);
+
+    public AiModelAvailability(
+        IEnumerable<KeyValuePair<AiOperationId, ImmutableDictionary<AiModelId, bool>>> operations)
+    {
+        ArgumentNullException.ThrowIfNull(operations);
+        Operations = operations.ToImmutableDictionary(pair => pair.Key, pair => pair.Value);
+    }
+
+    public ImmutableDictionary<AiOperationId, ImmutableDictionary<AiModelId, bool>> Operations { get; }
+
+    /// <summary>
+    /// Whether that model can be started. An operation the server did not
+    /// report says nothing about its models, so the answer falls back to the
+    /// operation-wide flag its caller already has.
+    /// </summary>
+    public bool CanStart(AiOperationId operation, AiModelId model, bool fallback)
+        => Operations.TryGetValue(operation, out ImmutableDictionary<AiModelId, bool>? models)
+           && models.TryGetValue(model, out bool allowed)
+            ? allowed
+            : fallback;
+}
+
+public sealed record AiEntitlements(
+    string? Plan,
+    string? SubscriptionStatus,
+    DateTimeOffset? CurrentPeriodStart,
+    DateTimeOffset? CurrentPeriodEnd,
+    bool CancelAtPeriodEnd,
+    bool CanUseAi,
+    AiBalance Balance,
+    AiOperationAvailability Availability)
+{
+    /// <summary>
+    /// Empty against a server that predates per-model pricing, which is the
+    /// same as saying nothing about any particular model.
+    /// </summary>
+    public AiModelAvailability ModelAvailability { get; init; } = AiModelAvailability.Empty;
+}
+
+public sealed record AiImageResult(
+    AiJobId? JobId,
+    AiContentId FileId,
+    Uri ContentUri,
+    AiContentMetadata? ContentMetadata = null);
+
+public sealed record AiVideoGenerationResult(
+    AiJobId JobId,
+    AiJobStatusId Status);
+
+public sealed record AiVideoJob(
+    AiJobId JobId,
+    AiJobStatusId Status,
+    AiContentId? FileId,
+    Uri? ContentUri,
+    string? Error,
+    AiContentMetadata? ContentMetadata = null);
+
+public sealed record AiContentMetadata
+{
+    public AiContentMetadata(string? fileName, string? contentType)
+    {
+        FileName = AiContentMetadataValidator.NormalizeFileName(fileName);
+        ContentType = AiContentMetadataValidator.NormalizeContentType(contentType);
+    }
+
+    public string? FileName { get; }
+
+    public string? ContentType { get; }
+
+    public static AiContentMetadata? Combine(
+        AiContentMetadata? declared,
+        AiContentMetadata? downloaded)
+    {
+        if (declared is null)
+            return downloaded;
+        if (downloaded is null)
+            return declared;
+
+        if (declared.FileName is not null
+            && downloaded.FileName is not null
+            && !StringComparer.Ordinal.Equals(declared.FileName, downloaded.FileName))
+        {
+            throw new AiException("The downloaded AI content filename does not match its job metadata.");
+        }
+
+        if (declared.ContentType is not null
+            && downloaded.ContentType is not null
+            && !StringComparer.OrdinalIgnoreCase.Equals(declared.ContentType, downloaded.ContentType))
+        {
+            throw new AiException("The downloaded AI content type does not match its job metadata.");
+        }
+
+        return new AiContentMetadata(
+            downloaded.FileName ?? declared.FileName,
+            downloaded.ContentType ?? declared.ContentType);
+    }
+
+    public string GetFileExtension(string fallbackExtension, string requiredMediaKind)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(requiredMediaKind);
+        string normalizedFallback = NormalizeExtension(fallbackExtension);
+        string? contentTypeExtension = ContentType?.ToLowerInvariant() switch
+        {
+            "image/png" => ".png",
+            "image/jpeg" => ".jpg",
+            "image/webp" => ".webp",
+            "image/gif" => ".gif",
+            "video/mp4" => ".mp4",
+            "video/webm" => ".webm",
+            "video/quicktime" => ".mov",
+            "video/x-matroska" => ".mkv",
+            "audio/wav" or "audio/x-wav" => ".wav",
+            "audio/mpeg" => ".mp3",
+            "audio/flac" => ".flac",
+            "audio/mp4" => ".m4a",
+            "audio/ogg" => ".ogg",
+            "audio/webm" => ".webm",
+            _ => null,
+        };
+        if (ContentType is not null && contentTypeExtension is null)
+            throw new AiException("The AI content type is unsupported.");
+
+        string? fileNameExtension = string.IsNullOrWhiteSpace(FileName)
+            ? null
+            : Path.GetExtension(FileName) is { Length: > 0 } extension
+                ? NormalizeExtension(extension)
+                : null;
+
+        if (contentTypeExtension is not null
+            && fileNameExtension is not null
+            && !StringComparer.OrdinalIgnoreCase.Equals(contentTypeExtension, fileNameExtension)
+            && !(contentTypeExtension == ".jpg" && fileNameExtension == ".jpeg"))
+        {
+            throw new AiException("The AI content filename and content type describe different formats.");
+        }
+
+        string result = contentTypeExtension ?? fileNameExtension ?? normalizedFallback;
+        bool mediaKindMatches = requiredMediaKind switch
+        {
+            "image" => result is ".png" or ".jpg" or ".jpeg" or ".webp" or ".gif",
+            "video" => result is ".mp4" or ".webm" or ".mov" or ".mkv",
+            "audio" => result is ".wav" or ".mp3" or ".flac" or ".m4a" or ".ogg" or ".webm",
+            _ => throw new ArgumentException("The required media kind is invalid.", nameof(requiredMediaKind)),
+        };
+        if (!mediaKindMatches)
+            throw new AiException($"The AI content is not valid {requiredMediaKind} media.");
+        return result;
+    }
+
+    private static string NormalizeExtension(string extension)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(extension);
+        string normalized = extension.StartsWith('.') ? extension : $".{extension}";
+        if (normalized.Length is < 2 or > 11
+            || normalized.Skip(1).Any(character => !char.IsAsciiLetterOrDigit(character)))
+        {
+            throw new ArgumentException("The file extension is invalid.", nameof(extension));
+        }
+
+        normalized = normalized.ToLowerInvariant();
+        if (normalized is not (
+            ".png" or ".jpg" or ".jpeg" or ".webp" or ".gif"
+            or ".mp4" or ".webm" or ".mov" or ".mkv"
+            or ".wav" or ".mp3" or ".flac" or ".m4a" or ".ogg"))
+        {
+            throw new AiException("The AI content uses an unsupported file format.");
+        }
+
+        return normalized;
+    }
+}
+
+public sealed record AiContentDownload(AiContentMetadata? Metadata);
+
+public sealed record AiTranscriptionResponse(
+    AiJobId? JobId,
+    AiTranscriptionSegment[] Segments,
+    string? Language,
+    AiTranscriptionWord[]? Words);
+
+public sealed class AiTranscriptionWord
+{
+    public required double Start { get; init; }
+
+    public required double End { get; init; }
+
+    public required string Word { get; init; }
+}
+
+public sealed class AiTranscriptionSegment
+{
+    public required double Start { get; init; }
+
+    public required double End { get; init; }
+
+    public required string Text { get; init; }
+}
+
+public sealed record AiCaptionTranslationSegment
+{
+    public required string Id { get; init; }
+
+    public required string Text { get; init; }
+
+    public AiCaptionTranslationSegmentContext? Context { get; init; }
+}
+
+public sealed record AiCaptionTranslationSegmentContext
+{
+    public AiCaptionTranslationSegmentContext(
+        string groupId,
+        int partIndex,
+        TimeSpan start,
+        TimeSpan end)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
+        if (!AiRequestLimits.IsSafeTranslationIdentifier(groupId))
+            throw new ArgumentException(
+                "Translation context group IDs must be 1 to 64 safe ASCII characters.",
+                nameof(groupId));
+        if (partIndex < 0)
+            throw new ArgumentOutOfRangeException(nameof(partIndex));
+        if (start < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(start));
+        if (end <= start)
+            throw new ArgumentOutOfRangeException(nameof(end));
+
+        GroupId = groupId.Trim();
+        PartIndex = partIndex;
+        Start = start;
+        End = end;
+    }
+
+    public string GroupId { get; }
+
+    public int PartIndex { get; }
+
+    public TimeSpan Start { get; }
+
+    public TimeSpan End { get; }
+}
+
+/// <summary>
+/// A rough version of a picture, sent while the finished one is still being
+/// worked out. The bytes are a whole image of their own and can be shown as
+/// they are.
+/// </summary>
+public sealed record AiImagePreview(int Index, ReadOnlyMemory<byte> Bytes);
+
+public sealed record AiCaptionTranslationResponse(
+    AiJobId? JobId,
+    AiCaptionTranslationSegment[] Segments);
+
+public sealed record AiJobPage(
+    ImmutableArray<AiJob> Jobs,
+    string? NextCursor);
+
+internal static class AiModelMapper
+{
+    public static AiEntitlements ToModel(EntitlementsResponse response)
+    {
+        if (!response.TryNormalize(out EntitlementsResponse? normalized))
+            throw new AiException("The AI entitlement response is invalid.");
+        EntitlementsResponse value = normalized!;
+
+        return new AiEntitlements(
+            value.Plan,
+            value.SubscriptionStatus,
+            ParseTimestamp(value.CurrentPeriodStart),
+            ParseTimestamp(value.CurrentPeriodEnd),
+            value.CancelAtPeriodEnd,
+            value.CanUseAi,
+            ToModel(value.Balance),
+            new AiOperationAvailability(
+                value.Availability.Select(pair =>
+                    new KeyValuePair<AiOperationId, bool>(
+                        new AiOperationId(pair.Key),
+                        pair.Value))))
+        {
+            ModelAvailability = ToModel(value.ModelAvailability),
+        };
+    }
+
+    private static AiModelAvailability ToModel(
+        ImmutableDictionary<string, ImmutableDictionary<string, bool>>? response)
+    {
+        if (response is null || response.Count == 0)
+            return AiModelAvailability.Empty;
+
+        return new AiModelAvailability(
+            response
+                .Where(pair => pair.Value is not null)
+                .Select(pair => new KeyValuePair<AiOperationId, ImmutableDictionary<AiModelId, bool>>(
+                    new AiOperationId(pair.Key),
+                    pair.Value.ToImmutableDictionary(
+                        model => new AiModelId(model.Key),
+                        model => model.Value))));
+    }
+
+    // Models the server did not describe well enough to offer are dropped
+    // rather than shown unnamed: an entry whose id cannot be sent back is not a
+    // choice.
+    public static AiModelCatalog ToModel(
+        AiCapabilitiesResponse response,
+        IAiOperationCapabilitySchemaProvider? capabilitySchemas = null)
+        => ToModel(
+            response,
+            (capabilitySchemas ?? BuiltInAiOperationCapabilitySchemaProvider.Instance)
+                .GetSnapshot());
+
+    public static AiModelCatalog ToModel(
+        AiCapabilitiesResponse response,
+        AiOperationCapabilitySchemaSnapshot capabilitySchemas)
+    {
+        if (response.Operations is null || response.Operations.Count == 0)
+            return AiModelCatalog.Empty;
+
+        (AiOperationId Operation,
+            ImmutableArray<AiModelOption> Models,
+            bool ModelsWereSpecified,
+            AiModelCapabilitySchema Schema,
+            AiOperationCapabilityResponse Capability)[]
+            operations =
+            response.Operations
+                .Select(pair =>
+                {
+                    var operation = new AiOperationId(pair.Key);
+                    AiModelCapabilitySchema schema = capabilitySchemas.GetSchema(operation);
+                    return (
+                        operation,
+                        ToModelOptions(pair.Value, schema),
+                        pair.Value.Models is not null,
+                        schema,
+                        pair.Value);
+                })
+                .ToArray();
+
+        return new AiModelCatalog(
+            operations
+                .Where(item => !item.Models.IsDefaultOrEmpty)
+                .Select(item => KeyValuePair.Create(item.Operation, item.Models)),
+            // An operation the server described but left with no usable model is
+            // explicitly unavailable. A missing operation stays absent here.
+            operations
+                .Where(item => item.ModelsWereSpecified && item.Models.IsDefaultOrEmpty)
+                .Select(item => item.Operation),
+            operations.Select(item => KeyValuePair.Create(item.Operation, item.Schema)),
+            operations
+                .Where(item => item.Schema == AiModelCapabilitySchema.Image)
+                .Select(item => KeyValuePair.Create(
+                    item.Operation,
+                    ToImageReferenceLimits(item.Capability))))
+        {
+            CaptionTranslationLimits = ToCaptionTranslationLimits(response),
+        };
+    }
+
+    private static AiImageReferenceLimits ToImageReferenceLimits(
+        AiOperationCapabilityResponse operation)
+        => operation.MaxReferenceImagesTotalBytes is > 0 and var maxTotalBytes
+                ? new AiImageReferenceLimits(maxTotalBytes)
+                : AiImageReferenceLimits.Default;
+
+    private static AiCaptionTranslationLimits ToCaptionTranslationLimits(
+        AiCapabilitiesResponse response)
+    {
+        if (!response.Operations.TryGetValue(
+                AiOperations.CaptionTranslation.Value,
+                out AiOperationCapabilityResponse? operation))
+        {
+            return AiCaptionTranslationLimits.Default;
+        }
+
+        return new AiCaptionTranslationLimits(
+            operation.MaxSegments is > 0 and var maxSegments
+                ? maxSegments
+                : AiRequestLimits.MaxTranslationSegments,
+            operation.MaxCharacters is > 0 and var maxCharacters
+                ? maxCharacters
+                : AiRequestLimits.MaxTranslationCharacters,
+            operation.MaxRequestBytes is > 0 and var maxRequestBytes
+                ? maxRequestBytes
+                : AiRequestLimits.MaxTranslationRequestBytes);
+    }
+
+    // Called only for image operations. A model with no fields of its own still
+    // inherits the operation dimensions; explicit operation emptiness remains
+    // Unsupported rather than being widened to client defaults.
+    private static AiImageModelCapabilities ToImageCapabilities(
+        AiModelDescriptionResponse model,
+        AiOperationCapabilityResponse capability)
+    {
+        return new AiImageModelCapabilities(
+            NarrowDimension(
+                model.AspectRatios is { } aspectRatios
+                    ? AiCapabilityDimension<string>.Supported(
+                        aspectRatios.Where(value => !string.IsNullOrWhiteSpace(value)))
+                    : AiCapabilityDimension<string>.Unspecified,
+                capability.AspectRatios),
+            NarrowDimension(
+                model.Backgrounds is { } backgrounds
+                    ? AiCapabilityDimension<string>.Supported(
+                        backgrounds.Where(value => !string.IsNullOrWhiteSpace(value)))
+                    : AiCapabilityDimension<string>.Unspecified,
+                capability.Backgrounds),
+            model.Seed ?? true,
+            model.MaxReferenceImages ?? AiRequestLimits.MaxImageReferences,
+            model.Resolution ?? true);
+    }
+
+    // Called only for video generation. Omitted model fields inherit operation
+    // dimensions, while omitted operation fields remain Unspecified.
+    private static AiVideoModelCapabilities ToVideoCapabilities(
+        AiModelDescriptionResponse model,
+        AiOperationCapabilityResponse capability)
+    {
+        return Narrow(
+            new AiVideoModelCapabilities(
+                model.DurationsSeconds is { } durations
+                    ? AiCapabilityDimension<int>.Supported(durations)
+                    : AiCapabilityDimension<int>.Unspecified,
+                model.Resolutions is { } resolutions
+                    ? AiCapabilityDimension<string>.Supported(
+                        resolutions.Where(value => !string.IsNullOrWhiteSpace(value)))
+                    : AiCapabilityDimension<string>.Unspecified,
+                model.AspectRatios is { } aspectRatios
+                    ? AiCapabilityDimension<string>.Supported(
+                        aspectRatios.Where(value => !string.IsNullOrWhiteSpace(value)))
+                    : AiCapabilityDimension<string>.Unspecified,
+                model.Audio ?? true,
+                model.Seed ?? true,
+                model.FirstFrame ?? true,
+                model.LastFrame ?? true),
+            capability);
+    }
+
+    private static ImmutableArray<AiModelOption> ToModelOptions(
+        AiOperationCapabilityResponse capability,
+        AiModelCapabilitySchema schema)
+    {
+        if (capability.Models is not { IsDefaultOrEmpty: false } models)
+            return [];
+
+        return models
+            .Where(model => !string.IsNullOrWhiteSpace(model.Id))
+            .Select(model => new AiModelOption(
+                new AiModelId(model.Id),
+                string.IsNullOrWhiteSpace(model.DisplayName)
+                    ? model.Id.Trim()
+                    : model.DisplayName.Trim(),
+                ToCostTier(model.CostTier),
+                model.IsDefault,
+                schema == AiModelCapabilitySchema.Video
+                    ? ToVideoCapabilities(model, capability)
+                    : null,
+                schema == AiModelCapabilitySchema.Image
+                    ? ToImageCapabilities(model, capability)
+                    : null))
+            .ToImmutableArray();
+    }
+
+    // A model's own lists narrowed to what the operation accepts, so a shape
+    // the server would refuse never reaches the dialog. Order follows the
+    // operation's, which runs from the smallest resolution upwards.
+    private static AiVideoModelCapabilities Narrow(
+        AiVideoModelCapabilities model,
+        AiOperationCapabilityResponse capability)
+    {
+        AiCapabilityDimension<int> durations;
+        if (!model.DurationsSeconds.IsSpecified
+            && (capability.MinDurationSeconds is not null
+                || capability.MaxDurationSeconds is not null))
+        {
+            int minimum = Math.Max(
+                capability.MinDurationSeconds ?? AiRequestLimits.MinVideoDurationSeconds,
+                AiRequestLimits.MinVideoDurationSeconds);
+            int maximum = Math.Min(
+                capability.MaxDurationSeconds ?? AiRequestLimits.MaxVideoDurationSeconds,
+                AiRequestLimits.MaxVideoDurationSeconds);
+            durations = minimum <= maximum
+                ? AiCapabilityDimension<int>.Supported(
+                    Enumerable.Range(minimum, maximum - minimum + 1))
+                : AiCapabilityDimension<int>.Unsupported;
+        }
+        else
+        {
+            durations = !model.DurationsSeconds.IsSpecified
+                ? model.DurationsSeconds
+                : AiCapabilityDimension<int>.Supported(model.DurationsSeconds.Values.Where(seconds =>
+                    AiRequestLimits.IsValidVideoDurationSeconds(seconds)
+                    && seconds >= (capability.MinDurationSeconds ?? int.MinValue)
+                    && seconds <= (capability.MaxDurationSeconds ?? int.MaxValue)));
+        }
+        return model with
+        {
+            DurationsSeconds = durations,
+            Resolutions = NarrowDimension(model.Resolutions, capability.Resolutions),
+            AspectRatios = NarrowDimension(model.AspectRatios, capability.AspectRatios),
+        };
+    }
+
+    private static AiCapabilityDimension<string> NarrowDimension(
+        AiCapabilityDimension<string> model,
+        ImmutableArray<string>? operation)
+    {
+        if (operation is null)
+            return model;
+        if (operation.Value.IsEmpty)
+            return AiCapabilityDimension<string>.Unsupported;
+        ImmutableArray<string> offered = operation.Value;
+        if (!model.IsSpecified)
+            return AiCapabilityDimension<string>.Supported(offered);
+        if (model.Values.IsEmpty)
+            return AiCapabilityDimension<string>.Unsupported;
+        return AiCapabilityDimension<string>.Supported(offered.Where(model.Values.Contains));
+    }
+
+    // An unrecognized tier is reported as none rather than guessed at: the
+    // label is the only thing said about relative cost, and a wrong one would
+    // send a user to the pricier model believing it is the cheaper.
+    private static AiModelCostTier? ToCostTier(string? value)
+        => value switch
+        {
+            "low" => AiModelCostTier.Low,
+            "medium" => AiModelCostTier.Medium,
+            "high" => AiModelCostTier.High,
+            _ => null,
+        };
+
+    public static AiBalance ToModel(AiBalanceResponse response)
+    {
+        if (!response.TryNormalize(out AiBalanceResponse? normalized))
+            throw new AiException("The AI balance response is invalid.");
+        AiBalanceResponse value = normalized!;
+        return new AiBalance(
+            ToModel(value.MonthlyUsage),
+            value.AdditionalCredits,
+            value.HasAdditionalCreditDebt);
+    }
+
+    internal static AiMonthlyUsage ToModel(AiMonthlyUsageResponse response)
+        => new(
+            response.UsedPercent,
+            response.RemainingPercent,
+            response.IsExhausted);
+
+    public static AiImageResult ToModel(AiImageResponse response)
+        => new(
+            ToOptionalJobId(response.JobId),
+            new AiContentId(response.FileId),
+            ParseContentUri(response.Url),
+            ToContentMetadata(response.FileName, response.ContentType));
+
+    public static AiVideoGenerationResult ToModel(CreateAiVideoResponse response)
+        => new(
+            new AiJobId(response.JobId),
+            new AiJobStatusId(response.Status));
+
+    public static AiVideoJob ToModel(AiVideoJobResponse response)
+        => new(
+            new AiJobId(response.JobId),
+            new AiJobStatusId(response.Status),
+            string.IsNullOrWhiteSpace(response.FileId) ? null : new AiContentId(response.FileId),
+            string.IsNullOrWhiteSpace(response.Url) ? null : ParseContentUri(response.Url),
+            response.Error,
+            ToContentMetadata(response.FileName, response.ContentType));
+
+    public static AiTranscriptionResponse ToModel(AiTranscriptionResponseDto response)
+        => new(
+            ToOptionalJobId(response.JobId),
+            response.Segments.Select(segment => new AiTranscriptionSegment
+            {
+                Start = segment.Start,
+                End = segment.End,
+                Text = segment.Text,
+            }).ToArray(),
+            response.Language,
+            response.Words?.Select(word => new AiTranscriptionWord
+            {
+                Start = word.Start,
+                End = word.End,
+                Word = word.Word,
+            }).ToArray());
+
+    public static AiCaptionTranslationResponse ToModel(AiCaptionTranslationResponseDto response)
+        => new(
+            ToOptionalJobId(response.JobId),
+            response.Segments.Select(segment => new AiCaptionTranslationSegment
+            {
+                Id = segment.Id,
+                Text = segment.Text,
+                Context = segment.Context is null
+                    ? null
+                    : new AiCaptionTranslationSegmentContext(
+                        segment.Context.GroupId,
+                        segment.Context.PartIndex,
+                        TimeSpan.FromSeconds(segment.Context.Start),
+                        TimeSpan.FromSeconds(segment.Context.End)),
+            }).ToArray());
+
+    public static AiJob ToModel(AiJobHistoryResponse response)
+        => new(
+            new AiJobId(response.Id),
+            new AiJobKindId(response.Kind),
+            new AiJobStatusId(response.Status),
+            response.InputParams?.Clone(),
+            string.IsNullOrWhiteSpace(response.FileId) ? null : new AiContentId(response.FileId),
+            string.IsNullOrWhiteSpace(response.Url) ? null : ParseContentUri(response.Url),
+            response.Error,
+            response.CanRetry,
+            response.CreatedAt.ToUniversalTime(),
+            response.UpdatedAt.ToUniversalTime(),
+            ToContentMetadata(response.FileName, response.ContentType))
+        {
+            Model = string.IsNullOrWhiteSpace(response.Model)
+                ? null
+                : new AiModelId(response.Model),
+        };
+
+    private static AiJobId? ToOptionalJobId(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : new AiJobId(value);
+
+    private static Uri ParseContentUri(string value)
+        => Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)
+            ? uri
+            : throw new AiException("The AI response contains an invalid content URI.");
+
+    private static AiContentMetadata? ToContentMetadata(string? fileName, string? contentType)
+        => string.IsNullOrWhiteSpace(fileName) && string.IsNullOrWhiteSpace(contentType)
+            ? null
+            : new AiContentMetadata(fileName, contentType);
+
+    private static DateTimeOffset? ParseTimestamp(string? value)
+        => string.IsNullOrWhiteSpace(value)
+            ? null
+            : DateTimeOffset.TryParse(value, out DateTimeOffset timestamp)
+                ? timestamp.ToUniversalTime()
+                : throw new AiException("The AI entitlement response contains an invalid timestamp.");
+}
+
+internal static class AiContentMetadataValidator
+{
+    public static string? NormalizeFileName(string? fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+            return null;
+        string normalized = fileName.Trim();
+        if (normalized.Length > 255
+            || normalized.Contains('/')
+            || normalized.Contains('\\')
+            || normalized.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0
+            || Path.IsPathRooted(normalized)
+            || Path.GetFileName(normalized) != normalized
+            || normalized is "." or "..")
+        {
+            throw new AiException("The AI response contains an invalid content filename.");
+        }
+
+        return normalized;
+    }
+
+    public static string? NormalizeContentType(string? contentType)
+    {
+        if (string.IsNullOrWhiteSpace(contentType))
+            return null;
+        if (!System.Net.Http.Headers.MediaTypeHeaderValue.TryParse(
+                contentType.Trim(),
+                out System.Net.Http.Headers.MediaTypeHeaderValue? parsed))
+        {
+            throw new AiException("The AI response contains an invalid content type.");
+        }
+
+        return parsed.MediaType;
+    }
+}

--- a/src/Beutl.Api/Services/AiModels.cs
+++ b/src/Beutl.Api/Services/AiModels.cs
@@ -388,6 +388,16 @@ public sealed class AiModelCatalog
                         "Model identifiers must be unique within an operation.",
                         nameof(operations));
                 }
+                if (model.Video?.DurationsSeconds is { IsSpecified: true } durations
+                    && durations.Values.Any(seconds =>
+                        !AiRequestLimits.IsValidVideoDurationSeconds(seconds)))
+                {
+                    throw new ArgumentException(
+                        $"Video duration capabilities must be between "
+                        + $"{AiRequestLimits.MinVideoDurationSeconds} and "
+                        + $"{AiRequestLimits.MaxVideoDurationSeconds} seconds.",
+                        nameof(operations));
+                }
             }
 
             return models;

--- a/src/Beutl.Api/Services/AiOperationCapabilitySchemas.cs
+++ b/src/Beutl.Api/Services/AiOperationCapabilitySchemas.cs
@@ -1,0 +1,405 @@
+﻿using System.Collections.Immutable;
+using System.Collections.Specialized;
+using Beutl.Extensibility;
+using Beutl.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace Beutl.Api.Services;
+
+/// <summary>Identifies the supported model-capability shape for an AI operation.</summary>
+public enum AiModelCapabilitySchema
+{
+    Generic,
+    Image,
+    Video,
+}
+
+public enum AiOperationCapabilitySchemaRegistrationMode
+{
+    Add,
+    Replace,
+}
+
+/// <summary>Associates one open AI operation identifier with a model-capability schema.</summary>
+public sealed class AiOperationCapabilitySchemaRegistration
+{
+    public AiOperationCapabilitySchemaRegistration(
+        AiOperationId operation,
+        AiModelCapabilitySchema schema,
+        AiOperationCapabilitySchemaRegistrationMode mode =
+            AiOperationCapabilitySchemaRegistrationMode.Add)
+    {
+        if (string.IsNullOrWhiteSpace(operation.Value))
+            throw new ArgumentException("An AI operation identifier is required.", nameof(operation));
+        if (!Enum.IsDefined(schema))
+            throw new ArgumentOutOfRangeException(nameof(schema));
+        if (!Enum.IsDefined(mode))
+            throw new ArgumentOutOfRangeException(nameof(mode));
+
+        Operation = operation;
+        Schema = schema;
+        Mode = mode;
+    }
+
+    public AiOperationId Operation { get; }
+
+    public AiModelCapabilitySchema Schema { get; }
+
+    public AiOperationCapabilitySchemaRegistrationMode Mode { get; }
+}
+
+/// <summary>
+/// Declares capability schemas for custom AI operations without retaining executable package code.
+/// </summary>
+public abstract class AiOperationCapabilitySchemaExtension : Extension, ILiveUnloadExtension
+{
+    public abstract IReadOnlyCollection<AiOperationCapabilitySchemaRegistration> Registrations { get; }
+}
+
+internal interface IAiOperationCapabilitySchemaProvider : IBeutlApiResource
+{
+    event EventHandler? Changed;
+
+    AiOperationCapabilitySchemaSnapshot GetSnapshot();
+}
+
+internal readonly record struct AiOperationCapabilitySchemaSnapshot(
+    long Revision,
+    ImmutableDictionary<AiOperationId, AiModelCapabilitySchema> Schemas)
+{
+    public AiModelCapabilitySchema GetSchema(AiOperationId operation)
+        => Schemas.GetValueOrDefault(operation, GetBuiltInSchema(operation));
+
+    private static AiModelCapabilitySchema GetBuiltInSchema(AiOperationId operation)
+    {
+        if (operation == AiOperations.VideoGeneration)
+            return AiModelCapabilitySchema.Video;
+        if (operation == AiOperations.ImageGeneration
+            || operation.Value.StartsWith("image.edit.", StringComparison.Ordinal))
+        {
+            return AiModelCapabilitySchema.Image;
+        }
+
+        return AiModelCapabilitySchema.Generic;
+    }
+}
+
+internal sealed class AiOperationCapabilitySchemaRegistry :
+    IAiOperationCapabilitySchemaProvider,
+    IDisposable
+{
+    private static readonly ILogger s_logger =
+        Log.CreateLogger<AiOperationCapabilitySchemaRegistry>();
+    private readonly IExtensionRegistry _extensions;
+    private readonly Action<string, Exception> _reportFailure;
+    private readonly object _compositionGate = new();
+    private readonly object _gate = new();
+    private ImmutableDictionary<AiOperationId, AiModelCapabilitySchema> _schemas =
+        ImmutableDictionary<AiOperationId, AiModelCapabilitySchema>.Empty;
+    private long _revision;
+    private bool _disposed;
+
+    public AiOperationCapabilitySchemaRegistry(IExtensionRegistry extensions)
+        : this(extensions, null)
+    {
+    }
+
+    internal AiOperationCapabilitySchemaRegistry(
+        IExtensionRegistry extensions,
+        Action<string, Exception>? reportFailure)
+    {
+        _extensions = extensions ?? throw new ArgumentNullException(nameof(extensions));
+        _reportFailure = reportFailure ?? LogFailure;
+        extensions.SynchronizeMutation(() =>
+        {
+            lock (_compositionGate)
+            {
+                extensions.AllExtensions.CollectionChanged += OnExtensionsChanged;
+                extensions.ExtensionsChanged += OnExtensionsCommitted;
+                try
+                {
+                    RebuildCore();
+                }
+                catch
+                {
+                    extensions.AllExtensions.CollectionChanged -= OnExtensionsChanged;
+                    extensions.ExtensionsChanged -= OnExtensionsCommitted;
+                    throw;
+                }
+            }
+        });
+    }
+
+    public event EventHandler? Changed;
+
+    public AiOperationCapabilitySchemaSnapshot GetSnapshot()
+    {
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return new AiOperationCapabilitySchemaSnapshot(_revision, _schemas);
+        }
+    }
+
+    internal AiModelCapabilitySchema GetSchema(AiOperationId operation)
+        => GetSnapshot().GetSchema(operation);
+
+    public void Dispose()
+    {
+        _extensions.SynchronizeMutation(() =>
+        {
+            lock (_compositionGate)
+            {
+                if (_disposed)
+                    return;
+                _disposed = true;
+                _extensions.AllExtensions.CollectionChanged -= OnExtensionsChanged;
+                _extensions.ExtensionsChanged -= OnExtensionsCommitted;
+                lock (_gate)
+                    _schemas = ImmutableDictionary<AiOperationId, AiModelCapabilitySchema>.Empty;
+            }
+        });
+    }
+
+    private void OnExtensionsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.Action != NotifyCollectionChangedAction.Add)
+            Rebuild();
+    }
+
+    private void OnExtensionsCommitted(object? sender, EventArgs e) => Rebuild();
+
+    private void Rebuild()
+    {
+        _extensions.SynchronizeMutation(() =>
+        {
+            lock (_compositionGate)
+            {
+                if (!_disposed)
+                    RebuildCore();
+            }
+        });
+    }
+
+    private void RebuildCore()
+    {
+        var readFailures = new List<(string ExtensionType, Exception Exception)>();
+        List<SchemaCandidate> candidates = ReadCommittedCandidates(readFailures);
+
+        var failures = new Dictionary<SchemaCandidate, Exception>(
+            ReferenceEqualityComparer.Instance);
+        Dictionary<AiOperationId, AiModelCapabilitySchema> accepted;
+        while (true)
+        {
+            accepted = [];
+            var newFailures = new Dictionary<SchemaCandidate, (Exception Exception, int Phase)>(
+                ReferenceEqualityComparer.Instance);
+            AiOperationCapabilitySchemaRegistrationMode[] phases =
+            [
+                AiOperationCapabilitySchemaRegistrationMode.Add,
+                AiOperationCapabilitySchemaRegistrationMode.Replace,
+            ];
+            for (int phaseIndex = 0; phaseIndex < phases.Length; phaseIndex++)
+            {
+                AiOperationCapabilitySchemaRegistrationMode phase = phases[phaseIndex];
+                foreach (SchemaCandidate candidate in candidates)
+                {
+                    if (failures.ContainsKey(candidate) || newFailures.ContainsKey(candidate))
+                        continue;
+
+                    try
+                    {
+                        var working = new Dictionary<AiOperationId, AiModelCapabilitySchema>(
+                            accepted);
+                        foreach (AiOperationCapabilitySchemaRegistration registration
+                                 in candidate.Registrations.Where(item => item.Mode == phase))
+                        {
+                            Apply(registration, working);
+                        }
+                        accepted = working;
+                    }
+                    catch (Exception ex)
+                    {
+                        newFailures.Add(candidate, (ex, phaseIndex));
+                    }
+                }
+            }
+
+            if (newFailures.Count == 0)
+                break;
+
+            int latestPhase = newFailures.Values.Max(failure => failure.Phase);
+            KeyValuePair<SchemaCandidate, (Exception Exception, int Phase)> rejected =
+                newFailures.First(failure => failure.Value.Phase == latestPhase);
+            failures.TryAdd(rejected.Key, rejected.Value.Exception);
+        }
+
+        ImmutableDictionary<AiOperationId, AiModelCapabilitySchema> next =
+            accepted.ToImmutableDictionary();
+        bool changed;
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+            changed = !HaveSameSchemas(_schemas, next);
+            if (changed)
+            {
+                _schemas = next;
+                _revision++;
+            }
+        }
+
+        if (changed)
+            NotifyChanged();
+        foreach ((string extensionType, Exception failure) in readFailures)
+            ReportFailure(extensionType, failure);
+        foreach ((SchemaCandidate candidate, Exception failure) in failures)
+            ReportFailure(candidate.ExtensionType, failure);
+    }
+
+    private List<SchemaCandidate> ReadCommittedCandidates(
+        List<(string ExtensionType, Exception Exception)> failures)
+    {
+        var result = new List<SchemaCandidate>();
+        foreach (ExtensionDescriptor descriptor
+                 in _extensions.GetDescriptors<AiOperationCapabilitySchemaExtension>())
+        {
+            if (!_extensions.TryAcquire(
+                    descriptor.Id,
+                    out IExtensionLease<AiOperationCapabilitySchemaExtension>? lease))
+            {
+                continue;
+            }
+
+            using (lease)
+            {
+                try
+                {
+                    IReadOnlyCollection<AiOperationCapabilitySchemaRegistration>? registrations =
+                        lease.Extension.Registrations;
+                    if (registrations is null
+                        || registrations.Any(registration => registration is null))
+                    {
+                        throw new InvalidOperationException(
+                            "An AI operation capability-schema extension returned invalid registrations.");
+                    }
+
+                    result.Add(new SchemaCandidate(
+                        descriptor.TypeName,
+                        registrations.Select(registration =>
+                            new AiOperationCapabilitySchemaRegistration(
+                                registration.Operation,
+                                registration.Schema,
+                                registration.Mode)).ToArray()));
+                }
+                catch (Exception ex)
+                {
+                    failures.Add((descriptor.TypeName, ex));
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static bool HaveSameSchemas(
+        ImmutableDictionary<AiOperationId, AiModelCapabilitySchema> left,
+        ImmutableDictionary<AiOperationId, AiModelCapabilitySchema> right)
+        => left.Count == right.Count
+           && left.All(pair => right.TryGetValue(pair.Key, out AiModelCapabilitySchema schema)
+                               && schema == pair.Value);
+
+    private static void Apply(
+        AiOperationCapabilitySchemaRegistration registration,
+        Dictionary<AiOperationId, AiModelCapabilitySchema> schemas)
+    {
+        bool exists = schemas.ContainsKey(registration.Operation)
+            || GetBuiltInSchema(registration.Operation) != AiModelCapabilitySchema.Generic;
+        if (registration.Mode == AiOperationCapabilitySchemaRegistrationMode.Add && exists)
+        {
+            throw new ArgumentException(
+                $"A capability schema for '{registration.Operation}' is already registered.");
+        }
+        if (registration.Mode == AiOperationCapabilitySchemaRegistrationMode.Replace && !exists)
+        {
+            throw new ArgumentException(
+                $"A capability schema for '{registration.Operation}' cannot be replaced because it is not registered.");
+        }
+
+        schemas[registration.Operation] = registration.Schema;
+    }
+
+    private static AiModelCapabilitySchema GetBuiltInSchema(AiOperationId operation)
+    {
+        if (operation == AiOperations.VideoGeneration)
+            return AiModelCapabilitySchema.Video;
+        if (operation == AiOperations.ImageGeneration
+            || operation.Value.StartsWith("image.edit.", StringComparison.Ordinal))
+        {
+            return AiModelCapabilitySchema.Image;
+        }
+
+        return AiModelCapabilitySchema.Generic;
+    }
+
+    private void NotifyChanged()
+    {
+        if (Changed is not { } observers)
+            return;
+
+        foreach (EventHandler observer in observers.GetInvocationList())
+        {
+            try
+            {
+                observer(this, EventArgs.Empty);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private void ReportFailure(string extensionType, Exception exception)
+    {
+        try
+        {
+            _reportFailure(extensionType, exception);
+        }
+        catch
+        {
+            // Diagnostics cannot veto a committed extension mutation or interrupt removal.
+        }
+    }
+
+    private static void LogFailure(string extensionType, Exception exception)
+        => s_logger.LogWarning(
+            exception,
+            "Ignoring invalid AI capability-schema contribution from {ExtensionType}.",
+            extensionType);
+
+    private sealed class SchemaCandidate(
+        string extensionType,
+        AiOperationCapabilitySchemaRegistration[] registrations)
+    {
+        public string ExtensionType { get; } = extensionType;
+
+        public AiOperationCapabilitySchemaRegistration[] Registrations { get; } = registrations;
+    }
+}
+
+internal sealed class BuiltInAiOperationCapabilitySchemaProvider :
+    IAiOperationCapabilitySchemaProvider
+{
+    public static BuiltInAiOperationCapabilitySchemaProvider Instance { get; } = new();
+
+    public event EventHandler? Changed
+    {
+        add { }
+        remove { }
+    }
+
+    public AiOperationCapabilitySchemaSnapshot GetSnapshot()
+        => new(
+            0,
+            ImmutableDictionary<AiOperationId, AiModelCapabilitySchema>.Empty);
+}

--- a/src/Beutl.Api/Services/AiRetryKeyStore.cs
+++ b/src/Beutl.Api/Services/AiRetryKeyStore.cs
@@ -1,0 +1,1310 @@
+﻿using System.ComponentModel;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Beutl.Api.Objects;
+
+namespace Beutl.Api.Services;
+
+internal enum AiRetryAttemptKind
+{
+    Recovery,
+    NewPurchase,
+}
+
+/// <summary>Opaque, single-use confirmation data produced by a retry preflight.</summary>
+internal sealed class AiRetryAttempt : IDisposable
+{
+    private readonly Action<AiRetryAttempt> _abandon;
+    private int _disposed;
+
+    public AiRetryAttempt(
+        string token,
+        string accountId,
+        string canonicalIdentity,
+        string key,
+        long generation,
+        AiRetryAttemptKind kind,
+        string payloadDigest,
+        int payloadVersion,
+        DateTimeOffset createdAt,
+        DateTimeOffset expiresAt,
+        Action<AiRetryAttempt> abandon)
+    {
+        Token = token;
+        AccountId = accountId;
+        CanonicalIdentity = canonicalIdentity;
+        Key = key;
+        Generation = generation;
+        Kind = kind;
+        PayloadDigest = payloadDigest;
+        PayloadVersion = payloadVersion;
+        CreatedAt = createdAt;
+        ExpiresAt = expiresAt;
+        _abandon = abandon ?? throw new ArgumentNullException(nameof(abandon));
+    }
+
+    public string Token { get; }
+
+    public string AccountId { get; }
+
+    public string CanonicalIdentity { get; }
+
+    public string Key { get; }
+
+    public long Generation { get; }
+
+    public AiRetryAttemptKind Kind { get; }
+
+    public string PayloadDigest { get; }
+
+    public int PayloadVersion { get; }
+
+    public DateTimeOffset CreatedAt { get; }
+
+    public DateTimeOffset ExpiresAt { get; }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) == 0)
+        {
+            try
+            {
+                _abandon(this);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Expiry pruning is the fail-safe when the store is locked or
+                // corrupt during UI teardown; cancellation must remain best effort.
+            }
+        }
+    }
+
+    public override bool Equals(object? obj)
+        => obj is AiRetryAttempt other
+            && StringComparer.Ordinal.Equals(Token, other.Token);
+
+    public override int GetHashCode()
+        => StringComparer.Ordinal.GetHashCode(Token);
+}
+
+internal interface IAiRetryKeyStore
+{
+    bool TryGet(AiJob job, string accountId, out string key);
+
+    string GetOrCreate(AiJob job, string accountId, out bool isRepeat);
+
+    void Retire(AiJob job, string accountId);
+
+    AiRetryAttempt PrepareAttempt(AiJob job, string accountId);
+
+    bool TryPrepareRecoveryAttempt(
+        AiJob job,
+        string accountId,
+        out AiRetryAttempt attempt);
+
+    void AbandonAttempt(AiRetryAttempt attempt);
+
+    bool TryConsumeAttempt(
+        AiRetryAttempt attempt,
+        AiJob job,
+        string accountId,
+        out string key,
+        out bool isRepeat);
+
+    bool TryRelease(
+        AiJob job,
+        string accountId,
+        string key,
+        long generation,
+        string ownerToken);
+
+    bool TryRetire(
+        AiJob job,
+        string accountId,
+        string key,
+        long generation,
+        string ownerToken);
+}
+
+internal sealed class AiRetryStoreUnavailableException(string message, Exception? inner = null)
+    : IOException(message, inner);
+
+internal sealed class AiRetryAttemptRejectedException()
+    : InvalidOperationException("The retry confirmation is no longer valid. Start a new confirmation.");
+
+/// <summary>Durably keeps idempotency keys and pending confirmations for AI history retries.</summary>
+internal sealed class FileAiRetryKeyStore : IAiRetryKeyStore
+{
+    private const int Version = 2;
+    private const int MaximumBytes = 1024 * 1024;
+    private const int MaximumEntries = 256;
+    private const int MaximumGenerations = 512;
+    private const int MaximumAttempts = 256;
+    private const int LockAttempts = 100;
+    private static readonly TimeSpan LockDelay = TimeSpan.FromMilliseconds(5);
+    private static readonly TimeSpan LeaseDuration = TimeSpan.FromMinutes(5);
+    private readonly object _gate = new();
+    private readonly string _path;
+    private readonly string _directory;
+    private string LockPath => _path + ".lock";
+
+    public FileAiRetryKeyStore(string storageDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(storageDirectory);
+        _directory = Path.GetFullPath(storageDirectory);
+        Directory.CreateDirectory(_directory);
+        RestrictDirectory(_directory);
+        _path = Path.Combine(_directory, "retry-keys.json");
+        SweepTemporaryFiles();
+    }
+
+    public string GetOrCreate(AiJob job, string accountId, out bool isRepeat)
+    {
+        string identity = CanonicalIdentity(job, accountId);
+        lock (_gate)
+        {
+            using FileStream lease = AcquireLock();
+            StoreData data = Load();
+            RemoveExpiredAttempts(data);
+            RemoveStaleAttempts(data);
+            if (data.Entries.TryGetValue(identity, out Entry? existing))
+            {
+                if (existing.PayloadVersion == 0)
+                {
+                    existing = existing with { PayloadDigest = PayloadDigest(job), PayloadVersion = 1 };
+                    data.Entries[identity] = existing;
+                    Save(data);
+                }
+                else if (!StringComparer.Ordinal.Equals(existing.PayloadDigest, PayloadDigest(job)))
+                    throw new AiRetryAttemptRejectedException();
+                if (existing.IsLeaseActive)
+                    throw new AiRetryAttemptRejectedException();
+                if (existing.InFlightOwner is not null)
+                {
+                    existing = existing with { InFlightOwner = null, InFlightUntil = null };
+                    data.Entries[identity] = existing;
+                    Save(data);
+                }
+
+                isRepeat = true;
+                return existing.Key;
+            }
+
+            isRepeat = false;
+            string key = CreateKey(job);
+            long generation = AdvanceGeneration(data, identity);
+            data.Entries.Add(
+                identity,
+                new Entry(key, generation, PayloadDigest(job), 1, null, null));
+            RemoveAttemptsForIdentity(data, identity);
+            PruneGenerations(data);
+            Save(data);
+            return key;
+        }
+    }
+
+    public bool TryGet(AiJob job, string accountId, out string key)
+    {
+        string identity = CanonicalIdentity(job, accountId);
+        lock (_gate)
+        {
+            using FileStream lease = AcquireLock();
+            StoreData data = Load();
+            RemoveExpiredAttempts(data);
+            RemoveStaleAttempts(data);
+            if (data.Entries.TryGetValue(identity, out Entry? entry)
+                && entry.PayloadVersion == 1
+                && StringComparer.Ordinal.Equals(entry.PayloadDigest, PayloadDigest(job)))
+            {
+                key = entry.Key;
+                return true;
+            }
+
+            key = string.Empty;
+            return false;
+        }
+    }
+
+    public void Retire(AiJob job, string accountId)
+    {
+        string identity = CanonicalIdentity(job, accountId);
+        lock (_gate)
+        {
+            using FileStream lease = AcquireLock();
+            StoreData data = Load();
+            if (data.Entries.Remove(identity))
+                AdvanceGeneration(data, identity);
+            RemoveAttemptsForIdentity(data, identity);
+            PruneGenerations(data);
+            Save(data);
+        }
+    }
+
+    public void AbandonAttempt(AiRetryAttempt attempt)
+    {
+        ArgumentNullException.ThrowIfNull(attempt);
+        lock (_gate)
+        {
+            using FileStream lease = AcquireLock();
+            StoreData data = Load();
+            RemoveExpiredAttempts(data);
+            RemoveStaleAttempts(data);
+            if (data.Attempts.Remove(attempt.Token))
+            {
+                PruneGenerations(data);
+                Save(data);
+            }
+        }
+    }
+
+    public bool TryRelease(
+        AiJob job,
+        string accountId,
+        string key,
+        long generation,
+        string ownerToken)
+    {
+        string identity = CanonicalIdentity(job, accountId);
+        lock (_gate)
+        {
+            using FileStream lease = AcquireLock();
+            StoreData data = Load();
+            if (!data.Entries.TryGetValue(identity, out Entry? entry)
+                || entry.Generation != generation
+                || !StringComparer.Ordinal.Equals(entry.Key, key)
+                || entry.PayloadVersion != 1
+                || !StringComparer.Ordinal.Equals(entry.PayloadDigest, PayloadDigest(job))
+                || !StringComparer.Ordinal.Equals(entry.InFlightOwner, ownerToken))
+            {
+                return false;
+            }
+
+            data.Entries[identity] = entry with { InFlightOwner = null, InFlightUntil = null };
+            Save(data);
+            return true;
+        }
+    }
+
+    public bool TryRetire(
+        AiJob job,
+        string accountId,
+        string key,
+        long generation,
+        string ownerToken)
+    {
+        string identity = CanonicalIdentity(job, accountId);
+        lock (_gate)
+        {
+            using FileStream lease = AcquireLock();
+            StoreData data = Load();
+            if (!data.Entries.TryGetValue(identity, out Entry? entry)
+                || entry.Generation != generation
+                || !StringComparer.Ordinal.Equals(entry.Key, key)
+                || entry.PayloadVersion != 1
+                || !StringComparer.Ordinal.Equals(entry.PayloadDigest, PayloadDigest(job))
+                || !StringComparer.Ordinal.Equals(entry.InFlightOwner, ownerToken))
+            {
+                return false;
+            }
+
+            data.Entries.Remove(identity);
+            AdvanceGeneration(data, identity);
+            RemoveAttemptsForIdentity(data, identity);
+            PruneGenerations(data);
+            Save(data);
+            return true;
+        }
+    }
+
+    public AiRetryAttempt PrepareAttempt(AiJob job, string accountId)
+    {
+        string identity = CanonicalIdentity(job, accountId);
+        lock (_gate)
+        {
+            using FileStream lease = AcquireLock();
+            StoreData data = Load();
+            RemoveExpiredAttempts(data);
+            RemoveStaleAttempts(data);
+
+            AiRetryAttemptKind kind;
+            string key;
+            long generation;
+            if (data.Entries.TryGetValue(identity, out Entry? entry))
+            {
+                if (entry.PayloadVersion == 0)
+                {
+                    entry = entry with { PayloadDigest = PayloadDigest(job), PayloadVersion = 1 };
+                    data.Entries[identity] = entry;
+                    Save(data);
+                }
+                else if (!StringComparer.Ordinal.Equals(entry.PayloadDigest, PayloadDigest(job)))
+                    throw new AiRetryAttemptRejectedException();
+                if (entry.IsLeaseActive)
+                    throw new AiRetryAttemptRejectedException();
+                if (entry.InFlightOwner is not null)
+                {
+                    entry = entry with { InFlightOwner = null, InFlightUntil = null };
+                    data.Entries[identity] = entry;
+                    Save(data);
+                }
+
+                kind = AiRetryAttemptKind.Recovery;
+                key = entry.Key;
+                generation = entry.Generation;
+            }
+            else
+            {
+                kind = AiRetryAttemptKind.NewPurchase;
+                generation = GetGeneration(data, identity);
+                PendingAttempt? existing = data.Attempts.Values.FirstOrDefault(candidate =>
+                    candidate.AccountId == accountId
+                    && candidate.Identity == identity
+                    && candidate.Generation == generation
+                    && candidate.Kind == kind);
+                if (existing is not null)
+                    return ToAttempt(existing);
+                key = CreateKey(job);
+            }
+
+            PendingAttempt? matching = data.Attempts.Values.FirstOrDefault(candidate =>
+                candidate.AccountId == accountId
+                && candidate.Identity == identity
+                && candidate.Key == key
+                && candidate.Generation == generation
+                && candidate.Kind == kind);
+            if (matching is not null)
+                return ToAttempt(matching);
+
+            if (data.Attempts.Count >= MaximumAttempts)
+                throw new AiRetryStoreUnavailableException("Retry confirmation store is full.");
+
+            DateTimeOffset createdAt = DateTimeOffset.UtcNow;
+            PendingAttempt pending = new(
+                CreateOpaqueToken(),
+                accountId,
+                identity,
+                key,
+                generation,
+                kind,
+                PayloadDigest(job),
+                1,
+                createdAt,
+                createdAt + LeaseDuration);
+            data.Attempts.Add(pending.Token, pending);
+            PruneGenerations(data);
+            Save(data);
+            return ToAttempt(pending);
+        }
+    }
+
+    public bool TryPrepareRecoveryAttempt(
+        AiJob job,
+        string accountId,
+        out AiRetryAttempt attempt)
+    {
+        string identity = CanonicalIdentity(job, accountId);
+        lock (_gate)
+        {
+            using FileStream lease = AcquireLock();
+            StoreData data = Load();
+            RemoveExpiredAttempts(data);
+            RemoveStaleAttempts(data);
+            if (!data.Entries.TryGetValue(identity, out Entry? entry))
+            {
+                attempt = null!;
+                return false;
+            }
+
+            if (entry.PayloadVersion != 1
+                || !StringComparer.Ordinal.Equals(entry.PayloadDigest, PayloadDigest(job)))
+                throw new AiRetryAttemptRejectedException();
+            if (entry.IsLeaseActive)
+                throw new AiRetryAttemptRejectedException();
+            if (entry.InFlightOwner is not null)
+            {
+                entry = entry with { InFlightOwner = null, InFlightUntil = null };
+                data.Entries[identity] = entry;
+                Save(data);
+            }
+
+            PendingAttempt? existing = data.Attempts.Values.FirstOrDefault(candidate =>
+                candidate.AccountId == accountId
+                && candidate.Identity == identity
+                && candidate.Key == entry.Key
+                && candidate.Generation == entry.Generation
+                && candidate.Kind == AiRetryAttemptKind.Recovery);
+            if (existing is not null)
+            {
+                attempt = ToAttempt(existing);
+                return true;
+            }
+
+            if (data.Attempts.Count >= MaximumAttempts)
+                throw new AiRetryStoreUnavailableException("Retry confirmation store is full.");
+            DateTimeOffset createdAt = DateTimeOffset.UtcNow;
+            PendingAttempt pending = new(
+                CreateOpaqueToken(),
+                accountId,
+                identity,
+                entry.Key,
+                entry.Generation,
+                AiRetryAttemptKind.Recovery,
+                entry.PayloadDigest,
+                entry.PayloadVersion,
+                createdAt,
+                createdAt + LeaseDuration);
+            data.Attempts.Add(pending.Token, pending);
+            PruneGenerations(data);
+            Save(data);
+            attempt = ToAttempt(pending);
+            return true;
+        }
+    }
+
+    public bool TryConsumeAttempt(
+        AiRetryAttempt attempt,
+        AiJob job,
+        string accountId,
+        out string key,
+        out bool isRepeat)
+    {
+        ArgumentNullException.ThrowIfNull(attempt);
+        string identity = CanonicalIdentity(job, accountId);
+        key = string.Empty;
+        isRepeat = false;
+        if (!StringComparer.Ordinal.Equals(attempt.AccountId, accountId)
+            || !StringComparer.Ordinal.Equals(attempt.CanonicalIdentity, identity)
+            || !StringComparer.Ordinal.Equals(attempt.PayloadDigest, PayloadDigest(job))
+            || attempt.PayloadVersion != 1)
+        {
+            return false;
+        }
+
+        lock (_gate)
+        {
+            using FileStream lease = AcquireLock();
+            StoreData data = Load();
+            RemoveExpiredAttempts(data);
+            if (!data.Attempts.TryGetValue(attempt.Token, out PendingAttempt? pending)
+                || !pending.Matches(attempt))
+            {
+                return false;
+            }
+
+            long generation = GetGeneration(data, identity);
+            if (generation != attempt.Generation)
+            {
+                data.Attempts.Remove(attempt.Token);
+                PruneGenerations(data);
+                Save(data);
+                return false;
+            }
+
+            DateTimeOffset leaseUntil = DateTimeOffset.UtcNow + LeaseDuration;
+            if (attempt.Kind == AiRetryAttemptKind.Recovery)
+            {
+                if (!data.Entries.TryGetValue(identity, out Entry? entry)
+                    || entry.Generation != attempt.Generation
+                    || !StringComparer.Ordinal.Equals(entry.Key, attempt.Key)
+                    || entry.PayloadVersion != attempt.PayloadVersion
+                    || !StringComparer.Ordinal.Equals(entry.PayloadDigest, attempt.PayloadDigest)
+                    || entry.IsLeaseActive)
+                {
+                    data.Attempts.Remove(attempt.Token);
+                    PruneGenerations(data);
+                    Save(data);
+                    return false;
+                }
+
+                key = entry.Key;
+                isRepeat = true;
+                data.Entries[identity] = entry with
+                {
+                    InFlightOwner = attempt.Token,
+                    InFlightUntil = leaseUntil,
+                };
+            }
+            else
+            {
+                if (data.Entries.ContainsKey(identity))
+                {
+                    data.Attempts.Remove(attempt.Token);
+                    PruneGenerations(data);
+                    Save(data);
+                    return false;
+                }
+
+                long nextGeneration = AdvanceGeneration(data, identity);
+                data.Entries.Add(
+                    identity,
+                    new Entry(
+                        attempt.Key,
+                        nextGeneration,
+                        attempt.PayloadDigest,
+                        attempt.PayloadVersion,
+                        attempt.Token,
+                        leaseUntil));
+                key = attempt.Key;
+            }
+
+            // The pending confirmation is consumed atomically with the claim.
+            // The durable key remains until the provider outcome is definitive.
+            data.Attempts.Remove(attempt.Token);
+            PruneGenerations(data);
+            Save(data);
+            return true;
+        }
+    }
+
+    internal static string CanonicalIdentity(AiJob job, string accountId)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ValidateAccount(accountId);
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(
+            $"v1\n{accountId}\n{job.Id.Value}")));
+    }
+
+    internal static string PayloadDigest(AiJob job)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        string input = CanonicalizePayload(job);
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(
+            $"v1\n{job.Kind.Value}\n{job.Model?.Value}\n{input}")));
+    }
+
+    private static string CanonicalizePayload(AiJob job)
+    {
+        if (job.InputParameters is not { } input)
+            return string.Empty;
+        using JsonDocument document = JsonDocument.Parse(input.GetRawText());
+        return CanonicalizeJson(document.RootElement);
+    }
+
+    private static string CanonicalizeJson(JsonElement element)
+        => element.ValueKind switch
+        {
+            JsonValueKind.Object => "{" + string.Join(",", element.EnumerateObject()
+                .OrderBy(property => property.Name, StringComparer.Ordinal)
+                .Select(property => JsonSerializer.Serialize(property.Name)
+                    + ":" + CanonicalizeJson(property.Value))) + "}",
+            JsonValueKind.Array => "[" + string.Join(",", element.EnumerateArray().Select(CanonicalizeJson)) + "]",
+            JsonValueKind.String => JsonSerializer.Serialize(element.GetString()),
+            JsonValueKind.Number => CanonicalizeNumber(element),
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            JsonValueKind.Null => "null",
+            _ => string.Empty,
+        };
+
+    private static string CanonicalizeNumber(JsonElement element)
+    {
+        if (element.TryGetDecimal(out decimal decimalValue))
+            return decimalValue.ToString("G29", CultureInfo.InvariantCulture);
+        if (element.TryGetDouble(out double doubleValue)
+            && double.IsFinite(doubleValue))
+            return doubleValue.ToString("R", CultureInfo.InvariantCulture);
+        throw new AiRetryAttemptRejectedException();
+    }
+
+    private static string CreateKey(AiJob job)
+        => $"history-retry:{job.Id.Value}:{Guid.NewGuid():N}";
+
+    private static string CreateOpaqueToken()
+        => Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
+
+    private StoreData Load()
+    {
+        try
+        {
+            if (!File.Exists(_path))
+                return new StoreData();
+            long length = new FileInfo(_path).Length;
+            if (length is <= 0 or > MaximumBytes)
+                throw new AiRetryStoreUnavailableException("Retry key store is unreadable.");
+
+            using JsonDocument document = JsonDocument.Parse(File.ReadAllBytes(_path));
+            JsonElement root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object
+                || !root.TryGetProperty("version", out JsonElement version)
+                || version.ValueKind != JsonValueKind.Number)
+            {
+                throw new AiRetryStoreUnavailableException("Retry key store has an unsupported version.");
+            }
+
+            int value = version.GetInt32();
+            return value switch
+            {
+                1 => LoadVersion1(root),
+                Version => LoadVersion2(root),
+                _ => throw new AiRetryStoreUnavailableException("Retry key store has an unsupported version."),
+            };
+        }
+        catch (AiRetryStoreUnavailableException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is IOException
+            or UnauthorizedAccessException
+            or JsonException
+            or FormatException
+            or OverflowException
+            or InvalidOperationException
+            or ArgumentException)
+        {
+            throw new AiRetryStoreUnavailableException("Retry key store could not be read.", ex);
+        }
+    }
+
+    private static StoreData LoadVersion1(JsonElement root)
+    {
+        if (root.EnumerateObject().Count() != 2
+            || !root.TryGetProperty("entries", out JsonElement entriesElement)
+            || entriesElement.ValueKind != JsonValueKind.Array)
+        {
+            throw new AiRetryStoreUnavailableException("Retry key store has an invalid legacy shape.");
+        }
+
+        var data = new StoreData();
+        int count = 0;
+        foreach (JsonElement element in entriesElement.EnumerateArray())
+        {
+            if (++count > MaximumEntries
+                || element.ValueKind != JsonValueKind.Object
+                || element.EnumerateObject().Count() != 2
+                || !element.TryGetProperty("identity", out JsonElement identity)
+                || !element.TryGetProperty("key", out JsonElement key))
+            {
+                throw new AiRetryStoreUnavailableException("Retry key store contains invalid entries.");
+            }
+
+            string identityValue = ReadIdentity(identity);
+            string keyValue = ReadKey(key);
+            if (!data.Entries.TryAdd(identityValue, new Entry(keyValue, 1, string.Empty, 0, null, null)))
+                throw new AiRetryStoreUnavailableException("Retry key store contains duplicate entries.");
+            data.Generations[identityValue] = 1;
+        }
+
+        return data;
+    }
+
+    private static StoreData LoadVersion2(JsonElement root)
+    {
+        if (root.EnumerateObject().Count() != 4
+            || !root.TryGetProperty("entries", out JsonElement entriesElement)
+            || entriesElement.ValueKind != JsonValueKind.Array
+            || !root.TryGetProperty("generations", out JsonElement generationsElement)
+            || generationsElement.ValueKind != JsonValueKind.Array
+            || !root.TryGetProperty("attempts", out JsonElement attemptsElement)
+            || attemptsElement.ValueKind != JsonValueKind.Array)
+        {
+            throw new AiRetryStoreUnavailableException("Retry key store has an invalid shape.");
+        }
+
+        var data = new StoreData();
+        int generationCount = 0;
+        foreach (JsonElement element in generationsElement.EnumerateArray())
+        {
+            if (++generationCount > MaximumGenerations
+                || element.ValueKind != JsonValueKind.Object
+                || element.EnumerateObject().Count() != 2
+                || !element.TryGetProperty("identity", out JsonElement identity)
+                || !element.TryGetProperty("generation", out JsonElement generation)
+                || generation.ValueKind != JsonValueKind.Number)
+            {
+                throw new AiRetryStoreUnavailableException("Retry key store contains invalid generations.");
+            }
+
+            string identityValue = ReadIdentity(identity);
+            long generationValue = generation.GetInt64();
+            if (generationValue < 0 || !data.Generations.TryAdd(identityValue, generationValue))
+                throw new AiRetryStoreUnavailableException("Retry key store contains invalid generations.");
+        }
+
+        int entryCount = 0;
+        foreach (JsonElement element in entriesElement.EnumerateArray())
+        {
+            if (++entryCount > MaximumEntries
+                || element.ValueKind != JsonValueKind.Object
+                || element.EnumerateObject().Count() != 7
+                || !element.TryGetProperty("identity", out JsonElement identity)
+                || !element.TryGetProperty("key", out JsonElement key)
+                || !element.TryGetProperty("generation", out JsonElement generation)
+                || !element.TryGetProperty("payloadDigest", out JsonElement payloadDigest)
+                || !element.TryGetProperty("payloadVersion", out JsonElement payloadVersion)
+                || !element.TryGetProperty("inFlightOwner", out JsonElement owner)
+                || !element.TryGetProperty("inFlightUntil", out JsonElement until)
+                || generation.ValueKind != JsonValueKind.Number
+                || payloadDigest.ValueKind != JsonValueKind.String
+                || payloadVersion.ValueKind != JsonValueKind.Number
+                || owner.ValueKind is not (JsonValueKind.String or JsonValueKind.Null)
+                || until.ValueKind is not (JsonValueKind.String or JsonValueKind.Null))
+            {
+                throw new AiRetryStoreUnavailableException("Retry key store contains invalid entries.");
+            }
+
+            string identityValue = ReadIdentity(identity);
+            string keyValue = ReadKey(key);
+            long generationValue = generation.GetInt64();
+            string payloadDigestValue = ReadDigest(payloadDigest);
+            int payloadVersionValue = payloadVersion.GetInt32();
+            string? ownerValue = owner.ValueKind == JsonValueKind.Null ? null : owner.GetString();
+            DateTimeOffset? untilValue = until.ValueKind == JsonValueKind.Null
+                ? null
+                : until.GetDateTimeOffset();
+            if (ownerValue is not null && !IsPrintable(ownerValue))
+                throw new AiRetryStoreUnavailableException("Retry key store contains an invalid lease owner.");
+            if (ownerValue is null != (untilValue is null)
+                || payloadVersionValue <= 0
+                || generationValue <= 0
+                || !data.Entries.TryAdd(
+                    identityValue,
+                    new Entry(
+                        keyValue,
+                        generationValue,
+                        payloadDigestValue,
+                        payloadVersionValue,
+                        ownerValue,
+                        untilValue))
+                || (!data.Generations.TryGetValue(identityValue, out long recorded)
+                    ? !data.Generations.TryAdd(identityValue, generationValue)
+                    : recorded != generationValue))
+            {
+                throw new AiRetryStoreUnavailableException("Retry key store contains invalid or duplicate entries.");
+            }
+        }
+
+        int attemptCount = 0;
+        foreach (JsonElement element in attemptsElement.EnumerateArray())
+        {
+            if (++attemptCount > MaximumAttempts
+                || element.ValueKind != JsonValueKind.Object
+                || element.EnumerateObject().Count() != 10
+                || !element.TryGetProperty("token", out JsonElement token)
+                || !element.TryGetProperty("accountId", out JsonElement account)
+                || !element.TryGetProperty("identity", out JsonElement identity)
+                || !element.TryGetProperty("key", out JsonElement key)
+                || !element.TryGetProperty("generation", out JsonElement generation)
+                || !element.TryGetProperty("kind", out JsonElement kind)
+                || !element.TryGetProperty("payloadDigest", out JsonElement payloadDigest)
+                || !element.TryGetProperty("payloadVersion", out JsonElement payloadVersion)
+                || !element.TryGetProperty("createdAt", out JsonElement createdAt)
+                || !element.TryGetProperty("expiresAt", out JsonElement expiresAt)
+                || generation.ValueKind != JsonValueKind.Number
+                || token.ValueKind != JsonValueKind.String
+                || account.ValueKind != JsonValueKind.String
+                || kind.ValueKind != JsonValueKind.String
+                || payloadDigest.ValueKind != JsonValueKind.String
+                || payloadVersion.ValueKind != JsonValueKind.Number
+                || createdAt.ValueKind != JsonValueKind.String
+                || expiresAt.ValueKind != JsonValueKind.String)
+            {
+                throw new AiRetryStoreUnavailableException("Retry key store contains invalid attempts.");
+            }
+
+            string tokenValue = token.GetString() ?? string.Empty;
+            string accountValue = account.GetString() ?? string.Empty;
+            string identityValue = ReadIdentity(identity);
+            string keyValue = ReadKey(key);
+            long generationValue = generation.GetInt64();
+            string payloadDigestValue = ReadDigest(payloadDigest);
+            int payloadVersionValue = payloadVersion.GetInt32();
+            DateTimeOffset createdAtValue = createdAt.GetDateTimeOffset();
+            DateTimeOffset expiresAtValue = expiresAt.GetDateTimeOffset();
+            AiRetryAttemptKind kindValue = kind.GetString() switch
+            {
+                "recovery" => AiRetryAttemptKind.Recovery,
+                "newPurchase" => AiRetryAttemptKind.NewPurchase,
+                _ => throw new AiRetryStoreUnavailableException("Retry key store contains an invalid attempt kind."),
+            };
+            if (tokenValue.Length is < 32 or > 128
+                || !IsPrintable(tokenValue)
+                || accountValue.Length is 0 or > 256
+                || generationValue < 0
+                || payloadVersionValue <= 0
+                || expiresAtValue <= createdAtValue
+                || !data.Attempts.TryAdd(
+                    tokenValue,
+                    new PendingAttempt(
+                        tokenValue,
+                        accountValue,
+                        identityValue,
+                        keyValue,
+                        generationValue,
+                        kindValue,
+                        payloadDigestValue,
+                        payloadVersionValue,
+                        createdAtValue,
+                        expiresAtValue)))
+            {
+                throw new AiRetryStoreUnavailableException("Retry key store contains invalid or duplicate attempts.");
+            }
+        }
+
+        foreach ((string identity, Entry entry) in data.Entries)
+        {
+            if (!data.Generations.TryGetValue(identity, out long generation)
+                || generation != entry.Generation)
+            {
+                throw new AiRetryStoreUnavailableException("Retry key store contains inconsistent generations.");
+            }
+        }
+
+        return data;
+    }
+
+    private static string ReadIdentity(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.String)
+            throw new AiRetryStoreUnavailableException("Retry key store contains an invalid identity.");
+        string value = element.GetString() ?? string.Empty;
+        if (value.Length != 64 || value.Any(c => !Uri.IsHexDigit(c)))
+            throw new AiRetryStoreUnavailableException("Retry key store contains an invalid identity.");
+        return value;
+    }
+
+    private static string ReadKey(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.String)
+            throw new AiRetryStoreUnavailableException("Retry key store contains an invalid key.");
+        string value = element.GetString() ?? string.Empty;
+        if (!IsPrintable(value))
+            throw new AiRetryStoreUnavailableException("Retry key store contains an invalid key.");
+        return value;
+    }
+
+    private static string ReadDigest(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.String)
+            throw new AiRetryStoreUnavailableException("Retry key store contains an invalid payload digest.");
+        string value = element.GetString() ?? string.Empty;
+        if (value.Length != 64 || value.Any(c => !Uri.IsHexDigit(c)))
+            throw new AiRetryStoreUnavailableException("Retry key store contains an invalid payload digest.");
+        return value;
+    }
+
+    private void Save(StoreData data)
+    {
+        if (data.Entries.Count > MaximumEntries
+            || data.Generations.Count > MaximumGenerations
+            || data.Attempts.Count > MaximumAttempts)
+        {
+            throw new AiRetryStoreUnavailableException("Retry key store is full.");
+        }
+
+        byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(new
+        {
+            version = Version,
+            entries = data.Entries
+                .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+                .Select(pair => new
+                {
+                    identity = pair.Key,
+                    key = pair.Value.Key,
+                    generation = pair.Value.Generation,
+                    payloadDigest = pair.Value.PayloadDigest,
+                    payloadVersion = pair.Value.PayloadVersion,
+                    inFlightOwner = pair.Value.InFlightOwner,
+                    inFlightUntil = pair.Value.InFlightUntil,
+                }),
+            generations = data.Generations
+                .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+                .Select(pair => new { identity = pair.Key, generation = pair.Value }),
+            attempts = data.Attempts.Values
+                .OrderBy(attempt => attempt.Token, StringComparer.Ordinal)
+                .Select(attempt => new
+                {
+                    token = attempt.Token,
+                    accountId = attempt.AccountId,
+                    identity = attempt.Identity,
+                    key = attempt.Key,
+                    generation = attempt.Generation,
+                    kind = attempt.Kind == AiRetryAttemptKind.Recovery
+                        ? "recovery"
+                        : "newPurchase",
+                    payloadDigest = attempt.PayloadDigest,
+                    payloadVersion = attempt.PayloadVersion,
+                    createdAt = attempt.CreatedAt,
+                    expiresAt = attempt.ExpiresAt,
+                }),
+        });
+        if (bytes.Length > MaximumBytes)
+            throw new AiRetryStoreUnavailableException("Retry key store is full.");
+
+        string temporary = _path + $".{Guid.NewGuid():N}.tmp";
+        try
+        {
+            WritePrivateBytes(temporary, bytes);
+            AtomicReplace(temporary, _path, overwrite: true);
+            RestrictFile(_path);
+            EnsureDirectorySynced(_directory);
+        }
+        finally
+        {
+            try { File.Delete(temporary); }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+
+    private FileStream AcquireLock()
+    {
+        IOException? last = null;
+        for (int attempt = 0; attempt < LockAttempts; attempt++)
+        {
+            try
+            {
+                FileStream stream = new(LockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+                RestrictFile(LockPath);
+                return stream;
+            }
+            catch (IOException ex)
+            {
+                last = ex;
+                Thread.Sleep(LockDelay);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                throw new AiRetryStoreUnavailableException("Retry key store is in use.", ex);
+            }
+        }
+
+        throw new AiRetryStoreUnavailableException("Retry key store is in use.", last);
+    }
+
+    private void SweepTemporaryFiles()
+    {
+        try
+        {
+            DateTime cutoff = DateTime.UtcNow - TimeSpan.FromHours(1);
+            foreach (string path in Directory.EnumerateFiles(_directory, "retry-keys.json.*.tmp"))
+            {
+                if (File.GetLastWriteTimeUtc(path) < cutoff
+                    && !IsFileLocked(path))
+                {
+                    try { File.Delete(path); }
+                    catch (IOException) { }
+                    catch (UnauthorizedAccessException) { }
+                }
+            }
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    private static bool IsFileLocked(string path)
+    {
+        try
+        {
+            using FileStream stream = new(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            return false;
+        }
+        catch (IOException)
+        {
+            return true;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return true;
+        }
+    }
+
+    private static long GetGeneration(StoreData data, string identity)
+        => data.Generations.TryGetValue(identity, out long generation) ? generation : 0;
+
+    private static long AdvanceGeneration(StoreData data, string identity)
+    {
+        long next = checked(GetGeneration(data, identity) + 1);
+        data.Generations[identity] = next;
+        return next;
+    }
+
+    private static void RemoveAttemptsForIdentity(StoreData data, string identity)
+    {
+        foreach (string token in data.Attempts.Values
+                     .Where(attempt => attempt.Identity == identity)
+                     .Select(attempt => attempt.Token)
+                     .ToArray())
+        {
+            data.Attempts.Remove(token);
+        }
+    }
+
+    private static void RemoveStaleAttempts(StoreData data)
+    {
+        foreach (PendingAttempt attempt in data.Attempts.Values.ToArray())
+        {
+            long generation = GetGeneration(data, attempt.Identity);
+            bool stale = generation != attempt.Generation;
+            if (!stale && attempt.Kind == AiRetryAttemptKind.Recovery)
+            {
+                stale = !data.Entries.TryGetValue(attempt.Identity, out Entry? entry)
+                    || entry.Generation != attempt.Generation
+                    || entry.Key != attempt.Key
+                    || entry.PayloadVersion != attempt.PayloadVersion
+                    || entry.PayloadDigest != attempt.PayloadDigest
+                    || entry.IsLeaseActive;
+            }
+            else if (!stale)
+            {
+                stale = data.Entries.ContainsKey(attempt.Identity);
+            }
+
+            if (stale)
+                data.Attempts.Remove(attempt.Token);
+        }
+    }
+
+    private static void RemoveExpiredAttempts(StoreData data)
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        foreach (PendingAttempt attempt in data.Attempts.Values
+                     .Where(candidate => candidate.ExpiresAt <= now)
+                     .ToArray())
+        {
+            data.Attempts.Remove(attempt.Token);
+        }
+    }
+
+    private static void PruneGenerations(StoreData data)
+    {
+        if (data.Generations.Count <= MaximumGenerations)
+            return;
+
+        HashSet<string> retained = new(data.Entries.Keys, StringComparer.Ordinal);
+        retained.UnionWith(data.Attempts.Values.Select(attempt => attempt.Identity));
+        foreach (string identity in data.Generations.Keys
+                     .Where(identity => !retained.Contains(identity))
+                     .ToArray())
+        {
+            data.Generations.Remove(identity);
+            if (data.Generations.Count <= MaximumGenerations)
+                break;
+        }
+    }
+
+    private AiRetryAttempt ToAttempt(PendingAttempt pending)
+        => new(
+            pending.Token,
+            pending.AccountId,
+            pending.Identity,
+            pending.Key,
+            pending.Generation,
+            pending.Kind,
+            pending.PayloadDigest,
+            pending.PayloadVersion,
+            pending.CreatedAt,
+            pending.ExpiresAt,
+            AbandonAttempt);
+
+    private static bool IsPrintable(string value)
+        => value.Length is > 0 and <= 255 && value.All(c => c is >= '\x20' and <= '\x7e');
+
+    private static void WritePrivateBytes(string path, ReadOnlySpan<byte> bytes)
+    {
+        var options = new FileStreamOptions
+        {
+            Mode = FileMode.CreateNew,
+            Access = FileAccess.Write,
+            Share = FileShare.None,
+            Options = FileOptions.WriteThrough | FileOptions.SequentialScan,
+        };
+        if (!OperatingSystem.IsWindows())
+            options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        using FileStream stream = new(path, options);
+        stream.Write(bytes);
+        stream.Flush(flushToDisk: true);
+        RestrictFile(path);
+    }
+
+    private static void AtomicReplace(string temporary, string destination, bool overwrite)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            File.Move(temporary, destination, overwrite);
+            return;
+        }
+        const uint replace = 0x1;
+        const uint writeThrough = 0x8;
+        if (!MoveFileEx(temporary, destination, writeThrough | (overwrite ? replace : 0)))
+            throw new IOException("Atomic retry-store replacement failed.", new Win32Exception(Marshal.GetLastWin32Error()));
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool MoveFileEx(string existingFileName, string newFileName, uint flags);
+
+    /// <summary>
+    /// Unix directory fsync closes the rename durability window. Windows has
+    /// no portable directory fsync; file bytes are flushed and rename is
+    /// atomic, while directory-entry persistence remains filesystem-defined.
+    /// </summary>
+    private static void EnsureDirectorySynced(string path)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+        int fd = UnixOpen(path, 0);
+        if (fd < 0)
+            throw new IOException($"Unable to open directory for durability sync (errno {Marshal.GetLastWin32Error()}).");
+        try
+        {
+            if (UnixFsync(fd) != 0)
+                throw new IOException($"Unable to fsync directory (errno {Marshal.GetLastWin32Error()}).");
+        }
+        finally
+        {
+            if (UnixClose(fd) != 0)
+                throw new IOException($"Unable to close synced directory (errno {Marshal.GetLastWin32Error()}).");
+        }
+    }
+
+    [DllImport("libc", EntryPoint = "open", SetLastError = true)]
+    private static extern int UnixOpen(string path, int flags);
+
+    [DllImport("libc", EntryPoint = "fsync", SetLastError = true)]
+    private static extern int UnixFsync(int fd);
+
+    [DllImport("libc", EntryPoint = "close", SetLastError = true)]
+    private static extern int UnixClose(int fd);
+
+    private static void ValidateAccount(string accountId)
+    {
+        if (string.IsNullOrWhiteSpace(accountId) || accountId.Length > 256)
+            throw new AuthenticationRequiredException();
+    }
+
+    private static void RestrictDirectory(string path)
+    {
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+    }
+
+    private static void RestrictFile(string path)
+    {
+        if (!OperatingSystem.IsWindows() && File.Exists(path))
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+    }
+
+    private sealed class StoreData
+    {
+        public Dictionary<string, Entry> Entries { get; } = new(StringComparer.Ordinal);
+
+        public Dictionary<string, long> Generations { get; } = new(StringComparer.Ordinal);
+
+        public Dictionary<string, PendingAttempt> Attempts { get; } = new(StringComparer.Ordinal);
+    }
+
+    private sealed record Entry(
+        string Key,
+        long Generation,
+        string PayloadDigest,
+        int PayloadVersion,
+        string? InFlightOwner,
+        DateTimeOffset? InFlightUntil)
+    {
+        public bool IsLeaseActive
+            => InFlightOwner is { Length: > 0 }
+                && InFlightUntil is { } until
+                && until > DateTimeOffset.UtcNow;
+    }
+
+    private sealed record PendingAttempt(
+        string Token,
+        string AccountId,
+        string Identity,
+        string Key,
+        long Generation,
+        AiRetryAttemptKind Kind,
+        string PayloadDigest,
+        int PayloadVersion,
+        DateTimeOffset CreatedAt,
+        DateTimeOffset ExpiresAt)
+    {
+        public bool Matches(AiRetryAttempt attempt)
+            => Token == attempt.Token
+                && AccountId == attempt.AccountId
+                && Identity == attempt.CanonicalIdentity
+                && Key == attempt.Key
+                && Generation == attempt.Generation
+                && Kind == attempt.Kind
+                && PayloadDigest == attempt.PayloadDigest
+                && PayloadVersion == attempt.PayloadVersion
+                && CreatedAt == attempt.CreatedAt
+                && ExpiresAt == attempt.ExpiresAt;
+    }
+}
+
+internal readonly record struct AiAuthenticatedRequestIdentity(
+    string AccountId,
+    AuthenticatedUser? User);
+
+internal sealed class AiRetryAttemptContext(
+    IAiRetryKeyStore store,
+    Func<AiAuthenticatedRequestIdentity?> identityProvider,
+    bool allowSyntheticIdentity = false) : IBeutlApiResource
+{
+    public IAiRetryKeyStore Store { get; } = store
+        ?? throw new ArgumentNullException(nameof(store));
+
+    private bool AllowSyntheticIdentity { get; } = allowSyntheticIdentity;
+
+    public AiAuthenticatedRequestIdentity GetRequiredIdentity()
+    {
+        AiAuthenticatedRequestIdentity identity = identityProvider()
+            ?? throw new AuthenticationRequiredException();
+        if (string.IsNullOrWhiteSpace(identity.AccountId)
+            || identity.User is null && !AllowSyntheticIdentity
+            || identity.User is { } user
+                && !StringComparer.Ordinal.Equals(user.Profile.Id, identity.AccountId))
+        {
+            throw new AuthenticationRequiredException();
+        }
+        return identity;
+    }
+
+    public IDisposable Enter(AiAuthenticatedRequestIdentity identity)
+        => identity.User is null
+            ? EmptyDisposable.Instance
+            : AiAuthenticatedRequestScope.Enter(identity.User);
+}
+
+internal static class AiAuthenticatedRequestScope
+{
+    private static readonly AsyncLocal<AuthenticatedUser?> s_current = new();
+
+    public static AuthenticatedUser? Current => s_current.Value;
+
+    public static IDisposable Enter(AuthenticatedUser user)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+        AuthenticatedUser? previous = s_current.Value;
+        s_current.Value = user;
+        return new Scope(previous);
+    }
+
+    private sealed class Scope(AuthenticatedUser? previous) : IDisposable
+    {
+        private AuthenticatedUser? _previous = previous;
+        private int _disposed;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                s_current.Value = _previous;
+                _previous = null;
+            }
+        }
+    }
+}
+
+internal sealed class EmptyDisposable : IDisposable
+{
+    public static EmptyDisposable Instance { get; } = new();
+
+    public void Dispose()
+    {
+    }
+}

--- a/src/Beutl.Api/Services/AiStreamJson.cs
+++ b/src/Beutl.Api/Services/AiStreamJson.cs
@@ -1,0 +1,27 @@
+﻿using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Beutl.Api.Services;
+
+/// <summary>
+/// How the AI endpoints' JSON is read outside Refit. The same shape Refit is
+/// configured with, so a body reads the same whichever path it came in on.
+/// </summary>
+internal static class AiStreamJson
+{
+    public static JsonSerializerOptions Options { get; } = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+    };
+
+    /// <summary>
+    /// The JSON.stringify-compatible representation used for request bodies
+    /// whose byte budget is measured before transport.
+    /// </summary>
+    public static JsonSerializerOptions CanonicalOptions { get; } = new(JsonSerializerDefaults.Web)
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+    };
+}

--- a/src/Beutl.Api/Services/AiUploadSource.cs
+++ b/src/Beutl.Api/Services/AiUploadSource.cs
@@ -1,0 +1,126 @@
+﻿using System.Net.Http.Headers;
+
+namespace Beutl.Api.Services;
+
+/// <summary>
+/// Describes one upload independently of local filesystem access. Each stream returned by the
+/// factory transfers ownership to the caller and is disposed after the upload attempt.
+/// </summary>
+public sealed class AiUploadSource
+{
+    private readonly Func<CancellationToken, ValueTask<Stream>> _openReadAsync;
+
+    public AiUploadSource(
+        string fileName,
+        string mediaType,
+        Func<CancellationToken, ValueTask<Stream>> openReadAsync,
+        long length)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(mediaType);
+        ArgumentNullException.ThrowIfNull(openReadAsync);
+        if (length < 0)
+            throw new ArgumentOutOfRangeException(nameof(length));
+        string normalizedFileName = fileName.Trim();
+        if (Path.GetFileName(normalizedFileName) != normalizedFileName)
+            throw new ArgumentException("The upload filename cannot contain a path.", nameof(fileName));
+        if (!MediaTypeHeaderValue.TryParse(mediaType.Trim(), out MediaTypeHeaderValue? parsedMediaType))
+            throw new ArgumentException("The upload media type is invalid.", nameof(mediaType));
+
+        FileName = normalizedFileName;
+        MediaType = parsedMediaType.ToString();
+        Length = length;
+        _openReadAsync = openReadAsync;
+    }
+
+    public string FileName { get; }
+
+    public string MediaType { get; }
+
+    public long Length { get; }
+
+    public static AiUploadSource FromFile(string filePath)
+        => FromFile(filePath, Path.GetFileName(Path.GetFullPath(filePath)));
+
+    /// <summary>
+    /// The same file sent under a name of the caller's choosing.
+    /// </summary>
+    /// <remarks>
+    /// The server fingerprints a request by, among other things, the name the
+    /// file was uploaded under, and a request that repeats an idempotency key
+    /// with a different fingerprint is refused. A caller that wants a retry to
+    /// recover the result it already paid for therefore has to send the same
+    /// name every time — which a temporary path, named for uniqueness on disk,
+    /// cannot do.
+    /// </remarks>
+    public static AiUploadSource FromFile(string filePath, string fileName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        string fullPath = Path.GetFullPath(filePath);
+        long length = new FileInfo(fullPath).Length;
+        return new AiUploadSource(
+            fileName,
+            AiMediaTypes.Get(fullPath),
+            cancellationToken =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Stream stream = new FileStream(
+                    fullPath,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.Read,
+                    bufferSize: 81920,
+                    FileOptions.Asynchronous | FileOptions.SequentialScan);
+                return ValueTask.FromResult(stream);
+            },
+            length);
+    }
+
+    /// <summary>
+    /// The bytes already in hand, sent under a name of the caller's choosing.
+    /// </summary>
+    /// <remarks>
+    /// A request is named partly by what its file contains, and the file on
+    /// disk can change between being read for the name and being read again to
+    /// be sent. One reading serves both, so the name always belongs to the
+    /// bytes that actually go out.
+    /// </remarks>
+    public static AiUploadSource FromBytes(string fileName, ReadOnlyMemory<byte> bytes)
+        => FromBytes(fileName, AiMediaTypes.Get(fileName), bytes);
+
+    public static AiUploadSource FromBytes(
+        string fileName,
+        string mediaType,
+        ReadOnlyMemory<byte> bytes)
+    {
+        byte[] snapshot = bytes.ToArray();
+        return new AiUploadSource(
+            fileName,
+            mediaType,
+            cancellationToken =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return ValueTask.FromResult<Stream>(
+                    new MemoryStream(snapshot, writable: false));
+            },
+            snapshot.Length);
+    }
+
+    /// <summary>
+    /// Opens a readable stream for this upload. The caller owns the returned stream and must dispose it.
+    /// </summary>
+    public async ValueTask<Stream> OpenReadAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Stream? stream = await _openReadAsync(cancellationToken);
+        if (stream is null)
+            throw new InvalidOperationException("The upload source returned no stream.");
+        if (!stream.CanRead)
+        {
+            await stream.DisposeAsync();
+            throw new InvalidOperationException("The upload source returned an unreadable stream.");
+        }
+
+        return stream;
+    }
+}

--- a/src/Beutl.Api/Services/AiUploadSource.cs
+++ b/src/Beutl.Api/Services/AiUploadSource.cs
@@ -22,7 +22,8 @@ public sealed class AiUploadSource
         if (length < 0)
             throw new ArgumentOutOfRangeException(nameof(length));
         string normalizedFileName = fileName.Trim();
-        if (Path.GetFileName(normalizedFileName) != normalizedFileName)
+        if (normalizedFileName.Contains('/') || normalizedFileName.Contains('\\')
+            || Path.GetFileName(normalizedFileName) != normalizedFileName)
             throw new ArgumentException("The upload filename cannot contain a path.", nameof(fileName));
         if (!MediaTypeHeaderValue.TryParse(mediaType.Trim(), out MediaTypeHeaderValue? parsedMediaType))
             throw new ArgumentException("The upload media type is invalid.", nameof(mediaType));

--- a/src/Beutl.Api/Services/AiUploadValidation.cs
+++ b/src/Beutl.Api/Services/AiUploadValidation.cs
@@ -1,0 +1,50 @@
+﻿namespace Beutl.Api.Services;
+
+internal static class AiUploadValidation
+{
+    public static async ValueTask<Stream> OpenAsync(
+        AiUploadSource source,
+        long maximumBytes,
+        CancellationToken cancellationToken)
+    {
+        Stream stream = await source.OpenReadAsync(cancellationToken);
+        MemoryStream? buffered = null;
+        try
+        {
+            if (stream.CanSeek)
+            {
+                long remaining = stream.Length - stream.Position;
+                if (remaining != source.Length || remaining > maximumBytes)
+                    throw new AiFileTooLargeException();
+                return stream;
+            }
+
+            buffered = new MemoryStream();
+            byte[] buffer = new byte[81920];
+            long total = 0;
+            while (true)
+            {
+                int read = await stream.ReadAsync(buffer, cancellationToken);
+                if (read == 0)
+                    break;
+                total += read;
+                if (total > source.Length || total > maximumBytes)
+                    throw new AiFileTooLargeException();
+                await buffered.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+            }
+
+            if (total != source.Length)
+                throw new AiFileTooLargeException();
+            buffered.Position = 0;
+            await stream.DisposeAsync();
+            return buffered;
+        }
+        catch
+        {
+            await stream.DisposeAsync();
+            if (buffered is not null)
+                await buffered.DisposeAsync();
+            throw;
+        }
+    }
+}

--- a/src/Beutl.Api/Services/AuthenticatedSessionContext.cs
+++ b/src/Beutl.Api/Services/AuthenticatedSessionContext.cs
@@ -1,0 +1,33 @@
+﻿using Beutl.Api.Objects;
+
+namespace Beutl.Api.Services;
+
+internal readonly record struct AuthenticatedApiResult<T>(
+    T Value,
+    AuthenticatedUser User);
+
+internal sealed class AuthenticatedSessionContext(
+    AuthenticatedUser user,
+    long generation,
+    string authorization,
+    CancellationToken authenticationToken,
+    CancellationToken applicationToken,
+    CancellationTokenSource linkedCancellation) : IDisposable
+{
+    public AuthenticatedUser User { get; } = user;
+
+    public long Generation { get; } = generation;
+
+    public string Authorization { get; } = authorization;
+
+    public CancellationToken AuthenticationToken { get; } = authenticationToken;
+
+    public CancellationToken ApplicationToken { get; } = applicationToken;
+
+    public CancellationToken CancellationToken => linkedCancellation.Token;
+
+    public void Dispose()
+    {
+        linkedCancellation.Dispose();
+    }
+}

--- a/src/Beutl.Api/Services/BuiltInAiJobKinds.cs
+++ b/src/Beutl.Api/Services/BuiltInAiJobKinds.cs
@@ -1,0 +1,870 @@
+﻿using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using Beutl.Language;
+
+namespace Beutl.Api.Services;
+
+internal sealed record BuiltInAiJobBehaviorRegistrations(
+    IReadOnlyList<AiJobStatusResolverRegistration> StatusResolvers,
+    IReadOnlyList<AiJobRefreshHandlerRegistration> RefreshHandlers,
+    IReadOnlyList<AiJobRetryHandlerRegistration> RetryHandlers);
+
+internal static class BuiltInAiJobKinds
+{
+    public static BuiltInAiJobBehaviorRegistrations Create(
+        IAiImageGenerationService images,
+        IAiVideoService videos,
+        IAiEntitlementService entitlements,
+        IAiOperationAvailabilityService availability,
+        IAiModelCatalogService models,
+        AiRetryAttemptContext retryContext)
+    {
+        ArgumentNullException.ThrowIfNull(images);
+        ArgumentNullException.ThrowIfNull(videos);
+        ArgumentNullException.ThrowIfNull(entitlements);
+        ArgumentNullException.ThrowIfNull(availability);
+        ArgumentNullException.ThrowIfNull(models);
+        ArgumentNullException.ThrowIfNull(retryContext);
+
+        var statuses = new AiJobStatusMap(
+        [
+            KeyValuePair.Create(AiJobStatuses.Queued, new AiJobStatusSemantics(false, true)),
+            KeyValuePair.Create(AiJobStatuses.Running, new AiJobStatusSemantics(false, true)),
+            KeyValuePair.Create(AiJobStatuses.Finalizing, new AiJobStatusSemantics(false, true)),
+            KeyValuePair.Create(
+                AiJobStatuses.Succeeded,
+                new AiJobStatusSemantics(true, false, AiJobOutcomes.Succeeded)),
+            KeyValuePair.Create(
+                AiJobStatuses.Failed,
+                new AiJobStatusSemantics(true, false, AiJobOutcomes.Failed)),
+            KeyValuePair.Create(
+                AiJobStatuses.Canceled,
+                new AiJobStatusSemantics(true, false, AiJobOutcomes.Canceled)),
+        ]);
+        AiJobKindId[] kinds =
+        [
+            AiJobKinds.Image,
+            AiJobKinds.ImageEdit,
+            AiJobKinds.Transcription,
+            AiJobKinds.CaptionTranslation,
+            AiJobKinds.Video,
+        ];
+        return new BuiltInAiJobBehaviorRegistrations(
+            kinds.Select(kind => new AiJobStatusResolverRegistration(kind, statuses)).ToArray(),
+            [
+                new AiJobRefreshHandlerRegistration(
+                    AiJobKinds.Video,
+                    new AiVideoJobRefreshHandler(videos)),
+            ],
+            [
+                new AiJobRetryHandlerRegistration(
+                    AiJobKinds.Image,
+                    new AiImageJobRetryHandler(
+                        images,
+                        entitlements,
+                        availability,
+                        models,
+                        retryContext)),
+                new AiJobRetryHandlerRegistration(
+                    AiJobKinds.Video,
+                    new AiVideoJobRetryHandler(
+                        videos,
+                        entitlements,
+                        availability,
+                        models,
+                        retryContext)),
+            ]);
+    }
+}
+
+internal static class AiJobInputParameters
+{
+    public static string? GetString(AiJob job, string propertyName)
+    {
+        if (job.InputParameters is not { ValueKind: JsonValueKind.Object } input
+            || !input.TryGetProperty(propertyName, out JsonElement value)
+            || value.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        return NormalizeText(value.GetString());
+    }
+
+    public static int? GetInt32(AiJob job, string propertyName)
+    {
+        if (job.InputParameters is not { ValueKind: JsonValueKind.Object } input
+            || !input.TryGetProperty(propertyName, out JsonElement value)
+            || value.ValueKind != JsonValueKind.Number
+            || !value.TryGetInt32(out int result))
+        {
+            return null;
+        }
+
+        return result;
+    }
+
+    public static bool? GetBoolean(AiJob job, string propertyName)
+    {
+        if (job.InputParameters is not { ValueKind: JsonValueKind.Object } input
+            || !input.TryGetProperty(propertyName, out JsonElement value))
+        {
+            return null;
+        }
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => null,
+        };
+    }
+
+    public static bool Has(AiJob job, string propertyName)
+        => job.InputParameters is { ValueKind: JsonValueKind.Object } input
+           && input.TryGetProperty(propertyName, out JsonElement value)
+           && value.ValueKind is not (JsonValueKind.Null or JsonValueKind.Undefined);
+
+    private static string? NormalizeText(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}
+
+internal abstract class MeteredAiJobRetryHandler(
+    AiOperationId operation,
+    IAiEntitlementService entitlementService,
+    IAiOperationAvailabilityService availabilityService,
+    IAiModelCatalogService modelCatalogService,
+    AiRetryAttemptContext retryContext) : IAiJobRetryHandler
+{
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, Lazy<Task>> _inFlight = [];
+
+    protected async Task RunRetrySingleFlightAsync(
+        AiJob job,
+        CancellationToken cancellationToken,
+        Func<string, bool, Task> operation,
+        AiRetryAttempt attempt)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        AiAuthenticatedRequestIdentity authenticated = retryContext.GetRequiredIdentity();
+        if (!StringComparer.Ordinal.Equals(authenticated.AccountId, attempt.AccountId))
+            throw new AiRetryAttemptRejectedException();
+        string identity = CanonicalIdentity(job, authenticated.AccountId);
+        string flightIdentity = $"{identity}:{attempt.Token}";
+        var flight = new Lazy<Task>(
+            () => ExecuteRetryAsync(job, authenticated, attempt, operation),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+        Lazy<Task> selected = _inFlight.GetOrAdd(flightIdentity, flight);
+        _ = selected.Value.ContinueWith(
+            _ => _inFlight.TryRemove(new KeyValuePair<string, Lazy<Task>>(flightIdentity, selected)),
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+        try
+        {
+            // Cancellation only stops this caller waiting. The paid operation is
+            // deliberately executed with CancellationToken.None.
+            await selected.Value.WaitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The caller may stop waiting, but the single-flight operation still owns
+            // the paid request and extension resources. Keep this task alive until it
+            // drains so the preparation lease cannot be released underneath it.
+            try
+            {
+                await selected.Value.ConfigureAwait(false);
+            }
+            catch
+            {
+                // Preserve the caller's cancellation outcome after the underlying
+                // operation has been observed and allowed to release its resources.
+            }
+
+            throw;
+        }
+        finally
+        {
+            if (selected.IsValueCreated && selected.Value.IsCompleted)
+                _inFlight.TryRemove(new KeyValuePair<string, Lazy<Task>>(flightIdentity, selected));
+        }
+    }
+
+    private async Task ExecuteRetryAsync(
+        AiJob job,
+        AiAuthenticatedRequestIdentity authenticated,
+        AiRetryAttempt attempt,
+        Func<string, bool, Task> operation)
+    {
+        string key;
+        bool isRepeat;
+        long generation = 0;
+        if (!retryContext.Store.TryConsumeAttempt(
+                attempt,
+                job,
+                authenticated.AccountId,
+                out key,
+                out isRepeat))
+        {
+            throw new AiRetryAttemptRejectedException();
+        }
+
+        if (attempt.Kind == AiRetryAttemptKind.Recovery || isRepeat)
+            generation = attempt.Generation;
+        else
+            generation = attempt.Generation + 1;
+
+        using IDisposable authenticatedScope = retryContext.Enter(authenticated);
+        try
+        {
+            await operation(key, isRepeat);
+            retryContext.Store.TryRetire(
+                job,
+                authenticated.AccountId,
+                key,
+                generation,
+                attempt.Token);
+        }
+        catch (Exception ex) when (IsDefinitive(ex))
+        {
+            retryContext.Store.TryRetire(
+                job,
+                authenticated.AccountId,
+                key,
+                generation,
+                attempt.Token);
+            throw;
+        }
+        catch
+        {
+            // A timeout/transport failure leaves the exact key available for a
+            // subsequent confirmation. It must never be replaced by a fresh
+            // key after an ambiguous provider response.
+            retryContext.Store.TryRelease(
+                job,
+                authenticated.AccountId,
+                key,
+                generation,
+                attempt.Token);
+            throw;
+        }
+    }
+
+    protected static string CanonicalIdentity(AiJob job, string accountId)
+        => FileAiRetryKeyStore.CanonicalIdentity(job, accountId);
+
+    protected static bool IsDefinitive(Exception exception)
+        => exception is AiPlanRequiredException
+            or AiUsageLimitExceededException
+            or AiJobLimitReachedException
+            or AiModelUnavailableException
+            or AiModelDoesNotSupportRequestException
+            or AiFileTooLargeException
+            or AiProviderErrorException
+            or AiRequestWasDeletedException;
+
+    public virtual bool CanRetry(AiJob job, AiJobStatusSemantics status)
+        => status.IsTerminal
+            && status.Outcome is { } outcome
+            && (outcome == AiJobOutcomes.Failed || outcome == AiJobOutcomes.Succeeded)
+            && job.CanRetry
+            && HasCanonicalPrompt(job);
+
+    private static bool HasCanonicalPrompt(AiJob job)
+    {
+        if (job.InputParameters is not { ValueKind: JsonValueKind.Object } input
+            || !input.TryGetProperty("prompt", out JsonElement prompt)
+            || prompt.ValueKind != JsonValueKind.String)
+            return false;
+        string? value = prompt.GetString();
+        return !string.IsNullOrWhiteSpace(value)
+            && value.Length <= AiRequestLimits.MaxPromptLength
+            && string.Equals(value, value.Trim(), StringComparison.Ordinal);
+    }
+
+    public async ValueTask<AiJobRetryPreflight> GetPreflightAsync(
+        AiJob job,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            AiAuthenticatedRequestIdentity authenticated = retryContext.GetRequiredIdentity();
+            // Preflight is deliberately resource-free. Reading the durable entry
+            // identifies a request that may already have been paid for, but does
+            // not create a pending confirmation or reserve a lease.
+            if (retryContext.Store.TryGet(job, authenticated.AccountId, out _))
+            {
+                return new AiJobRetryPreflight(
+                    IsAvailable: false,
+                    CanSubmit: true,
+                    Strings.AiResultUnavailable);
+            }
+
+            return await GetNewPurchasePreflightAsync(job, cancellationToken);
+        }
+        catch (AiRetryAttemptRejectedException ex)
+        {
+            throw new AiJobRetryPreparationRejectedException(ex);
+        }
+        catch (AiRetryStoreUnavailableException ex)
+        {
+            throw new AiJobRetryPreparationUnavailableException(ex);
+        }
+    }
+
+    public async ValueTask<AiJobRetryPreparationResult> PrepareAsync(
+        AiJob job,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ValidateRetryInputs(job);
+            AiAuthenticatedRequestIdentity authenticated = retryContext.GetRequiredIdentity();
+
+            // A durable entry means the request was already materialized in an
+            // earlier process. It must bypass today's plan, balance, model, and
+            // availability checks: those checks cannot make a paid request safer.
+            bool isRecovery = retryContext.Store.TryGet(
+                job,
+                authenticated.AccountId,
+                out _);
+            if (!isRecovery)
+            {
+                AiJobRetryPreflight preflight = await GetNewPurchasePreflightAsync(
+                    job,
+                    cancellationToken);
+                if (!preflight.CanSubmit)
+                    return AiJobRetryPreparationResult.Blocked(preflight.Explanation);
+            }
+
+            // The durable confirmation token is created only after all checks for a
+            // new purchase have passed. A recovery token is created from the exact
+            // existing key and payload.
+            AiRetryAttempt attempt = retryContext.Store.PrepareAttempt(
+                job,
+                authenticated.AccountId);
+            return AiJobRetryPreparationResult.Ready(new RetryPreparation(this, job, attempt));
+        }
+        catch (AiRetryAttemptRejectedException ex)
+        {
+            throw new AiJobRetryPreparationRejectedException(ex);
+        }
+        catch (AiRetryStoreUnavailableException ex)
+        {
+            throw new AiJobRetryPreparationUnavailableException(ex);
+        }
+    }
+
+    private async ValueTask<AiJobRetryPreflight> GetNewPurchasePreflightAsync(
+        AiJob job,
+        CancellationToken cancellationToken)
+    {
+        AiEntitlements? entitlements = await entitlementService.RefreshAsync(cancellationToken);
+        AiJobRetryPreflight result;
+        if (entitlements is null)
+        {
+            result = new AiJobRetryPreflight(false, false, Strings.AiPricingUnavailable);
+        }
+        else if (!entitlements.CanUseAi)
+        {
+            result = new AiJobRetryPreflight(true, false, Strings.AiProRequired);
+        }
+        else
+        {
+            AiModelCatalog catalog = await modelCatalogService.GetAsync(cancellationToken);
+            if (!IsModelStillOffered(catalog, job))
+            {
+                // The balance is not the problem, so saying it is would send the
+                // user to buy credits that would not help.
+                result = new AiJobRetryPreflight(true, false, Strings.AiModelUnavailable);
+            }
+            else if (!IsCurrentRequestSupported(catalog, job))
+            {
+                result = new AiJobRetryPreflight(
+                    true,
+                    false,
+                    Strings.AiModelDoesNotSupportRequest);
+            }
+            else if (entitlements.Availability.GetState(operation) == AiOperationAvailabilityState.Unavailable
+                 || !await availabilityService.CheckAsync(
+                     CreateAvailabilityRequest(job),
+                     cancellationToken))
+            {
+                result = new AiJobRetryPreflight(true, false, Strings.AiEstimatedUsageInsufficient);
+            }
+            else
+            {
+                string explanation = entitlements.Balance.MonthlyUsage.IsExhausted
+                    ? Strings.AiEstimatedUsageTopUp
+                    : Strings.AiEstimatedUsageMonthly;
+                result = new AiJobRetryPreflight(true, true, explanation);
+            }
+        }
+
+        return result;
+    }
+
+    protected abstract AiOperationAvailabilityRequest CreateAvailabilityRequest(AiJob job);
+
+    protected abstract Task DispatchAsync(
+        AiJob job,
+        string idempotencyKey,
+        bool isRepeat);
+
+    protected virtual void ValidateRetryInputs(AiJob job)
+    {
+    }
+
+    /// <summary>
+    /// Checks the exact retained request against the latest model capability
+    /// snapshot. Implementations remain permissive when the snapshot has no
+    /// assertion for this request (for example, an older server that publishes
+    /// no model data).
+    /// </summary>
+    protected virtual bool IsCurrentRequestSupported(AiModelCatalog catalog, AiJob job)
+        => true;
+
+    // A rerun repeats the model the job ran on, so a model that has since been
+    // withdrawn cannot be repeated. Falling back to the operation's default
+    // would quietly produce something else and charge the default's price for
+    // it; the server refuses this too.
+    private bool IsModelStillOffered(AiModelCatalog catalog, AiJob job)
+    {
+        if (job.Model is not { Value.Length: > 0 } model)
+            return !catalog.OffersNoModel(operation);
+
+        ImmutableArray<AiModelOption> models = catalog.ModelsFor(operation);
+        // A catalog that could not be fetched says nothing about any model, and
+        // the server has the last word regardless.
+        if (models.IsDefaultOrEmpty)
+            return true;
+
+        return models.Any(option => option.Id == model);
+    }
+
+    private sealed class RetryPreparation(
+        MeteredAiJobRetryHandler owner,
+        AiJob job,
+        AiRetryAttempt attempt) : IAiJobRetryPreparation
+    {
+        private int _state;
+
+        public async Task ExecuteAsync(CancellationToken cancellationToken)
+        {
+            if (Interlocked.CompareExchange(ref _state, 1, 0) != 0)
+                throw new AiJobRetryPreparationRejectedException();
+
+            try
+            {
+                try
+                {
+                    await owner.RunRetrySingleFlightAsync(
+                        job,
+                        cancellationToken,
+                        (key, isRepeat) => owner.DispatchAsync(job, key, isRepeat),
+                        attempt);
+                }
+                catch (AiRetryAttemptRejectedException ex)
+                {
+                    throw new AiJobRetryPreparationRejectedException(ex);
+                }
+                catch (AiRetryStoreUnavailableException ex)
+                {
+                    throw new AiJobRetryPreparationUnavailableException(ex);
+                }
+            }
+            finally
+            {
+                // The pending confirmation token is consumed by the store
+                // before dispatch. Dispose is therefore a no-op after consume,
+                // while a pre-consume cancellation still abandons it.
+                // Keep the attempt alive for another same-key confirmation
+                // after an ambiguous response; the store's release path clears
+                // the in-flight owner while retaining the exact key.
+                attempt.Dispose();
+                Volatile.Write(ref _state, 2);
+            }
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            if (Interlocked.CompareExchange(ref _state, 2, 0) == 0)
+                attempt.Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+}
+
+internal sealed class AiImageJobRetryHandler(
+    IAiImageGenerationService images,
+    IAiEntitlementService entitlementService,
+    IAiOperationAvailabilityService availabilityService,
+    IAiModelCatalogService modelCatalogService,
+    AiRetryAttemptContext retryContext)
+    : MeteredAiJobRetryHandler(
+        AiOperations.ImageGeneration,
+        entitlementService,
+        availabilityService,
+        modelCatalogService,
+        retryContext)
+{
+    private static readonly HashSet<string> s_allowedProperties =
+        ["prompt", "size", "aspectRatio", "background", "seed"];
+
+    public override bool CanRetry(AiJob job, AiJobStatusSemantics status)
+        => base.CanRetry(job, status)
+            && TryParseReplayInput(job, out _);
+
+    protected override AiOperationAvailabilityRequest CreateAvailabilityRequest(AiJob job)
+        => new AiOperationAvailabilityRequest.Fixed(AiOperations.ImageGeneration, job.Model);
+
+    protected override void ValidateRetryInputs(AiJob job)
+    {
+        _ = ParseReplayInput(job);
+    }
+
+    protected override bool IsCurrentRequestSupported(AiModelCatalog catalog, AiJob job)
+    {
+        if (!TryParseReplayInput(job, out ImageReplayInput input))
+            return false;
+
+        AiModelOption? model = ResolveModel(catalog, job);
+        AiImageModelCapabilities? capabilities = model?.Image;
+        if (capabilities is null)
+            return true;
+        return (!capabilities.AspectRatios.IsSpecified
+                || capabilities.AspectRatios.Values.Contains(input.AspectRatio))
+            && (input.Background is not { Length: > 0 } background
+                || string.Equals(background, "auto", StringComparison.Ordinal)
+                || !capabilities.Backgrounds.IsSpecified
+                || capabilities.Backgrounds.Values.Contains(background))
+            && (input.Seed is null || capabilities.SupportsSeed);
+    }
+
+    protected override async Task DispatchAsync(
+        AiJob job,
+        string idempotencyKey,
+        bool isRepeat)
+    {
+        ImageReplayInput input = ParseReplayInput(job);
+        await images.GenerateAsync(
+            new AiImageGenerationRequest(
+                input.Prompt,
+                new AiImageAspectRatioId(input.AspectRatio),
+                background: ResolveBackground(input),
+                seed: input.Seed,
+                model: job.Model,
+                idempotencyKey: idempotencyKey),
+            CancellationToken.None);
+    }
+
+    private static AiImageBackgroundId ResolveBackground(ImageReplayInput input)
+    {
+        string? background = input.Background;
+        return string.IsNullOrWhiteSpace(background)
+            ? default
+            : new AiImageBackgroundId(background);
+    }
+
+    // Jobs recorded before the endpoint spoke ratios carry the fixed size they
+    // were asked for. Mapping it back is what keeps a repeat the same shape.
+    private static ImageReplayInput ParseReplayInput(AiJob job)
+    {
+        if (!TryParseReplayInput(job, out ImageReplayInput input))
+            throw new InvalidOperationException("The retained image request cannot be replayed exactly.");
+        return input;
+    }
+
+    private static bool TryParseReplayInput(AiJob job, out ImageReplayInput result)
+    {
+        result = default;
+        if (job.InputParameters is not { ValueKind: JsonValueKind.Object } input)
+            return false;
+        foreach (JsonProperty property in input.EnumerateObject())
+        {
+            if (!s_allowedProperties.Contains(property.Name))
+                return false;
+        }
+        if (!input.TryGetProperty("prompt", out JsonElement prompt)
+            || prompt.ValueKind != JsonValueKind.String
+            || prompt.GetString() is not { } promptValue
+            || string.IsNullOrWhiteSpace(promptValue)
+            || promptValue.Length > AiRequestLimits.MaxPromptLength
+            || !string.Equals(promptValue, promptValue.Trim(), StringComparison.Ordinal))
+            return false;
+
+        bool hasAspect = input.TryGetProperty("aspectRatio", out JsonElement aspectElement);
+        bool hasSize = input.TryGetProperty("size", out JsonElement sizeElement);
+        if (hasAspect == hasSize)
+            return false;
+
+        string aspectRatio = hasAspect
+            ? aspectElement.ValueKind == JsonValueKind.String
+                ? aspectElement.GetString() ?? string.Empty
+                : string.Empty
+            : hasSize
+                ? sizeElement.ValueKind == JsonValueKind.String
+                    ? sizeElement.GetString() switch
+                    {
+                        "1024x1024" => "1:1",
+                        "1024x1536" => "2:3",
+                        "1536x1024" => "3:2",
+                        _ => string.Empty,
+                    }
+                    : string.Empty
+                : "1:1";
+        if (aspectRatio is not ("1:1" or "16:9" or "9:16" or "4:3" or "3:4" or "3:2" or "2:3"))
+            return false;
+
+        string? background = null;
+        if (input.TryGetProperty("background", out JsonElement backgroundElement))
+        {
+            if (backgroundElement.ValueKind != JsonValueKind.String)
+                return false;
+            background = backgroundElement.GetString();
+            if (background is not ("auto" or "opaque" or "transparent"))
+                return false;
+        }
+
+        int? seed = null;
+        if (input.TryGetProperty("seed", out JsonElement seedElement))
+        {
+            if (seedElement.ValueKind != JsonValueKind.Number
+                || !seedElement.TryGetInt32(out int seedValue)
+                || seedValue < AiRequestLimits.MinSeed
+                || seedValue > AiRequestLimits.MaxSeed)
+                return false;
+            seed = seedValue;
+        }
+
+        result = new ImageReplayInput(promptValue, aspectRatio, background, seed);
+        return true;
+    }
+
+    private static AiModelOption? ResolveModel(AiModelCatalog catalog, AiJob job)
+    {
+        ImmutableArray<AiModelOption> models = catalog.ModelsFor(AiOperations.ImageGeneration);
+        if (models.IsDefaultOrEmpty)
+            return null;
+        if (job.Model is { Value.Length: > 0 } model)
+            return models.FirstOrDefault(option => option.Id == model);
+        return catalog.DefaultFor(AiOperations.ImageGeneration);
+    }
+
+    private readonly record struct ImageReplayInput(
+        string Prompt,
+        string AspectRatio,
+        string? Background,
+        int? Seed);
+}
+
+internal sealed class AiVideoJobRetryHandler(
+    IAiVideoService videos,
+    IAiEntitlementService entitlementService,
+    IAiOperationAvailabilityService availabilityService,
+    IAiModelCatalogService modelCatalogService,
+    AiRetryAttemptContext retryContext)
+    : MeteredAiJobRetryHandler(
+        AiOperations.VideoGeneration,
+        entitlementService,
+        availabilityService,
+        modelCatalogService,
+        retryContext)
+{
+    private static readonly HashSet<string> s_allowedProperties =
+        ["prompt", "durationSeconds", "resolution", "aspectRatio", "generateAudio", "seed"];
+
+    public override bool CanRetry(AiJob job, AiJobStatusSemantics status)
+        => base.CanRetry(job, status)
+            && TryParseReplayInput(job, out _);
+
+    protected override AiOperationAvailabilityRequest CreateAvailabilityRequest(AiJob job)
+        => new AiOperationAvailabilityRequest.Video(
+            AiOperations.VideoGeneration,
+            ParseReplayInput(job).DurationSeconds,
+            job.Model);
+
+    protected override void ValidateRetryInputs(AiJob job)
+    {
+        _ = ParseReplayInput(job);
+    }
+
+    protected override bool IsCurrentRequestSupported(AiModelCatalog catalog, AiJob job)
+    {
+        if (!TryParseReplayInput(job, out VideoReplayInput input))
+            return false;
+
+        AiModelOption? model = ResolveModel(catalog, job);
+        AiVideoModelCapabilities? capabilities = model?.Video;
+        if (capabilities is null)
+            return true;
+        return (!capabilities.DurationsSeconds.IsSpecified
+                || capabilities.DurationsSeconds.Values.Contains(input.DurationSeconds))
+            && (!capabilities.Resolutions.IsSpecified
+                || capabilities.Resolutions.Values.Contains(input.Resolution))
+            && (!capabilities.AspectRatios.IsSpecified
+                || capabilities.AspectRatios.Values.Contains(input.AspectRatio))
+            && (!input.GenerateAudio || capabilities.SupportsAudio)
+            && (input.Seed is null || capabilities.SupportsSeed);
+    }
+
+    protected override async Task DispatchAsync(
+        AiJob job,
+        string idempotencyKey,
+        bool isRepeat)
+    {
+        VideoReplayInput input = ParseReplayInput(job);
+        await videos.CreateAsync(
+            new AiVideoGenerationRequest(
+                input.Prompt,
+                input.DurationSeconds,
+                new AiVideoResolutionId(input.Resolution),
+                new AiVideoAspectRatioId(input.AspectRatio),
+                generateAudio: input.GenerateAudio,
+                seed: input.Seed,
+                model: job.Model,
+                idempotencyKey: idempotencyKey),
+            CancellationToken.None);
+    }
+
+    private static VideoReplayInput ParseReplayInput(AiJob job)
+    {
+        if (!TryParseReplayInput(job, out VideoReplayInput input))
+            throw new InvalidOperationException("The retained video request cannot be replayed exactly.");
+        return input;
+    }
+
+    private static bool TryParseReplayInput(AiJob job, out VideoReplayInput result)
+    {
+        result = default;
+        if (job.InputParameters is not { ValueKind: JsonValueKind.Object } input)
+            return false;
+        foreach (JsonProperty property in input.EnumerateObject())
+        {
+            if (!s_allowedProperties.Contains(property.Name))
+                return false;
+        }
+        if (!input.TryGetProperty("prompt", out JsonElement prompt)
+            || prompt.ValueKind != JsonValueKind.String
+            || prompt.GetString() is not { } promptValue
+            || string.IsNullOrWhiteSpace(promptValue)
+            || promptValue.Length > AiRequestLimits.MaxPromptLength
+            || !string.Equals(promptValue, promptValue.Trim(), StringComparison.Ordinal))
+            return false;
+
+        int durationSeconds = 4;
+        if (input.TryGetProperty("durationSeconds", out JsonElement duration))
+        {
+            if (duration.ValueKind != JsonValueKind.Number
+                || !duration.TryGetInt32(out durationSeconds)
+                || durationSeconds < AiRequestLimits.MinVideoDurationSeconds
+                || durationSeconds > AiRequestLimits.MaxVideoDurationSeconds)
+                return false;
+        }
+
+        string resolution = "720p";
+        if (input.TryGetProperty("resolution", out JsonElement resolutionElement))
+        {
+            string? parsedResolution = resolutionElement.ValueKind == JsonValueKind.String
+                ? resolutionElement.GetString()
+                : null;
+            if (parsedResolution is not ("480p" or "720p" or "1080p" or "2K"))
+                return false;
+            resolution = parsedResolution;
+        }
+
+        string aspectRatio = "16:9";
+        if (input.TryGetProperty("aspectRatio", out JsonElement aspectElement))
+        {
+            string? parsedAspect = aspectElement.ValueKind == JsonValueKind.String
+                ? aspectElement.GetString()
+                : null;
+            if (!IsStructurallyValidAspectRatio(parsedAspect))
+                return false;
+            aspectRatio = parsedAspect;
+        }
+
+        bool generateAudio = true;
+        if (input.TryGetProperty("generateAudio", out JsonElement audio))
+        {
+            if (audio.ValueKind is not (JsonValueKind.True or JsonValueKind.False))
+                return false;
+            generateAudio = audio.GetBoolean();
+        }
+
+        int? seed = null;
+        if (input.TryGetProperty("seed", out JsonElement seedElement))
+        {
+            if (seedElement.ValueKind != JsonValueKind.Number
+                || !seedElement.TryGetInt32(out int seedValue)
+                || seedValue < AiRequestLimits.MinSeed
+                || seedValue > AiRequestLimits.MaxSeed)
+                return false;
+            seed = seedValue;
+        }
+
+        result = new VideoReplayInput(
+            promptValue,
+            durationSeconds,
+            resolution,
+            aspectRatio,
+            generateAudio,
+            seed);
+        return true;
+    }
+
+    private static bool IsStructurallyValidAspectRatio([NotNullWhen(true)] string? value)
+    {
+        if (value is not { Length: > 0 and <= 256 }
+            || !string.Equals(value, value.Trim(), StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        int separator = value.IndexOf(':');
+        return separator > 0
+            && separator == value.LastIndexOf(':')
+            && separator < value.Length - 1
+            && IsPositiveDecimal(value.AsSpan(0, separator))
+            && IsPositiveDecimal(value.AsSpan(separator + 1));
+    }
+
+    private static bool IsPositiveDecimal(ReadOnlySpan<char> value)
+    {
+        bool hasNonZeroDigit = false;
+        foreach (char character in value)
+        {
+            if (character is < '0' or > '9')
+                return false;
+            hasNonZeroDigit |= character != '0';
+        }
+
+        return hasNonZeroDigit;
+    }
+
+    private static AiModelOption? ResolveModel(AiModelCatalog catalog, AiJob job)
+    {
+        ImmutableArray<AiModelOption> models = catalog.ModelsFor(AiOperations.VideoGeneration);
+        if (models.IsDefaultOrEmpty)
+            return null;
+        if (job.Model is { Value.Length: > 0 } model)
+            return models.FirstOrDefault(option => option.Id == model);
+        return catalog.DefaultFor(AiOperations.VideoGeneration);
+    }
+
+    private readonly record struct VideoReplayInput(
+        string Prompt,
+        int DurationSeconds,
+        string Resolution,
+        string AspectRatio,
+        bool GenerateAudio,
+        int? Seed);
+}
+
+internal sealed class AiVideoJobRefreshHandler(IAiVideoService videos) : IAiJobRefreshHandler
+{
+    public async Task RefreshAsync(AiJob job, CancellationToken cancellationToken)
+        => await videos.GetAsync(job.Id, cancellationToken);
+}

--- a/src/Beutl.Api/Services/BuiltInAiJobKinds.cs
+++ b/src/Beutl.Api/Services/BuiltInAiJobKinds.cs
@@ -439,7 +439,7 @@ internal abstract class MeteredAiJobRetryHandler(
         // A catalog that could not be fetched says nothing about any model, and
         // the server has the last word regardless.
         if (models.IsDefaultOrEmpty)
-            return true;
+            return !catalog.OffersNoModel(operation);
 
         return models.Any(option => option.Id == model);
     }
@@ -494,6 +494,38 @@ internal abstract class MeteredAiJobRetryHandler(
                 attempt.Dispose();
             return ValueTask.CompletedTask;
         }
+    }
+}
+
+internal static class AiReplayInputValidation
+{
+    public static bool IsStructurallyValidAspectRatio([NotNullWhen(true)] string? value)
+    {
+        if (value is not { Length: > 0 and <= 256 }
+            || !string.Equals(value, value.Trim(), StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        int separator = value.IndexOf(':');
+        return separator > 0
+            && separator == value.LastIndexOf(':')
+            && separator < value.Length - 1
+            && IsPositiveDecimal(value.AsSpan(0, separator))
+            && IsPositiveDecimal(value.AsSpan(separator + 1));
+    }
+
+    private static bool IsPositiveDecimal(ReadOnlySpan<char> value)
+    {
+        bool hasNonZeroDigit = false;
+        foreach (char character in value)
+        {
+            if (character is < '0' or > '9')
+                return false;
+            hasNonZeroDigit |= character != '0';
+        }
+
+        return hasNonZeroDigit;
     }
 }
 
@@ -615,7 +647,7 @@ internal sealed class AiImageJobRetryHandler(
                     }
                     : string.Empty
                 : "1:1";
-        if (aspectRatio is not ("1:1" or "16:9" or "9:16" or "4:3" or "3:4" or "3:2" or "2:3"))
+        if (!AiReplayInputValidation.IsStructurallyValidAspectRatio(aspectRatio))
             return false;
 
         string? background = null;
@@ -781,7 +813,7 @@ internal sealed class AiVideoJobRetryHandler(
             string? parsedAspect = aspectElement.ValueKind == JsonValueKind.String
                 ? aspectElement.GetString()
                 : null;
-            if (!IsStructurallyValidAspectRatio(parsedAspect))
+            if (!AiReplayInputValidation.IsStructurallyValidAspectRatio(parsedAspect))
                 return false;
             aspectRatio = parsedAspect;
         }
@@ -813,35 +845,6 @@ internal sealed class AiVideoJobRetryHandler(
             generateAudio,
             seed);
         return true;
-    }
-
-    private static bool IsStructurallyValidAspectRatio([NotNullWhen(true)] string? value)
-    {
-        if (value is not { Length: > 0 and <= 256 }
-            || !string.Equals(value, value.Trim(), StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        int separator = value.IndexOf(':');
-        return separator > 0
-            && separator == value.LastIndexOf(':')
-            && separator < value.Length - 1
-            && IsPositiveDecimal(value.AsSpan(0, separator))
-            && IsPositiveDecimal(value.AsSpan(separator + 1));
-    }
-
-    private static bool IsPositiveDecimal(ReadOnlySpan<char> value)
-    {
-        bool hasNonZeroDigit = false;
-        foreach (char character in value)
-        {
-            if (character is < '0' or > '9')
-                return false;
-            hasNonZeroDigit |= character != '0';
-        }
-
-        return hasNonZeroDigit;
     }
 
     private static AiModelOption? ResolveModel(AiModelCatalog catalog, AiJob job)

--- a/src/Beutl.Api/Services/ExtensionProvider.cs
+++ b/src/Beutl.Api/Services/ExtensionProvider.cs
@@ -1,4 +1,8 @@
-﻿using Beutl.Collections;
+﻿using System.Collections;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using Beutl.Collections;
 using Beutl.Configuration;
 using Beutl.Extensibility;
 
@@ -6,46 +10,95 @@ using static Beutl.Configuration.ExtensionConfig;
 
 namespace Beutl.Api.Services;
 
-public sealed class ExtensionProvider : IBeutlApiResource, IExtensionProvider
+public sealed class ExtensionProvider : IExtensionRegistry
 {
-    private readonly Dictionary<int, Extension[]> _allExtensions = [];
+    private readonly Dictionary<int, ExtensionEntry[]> _entriesByPackage = [];
+    private readonly Dictionary<ExtensionId, ExtensionEntry> _entriesById = [];
     private readonly ExtensionConfig _config = GlobalConfiguration.Instance.ExtensionConfig;
     private readonly Dictionary<Type, Array> _cache = [];
-    private readonly CoreList<Extension> _extensions = [];
+    private readonly ExtensionCollection _extensions = new();
     private readonly object _lock = new();
-    private bool _cacheInvalidated;
+    private readonly object _mutationGate = new();
+    private Extension[] _snapshot = [];
+    private ExtensionEntry[] _entrySnapshot = [];
 
     public ExtensionProvider()
     {
     }
 
-    public ICoreReadOnlyList<Extension> AllExtensions => _extensions;
+    public event EventHandler? ExtensionsChanged;
 
-    public TExtension[] GetExtensions<TExtension>()
+    public IReadOnlyList<ExtensionDescriptor> Extensions
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return Array.AsReadOnly(_entrySnapshot
+                    .Select(entry => entry.Descriptor)
+                    .ToArray());
+            }
+        }
+    }
+
+    public IReadOnlyList<ExtensionDescriptor> GetDescriptors<TExtension>()
         where TExtension : Extension
     {
         lock (_lock)
         {
-            if (_cacheInvalidated)
-            {
-                _cache.Clear();
-                _cacheInvalidated = false;
-            }
+            return Array.AsReadOnly(_entrySnapshot
+                .Where(entry => entry.Extension is TExtension)
+                .Select(entry => entry.Descriptor)
+                .ToArray());
+        }
+    }
 
+    public bool TryAcquire<TExtension>(
+        ExtensionId id,
+        [NotNullWhen(true)] out IExtensionLease<TExtension>? lease)
+        where TExtension : Extension
+    {
+        lock (_lock)
+        {
+            if (_entriesById.TryGetValue(id, out ExtensionEntry? entry))
+                return entry.TryAcquire(out lease);
+
+            lease = null;
+            return false;
+        }
+    }
+
+    internal ICoreReadOnlyList<Extension> AllExtensions => _extensions;
+
+    internal TExtension[] GetExtensions<TExtension>()
+        where TExtension : Extension
+    {
+        lock (_lock)
+        {
             if (_cache.TryGetValue(typeof(TExtension), out Array? result))
             {
                 return (TExtension[])result;
             }
             else
             {
-                TExtension[] exts = AllExtensions.OfType<TExtension>().ToArray();
+                TExtension[] exts = _snapshot.OfType<TExtension>().ToArray();
                 _cache[typeof(TExtension)] = exts;
                 return exts;
             }
         }
     }
 
-    public EditorExtension? MatchEditorExtension(string file)
+    internal IReadOnlyList<Extension> GetPackageExtensions(int packageId)
+    {
+        lock (_lock)
+        {
+            return _entriesByPackage.TryGetValue(packageId, out ExtensionEntry[]? entries)
+                ? entries.Select(entry => entry.Extension).ToArray()
+                : [];
+        }
+    }
+
+    internal EditorExtension? MatchEditorExtension(string file)
     {
         lock (_lock)
         {
@@ -53,7 +106,7 @@ public sealed class ExtensionProvider : IBeutlApiResource, IExtensionProvider
 
             if (_config.EditorExtensions.TryGetValue(fileExt, out ICoreList<TypeLazy>? list))
             {
-                foreach (Extension extension in AllExtensions)
+                foreach (Extension extension in _snapshot)
                 {
                     Type extType = extension.GetType();
                     if (extension is not EditorExtension editorExtension) continue;
@@ -69,7 +122,7 @@ public sealed class ExtensionProvider : IBeutlApiResource, IExtensionProvider
                 }
             }
 
-            foreach (Extension extension in AllExtensions)
+            foreach (Extension extension in _snapshot)
             {
                 if (extension is EditorExtension editorExtension &&
                     editorExtension.IsSupported(file))
@@ -82,11 +135,11 @@ public sealed class ExtensionProvider : IBeutlApiResource, IExtensionProvider
         }
     }
 
-    public ProjectItemExtension? MatchProjectItemExtension(string file)
+    internal ProjectItemExtension? MatchProjectItemExtension(string file)
     {
         lock (_lock)
         {
-            foreach (Extension extension in AllExtensions)
+            foreach (Extension extension in _snapshot)
             {
                 if (extension is ProjectItemExtension wsiExtension &&
                     wsiExtension.IsSupported(file))
@@ -99,51 +152,445 @@ public sealed class ExtensionProvider : IBeutlApiResource, IExtensionProvider
         }
     }
 
-    public IEnumerable<ProjectItemExtension> MatchProjectItemExtensions(string file)
+    internal IEnumerable<ProjectItemExtension> MatchProjectItemExtensions(string file)
     {
+        ProjectItemExtension[] result;
         lock (_lock)
         {
-            foreach (Extension extension in AllExtensions)
+            result = _snapshot
+                .OfType<ProjectItemExtension>()
+                .Where(extension => extension.IsSupported(file))
+                .ToArray();
+        }
+
+        return result;
+    }
+
+    internal void AddExtensions(int packageId, IReadOnlyList<Extension> extensions)
+    {
+        ArgumentNullException.ThrowIfNull(extensions);
+        Extension[] ownedExtensions = extensions.ToArray();
+        if (ownedExtensions.Any(extension => extension is null))
+            throw new ArgumentException("Extensions cannot contain null.", nameof(extensions));
+        ExtensionEntry[] ownedEntries = ownedExtensions
+            .Select(extension => new ExtensionEntry(extension))
+            .ToArray();
+
+        lock (_mutationGate)
+        {
+            lock (_lock)
             {
-                if (extension is ProjectItemExtension wsiExtension &&
-                    wsiExtension.IsSupported(file))
+                if (_entriesByPackage.ContainsKey(packageId))
                 {
-                    yield return wsiExtension;
+                    throw new InvalidOperationException(
+                        $"Extensions for package (id: {packageId}) are already registered.");
+                }
+                if (ownedEntries
+                    .Select(entry => entry.Descriptor.Id)
+                    .Distinct()
+                    .Count() != ownedEntries.Length
+                    || ownedEntries.Any(entry => _entriesById.ContainsKey(entry.Descriptor.Id)))
+                {
+                    throw new InvalidOperationException("An extension identifier is already registered.");
+                }
+
+                // Internal composition observes executable instances first. Public metadata and
+                // acquisition remain unchanged until every internal observer accepts the batch.
+                _snapshot = [.. _snapshot, .. ownedExtensions];
+                _cache.Clear();
+            }
+
+            // Collection observers may perform package-lifetime cleanup. Run them without the
+            // provider lock so an in-flight extension operation can still query the provider.
+            try
+            {
+                _extensions.AddRange(ownedExtensions);
+            }
+            catch (Exception registrationFailure)
+            {
+                lock (_lock)
+                {
+                    var ownedSet = new HashSet<Extension>(
+                        ownedExtensions,
+                        ReferenceEqualityComparer.Instance);
+                    _snapshot = _snapshot
+                        .Where(extension => !ownedSet.Contains(extension))
+                        .ToArray();
+                    _cache.Clear();
+                }
+                Task[] providerLeaseDrains = ownedEntries
+                    .Select(entry => entry.RetireAsync())
+                    .ToArray();
+                try
+                {
+                    _extensions.RemoveAll(ownedExtensions);
+                }
+                catch (Exception removalFailure)
+                {
+                    registrationFailure = new AggregateException(
+                        registrationFailure,
+                        removalFailure);
+                }
+                throw new ExtensionRegistrationNotificationException(
+                    new ExtensionRemoval(ownedExtensions, providerLeaseDrains),
+                    registrationFailure);
+            }
+
+            lock (_lock)
+            {
+                _entriesByPackage.Add(packageId, ownedEntries);
+                foreach (ExtensionEntry entry in ownedEntries)
+                {
+                    _entriesById.Add(entry.Descriptor.Id, entry);
+                }
+                _entrySnapshot = [.. _entrySnapshot, .. ownedEntries];
+            }
+
+            if (ownedExtensions.Length > 0)
+            {
+                NotifyExtensionsChanged();
+            }
+        }
+    }
+
+    internal ExtensionRemoval RemoveExtensions(int packageId)
+    {
+        lock (_mutationGate)
+        {
+            Extension[] extensions;
+            ExtensionEntry[] entries;
+            Task[] providerLeaseDrains;
+            lock (_lock)
+            {
+                if (!_entriesByPackage.Remove(packageId, out ExtensionEntry[]? removed))
+                {
+                    return new ExtensionRemoval([]);
+                }
+
+                entries = removed;
+                extensions = entries.Select(entry => entry.Extension).ToArray();
+                foreach (ExtensionEntry entry in entries)
+                {
+                    _entriesById.Remove(entry.Descriptor.Id);
+                }
+                var removedSet = new HashSet<Extension>(extensions, ReferenceEqualityComparer.Instance);
+                _snapshot = _snapshot.Where(extension => !removedSet.Contains(extension)).ToArray();
+                var removedEntrySet = new HashSet<ExtensionEntry>(
+                    entries,
+                    ReferenceEqualityComparer.Instance);
+                _entrySnapshot = _entrySnapshot
+                    .Where(entry => !removedEntrySet.Contains(entry))
+                    .ToArray();
+                _cache.Clear();
+                providerLeaseDrains = entries.Select(entry => entry.RetireAsync()).ToArray();
+            }
+
+            // Caption and other dynamic catalogs retire their package-owned registrations from
+            // this synchronous notification before PackageManager invokes Extension.Unload().
+            Exception? notificationFailure = null;
+            try
+            {
+                _extensions.RemoveAll(extensions);
+            }
+            catch (Exception ex)
+            {
+                notificationFailure = ex;
+            }
+            if (extensions.Length > 0)
+            {
+                NotifyExtensionsChanged();
+            }
+            ExtensionRemoval removal = new(extensions, providerLeaseDrains);
+            if (notificationFailure is not null)
+                throw new ExtensionRemovalNotificationException(removal, notificationFailure);
+
+            return removal;
+        }
+    }
+
+    internal void SynchronizeMutation(Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        lock (_mutationGate)
+        {
+            action();
+        }
+    }
+
+    ICoreReadOnlyList<Extension> IExtensionRegistry.AllExtensions => AllExtensions;
+
+    TExtension[] IExtensionRegistry.GetExtensions<TExtension>() => GetExtensions<TExtension>();
+
+    EditorExtension? IExtensionRegistry.MatchEditorExtension(string file) => MatchEditorExtension(file);
+
+    void IExtensionRegistry.AddExtensions(int packageId, IReadOnlyList<Extension> extensions)
+        => AddExtensions(packageId, extensions);
+
+    IReadOnlyList<Extension> IExtensionRegistry.GetPackageExtensions(int packageId)
+        => GetPackageExtensions(packageId);
+
+    ExtensionRemoval IExtensionRegistry.RemoveExtensions(int packageId)
+        => RemoveExtensions(packageId);
+
+    void IExtensionRegistry.SynchronizeMutation(Action action) => SynchronizeMutation(action);
+
+    private void NotifyExtensionsChanged()
+    {
+        if (ExtensionsChanged is not { } observers)
+            return;
+
+        foreach (EventHandler observer in observers.GetInvocationList())
+        {
+            try
+            {
+                observer(this, EventArgs.Empty);
+            }
+            catch
+            {
+                // Public observers cannot veto or roll back a package mutation. Internal
+                // lifetime-sensitive composition runs through AllExtensions first.
+            }
+        }
+    }
+
+    private sealed class ExtensionEntry
+    {
+        private readonly object _gate = new();
+        private TaskCompletionSource? _drained;
+        private int _activeLeases;
+        private bool _retired;
+
+        public ExtensionEntry(Extension extension)
+        {
+            Extension = extension;
+            Type extensionType = extension.GetType();
+            Descriptor = new ExtensionDescriptor(
+                new ExtensionId(Guid.NewGuid()),
+                extensionType.AssemblyQualifiedName
+                    ?? extensionType.FullName
+                    ?? extensionType.Name);
+        }
+
+        public Extension Extension { get; }
+
+        public ExtensionDescriptor Descriptor { get; }
+
+        public bool TryAcquire<TExtension>(
+            [NotNullWhen(true)] out IExtensionLease<TExtension>? lease)
+            where TExtension : Extension
+        {
+            lock (_gate)
+            {
+                if (_retired || Extension is not TExtension typed)
+                {
+                    lease = null;
+                    return false;
+                }
+
+                _activeLeases++;
+                lease = new ExtensionLease<TExtension>(this, typed);
+                return true;
+            }
+        }
+
+        public Task RetireAsync()
+        {
+            lock (_gate)
+            {
+                _retired = true;
+                return _activeLeases == 0
+                    ? Task.CompletedTask
+                    : (_drained ??= new TaskCompletionSource(
+                        TaskCreationOptions.RunContinuationsAsynchronously)).Task;
+            }
+        }
+
+        public void Release()
+        {
+            TaskCompletionSource? drained = null;
+            lock (_gate)
+            {
+                _activeLeases--;
+                if (_retired && _activeLeases == 0)
+                    drained = _drained;
+            }
+
+            drained?.TrySetResult();
+        }
+    }
+
+    private sealed class ExtensionLease<TExtension>(ExtensionEntry entry, TExtension extension)
+        : IExtensionLease<TExtension>
+        where TExtension : Extension
+    {
+        private ExtensionEntry? _entry = entry;
+        private TExtension? _extension = extension;
+
+        public TExtension Extension
+            => Volatile.Read(ref _extension)
+                ?? throw new ObjectDisposedException(nameof(IExtensionLease<TExtension>));
+
+        public void Dispose()
+        {
+            Interlocked.Exchange(ref _extension, null);
+            Interlocked.Exchange(ref _entry, null)?.Release();
+        }
+    }
+
+    private sealed class ExtensionCollection : ICoreReadOnlyList<Extension>
+    {
+        private static readonly PropertyChangedEventArgs s_countChanged = new(nameof(Count));
+        private static readonly PropertyChangedEventArgs s_indexerChanged = new("Item[]");
+        private readonly List<Extension> _items = [];
+        private readonly object _gate = new();
+
+        public event NotifyCollectionChangedEventHandler? CollectionChanged;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public int Count
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _items.Count;
                 }
             }
         }
-    }
 
-    public void AddExtensions(int id, Extension[] extensions)
-    {
-        lock (_lock)
+        public Extension this[int index]
         {
-            if (!_allExtensions.TryAdd(id, extensions))
+            get
             {
-                throw new InvalidOperationException($"Extensions for package (id: {id}) are already registered.");
+                lock (_gate)
+                {
+                    return _items[index];
+                }
+            }
+        }
+
+        public IEnumerator<Extension> GetEnumerator()
+        {
+            lock (_gate)
+            {
+                return ((IEnumerable<Extension>)_items.ToArray()).GetEnumerator();
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public void AddRange(IReadOnlyList<Extension> extensions)
+        {
+            if (extensions.Count == 0)
+                return;
+
+            Extension[] added = extensions.ToArray();
+            int index;
+            lock (_gate)
+            {
+                index = _items.Count;
+                _items.AddRange(added);
             }
 
-            _extensions.AddRange(extensions);
-            InvalidateCache();
+            NotifyObservers(new NotifyCollectionChangedEventArgs(
+                NotifyCollectionChangedAction.Add,
+                (IList)added,
+                index));
         }
-    }
 
-    public Extension[] RemoveExtensions(int id)
-    {
-        lock (_lock)
+        public void RemoveAll(IReadOnlyList<Extension> extensions)
         {
-            if (_allExtensions.Remove(id, out Extension[]? extensions))
-            {
-                _extensions.RemoveAll(extensions);
-                _cache.Clear();
-                return extensions;
-            }
-            return [];
-        }
-    }
+            if (extensions.Count == 0)
+                return;
 
-    public void InvalidateCache()
-    {
-        _cacheInvalidated = true;
+            var removedSet = new HashSet<Extension>(
+                extensions,
+                ReferenceEqualityComparer.Instance);
+            Extension[] removed;
+            int firstIndex;
+            bool contiguous;
+            lock (_gate)
+            {
+                var removedIndices = new List<int>();
+                var removedItems = new List<Extension>();
+                for (int index = 0; index < _items.Count; index++)
+                {
+                    if (removedSet.Contains(_items[index]))
+                    {
+                        removedIndices.Add(index);
+                        removedItems.Add(_items[index]);
+                    }
+                }
+
+                if (removedItems.Count == 0)
+                    return;
+
+                firstIndex = removedIndices[0];
+                contiguous = removedIndices
+                    .Select((index, offset) => index == firstIndex + offset)
+                    .All(result => result);
+                _items.RemoveAll(removedSet.Contains);
+                removed = removedItems.ToArray();
+            }
+
+            NotifyCollectionChangedEventArgs args = contiguous
+                ? new NotifyCollectionChangedEventArgs(
+                    NotifyCollectionChangedAction.Remove,
+                    (IList)removed,
+                    firstIndex)
+                : new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
+            NotifyObservers(args);
+        }
+
+        private void NotifyObservers(NotifyCollectionChangedEventArgs collectionArgs)
+        {
+            List<Exception>? failures = null;
+            NotifyPropertyChanged(s_indexerChanged, ref failures);
+            NotifyCollectionChanged(collectionArgs, ref failures);
+            NotifyPropertyChanged(s_countChanged, ref failures);
+            if (failures is not null)
+                throw new AggregateException("One or more extension collection observers failed.", failures);
+        }
+
+        private void NotifyPropertyChanged(
+            PropertyChangedEventArgs args,
+            ref List<Exception>? failures)
+        {
+            if (PropertyChanged is not { } observers)
+                return;
+
+            foreach (PropertyChangedEventHandler observer in observers.GetInvocationList())
+            {
+                try
+                {
+                    observer(this, args);
+                }
+                catch (Exception ex)
+                {
+                    (failures ??= []).Add(ex);
+                }
+            }
+        }
+
+        private void NotifyCollectionChanged(
+            NotifyCollectionChangedEventArgs args,
+            ref List<Exception>? failures)
+        {
+            if (CollectionChanged is not { } observers)
+                return;
+
+            foreach (NotifyCollectionChangedEventHandler observer in observers.GetInvocationList())
+            {
+                try
+                {
+                    observer(this, args);
+                }
+                catch (Exception ex)
+                {
+                    (failures ??= []).Add(ex);
+                }
+            }
+        }
     }
 }

--- a/src/Beutl.Api/Services/ExtensionRegistrationLifetimes.cs
+++ b/src/Beutl.Api/Services/ExtensionRegistrationLifetimes.cs
@@ -1,0 +1,142 @@
+﻿using System.Runtime.CompilerServices;
+using Beutl.Extensibility;
+
+namespace Beutl.Api.Services;
+
+/// <summary>
+/// Coordinates host-owned registration retirement with package removal.
+/// </summary>
+internal static class ExtensionRegistrationLifetimes
+{
+    private static readonly ConditionalWeakTable<Extension, Retirement> s_retirements = new();
+
+    public static void Retire(Extension extension, Func<ValueTask> retireAsync)
+    {
+        ArgumentNullException.ThrowIfNull(extension);
+        ArgumentNullException.ThrowIfNull(retireAsync);
+
+        Retirement retirement = s_retirements.GetValue(
+            extension,
+            static _ => new Retirement());
+        retirement.BeginTracking();
+
+        ValueTask drain;
+        try
+        {
+            drain = retireAsync();
+        }
+        catch (Exception ex)
+        {
+            drain = new ValueTask(Task.FromException(ex));
+        }
+
+        retirement.CompleteTracking(drain);
+    }
+
+    internal static ExtensionRemovalDrain SealRemoval(IReadOnlyList<Extension> extensions)
+    {
+        ArgumentNullException.ThrowIfNull(extensions);
+        var drains = new Task[extensions.Count];
+        for (int index = 0; index < extensions.Count; index++)
+        {
+            Extension extension = extensions[index]
+                ?? throw new ArgumentException("Extensions cannot contain null.", nameof(extensions));
+            drains[index] = s_retirements.GetValue(
+                extension,
+                static _ => new Retirement()).Seal();
+            s_retirements.Remove(extension);
+        }
+
+        return new ExtensionRemovalDrain(extensions, drains);
+    }
+
+    private sealed class Retirement
+    {
+        private readonly object _gate = new();
+        private readonly List<Task> _drains = [];
+        private Task? _drainTask;
+        private bool _sealed;
+        private int _pendingRetirements;
+
+        public void BeginTracking()
+        {
+            lock (_gate)
+            {
+                if (_sealed)
+                {
+                    throw new InvalidOperationException(
+                        "An extension registration retired after package removal was sealed.");
+                }
+
+                _pendingRetirements++;
+            }
+        }
+
+        public void CompleteTracking(ValueTask drain)
+        {
+            Task task = drain.IsCompletedSuccessfully
+                ? Task.CompletedTask
+                : drain.AsTask();
+
+            lock (_gate)
+            {
+                if (!task.IsCompletedSuccessfully)
+                    _drains.Add(task);
+
+                _pendingRetirements--;
+                Monitor.PulseAll(_gate);
+            }
+        }
+
+        public Task Seal()
+        {
+            lock (_gate)
+            {
+                if (_drainTask is not null)
+                    return _drainTask;
+
+                _sealed = true;
+                while (_pendingRetirements != 0)
+                    Monitor.Wait(_gate);
+
+                _drainTask = _drains.Count == 0
+                    ? Task.CompletedTask
+                    : Task.WhenAll(_drains);
+                _drains.Clear();
+                return _drainTask;
+            }
+        }
+    }
+}
+
+internal interface ILiveUnloadExtension
+{
+}
+
+internal sealed class ExtensionRemovalDrain(
+    IReadOnlyList<Extension> extensions,
+    IReadOnlyList<Task> drains)
+{
+    public IReadOnlyList<Extension> Extensions { get; } = extensions;
+
+    public async Task DrainAllAsync()
+    {
+        List<Exception>? failures = null;
+        for (int index = 0; index < drains.Count; index++)
+        {
+            try
+            {
+                await drains[index].ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                (failures ??= []).Add(new InvalidOperationException(
+                    $"Extension '{Extensions[index].GetType().FullName}' failed to drain.",
+                    ex));
+            }
+        }
+
+        if (failures is not null)
+            throw new AggregateException(failures);
+    }
+}

--- a/src/Beutl.Api/Services/ExtensionRemoval.cs
+++ b/src/Beutl.Api/Services/ExtensionRemoval.cs
@@ -1,0 +1,65 @@
+﻿using Beutl.Extensibility;
+
+namespace Beutl.Api.Services;
+
+/// <summary>
+/// Owns one atomic extension-removal batch and the registrations that must drain before unload.
+/// </summary>
+internal sealed class ExtensionRemoval
+{
+    private readonly ExtensionRemovalDrain _drain;
+    private readonly Task _providerLeaseDrain;
+
+    /// <summary>
+    /// Creates a removal ticket after the extensions have been synchronously retired from the
+    /// registry's public view.
+    /// </summary>
+    public ExtensionRemoval(
+        IReadOnlyList<Extension> extensions,
+        IReadOnlyList<Task>? providerLeaseDrains = null)
+    {
+        ArgumentNullException.ThrowIfNull(extensions);
+        Extension[] snapshot = extensions.ToArray();
+        _drain = ExtensionRegistrationLifetimes.SealRemoval(snapshot);
+        _providerLeaseDrain = providerLeaseDrains is { Count: > 0 }
+            ? Task.WhenAll(providerLeaseDrains)
+            : Task.CompletedTask;
+        Extensions = snapshot;
+    }
+
+    internal IReadOnlyList<Extension> Extensions { get; }
+
+    internal ValueTask DrainAsync() => new(DrainCoreAsync());
+
+    private async Task DrainCoreAsync()
+    {
+        await _providerLeaseDrain.ConfigureAwait(false);
+        await _drain.DrainAllAsync().ConfigureAwait(false);
+    }
+}
+
+/// <summary>
+/// Reports that registry observers failed after an extension batch was synchronously removed.
+/// The attached ticket must still be drained before the package can be unloaded.
+/// </summary>
+internal sealed class ExtensionRemovalNotificationException(
+    ExtensionRemoval removal,
+    Exception innerException)
+    : Exception("An extension removal observer failed.", innerException)
+{
+    public ExtensionRemoval Removal { get; } = removal
+        ?? throw new ArgumentNullException(nameof(removal));
+}
+
+/// <summary>
+/// Reports that registry observers rejected an extension batch after it was published and then
+/// synchronously retired. The attached ticket must drain before the package code can unload.
+/// </summary>
+internal sealed class ExtensionRegistrationNotificationException(
+    ExtensionRemoval removal,
+    Exception innerException)
+    : Exception("An extension registration observer failed.", innerException)
+{
+    public ExtensionRemoval Removal { get; } = removal
+        ?? throw new ArgumentNullException(nameof(removal));
+}

--- a/src/Beutl.Api/Services/IAiCapabilities.cs
+++ b/src/Beutl.Api/Services/IAiCapabilities.cs
@@ -1,0 +1,109 @@
+﻿using Reactive.Bindings;
+
+namespace Beutl.Api.Services;
+
+public interface IAiEntitlementService : IBeutlApiResource
+{
+    IReadOnlyReactiveProperty<AiEntitlements?> Entitlements { get; }
+
+    Task<AiEntitlements?> RefreshAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// The models each operation offers. Registered on the server at runtime, so
+/// unlike every other list this client holds it cannot be a set of literals and
+/// has to be asked for.
+/// </summary>
+public interface IAiModelCatalogService : IBeutlApiResource
+{
+    /// <summary>
+    /// The catalog, fetched once and reused. An empty catalog is what a caller
+    /// gets when the server cannot be reached or offers nothing to choose from:
+    /// a request then names no model and runs on the server's default, which is
+    /// how this client behaved before models could be chosen at all.
+    /// </summary>
+    Task<AiModelCatalog> GetAsync(CancellationToken cancellationToken);
+
+    /// <summary>Discards the cached catalog so the next read fetches again.</summary>
+    void Invalidate();
+}
+
+public interface IAiOperationAvailabilityService : IBeutlApiResource
+{
+    Task<bool> CheckAsync(
+        AiOperationAvailabilityRequest request,
+        CancellationToken cancellationToken);
+}
+
+public interface IAiImageGenerationService : IBeutlApiResource
+{
+    Task<AiImageResult> GenerateAsync(
+        AiImageGenerationRequest request,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The same generation, reporting each rough version of the picture as the
+    /// model works it out. Only models whose provider streams send any.
+    /// </summary>
+    Task<AiImageResult> GenerateAsync(
+        AiImageGenerationRequest request,
+        IProgress<AiImagePreview>? progress,
+        CancellationToken cancellationToken);
+}
+
+public interface IAiImageEditingService : IBeutlApiResource
+{
+    Task<AiImageResult> EditAsync(
+        AiImageEditRequest request,
+        CancellationToken cancellationToken);
+}
+
+public interface IAiTranscriptionService : IBeutlApiResource
+{
+    Task<AiTranscriptionResponse> TranscribeAsync(
+        AiTranscriptionRequest request,
+        CancellationToken cancellationToken);
+}
+
+public interface IAiCaptionTranslationService : IBeutlApiResource
+{
+    Task<AiCaptionTranslationResponse> TranslateAsync(
+        AiCaptionTranslationRequest request,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The same translation, reported subtitle by subtitle as it arrives.
+    /// </summary>
+    /// <remarks>
+    /// What is reported is a preview: the result returned at the end is the
+    /// whole translation, checked as it always was, and a run that fails
+    /// reports nothing to keep however much of it was shown.
+    /// </remarks>
+    Task<AiCaptionTranslationResponse> TranslateAsync(
+        AiCaptionTranslationRequest request,
+        IProgress<AiCaptionTranslationSegment>? progress,
+        CancellationToken cancellationToken);
+}
+
+public interface IAiVideoService : IBeutlApiResource
+{
+    Task<AiVideoGenerationResult> CreateAsync(
+        AiVideoGenerationRequest request,
+        CancellationToken cancellationToken);
+
+    Task<AiVideoJob> GetAsync(
+        AiJobId jobId,
+        CancellationToken cancellationToken);
+}
+
+public interface IAuthenticatedContentService : IBeutlApiResource
+{
+    /// <summary>
+    /// Streams authenticated content into a caller-owned writable destination. The destination
+    /// remains open and ownership never transfers to the service.
+    /// </summary>
+    Task<AiContentDownload> CopyToAsync(
+        Uri contentUri,
+        Stream destination,
+        CancellationToken cancellationToken);
+}

--- a/src/Beutl.Api/Services/IAiJobClient.cs
+++ b/src/Beutl.Api/Services/IAiJobClient.cs
@@ -1,0 +1,13 @@
+﻿namespace Beutl.Api.Services;
+
+/// <summary>
+/// Stateless asynchronous client for AI job history operations.
+/// </summary>
+public interface IAiJobClient : IBeutlApiResource
+{
+    Task<AiJobPage> GetPageAsync(
+        AiJobPageRequest request,
+        CancellationToken cancellationToken);
+
+    Task DeleteAsync(AiJobId jobId, CancellationToken cancellationToken);
+}

--- a/src/Beutl.Api/Services/IAiJobMonitor.cs
+++ b/src/Beutl.Api/Services/IAiJobMonitor.cs
@@ -1,0 +1,17 @@
+﻿using Reactive.Bindings;
+
+namespace Beutl.Api.Services;
+
+/// <summary>
+/// Application-layer state and polling around the pure <see cref="IAiJobClient"/>.
+/// </summary>
+public interface IAiJobMonitor : IBeutlApiResource
+{
+    IReadOnlyReactiveProperty<AiJobMonitorSnapshot> Snapshot { get; }
+
+    IDisposable AcquirePolling();
+
+    Task RefreshAsync(CancellationToken cancellationToken);
+
+    Task LoadNextPageAsync(CancellationToken cancellationToken);
+}

--- a/src/Beutl.Api/Services/IExtensionRegistry.cs
+++ b/src/Beutl.Api/Services/IExtensionRegistry.cs
@@ -1,0 +1,44 @@
+﻿using Beutl.Collections;
+using Beutl.Extensibility;
+
+namespace Beutl.Api.Services;
+
+/// <summary>
+/// Host-only mutable and executable view of the current extension session.
+/// </summary>
+internal interface IExtensionRegistry : IExtensionProvider, IBeutlApiResource
+{
+    ICoreReadOnlyList<Extension> AllExtensions { get; }
+
+    TExtension[] GetExtensions<TExtension>()
+        where TExtension : Extension;
+
+    EditorExtension? MatchEditorExtension(string file);
+
+    /// <summary>
+    /// Registers all extensions owned by one package.
+    /// </summary>
+    void AddExtensions(int packageId, IReadOnlyList<Extension> extensions);
+
+    /// <summary>
+    /// Gets a stable snapshot of the extensions owned by one package. The result must contain the
+    /// same extension instances that a subsequent removal ticket exposes.
+    /// </summary>
+    IReadOnlyList<Extension> GetPackageExtensions(int packageId);
+
+    /// <summary>
+    /// Removes all extensions owned by one package from every public registry view and returns the
+    /// drain ticket that must complete before their code can unload. Implementations must throw
+    /// <see cref="ExtensionRemovalNotificationException"/> if an observer fails after removal.
+    /// </summary>
+    ExtensionRemoval RemoveExtensions(int packageId);
+
+    /// <summary>
+    /// Runs a synchronous registry transition without racing package addition or removal.
+    /// </summary>
+    /// <remarks>
+    /// The action may inspect or mutate this registry. Implementations must allow reentrant calls
+    /// from the same thread because a coordinated transition can call <see cref="RemoveExtensions"/>.
+    /// </remarks>
+    void SynchronizeMutation(Action action);
+}

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -34,10 +34,16 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
     private readonly Dictionary<PackageIdentity, PackageInstallContext> _installingContexts = [];
     private readonly object _gate = new();
     private readonly HashSet<Task> _operations = [];
+    private readonly Dictionary<Task, ShutdownFallback> _shutdownFallbacks = [];
     private Task? _disposeTask;
     private bool _disposed;
     private bool _drained;
+    private volatile bool _shutdownFallbackPublicationEnabled;
     private static readonly AsyncLocal<PackageInstaller?> s_transactionOwner = new();
+
+    internal Action? BeforeShutdownFallbackSnapshot { get; set; }
+
+    internal Action? AfterSuccessfulInstallFallbackDisarmed { get; set; }
 
     private const string DefaultNuGetConfigContentTemplate = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
@@ -115,6 +121,16 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         }
     }
 
+    internal void BeginShutdown()
+    {
+        lock (_gate)
+        {
+            _disposed = true;
+            _shutdownFallbackPublicationEnabled = true;
+        }
+    }
+
+
     protected virtual async Task DisposeCoreAsync()
     {
         long deadline = Environment.TickCount64 + DrainDeadlineMilliseconds;
@@ -124,7 +140,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
             Task[] operations;
             lock (_gate)
             {
-                _operations.RemoveWhere(task => task.IsCompleted);
+                RemoveCompletedOperations_NoLock();
                 if (_operations.Count == 0)
                 {
                     drained = true;
@@ -149,7 +165,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
 
             lock (_gate)
             {
-                _operations.RemoveWhere(task => task.IsCompleted);
+                RemoveCompletedOperations_NoLock();
             }
         }
 
@@ -183,7 +199,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
                 Task[] operations;
                 lock (_gate)
                 {
-                    _operations.RemoveWhere(task => task.IsCompleted);
+                    RemoveCompletedOperations_NoLock();
                     operations = _operations.ToArray();
                 }
 
@@ -224,12 +240,14 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
     // tracked operation never completes, so shutdown cannot hang behind it.
     internal async Task WaitUntilIdleAsync(TimeSpan timeout)
     {
+        _shutdownFallbackPublicationEnabled = true;
         long deadline = Environment.TickCount64 + (long)timeout.TotalMilliseconds;
         while (true)
         {
             long remaining = deadline - Environment.TickCount64;
             if (remaining <= 0)
             {
+                PublishShutdownFallbacks();
                 _logger.LogWarning("Package installer did not become idle within the shutdown deadline.");
                 return;
             }
@@ -237,7 +255,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
             Task[] operations;
             lock (_gate)
             {
-                _operations.RemoveWhere(task => task.IsCompleted);
+                RemoveCompletedOperations_NoLock();
                 operations = _operations.ToArray();
             }
 
@@ -256,6 +274,40 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         }
     }
 
+    private void PublishShutdownFallbacks()
+    {
+        ShutdownFallback[] fallbacks;
+        lock (_gate)
+        {
+            RemoveCompletedOperations_NoLock();
+            BeforeShutdownFallbackSnapshot?.Invoke();
+            fallbacks = _shutdownFallbacks
+                .Select(pair => pair.Value)
+                .ToArray();
+        }
+
+        foreach (ShutdownFallback fallback in fallbacks)
+        {
+            try
+            {
+                fallback.Invoke();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to publish a package shutdown fallback.");
+            }
+        }
+    }
+
+    private void RemoveCompletedOperations_NoLock()
+    {
+        foreach (Task operation in _operations.Where(task => task.IsCompleted).ToArray())
+        {
+            _operations.Remove(operation);
+            _shutdownFallbacks.Remove(operation);
+        }
+    }
+
     // Virtual so tests can shorten the drain window; production keeps the 30-second budget.
     protected virtual long DrainDeadlineMilliseconds => 30_000;
 
@@ -266,25 +318,38 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         => TrackAsyncCore(operation);
 
     public Task TrackInstallOperationAsync(Func<Task> operation)
+        => TrackInstallOperationWithShutdownFallbackAsync(operation, null);
+
+    internal Task TrackInstallOperationWithShutdownFallbackAsync(
+        Func<Task> operation,
+        Action? ensureShutdownFallback)
     {
         ArgumentNullException.ThrowIfNull(operation);
         TaskCompletionSource proxy = new(TaskCreationOptions.RunContinuationsAsynchronously);
         Task task = proxy.Task;
+        ShutdownFallback? shutdownFallback = ensureShutdownFallback is null
+            ? null
+            : CreateOneShotFallback(ensureShutdownFallback);
         lock (_gate)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            _operations.RemoveWhere(task => task.IsCompleted);
+            RemoveCompletedOperations_NoLock();
             // Register before invoking so a re-entrant DisposeAsync drains this transaction.
             _operations.Add(task);
+            if (shutdownFallback is not null)
+                _shutdownFallbacks.Add(task, shutdownFallback);
         }
 
         // Invoke outside the lock: a delegate that blocks before its first incomplete await
         // must not hold the gate, or a concurrent DisposeAsync could not even start its
         // drain deadline. The operation's awaits use ConfigureAwait(false) so shutdown can
         // block without deadlocking.
-        _ = RunTransactionAsync(operation, proxy);
+        _ = RunTransactionAsync(operation, proxy, shutdownFallback);
         return task;
     }
+
+    private ShutdownFallback CreateOneShotFallback(Action fallback)
+        => new(fallback, _logger);
 
     internal void TrackSyncOperation(Action operation)
     {
@@ -335,27 +400,72 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
         }
     }
 
-    private async Task RunTransactionAsync(Func<Task> operation, TaskCompletionSource proxy)
+    private async Task RunTransactionAsync(
+        Func<Task> operation,
+        TaskCompletionSource proxy,
+        ShutdownFallback? shutdownFallback)
     {
         PackageInstaller? previous = s_transactionOwner.Value;
         s_transactionOwner.Value = this;
         try
         {
             await operation().ConfigureAwait(false);
-            proxy.TrySetResult();
+            if (shutdownFallback is not null)
+            {
+                // The operation has committed successfully. Disarm first so a
+                // shutdown snapshot that already retained this object cannot
+                // publish stale recovery work, then remove it and publish the
+                // successful proxy atomically under the tracking gate.
+                shutdownFallback.Disarm();
+                AfterSuccessfulInstallFallbackDisarmed?.Invoke();
+            }
+            lock (_gate)
+            {
+                _shutdownFallbacks.Remove(proxy.Task);
+                proxy.TrySetResult();
+            }
         }
         catch (OperationCanceledException ex)
         {
+            if (_shutdownFallbackPublicationEnabled)
+                shutdownFallback?.Invoke();
             proxy.TrySetCanceled(ex.CancellationToken);
         }
         catch (Exception ex)
         {
             // Propagate the failure so the caller reports it and queues fallback.
+            shutdownFallback?.Invoke();
             proxy.TrySetException(ex);
         }
         finally
         {
             s_transactionOwner.Value = previous;
+        }
+    }
+
+    private sealed class ShutdownFallback(
+        Action fallback,
+        Microsoft.Extensions.Logging.ILogger logger)
+    {
+        private Action? _fallback = fallback;
+
+        public void Disarm()
+            => Interlocked.Exchange(ref _fallback, null);
+
+        public void Invoke()
+        {
+            Action? callback = Interlocked.Exchange(ref _fallback, null);
+            if (callback is null)
+                return;
+
+            try
+            {
+                callback();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to publish a package shutdown fallback.");
+            }
         }
     }
 
@@ -369,7 +479,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
             {
                 throw new ObjectDisposedException(nameof(PackageInstaller));
             }
-            _operations.RemoveWhere(task => task.IsCompleted);
+            RemoveCompletedOperations_NoLock();
             // Register before invoking so a concurrent DisposeAsync drains this phase.
             _operations.Add(proxy.Task);
         }
@@ -388,7 +498,7 @@ public partial class PackageInstaller : IBeutlApiResource, IAsyncDisposable
             {
                 throw new ObjectDisposedException(nameof(PackageInstaller));
             }
-            _operations.RemoveWhere(task => task.IsCompleted);
+            RemoveCompletedOperations_NoLock();
             // Register before invoking so a concurrent DisposeAsync drains this phase.
             _operations.Add(proxy.Task);
         }

--- a/src/Beutl.Api/Services/PackageManager.cs
+++ b/src/Beutl.Api/Services/PackageManager.cs
@@ -86,14 +86,14 @@ public sealed class PackageManager : PackageLoader
     public async Task<IReadOnlyList<PackageUpdate>> CheckUpdate(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        using CancellationTokenSource operationCts = apiApplication.CreateLifetimeLinkedTokenSource(cancellationToken);
+        var (discover, lifetime) = apiApplication.GetResourceWithLifetime<DiscoverService>(cancellationToken);
+        using CancellationTokenSource operationCts = lifetime;
         CancellationToken operationToken = operationCts.Token;
         using (Activity? activity = Telemetry.ActivitySource.StartActivity("CheckUpdate"))
         {
             PackageIdentity[] packages = installedPackageRepository.GetLocalPackages().ToArray();
 
             var updates = new List<PackageUpdate>(packages.Length);
-            DiscoverService discover = apiApplication.GetResource<DiscoverService>();
 
             for (int i = 0; i < packages.Length; i++)
             {
@@ -151,11 +151,11 @@ public sealed class PackageManager : PackageLoader
     public async Task<PackageUpdate?> CheckUpdate(string name, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        using CancellationTokenSource operationCts = apiApplication.CreateLifetimeLinkedTokenSource(cancellationToken);
+        var (discover, lifetime) = apiApplication.GetResourceWithLifetime<DiscoverService>(cancellationToken);
+        using CancellationTokenSource operationCts = lifetime;
         CancellationToken operationToken = operationCts.Token;
         using (Activity? activity = Telemetry.ActivitySource.StartActivity("CheckUpdate"))
         {
-            DiscoverService discover = apiApplication.GetResource<DiscoverService>();
 
             LocalPackage? pkg = _loadedPackages.Values
                 .Select(x => x.Package)

--- a/src/Beutl.Api/Services/PackageManager.cs
+++ b/src/Beutl.Api/Services/PackageManager.cs
@@ -19,20 +19,41 @@ namespace Beutl.Api.Services;
 
 public record LoadedPackageInfo(LocalPackage Package, PluginLoadContext? LoadContext);
 
-public sealed class PackageManager(
-    InstalledPackageRepository installedPackageRepository,
-    ExtensionProvider extensionProvider,
-    ContextCommandManager commandManager,
-    BeutlApiApplication apiApplication,
-    ILoadContextUnloadDiagnostics? unloadDiagnostics = null) : PackageLoader
+public sealed class PackageManager : PackageLoader
 {
+    private readonly InstalledPackageRepository installedPackageRepository;
+    private readonly IExtensionRegistry extensionRegistry;
+    private readonly ContextCommandManager commandManager;
+    private readonly BeutlApiApplication apiApplication;
+    private readonly ILoadContextUnloadDiagnostics? unloadDiagnostics;
     private readonly ILogger _logger = Log.CreateLogger<PackageManager>();
     private readonly ConcurrentDictionary<int, LoadedPackageInfo> _loadedPackages = new();
+    private readonly Dictionary<int, Task<bool>> _unloadOperations = [];
+    private readonly Dictionary<int, PendingRollbackInfo> _pendingRollbacks = [];
+    private readonly HashSet<int> _quarantinedPackages = [];
+    private readonly HashSet<int> _loadingPackages = [];
+    private readonly object _packageLifecycleGate = new();
     private readonly ExtensionSettingsStore _settingsStore = new();
+
+    internal PackageManager(
+        InstalledPackageRepository installedPackageRepository,
+        IExtensionRegistry extensionRegistry,
+        ContextCommandManager commandManager,
+        BeutlApiApplication apiApplication,
+        ILoadContextUnloadDiagnostics? unloadDiagnostics = null)
+    {
+        this.installedPackageRepository = installedPackageRepository;
+        this.extensionRegistry = extensionRegistry;
+        this.commandManager = commandManager;
+        this.apiApplication = apiApplication;
+        this.unloadDiagnostics = unloadDiagnostics;
+    }
 
     public IEnumerable<LocalPackage> LoadedPackage => _loadedPackages.Values.Select(x => x.Package);
 
-    public ExtensionProvider ExtensionProvider => extensionProvider;
+    internal IExtensionRegistry ExtensionRegistry => extensionRegistry;
+
+    internal Action? AfterExtensionRegistration { get; set; }
 
     public ContextCommandManager ContextCommandManager => commandManager;
 
@@ -65,96 +86,34 @@ public sealed class PackageManager(
     public async Task<IReadOnlyList<PackageUpdate>> CheckUpdate(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        // Resolve the resource and link the lifetime token under one dispose-gate hold so a
-        // concurrent DisposeAsync cannot invalidate the resource between admission and use.
-        DiscoverService discover = apiApplication.GetResourceWithLifetime<DiscoverService>(
-            cancellationToken, out CancellationTokenSource operationCts);
-        using (operationCts)
+        using CancellationTokenSource operationCts = apiApplication.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken operationToken = operationCts.Token;
+        using (Activity? activity = Telemetry.ActivitySource.StartActivity("CheckUpdate"))
         {
-            CancellationToken operationToken = operationCts.Token;
-            using (Activity? activity = Telemetry.ActivitySource.StartActivity("CheckUpdate"))
+            PackageIdentity[] packages = installedPackageRepository.GetLocalPackages().ToArray();
+
+            var updates = new List<PackageUpdate>(packages.Length);
+            DiscoverService discover = apiApplication.GetResource<DiscoverService>();
+
+            for (int i = 0; i < packages.Length; i++)
             {
-                PackageIdentity[] packages = installedPackageRepository.GetLocalPackages().ToArray();
-
-                var updates = new List<PackageUpdate>(packages.Length);
-
-                for (int i = 0; i < packages.Length; i++)
-                {
-                    operationToken.ThrowIfCancellationRequested();
-                    PackageIdentity pkg = packages[i];
-                    NuGetVersion version = pkg.Version;
-                    string versionStr = version.ToString();
-                    try
-                    {
-                        activity?.AddEvent(new("Checking updates"));
-                        activity?.SetTag("PackageId", pkg.Id);
-                        activity?.SetTag("Version", versionStr);
-                        Package remotePackage = await discover.GetPackage(pkg.Id, operationToken).ConfigureAwait(false);
-                        activity?.AddEvent(new("Checked updates"));
-
-                        Release[] releases = await remotePackage.GetReleasesAsync(operationToken).ConfigureAwait(false);
-
-                        foreach (Release? item in releases)
-                        {
-                            operationToken.ThrowIfCancellationRequested();
-                            // 降順
-                            if (new NuGetVersion(item.Version.Value).CompareTo(version) > 0)
-                            {
-                                Release? oldRelease = await Helper
-                                    .TryGetOrDefault(
-                                        () => remotePackage.GetReleaseAsync(versionStr, operationToken),
-                                        operationToken)
-                                    .ConfigureAwait(false);
-                                updates.Add(new PackageUpdate(remotePackage, oldRelease, item));
-                                _logger.LogInformation("Update found for package {PackageId}: {OldVersion} -> {NewVersion}", pkg.Id, versionStr, item.Version.Value);
-                                break;
-                            }
-                        }
-                    }
-                    catch (OperationCanceledException) when (operationToken.IsCancellationRequested)
-                    {
-                        throw;
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex,
-                            "An exception occurred while checking for package updates. (PackageId: {PackageId})", pkg.Id);
-                    }
-                }
-
                 operationToken.ThrowIfCancellationRequested();
-                return updates;
-            }
-        }
-    }
-
-    public async Task<PackageUpdate?> CheckUpdate(string name, CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        // See the other CheckUpdate overload: resolve the resource and link the lifetime
-        // token under one dispose-gate hold.
-        DiscoverService discover = apiApplication.GetResourceWithLifetime<DiscoverService>(
-            cancellationToken, out CancellationTokenSource operationCts);
-        using (operationCts)
-        {
-            CancellationToken operationToken = operationCts.Token;
-            using (Activity? activity = Telemetry.ActivitySource.StartActivity("CheckUpdate"))
-            {
-                LocalPackage? pkg = _loadedPackages.Values
-                    .Select(x => x.Package)
-                    .FirstOrDefault(v =>
-                        !v.SideLoad && StringComparer.OrdinalIgnoreCase.Equals(v.Name, name));
-                if (pkg != null)
+                PackageIdentity pkg = packages[i];
+                NuGetVersion version = pkg.Version;
+                string versionStr = version.ToString();
+                try
                 {
-                    string versionStr = pkg.Version;
-                    var version = new NuGetVersion(versionStr);
                     activity?.AddEvent(new("Checking updates"));
-                    activity?.SetTag("PackageName", pkg.Name);
+                    activity?.SetTag("PackageId", pkg.Id);
                     activity?.SetTag("Version", versionStr);
-                    Package remotePackage = await discover.GetPackage(pkg.Name, operationToken).ConfigureAwait(false);
+                    Package remotePackage = await discover
+                        .GetPackage(pkg.Id, operationToken)
+                        .ConfigureAwait(false);
                     activity?.AddEvent(new("Checked updates"));
 
-                    Release[] releases = await remotePackage.GetReleasesAsync(operationToken).ConfigureAwait(false);
+                    Release[] releases = await remotePackage
+                        .GetReleasesAsync(operationToken)
+                        .ConfigureAwait(false);
 
                     foreach (Release? item in releases)
                     {
@@ -162,21 +121,100 @@ public sealed class PackageManager(
                         // 降順
                         if (new NuGetVersion(item.Version.Value).CompareTo(version) > 0)
                         {
-                            Release? oldRelease = await Helper
-                                .TryGetOrDefault(
-                                    () => remotePackage.GetReleaseAsync(pkg.Version, operationToken),
+                            Release? oldRelease = await TryGetReleaseAsync(
+                                    remotePackage,
+                                    versionStr,
                                     operationToken)
                                 .ConfigureAwait(false);
-                            operationToken.ThrowIfCancellationRequested();
-                            _logger.LogInformation("Update found for package {PackageName}: {OldVersion} -> {NewVersion}", pkg.Name, versionStr, item.Version.Value);
-                            return new PackageUpdate(remotePackage, oldRelease, item);
+                            updates.Add(new PackageUpdate(remotePackage, oldRelease, item));
+                            _logger.LogInformation("Update found for package {PackageId}: {OldVersion} -> {NewVersion}", pkg.Id, versionStr, item.Version.Value);
+                            break;
                         }
                     }
                 }
-
-                operationToken.ThrowIfCancellationRequested();
-                return null;
+                catch (OperationCanceledException) when (operationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex,
+                        "An exception occurred while checking for package updates. (PackageId: {PackageId})", pkg.Id);
+                }
             }
+
+            operationToken.ThrowIfCancellationRequested();
+            return updates;
+        }
+    }
+
+    public async Task<PackageUpdate?> CheckUpdate(string name, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        using CancellationTokenSource operationCts = apiApplication.CreateLifetimeLinkedTokenSource(cancellationToken);
+        CancellationToken operationToken = operationCts.Token;
+        using (Activity? activity = Telemetry.ActivitySource.StartActivity("CheckUpdate"))
+        {
+            DiscoverService discover = apiApplication.GetResource<DiscoverService>();
+
+            LocalPackage? pkg = _loadedPackages.Values
+                .Select(x => x.Package)
+                .FirstOrDefault(v =>
+                    !v.SideLoad && StringComparer.OrdinalIgnoreCase.Equals(v.Name, name));
+            if (pkg != null)
+            {
+                string versionStr = pkg.Version;
+                var version = new NuGetVersion(versionStr);
+                activity?.AddEvent(new("Checking updates"));
+                activity?.SetTag("PackageName", pkg.Name);
+                activity?.SetTag("Version", versionStr);
+                Package remotePackage = await discover
+                    .GetPackage(pkg.Name, operationToken)
+                    .ConfigureAwait(false);
+                activity?.AddEvent(new("Checked updates"));
+
+                Release[] releases = await remotePackage
+                    .GetReleasesAsync(operationToken)
+                    .ConfigureAwait(false);
+
+                foreach (Release? item in releases)
+                {
+                    operationToken.ThrowIfCancellationRequested();
+                    // 降順
+                    if (new NuGetVersion(item.Version.Value).CompareTo(version) > 0)
+                    {
+                        Release? oldRelease = await TryGetReleaseAsync(
+                                remotePackage,
+                                pkg.Version,
+                                operationToken)
+                            .ConfigureAwait(false);
+                        _logger.LogInformation("Update found for package {PackageName}: {OldVersion} -> {NewVersion}", pkg.Name, versionStr, item.Version.Value);
+                        return new PackageUpdate(remotePackage, oldRelease, item);
+                    }
+                }
+            }
+
+            operationToken.ThrowIfCancellationRequested();
+            return null;
+        }
+    }
+
+    private static async Task<Release?> TryGetReleaseAsync(
+        Package package,
+        string version,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await package.GetReleaseAsync(version, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return null;
         }
     }
 
@@ -273,15 +311,68 @@ public sealed class PackageManager(
         }
     }
 
-    public async ValueTask<bool> Unload(LocalPackage package)
+    public ValueTask<bool> Unload(LocalPackage package)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+        TaskCompletionSource<bool>? completion = null;
+        Task<bool> operation;
+        lock (_packageLifecycleGate)
+        {
+            if (_unloadOperations.TryGetValue(package.LocalId, out operation!))
+                return new ValueTask<bool>(operation);
+
+            if (_quarantinedPackages.Contains(package.LocalId))
+                return new ValueTask<bool>(false);
+
+            if (_loadingPackages.Contains(package.LocalId))
+                return new ValueTask<bool>(false);
+
+            completion = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            operation = completion.Task;
+            _unloadOperations.Add(package.LocalId, operation);
+        }
+
+        _ = RunUnloadAsync(package, completion);
+        return new ValueTask<bool>(operation);
+    }
+
+    private async Task RunUnloadAsync(
+        LocalPackage package,
+        TaskCompletionSource<bool> completion)
+    {
+        try
+        {
+            completion.TrySetResult(await UnloadOnceAsync(package).ConfigureAwait(false));
+        }
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
+        }
+        finally
+        {
+            lock (_packageLifecycleGate)
+            {
+                if (!_quarantinedPackages.Contains(package.LocalId))
+                {
+                    _unloadOperations.Remove(package.LocalId);
+                }
+            }
+        }
+    }
+
+    private async Task<bool> UnloadOnceAsync(LocalPackage package)
     {
         using (Activity? activity = Telemetry.ActivitySource.StartActivity("Unload"))
         {
-            var result = UnloadCore(activity, package, out WeakReference? weakReference, out string[] assemblyNames);
-            if (!result || weakReference == null)
+            PackageUnloadResult? result = await UnloadCoreAsync(activity, package);
+            if (result is null)
             {
                 return false;
             }
+
+            WeakReference weakReference = result.LoadContextReference;
+            string[] assemblyNames = result.AssemblyNames;
 
             for (int i = 0; weakReference.IsAlive && (i < 10); i++)
             {
@@ -303,46 +394,143 @@ public sealed class PackageManager(
         }
     }
 
-    private bool UnloadCore(
-        Activity? activity, LocalPackage package,
-        [NotNullWhen(true)] out WeakReference? weakReference, out string[] assemblyNames)
+    private async ValueTask<PackageUnloadResult?> UnloadCoreAsync(
+        Activity? activity,
+        LocalPackage package)
     {
-        weakReference = null;
-        assemblyNames = [];
+        string[] assemblyNames = [];
         activity?.SetTag("PackageName", package.Name);
 
         if (package.LocalId == LocalPackage.Reserved0)
         {
             _logger.LogWarning("Cannot unload built-in extensions.");
-            return false;
+            return null;
         }
 
-        if (!_loadedPackages.TryRemove(package.LocalId, out LoadedPackageInfo? info))
+        if (!_loadedPackages.TryGetValue(package.LocalId, out LoadedPackageInfo? info))
         {
             _logger.LogWarning("Package {PackageName} is not loaded.", package.Name);
-            return false;
+            return null;
         }
 
-        Extension[] extensions = extensionProvider.RemoveExtensions(package.LocalId);
+        // Only the registries below have explicit operation leases. Other
+        // extension families create long-lived editor/output/window objects,
+        // so their package files are updated safely on the next restart.
+        ExtensionRemoval? removal = null;
+        var requiresRestart = false;
+        List<Exception>? retirementFailures = null;
+        try
+        {
+            extensionRegistry.SynchronizeMutation(() =>
+            {
+                IReadOnlyList<Extension> packageExtensions =
+                    extensionRegistry.GetPackageExtensions(package.LocalId);
+                if (packageExtensions.Any(extension => !SupportsLiveUnload(extension)))
+                {
+                    requiresRestart = true;
+                    return;
+                }
+
+                removal = extensionRegistry.RemoveExtensions(package.LocalId);
+            });
+        }
+        catch (ExtensionRemovalNotificationException ex)
+        {
+            removal = ex.Removal;
+            retirementFailures = [ex];
+        }
+        if (requiresRestart)
+        {
+            _logger.LogInformation(
+                "Package {PackageName} contains extensions that require restart for safe unload.",
+                package.Name);
+            return null;
+        }
+
+        if (removal is null)
+        {
+            throw new InvalidOperationException(
+                $"The extension registry did not remove package {package.Name}.");
+        }
+
+        IReadOnlyList<Extension> extensions = removal.Extensions;
+        foreach (Extension ext in extensions)
+        {
+            if (ext is ViewExtension viewExtension)
+            {
+                try
+                {
+                    // Commands are a discoverability surface too. Retire them before waiting so
+                    // no new package-owned callback can start while the package is draining.
+                    commandManager.Unregister(viewExtension);
+                }
+                catch (Exception ex)
+                {
+                    (retirementFailures ??= []).Add(ex);
+                    _logger.LogError(
+                        ex,
+                        "Failed to unregister commands for extension {ExtensionName}.",
+                        ext.GetType().Name);
+                }
+            }
+
+            try
+            {
+                // Configuration notifications can call package code and therefore belong to the
+                // synchronous retirement phase, not post-unload cleanup.
+                CleanupExtensionSettings(ext);
+            }
+            catch (Exception ex)
+            {
+                (retirementFailures ??= []).Add(ex);
+                _logger.LogError(
+                    ex,
+                    "Failed to detach settings for extension {ExtensionName}.",
+                    ext.GetType().Name);
+            }
+        }
+
+        try
+        {
+            // Drain every extension in the package before invoking any extension-level unload.
+            // Packages commonly share static resources across several extension entry points.
+            await removal.DrainAsync();
+        }
+        catch (Exception ex)
+        {
+            (retirementFailures ??= []).Add(ex);
+            _logger.LogError(
+                ex,
+                "Package {PackageName} registrations failed to drain; the load context remains quarantined.",
+                package.Name);
+        }
+
+        if (retirementFailures is not null)
+        {
+            lock (_packageLifecycleGate)
+            {
+                _quarantinedPackages.Add(package.LocalId);
+            }
+
+            activity?.SetStatus(ActivityStatusCode.Error, "Extension retirement failed");
+            return null;
+        }
+
         foreach (Extension ext in extensions)
         {
             try
             {
-                if (ext is ViewExtension viewExtension)
-                {
-                    commandManager.Unregister(viewExtension);
-                }
-
                 ext.Unload();
-                CleanupExtensionSettings(ext);
-
                 _logger.LogInformation("Extension {ExtensionName} unloaded.", ext.GetType().Name);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to unload extension {ExtensionName}.", ext.GetType().Name);
             }
+
         }
+
+        _loadedPackages.TryRemove(package.LocalId, out _);
 
         if (info.LoadContext is { } loadContext)
         {
@@ -365,9 +553,17 @@ public sealed class PackageManager(
         }
 
         // https://learn.microsoft.com/ja-jp/dotnet/standard/assembly/unloadability#use-a-custom-collectible-assemblyloadcontext
-        weakReference = new WeakReference(info.LoadContext, trackResurrection: true);
-        return true;
+        return new PackageUnloadResult(
+            new WeakReference(info.LoadContext, trackResurrection: true),
+            assemblyNames);
     }
+
+    private sealed record PackageUnloadResult(
+        WeakReference LoadContextReference,
+        string[] AssemblyNames);
+
+    private static bool SupportsLiveUnload(Extension extension)
+        => extension is ILiveUnloadExtension;
 
     private Action<string>? _dumpOpener;
 
@@ -460,7 +656,37 @@ public sealed class PackageManager(
         IEnumerable<Type> extensionTypes)
     {
         List<Extension> extensions = [];
+        ExtensionRemoval? rollbackRemoval = null;
         var addedToProvider = false;
+        var addedToLoadedPackages = false;
+        bool alreadyKnown;
+        lock (_packageLifecycleGate)
+        {
+            alreadyKnown = _loadingPackages.Contains(package.LocalId)
+                           || _unloadOperations.ContainsKey(package.LocalId)
+                           || _quarantinedPackages.Contains(package.LocalId)
+                           || _loadedPackages.ContainsKey(package.LocalId);
+            if (!alreadyKnown)
+            {
+                _loadingPackages.Add(package.LocalId);
+            }
+        }
+
+        if (alreadyKnown)
+        {
+            // The caller resolved the package's assemblies into a collectible
+            // context before this could be known. Nothing will ever reference
+            // them, so the context goes with the rejection rather than staying
+            // loaded for the life of the process.
+            if (loadContext is { })
+            {
+                TryUnloadLoadContext(package, loadContext);
+            }
+
+            throw new InvalidOperationException(
+                $"Package {package.Name} is already loaded, loading, unloading, or quarantined.");
+        }
+
         try
         {
             extensions = LoadPackageExtensions(extensionTypes);
@@ -468,33 +694,160 @@ public sealed class PackageManager(
             activity?.AddEvent(new ActivityEvent("Extensions loaded"));
             activity?.SetTag("ExtensionCount", extensions.Count);
 
-            ExtensionProvider.AddExtensions(package.LocalId, extensions.ToArray());
+            ExtensionRegistry.AddExtensions(package.LocalId, extensions);
             addedToProvider = true;
+            AfterExtensionRegistration?.Invoke();
 
-            if (!_loadedPackages.TryAdd(package.LocalId, new LoadedPackageInfo(package, loadContext)))
+            lock (_packageLifecycleGate)
             {
-                throw new InvalidOperationException($"Package {package.Name} is already loaded.");
+                if (!_loadedPackages.TryAdd(
+                        package.LocalId,
+                        new LoadedPackageInfo(package, loadContext)))
+                {
+                    throw new InvalidOperationException(
+                        $"Package {package.Name} is already loaded, unloading, or quarantined.");
+                }
+
+                _loadingPackages.Remove(package.LocalId);
             }
+            addedToLoadedPackages = true;
 
             return assemblies;
         }
-        catch
+        catch (Exception loadFailure)
         {
+            if (loadFailure is ExtensionRegistrationNotificationException registrationFailure)
+            {
+                rollbackRemoval = registrationFailure.Removal;
+            }
             if (addedToProvider)
             {
-                ExtensionProvider.RemoveExtensions(package.LocalId);
+                try
+                {
+                    rollbackRemoval = ExtensionRegistry.RemoveExtensions(package.LocalId);
+                }
+                catch (ExtensionRemovalNotificationException ex)
+                {
+                    rollbackRemoval = ex.Removal;
+                }
+            }
+            if (addedToLoadedPackages)
+            {
+                lock (_packageLifecycleGate)
+                {
+                    _loadedPackages.TryRemove(package.LocalId, out _);
+                }
             }
 
-            // LoadPackageExtensions already rolls back on failure, so extensions is non-empty
-            // only when a later registration step threw; this is not a double-unload.
-            RollbackLoadedExtensions(extensions);
-            if (loadContext is { })
+            bool rollbackPending = rollbackRemoval is not null;
+            lock (_packageLifecycleGate)
             {
-                TryUnloadLoadContext(package, loadContext);
+                _loadingPackages.Remove(package.LocalId);
+                if (rollbackPending)
+                {
+                    _quarantinedPackages.Add(package.LocalId);
+                }
+            }
+
+            if (rollbackRemoval is null)
+            {
+                // LoadPackageExtensions already rolls back on failure, so extensions is non-empty
+                // only when a later registration step threw; this is not a double-unload.
+                RollbackLoadedExtensions(extensions);
+                if (loadContext is { })
+                {
+                    TryUnloadLoadContext(package, loadContext);
+                }
+            }
+            else
+            {
+                StartRollbackAfterDrain(
+                    package,
+                    extensions,
+                    loadContext,
+                    rollbackRemoval);
             }
 
             throw;
         }
+    }
+
+    private void StartRollbackAfterDrain(
+        LocalPackage package,
+        List<Extension> extensions,
+        PluginLoadContext? loadContext,
+        ExtensionRemoval removal)
+    {
+        Extension[] rollbackExtensions = extensions.ToArray();
+        extensions.Clear();
+        var pendingRollback = new PendingRollbackInfo(
+            package,
+            rollbackExtensions,
+            loadContext);
+        lock (_packageLifecycleGate)
+        {
+            _pendingRollbacks.Add(package.LocalId, pendingRollback);
+        }
+        pendingRollback.Operation = DrainAndRollbackAsync(
+            pendingRollback,
+            removal);
+    }
+
+    private async Task DrainAndRollbackAsync(
+        PendingRollbackInfo pendingRollback,
+        ExtensionRemoval removal)
+    {
+        try
+        {
+            await removal.DrainAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            lock (_packageLifecycleGate)
+            {
+                _quarantinedPackages.Add(pendingRollback.Package.LocalId);
+            }
+            _logger.LogError(
+                ex,
+                "Package {PackageName} failed to drain after registration rollback; its load context remains quarantined.",
+                pendingRollback.Package.Name);
+            return;
+        }
+
+        if (pendingRollback.Extensions.Any(extension => !SupportsLiveUnload(extension)))
+        {
+            _logger.LogWarning(
+                "Package {PackageName} exposed restart-only extensions before registration rollback; "
+                + "the extensions and load context remain quarantined until restart.",
+                pendingRollback.Package.Name);
+            return;
+        }
+
+        var rollbackList = pendingRollback.Extensions.ToList();
+        RollbackLoadedExtensions(rollbackList);
+        if (pendingRollback.LoadContext is not null)
+        {
+            TryUnloadLoadContext(pendingRollback.Package, pendingRollback.LoadContext);
+        }
+        lock (_packageLifecycleGate)
+        {
+            _pendingRollbacks.Remove(pendingRollback.Package.LocalId);
+            _quarantinedPackages.Remove(pendingRollback.Package.LocalId);
+        }
+    }
+
+    private sealed class PendingRollbackInfo(
+        LocalPackage package,
+        IReadOnlyList<Extension> extensions,
+        PluginLoadContext? loadContext)
+    {
+        public LocalPackage Package { get; } = package;
+
+        public IReadOnlyList<Extension> Extensions { get; } = extensions;
+
+        public PluginLoadContext? LoadContext { get; } = loadContext;
+
+        public Task? Operation { get; set; }
     }
 
     internal List<Extension> LoadPackageExtensions(IEnumerable<Type> extensionTypes)

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -85,7 +85,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             .ToReadOnlyReactivePropertySlim()
             .AddTo(_disposables);
 
-        AddElement.Subscribe(desc => editorContext.GetRequiredService<IElementAdder>().AddElement(desc)).AddTo(_disposables);
+        AddElement.WithSubscribe(AddElementCore).AddTo(_disposables);
 
         Paste.Subscribe(PasteCore)
             .AddTo(_disposables);
@@ -240,6 +240,31 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         _logger.LogInformation("TimelineTabViewModel initialized successfully.");
     }
 
+    private async Task AddElementCore(ElementDescription description)
+    {
+        ElementAddResult result = await EditorContext
+            .GetRequiredService<IElementAdder>()
+            .AddAsync([description], CancellationToken.None);
+        if (result.IsSuccess)
+        {
+            Element scrollTarget = result.Items[^1].PrimaryElement;
+            ScrollTo.Execute((scrollTarget.Range, scrollTarget.ZIndex));
+            return;
+        }
+
+        if (result.Failure is LockedElementLayerFailure)
+        {
+            NotificationService.ShowWarning(Strings.Lock, Strings.LayerIsLocked);
+            return;
+        }
+
+        _logger.LogError(
+            result.Failure?.Exception,
+            "Failed to add a timeline element: {FailureId}",
+            result.Failure?.Id);
+        NotificationService.ShowError(Strings.AddElement, MessageStrings.UnexpectedError);
+    }
+
     private void RaiseCanExecuteChanged()
     {
         if (!_isDisposed)
@@ -326,7 +351,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
     public ReadOnlyReactivePropertySlim<Thickness> EndingBarMargin { get; }
 
-    public ReactiveCommand<ElementDescription> AddElement { get; } = new();
+    public AsyncReactiveCommand<ElementDescription> AddElement { get; } = new();
 
     public CoreList<ElementViewModel> Elements { get; } = [];
 
@@ -561,6 +586,14 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             if (outcome.Pasted && outcome.ScrollTo.Duration > TimeSpan.Zero)
             {
                 ScrollTo.Execute((outcome.ScrollTo, outcome.ScrollToZIndex));
+            }
+            else if (outcome.AddFailure is LockedElementLayerFailure)
+            {
+                NotificationService.ShowWarning(Strings.Lock, Strings.LayerIsLocked);
+            }
+            else if (outcome.AddFailure is not null)
+            {
+                NotificationService.ShowError(Strings.AddElement, MessageStrings.UnexpectedError);
             }
         }
         catch (Exception ex)

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
@@ -544,15 +544,13 @@ public sealed partial class TimelineTabView : UserControl
 
         if (template != null)
         {
-            if (viewModel.EditorContext.GetService<IElementAdder>() is { } adder
-                && (template.BaseType == typeof(Element)
-                    || template.BaseType.IsAssignableTo(typeof(EngineObject))))
+            if (typeof(Element).IsAssignableFrom(template.ActualType)
+                || typeof(EngineObject).IsAssignableFrom(template.ActualType))
             {
-                // Element テンプレート、もしくは EngineObject テンプレート → 新しい Element を作って配置
-                adder.AddElementFromTemplate(
+                viewModel.AddElement.Execute(ElementTemplateResolver.CreateDescription(
                     template,
                     viewModel.ClickedFrame,
-                    viewModel.CalculateClickedLayer());
+                    viewModel.CalculateClickedLayer()));
             }
 
             e.Handled = true;
@@ -562,7 +560,7 @@ public sealed partial class TimelineTabView : UserControl
         {
             viewModel.AddElement.Execute(new ElementDescription(
                 viewModel.ClickedFrame, TimeSpan.FromSeconds(5), viewModel.CalculateClickedLayer(),
-                EngineObjectFactory: () => (EngineObject)Activator.CreateInstance(type)!));
+                new ElementSource.EngineObject(() => (EngineObject)Activator.CreateInstance(type)!)));
 
             e.Handled = true;
         }
@@ -570,7 +568,7 @@ public sealed partial class TimelineTabView : UserControl
         {
             viewModel.AddElement.Execute(new ElementDescription(
                 viewModel.ClickedFrame, TimeSpan.FromSeconds(5), viewModel.CalculateClickedLayer(),
-                FileName: fileName));
+                new ElementSource.File(fileName)));
 
             e.Handled = true;
         }
@@ -653,7 +651,7 @@ public sealed partial class TimelineTabView : UserControl
             ViewModel.ClickedFrame,
             TimeSpan.FromSeconds(5),
             ViewModel.CalculateClickedLayer(),
-            EngineObjectFactory: () => (EngineObject)Activator.CreateInstance(operatorType)!));
+            new ElementSource.EngineObject(() => (EngineObject)Activator.CreateInstance(operatorType)!)));
     }
 
     private void AddAdjustmentLayerClick(object? sender, RoutedEventArgs e)
@@ -664,8 +662,9 @@ public sealed partial class TimelineTabView : UserControl
             ViewModel.ClickedFrame,
             TimeSpan.FromSeconds(5),
             ViewModel.CalculateClickedLayer(),
-            Name: Strings.AdjustmentLayer,
-            EngineObjectFactory: () => new Beutl.Graphics.SourceBackdrop { Clear = { CurrentValue = true } }));
+            new ElementSource.EngineObject(
+                () => new Beutl.Graphics.SourceBackdrop { Clear = { CurrentValue = true } }),
+            Name: Strings.AdjustmentLayer));
     }
 
     private void PopulateAddFromTemplateSubMenu()
@@ -687,14 +686,10 @@ public sealed partial class TimelineTabView : UserControl
         if (ViewModel == null) return;
         if (sender is not MenuFlyoutItem { Tag: ObjectTemplateItem template }) return;
 
-        if (ViewModel.EditorContext.GetService(typeof(IElementAdder))
-            is IElementAdder adder)
-        {
-            adder.AddElementFromTemplate(
-                template,
-                ViewModel.ClickedFrame,
-                ViewModel.CalculateClickedLayer());
-        }
+        ViewModel.AddElement.Execute(ElementTemplateResolver.CreateDescription(
+            template,
+            ViewModel.ClickedFrame,
+            ViewModel.CalculateClickedLayer()));
     }
 
     private void ShowSceneSettings(object? sender, RoutedEventArgs e)

--- a/src/Beutl.Editor/Beutl.Editor.csproj
+++ b/src/Beutl.Editor/Beutl.Editor.csproj
@@ -17,6 +17,7 @@
       <ProjectReference Include="..\Beutl.Configuration\Beutl.Configuration.csproj" />
       <ProjectReference Include="..\Beutl.Core\Beutl.Core.csproj" />
       <ProjectReference Include="..\Beutl.Engine\Beutl.Engine.csproj" />
+      <ProjectReference Include="..\Beutl.Api\Beutl.Api.csproj" />
       <ProjectReference Include="..\Beutl.Extensibility\Beutl.Extensibility.csproj" />
       <ProjectReference Include="..\Beutl.Language\Beutl.Language.csproj" />
       <ProjectReference Include="..\Beutl.NodeGraph\Beutl.NodeGraph.csproj" />

--- a/src/Beutl.Editor/Models/ElementDescription.cs
+++ b/src/Beutl.Editor/Models/ElementDescription.cs
@@ -1,30 +1,118 @@
 ﻿using Beutl.Engine;
 using Beutl.Graphics;
+using Beutl.ProjectSystem;
 
 namespace Beutl.Editor.Models;
 
 /// <summary>
-/// Describes how to create and place a new <c>Element</c> on the timeline.
+/// Identifies the single source used to create an element request.
 /// </summary>
-/// <param name="EngineObjectFactory">
-/// Produces the initial engine object hosted by the element. The factory both constructs and
-/// configures the object, so callers can supply a fully-typed object (e.g. an adjustment layer)
-/// without a separate post-construction configuration step. When <paramref name="FileName"/> is
-/// also set, file import takes precedence and the factory is ignored.
-/// </param>
-public record struct ElementDescription(
-    TimeSpan Start,
-    TimeSpan Length,
-    int Layer,
-    string Name = "",
-    Func<EngineObject>? EngineObjectFactory = null,
-    string? FileName = null,
-    Point Position = default)
+public abstract record ElementSource
 {
+    protected ElementSource()
+    {
+    }
+
+    /// <summary>
+    /// Imports an image, video, or audio file.
+    /// </summary>
+    public sealed record File : ElementSource
+    {
+        public File(string fileName)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+            FileName = fileName;
+        }
+
+        public string FileName { get; }
+    }
+
+    /// <summary>
+    /// Creates the engine object hosted by a new element.
+    /// </summary>
+    public sealed record EngineObject : ElementSource
+    {
+        public EngineObject(Func<Beutl.Engine.EngineObject> factory)
+        {
+            ArgumentNullException.ThrowIfNull(factory);
+            Factory = factory;
+        }
+
+        public Func<Beutl.Engine.EngineObject> Factory { get; }
+    }
+
+    /// <summary>
+    /// Creates a complete element from a saved element template.
+    /// </summary>
+    public sealed record ElementTemplate : ElementSource
+    {
+        public ElementTemplate(Func<Element> factory)
+        {
+            ArgumentNullException.ThrowIfNull(factory);
+            Factory = factory;
+        }
+
+        public Func<Element> Factory { get; }
+    }
+}
+
+/// <summary>
+/// Describes how to create and place new timeline content from exactly one source.
+/// </summary>
+public sealed record ElementDescription
+{
+    /// <summary>
+    /// Initializes an immutable element-add request.
+    /// </summary>
+    /// <param name="Start">The requested timeline start.</param>
+    /// <param name="Length">
+    /// The requested length. <see langword="null"/> lets the selected source handler preserve or
+    /// choose the materialized length; handlers that require an explicit value reject it during
+    /// preflight. Any value, including zero, explicitly requests that length.
+    /// </param>
+    /// <param name="Layer">The requested timeline layer.</param>
+    /// <param name="Source">The single source from which the element is created.</param>
+    /// <param name="Name">An optional element name.</param>
+    /// <param name="Position">An optional drawable translation.</param>
+    public ElementDescription(
+        TimeSpan Start,
+        TimeSpan? Length,
+        int Layer,
+        ElementSource Source,
+        string Name = "",
+        Point? Position = null)
+    {
+        ArgumentNullException.ThrowIfNull(Source);
+        ArgumentNullException.ThrowIfNull(Name);
+
+        this.Start = Start;
+        this.Length = Length;
+        this.Layer = Layer;
+        this.Source = Source;
+        this.Name = Name;
+        this.Position = Position;
+    }
+
+    public TimeSpan Start { get; }
+
+    public TimeSpan? Length { get; }
+
+    public int Layer { get; }
+
+    public ElementSource Source { get; }
+
+    public string Name { get; }
+
+    /// <summary>
+    /// An optional drawable translation. <see langword="null"/> preserves the source transform;
+    /// a value of <c>(0, 0)</c> explicitly places the drawable at the origin.
+    /// </summary>
+    public Point? Position { get; init; }
+
     /// <summary>
     /// Resolves the element name: the explicit <see cref="Name"/> when set, otherwise the
     /// localized display name of <paramref name="fallbackType"/>.
     /// </summary>
-    public readonly string ResolveName(Type fallbackType) =>
+    public string ResolveName(Type fallbackType) =>
         string.IsNullOrEmpty(Name) ? TypeDisplayHelpers.GetLocalizedName(fallbackType) : Name;
 }

--- a/src/Beutl.Editor/Services/AI/AiJobResultContracts.cs
+++ b/src/Beutl.Editor/Services/AI/AiJobResultContracts.cs
@@ -1,0 +1,455 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Beutl.Api.Services;
+using Beutl.Extensibility;
+using Beutl.ProjectSystem;
+
+namespace Beutl.Editor.Services.AI;
+
+/// <summary>
+/// Provides the scene-editing capabilities required to apply an AI job result without coupling
+/// result applicators to a concrete desktop view model.
+/// </summary>
+public interface IAiJobResultEditorContext : IEditorContext
+{
+    Scene Scene { get; }
+
+    TimeSpan CurrentTime { get; }
+
+    IElementAdder ElementAdder { get; }
+
+    int GetNextLayer(TimeSpan start);
+}
+
+/// <summary>
+/// Provides the editor-specific dependencies needed to apply an AI job result.
+/// </summary>
+public interface IAiJobResultContext
+{
+    IAiJobResultEditorContext Editor { get; }
+
+    Task<AiContentDownload> CopyContentToAsync(
+        Uri contentUri,
+        Stream destination,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Describes an AI job for editor UI surfaces.
+/// </summary>
+/// <param name="HasImagePreview">
+/// Whether the job's content is a still picture the job list can show. Only the
+/// presenter knows what its kind produces, and a list of prompts is far harder to
+/// search than a list of pictures.
+/// </param>
+public sealed record AiJobPresentation(
+    string KindDisplayName,
+    string StatusDisplayName,
+    string Summary,
+    string Details,
+    bool IsFailure,
+    bool HasImagePreview = false);
+
+/// <summary>The notification severity for a terminal AI job.</summary>
+public enum AiJobNotificationKind
+{
+    Information,
+    Success,
+    Warning,
+}
+
+/// <summary>Describes an editor notification for a terminal AI job.</summary>
+public sealed record AiJobCompletionPresentation(
+    string Title,
+    string Message,
+    AiJobNotificationKind Notification,
+    TimeSpan? Expiration = null);
+
+/// <summary>Provides list presentation for one AI job kind.</summary>
+public interface IAiJobPresenter
+{
+    AiJobPresentation Present(AiJob job, AiJobStatusSemantics status);
+}
+
+/// <summary>Provides completion notifications for one AI job kind.</summary>
+public interface IAiJobCompletionPresenter
+{
+    AiJobCompletionPresentation? CreateCompletion(
+        AiJob job,
+        AiJobStatusSemantics status);
+}
+
+/// <summary>Applies successful results for one AI job kind to an editor.</summary>
+public interface IAiJobResultApplicator
+{
+    bool CanApply(AiJob job, AiJobStatusSemantics status);
+
+    Task ApplyAsync(
+        AiJob job,
+        IAiJobResultContext context,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>Controls collision handling independently for each result capability.</summary>
+public enum AiJobResultRegistrationMode
+{
+    Add,
+    Replace,
+}
+
+/// <summary>Identifies one independently registered editor-side AI result capability.</summary>
+public enum AiJobResultCapability
+{
+    Presentation,
+    Completion,
+    Application,
+}
+
+/// <summary>Registers list presentation for one AI job kind.</summary>
+public sealed class AiJobPresentationRegistration
+{
+    public AiJobPresentationRegistration(
+        AiJobKindId kind,
+        IAiJobPresenter presenter,
+        AiJobResultRegistrationMode mode = AiJobResultRegistrationMode.Add)
+    {
+        AiJobResultContractValidation.Validate(kind, mode);
+        Kind = kind;
+        Presenter = presenter ?? throw new ArgumentNullException(nameof(presenter));
+        Mode = mode;
+    }
+
+    public AiJobKindId Kind { get; }
+
+    public IAiJobPresenter Presenter { get; }
+
+    public AiJobResultRegistrationMode Mode { get; }
+}
+
+/// <summary>Registers completion notification presentation for one AI job kind.</summary>
+public sealed class AiJobCompletionRegistration
+{
+    public AiJobCompletionRegistration(
+        AiJobKindId kind,
+        IAiJobCompletionPresenter presenter,
+        AiJobResultRegistrationMode mode = AiJobResultRegistrationMode.Add)
+    {
+        AiJobResultContractValidation.Validate(kind, mode);
+        Kind = kind;
+        Presenter = presenter ?? throw new ArgumentNullException(nameof(presenter));
+        Mode = mode;
+    }
+
+    public AiJobKindId Kind { get; }
+
+    public IAiJobCompletionPresenter Presenter { get; }
+
+    public AiJobResultRegistrationMode Mode { get; }
+}
+
+/// <summary>Registers result application for one AI job kind.</summary>
+public sealed class AiJobResultApplicatorRegistration
+{
+    public AiJobResultApplicatorRegistration(
+        AiJobKindId kind,
+        IAiJobResultApplicator applicator,
+        AiJobResultRegistrationMode mode = AiJobResultRegistrationMode.Add)
+    {
+        AiJobResultContractValidation.Validate(kind, mode);
+        Kind = kind;
+        Applicator = applicator ?? throw new ArgumentNullException(nameof(applicator));
+        Mode = mode;
+    }
+
+    public AiJobKindId Kind { get; }
+
+    public IAiJobResultApplicator Applicator { get; }
+
+    public AiJobResultRegistrationMode Mode { get; }
+}
+
+/// <summary>
+/// Contributes list presentation independently of completion notification and result application.
+/// Active presenter calls are drained before the package unloads.
+/// </summary>
+public abstract class AiJobPresentationExtension : Extension, ILiveUnloadExtension
+{
+    public abstract IReadOnlyCollection<AiJobPresentationRegistration> Registrations { get; }
+}
+
+/// <summary>
+/// Contributes completion notification presentation independently of list presentation and result
+/// application. Active presenter calls are drained before the package unloads.
+/// </summary>
+public abstract class AiJobCompletionExtension : Extension, ILiveUnloadExtension
+{
+    public abstract IReadOnlyCollection<AiJobCompletionRegistration> Registrations { get; }
+}
+
+/// <summary>
+/// Contributes result application independently of presentation. Applicators can persist
+/// package-defined scene graphs, so their packages remain loaded until restart.
+/// </summary>
+public abstract class AiJobResultApplicatorExtension : Extension
+{
+    public abstract IReadOnlyCollection<AiJobResultApplicatorRegistration> Registrations { get; }
+}
+
+public sealed record AiJobResultExtensionFailure(
+    string ExtensionType,
+    AiJobResultCapability Capability,
+    Exception Exception);
+
+/// <summary>Keeps a resolved list presenter alive for one operation.</summary>
+public interface IAiJobPresenterLease : IDisposable
+{
+    IAiJobPresenter Presenter { get; }
+}
+
+/// <summary>Keeps a resolved completion presenter alive for one operation.</summary>
+public interface IAiJobCompletionPresenterLease : IDisposable
+{
+    IAiJobCompletionPresenter Presenter { get; }
+}
+
+/// <summary>Keeps a resolved result applicator alive for one operation.</summary>
+public interface IAiJobResultApplicatorLease : IDisposable
+{
+    IAiJobResultApplicator Applicator { get; }
+}
+
+/// <summary>Owns one list-presentation registration and drains its active leases on disposal.</summary>
+public interface IAiJobPresentationRegistration : IAsyncDisposable
+{
+}
+
+/// <summary>Owns one completion-presentation registration and drains its active leases on disposal.</summary>
+public interface IAiJobCompletionRegistration : IAsyncDisposable
+{
+}
+
+/// <summary>Owns one result-application registration and drains its active leases on disposal.</summary>
+public interface IAiJobResultApplicatorRegistration : IAsyncDisposable
+{
+}
+
+/// <summary>
+/// Resolves presentation, completion notification, and application through independent slots.
+/// Replacing one capability leaves the other two unchanged.
+/// </summary>
+public sealed class AiJobResultRegistry : IAsyncDisposable
+{
+    private readonly AiJobSlotRegistry<
+        IAiJobPresenter,
+        AiJobPresentationRegistration,
+        AiJobPresentationExtension> _presenters;
+    private readonly AiJobSlotRegistry<
+        IAiJobCompletionPresenter,
+        AiJobCompletionRegistration,
+        AiJobCompletionExtension> _completionPresenters;
+    private readonly AiJobSlotRegistry<
+        IAiJobResultApplicator,
+        AiJobResultApplicatorRegistration,
+        AiJobResultApplicatorExtension> _applicators;
+
+    public AiJobResultRegistry(
+        IEnumerable<AiJobPresentationRegistration> presentations,
+        IEnumerable<AiJobCompletionRegistration> completions,
+        IEnumerable<AiJobResultApplicatorRegistration> applicators)
+        : this(presentations, completions, applicators, null, null)
+    {
+    }
+
+    internal AiJobResultRegistry(
+        IEnumerable<AiJobPresentationRegistration> presentations,
+        IEnumerable<AiJobCompletionRegistration> completions,
+        IEnumerable<AiJobResultApplicatorRegistration> applicators,
+        IExtensionRegistry? extensionProvider,
+        Action<AiJobResultExtensionFailure>? reportFailure)
+    {
+        _presenters = new AiJobSlotRegistry<
+            IAiJobPresenter,
+            AiJobPresentationRegistration,
+            AiJobPresentationExtension>(
+                presentations,
+                static registration => registration.Kind,
+                static registration => registration.Presenter,
+                static registration => ToSlotMode(registration.Mode),
+                static (kind, capability) => new AiJobPresentationRegistration(kind, capability),
+                static extension => extension.Registrations,
+                extensionProvider,
+                (extension, exception) => ReportFailure(
+                    reportFailure,
+                    extension,
+                    AiJobResultCapability.Presentation,
+                    exception));
+        _completionPresenters = new AiJobSlotRegistry<
+            IAiJobCompletionPresenter,
+            AiJobCompletionRegistration,
+            AiJobCompletionExtension>(
+                completions,
+                static registration => registration.Kind,
+                static registration => registration.Presenter,
+                static registration => ToSlotMode(registration.Mode),
+                static (kind, capability) => new AiJobCompletionRegistration(kind, capability),
+                static extension => extension.Registrations,
+                extensionProvider,
+                (extension, exception) => ReportFailure(
+                    reportFailure,
+                    extension,
+                    AiJobResultCapability.Completion,
+                    exception));
+        _applicators = new AiJobSlotRegistry<
+            IAiJobResultApplicator,
+            AiJobResultApplicatorRegistration,
+            AiJobResultApplicatorExtension>(
+                applicators,
+                static registration => registration.Kind,
+                static registration => registration.Applicator,
+                static registration => ToSlotMode(registration.Mode),
+                static (kind, capability) => new AiJobResultApplicatorRegistration(kind, capability),
+                static extension => extension.Registrations,
+                extensionProvider,
+                (extension, exception) => ReportFailure(
+                    reportFailure,
+                    extension,
+                    AiJobResultCapability.Application,
+                    exception));
+    }
+
+    public IAiJobPresentationRegistration Register(AiJobPresentationRegistration registration)
+        => new PresentationRegistration(_presenters.Register(registration));
+
+    public IAiJobCompletionRegistration Register(AiJobCompletionRegistration registration)
+        => new CompletionRegistration(_completionPresenters.Register(registration));
+
+    public IAiJobResultApplicatorRegistration Register(AiJobResultApplicatorRegistration registration)
+        => new ApplicatorRegistration(_applicators.Register(registration));
+
+    public bool TryAcquirePresenter(
+        AiJobKindId kind,
+        [NotNullWhen(true)] out IAiJobPresenterLease? lease)
+    {
+        if (_presenters.TryAcquire(kind, out AiJobSlotLease<IAiJobPresenter>? inner))
+        {
+            lease = new PresenterLease(inner);
+            return true;
+        }
+
+        lease = null;
+        return false;
+    }
+
+    public bool TryAcquireCompletionPresenter(
+        AiJobKindId kind,
+        [NotNullWhen(true)] out IAiJobCompletionPresenterLease? lease)
+    {
+        if (_completionPresenters.TryAcquire(
+                kind,
+                out AiJobSlotLease<IAiJobCompletionPresenter>? inner))
+        {
+            lease = new CompletionPresenterLease(inner);
+            return true;
+        }
+
+        lease = null;
+        return false;
+    }
+
+    public bool TryAcquireApplicator(
+        AiJobKindId kind,
+        [NotNullWhen(true)] out IAiJobResultApplicatorLease? lease)
+    {
+        if (_applicators.TryAcquire(
+                kind,
+                out AiJobSlotLease<IAiJobResultApplicator>? inner))
+        {
+            lease = new ApplicatorLease(inner);
+            return true;
+        }
+
+        lease = null;
+        return false;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Task.WhenAll(
+            _presenters.DisposeAsync().AsTask(),
+            _completionPresenters.DisposeAsync().AsTask(),
+            _applicators.DisposeAsync().AsTask());
+    }
+
+    private static void ReportFailure<TExtension>(
+        Action<AiJobResultExtensionFailure>? reportFailure,
+        TExtension extension,
+        AiJobResultCapability capability,
+        Exception exception)
+        where TExtension : Extension
+    {
+        if (reportFailure is null)
+            return;
+
+        reportFailure(new AiJobResultExtensionFailure(
+            extension.GetType().FullName ?? extension.GetType().Name,
+            capability,
+            exception));
+    }
+
+    private static AiJobSlotRegistrationMode ToSlotMode(AiJobResultRegistrationMode mode)
+        => mode == AiJobResultRegistrationMode.Replace
+            ? AiJobSlotRegistrationMode.Replace
+            : AiJobSlotRegistrationMode.Add;
+
+    private sealed class PresenterLease(
+        AiJobSlotLease<IAiJobPresenter> inner) : IAiJobPresenterLease
+    {
+        public IAiJobPresenter Presenter => inner.Capability;
+
+        public void Dispose() => inner.Dispose();
+    }
+
+    private sealed class CompletionPresenterLease(
+        AiJobSlotLease<IAiJobCompletionPresenter> inner) : IAiJobCompletionPresenterLease
+    {
+        public IAiJobCompletionPresenter Presenter => inner.Capability;
+
+        public void Dispose() => inner.Dispose();
+    }
+
+    private sealed class ApplicatorLease(
+        AiJobSlotLease<IAiJobResultApplicator> inner) : IAiJobResultApplicatorLease
+    {
+        public IAiJobResultApplicator Applicator => inner.Capability;
+
+        public void Dispose() => inner.Dispose();
+    }
+
+    private sealed class PresentationRegistration(
+        IAiJobSlotRegistration inner) : IAiJobPresentationRegistration
+    {
+        public ValueTask DisposeAsync() => inner.DisposeAsync();
+    }
+
+    private sealed class CompletionRegistration(
+        IAiJobSlotRegistration inner) : IAiJobCompletionRegistration
+    {
+        public ValueTask DisposeAsync() => inner.DisposeAsync();
+    }
+
+    private sealed class ApplicatorRegistration(
+        IAiJobSlotRegistration inner) : IAiJobResultApplicatorRegistration
+    {
+        public ValueTask DisposeAsync() => inner.DisposeAsync();
+    }
+}
+
+internal static class AiJobResultContractValidation
+{
+    public static void Validate(AiJobKindId kind, AiJobResultRegistrationMode mode)
+    {
+        if (string.IsNullOrWhiteSpace(kind.Value))
+            throw new ArgumentException("An AI job kind identifier is required.", nameof(kind));
+        if (!Enum.IsDefined(mode))
+            throw new ArgumentOutOfRangeException(nameof(mode));
+    }
+}

--- a/src/Beutl.Editor/Services/Captions/AssCaptionCodec.cs
+++ b/src/Beutl.Editor/Services/Captions/AssCaptionCodec.cs
@@ -1,0 +1,404 @@
+﻿using System.Text;
+
+namespace Beutl.Editor.Services.Captions;
+
+public sealed class AssCaptionCodec : ICaptionDecoder, ICaptionEncoder
+{
+    private const string LanguageEffectPrefix = "beutl-language=";
+    private const string ImplicitStyleEffect = "beutl-style=implicit";
+
+    public CaptionFormatId Format => CaptionFormats.Ass;
+
+    public CaptionImportResult Decode(string content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        string[] lines = CaptionTextUtilities.GetLines(content);
+        var cues = new List<CaptionCue>();
+        var errors = new List<CaptionDiagnostic>();
+        string[]? format = null;
+        bool inEvents = false;
+        bool foundEvents = false;
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            string trimmedLine = lines[i].Trim();
+            if (trimmedLine.StartsWith('[') && trimmedLine.EndsWith(']'))
+            {
+                inEvents = trimmedLine.Equals("[Events]", StringComparison.OrdinalIgnoreCase);
+                foundEvents |= inEvents;
+                continue;
+            }
+
+            if (!inEvents || trimmedLine.Length == 0 || trimmedLine.StartsWith(';'))
+                continue;
+
+            string directiveLine = lines[i].TrimStart();
+            if (TryGetDirective(directiveLine, "Format", out string formatValue))
+            {
+                string[] candidate = formatValue.Split(',').Select(field => field.Trim()).ToArray();
+                if (!IsSupportedFormat(candidate))
+                {
+                    errors.Add(new CaptionDiagnostic(
+                        CaptionDiagnosticKinds.InvalidStructure,
+                        i + 1,
+                        "ASS/SSA event format must contain Start, End, and a final Text field."));
+                    format = null;
+                }
+                else
+                {
+                    format = candidate;
+                }
+
+                continue;
+            }
+
+            if (!TryGetDirective(directiveLine, "Dialogue", out string dialogue))
+                continue;
+
+            if (format is null)
+            {
+                errors.Add(new CaptionDiagnostic(
+                    CaptionDiagnosticKinds.InvalidStructure,
+                    i + 1,
+                    "ASS/SSA Dialogue appears before a supported event Format line."));
+                continue;
+            }
+
+            string[] fields = dialogue.Split(',', format.Length, StringSplitOptions.None);
+            if (fields.Length != format.Length)
+            {
+                errors.Add(new CaptionDiagnostic(
+                    CaptionDiagnosticKinds.InvalidStructure,
+                    i + 1,
+                    "ASS/SSA Dialogue has fewer fields than its event Format line."));
+                continue;
+            }
+
+            int startIndex = FindField(format, "Start");
+            int endIndex = FindField(format, "End");
+            int textIndex = FindField(format, "Text");
+            if (!CaptionCodecUtilities.TryParseAssTime(fields[startIndex], out TimeSpan start)
+                || !CaptionCodecUtilities.TryParseAssTime(fields[endIndex], out TimeSpan end)
+                || end <= start)
+            {
+                errors.Add(new CaptionDiagnostic(
+                    CaptionDiagnosticKinds.InvalidTiming,
+                    i + 1,
+                    "ASS/SSA timing must use H:MM:SS.cc and have an end after its start."));
+                continue;
+            }
+
+            int speakerIndex = FindOptionalField(format, "Name", "Actor");
+            int styleIndex = FindOptionalField(format, "Style");
+            int effectIndex = FindOptionalField(format, "Effect");
+            string? speaker = speakerIndex >= 0 ? EmptyToNull(fields[speakerIndex].Trim()) : null;
+            string? style = styleIndex >= 0 ? EmptyToNull(fields[styleIndex].Trim()) : null;
+            string effect = effectIndex >= 0 ? fields[effectIndex].Trim() : string.Empty;
+            string? language = DecodeLanguage(effect);
+            bool hasImplicitStyle = string.Equals(
+                style,
+                "Default",
+                StringComparison.OrdinalIgnoreCase) && HasEffect(effect, ImplicitStyleEffect);
+
+            CaptionMetadata metadata = style is null || hasImplicitStyle
+                ? CaptionMetadata.Empty
+                : CaptionMetadata.Empty.Set(CaptionMetadataKeys.AssStyle, style);
+            cues.Add(new CaptionCue(
+                start,
+                end,
+                DecodeText(fields[textIndex]),
+                speaker,
+                language,
+                metadata));
+        }
+
+        if (!foundEvents)
+        {
+            errors.Add(new CaptionDiagnostic(
+                CaptionDiagnosticKinds.InvalidHeader,
+                null,
+                "An ASS/SSA document must contain an [Events] section."));
+        }
+        else if (format is null && !errors.Any(error => error.Kind == CaptionDiagnosticKinds.InvalidStructure))
+        {
+            errors.Add(new CaptionDiagnostic(
+                CaptionDiagnosticKinds.InvalidStructure,
+                null,
+                "The ASS/SSA [Events] section must contain a supported Format line."));
+        }
+
+        var document = new CaptionDocument(cues);
+        return errors.Count == 0 || cues.Count > 0
+            ? CaptionImportResult.Imported(document, errors)
+            : CaptionImportResult.Failure(errors);
+    }
+
+    public string Encode(CaptionDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var styles = new List<string> { "Default" };
+        var seenStyles = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Default" };
+        for (int i = 0; i < document.Count; i++)
+        {
+            CaptionCue cue = document[i];
+            string? style = cue.Metadata.GetValueOrDefault(CaptionMetadataKeys.AssStyle);
+            CaptionCodecUtilities.EnsureCueCanExport(cue, i);
+            EnsureAssField(cue.Speaker, i, "speaker");
+            EnsureAssField(style, i, "style");
+            if (cue.Text.IndexOfAny('{', '}') >= 0)
+            {
+                throw new CaptionExportException(
+                    i,
+                    "ASS/SSA cannot safely represent literal braces because they delimit override blocks.");
+            }
+            if (ContainsLegacyFormattingTag(cue.Text))
+            {
+                throw new CaptionExportException(
+                    i,
+                    "ASS/SSA cannot safely represent literal legacy formatting tags.");
+            }
+
+            if (!string.IsNullOrEmpty(style) && seenStyles.Add(style))
+                styles.Add(style);
+        }
+
+        var builder = new StringBuilder();
+        builder.Append("[Script Info]\r\n");
+        builder.Append("ScriptType: v4.00+\r\n");
+        builder.Append("Collisions: Normal\r\n");
+        builder.Append("WrapStyle: 0\r\n");
+        builder.Append("ScaledBorderAndShadow: yes\r\n\r\n");
+        builder.Append("[V4+ Styles]\r\n");
+        builder.Append("Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding\r\n");
+        foreach (string style in styles)
+        {
+            builder.Append("Style: ").Append(style);
+            builder.Append(",Arial,48,&H00FFFFFF,&H000000FF,&H00000000,&H80000000,0,0,0,0,100,100,0,0,1,2,1,2,20,20,20,1\r\n");
+        }
+
+        builder.Append("\r\n[Events]\r\n");
+        builder.Append("Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\r\n");
+        for (int i = 0; i < document.Count; i++)
+        {
+            CaptionCue cue = document[i];
+            (TimeSpan start, TimeSpan end) = CaptionCodecUtilities.QuantizeCue(
+                cue,
+                i,
+                TimeSpan.TicksPerSecond / 100);
+            string? explicitStyle = cue.Metadata.GetValueOrDefault(CaptionMetadataKeys.AssStyle);
+            string style = explicitStyle ?? "Default";
+            string effect = EncodeEffect(cue.Language, implicitStyle: explicitStyle is null);
+
+            builder.Append("Dialogue: 0,");
+            builder.Append(CaptionCodecUtilities.FormatAssTime(start)).Append(',');
+            builder.Append(CaptionCodecUtilities.FormatAssTime(end)).Append(',');
+            builder.Append(style).Append(',');
+            builder.Append(cue.Speaker).Append(",0,0,0,");
+            builder.Append(effect).Append(',');
+            builder.Append(EncodeText(cue.Text)).Append("\r\n");
+        }
+
+        return builder.ToString();
+    }
+
+    private static string DecodeText(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+        for (int i = 0; i < value.Length; i++)
+        {
+            char character = value[i];
+            if (character == '\\' && i + 1 < value.Length)
+            {
+                char escape = value[i + 1];
+                if (escape == '\\')
+                {
+                    builder.Append('\\');
+                    i++;
+                    continue;
+                }
+
+                if (escape is 'N' or 'n')
+                {
+                    builder.Append('\n');
+                    i++;
+                    continue;
+                }
+
+                if (escape == 'h')
+                {
+                    builder.Append('\u00A0');
+                    i++;
+                    continue;
+                }
+            }
+
+            if (character == '{')
+            {
+                int close = value.IndexOf('}', i + 1);
+                if (close >= 0)
+                {
+                    i = close;
+                    continue;
+                }
+            }
+
+            if (character == '<')
+            {
+                int close = value.IndexOf('>', i + 1);
+                if (close >= 0 && IsLegacyFormattingTag(value.AsSpan(i + 1, close - i - 1)))
+                {
+                    i = close;
+                    continue;
+                }
+            }
+
+            builder.Append(character);
+        }
+
+        return builder.ToString();
+    }
+
+    private static string EncodeText(string value)
+    {
+        string normalized = CaptionTextUtilities.NormalizeLineEndings(value);
+        var builder = new StringBuilder(normalized.Length);
+        foreach (char character in normalized)
+        {
+            switch (character)
+            {
+                case '\\':
+                    builder.Append("\\\\");
+                    break;
+                case '\n':
+                    builder.Append("\\N");
+                    break;
+                case '\u00A0':
+                    builder.Append("\\h");
+                    break;
+                default:
+                    builder.Append(character);
+                    break;
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool TryGetDirective(string line, string name, out string value)
+    {
+        if (line.StartsWith(name, StringComparison.OrdinalIgnoreCase)
+            && line.Length > name.Length
+            && line[name.Length] == ':')
+        {
+            value = line[(name.Length + 1)..].TrimStart();
+            return true;
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
+    private static bool IsSupportedFormat(string[] fields)
+        => fields.Length > 0
+           && fields[^1].Equals("Text", StringComparison.OrdinalIgnoreCase)
+           && FindField(fields, "Start") >= 0
+           && FindField(fields, "End") >= 0;
+
+    private static int FindField(string[] fields, string name)
+        => Array.FindIndex(fields, field => field.Equals(name, StringComparison.OrdinalIgnoreCase));
+
+    private static int FindOptionalField(string[] fields, params string[] names)
+    {
+        foreach (string name in names)
+        {
+            int index = FindField(fields, name);
+            if (index >= 0)
+                return index;
+        }
+
+        return -1;
+    }
+
+    private static string? DecodeLanguage(string effect)
+    {
+        foreach (string value in effect.Split(';', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!value.StartsWith(LanguageEffectPrefix, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            try
+            {
+                return EmptyToNull(Uri.UnescapeDataString(value[LanguageEffectPrefix.Length..]));
+            }
+            catch (UriFormatException)
+            {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool HasEffect(string effect, string expected)
+        => effect.Split(';', StringSplitOptions.RemoveEmptyEntries)
+            .Any(value => value.Equals(expected, StringComparison.OrdinalIgnoreCase));
+
+    private static string EncodeEffect(string? language, bool implicitStyle)
+    {
+        string languageEffect = language is null
+            ? string.Empty
+            : LanguageEffectPrefix + Uri.EscapeDataString(language);
+        if (!implicitStyle)
+            return languageEffect;
+        return languageEffect.Length == 0
+            ? ImplicitStyleEffect
+            : languageEffect + ';' + ImplicitStyleEffect;
+    }
+
+    private static void EnsureAssField(string? value, int cueIndex, string fieldName)
+    {
+        if (value is not null && !string.Equals(value, value.Trim(), StringComparison.Ordinal))
+        {
+            throw new CaptionExportException(
+                cueIndex,
+                $"ASS/SSA cue {fieldName} cannot have leading or trailing whitespace.");
+        }
+
+        if (value?.IndexOfAny(',', '\r', '\n') >= 0)
+        {
+            throw new CaptionExportException(
+                cueIndex,
+                $"ASS/SSA cue {fieldName} cannot contain commas or line breaks.");
+        }
+    }
+
+    private static bool IsLegacyFormattingTag(ReadOnlySpan<char> value)
+    {
+        ReadOnlySpan<char> tag = value.Trim();
+        if (!tag.IsEmpty && tag[0] == '/')
+            tag = tag[1..];
+        return tag.Equals("b", StringComparison.OrdinalIgnoreCase)
+               || tag.Equals("i", StringComparison.OrdinalIgnoreCase)
+               || tag.Equals("u", StringComparison.OrdinalIgnoreCase)
+               || tag.Equals("s", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool ContainsLegacyFormattingTag(string value)
+    {
+        for (int index = 0; index < value.Length; index++)
+        {
+            if (value[index] != '<')
+                continue;
+
+            int close = value.IndexOf('>', index + 1);
+            if (close >= 0 && IsLegacyFormattingTag(value.AsSpan(index + 1, close - index - 1)))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string? EmptyToNull(string value) => value.Length == 0 ? null : value;
+}

--- a/src/Beutl.Editor/Services/Captions/AssCaptionCodec.cs
+++ b/src/Beutl.Editor/Services/Captions/AssCaptionCodec.cs
@@ -104,10 +104,18 @@ public sealed class AssCaptionCodec : ICaptionDecoder, ICaptionEncoder
             CaptionMetadata metadata = style is null || hasImplicitStyle
                 ? CaptionMetadata.Empty
                 : CaptionMetadata.Empty.Set(CaptionMetadataKeys.AssStyle, style);
+            string text = DecodeText(fields[textIndex], out bool discardedOverrideBlock);
+            if (discardedOverrideBlock)
+            {
+                errors.Add(new CaptionDiagnostic(
+                    CaptionDiagnosticKinds.UnsupportedMarkup,
+                    i + 1,
+                    "ASS/SSA override blocks cannot be represented and were removed from the cue text."));
+            }
             cues.Add(new CaptionCue(
                 start,
                 end,
-                DecodeText(fields[textIndex]),
+                text,
                 speaker,
                 language,
                 metadata));
@@ -203,8 +211,9 @@ public sealed class AssCaptionCodec : ICaptionDecoder, ICaptionEncoder
         return builder.ToString();
     }
 
-    private static string DecodeText(string value)
+    private static string DecodeText(string value, out bool discardedOverrideBlock)
     {
+        discardedOverrideBlock = false;
         var builder = new StringBuilder(value.Length);
         for (int i = 0; i < value.Length; i++)
         {
@@ -239,6 +248,7 @@ public sealed class AssCaptionCodec : ICaptionDecoder, ICaptionEncoder
                 int close = value.IndexOf('}', i + 1);
                 if (close >= 0)
                 {
+                    discardedOverrideBlock = true;
                     i = close;
                     continue;
                 }

--- a/src/Beutl.Editor/Services/Captions/AssCaptionCodec.cs
+++ b/src/Beutl.Editor/Services/Captions/AssCaptionCodec.cs
@@ -6,6 +6,10 @@ public sealed class AssCaptionCodec : ICaptionDecoder, ICaptionEncoder
 {
     private const string LanguageEffectPrefix = "beutl-language=";
     private const string ImplicitStyleEffect = "beutl-style=implicit";
+    private const string GeneratedStyleFormat =
+        "Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding";
+    private const string GeneratedStyleSuffix =
+        ",Arial,48,&H00FFFFFF,&H000000FF,&H00000000,&H80000000,0,0,0,0,100,100,0,0,1,2,1,2,20,20,20,1";
 
     public CaptionFormatId Format => CaptionFormats.Ass;
 
@@ -16,8 +20,11 @@ public sealed class AssCaptionCodec : ICaptionDecoder, ICaptionEncoder
         string[] lines = CaptionTextUtilities.GetLines(content);
         var cues = new List<CaptionCue>();
         var errors = new List<CaptionDiagnostic>();
+        var styleDefinitions = new List<AssStyleDefinition>();
         string[]? format = null;
         bool inEvents = false;
+        bool inStyles = false;
+        bool usesGeneratedStyleFormat = false;
         bool foundEvents = false;
 
         for (int i = 0; i < lines.Length; i++)
@@ -26,14 +33,37 @@ public sealed class AssCaptionCodec : ICaptionDecoder, ICaptionEncoder
             if (trimmedLine.StartsWith('[') && trimmedLine.EndsWith(']'))
             {
                 inEvents = trimmedLine.Equals("[Events]", StringComparison.OrdinalIgnoreCase);
+                inStyles = trimmedLine.Equals("[V4+ Styles]", StringComparison.OrdinalIgnoreCase)
+                    || trimmedLine.Equals("[V4 Styles]", StringComparison.OrdinalIgnoreCase);
+                if (inStyles)
+                    usesGeneratedStyleFormat = false;
                 foundEvents |= inEvents;
                 continue;
             }
 
-            if (!inEvents || trimmedLine.Length == 0 || trimmedLine.StartsWith(';'))
+            if (trimmedLine.Length == 0 || trimmedLine.StartsWith(';'))
                 continue;
 
             string directiveLine = lines[i].TrimStart();
+            if (inStyles)
+            {
+                if (TryGetDirective(directiveLine, "Format", out string styleFormat))
+                {
+                    usesGeneratedStyleFormat = IsGeneratedStyleFormat(styleFormat);
+                }
+                else if (TryGetDirective(directiveLine, "Style", out string styleDefinition))
+                {
+                    styleDefinitions.Add(new AssStyleDefinition(
+                        GetStyleDefinitionName(styleDefinition),
+                        i + 1,
+                        usesGeneratedStyleFormat && IsGeneratedStyleDefinition(styleDefinition)));
+                }
+                continue;
+            }
+
+            if (!inEvents)
+                continue;
+
             if (TryGetDirective(directiveLine, "Format", out string formatValue))
             {
                 string[] candidate = formatValue.Split(',').Select(field => field.Trim()).ToArray();
@@ -121,6 +151,26 @@ public sealed class AssCaptionCodec : ICaptionDecoder, ICaptionEncoder
                 metadata));
         }
 
+        var regeneratedStyleNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Default",
+        };
+        foreach (CaptionCue cue in cues)
+        {
+            if (cue.Metadata.GetValueOrDefault(CaptionMetadataKeys.AssStyle) is { } style)
+                regeneratedStyleNames.Add(style);
+        }
+        foreach (AssStyleDefinition definition in styleDefinitions)
+        {
+            if (!definition.HasGeneratedValues || !regeneratedStyleNames.Contains(definition.Name))
+            {
+                errors.Add(new CaptionDiagnostic(
+                    CaptionDiagnosticKinds.UnsupportedMarkup,
+                    definition.LineNumber,
+                    "ASS/SSA custom style definitions cannot be represented and were removed."));
+            }
+        }
+
         if (!foundEvents)
         {
             errors.Add(new CaptionDiagnostic(
@@ -179,11 +229,11 @@ public sealed class AssCaptionCodec : ICaptionDecoder, ICaptionEncoder
         builder.Append("WrapStyle: 0\r\n");
         builder.Append("ScaledBorderAndShadow: yes\r\n\r\n");
         builder.Append("[V4+ Styles]\r\n");
-        builder.Append("Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding\r\n");
+        builder.Append("Format: ").Append(GeneratedStyleFormat).Append("\r\n");
         foreach (string style in styles)
         {
             builder.Append("Style: ").Append(style);
-            builder.Append(",Arial,48,&H00FFFFFF,&H000000FF,&H00000000,&H80000000,0,0,0,0,100,100,0,0,1,2,1,2,20,20,20,1\r\n");
+            builder.Append(GeneratedStyleSuffix).Append("\r\n");
         }
 
         builder.Append("\r\n[Events]\r\n");
@@ -268,6 +318,28 @@ public sealed class AssCaptionCodec : ICaptionDecoder, ICaptionEncoder
         }
 
         return builder.ToString();
+    }
+
+    private static bool IsGeneratedStyleDefinition(string value)
+    {
+        int separator = value.IndexOf(',');
+        return separator > 0
+            && value.AsSpan(separator).Equals(GeneratedStyleSuffix, StringComparison.Ordinal);
+    }
+
+    private static bool IsGeneratedStyleFormat(string value)
+    {
+        string[] fields = value.Split(',').Select(field => field.Trim()).ToArray();
+        string[] generatedFields = GeneratedStyleFormat.Split(',')
+            .Select(field => field.Trim())
+            .ToArray();
+        return fields.SequenceEqual(generatedFields, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string GetStyleDefinitionName(string value)
+    {
+        int separator = value.IndexOf(',');
+        return separator < 0 ? string.Empty : value[..separator].Trim();
     }
 
     private static string EncodeText(string value)
@@ -411,4 +483,6 @@ public sealed class AssCaptionCodec : ICaptionDecoder, ICaptionEncoder
     }
 
     private static string? EmptyToNull(string value) => value.Length == 0 ? null : value;
+
+    private sealed record AssStyleDefinition(string Name, int LineNumber, bool HasGeneratedValues);
 }

--- a/src/Beutl.Editor/Services/Captions/CaptionCatalog.cs
+++ b/src/Beutl.Editor/Services/Captions/CaptionCatalog.cs
@@ -1,0 +1,814 @@
+﻿using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
+using Beutl.Api.Services;
+using Beutl.Extensibility;
+
+namespace Beutl.Editor.Services.Captions;
+
+public enum CaptionCatalogContributionKind
+{
+    CodecDescriptor,
+    Decoder,
+    Encoder,
+    TemplateDescriptor,
+    ElementFactory,
+    Placement,
+}
+
+public sealed record CaptionCatalogExtensionFailure(
+    CaptionCatalogContributionKind Kind,
+    string ExtensionName,
+    Exception Exception);
+
+/// <summary>
+/// Provides one reusable, dynamically updated view of the caption codecs and templates available
+/// to the editor. Package-owned implementations remain only in lease-backed registry states.
+/// </summary>
+public sealed class CaptionCatalog : IAsyncDisposable
+{
+    private readonly object _gate = new();
+    private readonly CaptionCodecRegistry _codecs;
+    private readonly CaptionTemplateRegistry _templates;
+    private readonly bool _ownsRegistries;
+    private readonly IExtensionRegistry? _extensionProvider;
+    private readonly CaptionCodecDescriptorRegistration[] _hostCodecDescriptors;
+    private readonly CaptionDecoderRegistration[] _hostCodecDecoders;
+    private readonly CaptionEncoderRegistration[] _hostCodecEncoders;
+    private readonly CaptionTemplateRegistrationSet? _defaultTemplateRegistrations;
+    private readonly Action<CaptionCatalogExtensionFailure>? _reportFailure;
+    private readonly HashSet<CaptionCodecDescriptorExtension> _activeCodecDescriptorExtensions =
+        new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<CaptionDecoderExtension> _activeDecoderExtensions =
+        new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<CaptionEncoderExtension> _activeEncoderExtensions =
+        new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<CaptionTemplateDescriptorExtension> _activeDescriptorExtensions =
+        new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<CaptionElementFactoryExtension> _activeFactoryExtensions =
+        new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<CaptionPlacementPolicyExtension> _activePlacementExtensions =
+        new(ReferenceEqualityComparer.Instance);
+    private CaptionTemplateDescriptorRegistration[] _hostTemplateDescriptors;
+    private CaptionElementFactoryRegistration[] _hostTemplateFactories;
+    private CaptionPlacementPolicyRegistration[] _hostTemplatePlacements;
+    private Task? _disposeTask;
+    private bool _disposed;
+
+    public CaptionCatalog(
+        CaptionCodecRegistry codecs,
+        CaptionTemplateRegistry templates)
+        : this(codecs, templates, ownsRegistries: false)
+    {
+    }
+
+    private CaptionCatalog(
+        CaptionCodecRegistry codecs,
+        CaptionTemplateRegistry templates,
+        bool ownsRegistries)
+    {
+        ArgumentNullException.ThrowIfNull(codecs);
+        ArgumentNullException.ThrowIfNull(templates);
+
+        _codecs = codecs;
+        _templates = templates;
+        _ownsRegistries = ownsRegistries;
+        Codecs = new CaptionCodecProviderView(codecs);
+        Templates = new CaptionTemplateProviderView(templates);
+        Serializer = new CaptionDocumentSerializer(Codecs);
+        _hostCodecDescriptors = [];
+        _hostCodecDecoders = [];
+        _hostCodecEncoders = [];
+        _hostTemplateDescriptors = [];
+        _hostTemplateFactories = [];
+        _hostTemplatePlacements = [];
+    }
+
+    private CaptionCatalog(
+        IExtensionRegistry extensionProvider,
+        CaptionCodecDescriptorRegistration[] hostCodecDescriptors,
+        CaptionDecoderRegistration[] hostCaptionDecoders,
+        CaptionEncoderRegistration[] hostCaptionEncoders,
+        CaptionTemplateRegistrationSet defaultTemplateRegistrations,
+        CaptionTemplateDescriptorRegistration[] hostTemplateDescriptors,
+        CaptionElementFactoryRegistration[] hostTemplateFactories,
+        CaptionPlacementPolicyRegistration[] hostTemplatePlacements,
+        Action<CaptionCatalogExtensionFailure>? reportFailure)
+        : this(new CaptionCodecRegistry(), new CaptionTemplateRegistry(), ownsRegistries: true)
+    {
+        _extensionProvider = extensionProvider;
+        _hostCodecDescriptors = hostCodecDescriptors;
+        _hostCodecDecoders = hostCaptionDecoders;
+        _hostCodecEncoders = hostCaptionEncoders;
+        _defaultTemplateRegistrations = defaultTemplateRegistrations;
+        _hostTemplateDescriptors = hostTemplateDescriptors;
+        _hostTemplateFactories = hostTemplateFactories;
+        _hostTemplatePlacements = hostTemplatePlacements;
+        _reportFailure = reportFailure;
+
+        extensionProvider.SynchronizeMutation(() =>
+        {
+            lock (_gate)
+            {
+                extensionProvider.AllExtensions.CollectionChanged += OnExtensionsChanged;
+                extensionProvider.ExtensionsChanged += OnExtensionsCommitted;
+                try
+                {
+                    RebuildCore();
+                }
+                catch
+                {
+                    extensionProvider.AllExtensions.CollectionChanged -= OnExtensionsChanged;
+                    extensionProvider.ExtensionsChanged -= OnExtensionsCommitted;
+                    throw;
+                }
+            }
+        });
+    }
+
+    public ICaptionCodecProvider Codecs { get; }
+
+    public ICaptionTemplateProvider Templates { get; }
+
+    public CaptionDocumentSerializer Serializer { get; }
+
+    public static CaptionCatalog CreateDefault(string defaultTemplateName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(defaultTemplateName);
+        CaptionTemplateRegistrationSet template =
+            CaptionTemplateDefaults.CreateDefaultText(defaultTemplateName);
+        var templates = new CaptionTemplateRegistry(
+            [template.DescriptorRegistration],
+            [template.ElementFactoryRegistration],
+            [template.PlacementPolicyRegistration]);
+        BuiltInCaptionCodecRegistrations codecs = CreateDefaultCodecRegistrations();
+        return new CaptionCatalog(
+            new CaptionCodecRegistry(codecs.Descriptors, codecs.Decoders, codecs.Encoders),
+            templates,
+            ownsRegistries: true);
+    }
+
+    internal static CaptionCatalog Compose(
+        string defaultTemplateName,
+        IEnumerable<ObjectTemplateItem> objectTemplates,
+        IExtensionRegistry extensionProvider,
+        Action<CaptionCatalogExtensionFailure>? reportFailure = null)
+        => ComposeWithDefaultElementFactory(
+            defaultTemplateName,
+            objectTemplates,
+            extensionProvider,
+            DefaultTextCaptionElementFactory.Instance,
+            reportFailure);
+
+    /// <summary>
+    /// Creates a dynamically composed catalog using a host-supplied factory for its default template.
+    /// </summary>
+    internal static CaptionCatalog ComposeWithDefaultElementFactory(
+        string defaultTemplateName,
+        IEnumerable<ObjectTemplateItem> objectTemplates,
+        IExtensionRegistry extensionProvider,
+        ICaptionElementFactory defaultElementFactory,
+        Action<CaptionCatalogExtensionFailure>? reportFailure = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(defaultTemplateName);
+        ArgumentNullException.ThrowIfNull(objectTemplates);
+        ArgumentNullException.ThrowIfNull(extensionProvider);
+        ArgumentNullException.ThrowIfNull(defaultElementFactory);
+
+        CaptionTemplateRegistrationSet defaultTemplate =
+            CaptionTemplateDefaults.CreateDefaultText(defaultTemplateName, defaultElementFactory);
+        CaptionTemplateRegistrationSet[] objectTemplateRegistrations =
+            CreateObjectTemplateRegistrations(objectTemplates);
+        BuiltInCaptionCodecRegistrations codecs = CreateDefaultCodecRegistrations();
+        CaptionTemplateDescriptorRegistration[] descriptors =
+            [defaultTemplate.DescriptorRegistration, .. objectTemplateRegistrations.Select(item => item.DescriptorRegistration)];
+        CaptionElementFactoryRegistration[] factories =
+            [defaultTemplate.ElementFactoryRegistration, .. objectTemplateRegistrations.Select(item => item.ElementFactoryRegistration)];
+        CaptionPlacementPolicyRegistration[] placements =
+            [defaultTemplate.PlacementPolicyRegistration, .. objectTemplateRegistrations.Select(item => item.PlacementPolicyRegistration)];
+        return new CaptionCatalog(
+            extensionProvider,
+            codecs.Descriptors,
+            codecs.Decoders,
+            codecs.Encoders,
+            defaultTemplate,
+            descriptors,
+            factories,
+            placements,
+            reportFailure);
+    }
+
+    /// <summary>
+    /// Refreshes host-owned object templates while preserving all current extension registrations.
+    /// </summary>
+    public void RefreshObjectTemplates(IEnumerable<ObjectTemplateItem> objectTemplates)
+    {
+        ArgumentNullException.ThrowIfNull(objectTemplates);
+        CaptionTemplateRegistrationSet[] registrations =
+            CreateObjectTemplateRegistrations(objectTemplates);
+        IExtensionRegistry extensionProvider = _extensionProvider
+            ?? throw new InvalidOperationException(
+                "Only a dynamically composed caption catalog can refresh object templates.");
+        extensionProvider.SynchronizeMutation(() =>
+        {
+            lock (_gate)
+            {
+                ObjectDisposedException.ThrowIf(_disposed, this);
+                if (_defaultTemplateRegistrations is null)
+                {
+                    throw new InvalidOperationException(
+                        "Only a dynamically composed caption catalog can refresh object templates.");
+                }
+
+                _hostTemplateDescriptors =
+                    [_defaultTemplateRegistrations.DescriptorRegistration, .. registrations.Select(item => item.DescriptorRegistration)];
+                _hostTemplateFactories =
+                    [_defaultTemplateRegistrations.ElementFactoryRegistration, .. registrations.Select(item => item.ElementFactoryRegistration)];
+                _hostTemplatePlacements =
+                    [_defaultTemplateRegistrations.PlacementPolicyRegistration, .. registrations.Select(item => item.PlacementPolicyRegistration)];
+                RebuildCore();
+            }
+        });
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (_extensionProvider is IExtensionRegistry registry)
+        {
+            ValueTask result = default;
+            registry.SynchronizeMutation(() => result = StartDispose());
+            return result;
+        }
+
+        return StartDispose();
+    }
+
+    private ValueTask StartDispose()
+    {
+        lock (_gate)
+        {
+            return new ValueTask(_disposeTask ??= DisposeCoreAsync());
+        }
+    }
+
+    private Task DisposeCoreAsync()
+    {
+        CaptionCodecDescriptorExtension[] codecDescriptorExtensions;
+        CaptionDecoderExtension[] decoderExtensions;
+        CaptionEncoderExtension[] encoderExtensions;
+        CaptionTemplateDescriptorExtension[] descriptorExtensions;
+        CaptionElementFactoryExtension[] factoryExtensions;
+        CaptionPlacementPolicyExtension[] placementExtensions;
+        ValueTask codecDrain;
+        ValueTask templateDrain;
+        lock (_gate)
+        {
+            if (_disposed)
+                return Task.CompletedTask;
+
+            _disposed = true;
+            if (_extensionProvider is not null)
+            {
+                _extensionProvider.AllExtensions.CollectionChanged -= OnExtensionsChanged;
+                _extensionProvider.ExtensionsChanged -= OnExtensionsCommitted;
+                codecDescriptorExtensions = _activeCodecDescriptorExtensions.ToArray();
+                decoderExtensions = _activeDecoderExtensions.ToArray();
+                encoderExtensions = _activeEncoderExtensions.ToArray();
+                descriptorExtensions = _activeDescriptorExtensions.ToArray();
+                factoryExtensions = _activeFactoryExtensions.ToArray();
+                placementExtensions = _activePlacementExtensions.ToArray();
+                _activeCodecDescriptorExtensions.Clear();
+                _activeDecoderExtensions.Clear();
+                _activeEncoderExtensions.Clear();
+                _activeDescriptorExtensions.Clear();
+                _activeFactoryExtensions.Clear();
+                _activePlacementExtensions.Clear();
+                CaptionRegistryDrain<Extension> retiredCodecs = _codecs.ReplaceOwned(
+                    _hostCodecDescriptors,
+                    _hostCodecDecoders,
+                    _hostCodecEncoders,
+                    new Dictionary<CaptionFormatId, Extension>(),
+                    new Dictionary<CaptionFormatId, Extension>(),
+                    new Dictionary<CaptionFormatId, Extension>());
+                CaptionRegistryDrain<Extension> retiredTemplates = _templates.ReplaceOwned(
+                    _hostTemplateDescriptors,
+                    _hostTemplateFactories,
+                    _hostTemplatePlacements,
+                    new Dictionary<CaptionTemplateId, Extension>(),
+                    new Dictionary<CaptionTemplateId, Extension>(),
+                    new Dictionary<CaptionTemplateId, Extension>());
+                codecDrain = Combine(retiredCodecs.All, _codecs.DisposeAsync());
+                templateDrain = Combine(retiredTemplates.All, _templates.DisposeAsync());
+                foreach (Extension extension in codecDescriptorExtensions
+                             .Cast<Extension>()
+                             .Concat(decoderExtensions)
+                             .Concat(encoderExtensions))
+                {
+                    ExtensionRegistrationLifetimes.Retire(
+                        extension,
+                        () => new ValueTask(retiredCodecs.DrainOwnerAsync(extension)));
+                }
+                foreach (Extension extension in descriptorExtensions
+                             .Cast<Extension>()
+                             .Concat(factoryExtensions)
+                             .Concat(placementExtensions))
+                {
+                    ExtensionRegistrationLifetimes.Retire(
+                        extension,
+                        () => new ValueTask(retiredTemplates.DrainOwnerAsync(extension)));
+                }
+            }
+            else
+            {
+                codecDescriptorExtensions = [];
+                decoderExtensions = [];
+                encoderExtensions = [];
+                descriptorExtensions = [];
+                factoryExtensions = [];
+                placementExtensions = [];
+                codecDrain = _ownsRegistries ? _codecs.DisposeAsync() : ValueTask.CompletedTask;
+                templateDrain = _ownsRegistries ? _templates.DisposeAsync() : ValueTask.CompletedTask;
+            }
+        }
+
+        return Combine(codecDrain, templateDrain).AsTask();
+    }
+
+    private void OnExtensionsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.Action != NotifyCollectionChangedAction.Add)
+            Rebuild();
+    }
+
+    private void OnExtensionsCommitted(object? sender, EventArgs e) => Rebuild();
+
+    private void Rebuild()
+    {
+        lock (_gate)
+        {
+            if (_disposed || _extensionProvider is null)
+                return;
+
+            RebuildCore();
+        }
+    }
+
+    private ValueTask RebuildCore()
+    {
+        IExtensionRegistry extensionProvider = _extensionProvider
+            ?? throw new InvalidOperationException("The caption catalog is not dynamically composed.");
+        CaptionCodecDescriptorExtension[] previousCodecDescriptorExtensions =
+            _activeCodecDescriptorExtensions.ToArray();
+        CaptionDecoderExtension[] previousDecoderExtensions = _activeDecoderExtensions.ToArray();
+        CaptionEncoderExtension[] previousEncoderExtensions = _activeEncoderExtensions.ToArray();
+        CaptionTemplateDescriptorExtension[] previousDescriptorExtensions =
+            _activeDescriptorExtensions.ToArray();
+        CaptionElementFactoryExtension[] previousFactoryExtensions =
+            _activeFactoryExtensions.ToArray();
+        CaptionPlacementPolicyExtension[] previousPlacementExtensions =
+            _activePlacementExtensions.ToArray();
+        List<CaptionCodecDescriptorRegistration> codecDescriptors =
+            [.. _hostCodecDescriptors];
+        List<CaptionDecoderRegistration> captionDecoders = [.. _hostCodecDecoders];
+        List<CaptionEncoderRegistration> captionEncoders = [.. _hostCodecEncoders];
+        var codecDescriptorOwners = new Dictionary<CaptionFormatId, Extension>();
+        var decoderOwners = new Dictionary<CaptionFormatId, Extension>();
+        var encoderOwners = new Dictionary<CaptionFormatId, Extension>();
+
+        CaptionCodecDescriptorExtension[] codecDescriptorExtensions =
+            extensionProvider.GetExtensions<CaptionCodecDescriptorExtension>();
+        List<(CaptionCodecDescriptorExtension Extension,
+            CaptionCodecDescriptorRegistration[] Registrations)> codecDescriptorCandidates =
+            CreateCandidates(
+                codecDescriptorExtensions,
+                extension => extension.Registrations,
+                CaptionCatalogContributionKind.CodecDescriptor,
+                "codec descriptor");
+        ComposeSlotExtensions(
+            codecDescriptorCandidates,
+            codecDescriptors,
+            codecDescriptorOwners,
+            static registration => registration.Descriptor.Format,
+            static registration => registration.Mode == CaptionCodecRegistrationMode.Add,
+            CaptionCatalogContributionKind.CodecDescriptor,
+            registrations => new CaptionCodecRegistry(registrations, [], []));
+
+        CaptionDecoderExtension[] decoderExtensions =
+            extensionProvider.GetExtensions<CaptionDecoderExtension>();
+        List<(CaptionDecoderExtension Extension,
+            CaptionDecoderRegistration[] Registrations)> decoderCandidates =
+            CreateCandidates(
+                decoderExtensions,
+                extension => extension.Registrations,
+                CaptionCatalogContributionKind.Decoder,
+                "caption decoder");
+        ComposeSlotExtensions(
+            decoderCandidates,
+            captionDecoders,
+            decoderOwners,
+            static registration => registration.Format,
+            static registration => registration.Mode == CaptionCodecRegistrationMode.Add,
+            CaptionCatalogContributionKind.Decoder,
+            registrations => new CaptionCodecRegistry([], registrations, []));
+
+        CaptionEncoderExtension[] encoderExtensions =
+            extensionProvider.GetExtensions<CaptionEncoderExtension>();
+        List<(CaptionEncoderExtension Extension,
+            CaptionEncoderRegistration[] Registrations)> encoderCandidates =
+            CreateCandidates(
+                encoderExtensions,
+                extension => extension.Registrations,
+                CaptionCatalogContributionKind.Encoder,
+                "caption encoder");
+        ComposeSlotExtensions(
+            encoderCandidates,
+            captionEncoders,
+            encoderOwners,
+            static registration => registration.Format,
+            static registration => registration.Mode == CaptionCodecRegistrationMode.Add,
+            CaptionCatalogContributionKind.Encoder,
+            registrations => new CaptionCodecRegistry([], [], registrations));
+
+        List<CaptionTemplateDescriptorRegistration> descriptorRegistrations =
+            [.. _hostTemplateDescriptors];
+        List<CaptionElementFactoryRegistration> factoryRegistrations =
+            [.. _hostTemplateFactories];
+        List<CaptionPlacementPolicyRegistration> placementRegistrations =
+            [.. _hostTemplatePlacements];
+        var descriptorOwners = new Dictionary<CaptionTemplateId, Extension>();
+        var factoryOwners = new Dictionary<CaptionTemplateId, Extension>();
+        var placementOwners = new Dictionary<CaptionTemplateId, Extension>();
+
+        CaptionTemplateDescriptorExtension[] descriptorExtensions =
+            extensionProvider.GetExtensions<CaptionTemplateDescriptorExtension>();
+        List<(CaptionTemplateDescriptorExtension Extension,
+            CaptionTemplateDescriptorRegistration[] Registrations)> descriptorCandidates =
+            CreateCandidates(
+                descriptorExtensions,
+                extension => extension.Registrations,
+                CaptionCatalogContributionKind.TemplateDescriptor,
+                "descriptor");
+        ComposeSlotExtensions(
+            descriptorCandidates,
+            descriptorRegistrations,
+            descriptorOwners,
+            static registration => registration.Descriptor.Id,
+            static registration => registration.Mode == CaptionTemplateRegistrationMode.Add,
+            CaptionCatalogContributionKind.TemplateDescriptor,
+            registrations => new CaptionTemplateRegistry(registrations, [], []));
+
+        CaptionElementFactoryExtension[] factoryExtensions =
+            extensionProvider.GetExtensions<CaptionElementFactoryExtension>();
+        List<(CaptionElementFactoryExtension Extension,
+            CaptionElementFactoryRegistration[] Registrations)> factoryCandidates =
+            CreateCandidates(
+                factoryExtensions,
+                extension => extension.Registrations,
+                CaptionCatalogContributionKind.ElementFactory,
+                "element-factory");
+        ComposeSlotExtensions(
+            factoryCandidates,
+            factoryRegistrations,
+            factoryOwners,
+            static registration => registration.TemplateId,
+            static registration => registration.Mode == CaptionTemplateRegistrationMode.Add,
+            CaptionCatalogContributionKind.ElementFactory,
+            registrations => new CaptionTemplateRegistry([], registrations, []));
+
+        CaptionPlacementPolicyExtension[] placementExtensions =
+            extensionProvider.GetExtensions<CaptionPlacementPolicyExtension>();
+        List<(CaptionPlacementPolicyExtension Extension,
+            CaptionPlacementPolicyRegistration[] Registrations)> placementCandidates =
+            CreateCandidates(
+                placementExtensions,
+                extension => extension.Registrations,
+                CaptionCatalogContributionKind.Placement,
+                "placement");
+        ComposeSlotExtensions(
+            placementCandidates,
+            placementRegistrations,
+            placementOwners,
+            static registration => registration.TemplateId,
+            static registration => registration.Mode == CaptionTemplateRegistrationMode.Add,
+            CaptionCatalogContributionKind.Placement,
+            registrations => new CaptionTemplateRegistry([], [], registrations));
+
+        _activeCodecDescriptorExtensions.Clear();
+        _activeCodecDescriptorExtensions.UnionWith(codecDescriptorExtensions);
+        _activeDecoderExtensions.Clear();
+        _activeDecoderExtensions.UnionWith(decoderExtensions);
+        _activeEncoderExtensions.Clear();
+        _activeEncoderExtensions.UnionWith(encoderExtensions);
+        _activeDescriptorExtensions.Clear();
+        _activeDescriptorExtensions.UnionWith(descriptorExtensions);
+        _activeFactoryExtensions.Clear();
+        _activeFactoryExtensions.UnionWith(factoryExtensions);
+        _activePlacementExtensions.Clear();
+        _activePlacementExtensions.UnionWith(placementExtensions);
+
+        // Each replacement synchronously publishes a state that excludes removed packages. The
+        // returned tasks drain calls that still hold the retired package-owned state.
+        CaptionRegistryDrain<Extension> retiredCodecs =
+            _codecs.ReplaceOwned(
+                codecDescriptors,
+                captionDecoders,
+                captionEncoders,
+                codecDescriptorOwners,
+                decoderOwners,
+                encoderOwners);
+        CaptionRegistryDrain<Extension> retiredTemplates =
+            _templates.ReplaceOwned(
+                descriptorRegistrations,
+                factoryRegistrations,
+                placementRegistrations,
+                descriptorOwners,
+                factoryOwners,
+                placementOwners);
+        ValueTask codecDrain = retiredCodecs.All;
+        ValueTask templateDrain = retiredTemplates.All;
+        // Track every replaced category state against the extensions that could be retained by
+        // that state. This also covers an older state retired by a host-template refresh long
+        // before its package is removed.
+        foreach (Extension extension in previousCodecDescriptorExtensions
+                     .Cast<Extension>()
+                     .Concat(previousDecoderExtensions)
+                     .Concat(previousEncoderExtensions))
+        {
+            ExtensionRegistrationLifetimes.Retire(
+                extension,
+                () => new ValueTask(retiredCodecs.DrainOwnerAsync(extension)));
+        }
+
+        foreach (Extension extension in previousDescriptorExtensions
+                     .Cast<Extension>()
+                     .Concat(previousFactoryExtensions)
+                     .Concat(previousPlacementExtensions))
+        {
+            ExtensionRegistrationLifetimes.Retire(
+                extension,
+                () => new ValueTask(retiredTemplates.DrainOwnerAsync(extension)));
+        }
+
+        return Combine(codecDrain, templateDrain);
+    }
+
+    private static ValueTask Combine(ValueTask first, ValueTask second)
+    {
+        if (first.IsCompletedSuccessfully && second.IsCompletedSuccessfully)
+            return ValueTask.CompletedTask;
+
+        return new ValueTask(Task.WhenAll(first.AsTask(), second.AsTask()));
+    }
+
+    private sealed class CaptionCodecProviderView(CaptionCodecRegistry registry) : ICaptionCodecProvider
+    {
+        public Beutl.Collections.ICoreReadOnlyList<CaptionCodecInfo> Codecs => registry.Codecs;
+
+        public bool TryGet(
+            CaptionFormatId format,
+            [NotNullWhen(true)] out CaptionCodecInfo? codec)
+            => registry.TryGet(format, out codec);
+
+        public CaptionCodecInfo GetRequired(CaptionFormatId format) => registry.GetRequired(format);
+
+        public bool TryGetByFileExtension(
+            string extension,
+            [NotNullWhen(true)] out CaptionCodecInfo? codec)
+            => registry.TryGetByFileExtension(extension, out codec);
+
+        public bool TryGetByFileName(
+            string fileName,
+            [NotNullWhen(true)] out CaptionCodecInfo? codec)
+            => registry.TryGetByFileName(fileName, out codec);
+
+        public CaptionImportResult Decode(CaptionFormatId format, string content)
+            => registry.Decode(format, content);
+
+        public string Encode(CaptionFormatId format, CaptionDocument document)
+            => registry.Encode(format, document);
+    }
+
+    private sealed class CaptionTemplateProviderView(CaptionTemplateRegistry registry) : ICaptionTemplateProvider
+    {
+        public Beutl.Collections.ICoreReadOnlyList<CaptionTemplateDescriptor> Templates
+            => registry.Templates;
+
+        public bool TryGet(
+            CaptionTemplateId id,
+            [NotNullWhen(true)] out CaptionTemplateDescriptor? template)
+            => registry.TryGet(id, out template);
+
+        public CaptionTemplateDescriptor GetRequired(CaptionTemplateId id) => registry.GetRequired(id);
+
+        public ICaptionTemplateLease Acquire(CaptionTemplateId id) => registry.Acquire(id);
+    }
+
+    private List<(TExtension Extension, TRegistration[] Registrations)> CreateCandidates<
+        TExtension,
+        TRegistration>(
+        IEnumerable<TExtension> extensions,
+        Func<TExtension, IReadOnlyCollection<TRegistration>?> getRegistrations,
+        CaptionCatalogContributionKind kind,
+        string capabilityName)
+        where TExtension : Extension
+        where TRegistration : class
+    {
+        var result = new List<(TExtension Extension, TRegistration[] Registrations)>();
+        foreach (TExtension extension in extensions)
+        {
+            try
+            {
+                TRegistration[] registrations = ValidateRegistrations(
+                    getRegistrations(extension),
+                    $"A caption {capabilityName} extension returned a null registration collection.",
+                    $"A caption {capabilityName} extension returned a null registration.");
+                result.Add((extension, registrations));
+            }
+            catch (Exception ex)
+            {
+                ReportFailure(kind, extension, ex);
+            }
+        }
+
+        return result;
+    }
+
+    private void ComposeSlotExtensions<TExtension, TRegistration, TId>(
+        List<(TExtension Extension, TRegistration[] Registrations)> candidates,
+        List<TRegistration> accepted,
+        Dictionary<TId, Extension> owners,
+        Func<TRegistration, TId> getId,
+        Func<TRegistration, bool> isAdd,
+        CaptionCatalogContributionKind kind,
+        Func<IEnumerable<TRegistration>, object> validate)
+        where TExtension : Extension
+        where TRegistration : class
+        where TId : notnull
+    {
+        var failures = new Dictionary<TExtension, Exception>(ReferenceEqualityComparer.Instance);
+        TRegistration[] hostRegistrations = accepted.ToArray();
+        while (true)
+        {
+            var working = new List<TRegistration>(hostRegistrations);
+            var newFailures = new Dictionary<TExtension, (Exception Exception, int Phase)>(
+                ReferenceEqualityComparer.Instance);
+            for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++)
+            {
+                foreach ((TExtension extension, TRegistration[] registrations) in candidates)
+                {
+                    if (failures.ContainsKey(extension) || newFailures.ContainsKey(extension))
+                        continue;
+                    TRegistration[] phase = registrations
+                        .Where(registration => phaseIndex == 0
+                            ? isAdd(registration)
+                            : !isAdd(registration))
+                        .ToArray();
+                    if (phase.Length == 0)
+                        continue;
+                    try
+                    {
+                        _ = validate(working.Concat(phase));
+                        working.AddRange(phase);
+                    }
+                    catch (Exception ex)
+                    {
+                        newFailures.Add(extension, (ex, phaseIndex));
+                    }
+                }
+            }
+
+            if (newFailures.Count > 0)
+            {
+                int latestFailedPhase = newFailures.Values.Max(failure => failure.Phase);
+                KeyValuePair<TExtension, (Exception Exception, int Phase)> rejected =
+                    newFailures.First(failure => failure.Value.Phase == latestFailedPhase);
+                failures.TryAdd(rejected.Key, rejected.Value.Exception);
+                continue;
+            }
+
+            accepted.Clear();
+            accepted.AddRange(working);
+            owners.Clear();
+            for (int phaseIndex = 0; phaseIndex < 2; phaseIndex++)
+            {
+                foreach ((TExtension extension, TRegistration[] registrations)
+                         in candidates.Where(candidate => !failures.ContainsKey(candidate.Extension)))
+                {
+                    foreach (TRegistration registration in registrations.Where(registration =>
+                                 phaseIndex == 0
+                                     ? isAdd(registration)
+                                     : !isAdd(registration)))
+                    {
+                        owners[getId(registration)] = extension;
+                    }
+                }
+            }
+            break;
+        }
+
+        foreach ((TExtension extension, Exception failure) in failures)
+        {
+            ReportFailure(kind, extension, failure);
+        }
+    }
+
+    private void ReportFailure(
+        CaptionCatalogContributionKind kind,
+        Extension extension,
+        Exception exception)
+    {
+        if (_reportFailure is null)
+            return;
+
+        string extensionName;
+        try
+        {
+            extensionName = extension.Name;
+        }
+        catch
+        {
+            extensionName = extension.GetType().FullName ?? "Unknown extension";
+        }
+
+        try
+        {
+            _reportFailure(new CaptionCatalogExtensionFailure(kind, extensionName, exception));
+        }
+        catch
+        {
+            // Diagnostics must never interrupt registry removal before Extension.Unload().
+        }
+    }
+
+    private static TRegistration[] ValidateRegistrations<TRegistration>(
+        IReadOnlyCollection<TRegistration>? registrations,
+        string nullCollectionMessage,
+        string nullRegistrationMessage)
+        where TRegistration : class
+    {
+        if (registrations is null)
+            throw new InvalidOperationException(nullCollectionMessage);
+
+        TRegistration[] result = registrations.ToArray();
+        if (result.Any(registration => registration is null))
+            throw new InvalidOperationException(nullRegistrationMessage);
+
+        return result;
+    }
+
+    private static BuiltInCaptionCodecRegistrations CreateDefaultCodecRegistrations()
+    {
+        var srt = new SrtCaptionCodec();
+        var webVtt = new WebVttCaptionCodec();
+        var ass = new AssCaptionCodec();
+        return new BuiltInCaptionCodecRegistrations(
+            Descriptors:
+            [
+                new CaptionCodecDescriptorRegistration(
+                    new CaptionCodecDescriptor(CaptionFormats.Srt, [".srt"])),
+                new CaptionCodecDescriptorRegistration(
+                    new CaptionCodecDescriptor(CaptionFormats.WebVtt, [".vtt"])),
+                new CaptionCodecDescriptorRegistration(
+                    new CaptionCodecDescriptor(CaptionFormats.Ass, [".ass", ".ssa"])),
+            ],
+            Decoders:
+            [
+                new CaptionDecoderRegistration(CaptionFormats.Srt, srt),
+                new CaptionDecoderRegistration(CaptionFormats.WebVtt, webVtt),
+                new CaptionDecoderRegistration(CaptionFormats.Ass, ass),
+            ],
+            Encoders:
+            [
+                new CaptionEncoderRegistration(CaptionFormats.Srt, srt),
+                new CaptionEncoderRegistration(CaptionFormats.WebVtt, webVtt),
+                new CaptionEncoderRegistration(CaptionFormats.Ass, ass),
+            ]);
+    }
+
+    private sealed record BuiltInCaptionCodecRegistrations(
+        CaptionCodecDescriptorRegistration[] Descriptors,
+        CaptionDecoderRegistration[] Decoders,
+        CaptionEncoderRegistration[] Encoders);
+
+    private static CaptionTemplateRegistrationSet[] CreateObjectTemplateRegistrations(
+        IEnumerable<ObjectTemplateItem> objectTemplates)
+    {
+        return objectTemplates
+            .Select(TextBlockCaptionTemplateAdapter.TryCreate)
+            .OfType<CaptionTemplateRegistrationSet>()
+            .OrderBy(item => item.DescriptorRegistration.Descriptor.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(item => item.DescriptorRegistration.Descriptor.Id.Value, StringComparer.OrdinalIgnoreCase)
+            .Select((item, index) =>
+            {
+                CaptionTemplateDescriptor descriptor = item.DescriptorRegistration.Descriptor;
+                return new CaptionTemplateRegistrationSet(
+                    new CaptionTemplateDescriptorRegistration(new CaptionTemplateDescriptor(
+                        descriptor.Id,
+                        descriptor.ProviderId,
+                        descriptor.Name,
+                        index)),
+                    item.ElementFactoryRegistration,
+                    item.PlacementPolicyRegistration);
+            })
+            .ToArray();
+    }
+}

--- a/src/Beutl.Editor/Services/Captions/CaptionCodecCapabilities.cs
+++ b/src/Beutl.Editor/Services/Captions/CaptionCodecCapabilities.cs
@@ -1,0 +1,118 @@
+﻿namespace Beutl.Editor.Services.Captions;
+
+public sealed class CaptionCodecDescriptor
+{
+    public CaptionCodecDescriptor(
+        CaptionFormatId format,
+        IEnumerable<string> fileExtensions,
+        int order = 0)
+    {
+        if (format.Value.Length == 0)
+            throw new ArgumentException("A caption format identifier is required.", nameof(format));
+        ArgumentNullException.ThrowIfNull(fileExtensions);
+        string[] extensions = fileExtensions.ToArray();
+        if (extensions.Length == 0 || extensions.Any(string.IsNullOrWhiteSpace))
+        {
+            throw new ArgumentException(
+                "A caption descriptor requires at least one non-empty file extension.",
+                nameof(fileExtensions));
+        }
+
+        Format = format;
+        FileExtensions = Array.AsReadOnly(extensions);
+        Order = order;
+    }
+
+    public CaptionFormatId Format { get; }
+
+    public IReadOnlyCollection<string> FileExtensions { get; }
+
+    /// <summary>
+    /// Determines presentation order. Formats with the same order are sorted by their stable
+    /// format identifier.
+    /// </summary>
+    public int Order { get; }
+}
+
+public interface ICaptionDecoder
+{
+    CaptionImportResult Decode(string content);
+}
+
+public interface ICaptionEncoder
+{
+    string Encode(CaptionDocument document);
+}
+
+/// <summary>Controls whether one caption capability adds or replaces its own slot.</summary>
+public enum CaptionCodecRegistrationMode
+{
+    Add,
+    Replace,
+}
+
+/// <summary>Registers metadata and file-extension lookup for one caption format.</summary>
+public sealed class CaptionCodecDescriptorRegistration
+{
+    public CaptionCodecDescriptorRegistration(
+        CaptionCodecDescriptor descriptor,
+        CaptionCodecRegistrationMode mode = CaptionCodecRegistrationMode.Add)
+    {
+        Descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
+        if (!Enum.IsDefined(mode))
+            throw new ArgumentOutOfRangeException(nameof(mode));
+        Mode = mode;
+    }
+
+    public CaptionCodecDescriptor Descriptor { get; }
+
+    public CaptionCodecRegistrationMode Mode { get; }
+}
+
+/// <summary>Registers decoding independently from metadata and encoding.</summary>
+public sealed class CaptionDecoderRegistration
+{
+    public CaptionDecoderRegistration(
+        CaptionFormatId format,
+        ICaptionDecoder decoder,
+        CaptionCodecRegistrationMode mode = CaptionCodecRegistrationMode.Add)
+    {
+        if (format.Value.Length == 0)
+            throw new ArgumentException("A caption format identifier is required.", nameof(format));
+        Format = format;
+        Decoder = decoder ?? throw new ArgumentNullException(nameof(decoder));
+        if (!Enum.IsDefined(mode))
+            throw new ArgumentOutOfRangeException(nameof(mode));
+        Mode = mode;
+    }
+
+    public CaptionFormatId Format { get; }
+
+    public ICaptionDecoder Decoder { get; }
+
+    public CaptionCodecRegistrationMode Mode { get; }
+}
+
+/// <summary>Registers encoding independently from metadata and decoding.</summary>
+public sealed class CaptionEncoderRegistration
+{
+    public CaptionEncoderRegistration(
+        CaptionFormatId format,
+        ICaptionEncoder encoder,
+        CaptionCodecRegistrationMode mode = CaptionCodecRegistrationMode.Add)
+    {
+        if (format.Value.Length == 0)
+            throw new ArgumentException("A caption format identifier is required.", nameof(format));
+        Format = format;
+        Encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+        if (!Enum.IsDefined(mode))
+            throw new ArgumentOutOfRangeException(nameof(mode));
+        Mode = mode;
+    }
+
+    public CaptionFormatId Format { get; }
+
+    public ICaptionEncoder Encoder { get; }
+
+    public CaptionCodecRegistrationMode Mode { get; }
+}

--- a/src/Beutl.Editor/Services/Captions/CaptionCodecExtensions.cs
+++ b/src/Beutl.Editor/Services/Captions/CaptionCodecExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Beutl.Api.Services;
+using Beutl.Extensibility;
+
+namespace Beutl.Editor.Services.Captions;
+
+/// <summary>Contributes caption format metadata independently from executable codecs.</summary>
+public abstract class CaptionCodecDescriptorExtension : Extension, ILiveUnloadExtension
+{
+    public abstract IReadOnlyCollection<CaptionCodecDescriptorRegistration> Registrations { get; }
+}
+
+/// <summary>Contributes caption decoders whose active calls drain before live unload.</summary>
+public abstract class CaptionDecoderExtension : Extension, ILiveUnloadExtension
+{
+    public abstract IReadOnlyCollection<CaptionDecoderRegistration> Registrations { get; }
+}
+
+/// <summary>Contributes caption encoders whose active calls drain before live unload.</summary>
+public abstract class CaptionEncoderExtension : Extension, ILiveUnloadExtension
+{
+    public abstract IReadOnlyCollection<CaptionEncoderRegistration> Registrations { get; }
+}

--- a/src/Beutl.Editor/Services/Captions/CaptionCodecRegistry.cs
+++ b/src/Beutl.Editor/Services/Captions/CaptionCodecRegistry.cs
@@ -1,0 +1,789 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Beutl.Collections;
+using Beutl.Extensibility;
+
+namespace Beutl.Editor.Services.Captions;
+
+/// <summary>
+/// Describes one caption format whose descriptor is currently registered. Decoder-only and
+/// encoder-only formats remain available by exact identifier but do not appear in this metadata
+/// view or file-extension lookup.
+/// </summary>
+public sealed class CaptionCodecInfo
+{
+    internal CaptionCodecInfo(
+        CaptionCodecDescriptor descriptor,
+        bool canDecode,
+        bool canEncode)
+        : this(
+            descriptor.Format,
+            descriptor.FileExtensions,
+            canDecode,
+            canEncode,
+            descriptor.Order)
+    {
+    }
+
+    public CaptionCodecInfo(
+        CaptionFormatId format,
+        IEnumerable<string> fileExtensions,
+        bool canDecode,
+        bool canEncode,
+        int order = 0)
+    {
+        if (format.Value.Length == 0)
+            throw new ArgumentException("A caption format identifier is required.", nameof(format));
+        ArgumentNullException.ThrowIfNull(fileExtensions);
+        string[] normalizedExtensions = fileExtensions.Select(NormalizeExtension).ToArray();
+        if (normalizedExtensions.Distinct(StringComparer.OrdinalIgnoreCase).Count()
+            != normalizedExtensions.Length)
+        {
+            throw new ArgumentException(
+                "A caption codec cannot describe the same file extension more than once.",
+                nameof(fileExtensions));
+        }
+
+        Format = format;
+        FileExtensions = Array.AsReadOnly(normalizedExtensions);
+        CanDecode = canDecode;
+        CanEncode = canEncode;
+        Order = order;
+    }
+
+    public CaptionFormatId Format { get; }
+
+    public IReadOnlyList<string> FileExtensions { get; }
+
+    public bool CanDecode { get; }
+
+    public bool CanEncode { get; }
+
+    public int Order { get; }
+
+    private static string NormalizeExtension(string extension)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(extension);
+        string normalized = extension.Trim();
+        return normalized[0] == '.' ? normalized : '.' + normalized;
+    }
+}
+
+/// <summary>Owns one descriptor registration.</summary>
+public interface ICaptionCodecDescriptorRegistration : IAsyncDisposable
+{
+}
+
+/// <summary>Owns one decoder registration and drains its active decode calls on disposal.</summary>
+public interface ICaptionDecoderRegistration : IAsyncDisposable
+{
+}
+
+/// <summary>Owns one encoder registration and drains its active encode calls on disposal.</summary>
+public interface ICaptionEncoderRegistration : IAsyncDisposable
+{
+}
+
+/// <summary>
+/// Resolves caption capabilities by exact format identifier. Only formats with registered
+/// descriptors appear in <see cref="Codecs"/> and file-extension lookup.
+/// </summary>
+public interface ICaptionCodecProvider
+{
+    ICoreReadOnlyList<CaptionCodecInfo> Codecs { get; }
+
+    bool TryGet(
+        CaptionFormatId format,
+        [NotNullWhen(true)] out CaptionCodecInfo? codec);
+
+    CaptionCodecInfo GetRequired(CaptionFormatId format);
+
+    bool TryGetByFileExtension(
+        string extension,
+        [NotNullWhen(true)] out CaptionCodecInfo? codec);
+
+    bool TryGetByFileName(
+        string fileName,
+        [NotNullWhen(true)] out CaptionCodecInfo? codec);
+
+    CaptionImportResult Decode(CaptionFormatId format, string content);
+
+    string Encode(CaptionFormatId format, CaptionDocument document);
+}
+
+/// <summary>Composes descriptor, decoder, and encoder slots independently by format.</summary>
+public sealed class CaptionCodecRegistry : ICaptionCodecProvider, IAsyncDisposable
+{
+    private readonly object _mutationGate = new();
+    private readonly object _stateGate = new();
+    private readonly CoreList<CaptionCodecInfo> _codecs = [];
+    private readonly List<DescriptorEntry> _descriptorEntries = [];
+    private readonly List<DecoderEntry> _decoderEntries = [];
+    private readonly List<EncoderEntry> _encoderEntries = [];
+    private readonly HashSet<State> _retiredStates = [];
+    private State _state = State.Create([], [], []);
+    private Task? _disposeTask;
+    private bool _disposed;
+
+    public CaptionCodecRegistry()
+    {
+    }
+
+    public CaptionCodecRegistry(
+        IEnumerable<CaptionCodecDescriptorRegistration> descriptors,
+        IEnumerable<CaptionDecoderRegistration> decoders,
+        IEnumerable<CaptionEncoderRegistration> encoders)
+    {
+        ArgumentNullException.ThrowIfNull(descriptors);
+        ArgumentNullException.ThrowIfNull(decoders);
+        ArgumentNullException.ThrowIfNull(encoders);
+        _descriptorEntries.AddRange(descriptors.Select(registration =>
+            new DescriptorEntry(registration)));
+        _decoderEntries.AddRange(decoders.Select(registration => new DecoderEntry(registration)));
+        _encoderEntries.AddRange(encoders.Select(registration => new EncoderEntry(registration)));
+        _state = State.Create(
+            _descriptorEntries.Select(entry => entry.Registration),
+            _decoderEntries.Select(entry => entry.Registration),
+            _encoderEntries.Select(entry => entry.Registration));
+        _codecs.Replace(_state.Codecs);
+    }
+
+    public ICoreReadOnlyList<CaptionCodecInfo> Codecs => _codecs;
+
+    public ICaptionCodecDescriptorRegistration Register(
+        CaptionCodecDescriptorRegistration registration)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+        lock (_mutationGate)
+        {
+            ThrowIfDisposed();
+            ValidateRegistrationMode(
+                registration.Descriptor.Format,
+                registration.Mode,
+                _descriptorEntries.Any(entry =>
+                    entry.Registration.Descriptor.Format == registration.Descriptor.Format),
+                "descriptor");
+            var entry = new DescriptorEntry(registration);
+            _descriptorEntries.Add(entry);
+            try
+            {
+                SwapState(CreateDirectState());
+                return new DescriptorHandle(this, entry);
+            }
+            catch
+            {
+                _descriptorEntries.Remove(entry);
+                throw;
+            }
+        }
+    }
+
+    public ICaptionDecoderRegistration Register(CaptionDecoderRegistration registration)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+        lock (_mutationGate)
+        {
+            ThrowIfDisposed();
+            ValidateRegistrationMode(
+                registration.Format,
+                registration.Mode,
+                _decoderEntries.Any(entry => entry.Registration.Format == registration.Format),
+                "decoder");
+            var entry = new DecoderEntry(registration);
+            _decoderEntries.Add(entry);
+            try
+            {
+                SwapState(CreateDirectState());
+                return new DecoderHandle(this, entry);
+            }
+            catch
+            {
+                _decoderEntries.Remove(entry);
+                throw;
+            }
+        }
+    }
+
+    public ICaptionEncoderRegistration Register(CaptionEncoderRegistration registration)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+        lock (_mutationGate)
+        {
+            ThrowIfDisposed();
+            ValidateRegistrationMode(
+                registration.Format,
+                registration.Mode,
+                _encoderEntries.Any(entry => entry.Registration.Format == registration.Format),
+                "encoder");
+            var entry = new EncoderEntry(registration);
+            _encoderEntries.Add(entry);
+            try
+            {
+                SwapState(CreateDirectState());
+                return new EncoderHandle(this, entry);
+            }
+            catch
+            {
+                _encoderEntries.Remove(entry);
+                throw;
+            }
+        }
+    }
+
+    internal CaptionRegistryDrain<Extension> ReplaceOwned(
+        IEnumerable<CaptionCodecDescriptorRegistration> descriptors,
+        IEnumerable<CaptionDecoderRegistration> decoders,
+        IEnumerable<CaptionEncoderRegistration> encoders,
+        IReadOnlyDictionary<CaptionFormatId, Extension> descriptorOwners,
+        IReadOnlyDictionary<CaptionFormatId, Extension> decoderOwners,
+        IReadOnlyDictionary<CaptionFormatId, Extension> encoderOwners)
+    {
+        lock (_mutationGate)
+        {
+            ThrowIfDisposed();
+            CaptionRegistryDrain<object> retired = SwapState(State.Create(
+                descriptors,
+                decoders,
+                encoders,
+                ToObjectOwners(descriptorOwners),
+                ToObjectOwners(decoderOwners),
+                ToObjectOwners(encoderOwners)));
+            return new CaptionRegistryDrain<Extension>(
+                retired.All.AsTask(),
+                owner => retired.DrainOwnerAsync(owner));
+        }
+    }
+
+    public bool TryGet(
+        CaptionFormatId format,
+        [NotNullWhen(true)] out CaptionCodecInfo? codec)
+    {
+        lock (_stateGate)
+            return _state.CodecsByFormat.TryGetValue(format, out codec);
+    }
+
+    public CaptionCodecInfo GetRequired(CaptionFormatId format)
+    {
+        if (TryGet(format, out CaptionCodecInfo? codec))
+            return codec;
+        throw new KeyNotFoundException(
+            $"No caption codec descriptor is registered for format '{format}'.");
+    }
+
+    public bool TryGetByFileExtension(
+        string extension,
+        [NotNullWhen(true)] out CaptionCodecInfo? codec)
+    {
+        string normalized = NormalizeExtension(extension);
+        lock (_stateGate)
+        {
+            if (_state.FormatsByExtension.TryGetValue(normalized, out CaptionFormatId format))
+                return _state.CodecsByFormat.TryGetValue(format, out codec);
+        }
+
+        codec = null;
+        return false;
+    }
+
+    public bool TryGetByFileName(
+        string fileName,
+        [NotNullWhen(true)] out CaptionCodecInfo? codec)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        lock (_stateGate)
+        {
+            KeyValuePair<string, CaptionFormatId>? bestMatch = null;
+            foreach (KeyValuePair<string, CaptionFormatId> candidate in _state.FormatsByExtension)
+            {
+                if (fileName.EndsWith(candidate.Key, StringComparison.OrdinalIgnoreCase)
+                    && (bestMatch is null || candidate.Key.Length > bestMatch.Value.Key.Length))
+                {
+                    bestMatch = candidate;
+                }
+            }
+
+            if (bestMatch is { } match)
+                return _state.CodecsByFormat.TryGetValue(match.Value, out codec);
+        }
+
+        codec = null;
+        return false;
+    }
+
+    public CaptionImportResult Decode(CaptionFormatId format, string content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        using CapabilityLease<ICaptionDecoder> lease = AcquireDecoder(format);
+        return lease.Capability.Decode(content)
+               ?? throw new InvalidOperationException(
+                   $"Caption decoder '{format}' returned a null import result.");
+    }
+
+    public string Encode(CaptionFormatId format, CaptionDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        using CapabilityLease<ICaptionEncoder> lease = AcquireEncoder(format);
+        return lease.Capability.Encode(document)
+               ?? throw new InvalidOperationException(
+                   $"Caption encoder '{format}' returned null export content.");
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        lock (_mutationGate)
+            return new ValueTask(_disposeTask ??= DisposeCoreAsync());
+    }
+
+    private CapabilityLease<ICaptionDecoder> AcquireDecoder(CaptionFormatId format)
+    {
+        lock (_stateGate)
+        {
+            State state = _state;
+            if (!state.Decoders.TryGetValue(format, out ICaptionDecoder? decoder))
+            {
+                throw new NotSupportedException(
+                    $"Caption format '{format}' does not support decoding.");
+            }
+
+            return new CapabilityLease<ICaptionDecoder>(
+                decoder,
+                state.AcquireLease(state.GetDecoderOwners(format)));
+        }
+    }
+
+    private CapabilityLease<ICaptionEncoder> AcquireEncoder(CaptionFormatId format)
+    {
+        lock (_stateGate)
+        {
+            State state = _state;
+            if (!state.Encoders.TryGetValue(format, out ICaptionEncoder? encoder))
+            {
+                throw new NotSupportedException(
+                    $"Caption format '{format}' does not support encoding.");
+            }
+
+            return new CapabilityLease<ICaptionEncoder>(
+                encoder,
+                state.AcquireLease(state.GetEncoderOwners(format)));
+        }
+    }
+
+    private Task DisposeCoreAsync()
+    {
+        if (_disposed)
+            return Task.CompletedTask;
+        _disposed = true;
+        _descriptorEntries.Clear();
+        _decoderEntries.Clear();
+        _encoderEntries.Clear();
+        CaptionRegistryDrain<object> retired = SwapState(State.Create([], [], []));
+        return Task.WhenAll(
+            _retiredStates.Select(state => state.RetireAsync())
+                .Append(retired.All.AsTask())
+                .Distinct());
+    }
+
+    private State CreateDirectState()
+    {
+        DescriptorEntry[] descriptors = _descriptorEntries
+            .GroupBy(entry => entry.Registration.Descriptor.Format)
+            .Select(group => group.Last())
+            .ToArray();
+        DecoderEntry[] decoders = _decoderEntries
+            .GroupBy(entry => entry.Registration.Format)
+            .Select(group => group.Last())
+            .ToArray();
+        EncoderEntry[] encoders = _encoderEntries
+            .GroupBy(entry => entry.Registration.Format)
+            .Select(group => group.Last())
+            .ToArray();
+        return State.Create(
+            descriptors.Select(entry => new CaptionCodecDescriptorRegistration(
+                entry.Registration.Descriptor)),
+            decoders.Select(entry => new CaptionDecoderRegistration(
+                entry.Registration.Format,
+                entry.Registration.Decoder)),
+            encoders.Select(entry => new CaptionEncoderRegistration(
+                entry.Registration.Format,
+                entry.Registration.Encoder)),
+            descriptors.ToDictionary(
+                entry => entry.Registration.Descriptor.Format,
+                entry => (object)entry),
+            decoders.ToDictionary(
+                entry => entry.Registration.Format,
+                entry => (object)entry),
+            encoders.ToDictionary(
+                entry => entry.Registration.Format,
+                entry => (object)entry));
+    }
+
+    private CaptionRegistryDrain<object> SwapState(State next)
+    {
+        State previous;
+        lock (_stateGate)
+        {
+            previous = _state;
+            _state = next;
+        }
+
+        try
+        {
+            if (!HaveSameMetadata(_codecs, next.Codecs))
+                _codecs.Replace(next.Codecs);
+        }
+        catch
+        {
+            // Metadata observers cannot roll back a committed capability transition.
+        }
+
+        Task retired = previous.RetireAndReleasePayloadAsync();
+        if (!retired.IsCompleted)
+        {
+            _retiredStates.Add(previous);
+            _ = retired.ContinueWith(
+                _ => RemoveRetiredState(previous),
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+
+        return new CaptionRegistryDrain<object>(retired, previous.DrainOwnerAsync);
+    }
+
+    private static bool HaveSameMetadata(
+        IReadOnlyList<CaptionCodecInfo> current,
+        IReadOnlyList<CaptionCodecInfo> next)
+    {
+        if (current.Count != next.Count)
+            return false;
+
+        for (int index = 0; index < current.Count; index++)
+        {
+            CaptionCodecInfo left = current[index];
+            CaptionCodecInfo right = next[index];
+            if (left.Format != right.Format
+                || left.CanDecode != right.CanDecode
+                || left.CanEncode != right.CanEncode
+                || left.Order != right.Order
+                || !left.FileExtensions.SequenceEqual(
+                    right.FileExtensions,
+                    StringComparer.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private void RemoveRetiredState(State state)
+    {
+        lock (_mutationGate)
+            _retiredStates.Remove(state);
+    }
+
+    private Task RemoveAsync(DescriptorEntry entry)
+    {
+        lock (_mutationGate)
+        {
+            if (!_descriptorEntries.Remove(entry))
+                return _disposeTask ?? Task.CompletedTask;
+            CaptionRegistryDrain<object> retired = SwapState(CreateDirectState());
+            return DrainOwnerAcrossRetiredStates(entry, retired);
+        }
+    }
+
+    private Task RemoveAsync(DecoderEntry entry)
+    {
+        lock (_mutationGate)
+        {
+            if (!_decoderEntries.Remove(entry))
+                return _disposeTask ?? Task.CompletedTask;
+            CaptionRegistryDrain<object> retired = SwapState(CreateDirectState());
+            return DrainOwnerAcrossRetiredStates(entry, retired);
+        }
+    }
+
+    private Task RemoveAsync(EncoderEntry entry)
+    {
+        lock (_mutationGate)
+        {
+            if (!_encoderEntries.Remove(entry))
+                return _disposeTask ?? Task.CompletedTask;
+            CaptionRegistryDrain<object> retired = SwapState(CreateDirectState());
+            return DrainOwnerAcrossRetiredStates(entry, retired);
+        }
+    }
+
+    private Task DrainOwnerAcrossRetiredStates(object owner, CaptionRegistryDrain<object> retired)
+        => Task.WhenAll(
+            _retiredStates.Select(state => state.DrainOwnerAsync(owner))
+                .Append(retired.DrainOwnerAsync(owner))
+                .Distinct());
+
+    private static IReadOnlyDictionary<CaptionFormatId, object> ToObjectOwners(
+        IReadOnlyDictionary<CaptionFormatId, Extension> owners)
+        => owners.ToDictionary(pair => pair.Key, pair => (object)pair.Value);
+
+    private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
+
+    private static void ValidateRegistrationMode(
+        CaptionFormatId format,
+        CaptionCodecRegistrationMode mode,
+        bool exists,
+        string capabilityName)
+    {
+        if (mode == CaptionCodecRegistrationMode.Add && exists)
+        {
+            throw new ArgumentException(
+                $"Caption format '{format}' already has a {capabilityName}. Use Replace explicitly.");
+        }
+        if (mode == CaptionCodecRegistrationMode.Replace && !exists)
+        {
+            throw new ArgumentException(
+                $"Caption format '{format}' has no {capabilityName} to replace.");
+        }
+    }
+
+    private static string NormalizeExtension(string extension)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(extension);
+        string normalized = extension.Trim();
+        if (normalized[0] != '.')
+            normalized = '.' + normalized;
+
+        if (normalized.Length == 1
+            || normalized.IndexOfAny(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) >= 0)
+        {
+            throw new ArgumentException($"'{extension}' is not a valid file extension.", nameof(extension));
+        }
+
+        return normalized;
+    }
+
+    private sealed class State : CaptionRegistryLeaseState<object>
+    {
+        private State(
+            Dictionary<CaptionFormatId, CaptionCodecDescriptor> descriptors,
+            Dictionary<CaptionFormatId, ICaptionDecoder> decoders,
+            Dictionary<CaptionFormatId, ICaptionEncoder> encoders,
+            Dictionary<string, CaptionFormatId> formatsByExtension,
+            IReadOnlyDictionary<CaptionFormatId, object> descriptorOwners,
+            IReadOnlyDictionary<CaptionFormatId, object> decoderOwners,
+            IReadOnlyDictionary<CaptionFormatId, object> encoderOwners)
+        {
+            Descriptors = descriptors;
+            Decoders = decoders;
+            Encoders = encoders;
+            FormatsByExtension = formatsByExtension;
+            DescriptorOwners = descriptorOwners;
+            DecoderOwners = decoderOwners;
+            EncoderOwners = encoderOwners;
+            CaptionCodecInfo[] codecs = descriptors.Values
+                .Select(descriptor => new CaptionCodecInfo(
+                    descriptor,
+                    decoders.ContainsKey(descriptor.Format),
+                    encoders.ContainsKey(descriptor.Format)))
+                .OrderBy(codec => codec.Order)
+                .ThenBy(codec => codec.Format.Value, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            Codecs = codecs;
+            CodecsByFormat = codecs.ToDictionary(codec => codec.Format);
+        }
+
+        public Dictionary<CaptionFormatId, CaptionCodecDescriptor> Descriptors
+        { get; private set; }
+
+        public Dictionary<CaptionFormatId, ICaptionDecoder> Decoders { get; private set; }
+
+        public Dictionary<CaptionFormatId, ICaptionEncoder> Encoders { get; private set; }
+
+        public CaptionCodecInfo[] Codecs { get; private set; }
+
+        public Dictionary<CaptionFormatId, CaptionCodecInfo> CodecsByFormat { get; private set; }
+
+        public Dictionary<string, CaptionFormatId> FormatsByExtension { get; private set; }
+
+        public IReadOnlyDictionary<CaptionFormatId, object> DescriptorOwners { get; private set; }
+
+        public IReadOnlyDictionary<CaptionFormatId, object> DecoderOwners { get; private set; }
+
+        public IReadOnlyDictionary<CaptionFormatId, object> EncoderOwners { get; private set; }
+
+        public IReadOnlyCollection<object> GetDecoderOwners(CaptionFormatId format)
+            => DecoderOwners.TryGetValue(format, out object? owner) ? [owner] : [];
+
+        public IReadOnlyCollection<object> GetEncoderOwners(CaptionFormatId format)
+            => EncoderOwners.TryGetValue(format, out object? owner) ? [owner] : [];
+
+        public Task RetireAndReleasePayloadAsync()
+        {
+            Task drain = RetireAsync();
+            Descriptors = [];
+            Decoders = [];
+            Encoders = [];
+            Codecs = [];
+            CodecsByFormat = [];
+            FormatsByExtension = new Dictionary<string, CaptionFormatId>(
+                StringComparer.OrdinalIgnoreCase);
+            DescriptorOwners = new Dictionary<CaptionFormatId, object>();
+            DecoderOwners = new Dictionary<CaptionFormatId, object>();
+            EncoderOwners = new Dictionary<CaptionFormatId, object>();
+            return drain;
+        }
+
+        public static State Create(
+            IEnumerable<CaptionCodecDescriptorRegistration> descriptorRegistrations,
+            IEnumerable<CaptionDecoderRegistration> decoderRegistrations,
+            IEnumerable<CaptionEncoderRegistration> encoderRegistrations,
+            IReadOnlyDictionary<CaptionFormatId, object>? descriptorOwners = null,
+            IReadOnlyDictionary<CaptionFormatId, object>? decoderOwners = null,
+            IReadOnlyDictionary<CaptionFormatId, object>? encoderOwners = null)
+        {
+            var descriptors = new Dictionary<CaptionFormatId, CaptionCodecDescriptor>();
+            var decoders = new Dictionary<CaptionFormatId, ICaptionDecoder>();
+            var encoders = new Dictionary<CaptionFormatId, ICaptionEncoder>();
+            foreach (CaptionCodecDescriptorRegistration registration in descriptorRegistrations)
+            {
+                Apply(
+                    registration.Descriptor.Format,
+                    registration.Descriptor,
+                    registration.Mode,
+                    descriptors,
+                    "descriptor");
+            }
+            foreach (CaptionDecoderRegistration registration in decoderRegistrations)
+            {
+                Apply(
+                    registration.Format,
+                    registration.Decoder,
+                    registration.Mode,
+                    decoders,
+                    "decoder");
+            }
+            foreach (CaptionEncoderRegistration registration in encoderRegistrations)
+            {
+                Apply(
+                    registration.Format,
+                    registration.Encoder,
+                    registration.Mode,
+                    encoders,
+                    "encoder");
+            }
+
+            var formatsByExtension = new Dictionary<string, CaptionFormatId>(
+                StringComparer.OrdinalIgnoreCase);
+            foreach (CaptionCodecDescriptor descriptor in descriptors.Values)
+            {
+                foreach (string extension in descriptor.FileExtensions)
+                {
+                    string normalized = NormalizeExtension(extension);
+                    if (!formatsByExtension.TryAdd(normalized, descriptor.Format))
+                    {
+                        throw new ArgumentException(
+                            $"File extension '{normalized}' is registered more than once.",
+                            nameof(descriptorRegistrations));
+                    }
+                }
+            }
+
+            return new State(
+                descriptors,
+                decoders,
+                encoders,
+                formatsByExtension,
+                descriptorOwners ?? new Dictionary<CaptionFormatId, object>(),
+                decoderOwners ?? new Dictionary<CaptionFormatId, object>(),
+                encoderOwners ?? new Dictionary<CaptionFormatId, object>());
+        }
+
+        private static void Apply<TCapability>(
+            CaptionFormatId format,
+            TCapability capability,
+            CaptionCodecRegistrationMode mode,
+            Dictionary<CaptionFormatId, TCapability> capabilities,
+            string capabilityName)
+        {
+            bool exists = capabilities.ContainsKey(format);
+            if (mode == CaptionCodecRegistrationMode.Add && exists)
+            {
+                throw new ArgumentException(
+                    $"Caption format '{format}' already has a {capabilityName}. Use Replace explicitly.");
+            }
+            if (mode == CaptionCodecRegistrationMode.Replace && !exists)
+            {
+                throw new ArgumentException(
+                    $"Caption format '{format}' has no {capabilityName} to replace.");
+            }
+            capabilities[format] = capability;
+        }
+    }
+
+    private sealed class CapabilityLease<TCapability>(
+        TCapability capability,
+        IDisposable lifetime) : IDisposable
+        where TCapability : class
+    {
+        private TCapability? _capability = capability;
+        private IDisposable? _lifetime = lifetime;
+
+        public TCapability Capability
+            => _capability ?? throw new ObjectDisposedException(nameof(CapabilityLease<TCapability>));
+
+        public void Dispose()
+        {
+            _capability = null;
+            Interlocked.Exchange(ref _lifetime, null)?.Dispose();
+        }
+    }
+
+    private sealed class DescriptorEntry(CaptionCodecDescriptorRegistration registration)
+    {
+        public CaptionCodecDescriptorRegistration Registration { get; } = registration;
+    }
+
+    private sealed class DecoderEntry(CaptionDecoderRegistration registration)
+    {
+        public CaptionDecoderRegistration Registration { get; } = registration;
+    }
+
+    private sealed class EncoderEntry(CaptionEncoderRegistration registration)
+    {
+        public CaptionEncoderRegistration Registration { get; } = registration;
+    }
+
+    private abstract class Handle
+    {
+        private readonly Lazy<Task> _dispose;
+
+        protected Handle(Func<Task> dispose)
+        {
+            _dispose = new Lazy<Task>(dispose, LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+
+        protected ValueTask DisposeCoreAsync() => new(_dispose.Value);
+    }
+
+    private sealed class DescriptorHandle(
+        CaptionCodecRegistry registry,
+        DescriptorEntry entry) : Handle(() => registry.RemoveAsync(entry)),
+        ICaptionCodecDescriptorRegistration
+    {
+        public ValueTask DisposeAsync() => DisposeCoreAsync();
+    }
+
+    private sealed class DecoderHandle(
+        CaptionCodecRegistry registry,
+        DecoderEntry entry) : Handle(() => registry.RemoveAsync(entry)),
+        ICaptionDecoderRegistration
+    {
+        public ValueTask DisposeAsync() => DisposeCoreAsync();
+    }
+
+    private sealed class EncoderHandle(
+        CaptionCodecRegistry registry,
+        EncoderEntry entry) : Handle(() => registry.RemoveAsync(entry)),
+        ICaptionEncoderRegistration
+    {
+        public ValueTask DisposeAsync() => DisposeCoreAsync();
+    }
+}

--- a/src/Beutl.Editor/Services/Captions/CaptionCodecResults.cs
+++ b/src/Beutl.Editor/Services/Captions/CaptionCodecResults.cs
@@ -1,0 +1,118 @@
+﻿using System.Collections.ObjectModel;
+
+namespace Beutl.Editor.Services.Captions;
+
+public readonly struct CaptionDiagnosticKind : IEquatable<CaptionDiagnosticKind>
+{
+    private readonly string? _value;
+
+    public CaptionDiagnosticKind(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        _value = value.Trim();
+    }
+
+    public string Value => _value ?? string.Empty;
+
+    public bool Equals(CaptionDiagnosticKind other)
+        => StringComparer.Ordinal.Equals(Value, other.Value);
+
+    public override bool Equals(object? obj)
+        => obj is CaptionDiagnosticKind other && Equals(other);
+
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Value);
+
+    public override string ToString() => Value;
+
+    public static bool operator ==(CaptionDiagnosticKind left, CaptionDiagnosticKind right)
+        => left.Equals(right);
+
+    public static bool operator !=(CaptionDiagnosticKind left, CaptionDiagnosticKind right)
+        => !left.Equals(right);
+}
+
+public static class CaptionDiagnosticKinds
+{
+    public static CaptionDiagnosticKind InvalidUtf8 { get; } = new("caption.invalid-utf8");
+
+    public static CaptionDiagnosticKind InvalidHeader { get; } = new("caption.invalid-header");
+
+    public static CaptionDiagnosticKind InvalidStructure { get; } = new("caption.invalid-structure");
+
+    public static CaptionDiagnosticKind InvalidTiming { get; } = new("caption.invalid-timing");
+
+    public static CaptionDiagnosticKind UnsupportedMarkup { get; } =
+        new("caption.unsupported-markup");
+}
+
+public sealed record CaptionDiagnostic(
+    CaptionDiagnosticKind Kind,
+    int? LineNumber,
+    string Message);
+
+public sealed class CaptionImportResult
+{
+    private CaptionImportResult(
+        CaptionDocument? document,
+        ReadOnlyCollection<CaptionDiagnostic> diagnostics)
+    {
+        Document = document;
+        Diagnostics = diagnostics;
+    }
+
+    /// <summary>
+    /// Whether the decoder produced a usable document. A successful import can still contain
+    /// diagnostics for malformed cues that were skipped.
+    /// </summary>
+    public bool IsSuccess => Document is not null;
+
+    public CaptionDocument? Document { get; }
+
+    public IReadOnlyList<CaptionDiagnostic> Diagnostics { get; }
+
+    public static CaptionImportResult Imported(
+        CaptionDocument document,
+        IEnumerable<CaptionDiagnostic>? diagnostics = null)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        CaptionDiagnostic[] diagnosticList = ValidateDiagnostics(diagnostics ?? []);
+        return new CaptionImportResult(document, Array.AsReadOnly(diagnosticList));
+    }
+
+    public static CaptionImportResult Failure(IEnumerable<CaptionDiagnostic> diagnostics)
+    {
+        ArgumentNullException.ThrowIfNull(diagnostics);
+
+        CaptionDiagnostic[] diagnosticList = ValidateDiagnostics(diagnostics);
+        if (diagnosticList.Length == 0)
+            throw new ArgumentException("A failed import must contain at least one diagnostic.", nameof(diagnostics));
+
+        return new CaptionImportResult(null, Array.AsReadOnly(diagnosticList));
+    }
+
+    public static CaptionImportResult Failure(CaptionDiagnostic diagnostic)
+    {
+        ArgumentNullException.ThrowIfNull(diagnostic);
+        return Failure([diagnostic]);
+    }
+
+    private static CaptionDiagnostic[] ValidateDiagnostics(
+        IEnumerable<CaptionDiagnostic> diagnostics)
+    {
+        CaptionDiagnostic[] result = diagnostics.ToArray();
+        if (result.Any(diagnostic => diagnostic is null))
+            throw new ArgumentException("Diagnostics cannot contain null.", nameof(diagnostics));
+        return result;
+    }
+}
+
+public sealed class CaptionExportException : FormatException
+{
+    public CaptionExportException(int? cueIndex, string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+        CueIndex = cueIndex;
+    }
+
+    public int? CueIndex { get; }
+}

--- a/src/Beutl.Editor/Services/Captions/CaptionCodecUtilities.cs
+++ b/src/Beutl.Editor/Services/Captions/CaptionCodecUtilities.cs
@@ -1,0 +1,233 @@
+﻿using System.Globalization;
+using System.Text;
+
+namespace Beutl.Editor.Services.Captions;
+
+internal static class CaptionCodecUtilities
+{
+    private static readonly UTF8Encoding s_utf8 = new(false, true);
+
+    public static void EnsureCueCanExport(CaptionCue cue, int cueIndex)
+    {
+        if (cue.Start < TimeSpan.Zero)
+            throw new CaptionExportException(cueIndex, "Cue start time cannot be negative.");
+
+        if (cue.End <= cue.Start)
+            throw new CaptionExportException(cueIndex, "Cue end time must be after its start time.");
+
+        EnsureValidUnicode(cue.Text, cueIndex, "text");
+        EnsureValidUnicode(cue.Speaker, cueIndex, "speaker");
+        EnsureValidUnicode(cue.Language, cueIndex, "language");
+        foreach ((string key, string value) in cue.Metadata)
+        {
+            EnsureValidUnicode(key, cueIndex, $"metadata key '{key}'");
+            EnsureValidUnicode(value, cueIndex, $"metadata value '{key}'");
+        }
+    }
+
+    public static void EnsureNoBlankCueLines(string text, int cueIndex, CaptionFormatId format)
+    {
+        if (text.Length == 0)
+            return;
+
+        if (CaptionTextUtilities.GetLines(text).Any(line => line.Length == 0))
+        {
+            throw new CaptionExportException(
+                cueIndex,
+                $"{format} cannot represent a blank line inside one cue without ending the cue block.");
+        }
+    }
+
+    public static bool TrySplitTimingLine(
+        string value,
+        out string start,
+        out string end)
+    {
+        int separator = value.IndexOf("-->", StringComparison.Ordinal);
+        if (separator < 0
+            || value.IndexOf("-->", separator + 3, StringComparison.Ordinal) >= 0)
+        {
+            start = string.Empty;
+            end = string.Empty;
+            return false;
+        }
+
+        start = value[..separator].Trim();
+        ReadOnlySpan<char> right = value.AsSpan(separator + 3).TrimStart();
+        int whitespace = right.IndexOfAny(' ', '\t');
+        end = (whitespace >= 0 ? right[..whitespace] : right).ToString();
+        return start.Length > 0 && end.Length > 0;
+    }
+
+    public static bool TryParseSrtTime(string value, out TimeSpan result)
+        => TryParseTime(value, ',', 3, allowOmittedHours: false, minimumHourDigits: 2, out result);
+
+    public static bool TryParseWebVttTime(string value, out TimeSpan result)
+        => TryParseTime(value, '.', 3, allowOmittedHours: true, minimumHourDigits: 2, out result);
+
+    public static bool TryParseAssTime(string value, out TimeSpan result)
+        => TryParseTime(value, '.', 2, allowOmittedHours: false, minimumHourDigits: 1, out result);
+
+    public static (TimeSpan Start, TimeSpan End) QuantizeCue(
+        CaptionCue cue,
+        int cueIndex,
+        long resolutionTicks)
+    {
+        EnsureCueCanExport(cue, cueIndex);
+
+        long startTicks = cue.Start.Ticks - cue.Start.Ticks % resolutionTicks;
+        long endTicks = cue.End.Ticks;
+        long remainder = endTicks % resolutionTicks;
+        if (remainder != 0)
+        {
+            long increment = resolutionTicks - remainder;
+            endTicks = endTicks <= TimeSpan.MaxValue.Ticks - increment
+                ? endTicks + increment
+                : endTicks - remainder;
+        }
+
+        if (endTicks <= startTicks)
+        {
+            throw new CaptionExportException(
+                cueIndex,
+                "The cue is too short to represent at the target format's timing precision.");
+        }
+
+        return (new TimeSpan(startTicks), new TimeSpan(endTicks));
+    }
+
+    public static string FormatSrtTime(TimeSpan value)
+        => FormatTime(value, ',', 3);
+
+    public static string FormatWebVttTime(TimeSpan value)
+        => FormatTime(value, '.', 3);
+
+    public static string FormatAssTime(TimeSpan value)
+        => FormatTime(value, '.', 2, minimumHourDigits: 1);
+
+    private static bool TryParseTime(
+        string value,
+        char fractionSeparator,
+        int fractionDigits,
+        bool allowOmittedHours,
+        int minimumHourDigits,
+        out TimeSpan result)
+    {
+        result = default;
+        value = value.Trim();
+
+        int fractionIndex = value.LastIndexOf(fractionSeparator);
+        if (fractionIndex < 0 || fractionIndex != value.Length - fractionDigits - 1)
+            return false;
+
+        ReadOnlySpan<char> fractionSpan = value.AsSpan(fractionIndex + 1);
+        if (!IsAsciiDigits(fractionSpan)
+            || !int.TryParse(fractionSpan, NumberStyles.None, CultureInfo.InvariantCulture, out int fraction))
+        {
+            return false;
+        }
+
+        string[] clockParts = value[..fractionIndex].Split(':');
+        if (clockParts.Length != 3 && (!allowOmittedHours || clockParts.Length != 2))
+            return false;
+
+        ReadOnlySpan<char> hoursSpan;
+        ReadOnlySpan<char> minutesSpan;
+        ReadOnlySpan<char> secondsSpan;
+        if (clockParts.Length == 3)
+        {
+            hoursSpan = clockParts[0];
+            minutesSpan = clockParts[1];
+            secondsSpan = clockParts[2];
+        }
+        else
+        {
+            hoursSpan = "0";
+            minutesSpan = clockParts[0];
+            secondsSpan = clockParts[1];
+        }
+
+        if (hoursSpan.Length < (clockParts.Length == 3 ? minimumHourDigits : 1)
+            || minutesSpan.Length != 2
+            || secondsSpan.Length != 2
+            || !IsAsciiDigits(hoursSpan)
+            || !IsAsciiDigits(minutesSpan)
+            || !IsAsciiDigits(secondsSpan)
+            || !long.TryParse(hoursSpan, NumberStyles.None, CultureInfo.InvariantCulture, out long hours)
+            || !int.TryParse(minutesSpan, NumberStyles.None, CultureInfo.InvariantCulture, out int minutes)
+            || !int.TryParse(secondsSpan, NumberStyles.None, CultureInfo.InvariantCulture, out int seconds)
+            || minutes > 59
+            || seconds > 59)
+        {
+            return false;
+        }
+
+        try
+        {
+            long totalSeconds = checked(checked(hours * 60 + minutes) * 60 + seconds);
+            long fractionTicks = fractionDigits == 3
+                ? fraction * TimeSpan.TicksPerMillisecond
+                : fraction * (TimeSpan.TicksPerSecond / 100);
+            long ticks = checked(totalSeconds * TimeSpan.TicksPerSecond + fractionTicks);
+            if (ticks > TimeSpan.MaxValue.Ticks)
+                return false;
+
+            result = new TimeSpan(ticks);
+            return true;
+        }
+        catch (OverflowException)
+        {
+            return false;
+        }
+    }
+
+    private static string FormatTime(
+        TimeSpan value,
+        char fractionSeparator,
+        int fractionDigits,
+        int minimumHourDigits = 2)
+    {
+        long hours = value.Ticks / TimeSpan.TicksPerHour;
+        int minutes = value.Minutes;
+        int seconds = value.Seconds;
+        long fraction = fractionDigits == 3
+            ? value.Ticks % TimeSpan.TicksPerSecond / TimeSpan.TicksPerMillisecond
+            : value.Ticks % TimeSpan.TicksPerSecond / (TimeSpan.TicksPerSecond / 100);
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{hours.ToString(new string('0', minimumHourDigits), CultureInfo.InvariantCulture)}:{minutes:00}:{seconds:00}{fractionSeparator}{fraction.ToString(new string('0', fractionDigits), CultureInfo.InvariantCulture)}");
+    }
+
+    private static bool IsAsciiDigits(ReadOnlySpan<char> value)
+    {
+        if (value.IsEmpty)
+            return false;
+
+        foreach (char character in value)
+        {
+            if (character is < '0' or > '9')
+                return false;
+        }
+
+        return true;
+    }
+
+    private static void EnsureValidUnicode(string? value, int cueIndex, string fieldName)
+    {
+        if (value is null)
+            return;
+
+        try
+        {
+            _ = s_utf8.GetByteCount(value);
+        }
+        catch (EncoderFallbackException ex)
+        {
+            throw new CaptionExportException(
+                cueIndex,
+                $"Cue {fieldName} contains invalid Unicode.",
+                ex);
+        }
+    }
+}

--- a/src/Beutl.Editor/Services/Captions/CaptionCue.cs
+++ b/src/Beutl.Editor/Services/Captions/CaptionCue.cs
@@ -1,0 +1,56 @@
+﻿namespace Beutl.Editor.Services.Captions;
+
+/// <summary>
+/// Represents one provider-independent caption cue.
+/// </summary>
+public sealed record CaptionCue
+{
+    private string _text = string.Empty;
+    private CaptionMetadata _metadata = CaptionMetadata.Empty;
+
+    public CaptionCue(
+        TimeSpan start,
+        TimeSpan end,
+        string text,
+        string? speaker = null,
+        string? language = null,
+        CaptionMetadata? metadata = null)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        Start = start;
+        End = end;
+        Text = text;
+        Speaker = speaker;
+        Language = language;
+        Metadata = metadata ?? CaptionMetadata.Empty;
+    }
+
+    public TimeSpan Start { get; init; }
+
+    public TimeSpan End { get; init; }
+
+    public string Text
+    {
+        get => _text;
+        init
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            _text = value;
+        }
+    }
+
+    public string? Speaker { get; init; }
+
+    public string? Language { get; init; }
+
+    public CaptionMetadata Metadata
+    {
+        get => _metadata;
+        init
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            _metadata = value;
+        }
+    }
+}

--- a/src/Beutl.Editor/Services/Captions/CaptionDocument.cs
+++ b/src/Beutl.Editor/Services/Captions/CaptionDocument.cs
@@ -1,0 +1,161 @@
+﻿using System.Collections.ObjectModel;
+using System.Globalization;
+
+namespace Beutl.Editor.Services.Captions;
+
+/// <summary>
+/// Owns an editable ordered collection of caption cues.
+/// </summary>
+public sealed class CaptionDocument
+{
+    private readonly List<CaptionCue> _cues;
+    private readonly ReadOnlyCollection<CaptionCue> _readOnlyCues;
+
+    public CaptionDocument()
+        : this([])
+    {
+    }
+
+    public CaptionDocument(IEnumerable<CaptionCue> cues)
+    {
+        ArgumentNullException.ThrowIfNull(cues);
+
+        _cues = [];
+        foreach (CaptionCue cue in cues)
+        {
+            ArgumentNullException.ThrowIfNull(cue);
+            _cues.Add(cue);
+        }
+
+        _readOnlyCues = _cues.AsReadOnly();
+    }
+
+    public IReadOnlyList<CaptionCue> Cues => _readOnlyCues;
+
+    public int Count => _cues.Count;
+
+    public CaptionCue this[int index] => _cues[index];
+
+    public void Add(CaptionCue cue)
+    {
+        ArgumentNullException.ThrowIfNull(cue);
+        _cues.Add(cue);
+    }
+
+    public void Insert(int index, CaptionCue cue)
+    {
+        ArgumentNullException.ThrowIfNull(cue);
+        _cues.Insert(index, cue);
+    }
+
+    public void Replace(int index, CaptionCue cue)
+    {
+        ArgumentNullException.ThrowIfNull(cue);
+        _cues[index] = cue;
+    }
+
+    public CaptionCue RemoveAt(int index)
+    {
+        CaptionCue cue = _cues[index];
+        _cues.RemoveAt(index);
+        return cue;
+    }
+
+    /// <summary>
+    /// Splits a cue at a timeline position and UTF-16 text offset while retaining its metadata.
+    /// </summary>
+    public (CaptionCue First, CaptionCue Second) SplitCue(
+        int cueIndex,
+        TimeSpan splitTime,
+        int textOffset)
+    {
+        CaptionCue cue = GetCue(cueIndex);
+        if (splitTime <= cue.Start || splitTime >= cue.End)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(splitTime),
+                splitTime,
+                "The split time must be strictly inside the cue interval.");
+        }
+
+        if ((uint)textOffset > (uint)cue.Text.Length)
+        {
+            throw new ArgumentOutOfRangeException(nameof(textOffset));
+        }
+
+        if (!IsTextElementBoundary(cue.Text, textOffset))
+        {
+            throw new ArgumentException(
+                "The text offset must not split a Unicode text element.",
+                nameof(textOffset));
+        }
+
+        var first = cue with
+        {
+            End = splitTime,
+            Text = cue.Text[..textOffset],
+        };
+        var second = cue with
+        {
+            Start = splitTime,
+            Text = cue.Text[textOffset..],
+        };
+
+        _cues[cueIndex] = first;
+        _cues.Insert(cueIndex + 1, second);
+        return (first, second);
+    }
+
+    /// <summary>
+    /// Merges a cue with the cue immediately after it.
+    /// Metadata is retained only when both cues agree on its value.
+    /// </summary>
+    public CaptionCue MergeWithNext(int firstCueIndex, string separator = "\n")
+    {
+        ArgumentNullException.ThrowIfNull(separator);
+        CaptionCue first = GetCue(firstCueIndex);
+        if (firstCueIndex == _cues.Count - 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(firstCueIndex),
+                firstCueIndex,
+                "The last cue has no following cue to merge.");
+        }
+
+        CaptionCue second = _cues[firstCueIndex + 1];
+        var merged = new CaptionCue(
+            Min(first.Start, second.Start),
+            Max(first.End, second.End),
+            first.Text + separator + second.Text,
+            MergeMetadata(first.Speaker, second.Speaker),
+            MergeMetadata(first.Language, second.Language),
+            first.Metadata.RetainMatching(second.Metadata));
+
+        _cues[firstCueIndex] = merged;
+        _cues.RemoveAt(firstCueIndex + 1);
+        return merged;
+    }
+
+    private CaptionCue GetCue(int index)
+    {
+        if ((uint)index >= (uint)_cues.Count)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        return _cues[index];
+    }
+
+    private static bool IsTextElementBoundary(string text, int offset)
+    {
+        if (offset == 0 || offset == text.Length)
+            return true;
+
+        return Array.BinarySearch(StringInfo.ParseCombiningCharacters(text), offset) >= 0;
+    }
+
+    private static string? MergeMetadata(string? first, string? second)
+        => string.Equals(first, second, StringComparison.Ordinal) ? first : null;
+
+    private static TimeSpan Min(TimeSpan first, TimeSpan second) => first <= second ? first : second;
+
+    private static TimeSpan Max(TimeSpan first, TimeSpan second) => first >= second ? first : second;
+}

--- a/src/Beutl.Editor/Services/Captions/CaptionDocumentSerializer.cs
+++ b/src/Beutl.Editor/Services/Captions/CaptionDocumentSerializer.cs
@@ -1,0 +1,60 @@
+﻿using System.Text;
+
+namespace Beutl.Editor.Services.Captions;
+
+/// <summary>
+/// Imports and exports provider-independent caption documents as strict UTF-8.
+/// </summary>
+public sealed class CaptionDocumentSerializer
+{
+    private static readonly UTF8Encoding s_utf8 = new(false, true);
+    private readonly ICaptionCodecProvider _codecs;
+
+    public CaptionDocumentSerializer(ICaptionCodecProvider codecs)
+    {
+        ArgumentNullException.ThrowIfNull(codecs);
+        _codecs = codecs;
+    }
+
+    public CaptionImportResult Import(ReadOnlySpan<byte> utf8, CaptionFormatId format)
+    {
+        string content;
+        try
+        {
+            content = s_utf8.GetString(utf8);
+        }
+        catch (DecoderFallbackException ex)
+        {
+            return CaptionImportResult.Failure(
+            [
+                new CaptionDiagnostic(
+                    CaptionDiagnosticKinds.InvalidUtf8,
+                    null,
+                    $"The input is not valid UTF-8: {ex.Message}"),
+            ]);
+        }
+
+        if (content.Length > 0 && content[0] == '\uFEFF')
+            content = content[1..];
+
+        return _codecs.Decode(format, content);
+    }
+
+    public byte[] Export(CaptionDocument document, CaptionFormatId format)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        string content = _codecs.Encode(format, document);
+
+        try
+        {
+            return s_utf8.GetBytes(content);
+        }
+        catch (EncoderFallbackException ex)
+        {
+            throw new CaptionExportException(
+                null,
+                "The document contains invalid UTF-16 and cannot be encoded as UTF-8.",
+                ex);
+        }
+    }
+}

--- a/src/Beutl.Editor/Services/Captions/CaptionFormatId.cs
+++ b/src/Beutl.Editor/Services/Captions/CaptionFormatId.cs
@@ -1,0 +1,45 @@
+﻿namespace Beutl.Editor.Services.Captions;
+
+/// <summary>
+/// Identifies a caption format without restricting codecs to a closed set of values.
+/// </summary>
+public readonly struct CaptionFormatId : IEquatable<CaptionFormatId>
+{
+    private readonly string? _value;
+
+    public CaptionFormatId(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        _value = value.Trim();
+    }
+
+    public string Value => _value ?? string.Empty;
+
+    public bool Equals(CaptionFormatId other)
+        => StringComparer.OrdinalIgnoreCase.Equals(Value, other.Value);
+
+    public override bool Equals(object? obj)
+        => obj is CaptionFormatId other && Equals(other);
+
+    public override int GetHashCode()
+        => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
+
+    public override string ToString() => Value;
+
+    public static bool operator ==(CaptionFormatId left, CaptionFormatId right) => left.Equals(right);
+
+    public static bool operator !=(CaptionFormatId left, CaptionFormatId right) => !left.Equals(right);
+
+}
+
+/// <summary>
+/// Well-known format identifiers supplied by the built-in codecs.
+/// </summary>
+public static class CaptionFormats
+{
+    public static CaptionFormatId Srt { get; } = new("srt");
+
+    public static CaptionFormatId WebVtt { get; } = new("webvtt");
+
+    public static CaptionFormatId Ass { get; } = new("ass");
+}

--- a/src/Beutl.Editor/Services/Captions/CaptionMetadata.cs
+++ b/src/Beutl.Editor/Services/Captions/CaptionMetadata.cs
@@ -1,0 +1,151 @@
+﻿using System.Collections;
+using System.Collections.ObjectModel;
+
+namespace Beutl.Editor.Services.Captions;
+
+/// <summary>
+/// An immutable, structurally comparable collection of extensible caption metadata.
+/// </summary>
+public sealed class CaptionMetadata : IReadOnlyDictionary<string, string>, IEquatable<CaptionMetadata>
+{
+    private readonly ReadOnlyDictionary<string, string> _values;
+
+    public CaptionMetadata(IEnumerable<KeyValuePair<string, string>> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+
+        var copy = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach ((string key, string value) in values)
+        {
+            ValidateEntry(key, value);
+            if (!copy.TryAdd(key, value))
+                throw new ArgumentException($"Metadata key '{key}' occurs more than once.", nameof(values));
+        }
+
+        _values = new ReadOnlyDictionary<string, string>(copy);
+    }
+
+    private CaptionMetadata(Dictionary<string, string> values)
+    {
+        _values = new ReadOnlyDictionary<string, string>(values);
+    }
+
+    public static CaptionMetadata Empty { get; } = new(new Dictionary<string, string>(StringComparer.Ordinal));
+
+    public int Count => _values.Count;
+
+    public IEnumerable<string> Keys => _values.Keys;
+
+    public IEnumerable<string> Values => _values.Values;
+
+    public string this[string key] => _values[key];
+
+    public CaptionMetadata Set(string key, string value)
+    {
+        ValidateEntry(key, value);
+        if (_values.TryGetValue(key, out string? existing)
+            && string.Equals(existing, value, StringComparison.Ordinal))
+        {
+            return this;
+        }
+
+        var copy = new Dictionary<string, string>(_values, StringComparer.Ordinal)
+        {
+            [key] = value,
+        };
+        return new CaptionMetadata(copy);
+    }
+
+    public CaptionMetadata Remove(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        if (!_values.ContainsKey(key))
+            return this;
+
+        var copy = new Dictionary<string, string>(_values, StringComparer.Ordinal);
+        copy.Remove(key);
+        return copy.Count == 0 ? Empty : new CaptionMetadata(copy);
+    }
+
+    public string? GetValueOrDefault(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        return _values.GetValueOrDefault(key);
+    }
+
+    public bool ContainsKey(string key) => _values.ContainsKey(key);
+
+    public bool TryGetValue(string key, out string value) => _values.TryGetValue(key, out value!);
+
+    public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => _values.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public bool Equals(CaptionMetadata? other)
+    {
+        if (ReferenceEquals(this, other))
+            return true;
+
+        if (other is null || Count != other.Count)
+            return false;
+
+        foreach ((string key, string value) in _values)
+        {
+            if (!other._values.TryGetValue(key, out string? otherValue)
+                || !string.Equals(value, otherValue, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public override bool Equals(object? obj) => Equals(obj as CaptionMetadata);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        foreach ((string key, string value) in _values.OrderBy(item => item.Key, StringComparer.Ordinal))
+        {
+            hash.Add(key, StringComparer.Ordinal);
+            hash.Add(value, StringComparer.Ordinal);
+        }
+
+        return hash.ToHashCode();
+    }
+
+    internal CaptionMetadata RetainMatching(CaptionMetadata other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        var matches = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach ((string key, string value) in _values)
+        {
+            if (other._values.TryGetValue(key, out string? otherValue)
+                && string.Equals(value, otherValue, StringComparison.Ordinal))
+            {
+                matches.Add(key, value);
+            }
+        }
+
+        return matches.Count == 0 ? Empty : new CaptionMetadata(matches);
+    }
+
+    private static void ValidateEntry(string key, string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ArgumentNullException.ThrowIfNull(value);
+    }
+}
+
+/// <summary>
+/// Metadata keys interpreted by the built-in caption codecs.
+/// Third-party codecs may define additional namespaced keys.
+/// </summary>
+public static class CaptionMetadataKeys
+{
+    public const string WebVttClasses = "webvtt.classes";
+
+    public const string AssStyle = "ass.style";
+}

--- a/src/Beutl.Editor/Services/Captions/CaptionRegistryLeaseState.cs
+++ b/src/Beutl.Editor/Services/Captions/CaptionRegistryLeaseState.cs
@@ -1,0 +1,124 @@
+﻿namespace Beutl.Editor.Services.Captions;
+
+internal abstract class CaptionRegistryLeaseState<TOwner>
+    where TOwner : class
+{
+    private readonly object _gate = new();
+    private TaskCompletionSource? _drained;
+    private readonly Dictionary<TOwner, int> _leases =
+        new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<TOwner, TaskCompletionSource> _ownerDrains =
+        new(ReferenceEqualityComparer.Instance);
+    private int _leaseCount;
+    private bool _retired;
+
+    public IDisposable AcquireLease(IReadOnlyCollection<TOwner> owners)
+    {
+        ArgumentNullException.ThrowIfNull(owners);
+        var seen = new HashSet<TOwner>(ReferenceEqualityComparer.Instance);
+        TOwner[] snapshot = owners.Where(seen.Add).ToArray();
+        lock (_gate)
+        {
+            if (_retired)
+                throw new InvalidOperationException("The caption registry state has been retired.");
+
+            foreach (TOwner owner in snapshot)
+            {
+                _leases.TryGetValue(owner, out int count);
+                _leases[owner] = count + 1;
+            }
+            _leaseCount++;
+
+            return new Lease(this, snapshot);
+        }
+    }
+
+    public Task DrainOwnerAsync(TOwner owner)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+        lock (_gate)
+        {
+            if (!_leases.ContainsKey(owner))
+                return Task.CompletedTask;
+
+            return _ownerDrains.GetValueOrDefault(owner)?.Task
+                ?? AddOwnerDrain(owner).Task;
+        }
+    }
+
+    public Task RetireAsync()
+    {
+        lock (_gate)
+        {
+            _retired = true;
+            return _leaseCount == 0
+                ? Task.CompletedTask
+                : (_drained ??= new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously)).Task;
+        }
+    }
+
+    private TaskCompletionSource AddOwnerDrain(TOwner owner)
+    {
+        var drain = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        _ownerDrains.Add(owner, drain);
+        return drain;
+    }
+
+    private void Release(IReadOnlyList<TOwner> owners)
+    {
+        TaskCompletionSource? drained = null;
+        List<TaskCompletionSource>? ownerDrains = null;
+        lock (_gate)
+        {
+            _leaseCount--;
+            foreach (TOwner owner in owners)
+            {
+                int count = _leases[owner] - 1;
+                if (count == 0)
+                {
+                    _leases.Remove(owner);
+                    if (_ownerDrains.Remove(owner, out TaskCompletionSource? ownerDrain))
+                        (ownerDrains ??= []).Add(ownerDrain);
+                }
+                else
+                {
+                    _leases[owner] = count;
+                }
+            }
+
+            if (_leaseCount == 0 && _retired)
+            {
+                drained = _drained;
+            }
+        }
+
+        if (ownerDrains is not null)
+        {
+            foreach (TaskCompletionSource ownerDrain in ownerDrains)
+                ownerDrain.TrySetResult();
+        }
+        drained?.TrySetResult();
+    }
+
+    private sealed class Lease(
+        CaptionRegistryLeaseState<TOwner> owner,
+        IReadOnlyList<TOwner> owners) : IDisposable
+    {
+        private CaptionRegistryLeaseState<TOwner>? _owner = owner;
+
+        public void Dispose()
+            => Interlocked.Exchange(ref _owner, null)?.Release(owners);
+    }
+}
+
+internal sealed class CaptionRegistryDrain<TOwner>(
+    Task all,
+    Func<TOwner, Task> drainOwner)
+    where TOwner : class
+{
+    public ValueTask All => new(all);
+
+    public Task DrainOwnerAsync(TOwner owner) => drainOwner(owner);
+}

--- a/src/Beutl.Editor/Services/Captions/CaptionTemplate.cs
+++ b/src/Beutl.Editor/Services/Captions/CaptionTemplate.cs
@@ -1,0 +1,312 @@
+﻿using Beutl.Editor.Models;
+using Beutl.Engine;
+using Beutl.Graphics;
+
+namespace Beutl.Editor.Services.Captions;
+
+/// <summary>
+/// Provides shared defaults to caption element factories without constraining the number or type
+/// of element descriptions they produce.
+/// </summary>
+public sealed record CaptionElementContext
+{
+    public CaptionElementContext(
+        int layer,
+        string elementName,
+        Point defaultPosition = default,
+        TimeSpan? minimumLength = null)
+    {
+        ArgumentNullException.ThrowIfNull(elementName);
+        TimeSpan resolvedMinimumLength = minimumLength ?? TimeSpan.FromSeconds(0.5);
+        if (resolvedMinimumLength <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(minimumLength));
+
+        Layer = layer;
+        ElementName = elementName;
+        DefaultPosition = defaultPosition;
+        MinimumLength = resolvedMinimumLength;
+    }
+
+    public int Layer { get; }
+
+    public string ElementName { get; }
+
+    public Point DefaultPosition { get; }
+
+    public TimeSpan MinimumLength { get; }
+
+    public ElementDescription CreateDescription(
+        CaptionCue cue,
+        Func<EngineObject> engineObjectFactory,
+        int layerOffset = 0,
+        string? name = null,
+        Point? position = null)
+    {
+        ArgumentNullException.ThrowIfNull(cue);
+        ArgumentNullException.ThrowIfNull(engineObjectFactory);
+
+        TimeSpan cueLength = cue.End > cue.Start ? cue.End - cue.Start : TimeSpan.Zero;
+        return new ElementDescription(
+            Start: cue.Start,
+            Length: cueLength < MinimumLength ? MinimumLength : cueLength,
+            Layer: checked(Layer + layerOffset),
+            Source: new ElementSource.EngineObject(engineObjectFactory),
+            Name: name ?? ElementName,
+            Position: position);
+    }
+}
+
+/// <summary>
+/// Creates one or more timeline element requests for a caption cue.
+/// </summary>
+public interface ICaptionElementFactory
+{
+    IReadOnlyList<ElementDescription> CreateElements(CaptionCue cue, CaptionElementContext context);
+}
+
+/// <summary>
+/// Host-owned layout values that a placement policy may change without replacing an element's
+/// package-owned source.
+/// </summary>
+public sealed record CaptionElementPlacement
+{
+    public CaptionElementPlacement(
+        TimeSpan start,
+        TimeSpan? length,
+        int layer,
+        string name,
+        Point? position)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        Start = start;
+        Length = length;
+        Layer = layer;
+        Name = name;
+        Position = position;
+    }
+
+    public TimeSpan Start { get; init; }
+
+    public TimeSpan? Length { get; init; }
+
+    public int Layer { get; init; }
+
+    public string Name { get; init; }
+
+    public Point? Position { get; init; }
+
+    internal static CaptionElementPlacement FromDescription(ElementDescription description)
+        => new(
+            description.Start,
+            description.Length,
+            description.Layer,
+            description.Name,
+            description.Position);
+
+    internal ElementDescription ApplyTo(ElementDescription description)
+        => new(Start, Length, Layer, description.Source, Name, Position);
+}
+
+/// <summary>
+/// Applies data-only placement independently from element construction. The host always preserves
+/// the factory-created <see cref="ElementDescription.Source"/>.
+/// </summary>
+public interface ICaptionPlacementPolicy
+{
+    CaptionElementPlacement Place(
+        CaptionCue cue,
+        CaptionElementContext context,
+        CaptionElementPlacement placement,
+        int elementIndex);
+}
+
+/// <summary>
+/// Places requests at the context default when their factory did not request an explicit position.
+/// </summary>
+public sealed class DefaultCaptionPlacementPolicy : ICaptionPlacementPolicy
+{
+    public static DefaultCaptionPlacementPolicy Instance { get; } = new();
+
+    public CaptionElementPlacement Place(
+        CaptionCue cue,
+        CaptionElementContext context,
+        CaptionElementPlacement placement,
+        int elementIndex)
+    {
+        ArgumentNullException.ThrowIfNull(cue);
+        ArgumentNullException.ThrowIfNull(context);
+        return placement.Position is null
+            ? placement with { Position = context.DefaultPosition }
+            : placement;
+    }
+}
+
+/// <summary>
+/// Leaves positions supplied by a factory or object template unchanged.
+/// </summary>
+public sealed class PreserveCaptionPlacementPolicy : ICaptionPlacementPolicy
+{
+    public static PreserveCaptionPlacementPolicy Instance { get; } = new();
+
+    public CaptionElementPlacement Place(
+        CaptionCue cue,
+        CaptionElementContext context,
+        CaptionElementPlacement placement,
+        int elementIndex)
+    {
+        ArgumentNullException.ThrowIfNull(cue);
+        ArgumentNullException.ThrowIfNull(context);
+        return placement;
+    }
+}
+
+/// <summary>
+/// Identifies a caption template without constraining extensions to a closed set of values.
+/// </summary>
+public readonly struct CaptionTemplateId : IEquatable<CaptionTemplateId>
+{
+    private readonly string? _value;
+
+    public CaptionTemplateId(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        _value = value.Trim();
+    }
+
+    public string Value => _value ?? string.Empty;
+
+    public bool Equals(CaptionTemplateId other)
+        => StringComparer.OrdinalIgnoreCase.Equals(Value, other.Value);
+
+    public override bool Equals(object? obj)
+        => obj is CaptionTemplateId other && Equals(other);
+
+    public override int GetHashCode()
+        => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
+
+    public override string ToString() => Value;
+
+    public static bool operator ==(CaptionTemplateId left, CaptionTemplateId right) => left.Equals(right);
+
+    public static bool operator !=(CaptionTemplateId left, CaptionTemplateId right) => !left.Equals(right);
+}
+
+/// <summary>
+/// Identifies the extension or host component that owns a caption template.
+/// </summary>
+public readonly struct CaptionTemplateProviderId : IEquatable<CaptionTemplateProviderId>
+{
+    private readonly string? _value;
+
+    public CaptionTemplateProviderId(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        _value = value.Trim();
+    }
+
+    public string Value => _value ?? string.Empty;
+
+    public bool Equals(CaptionTemplateProviderId other)
+        => StringComparer.OrdinalIgnoreCase.Equals(Value, other.Value);
+
+    public override bool Equals(object? obj)
+        => obj is CaptionTemplateProviderId other && Equals(other);
+
+    public override int GetHashCode()
+        => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
+
+    public override string ToString() => Value;
+
+    public static bool operator ==(
+        CaptionTemplateProviderId left,
+        CaptionTemplateProviderId right)
+        => left.Equals(right);
+
+    public static bool operator !=(
+        CaptionTemplateProviderId left,
+        CaptionTemplateProviderId right)
+        => !left.Equals(right);
+}
+
+public static class CaptionTemplateIds
+{
+    public static CaptionTemplateId DefaultText { get; } = new("beutl.caption.default-text");
+}
+
+public static class CaptionTemplateProviders
+{
+    public static CaptionTemplateProviderId BuiltIn { get; } = new("beutl");
+
+    public static CaptionTemplateProviderId User { get; } = new("beutl.user");
+}
+
+/// <summary>A convenience bundle containing the three independent registrations for a template.</summary>
+public sealed class CaptionTemplateRegistrationSet
+{
+    public CaptionTemplateRegistrationSet(
+        CaptionTemplateDescriptorRegistration descriptor,
+        CaptionElementFactoryRegistration elementFactory,
+        CaptionPlacementPolicyRegistration placement)
+    {
+        DescriptorRegistration = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
+        ElementFactoryRegistration = elementFactory ?? throw new ArgumentNullException(nameof(elementFactory));
+        PlacementPolicyRegistration = placement ?? throw new ArgumentNullException(nameof(placement));
+        if (DescriptorRegistration.Descriptor.Id != ElementFactoryRegistration.TemplateId
+            || DescriptorRegistration.Descriptor.Id != PlacementPolicyRegistration.TemplateId)
+        {
+            throw new ArgumentException("Caption template registration identifiers must match.");
+        }
+    }
+
+    public CaptionTemplateDescriptorRegistration DescriptorRegistration { get; }
+
+    public CaptionElementFactoryRegistration ElementFactoryRegistration { get; }
+
+    public CaptionPlacementPolicyRegistration PlacementPolicyRegistration { get; }
+}
+
+internal sealed class CaptionTemplateComposition(
+    CaptionTemplateDescriptor descriptor,
+    ICaptionElementFactory elementFactory,
+    ICaptionPlacementPolicy placementPolicy)
+{
+    public CaptionTemplateDescriptor Descriptor { get; } = descriptor;
+
+    public ICaptionElementFactory ElementFactory { get; } = elementFactory;
+
+    public ICaptionPlacementPolicy PlacementPolicy { get; } = placementPolicy;
+
+    public IReadOnlyList<ElementDescription> CreateElements(CaptionCue cue, CaptionElementContext context)
+    {
+        ArgumentNullException.ThrowIfNull(cue);
+        ArgumentNullException.ThrowIfNull(context);
+
+        IReadOnlyList<ElementDescription> descriptions = ElementFactory.CreateElements(cue, context)
+            ?? throw new InvalidOperationException($"Caption template '{Descriptor.Id}' returned null.");
+        if (descriptions.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Caption template '{Descriptor.Id}' must create at least one element description.");
+        }
+        if (descriptions.Any(description => description is null))
+        {
+            throw new InvalidOperationException(
+                $"Caption template '{Descriptor.Id}' returned a null element description.");
+        }
+
+        var placed = new ElementDescription[descriptions.Count];
+        for (int i = 0; i < descriptions.Count; i++)
+        {
+            CaptionElementPlacement placement = PlacementPolicy.Place(
+                    cue,
+                    context,
+                    CaptionElementPlacement.FromDescription(descriptions[i]),
+                    i)
+                ?? throw new InvalidOperationException(
+                    $"Caption template '{Descriptor.Id}' placement returned null for element {i}.");
+            placed[i] = placement.ApplyTo(descriptions[i]);
+        }
+
+        return Array.AsReadOnly(placed);
+    }
+}

--- a/src/Beutl.Editor/Services/Captions/CaptionTemplateExtensions.cs
+++ b/src/Beutl.Editor/Services/Captions/CaptionTemplateExtensions.cs
@@ -1,0 +1,27 @@
+﻿using Beutl.Api.Services;
+using Beutl.Extensibility;
+
+namespace Beutl.Editor.Services.Captions;
+
+/// <summary>Contributes template metadata without retaining executable package code.</summary>
+public abstract class CaptionTemplateDescriptorExtension : Extension, ILiveUnloadExtension
+{
+    public abstract IReadOnlyCollection<CaptionTemplateDescriptorRegistration> Registrations { get; }
+}
+
+/// <summary>
+/// Contributes element factories. Factories can persist package-defined scene graphs, so their
+/// packages remain loaded until restart.
+/// </summary>
+public abstract class CaptionElementFactoryExtension : Extension
+{
+    public abstract IReadOnlyCollection<CaptionElementFactoryRegistration> Registrations { get; }
+}
+
+/// <summary>
+/// Contributes data-only placement policies. Active placement calls are drained before unload.
+/// </summary>
+public abstract class CaptionPlacementPolicyExtension : Extension, ILiveUnloadExtension
+{
+    public abstract IReadOnlyCollection<CaptionPlacementPolicyRegistration> Registrations { get; }
+}

--- a/src/Beutl.Editor/Services/Captions/CaptionTemplateRegistry.cs
+++ b/src/Beutl.Editor/Services/Captions/CaptionTemplateRegistry.cs
@@ -1,0 +1,704 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Beutl.Collections;
+using Beutl.Editor.Models;
+using Beutl.Extensibility;
+
+namespace Beutl.Editor.Services.Captions;
+
+public enum CaptionTemplateRegistrationMode
+{
+    Add,
+    Replace,
+}
+
+/// <summary>Describes one currently available caption template.</summary>
+public sealed record CaptionTemplateDescriptor
+{
+    public CaptionTemplateDescriptor(
+        CaptionTemplateId id,
+        CaptionTemplateProviderId providerId,
+        string name,
+        int order = 0)
+    {
+        if (id.Value.Length == 0)
+            throw new ArgumentException("A caption template identifier is required.", nameof(id));
+        if (providerId.Value.Length == 0)
+            throw new ArgumentException("A caption template provider identifier is required.", nameof(providerId));
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        Id = id;
+        ProviderId = providerId;
+        Name = name;
+        Order = order;
+    }
+
+    public CaptionTemplateId Id { get; }
+
+    public CaptionTemplateProviderId ProviderId { get; }
+
+    public string Name { get; }
+
+    public int Order { get; }
+}
+
+public sealed class CaptionTemplateDescriptorRegistration
+{
+    public CaptionTemplateDescriptorRegistration(
+        CaptionTemplateDescriptor descriptor,
+        CaptionTemplateRegistrationMode mode = CaptionTemplateRegistrationMode.Add)
+    {
+        Descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
+        if (!Enum.IsDefined(mode))
+            throw new ArgumentOutOfRangeException(nameof(mode));
+        Mode = mode;
+    }
+
+    public CaptionTemplateDescriptor Descriptor { get; }
+
+    public CaptionTemplateRegistrationMode Mode { get; }
+}
+
+public sealed class CaptionElementFactoryRegistration
+{
+    public CaptionElementFactoryRegistration(
+        CaptionTemplateId templateId,
+        ICaptionElementFactory factory,
+        CaptionTemplateRegistrationMode mode = CaptionTemplateRegistrationMode.Add)
+    {
+        if (templateId.Value.Length == 0)
+            throw new ArgumentException("A caption template identifier is required.", nameof(templateId));
+        TemplateId = templateId;
+        Factory = factory ?? throw new ArgumentNullException(nameof(factory));
+        if (!Enum.IsDefined(mode))
+            throw new ArgumentOutOfRangeException(nameof(mode));
+        Mode = mode;
+    }
+
+    public CaptionTemplateId TemplateId { get; }
+
+    public ICaptionElementFactory Factory { get; }
+
+    public CaptionTemplateRegistrationMode Mode { get; }
+}
+
+public sealed class CaptionPlacementPolicyRegistration
+{
+    public CaptionPlacementPolicyRegistration(
+        CaptionTemplateId templateId,
+        ICaptionPlacementPolicy policy,
+        CaptionTemplateRegistrationMode mode = CaptionTemplateRegistrationMode.Add)
+    {
+        if (templateId.Value.Length == 0)
+            throw new ArgumentException("A caption template identifier is required.", nameof(templateId));
+        TemplateId = templateId;
+        Policy = policy ?? throw new ArgumentNullException(nameof(policy));
+        if (!Enum.IsDefined(mode))
+            throw new ArgumentOutOfRangeException(nameof(mode));
+        Mode = mode;
+    }
+
+    public CaptionTemplateId TemplateId { get; }
+
+    public ICaptionPlacementPolicy Policy { get; }
+
+    public CaptionTemplateRegistrationMode Mode { get; }
+}
+
+public interface ICaptionTemplateDescriptorRegistration : IAsyncDisposable
+{
+}
+
+public interface ICaptionElementFactoryRegistration : IAsyncDisposable
+{
+}
+
+public interface ICaptionPlacementPolicyRegistration : IAsyncDisposable
+{
+}
+
+/// <summary>
+/// Holds one coherent descriptor/factory/placement snapshot. Materialize or discard every returned
+/// description before disposing the lease.
+/// </summary>
+public interface ICaptionTemplateLease : IDisposable
+{
+    IReadOnlyList<ElementDescription> CreateElements(
+        CaptionCue cue,
+        CaptionElementContext context);
+}
+
+public sealed class CaptionTemplateLease : ICaptionTemplateLease
+{
+    private readonly object _gate = new();
+    private CaptionTemplateComposition? _composition;
+    private IDisposable? _lifetime;
+
+    internal CaptionTemplateLease(
+        CaptionTemplateComposition composition,
+        IDisposable lifetime)
+    {
+        _composition = composition;
+        _lifetime = lifetime;
+    }
+
+    public IReadOnlyList<ElementDescription> CreateElements(
+        CaptionCue cue,
+        CaptionElementContext context)
+    {
+        lock (_gate)
+        {
+            return (_composition
+                    ?? throw new ObjectDisposedException(nameof(CaptionTemplateLease)))
+                .CreateElements(cue, context);
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            _composition = null;
+            Interlocked.Exchange(ref _lifetime, null)?.Dispose();
+        }
+    }
+}
+
+public interface ICaptionTemplateProvider
+{
+    ICoreReadOnlyList<CaptionTemplateDescriptor> Templates { get; }
+
+    bool TryGet(
+        CaptionTemplateId id,
+        [NotNullWhen(true)] out CaptionTemplateDescriptor? template);
+
+    CaptionTemplateDescriptor GetRequired(CaptionTemplateId id);
+
+    ICaptionTemplateLease Acquire(CaptionTemplateId id);
+}
+
+public sealed class CaptionTemplateRegistry : ICaptionTemplateProvider, IAsyncDisposable
+{
+    private readonly object _mutationGate = new();
+    private readonly object _stateGate = new();
+    private readonly CoreList<CaptionTemplateDescriptor> _templates = [];
+    private readonly List<DescriptorEntry> _descriptorEntries = [];
+    private readonly List<FactoryEntry> _factoryEntries = [];
+    private readonly List<PlacementEntry> _placementEntries = [];
+    private readonly HashSet<State> _retiredStates = [];
+    private State _state = State.Create([], [], []);
+    private Task? _disposeTask;
+    private bool _disposed;
+
+    public CaptionTemplateRegistry()
+    {
+    }
+
+    public CaptionTemplateRegistry(
+        IEnumerable<CaptionTemplateDescriptorRegistration> descriptors,
+        IEnumerable<CaptionElementFactoryRegistration> factories,
+        IEnumerable<CaptionPlacementPolicyRegistration> placements)
+    {
+        ArgumentNullException.ThrowIfNull(descriptors);
+        ArgumentNullException.ThrowIfNull(factories);
+        ArgumentNullException.ThrowIfNull(placements);
+        _descriptorEntries.AddRange(descriptors.Select(registration => new DescriptorEntry(registration)));
+        _factoryEntries.AddRange(factories.Select(registration => new FactoryEntry(registration)));
+        _placementEntries.AddRange(placements.Select(registration => new PlacementEntry(registration)));
+        _state = State.Create(
+            _descriptorEntries.Select(entry => entry.Registration),
+            _factoryEntries.Select(entry => entry.Registration),
+            _placementEntries.Select(entry => entry.Registration));
+        _templates.Replace(_state.Templates);
+    }
+
+    public ICoreReadOnlyList<CaptionTemplateDescriptor> Templates => _templates;
+
+    public ICaptionTemplateDescriptorRegistration Register(
+        CaptionTemplateDescriptorRegistration registration)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+        lock (_mutationGate)
+        {
+            ThrowIfDisposed();
+            ValidateRegistrationMode(
+                registration.Descriptor.Id,
+                registration.Mode,
+                _descriptorEntries.Any(entry =>
+                    entry.Registration.Descriptor.Id == registration.Descriptor.Id),
+                "descriptor");
+            var entry = new DescriptorEntry(registration);
+            _descriptorEntries.Add(entry);
+            try
+            {
+                SwapState(CreateDirectState());
+                return new DescriptorHandle(this, entry);
+            }
+            catch
+            {
+                _descriptorEntries.Remove(entry);
+                throw;
+            }
+        }
+    }
+
+    public ICaptionElementFactoryRegistration Register(CaptionElementFactoryRegistration registration)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+        lock (_mutationGate)
+        {
+            ThrowIfDisposed();
+            ValidateRegistrationMode(
+                registration.TemplateId,
+                registration.Mode,
+                _factoryEntries.Any(entry =>
+                    entry.Registration.TemplateId == registration.TemplateId),
+                "element factory");
+            var entry = new FactoryEntry(registration);
+            _factoryEntries.Add(entry);
+            try
+            {
+                SwapState(CreateDirectState());
+                return new FactoryHandle(this, entry);
+            }
+            catch
+            {
+                _factoryEntries.Remove(entry);
+                throw;
+            }
+        }
+    }
+
+    public ICaptionPlacementPolicyRegistration Register(
+        CaptionPlacementPolicyRegistration registration)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+        lock (_mutationGate)
+        {
+            ThrowIfDisposed();
+            ValidateRegistrationMode(
+                registration.TemplateId,
+                registration.Mode,
+                _placementEntries.Any(entry =>
+                    entry.Registration.TemplateId == registration.TemplateId),
+                "placement policy");
+            var entry = new PlacementEntry(registration);
+            _placementEntries.Add(entry);
+            try
+            {
+                SwapState(CreateDirectState());
+                return new PlacementHandle(this, entry);
+            }
+            catch
+            {
+                _placementEntries.Remove(entry);
+                throw;
+            }
+        }
+    }
+
+    internal CaptionRegistryDrain<Extension> ReplaceOwned(
+        IEnumerable<CaptionTemplateDescriptorRegistration> descriptors,
+        IEnumerable<CaptionElementFactoryRegistration> factories,
+        IEnumerable<CaptionPlacementPolicyRegistration> placements,
+        IReadOnlyDictionary<CaptionTemplateId, Extension> descriptorOwners,
+        IReadOnlyDictionary<CaptionTemplateId, Extension> factoryOwners,
+        IReadOnlyDictionary<CaptionTemplateId, Extension> placementOwners)
+    {
+        lock (_mutationGate)
+        {
+            ThrowIfDisposed();
+            CaptionRegistryDrain<object> retired = SwapState(State.Create(
+                descriptors,
+                factories,
+                placements,
+                ToObjectOwners(descriptorOwners),
+                ToObjectOwners(factoryOwners),
+                ToObjectOwners(placementOwners)));
+            return new CaptionRegistryDrain<Extension>(
+                retired.All.AsTask(),
+                owner => retired.DrainOwnerAsync(owner));
+        }
+    }
+
+    public bool TryGet(
+        CaptionTemplateId id,
+        [NotNullWhen(true)] out CaptionTemplateDescriptor? template)
+    {
+        lock (_stateGate)
+            return _state.TemplatesById.TryGetValue(id, out template);
+    }
+
+    public CaptionTemplateDescriptor GetRequired(CaptionTemplateId id)
+    {
+        if (TryGet(id, out CaptionTemplateDescriptor? template))
+            return template;
+        throw new KeyNotFoundException($"No caption template is registered with identifier '{id}'.");
+    }
+
+    public CaptionTemplateLease Acquire(CaptionTemplateId id)
+    {
+        lock (_stateGate)
+        {
+            State state = _state;
+            if (!state.Compositions.TryGetValue(id, out CaptionTemplateComposition? composition))
+            {
+                throw new KeyNotFoundException(
+                    $"No complete caption template is registered with identifier '{id}'.");
+            }
+
+            return new CaptionTemplateLease(
+                composition,
+                state.AcquireLease(state.GetOwners(id)));
+        }
+    }
+
+    ICaptionTemplateLease ICaptionTemplateProvider.Acquire(CaptionTemplateId id) => Acquire(id);
+
+    public ValueTask DisposeAsync()
+    {
+        lock (_mutationGate)
+        {
+            return new ValueTask(_disposeTask ??= DisposeCoreAsync());
+        }
+    }
+
+    private Task DisposeCoreAsync()
+    {
+        if (_disposed)
+            return Task.CompletedTask;
+        _disposed = true;
+        _descriptorEntries.Clear();
+        _factoryEntries.Clear();
+        _placementEntries.Clear();
+        CaptionRegistryDrain<object> retired = SwapState(State.Create([], [], []));
+        return Task.WhenAll(
+            _retiredStates.Select(state => state.RetireAsync())
+                .Append(retired.All.AsTask())
+                .Distinct());
+    }
+
+    private State CreateDirectState()
+    {
+        DescriptorEntry[] descriptors = _descriptorEntries
+            .GroupBy(entry => entry.Registration.Descriptor.Id)
+            .Select(group => group.Last())
+            .ToArray();
+        FactoryEntry[] factories = _factoryEntries
+            .GroupBy(entry => entry.Registration.TemplateId)
+            .Select(group => group.Last())
+            .ToArray();
+        PlacementEntry[] placements = _placementEntries
+            .GroupBy(entry => entry.Registration.TemplateId)
+            .Select(group => group.Last())
+            .ToArray();
+        return State.Create(
+            descriptors.Select(entry => new CaptionTemplateDescriptorRegistration(
+                entry.Registration.Descriptor)),
+            factories.Select(entry => new CaptionElementFactoryRegistration(
+                entry.Registration.TemplateId,
+                entry.Registration.Factory)),
+            placements.Select(entry => new CaptionPlacementPolicyRegistration(
+                entry.Registration.TemplateId,
+                entry.Registration.Policy)),
+            descriptors.ToDictionary(
+                entry => entry.Registration.Descriptor.Id,
+                entry => (object)entry),
+            factories.ToDictionary(
+                entry => entry.Registration.TemplateId,
+                entry => (object)entry),
+            placements.ToDictionary(
+                entry => entry.Registration.TemplateId,
+                entry => (object)entry));
+    }
+
+    private CaptionRegistryDrain<object> SwapState(State next)
+    {
+        State previous;
+        lock (_stateGate)
+        {
+            previous = _state;
+            _state = next;
+        }
+
+        try
+        {
+            _templates.Replace(next.Templates);
+        }
+        catch
+        {
+        }
+
+        Task retired = previous.RetireAndReleasePayloadAsync();
+        if (!retired.IsCompleted)
+        {
+            _retiredStates.Add(previous);
+            _ = retired.ContinueWith(
+                _ => RemoveRetiredState(previous),
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+
+        return new CaptionRegistryDrain<object>(
+            retired,
+            previous.DrainOwnerAsync);
+    }
+
+    private void RemoveRetiredState(State state)
+    {
+        lock (_mutationGate)
+            _retiredStates.Remove(state);
+    }
+
+    private Task RemoveAsync(DescriptorEntry entry)
+    {
+        lock (_mutationGate)
+        {
+            if (!_descriptorEntries.Remove(entry))
+                return _disposeTask ?? Task.CompletedTask;
+            CaptionRegistryDrain<object> retired = SwapState(CreateDirectState());
+            return DrainOwnerAcrossRetiredStates(entry, retired);
+        }
+    }
+
+    private Task RemoveAsync(FactoryEntry entry)
+    {
+        lock (_mutationGate)
+        {
+            if (!_factoryEntries.Remove(entry))
+                return _disposeTask ?? Task.CompletedTask;
+            CaptionRegistryDrain<object> retired = SwapState(CreateDirectState());
+            return DrainOwnerAcrossRetiredStates(entry, retired);
+        }
+    }
+
+    private Task RemoveAsync(PlacementEntry entry)
+    {
+        lock (_mutationGate)
+        {
+            if (!_placementEntries.Remove(entry))
+                return _disposeTask ?? Task.CompletedTask;
+            CaptionRegistryDrain<object> retired = SwapState(CreateDirectState());
+            return DrainOwnerAcrossRetiredStates(entry, retired);
+        }
+    }
+
+    private Task DrainOwnerAcrossRetiredStates(object owner, CaptionRegistryDrain<object> retired)
+        => Task.WhenAll(
+            _retiredStates.Select(state => state.DrainOwnerAsync(owner))
+                .Append(retired.DrainOwnerAsync(owner))
+                .Distinct());
+
+    private static IReadOnlyDictionary<CaptionTemplateId, object> ToObjectOwners(
+        IReadOnlyDictionary<CaptionTemplateId, Extension> owners)
+        => owners.ToDictionary(pair => pair.Key, pair => (object)pair.Value);
+
+    private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
+
+    private static void ValidateRegistrationMode(
+        CaptionTemplateId id,
+        CaptionTemplateRegistrationMode mode,
+        bool exists,
+        string capabilityName)
+    {
+        if (mode == CaptionTemplateRegistrationMode.Add && exists)
+        {
+            throw new ArgumentException(
+                $"Caption template '{id}' already has a {capabilityName}. Use Replace explicitly.");
+        }
+        if (mode == CaptionTemplateRegistrationMode.Replace && !exists)
+        {
+            throw new ArgumentException(
+                $"Caption template '{id}' has no {capabilityName} to replace.");
+        }
+    }
+
+    private sealed class State : CaptionRegistryLeaseState<object>
+    {
+        private State(
+            Dictionary<CaptionTemplateId, CaptionTemplateDescriptor> descriptors,
+            Dictionary<CaptionTemplateId, ICaptionElementFactory> factories,
+            Dictionary<CaptionTemplateId, ICaptionPlacementPolicy> placements,
+            IReadOnlyDictionary<CaptionTemplateId, object> descriptorOwners,
+            IReadOnlyDictionary<CaptionTemplateId, object> factoryOwners,
+            IReadOnlyDictionary<CaptionTemplateId, object> placementOwners)
+        {
+            DescriptorOwners = descriptorOwners;
+            FactoryOwners = factoryOwners;
+            PlacementOwners = placementOwners;
+            Compositions = descriptors.Keys
+                .Where(factories.ContainsKey)
+                .Where(placements.ContainsKey)
+                .ToDictionary(
+                    id => id,
+                    id => new CaptionTemplateComposition(
+                        descriptors[id],
+                        factories[id],
+                        placements[id]));
+            Templates = Compositions.Values
+                .Select(composition => composition.Descriptor)
+                .OrderBy(template => template.Order)
+                .ThenBy(template => template.Id.Value, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            TemplatesById = Templates.ToDictionary(template => template.Id);
+        }
+
+        public Dictionary<CaptionTemplateId, CaptionTemplateComposition> Compositions
+        { get; private set; }
+
+        public CaptionTemplateDescriptor[] Templates { get; private set; }
+
+        public Dictionary<CaptionTemplateId, CaptionTemplateDescriptor> TemplatesById
+        { get; private set; }
+
+        public IReadOnlyDictionary<CaptionTemplateId, object> DescriptorOwners { get; private set; }
+
+        public IReadOnlyDictionary<CaptionTemplateId, object> FactoryOwners { get; private set; }
+
+        public IReadOnlyDictionary<CaptionTemplateId, object> PlacementOwners { get; private set; }
+
+        public IReadOnlyCollection<object> GetOwners(CaptionTemplateId id)
+        {
+            var owners = new HashSet<object>(ReferenceEqualityComparer.Instance);
+            if (DescriptorOwners.TryGetValue(id, out object? descriptorOwner))
+                owners.Add(descriptorOwner);
+            if (FactoryOwners.TryGetValue(id, out object? factoryOwner))
+                owners.Add(factoryOwner);
+            if (PlacementOwners.TryGetValue(id, out object? placementOwner))
+                owners.Add(placementOwner);
+            return owners.ToArray();
+        }
+
+        public Task RetireAndReleasePayloadAsync()
+        {
+            Task drain = RetireAsync();
+            Compositions = [];
+            Templates = [];
+            TemplatesById = [];
+            DescriptorOwners = new Dictionary<CaptionTemplateId, object>();
+            FactoryOwners = new Dictionary<CaptionTemplateId, object>();
+            PlacementOwners = new Dictionary<CaptionTemplateId, object>();
+            return drain;
+        }
+
+        public static State Create(
+            IEnumerable<CaptionTemplateDescriptorRegistration> descriptorRegistrations,
+            IEnumerable<CaptionElementFactoryRegistration> factoryRegistrations,
+            IEnumerable<CaptionPlacementPolicyRegistration> placementRegistrations,
+            IReadOnlyDictionary<CaptionTemplateId, object>? descriptorOwners = null,
+            IReadOnlyDictionary<CaptionTemplateId, object>? factoryOwners = null,
+            IReadOnlyDictionary<CaptionTemplateId, object>? placementOwners = null)
+        {
+            var descriptors = new Dictionary<CaptionTemplateId, CaptionTemplateDescriptor>();
+            var factories = new Dictionary<CaptionTemplateId, ICaptionElementFactory>();
+            var placements = new Dictionary<CaptionTemplateId, ICaptionPlacementPolicy>();
+            foreach (CaptionTemplateDescriptorRegistration registration in descriptorRegistrations)
+            {
+                Apply(
+                    registration.Descriptor.Id,
+                    registration.Descriptor,
+                    registration.Mode,
+                    descriptors,
+                    "descriptor");
+            }
+            foreach (CaptionElementFactoryRegistration registration in factoryRegistrations)
+            {
+                Apply(
+                    registration.TemplateId,
+                    registration.Factory,
+                    registration.Mode,
+                    factories,
+                    "element factory");
+            }
+            foreach (CaptionPlacementPolicyRegistration registration in placementRegistrations)
+            {
+                Apply(
+                    registration.TemplateId,
+                    registration.Policy,
+                    registration.Mode,
+                    placements,
+                    "placement policy");
+            }
+
+            return new State(
+                descriptors,
+                factories,
+                placements,
+                descriptorOwners ?? new Dictionary<CaptionTemplateId, object>(),
+                factoryOwners ?? new Dictionary<CaptionTemplateId, object>(),
+                placementOwners ?? new Dictionary<CaptionTemplateId, object>());
+        }
+
+        private static void Apply<TCapability>(
+            CaptionTemplateId id,
+            TCapability capability,
+            CaptionTemplateRegistrationMode mode,
+            Dictionary<CaptionTemplateId, TCapability> capabilities,
+            string capabilityName)
+        {
+            bool exists = capabilities.ContainsKey(id);
+            if (mode == CaptionTemplateRegistrationMode.Add && exists)
+            {
+                throw new ArgumentException(
+                    $"Caption template '{id}' already has a {capabilityName}. Use Replace explicitly.");
+            }
+            if (mode == CaptionTemplateRegistrationMode.Replace && !exists)
+            {
+                throw new ArgumentException(
+                    $"Caption template '{id}' has no {capabilityName} to replace.");
+            }
+            capabilities[id] = capability;
+        }
+    }
+
+    private sealed class DescriptorEntry(CaptionTemplateDescriptorRegistration registration)
+    {
+        public CaptionTemplateDescriptorRegistration Registration { get; } = registration;
+    }
+
+    private sealed class FactoryEntry(CaptionElementFactoryRegistration registration)
+    {
+        public CaptionElementFactoryRegistration Registration { get; } = registration;
+    }
+
+    private sealed class PlacementEntry(CaptionPlacementPolicyRegistration registration)
+    {
+        public CaptionPlacementPolicyRegistration Registration { get; } = registration;
+    }
+
+    private abstract class Handle
+    {
+        private readonly Lazy<Task> _dispose;
+
+        protected Handle(Func<Task> dispose)
+        {
+            _dispose = new Lazy<Task>(dispose, LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+
+        protected ValueTask DisposeCoreAsync() => new(_dispose.Value);
+    }
+
+    private sealed class DescriptorHandle(
+        CaptionTemplateRegistry registry,
+        DescriptorEntry entry) : Handle(() => registry.RemoveAsync(entry)),
+        ICaptionTemplateDescriptorRegistration
+    {
+        public ValueTask DisposeAsync() => DisposeCoreAsync();
+    }
+
+    private sealed class FactoryHandle(
+        CaptionTemplateRegistry registry,
+        FactoryEntry entry) : Handle(() => registry.RemoveAsync(entry)),
+        ICaptionElementFactoryRegistration
+    {
+        public ValueTask DisposeAsync() => DisposeCoreAsync();
+    }
+
+    private sealed class PlacementHandle(
+        CaptionTemplateRegistry registry,
+        PlacementEntry entry) : Handle(() => registry.RemoveAsync(entry)),
+        ICaptionPlacementPolicyRegistration
+    {
+        public ValueTask DisposeAsync() => DisposeCoreAsync();
+    }
+}

--- a/src/Beutl.Editor/Services/Captions/CaptionTextConstraints.cs
+++ b/src/Beutl.Editor/Services/Captions/CaptionTextConstraints.cs
@@ -1,0 +1,26 @@
+﻿namespace Beutl.Editor.Services.Captions;
+
+/// <summary>
+/// Defines line-length and line-count constraints for caption text.
+/// </summary>
+public sealed record CaptionTextConstraints
+{
+    public CaptionTextConstraints(int maximumLineLength = 42, int maximumLineCount = 2)
+    {
+        if (maximumLineLength <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maximumLineLength));
+
+        if (maximumLineCount <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maximumLineCount));
+
+        MaximumLineLength = maximumLineLength;
+        MaximumLineCount = maximumLineCount;
+    }
+
+    /// <summary>
+    /// Gets the maximum number of Unicode text elements on one line.
+    /// </summary>
+    public int MaximumLineLength { get; }
+
+    public int MaximumLineCount { get; }
+}

--- a/src/Beutl.Editor/Services/Captions/CaptionTextUtilities.cs
+++ b/src/Beutl.Editor/Services/Captions/CaptionTextUtilities.cs
@@ -1,0 +1,26 @@
+﻿using System.Buffers;
+using System.Globalization;
+using System.Text;
+
+namespace Beutl.Editor.Services.Captions;
+
+internal static class CaptionTextUtilities
+{
+    public static string NormalizeLineEndings(string value)
+        => value.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
+
+    public static string[] GetLines(string value)
+        => NormalizeLineEndings(value).Split('\n');
+
+    public static int GetTextElementCount(string value)
+        => StringInfo.ParseCombiningCharacters(value).Length;
+
+    public static bool IsTextElementWhiteSpace(string value, int start, int end)
+    {
+        ReadOnlySpan<char> element = value.AsSpan(start, end - start);
+        OperationStatus status = Rune.DecodeFromUtf16(element, out Rune rune, out int consumed);
+        return status == OperationStatus.Done
+               && consumed == element.Length
+               && Rune.IsWhiteSpace(rune);
+    }
+}

--- a/src/Beutl.Editor/Services/Captions/CaptionTextWrapper.cs
+++ b/src/Beutl.Editor/Services/Captions/CaptionTextWrapper.cs
@@ -1,0 +1,96 @@
+﻿using System.Globalization;
+
+namespace Beutl.Editor.Services.Captions;
+
+/// <summary>
+/// Wraps caption text without splitting Unicode text elements or truncating content.
+/// </summary>
+public static class CaptionTextWrapper
+{
+    public static string Wrap(string text, CaptionTextConstraints constraints)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        ArgumentNullException.ThrowIfNull(constraints);
+
+        var output = new List<string>();
+        foreach (string line in CaptionTextUtilities.GetLines(text))
+        {
+            WrapLine(line, constraints.MaximumLineLength, output);
+        }
+
+        return string.Join('\n', output);
+    }
+
+    /// <summary>
+    /// Wraps all content and reports whether the result also fits the maximum line count.
+    /// </summary>
+    public static bool TryWrap(
+        string text,
+        CaptionTextConstraints constraints,
+        out string wrappedText)
+    {
+        wrappedText = Wrap(text, constraints);
+        return CaptionTextUtilities.GetLines(wrappedText).Length <= constraints.MaximumLineCount;
+    }
+
+    private static void WrapLine(string line, int maximumLineLength, List<string> output)
+    {
+        string remaining = line;
+        while (true)
+        {
+            int[] boundaries = StringInfo.ParseCombiningCharacters(remaining);
+            if (boundaries.Length <= maximumLineLength)
+            {
+                output.Add(remaining);
+                return;
+            }
+
+            int breakElement = FindWordBreak(remaining, boundaries, maximumLineLength);
+            if (breakElement > 0)
+            {
+                int breakOffset = boundaries[breakElement];
+                string segment = remaining[..breakOffset];
+                if (!string.IsNullOrWhiteSpace(segment))
+                {
+                    output.Add(segment);
+
+                    int nextElement = breakElement;
+                    while (nextElement < boundaries.Length
+                           && IsWhiteSpace(remaining, boundaries, nextElement))
+                    {
+                        nextElement++;
+                    }
+
+                    if (nextElement == boundaries.Length)
+                        return;
+
+                    remaining = remaining[boundaries[nextElement]..];
+                    continue;
+                }
+            }
+
+            int hardBreakOffset = boundaries[maximumLineLength];
+            output.Add(remaining[..hardBreakOffset]);
+            remaining = remaining[hardBreakOffset..];
+        }
+    }
+
+    private static int FindWordBreak(string value, int[] boundaries, int maximumLineLength)
+    {
+        int candidate = Math.Min(maximumLineLength, boundaries.Length - 1);
+        for (int i = candidate; i > 0; i--)
+        {
+            if (IsWhiteSpace(value, boundaries, i))
+                return i;
+        }
+
+        return -1;
+    }
+
+    private static bool IsWhiteSpace(string value, int[] boundaries, int elementIndex)
+    {
+        int start = boundaries[elementIndex];
+        int end = elementIndex + 1 < boundaries.Length ? boundaries[elementIndex + 1] : value.Length;
+        return CaptionTextUtilities.IsTextElementWhiteSpace(value, start, end);
+    }
+}

--- a/src/Beutl.Editor/Services/Captions/CaptionValidation.cs
+++ b/src/Beutl.Editor/Services/Captions/CaptionValidation.cs
@@ -1,0 +1,141 @@
+﻿namespace Beutl.Editor.Services.Captions;
+
+public enum CaptionValidationIssueKind
+{
+    NegativeStart,
+    EndNotAfterStart,
+    OutOfOrder,
+    Overlap,
+    TooManyLines,
+    LineTooLong,
+}
+
+/// <param name="CueIndex">The zero-based index of the cue containing the issue.</param>
+/// <param name="RelatedCueIndex">The zero-based index of a related cue, when applicable.</param>
+/// <param name="LineIndex">The zero-based line index, when applicable.</param>
+public sealed record CaptionValidationIssue(
+    CaptionValidationIssueKind Kind,
+    int CueIndex,
+    int? RelatedCueIndex = null,
+    int? LineIndex = null,
+    int? ActualValue = null,
+    int? Limit = null);
+
+public static class CaptionDocumentValidator
+{
+    public static IReadOnlyList<CaptionValidationIssue> Validate(
+        CaptionDocument document,
+        CaptionTextConstraints? textConstraints = null)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var issues = new List<CaptionValidationIssue>();
+        ValidateTimingAndOrder(document, issues);
+        ValidateOverlaps(document, issues);
+
+        if (textConstraints is not null)
+            ValidateText(document, textConstraints, issues);
+
+        return issues.AsReadOnly();
+    }
+
+    private static void ValidateTimingAndOrder(
+        CaptionDocument document,
+        List<CaptionValidationIssue> issues)
+    {
+        for (int i = 0; i < document.Count; i++)
+        {
+            CaptionCue cue = document[i];
+            if (cue.Start < TimeSpan.Zero)
+            {
+                issues.Add(new CaptionValidationIssue(
+                    CaptionValidationIssueKind.NegativeStart,
+                    i));
+            }
+
+            if (cue.End <= cue.Start)
+            {
+                issues.Add(new CaptionValidationIssue(
+                    CaptionValidationIssueKind.EndNotAfterStart,
+                    i));
+            }
+
+            if (i > 0 && cue.Start < document[i - 1].Start)
+            {
+                issues.Add(new CaptionValidationIssue(
+                    CaptionValidationIssueKind.OutOfOrder,
+                    i,
+                    i - 1));
+            }
+        }
+    }
+
+    private static void ValidateOverlaps(
+        CaptionDocument document,
+        List<CaptionValidationIssue> issues)
+    {
+        (CaptionCue Cue, int Index)[] ordered = document.Cues
+            .Select((cue, index) => (cue, index))
+            .Where(item => item.cue.Start >= TimeSpan.Zero && item.cue.End > item.cue.Start)
+            .OrderBy(item => item.cue.Start)
+            .ThenBy(item => item.cue.End)
+            .Select(item => (item.cue, item.index))
+            .ToArray();
+
+        if (ordered.Length == 0)
+            return;
+
+        TimeSpan greatestEnd = ordered[0].Cue.End;
+        int greatestEndIndex = ordered[0].Index;
+        for (int i = 1; i < ordered.Length; i++)
+        {
+            (CaptionCue cue, int index) = ordered[i];
+            if (cue.Start < greatestEnd)
+            {
+                issues.Add(new CaptionValidationIssue(
+                    CaptionValidationIssueKind.Overlap,
+                    index,
+                    greatestEndIndex));
+            }
+
+            if (cue.End > greatestEnd)
+            {
+                greatestEnd = cue.End;
+                greatestEndIndex = index;
+            }
+        }
+    }
+
+    private static void ValidateText(
+        CaptionDocument document,
+        CaptionTextConstraints constraints,
+        List<CaptionValidationIssue> issues)
+    {
+        for (int cueIndex = 0; cueIndex < document.Count; cueIndex++)
+        {
+            string[] lines = CaptionTextUtilities.GetLines(document[cueIndex].Text);
+            if (lines.Length > constraints.MaximumLineCount)
+            {
+                issues.Add(new CaptionValidationIssue(
+                    CaptionValidationIssueKind.TooManyLines,
+                    cueIndex,
+                    ActualValue: lines.Length,
+                    Limit: constraints.MaximumLineCount));
+            }
+
+            for (int lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+            {
+                int lineLength = CaptionTextUtilities.GetTextElementCount(lines[lineIndex]);
+                if (lineLength > constraints.MaximumLineLength)
+                {
+                    issues.Add(new CaptionValidationIssue(
+                        CaptionValidationIssueKind.LineTooLong,
+                        cueIndex,
+                        LineIndex: lineIndex,
+                        ActualValue: lineLength,
+                        Limit: constraints.MaximumLineLength));
+                }
+            }
+        }
+    }
+}

--- a/src/Beutl.Editor/Services/Captions/DefaultTextCaptionElementFactory.cs
+++ b/src/Beutl.Editor/Services/Captions/DefaultTextCaptionElementFactory.cs
@@ -1,0 +1,99 @@
+﻿using Beutl.Editor.Models;
+using Beutl.Graphics.Shapes;
+using Beutl.Media;
+
+namespace Beutl.Editor.Services.Captions;
+
+/// <summary>
+/// Creates the built-in text element used when no saved caption template is selected.
+/// </summary>
+public sealed class DefaultTextCaptionElementFactory : ICaptionElementFactory
+{
+    public static DefaultTextCaptionElementFactory Instance { get; } = new();
+
+    /// <summary>
+    /// Initializes a factory that uses the rendering engine's default font family.
+    /// </summary>
+    public DefaultTextCaptionElementFactory()
+        : this(Beutl.Media.FontFamily.Default)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a factory that uses <paramref name="fontFamily"/> for every created caption.
+    /// </summary>
+    public DefaultTextCaptionElementFactory(FontFamily fontFamily)
+    {
+        ArgumentNullException.ThrowIfNull(fontFamily);
+        FontFamily = fontFamily;
+    }
+
+    /// <summary>
+    /// Gets the font family assigned to created captions.
+    /// </summary>
+    public FontFamily FontFamily { get; }
+
+    public IReadOnlyList<ElementDescription> CreateElements(CaptionCue cue, CaptionElementContext context)
+    {
+        ArgumentNullException.ThrowIfNull(cue);
+        ArgumentNullException.ThrowIfNull(context);
+
+        return
+        [
+            context.CreateDescription(
+                cue,
+                () => new TextBlock
+                {
+                    Text = { CurrentValue = cue.Text },
+                    Size = { CurrentValue = 48 },
+                    FontFamily = { CurrentValue = FontFamily },
+                    AlignmentX = { CurrentValue = AlignmentX.Center },
+                    AlignmentY = { CurrentValue = AlignmentY.Center },
+                }),
+        ];
+    }
+}
+
+public static class CaptionTemplateDefaults
+{
+    public static CaptionTemplateRegistrationSet CreateDefaultText(string name)
+        => CreateDefaultText(name, DefaultTextCaptionElementFactory.Instance);
+
+    /// <summary>
+    /// Creates the built-in default template with a host-supplied element factory.
+    /// </summary>
+    public static CaptionTemplateRegistrationSet CreateDefaultText(
+        string name,
+        ICaptionElementFactory elementFactory)
+    {
+        ArgumentNullException.ThrowIfNull(elementFactory);
+        var descriptor = new CaptionTemplateDescriptor(
+            CaptionTemplateIds.DefaultText,
+            CaptionTemplateProviders.BuiltIn,
+            name,
+            order: int.MinValue);
+        return new CaptionTemplateRegistrationSet(
+            new CaptionTemplateDescriptorRegistration(descriptor),
+            new CaptionElementFactoryRegistration(descriptor.Id, elementFactory),
+            new CaptionPlacementPolicyRegistration(
+                descriptor.Id,
+                DefaultCaptionPlacementPolicy.Instance));
+    }
+
+    public static CaptionTemplateRegistrationSet CreateText(
+        CaptionTemplateId id,
+        CaptionTemplateProviderId providerId,
+        string name,
+        int order = 0)
+    {
+        var descriptor = new CaptionTemplateDescriptor(id, providerId, name, order);
+        return new CaptionTemplateRegistrationSet(
+            new CaptionTemplateDescriptorRegistration(descriptor),
+            new CaptionElementFactoryRegistration(
+                id,
+                DefaultTextCaptionElementFactory.Instance),
+            new CaptionPlacementPolicyRegistration(
+                id,
+                DefaultCaptionPlacementPolicy.Instance));
+    }
+}

--- a/src/Beutl.Editor/Services/Captions/ObjectTemplateCaptionElementFactory.cs
+++ b/src/Beutl.Editor/Services/Captions/ObjectTemplateCaptionElementFactory.cs
@@ -1,0 +1,88 @@
+﻿using Beutl.Editor.Models;
+using Beutl.Engine;
+using Beutl.Graphics.Shapes;
+using Beutl.Serialization;
+
+namespace Beutl.Editor.Services.Captions;
+
+/// <summary>
+/// Adapts a saved object template to caption element creation and binds each cue to a fresh object.
+/// </summary>
+public sealed class ObjectTemplateCaptionElementFactory<TObject> : ICaptionElementFactory
+    where TObject : EngineObject
+{
+    private readonly Action<TObject, CaptionCue> _applyCue;
+
+    public ObjectTemplateCaptionElementFactory(
+        ObjectTemplateItem objectTemplate,
+        Action<TObject, CaptionCue> applyCue)
+    {
+        ArgumentNullException.ThrowIfNull(objectTemplate);
+        ArgumentNullException.ThrowIfNull(applyCue);
+        if (!typeof(TObject).IsAssignableFrom(objectTemplate.ActualType))
+        {
+            throw new ArgumentException(
+                $"Object template type '{objectTemplate.ActualType}' cannot be adapted as '{typeof(TObject)}'.",
+                nameof(objectTemplate));
+        }
+
+        ObjectTemplate = objectTemplate;
+        _applyCue = applyCue;
+    }
+
+    public ObjectTemplateItem ObjectTemplate { get; }
+
+    public IReadOnlyList<ElementDescription> CreateElements(CaptionCue cue, CaptionElementContext context)
+    {
+        ArgumentNullException.ThrowIfNull(cue);
+        ArgumentNullException.ThrowIfNull(context);
+
+        return [context.CreateDescription(cue, () => CreateObject(cue))];
+    }
+
+    private TObject CreateObject(CaptionCue cue)
+    {
+        TObject source = ObjectTemplate.CreateInstance() as TObject
+                         ?? throw new InvalidOperationException(
+                             $"Failed to create caption object template '{ObjectTemplate.Name.Value}'.");
+
+        ObjectRegenerator.Regenerate(source, source.GetType(), out ICoreSerializable regenerated);
+        TObject result = regenerated as TObject
+                         ?? throw new InvalidOperationException(
+                             $"Caption object template '{ObjectTemplate.Name.Value}' created an incompatible object.");
+        _applyCue(result, cue);
+        return result;
+    }
+}
+
+/// <summary>
+/// Adapts saved text-block templates while keeping their authored transforms intact.
+/// </summary>
+public static class TextBlockCaptionTemplateAdapter
+{
+    public static CaptionTemplateRegistrationSet? TryCreate(ObjectTemplateItem objectTemplate)
+    {
+        ArgumentNullException.ThrowIfNull(objectTemplate);
+        if (!typeof(TextBlock).IsAssignableFrom(objectTemplate.ActualType))
+            return null;
+
+        var descriptor = new CaptionTemplateDescriptor(
+            new CaptionTemplateId($"beutl.user.object-template.{objectTemplate.Id:N}"),
+            CaptionTemplateProviders.User,
+            objectTemplate.Name.Value);
+        return new CaptionTemplateRegistrationSet(
+            new CaptionTemplateDescriptorRegistration(descriptor),
+            new CaptionElementFactoryRegistration(
+                descriptor.Id,
+                new ObjectTemplateCaptionElementFactory<TextBlock>(objectTemplate, ApplyCue)),
+            new CaptionPlacementPolicyRegistration(
+                descriptor.Id,
+                PreserveCaptionPlacementPolicy.Instance));
+    }
+
+    private static void ApplyCue(TextBlock textBlock, CaptionCue cue)
+    {
+        textBlock.Text.Expression = null;
+        textBlock.Text.CurrentValue = cue.Text;
+    }
+}

--- a/src/Beutl.Editor/Services/Captions/SrtCaptionCodec.cs
+++ b/src/Beutl.Editor/Services/Captions/SrtCaptionCodec.cs
@@ -1,0 +1,173 @@
+﻿using System.Text;
+
+namespace Beutl.Editor.Services.Captions;
+
+public sealed class SrtCaptionCodec : ICaptionDecoder, ICaptionEncoder
+{
+    public CaptionFormatId Format => CaptionFormats.Srt;
+
+    public CaptionImportResult Decode(string content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        string[] lines = CaptionTextUtilities.GetLines(content);
+        var cues = new List<CaptionCue>();
+        var errors = new List<CaptionDiagnostic>();
+        int index = 0;
+
+        while (index < lines.Length)
+        {
+            while (index < lines.Length && IsBlankLine(lines[index]))
+                index++;
+
+            if (index >= lines.Length)
+                break;
+
+            int blockLine = index + 1;
+            string timingLine;
+            int timingLineNumber;
+            if (lines[index].Contains("-->", StringComparison.Ordinal))
+            {
+                timingLine = lines[index];
+                timingLineNumber = index + 1;
+                index++;
+            }
+            else
+            {
+                if (!IsCueNumber(lines[index]))
+                {
+                    errors.Add(new CaptionDiagnostic(
+                        CaptionDiagnosticKinds.InvalidStructure,
+                        blockLine,
+                        "Expected a numeric SRT cue identifier or timing line."));
+                    SkipBlock(lines, ref index);
+                    continue;
+                }
+
+                index++;
+                if (index >= lines.Length || !lines[index].Contains("-->", StringComparison.Ordinal))
+                {
+                    errors.Add(new CaptionDiagnostic(
+                        CaptionDiagnosticKinds.InvalidStructure,
+                        blockLine,
+                        "The SRT cue is missing its timing line."));
+                    SkipBlock(lines, ref index);
+                    continue;
+                }
+
+                timingLine = lines[index];
+                timingLineNumber = index + 1;
+                index++;
+            }
+
+            bool timingIsValid = TryParseTiming(
+                timingLine,
+                timingLineNumber,
+                errors,
+                out TimeSpan start,
+                out TimeSpan end);
+
+            int textStart = index;
+            while (index < lines.Length && !IsBlankLine(lines[index]))
+                index++;
+
+            if (timingIsValid)
+            {
+                cues.Add(new CaptionCue(
+                    start,
+                    end,
+                    string.Join('\n', lines[textStart..index])));
+            }
+        }
+
+        var document = new CaptionDocument(cues);
+        return errors.Count == 0 || cues.Count > 0
+            ? CaptionImportResult.Imported(document, errors)
+            : CaptionImportResult.Failure(errors);
+    }
+
+    public string Encode(CaptionDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var builder = new StringBuilder();
+        for (int i = 0; i < document.Count; i++)
+        {
+            CaptionCue cue = document[i];
+            CaptionCodecUtilities.EnsureCueCanExport(cue, i);
+            EnsureMetadataCanExport(cue, i);
+            EnsureNoBlankCueLines(cue.Text, i);
+            (TimeSpan start, TimeSpan end) = CaptionCodecUtilities.QuantizeCue(
+                cue,
+                i,
+                TimeSpan.TicksPerMillisecond);
+
+            builder.Append(i + 1).Append("\r\n");
+            builder.Append(CaptionCodecUtilities.FormatSrtTime(start));
+            builder.Append(" --> ");
+            builder.Append(CaptionCodecUtilities.FormatSrtTime(end));
+            builder.Append("\r\n");
+            builder.Append(CaptionTextUtilities.NormalizeLineEndings(cue.Text).Replace("\n", "\r\n", StringComparison.Ordinal));
+            builder.Append("\r\n\r\n");
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool TryParseTiming(
+        string line,
+        int lineNumber,
+        List<CaptionDiagnostic> errors,
+        out TimeSpan start,
+        out TimeSpan end)
+    {
+        start = default;
+        end = default;
+        if (!CaptionCodecUtilities.TrySplitTimingLine(line, out string startText, out string endText)
+            || !CaptionCodecUtilities.TryParseSrtTime(startText, out start)
+            || !CaptionCodecUtilities.TryParseSrtTime(endText, out end)
+            || start < TimeSpan.Zero
+            || end <= start)
+        {
+            errors.Add(new CaptionDiagnostic(
+                CaptionDiagnosticKinds.InvalidTiming,
+                lineNumber,
+                "The SRT timing must use HH:MM:SS,mmm and have an end after its start."));
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsCueNumber(string value)
+        => value.Length > 0 && value.All(character => character is >= '0' and <= '9');
+
+    private static bool IsBlankLine(string value)
+        => value.All(character => character is ' ' or '\t');
+
+    private static void EnsureNoBlankCueLines(string text, int cueIndex)
+    {
+        if (text.Length > 0 && CaptionTextUtilities.GetLines(text).Any(IsBlankLine))
+        {
+            throw new CaptionExportException(
+                cueIndex,
+                $"{CaptionFormats.Srt} cannot represent a blank line inside one cue without ending the cue block.");
+        }
+    }
+
+    private static void EnsureMetadataCanExport(CaptionCue cue, int cueIndex)
+    {
+        if (cue.Speaker is not null || cue.Language is not null || cue.Metadata.Count > 0)
+        {
+            throw new CaptionExportException(
+                cueIndex,
+                "SRT cannot represent speaker, language, or structured caption metadata.");
+        }
+    }
+
+    private static void SkipBlock(string[] lines, ref int index)
+    {
+        while (index < lines.Length && !IsBlankLine(lines[index]))
+            index++;
+    }
+}

--- a/src/Beutl.Editor/Services/Captions/WebVttCaptionCodec.cs
+++ b/src/Beutl.Editor/Services/Captions/WebVttCaptionCodec.cs
@@ -437,8 +437,15 @@ public sealed class WebVttCaptionCodec : ICaptionDecoder, ICaptionEncoder
             || name.Equals("u", StringComparison.OrdinalIgnoreCase)
             || name.Equals("ruby", StringComparison.OrdinalIgnoreCase)
             || name.Equals("rt", StringComparison.OrdinalIgnoreCase)
+            || HasTagClasses(tag, "lang")
+            || HasTagClasses(tag, "v")
             || CaptionCodecUtilities.TryParseWebVttTime(tag.ToString(), out _);
     }
+
+    private static bool HasTagClasses(ReadOnlySpan<char> tag, string name)
+        => tag.Length > name.Length
+            && tag.StartsWith(name, StringComparison.OrdinalIgnoreCase)
+            && tag[name.Length] == '.';
 
     private static bool IsLanguageCharacter(char value)
         => value is >= 'a' and <= 'z'
@@ -499,16 +506,36 @@ public sealed class WebVttCaptionCodec : ICaptionDecoder, ICaptionEncoder
         string name,
         out string annotation)
     {
-        if (tag.Length > name.Length
-            && tag.StartsWith(name, StringComparison.OrdinalIgnoreCase)
-            && IsWebVttWhitespace(tag[name.Length]))
+        if (tag.Length <= name.Length
+            || !tag.StartsWith(name, StringComparison.OrdinalIgnoreCase))
         {
-            annotation = tag[(name.Length + 1)..];
-            return true;
+            annotation = string.Empty;
+            return false;
         }
 
-        annotation = string.Empty;
-        return false;
+        int annotationStart;
+        if (IsWebVttWhitespace(tag[name.Length]))
+        {
+            annotationStart = name.Length + 1;
+        }
+        else if (tag[name.Length] == '.')
+        {
+            int whitespace = tag.AsSpan(name.Length + 1).IndexOfAny("\t\n\f\r ".AsSpan());
+            if (whitespace < 0)
+            {
+                annotation = string.Empty;
+                return false;
+            }
+            annotationStart = name.Length + 1 + whitespace + 1;
+        }
+        else
+        {
+            annotation = string.Empty;
+            return false;
+        }
+
+        annotation = tag[annotationStart..];
+        return true;
     }
 
     private static bool IsClosingTag(string tag, string name)

--- a/src/Beutl.Editor/Services/Captions/WebVttCaptionCodec.cs
+++ b/src/Beutl.Editor/Services/Captions/WebVttCaptionCodec.cs
@@ -1,0 +1,442 @@
+﻿using System.Net;
+using System.Text;
+
+namespace Beutl.Editor.Services.Captions;
+
+public sealed class WebVttCaptionCodec : ICaptionDecoder, ICaptionEncoder
+{
+    public CaptionFormatId Format => CaptionFormats.WebVtt;
+
+    public CaptionImportResult Decode(string content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        string[] lines = CaptionTextUtilities.GetLines(content);
+        if (lines.Length == 0 || !IsHeader(lines[0]))
+        {
+            return CaptionImportResult.Failure(
+            [
+                new CaptionDiagnostic(
+                    CaptionDiagnosticKinds.InvalidHeader,
+                    1,
+                    "A WebVTT document must begin with WEBVTT."),
+            ]);
+        }
+
+        var cues = new List<CaptionCue>();
+        var errors = new List<CaptionDiagnostic>();
+        int index = 1;
+
+        while (index < lines.Length && lines[index].Length > 0)
+        {
+            if (lines[index].Contains("-->", StringComparison.Ordinal))
+                break;
+            index++;
+        }
+
+        while (index < lines.Length)
+        {
+            while (index < lines.Length && lines[index].Length == 0)
+                index++;
+
+            if (index >= lines.Length)
+                break;
+
+            if (IsBlock(lines[index], "NOTE")
+                || IsBlock(lines[index], "STYLE")
+                || IsBlock(lines[index], "REGION"))
+            {
+                SkipBlock(lines, ref index);
+                continue;
+            }
+
+            int cueLine = index + 1;
+            if (!lines[index].Contains("-->", StringComparison.Ordinal))
+            {
+                index++;
+                if (index >= lines.Length || !lines[index].Contains("-->", StringComparison.Ordinal))
+                {
+                    errors.Add(new CaptionDiagnostic(
+                        CaptionDiagnosticKinds.InvalidStructure,
+                        cueLine,
+                        "The WebVTT cue identifier is not followed by a timing line."));
+                    SkipBlock(lines, ref index);
+                    continue;
+                }
+            }
+
+            string timingLine = lines[index];
+            int timingLineNumber = index + 1;
+            index++;
+            bool timingIsValid = TryParseTiming(
+                timingLine,
+                timingLineNumber,
+                errors,
+                out TimeSpan start,
+                out TimeSpan end);
+
+            int textStart = index;
+            while (index < lines.Length && lines[index].Length > 0)
+                index++;
+
+            if (timingIsValid)
+            {
+                string payload = string.Join('\n', lines[textStart..index]);
+                ParsedWebVttText parsed = ParseText(payload);
+                if (parsed.HasMultipleVoiceSpans)
+                {
+                    errors.Add(new CaptionDiagnostic(
+                        CaptionDiagnosticKinds.UnsupportedMarkup,
+                        textStart + 1,
+                        "A WebVTT cue with multiple voice spans cannot be represented by one caption speaker."));
+                }
+                else if (parsed.HasPartialVoiceSpan)
+                {
+                    errors.Add(new CaptionDiagnostic(
+                        CaptionDiagnosticKinds.UnsupportedMarkup,
+                        textStart + 1,
+                        "A WebVTT voice span that does not cover the whole cue cannot be represented by one caption speaker."));
+                }
+                CaptionMetadata metadata = parsed.Classes is null
+                    ? CaptionMetadata.Empty
+                    : CaptionMetadata.Empty.Set(CaptionMetadataKeys.WebVttClasses, parsed.Classes);
+                cues.Add(new CaptionCue(
+                    start,
+                    end,
+                    parsed.Text,
+                    parsed.Speaker,
+                    parsed.Language,
+                    metadata));
+            }
+        }
+
+        var document = new CaptionDocument(cues);
+        return errors.Count == 0 || cues.Count > 0
+            ? CaptionImportResult.Imported(document, errors)
+            : CaptionImportResult.Failure(errors);
+    }
+
+    public string Encode(CaptionDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var builder = new StringBuilder("WEBVTT\r\n\r\n");
+        for (int i = 0; i < document.Count; i++)
+        {
+            CaptionCue cue = document[i];
+            CaptionCodecUtilities.EnsureCueCanExport(cue, i);
+            CaptionCodecUtilities.EnsureNoBlankCueLines(cue.Text, i, Format);
+            ValidateMetadata(cue, i);
+            (TimeSpan start, TimeSpan end) = CaptionCodecUtilities.QuantizeCue(
+                cue,
+                i,
+                TimeSpan.TicksPerMillisecond);
+
+            builder.Append(CaptionCodecUtilities.FormatWebVttTime(start));
+            builder.Append(" --> ");
+            builder.Append(CaptionCodecUtilities.FormatWebVttTime(end));
+            builder.Append("\r\n");
+            builder.Append(EncodeText(cue).Replace("\n", "\r\n", StringComparison.Ordinal));
+            builder.Append("\r\n\r\n");
+        }
+
+        return builder.ToString();
+    }
+
+    private static ParsedWebVttText ParseText(string payload)
+    {
+        string? speaker = null;
+        string? language = null;
+        string? style = null;
+        int position = 0;
+        while (position < payload.Length && payload[position] == '<')
+        {
+            int close = payload.IndexOf('>', position + 1);
+            if (close < 0)
+                break;
+
+            string tag = TrimWebVttWhitespace(payload[(position + 1)..close]);
+            if (TryGetAnnotation(tag, "v", out string voiceAnnotation))
+            {
+                speaker ??= CanonicalizeVoiceAnnotation(WebUtility.HtmlDecode(voiceAnnotation));
+            }
+            else if (TryGetAnnotation(tag, "lang", out string languageAnnotation))
+            {
+                language ??= WebUtility.HtmlDecode(TrimWebVttWhitespace(languageAnnotation));
+            }
+            else if (tag.StartsWith("c.", StringComparison.OrdinalIgnoreCase))
+            {
+                style ??= WebUtility.HtmlDecode(tag[2..].Trim());
+            }
+            else
+            {
+                break;
+            }
+
+            position = close + 1;
+        }
+
+        var plainText = new StringBuilder(payload.Length);
+        int voiceSpanCount = 0;
+        int voiceDepth = 0;
+        bool hasTextOutsideVoiceSpan = false;
+        for (int i = 0; i < payload.Length; i++)
+        {
+            if (payload[i] == '<')
+            {
+                int close = payload.IndexOf('>', i + 1);
+                ReadOnlySpan<char> tagSpan = close >= 0
+                    ? payload.AsSpan(i + 1, close - i - 1)
+                    : [];
+                if (close >= 0 && IsRecognizedCueTag(tagSpan))
+                {
+                    string tag = TrimWebVttWhitespace(tagSpan.ToString());
+                    if (TryGetAnnotation(tag, "v", out string voiceAnnotation))
+                    {
+                        voiceSpanCount++;
+                        if (voiceSpanCount == 1 && !hasTextOutsideVoiceSpan && speaker is null)
+                        {
+                            speaker = CanonicalizeVoiceAnnotation(
+                                WebUtility.HtmlDecode(voiceAnnotation));
+                        }
+                        voiceDepth++;
+                    }
+                    else if (IsClosingTag(tag, "v") && voiceDepth > 0)
+                    {
+                        voiceDepth--;
+                    }
+                    i = close;
+                    continue;
+                }
+            }
+
+            plainText.Append(payload[i]);
+            if (voiceDepth == 0)
+                hasTextOutsideVoiceSpan = true;
+        }
+
+        return new ParsedWebVttText(
+            WebUtility.HtmlDecode(plainText.ToString()),
+            EmptyToNull(speaker),
+            EmptyToNull(language),
+            EmptyToNull(style),
+            voiceSpanCount > 1,
+            voiceSpanCount > 0
+                && (string.IsNullOrEmpty(speaker) || hasTextOutsideVoiceSpan));
+    }
+
+    private static string EncodeText(CaptionCue cue)
+    {
+        string? classes = cue.Metadata.GetValueOrDefault(CaptionMetadataKeys.WebVttClasses);
+        var builder = new StringBuilder();
+        if (cue.Speaker is not null)
+            builder.Append("<v ").Append(WebUtility.HtmlEncode(cue.Speaker)).Append('>');
+        if (cue.Language is not null)
+            builder.Append("<lang ").Append(cue.Language).Append('>');
+        if (classes is not null)
+            builder.Append("<c.").Append(classes).Append('>');
+
+        builder.Append(WebUtility.HtmlEncode(CaptionTextUtilities.NormalizeLineEndings(cue.Text)));
+
+        if (classes is not null)
+            builder.Append("</c>");
+        if (cue.Language is not null)
+            builder.Append("</lang>");
+        if (cue.Speaker is not null)
+            builder.Append("</v>");
+        return builder.ToString();
+    }
+
+    private static void ValidateMetadata(CaptionCue cue, int cueIndex)
+    {
+        string? classes = cue.Metadata.GetValueOrDefault(CaptionMetadataKeys.WebVttClasses);
+        if (cue.Speaker is { } speaker)
+        {
+            string canonical = CanonicalizeVoiceAnnotation(speaker);
+            if (canonical.Length == 0
+                || !string.Equals(speaker, canonical, StringComparison.Ordinal))
+            {
+                throw new CaptionExportException(
+                    cueIndex,
+                    "A WebVTT voice annotation must use canonical single-space separation without surrounding whitespace.");
+            }
+        }
+
+        if (cue.Speaker?.IndexOfAny('\r', '\n') >= 0)
+        {
+            throw new CaptionExportException(
+                cueIndex,
+                "A WebVTT voice annotation cannot contain a line break.");
+        }
+
+        if (cue.Language is not null && !cue.Language.All(IsLanguageCharacter))
+        {
+            throw new CaptionExportException(
+                cueIndex,
+                "A WebVTT language annotation may contain only ASCII letters, digits, and hyphens.");
+        }
+
+        if (classes is not null && !classes.All(IsClassCharacter))
+        {
+            throw new CaptionExportException(
+                cueIndex,
+                "A WebVTT class annotation may contain only letters, digits, periods, underscores, and hyphens.");
+        }
+    }
+
+    private static bool TryParseTiming(
+        string line,
+        int lineNumber,
+        List<CaptionDiagnostic> errors,
+        out TimeSpan start,
+        out TimeSpan end)
+    {
+        start = default;
+        end = default;
+        if (!CaptionCodecUtilities.TrySplitTimingLine(line, out string startText, out string endText)
+            || !CaptionCodecUtilities.TryParseWebVttTime(startText, out start)
+            || !CaptionCodecUtilities.TryParseWebVttTime(endText, out end)
+            || end <= start)
+        {
+            errors.Add(new CaptionDiagnostic(
+                CaptionDiagnosticKinds.InvalidTiming,
+                lineNumber,
+                "The WebVTT timing is malformed or does not end after it starts."));
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsHeader(string value)
+        => value.Equals("WEBVTT", StringComparison.Ordinal)
+           || (value.StartsWith("WEBVTT", StringComparison.Ordinal)
+               && value.Length > 6
+               && char.IsWhiteSpace(value[6]));
+
+    private static bool IsBlock(string value, string name)
+        => value.Equals(name, StringComparison.Ordinal)
+           || (value.StartsWith(name, StringComparison.Ordinal)
+               && value.Length > name.Length
+               && char.IsWhiteSpace(value[name.Length]));
+
+    private static void SkipBlock(string[] lines, ref int index)
+    {
+        while (index < lines.Length && lines[index].Length > 0)
+            index++;
+    }
+
+    private static bool IsRecognizedCueTag(ReadOnlySpan<char> rawTag)
+    {
+        ReadOnlySpan<char> tag = rawTag.Trim();
+        if (!tag.IsEmpty && tag[0] == '/')
+            tag = tag[1..].TrimStart();
+
+        int annotation = IndexOfAnnotationSeparator(tag);
+        ReadOnlySpan<char> name = annotation >= 0 ? tag[..annotation] : tag;
+        if (name.Equals("b", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("i", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("u", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("ruby", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("rt", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("v", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("lang", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("c", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return CaptionCodecUtilities.TryParseWebVttTime(tag.ToString(), out _);
+    }
+
+    private static bool IsLanguageCharacter(char value)
+        => value is >= 'a' and <= 'z'
+           or >= 'A' and <= 'Z'
+           or >= '0' and <= '9'
+           or '-';
+
+    private static bool IsClassCharacter(char value)
+        => char.IsLetterOrDigit(value) || value is '.' or '_' or '-';
+
+    private static int IndexOfAnnotationSeparator(ReadOnlySpan<char> value)
+    {
+        for (int index = 0; index < value.Length; index++)
+        {
+            if (value[index] == '.' || IsWebVttWhitespace(value[index]))
+                return index;
+        }
+
+        return -1;
+    }
+
+    private static string CanonicalizeVoiceAnnotation(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+        bool pendingSpace = false;
+        foreach (char character in value)
+        {
+            if (IsWebVttWhitespace(character))
+            {
+                pendingSpace = builder.Length > 0;
+                continue;
+            }
+
+            if (pendingSpace)
+            {
+                builder.Append(' ');
+                pendingSpace = false;
+            }
+            builder.Append(character);
+        }
+
+        return builder.ToString();
+    }
+
+    private static string TrimWebVttWhitespace(string value)
+    {
+        int start = 0;
+        while (start < value.Length && IsWebVttWhitespace(value[start]))
+            start++;
+        int end = value.Length;
+        while (end > start && IsWebVttWhitespace(value[end - 1]))
+            end--;
+        return value[start..end];
+    }
+
+    private static bool TryGetAnnotation(
+        string tag,
+        string name,
+        out string annotation)
+    {
+        if (tag.Length > name.Length
+            && tag.StartsWith(name, StringComparison.OrdinalIgnoreCase)
+            && IsWebVttWhitespace(tag[name.Length]))
+        {
+            annotation = tag[(name.Length + 1)..];
+            return true;
+        }
+
+        annotation = string.Empty;
+        return false;
+    }
+
+    private static bool IsClosingTag(string tag, string name)
+        => tag.Length > 1
+           && tag[0] == '/'
+           && TrimWebVttWhitespace(tag[1..]).Equals(
+               name,
+               StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsWebVttWhitespace(char value)
+        => value is '\t' or '\n' or '\f' or '\r' or ' ';
+
+    private static string? EmptyToNull(string? value) => string.IsNullOrEmpty(value) ? null : value;
+
+    private sealed record ParsedWebVttText(
+        string Text,
+        string? Speaker,
+        string? Language,
+        string? Classes,
+        bool HasMultipleVoiceSpans,
+        bool HasPartialVoiceSpan);
+}

--- a/src/Beutl.Editor/Services/Captions/WebVttCaptionCodec.cs
+++ b/src/Beutl.Editor/Services/Captions/WebVttCaptionCodec.cs
@@ -125,7 +125,8 @@ public sealed class WebVttCaptionCodec : ICaptionDecoder, ICaptionEncoder
         }
 
         var document = new CaptionDocument(cues);
-        return errors.Count == 0 || cues.Count > 0
+        return cues.Count > 0
+            || errors.All(error => error.Kind == CaptionDiagnosticKinds.UnsupportedMarkup)
             ? CaptionImportResult.Imported(document, errors)
             : CaptionImportResult.Failure(errors);
     }

--- a/src/Beutl.Editor/Services/Captions/WebVttCaptionCodec.cs
+++ b/src/Beutl.Editor/Services/Captions/WebVttCaptionCodec.cs
@@ -42,10 +42,17 @@ public sealed class WebVttCaptionCodec : ICaptionDecoder, ICaptionEncoder
             if (index >= lines.Length)
                 break;
 
-            if (IsBlock(lines[index], "NOTE")
-                || IsBlock(lines[index], "STYLE")
-                || IsBlock(lines[index], "REGION"))
+            if (IsBlock(lines[index], "NOTE"))
             {
+                SkipBlock(lines, ref index);
+                continue;
+            }
+            if (IsBlock(lines[index], "STYLE") || IsBlock(lines[index], "REGION"))
+            {
+                errors.Add(new CaptionDiagnostic(
+                    CaptionDiagnosticKinds.UnsupportedMarkup,
+                    index + 1,
+                    "WebVTT STYLE and REGION blocks cannot be represented and were removed."));
                 SkipBlock(lines, ref index);
                 continue;
             }

--- a/src/Beutl.Editor/Services/Captions/WebVttCaptionCodec.cs
+++ b/src/Beutl.Editor/Services/Captions/WebVttCaptionCodec.cs
@@ -97,6 +97,13 @@ public sealed class WebVttCaptionCodec : ICaptionDecoder, ICaptionEncoder
                         textStart + 1,
                         "A WebVTT voice span that does not cover the whole cue cannot be represented by one caption speaker."));
                 }
+                if (parsed.HasUnsupportedInlineMarkup)
+                {
+                    errors.Add(new CaptionDiagnostic(
+                        CaptionDiagnosticKinds.UnsupportedMarkup,
+                        textStart + 1,
+                        "WebVTT inline formatting, ruby, and timestamp tags cannot be represented by a plain caption cue."));
+                }
                 CaptionMetadata metadata = parsed.Classes is null
                     ? CaptionMetadata.Empty
                     : CaptionMetadata.Empty.Set(CaptionMetadataKeys.WebVttClasses, parsed.Classes);
@@ -180,6 +187,7 @@ public sealed class WebVttCaptionCodec : ICaptionDecoder, ICaptionEncoder
         int voiceSpanCount = 0;
         int voiceDepth = 0;
         bool hasTextOutsideVoiceSpan = false;
+        bool hasUnsupportedInlineMarkup = false;
         for (int i = 0; i < payload.Length; i++)
         {
             if (payload[i] == '<')
@@ -190,6 +198,7 @@ public sealed class WebVttCaptionCodec : ICaptionDecoder, ICaptionEncoder
                     : [];
                 if (close >= 0 && IsRecognizedCueTag(tagSpan))
                 {
+                    hasUnsupportedInlineMarkup |= IsUnsupportedInlineCueTag(tagSpan);
                     string tag = TrimWebVttWhitespace(tagSpan.ToString());
                     if (TryGetAnnotation(tag, "v", out string voiceAnnotation))
                     {
@@ -222,7 +231,8 @@ public sealed class WebVttCaptionCodec : ICaptionDecoder, ICaptionEncoder
             EmptyToNull(style),
             voiceSpanCount > 1,
             voiceSpanCount > 0
-                && (string.IsNullOrEmpty(speaker) || hasTextOutsideVoiceSpan));
+                && (string.IsNullOrEmpty(speaker) || hasTextOutsideVoiceSpan),
+            hasUnsupportedInlineMarkup);
     }
 
     private static string EncodeText(CaptionCue cue)
@@ -349,6 +359,22 @@ public sealed class WebVttCaptionCodec : ICaptionDecoder, ICaptionEncoder
         return CaptionCodecUtilities.TryParseWebVttTime(tag.ToString(), out _);
     }
 
+    private static bool IsUnsupportedInlineCueTag(ReadOnlySpan<char> rawTag)
+    {
+        ReadOnlySpan<char> tag = rawTag.Trim();
+        if (!tag.IsEmpty && tag[0] == '/')
+            tag = tag[1..].TrimStart();
+
+        int annotation = IndexOfAnnotationSeparator(tag);
+        ReadOnlySpan<char> name = annotation >= 0 ? tag[..annotation] : tag;
+        return name.Equals("b", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("i", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("u", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("ruby", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("rt", StringComparison.OrdinalIgnoreCase)
+            || CaptionCodecUtilities.TryParseWebVttTime(tag.ToString(), out _);
+    }
+
     private static bool IsLanguageCharacter(char value)
         => value is >= 'a' and <= 'z'
            or >= 'A' and <= 'Z'
@@ -438,5 +464,6 @@ public sealed class WebVttCaptionCodec : ICaptionDecoder, ICaptionEncoder
         string? Language,
         string? Classes,
         bool HasMultipleVoiceSpans,
-        bool HasPartialVoiceSpan);
+        bool HasPartialVoiceSpan,
+        bool HasUnsupportedInlineMarkup);
 }

--- a/src/Beutl.Editor/Services/Captions/WebVttCaptionCodec.cs
+++ b/src/Beutl.Editor/Services/Captions/WebVttCaptionCodec.cs
@@ -104,6 +104,20 @@ public sealed class WebVttCaptionCodec : ICaptionDecoder, ICaptionEncoder
                         textStart + 1,
                         "A WebVTT voice span that does not cover the whole cue cannot be represented by one caption speaker."));
                 }
+                if (parsed.HasMultipleLanguageSpans)
+                {
+                    errors.Add(new CaptionDiagnostic(
+                        CaptionDiagnosticKinds.UnsupportedMarkup,
+                        textStart + 1,
+                        "A WebVTT cue with multiple language spans cannot be represented by one caption language."));
+                }
+                else if (parsed.HasPartialLanguageSpan)
+                {
+                    errors.Add(new CaptionDiagnostic(
+                        CaptionDiagnosticKinds.UnsupportedMarkup,
+                        textStart + 1,
+                        "A WebVTT language span that does not cover the whole cue cannot be represented by one caption language."));
+                }
                 if (parsed.HasUnsupportedInlineMarkup)
                 {
                     errors.Add(new CaptionDiagnostic(
@@ -195,6 +209,9 @@ public sealed class WebVttCaptionCodec : ICaptionDecoder, ICaptionEncoder
         int voiceSpanCount = 0;
         int voiceDepth = 0;
         bool hasTextOutsideVoiceSpan = false;
+        int languageSpanCount = 0;
+        int languageDepth = 0;
+        bool hasTextOutsideLanguageSpan = false;
         bool hasUnsupportedInlineMarkup = false;
         for (int i = 0; i < payload.Length; i++)
         {
@@ -222,6 +239,22 @@ public sealed class WebVttCaptionCodec : ICaptionDecoder, ICaptionEncoder
                     {
                         voiceDepth--;
                     }
+                    else if (TryGetAnnotation(tag, "lang", out string languageAnnotation))
+                    {
+                        languageSpanCount++;
+                        if (languageSpanCount == 1
+                            && !hasTextOutsideLanguageSpan
+                            && language is null)
+                        {
+                            language = WebUtility.HtmlDecode(
+                                TrimWebVttWhitespace(languageAnnotation));
+                        }
+                        languageDepth++;
+                    }
+                    else if (IsClosingTag(tag, "lang") && languageDepth > 0)
+                    {
+                        languageDepth--;
+                    }
                     i = close;
                     continue;
                 }
@@ -230,6 +263,8 @@ public sealed class WebVttCaptionCodec : ICaptionDecoder, ICaptionEncoder
             plainText.Append(payload[i]);
             if (voiceDepth == 0)
                 hasTextOutsideVoiceSpan = true;
+            if (languageDepth == 0)
+                hasTextOutsideLanguageSpan = true;
         }
 
         return new ParsedWebVttText(
@@ -240,6 +275,9 @@ public sealed class WebVttCaptionCodec : ICaptionDecoder, ICaptionEncoder
             voiceSpanCount > 1,
             voiceSpanCount > 0
                 && (string.IsNullOrEmpty(speaker) || hasTextOutsideVoiceSpan),
+            languageSpanCount > 1,
+            languageSpanCount > 0
+                && (string.IsNullOrEmpty(language) || hasTextOutsideLanguageSpan),
             hasUnsupportedInlineMarkup);
     }
 
@@ -323,7 +361,26 @@ public sealed class WebVttCaptionCodec : ICaptionDecoder, ICaptionEncoder
             return false;
         }
 
+        if (HasCueSettings(line))
+        {
+            errors.Add(new CaptionDiagnostic(
+                CaptionDiagnosticKinds.UnsupportedMarkup,
+                lineNumber,
+                "WebVTT cue settings cannot be represented and were removed."));
+        }
+
         return true;
+    }
+
+    private static bool HasCueSettings(string line)
+    {
+        int separator = line.IndexOf("-->", StringComparison.Ordinal);
+        if (separator < 0)
+            return false;
+
+        ReadOnlySpan<char> right = line.AsSpan(separator + 3).Trim();
+        int whitespace = right.IndexOfAny(' ', '\t');
+        return whitespace >= 0 && !right[(whitespace + 1)..].Trim().IsEmpty;
     }
 
     private static bool IsHeader(string value)
@@ -473,5 +530,7 @@ public sealed class WebVttCaptionCodec : ICaptionDecoder, ICaptionEncoder
         string? Classes,
         bool HasMultipleVoiceSpans,
         bool HasPartialVoiceSpan,
+        bool HasMultipleLanguageSpans,
+        bool HasPartialLanguageSpan,
         bool HasUnsupportedInlineMarkup);
 }

--- a/src/Beutl.Editor/Services/ElementAddResult.cs
+++ b/src/Beutl.Editor/Services/ElementAddResult.cs
@@ -1,0 +1,244 @@
+﻿using Beutl.Editor.Models;
+using Beutl.ProjectSystem;
+
+namespace Beutl.Editor.Services;
+
+public readonly struct ElementAddFailureId : IEquatable<ElementAddFailureId>
+{
+    private readonly string? _value;
+
+    public ElementAddFailureId(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        _value = value.Trim();
+    }
+
+    public string Value => _value ?? string.Empty;
+
+    public bool Equals(ElementAddFailureId other)
+        => StringComparer.Ordinal.Equals(Value, other.Value);
+
+    public override bool Equals(object? obj)
+        => obj is ElementAddFailureId other && Equals(other);
+
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Value);
+
+    public override string ToString() => Value;
+
+    public static bool operator ==(ElementAddFailureId left, ElementAddFailureId right)
+        => left.Equals(right);
+
+    public static bool operator !=(ElementAddFailureId left, ElementAddFailureId right)
+        => !left.Equals(right);
+}
+
+public static class ElementAddFailureIds
+{
+    public static ElementAddFailureId EmptyRequest { get; } = new("element.empty-request");
+
+    public static ElementAddFailureId UnsupportedSource { get; } = new("element.unsupported-source");
+
+    public static ElementAddFailureId LockedLayer { get; } = new("element.locked-layer");
+
+    public static ElementAddFailureId Preflight { get; } = new("element.preflight");
+
+    public static ElementAddFailureId Materialization { get; } = new("element.materialization");
+
+    public static ElementAddFailureId InvalidMaterialization { get; }
+        = new("element.invalid-materialization");
+
+    public static ElementAddFailureId Persistence { get; } = new("element.persistence");
+
+    public static ElementAddFailureId SceneChanged { get; } = new("element.scene-changed");
+
+    public static ElementAddFailureId SceneMutation { get; } = new("element.scene-mutation");
+}
+
+/// <summary>
+/// Base type for failures returned by the element-add pipeline. Source handlers may expose
+/// their own typed failures with an open identifier.
+/// </summary>
+public abstract record ElementAddFailure
+{
+    protected ElementAddFailure(
+        ElementAddFailureId id,
+        string message,
+        Exception? exception = null)
+    {
+        if (id.Value.Length == 0)
+            throw new ArgumentException("A failure identifier is required.", nameof(id));
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+
+        Id = id;
+        Message = message;
+        Exception = exception;
+    }
+
+    public ElementAddFailureId Id { get; }
+
+    public string Message { get; }
+
+    public Exception? Exception { get; }
+}
+
+public sealed record EmptyElementAddRequestFailure : ElementAddFailure
+{
+    public EmptyElementAddRequestFailure()
+        : base(ElementAddFailureIds.EmptyRequest, "At least one element description is required.")
+    {
+    }
+}
+
+public sealed record UnsupportedElementSourceFailure : ElementAddFailure
+{
+    public UnsupportedElementSourceFailure(Type sourceType, string? message = null)
+        : base(
+            ElementAddFailureIds.UnsupportedSource,
+            message ?? $"No element source handler is registered for '{sourceType.FullName}'.")
+    {
+        ArgumentNullException.ThrowIfNull(sourceType);
+        SourceType = sourceType;
+    }
+
+    public Type SourceType { get; }
+}
+
+public sealed record LockedElementLayerFailure : ElementAddFailure
+{
+    public LockedElementLayerFailure(int layer)
+        : base(ElementAddFailureIds.LockedLayer, $"Timeline layer {layer} is locked.")
+    {
+        Layer = layer;
+    }
+
+    public int Layer { get; }
+}
+
+public sealed record ElementSourcePreflightFailure : ElementAddFailure
+{
+    public ElementSourcePreflightFailure(string message, Exception? exception = null)
+        : base(ElementAddFailureIds.Preflight, message, exception)
+    {
+    }
+}
+
+public sealed record ElementMaterializationFailure : ElementAddFailure
+{
+    public ElementMaterializationFailure(string message, Exception? exception = null)
+        : base(ElementAddFailureIds.Materialization, message, exception)
+    {
+    }
+}
+
+public sealed record InvalidElementMaterializationFailure : ElementAddFailure
+{
+    public InvalidElementMaterializationFailure(string message)
+        : base(ElementAddFailureIds.InvalidMaterialization, message)
+    {
+    }
+}
+
+public sealed record ElementPersistenceFailure : ElementAddFailure
+{
+    public ElementPersistenceFailure(Exception exception)
+        : base(ElementAddFailureIds.Persistence, "The element batch could not be persisted.", exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+    }
+}
+
+public sealed record ElementSceneChangedFailure : ElementAddFailure
+{
+    public ElementSceneChangedFailure(Guid expectedSceneId, Guid actualSceneId)
+        : base(
+            ElementAddFailureIds.SceneChanged,
+            $"The target scene changed from '{expectedSceneId}' to '{actualSceneId}' while elements were materialized.")
+    {
+        ExpectedSceneId = expectedSceneId;
+        ActualSceneId = actualSceneId;
+    }
+
+    public Guid ExpectedSceneId { get; }
+
+    public Guid ActualSceneId { get; }
+}
+
+public sealed record ElementSceneMutationFailure : ElementAddFailure
+{
+    public ElementSceneMutationFailure(Exception exception)
+        : base(ElementAddFailureIds.SceneMutation, "The element batch could not be added to the scene.", exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+    }
+}
+
+public sealed class ElementAddItemResult
+{
+    public ElementAddItemResult(
+        ElementDescription description,
+        Element primaryElement,
+        IReadOnlyList<Element> companionElements)
+    {
+        ArgumentNullException.ThrowIfNull(description);
+        ArgumentNullException.ThrowIfNull(primaryElement);
+        ArgumentNullException.ThrowIfNull(companionElements);
+        if (companionElements.Any(element => element is null))
+            throw new ArgumentException("Companion elements cannot contain null.", nameof(companionElements));
+
+        Description = description;
+        PrimaryElement = primaryElement;
+        CompanionElements = Array.AsReadOnly(companionElements.ToArray());
+        Elements = Array.AsReadOnly(new[] { primaryElement }.Concat(CompanionElements).ToArray());
+    }
+
+    public ElementDescription Description { get; }
+
+    public Element PrimaryElement { get; }
+
+    public IReadOnlyList<Element> CompanionElements { get; }
+
+    public IReadOnlyList<Element> Elements { get; }
+}
+
+public sealed class ElementAddResult
+{
+    private ElementAddResult(
+        IReadOnlyList<ElementAddItemResult> items,
+        ElementAddFailure? failure,
+        ElementDescription? failedDescription)
+    {
+        Items = Array.AsReadOnly(items.ToArray());
+        Elements = Array.AsReadOnly(Items.SelectMany(item => item.Elements).ToArray());
+        Failure = failure;
+        FailedDescription = failedDescription;
+    }
+
+    public bool IsSuccess => Failure is null;
+
+    public IReadOnlyList<ElementAddItemResult> Items { get; }
+
+    public IReadOnlyList<Element> Elements { get; }
+
+    public ElementAddFailure? Failure { get; }
+
+    public ElementDescription? FailedDescription { get; }
+
+    public static ElementAddResult Succeeded(IReadOnlyList<ElementAddItemResult> items)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        if (items.Count == 0)
+            throw new ArgumentException("A successful add must contain at least one item.", nameof(items));
+        if (items.Any(item => item is null))
+            throw new ArgumentException("A successful add cannot contain null items.", nameof(items));
+
+        return new ElementAddResult(items, null, null);
+    }
+
+    public static ElementAddResult Failed(
+        ElementAddFailure failure,
+        ElementDescription? failedDescription = null)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        return new ElementAddResult([], failure, failedDescription);
+    }
+}

--- a/src/Beutl.Editor/Services/ElementClipboardService.cs
+++ b/src/Beutl.Editor/Services/ElementClipboardService.cs
@@ -167,7 +167,8 @@ public sealed class ElementClipboardService : IElementClipboardService
             Pasted: true,
             NewElements: [],
             ScrollTo: outcome.ScrollToRange,
-            ScrollToZIndex: outcome.ScrollToZIndex);
+            ScrollToZIndex: outcome.ScrollToZIndex,
+            AddFailure: null);
     }
 
     private async Task<ElementPasteOutcome> PasteSingleElementAsync(Scene scene, TimeSpan clickedFrame, int clickedLayer)
@@ -211,7 +212,8 @@ public sealed class ElementClipboardService : IElementClipboardService
             Pasted: true,
             NewElements: [newElement],
             ScrollTo: newElement.Range,
-            ScrollToZIndex: newElement.ZIndex);
+            ScrollToZIndex: newElement.ZIndex,
+            AddFailure: null);
     }
 
     private async Task<ElementPasteOutcome> PasteFilesAsync(Scene scene, TimeSpan clickedFrame, int clickedLayer)
@@ -221,13 +223,31 @@ public sealed class ElementClipboardService : IElementClipboardService
         IReadOnlyList<string>? files = await _clipboard.TryGetFilePathsAsync();
         if (files is null || files.Count == 0) return ElementPasteOutcome.Empty;
 
-        foreach (string file in files)
+        ElementAddResult result = await _elementAdder.AddAsync(files
+            .Select(file => new ElementDescription(
+                clickedFrame,
+                TimeSpan.FromSeconds(5),
+                clickedLayer,
+                new ElementSource.File(file)))
+            .ToArray(), CancellationToken.None);
+        if (!result.IsSuccess)
         {
-            _elementAdder.AddElement(new ElementDescription(
-                clickedFrame, TimeSpan.FromSeconds(5), clickedLayer, FileName: file));
+            return new ElementPasteOutcome(
+                Pasted: false,
+                NewElements: [],
+                ScrollTo: default,
+                ScrollToZIndex: 0,
+                AddFailure: result.Failure);
         }
 
-        return new ElementPasteOutcome(true, [], default, 0);
+        IReadOnlyList<Element> newElements = result.Elements;
+        Element scrollTarget = result.Items[^1].PrimaryElement;
+        return new ElementPasteOutcome(
+            Pasted: true,
+            NewElements: newElements,
+            ScrollTo: scrollTarget.Range,
+            ScrollToZIndex: scrollTarget.ZIndex,
+            AddFailure: null);
     }
 
     private async Task<ElementPasteOutcome> PasteBitmapAsync(Scene scene, TimeSpan clickedFrame, int clickedLayer)
@@ -300,6 +320,7 @@ public sealed class ElementClipboardService : IElementClipboardService
             Pasted: true,
             NewElements: [newElement],
             ScrollTo: newElement.Range,
-            ScrollToZIndex: newElement.ZIndex);
+            ScrollToZIndex: newElement.ZIndex,
+            AddFailure: null);
     }
 }

--- a/src/Beutl.Editor/Services/ElementSourceHandlerRegistry.cs
+++ b/src/Beutl.Editor/Services/ElementSourceHandlerRegistry.cs
@@ -1,0 +1,709 @@
+﻿using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
+using Beutl.Api.Services;
+using Beutl.Collections;
+using Beutl.Extensibility;
+
+namespace Beutl.Editor.Services;
+
+/// <summary>
+/// Resolves source handlers from host and package contributions. Removing a contribution retires
+/// it before package unload and waits for active materialization calls to finish.
+/// </summary>
+public sealed class ElementSourceHandlerRegistry : IElementSourceHandlerRegistry, IAsyncDisposable
+{
+    private readonly Dictionary<Type, List<Registration>> _handlers = [];
+    private readonly CoreList<ElementSourceHandlerDescriptor> _handlerMetadata = [];
+    private readonly HashSet<Task> _activeRegistrationRetirements = [];
+    private readonly Dictionary<ElementSourceHandlerExtension, List<Registration>> _extensionRegistrations =
+        new(ReferenceEqualityComparer.Instance);
+    private readonly object _extensionCompositionGate = new();
+    private readonly object _gate = new();
+    private readonly Action<ElementSourceHandlerExtensionFailure>? _reportFailure;
+    private IExtensionRegistry? _extensionProvider;
+    private Task? _disposeTask;
+    private long _registrationSequence;
+    private int _metadataBatchDepth;
+    private bool _disposed;
+
+    public ElementSourceHandlerRegistry()
+        : this([])
+    {
+    }
+
+    public ElementSourceHandlerRegistry(
+        IEnumerable<ElementSourceHandlerRegistration> hostRegistrations)
+        : this(hostRegistrations, null, null)
+    {
+    }
+
+    internal ElementSourceHandlerRegistry(
+        IEnumerable<ElementSourceHandlerRegistration> hostRegistrations,
+        IExtensionRegistry? extensionProvider,
+        Action<ElementSourceHandlerExtensionFailure>? reportFailure = null)
+    {
+        ArgumentNullException.ThrowIfNull(hostRegistrations);
+        _reportFailure = reportFailure;
+        foreach (ElementSourceHandlerRegistration registration in hostRegistrations)
+        {
+            Register(registration);
+        }
+
+        if (extensionProvider is not null)
+        {
+            AttachExtensionProvider(extensionProvider);
+        }
+    }
+
+    public ICoreReadOnlyList<ElementSourceHandlerDescriptor> Handlers => _handlerMetadata;
+
+    public IElementSourceHandlerRegistration Register(ElementSourceHandlerRegistration registration)
+    {
+        PreparedRegistration prepared = PrepareRegistration(registration);
+
+        lock (_extensionCompositionGate)
+        {
+            Registration result;
+            ElementSourceHandlerDescriptor[] metadata;
+            lock (_gate)
+            {
+                result = RegisterPrepared_NoLock(prepared);
+                metadata = CreateMetadata_NoLock();
+            }
+            PublishMetadata(metadata);
+            return result;
+        }
+    }
+
+    public bool TryAcquire(
+        Type sourceType,
+        [NotNullWhen(true)] out IElementSourceHandlerLease? lease)
+    {
+        ArgumentNullException.ThrowIfNull(sourceType);
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_handlers.TryGetValue(sourceType, out List<Registration>? entries))
+            {
+                for (int index = entries.Count - 1; index >= 0; index--)
+                {
+                    Registration registration = entries[index];
+                    if (registration.TryAcquire(out HandlerLease? handlerLease))
+                    {
+                        lease = handlerLease;
+                        return true;
+                    }
+
+                    entries.RemoveAt(index);
+                }
+
+                _handlers.Remove(sourceType);
+            }
+
+            lease = null;
+            return false;
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (_extensionProvider is IExtensionRegistry registry)
+        {
+            ValueTask result = default;
+            registry.SynchronizeMutation(() => result = StartDispose());
+            return result;
+        }
+
+        return StartDispose();
+    }
+
+    private ValueTask StartDispose()
+    {
+        lock (_extensionCompositionGate)
+        {
+            if (_disposeTask is not null)
+                return new ValueTask(_disposeTask);
+
+            var completion = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _disposeTask = completion.Task;
+            try
+            {
+                _ = CompleteDisposeAsync(DisposeCoreAsync(), completion);
+            }
+            catch (Exception ex)
+            {
+                completion.TrySetException(ex);
+            }
+
+            return new ValueTask(_disposeTask);
+        }
+    }
+
+    private static async Task CompleteDisposeAsync(
+        Task dispose,
+        TaskCompletionSource completion)
+    {
+        try
+        {
+            await dispose.ConfigureAwait(false);
+            completion.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
+        }
+    }
+
+    private Task DisposeCoreAsync()
+    {
+        Registration[] registrations;
+        Task[] activeRetirements;
+        ElementSourceHandlerDescriptor[] metadata;
+        KeyValuePair<ElementSourceHandlerExtension, List<Registration>>[] extensionRegistrations;
+        lock (_extensionCompositionGate)
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                    return Task.CompletedTask;
+
+                _disposed = true;
+                registrations = _handlers.Values.SelectMany(value => value).ToArray();
+                _handlers.Clear();
+                metadata = CreateMetadata_NoLock();
+                activeRetirements = _activeRegistrationRetirements.ToArray();
+                _activeRegistrationRetirements.Clear();
+            }
+
+            PublishMetadata(metadata);
+
+            if (_extensionProvider is not null)
+            {
+                _extensionProvider.AllExtensions.CollectionChanged -= OnExtensionsChanged;
+                _extensionProvider.ExtensionsChanged -= OnExtensionsCommitted;
+                _extensionProvider = null;
+            }
+
+            extensionRegistrations = _extensionRegistrations.ToArray();
+            _extensionRegistrations.Clear();
+        }
+
+        foreach ((ElementSourceHandlerExtension extension, List<Registration> owned)
+                 in extensionRegistrations)
+        {
+            ExtensionRegistrationLifetimes.Retire(
+                extension,
+                () => DisposeRegistrationsAsync(owned));
+        }
+
+        Task registrationsDisposed = DisposeRegistrationsAsync(registrations).AsTask();
+        return Task.WhenAll(activeRetirements.Append(registrationsDisposed));
+    }
+
+    private void AttachExtensionProvider(IExtensionRegistry extensionProvider)
+    {
+        ArgumentNullException.ThrowIfNull(extensionProvider);
+        extensionProvider.SynchronizeMutation(() =>
+        {
+            lock (_extensionCompositionGate)
+            {
+                ObjectDisposedException.ThrowIf(_disposed, this);
+                if (_extensionProvider is not null)
+                    throw new InvalidOperationException("An extension provider is already attached.");
+
+                _extensionProvider = extensionProvider;
+                extensionProvider.AllExtensions.CollectionChanged += OnExtensionsChanged;
+                extensionProvider.ExtensionsChanged += OnExtensionsCommitted;
+                try
+                {
+                    SynchronizeExtensionRegistrationsCore();
+                }
+                catch
+                {
+                    extensionProvider.AllExtensions.CollectionChanged -= OnExtensionsChanged;
+                    extensionProvider.ExtensionsChanged -= OnExtensionsCommitted;
+                    _extensionProvider = null;
+                    throw;
+                }
+            }
+        });
+    }
+
+    private void OnExtensionsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.Action == NotifyCollectionChangedAction.Add)
+            return;
+
+        lock (_extensionCompositionGate)
+        {
+            if (!_disposed)
+            {
+                SynchronizeExtensionRegistrationsCore();
+            }
+        }
+    }
+
+    private void OnExtensionsCommitted(object? sender, EventArgs e)
+    {
+        lock (_extensionCompositionGate)
+        {
+            if (!_disposed)
+                SynchronizeExtensionRegistrationsCore();
+        }
+    }
+
+    private void SynchronizeExtensionRegistrationsCore()
+    {
+        IExtensionRegistry extensionProvider = _extensionProvider
+            ?? throw new InvalidOperationException("No extension provider is attached.");
+        ElementSourceHandlerExtension[] currentExtensions =
+            extensionProvider.GetExtensions<ElementSourceHandlerExtension>();
+        var currentSet = new HashSet<ElementSourceHandlerExtension>(
+            currentExtensions,
+            ReferenceEqualityComparer.Instance);
+
+        KeyValuePair<ElementSourceHandlerExtension, List<Registration>>[] removedRegistrations =
+            _extensionRegistrations
+            .Where(pair => !currentSet.Contains(pair.Key))
+            .ToArray();
+
+        var candidates = new List<(
+            ElementSourceHandlerExtension Extension,
+            PreparedRegistration[] Registrations)>();
+        foreach (ElementSourceHandlerExtension extension in currentExtensions)
+        {
+            if (_extensionRegistrations.ContainsKey(extension))
+                continue;
+
+            try
+            {
+                candidates.Add((
+                    extension,
+                    ValidateRegistrations(extension).Select(PrepareRegistration).ToArray()));
+            }
+            catch (Exception ex)
+            {
+                ReportFailure(extension, ex);
+            }
+        }
+
+        var failures = new Dictionary<ElementSourceHandlerExtension, Exception>(
+            ReferenceEqualityComparer.Instance);
+        ElementSourceHandlerDescriptor[] metadata;
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            _metadataBatchDepth++;
+            try
+            {
+                foreach ((ElementSourceHandlerExtension extension, List<Registration> registrations)
+                         in removedRegistrations)
+                {
+                    _extensionRegistrations.Remove(extension);
+                    ExtensionRegistrationLifetimes.Retire(
+                        extension,
+                        () => DisposeRegistrationsAsync(registrations));
+                }
+
+                while (true)
+                {
+                    var attemptOwned = new Dictionary<
+                        ElementSourceHandlerExtension,
+                        List<Registration>>(ReferenceEqualityComparer.Instance);
+                    foreach ((ElementSourceHandlerExtension extension, _) in candidates)
+                    {
+                        if (!failures.ContainsKey(extension))
+                            attemptOwned.Add(extension, []);
+                    }
+                    var newFailures = new Dictionary<
+                        ElementSourceHandlerExtension,
+                        (Exception Exception, int Phase)>(ReferenceEqualityComparer.Instance);
+                    ElementSourceHandlerRegistrationMode[] phases =
+                    [
+                        ElementSourceHandlerRegistrationMode.Add,
+                        ElementSourceHandlerRegistrationMode.Replace,
+                    ];
+                    for (int phaseIndex = 0; phaseIndex < phases.Length; phaseIndex++)
+                    {
+                        ElementSourceHandlerRegistrationMode mode = phases[phaseIndex];
+                        foreach ((ElementSourceHandlerExtension extension,
+                                 PreparedRegistration[] registrations) in candidates)
+                        {
+                            if (failures.ContainsKey(extension) || newFailures.ContainsKey(extension))
+                                continue;
+                            try
+                            {
+                                foreach (PreparedRegistration registration in registrations
+                                             .Where(registration => registration.Mode == mode))
+                                {
+                                    attemptOwned[extension].Add(RegisterPrepared_NoLock(registration));
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                newFailures.Add(extension, (ex, phaseIndex));
+                            }
+                        }
+                    }
+
+                    if (newFailures.Count > 0)
+                    {
+                        foreach (List<Registration> owned in attemptOwned.Values)
+                        {
+                            DisposeRegistrationsAsync(owned).AsTask().GetAwaiter().GetResult();
+                        }
+                        int latestFailedPhase = newFailures.Values.Max(failure => failure.Phase);
+                        KeyValuePair<ElementSourceHandlerExtension, (Exception Exception, int Phase)> rejected =
+                            newFailures.First(failure => failure.Value.Phase == latestFailedPhase);
+                        failures.TryAdd(rejected.Key, rejected.Value.Exception);
+                        continue;
+                    }
+
+                    foreach ((ElementSourceHandlerExtension extension, List<Registration> owned)
+                             in attemptOwned)
+                    {
+                        _extensionRegistrations.Add(extension, owned);
+                    }
+                    break;
+                }
+            }
+            finally
+            {
+                _metadataBatchDepth--;
+            }
+
+            metadata = CreateMetadata_NoLock();
+        }
+
+        PublishMetadata(metadata);
+
+        foreach ((ElementSourceHandlerExtension extension, Exception failure) in failures)
+            ReportFailure(extension, failure);
+    }
+
+    private Task UnregisterAsync(Registration registration, RegistrationState state)
+    {
+        Task drain;
+        ElementSourceHandlerDescriptor[]? metadata = null;
+        lock (_extensionCompositionGate)
+        {
+            lock (_gate)
+            {
+                drain = state.RetireAsync();
+                if (!drain.IsCompleted)
+                {
+                    _activeRegistrationRetirements.Add(drain);
+                    _ = ForgetRetirementWhenCompleteAsync(drain);
+                }
+
+                if (_handlers.TryGetValue(state.SourceType, out List<Registration>? entries))
+                {
+                    entries.Remove(registration);
+                    if (entries.Count == 0)
+                    {
+                        _handlers.Remove(state.SourceType);
+                    }
+                }
+
+                if (_metadataBatchDepth == 0)
+                    metadata = CreateMetadata_NoLock();
+            }
+
+            if (metadata is not null)
+                PublishMetadata(metadata);
+        }
+
+        return drain;
+    }
+
+    private async Task ForgetRetirementWhenCompleteAsync(Task retirement)
+    {
+        try
+        {
+            await retirement.ConfigureAwait(false);
+        }
+        catch
+        {
+            // The registration owner and any concurrent registry disposal still observe the
+            // original task. This continuation only releases completed tracking state.
+        }
+        finally
+        {
+            lock (_gate)
+            {
+                _activeRegistrationRetirements.Remove(retirement);
+            }
+        }
+    }
+
+    private ElementSourceHandlerDescriptor[] CreateMetadata_NoLock()
+        => _handlers
+            .Select(pair => pair.Value[^1].State)
+            .OrderBy(state => state.Order)
+            .ThenBy(state => state.SourceType.FullName, StringComparer.Ordinal)
+            .ThenBy(state => state.Sequence)
+            .Select(state => state.Descriptor)
+            .ToArray();
+
+    private void PublishMetadata(ElementSourceHandlerDescriptor[] metadata)
+    {
+        if (_handlerMetadata.Count == metadata.Length
+            && _handlerMetadata.Select((current, index) =>
+                    current.SourceTypeName == metadata[index].SourceTypeName
+                    && current.Order == metadata[index].Order)
+                .All(matches => matches))
+        {
+            return;
+        }
+
+        try
+        {
+            _handlerMetadata.Replace(metadata);
+        }
+        catch
+        {
+            // Metadata observers cannot veto or roll back handler registration changes.
+        }
+    }
+
+    private static PreparedRegistration PrepareRegistration(
+        ElementSourceHandlerRegistration registration)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+        IElementSourceHandler handler = registration.Handler;
+        ArgumentNullException.ThrowIfNull(handler);
+        Type sourceType = handler.SourceType
+            ?? throw new ArgumentException("A source handler must declare its source type.", nameof(handler));
+        if (!typeof(Models.ElementSource).IsAssignableFrom(sourceType))
+        {
+            throw new ArgumentException(
+                $"Source type '{sourceType.FullName}' does not derive from ElementSource.",
+                nameof(handler));
+        }
+
+        return new PreparedRegistration(
+            sourceType,
+            handler,
+            registration.Mode,
+            registration.Order);
+    }
+
+    private Registration RegisterPrepared_NoLock(PreparedRegistration registration)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        bool exists = _handlers.TryGetValue(registration.SourceType, out List<Registration>? entries)
+            && entries.Count > 0;
+        if (registration.Mode == ElementSourceHandlerRegistrationMode.Add && exists)
+        {
+            throw new ArgumentException(
+                $"A handler for element source '{registration.SourceType.FullName}' is already registered. "
+                + "Use Replace explicitly.",
+                nameof(registration));
+        }
+        if (registration.Mode == ElementSourceHandlerRegistrationMode.Replace && !exists)
+        {
+            throw new ArgumentException(
+                $"A handler for element source '{registration.SourceType.FullName}' cannot be replaced "
+                + "because it is not registered.",
+                nameof(registration));
+        }
+
+        entries ??= [];
+        _handlers[registration.SourceType] = entries;
+        var state = new RegistrationState(
+            registration.SourceType,
+            registration.Handler,
+            registration.Order,
+            ++_registrationSequence);
+        var owner = new Registration(this, state);
+        entries.Add(owner);
+        return owner;
+    }
+
+    private static ValueTask DisposeRegistrationsAsync(IEnumerable<Registration> registrations)
+    {
+        Task[] drains = registrations
+            .Select(registration => registration.DisposeAsync().AsTask())
+            .ToArray();
+        return drains.Length == 0
+            ? ValueTask.CompletedTask
+            : new ValueTask(Task.WhenAll(drains));
+    }
+
+    private static ElementSourceHandlerRegistration[] ValidateRegistrations(
+        ElementSourceHandlerExtension extension)
+    {
+        IReadOnlyCollection<ElementSourceHandlerRegistration>? registrations = extension.Registrations;
+        if (registrations is null)
+        {
+            throw new InvalidOperationException(
+                "An element source-handler extension returned a null registration collection.");
+        }
+
+        ElementSourceHandlerRegistration[] snapshot = registrations.ToArray();
+        if (snapshot.Any(registration => registration is null))
+        {
+            throw new InvalidOperationException(
+                "An element source-handler extension returned a null registration.");
+        }
+
+        return snapshot;
+    }
+
+    private readonly record struct PreparedRegistration(
+        Type SourceType,
+        IElementSourceHandler Handler,
+        ElementSourceHandlerRegistrationMode Mode,
+        int Order);
+
+    private void ReportFailure(ElementSourceHandlerExtension extension, Exception exception)
+    {
+        if (_reportFailure is null)
+            return;
+
+        try
+        {
+            _reportFailure(new ElementSourceHandlerExtensionFailure(
+                extension.GetType().FullName ?? extension.GetType().Name,
+                exception));
+        }
+        catch
+        {
+            // Diagnostics must not interrupt extension removal before Extension.Unload().
+        }
+    }
+
+    private sealed class RegistrationState(
+        Type sourceType,
+        IElementSourceHandler handler,
+        int order,
+        long sequence)
+    {
+        private readonly object _gate = new();
+        private TaskCompletionSource? _drained;
+        private int _activeLeases;
+        private bool _retired;
+
+        public Type SourceType { get; } = sourceType;
+
+        public IElementSourceHandler Handler { get; } = handler;
+
+        public ElementSourceHandlerDescriptor Descriptor { get; } = new(
+            sourceType.AssemblyQualifiedName
+                ?? sourceType.FullName
+                ?? sourceType.Name,
+            order);
+
+        public int Order { get; } = order;
+
+        public long Sequence { get; } = sequence;
+
+        public bool TryAcquire([NotNullWhen(true)] out HandlerLease? lease)
+        {
+            lock (_gate)
+            {
+                if (_retired)
+                {
+                    lease = null;
+                    return false;
+                }
+
+                _activeLeases++;
+                lease = new HandlerLease(this);
+                return true;
+            }
+        }
+
+        public Task RetireAsync()
+        {
+            lock (_gate)
+            {
+                _retired = true;
+                return _activeLeases == 0
+                    ? Task.CompletedTask
+                    : (_drained ??= new TaskCompletionSource(
+                        TaskCreationOptions.RunContinuationsAsynchronously)).Task;
+            }
+        }
+
+        public void ReleaseLease()
+        {
+            TaskCompletionSource? drained = null;
+            lock (_gate)
+            {
+                _activeLeases--;
+                if (_activeLeases == 0 && _retired)
+                {
+                    drained = _drained;
+                }
+            }
+
+            drained?.TrySetResult();
+        }
+    }
+
+    private sealed class Registration : IElementSourceHandlerRegistration
+    {
+        private readonly Lazy<Task> _retirement;
+        private RegistrationOwner? _owner;
+
+        public Registration(ElementSourceHandlerRegistry owner, RegistrationState state)
+        {
+            _owner = new RegistrationOwner(owner, state);
+            _retirement = new Lazy<Task>(
+                RetireCoreAsync,
+                LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+
+        public RegistrationState State => Volatile.Read(ref _owner)?.State
+            ?? throw new ObjectDisposedException(nameof(IElementSourceHandlerRegistration));
+
+        public bool TryAcquire([NotNullWhen(true)] out HandlerLease? lease)
+        {
+            RegistrationOwner? current = Volatile.Read(ref _owner);
+            if (_retirement.IsValueCreated || current is null)
+            {
+                lease = null;
+                return false;
+            }
+
+            return current.State.TryAcquire(out lease);
+        }
+
+        public ValueTask DisposeAsync()
+            => new(_retirement.Value);
+
+        private async Task RetireCoreAsync()
+        {
+            RegistrationOwner? current = Volatile.Read(ref _owner);
+            if (current is null)
+                return;
+
+            try
+            {
+                await current.Registry.UnregisterAsync(this, current.State).ConfigureAwait(false);
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _owner, null);
+            }
+        }
+
+        private sealed record RegistrationOwner(
+            ElementSourceHandlerRegistry Registry,
+            RegistrationState State);
+    }
+
+    private sealed class HandlerLease(RegistrationState state) : IElementSourceHandlerLease
+    {
+        private RegistrationState? _state = state;
+
+        public IElementSourceHandler Handler
+            => Volatile.Read(ref _state)?.Handler
+                ?? throw new ObjectDisposedException(nameof(IElementSourceHandlerLease));
+
+        public void Dispose()
+            => Interlocked.Exchange(ref _state, null)?.ReleaseLease();
+    }
+}

--- a/src/Beutl.Editor/Services/ElementTemplateResolver.cs
+++ b/src/Beutl.Editor/Services/ElementTemplateResolver.cs
@@ -1,0 +1,61 @@
+﻿using Beutl.Editor.Models;
+using Beutl.Engine;
+using Beutl.ProjectSystem;
+using Beutl.Serialization;
+
+namespace Beutl.Editor.Services;
+
+public static class ElementTemplateResolver
+{
+    public static ElementDescription CreateDescription(
+        ObjectTemplateItem template,
+        TimeSpan start,
+        int layer,
+        TimeSpan? lengthOverride = null)
+    {
+        ArgumentNullException.ThrowIfNull(template);
+
+        if (typeof(Element).IsAssignableFrom(template.ActualType))
+        {
+            return new ElementDescription(
+                start,
+                lengthOverride,
+                layer,
+                new ElementSource.ElementTemplate(() => CreateElement(template)));
+        }
+
+        if (typeof(EngineObject).IsAssignableFrom(template.ActualType))
+        {
+            return new ElementDescription(
+                start,
+                lengthOverride ?? TimeSpan.FromSeconds(5),
+                layer,
+                new ElementSource.EngineObject(() => CreateEngineObject(template)),
+                template.Name.Value);
+        }
+
+        throw new ArgumentException(
+            $"Template type '{template.ActualType}' cannot be added to a scene.",
+            nameof(template));
+    }
+
+    private static Element CreateElement(ObjectTemplateItem template)
+    {
+        Element source = template.CreateInstance() as Element
+                         ?? throw new InvalidOperationException(
+                             $"Template '{template.Name.Value}' did not create an element.");
+        ObjectRegenerator.Regenerate(source, out Element result);
+        return result;
+    }
+
+    private static EngineObject CreateEngineObject(ObjectTemplateItem template)
+    {
+        EngineObject source = template.CreateInstance() as EngineObject
+                              ?? throw new InvalidOperationException(
+                                  $"Template '{template.Name.Value}' did not create an engine object.");
+        ObjectRegenerator.Regenerate(source, source.GetType(), out ICoreSerializable result);
+        return result as EngineObject
+               ?? throw new InvalidOperationException(
+                   $"Template '{template.Name.Value}' created an incompatible object.");
+    }
+}

--- a/src/Beutl.Editor/Services/IElementAdder.cs
+++ b/src/Beutl.Editor/Services/IElementAdder.cs
@@ -4,7 +4,9 @@ namespace Beutl.Editor.Services;
 
 public interface IElementAdder
 {
-    void AddElement(ElementDescription desc);
+    IElementSourceHandlerRegistry SourceHandlers { get; }
 
-    void AddElementFromTemplate(ObjectTemplateItem template, TimeSpan start, int layer);
+    ValueTask<ElementAddResult> AddAsync(
+        IReadOnlyList<ElementDescription> descriptions,
+        CancellationToken cancellationToken);
 }

--- a/src/Beutl.Editor/Services/IElementClipboardService.cs
+++ b/src/Beutl.Editor/Services/IElementClipboardService.cs
@@ -27,7 +27,8 @@ public sealed record ElementPasteOutcome(
     bool Pasted,
     IReadOnlyList<Element> NewElements,
     TimeRange ScrollTo,
-    int ScrollToZIndex)
+    int ScrollToZIndex,
+    ElementAddFailure? AddFailure)
 {
-    public static readonly ElementPasteOutcome Empty = new(false, [], default, 0);
+    public static readonly ElementPasteOutcome Empty = new(false, [], default, 0, null);
 }

--- a/src/Beutl.Editor/Services/IElementSourceHandler.cs
+++ b/src/Beutl.Editor/Services/IElementSourceHandler.cs
@@ -1,0 +1,286 @@
+﻿using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using Beutl.Api.Services;
+using Beutl.Collections;
+using Beutl.Editor.Models;
+using Beutl.Extensibility;
+using Beutl.ProjectSystem;
+
+namespace Beutl.Editor.Services;
+
+/// <summary>
+/// Opaque, handler-owned state produced during preflight and consumed during materialization.
+/// Returning it through <see cref="ElementSourcePreflightResult.Ready"/> transfers lease ownership
+/// to the host, which asynchronously disposes it exactly once after the whole batch finishes,
+/// including validation, cancellation, persistence, and rollback failures.
+/// </summary>
+public interface IElementSourcePreflight : IAsyncDisposable
+{
+}
+
+public sealed record ElementSourcePreflightContext(
+    Scene Scene,
+    ElementDescription Description);
+
+public sealed class ElementSourcePreflightResult
+{
+    private ElementSourcePreflightResult(
+        IElementSourcePreflight? preflight,
+        IReadOnlyList<int> targetLayers,
+        ElementAddFailure? failure)
+    {
+        Preflight = preflight;
+        TargetLayers = targetLayers;
+        Failure = failure;
+    }
+
+    public bool IsSuccess => Failure is null;
+
+    public IElementSourcePreflight? Preflight { get; }
+
+    public IReadOnlyList<int> TargetLayers { get; }
+
+    public ElementAddFailure? Failure { get; }
+
+    public static ElementSourcePreflightResult Ready(
+        IElementSourcePreflight preflight,
+        IEnumerable<int> targetLayers)
+    {
+        ArgumentNullException.ThrowIfNull(preflight);
+        ArgumentNullException.ThrowIfNull(targetLayers);
+        int[] layers = targetLayers.Distinct().ToArray();
+        if (layers.Length == 0)
+            throw new ArgumentException("Preflight must reserve at least one target layer.", nameof(targetLayers));
+
+        return new ElementSourcePreflightResult(preflight, Array.AsReadOnly(layers), null);
+    }
+
+    public static ElementSourcePreflightResult Rejected(ElementAddFailure failure)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        return new ElementSourcePreflightResult(null, Array.Empty<int>(), failure);
+    }
+}
+
+public sealed record ElementSourceMaterializationContext(
+    Scene Scene,
+    ElementDescription Description);
+
+public sealed class ElementMaterializationResource : IAsyncDisposable
+{
+    private Func<ValueTask>? _disposeAsync;
+
+    private ElementMaterializationResource(Func<ValueTask> disposeAsync)
+    {
+        _disposeAsync = disposeAsync;
+    }
+
+    public static ElementMaterializationResource Temporary(IDisposable resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+        return new ElementMaterializationResource(
+            () =>
+            {
+                resource.Dispose();
+                return ValueTask.CompletedTask;
+            });
+    }
+
+    public static ElementMaterializationResource TemporaryAsync(IAsyncDisposable resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+        return new ElementMaterializationResource(
+            resource.DisposeAsync);
+    }
+
+    public ValueTask DisposeAsync()
+        => Interlocked.Exchange(ref _disposeAsync, null)?.Invoke() ?? ValueTask.CompletedTask;
+}
+
+public sealed class ElementMaterialization
+{
+    public ElementMaterialization(
+        Element primaryElement,
+        IEnumerable<Element>? companionElements = null,
+        IEnumerable<IReadOnlySet<Guid>>? groups = null,
+        IEnumerable<ElementMaterializationResource>? resources = null)
+    {
+        ArgumentNullException.ThrowIfNull(primaryElement);
+        Element[] companions = companionElements?.ToArray() ?? [];
+        IReadOnlySet<Guid>[] suppliedGroups = groups?.ToArray() ?? [];
+        ElementMaterializationResource[] resourceArray = resources?.ToArray() ?? [];
+        if (companions.Any(element => element is null))
+            throw new ArgumentException("Companion elements cannot contain null.", nameof(companionElements));
+        if (suppliedGroups.Any(group => group is null))
+            throw new ArgumentException("Groups cannot contain null.", nameof(groups));
+        if (resourceArray.Any(resource => resource is null))
+            throw new ArgumentException("Resources cannot contain null.", nameof(resources));
+
+        PrimaryElement = primaryElement;
+        CompanionElements = Array.AsReadOnly(companions);
+        Elements = Array.AsReadOnly(new[] { primaryElement }.Concat(companions).ToArray());
+        Groups = Array.AsReadOnly<IReadOnlySet<Guid>>(
+            suppliedGroups.Select(group => group.ToImmutableHashSet(
+                EqualityComparer<Guid>.Default)).ToArray());
+        Resources = Array.AsReadOnly(resourceArray);
+    }
+
+    public Element PrimaryElement { get; }
+
+    public IReadOnlyList<Element> CompanionElements { get; }
+
+    public IReadOnlyList<Element> Elements { get; }
+
+    public IReadOnlyList<IReadOnlySet<Guid>> Groups { get; }
+
+    /// <summary>
+    /// Resource leases acquired during materialization. The host releases every lease after the
+    /// materialization pipeline finishes. A handler that needs a resource to outlive materialization
+    /// must attach it to the returned element graph itself.
+    /// </summary>
+    public IReadOnlyList<ElementMaterializationResource> Resources { get; }
+}
+
+public sealed class ElementSourceMaterializationResult
+{
+    private ElementSourceMaterializationResult(
+        ElementMaterialization? materialization,
+        ElementAddFailure? failure)
+    {
+        Materialization = materialization;
+        Failure = failure;
+    }
+
+    public bool IsSuccess => Failure is null;
+
+    public ElementMaterialization? Materialization { get; }
+
+    public ElementAddFailure? Failure { get; }
+
+    public static ElementSourceMaterializationResult Materialized(ElementMaterialization materialization)
+    {
+        ArgumentNullException.ThrowIfNull(materialization);
+        return new ElementSourceMaterializationResult(materialization, null);
+    }
+
+    public static ElementSourceMaterializationResult Rejected(ElementAddFailure failure)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        return new ElementSourceMaterializationResult(null, failure);
+    }
+}
+
+/// <summary>
+/// Performs source-specific preflight and materialization. Implementations are registered by
+/// their exact <see cref="SourceType"/> so third-party element sources do not require host changes.
+/// </summary>
+public interface IElementSourceHandler
+{
+    Type SourceType { get; }
+
+    ValueTask<ElementSourcePreflightResult> PreflightAsync(
+        ElementSourcePreflightContext context,
+        CancellationToken cancellationToken);
+
+    ValueTask<ElementSourceMaterializationResult> MaterializeAsync(
+        ElementSourceMaterializationContext context,
+        IElementSourcePreflight preflight,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Contributes element source handlers from an extension package. Registrations are dynamically
+/// composed for every open editor. Packages containing these extensions require a restart to
+/// unload because materialized scene graphs may retain package-defined objects after an add
+/// operation releases its handler lease.
+/// </summary>
+public abstract class ElementSourceHandlerExtension : Extension
+{
+    public abstract IReadOnlyCollection<ElementSourceHandlerRegistration> Registrations { get; }
+}
+
+public sealed record ElementSourceHandlerExtensionFailure(
+    string ExtensionType,
+    Exception Exception);
+
+/// <summary>
+/// Owns a source-handler registration. Retain this object while the handler is available and
+/// asynchronously dispose it before unloading handler-owned resources. Disposal first retires
+/// the handler synchronously, then asynchronously waits for existing operation leases to finish.
+/// </summary>
+public interface IElementSourceHandlerRegistration : IAsyncDisposable
+{
+}
+
+/// <summary>
+/// Keeps a resolved handler alive for one operation. Consumers must not cache
+/// <see cref="Handler"/> beyond this lease.
+/// </summary>
+public interface IElementSourceHandlerLease : IDisposable
+{
+    IElementSourceHandler Handler { get; }
+}
+
+/// <summary>
+/// Describes an active source handler without retaining its package-owned implementation or source
+/// <see cref="Type"/>. Resolve executable handlers through <see cref="IElementSourceHandlerRegistry.TryAcquire"/>.
+/// </summary>
+public sealed class ElementSourceHandlerDescriptor
+{
+    public ElementSourceHandlerDescriptor(string sourceTypeName, int order)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceTypeName);
+        SourceTypeName = sourceTypeName.Trim();
+        Order = order;
+    }
+
+    public string SourceTypeName { get; }
+
+    public int Order { get; }
+}
+
+public interface IElementSourceHandlerRegistry
+{
+    /// <summary>
+    /// Gets metadata for the active handlers without retaining package-owned instances.
+    /// </summary>
+    ICoreReadOnlyList<ElementSourceHandlerDescriptor> Handlers { get; }
+
+    IElementSourceHandlerRegistration Register(ElementSourceHandlerRegistration registration);
+
+    bool TryAcquire(
+        Type sourceType,
+        [NotNullWhen(true)] out IElementSourceHandlerLease? lease);
+}
+
+public enum ElementSourceHandlerRegistrationMode
+{
+    Add,
+    Replace,
+}
+
+/// <summary>
+/// Registers a handler with explicit collision and deterministic enumeration semantics.
+/// </summary>
+public sealed class ElementSourceHandlerRegistration
+{
+    public ElementSourceHandlerRegistration(
+        IElementSourceHandler handler,
+        ElementSourceHandlerRegistrationMode mode = ElementSourceHandlerRegistrationMode.Add,
+        int order = 0)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        if (!Enum.IsDefined(mode))
+            throw new ArgumentOutOfRangeException(nameof(mode));
+
+        Handler = handler;
+        Mode = mode;
+        Order = order;
+    }
+
+    public IElementSourceHandler Handler { get; }
+
+    public ElementSourceHandlerRegistrationMode Mode { get; }
+
+    public int Order { get; }
+}

--- a/src/Beutl.Editor/Services/ObjectTemplatePreviewRenderer.cs
+++ b/src/Beutl.Editor/Services/ObjectTemplatePreviewRenderer.cs
@@ -24,6 +24,8 @@ public static class ObjectTemplatePreviewRenderer
     public const int PreviewWidth = 256;
     public const int PreviewHeight = 144;
 
+    private const int MaxRenderDimension = 2048;
+
     private const int MaxPreviewBytes = 256 * 1024;
     private const float MaxPreviewScale = 64f;
     private const byte BlankAlphaThreshold = 8;
@@ -73,6 +75,32 @@ public static class ObjectTemplatePreviewRenderer
         }
     }
 
+    /// <summary>
+    /// Renders element previews at an explicit output density. The output dimensions are bounded
+    /// to keep callers from allocating an unbounded render target.
+    /// </summary>
+    internal static async ValueTask<byte[]?> RenderElementsPngAsync(
+        IReadOnlyList<Element> elements,
+        PixelSize frameSize,
+        PixelSize outputSize,
+        CancellationToken cancellationToken = default)
+    {
+        if (elements.Count == 0) return null;
+        ValidateOutputSize(outputSize);
+        try
+        {
+            return await RenderThread.Dispatcher.InvokeAsync(
+                () => RenderElements(elements, frameSize, outputSize, cancellationToken), ct: cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            s_logger.LogDebug(ex, "Failed to render caption template preview.");
+            return null;
+        }
+    }
+
     private static byte[]? Render(ICoreSerializable instance)
     {
         return instance switch
@@ -88,18 +116,38 @@ public static class ObjectTemplatePreviewRenderer
     {
         // The element belongs to the edited scene, so the throwaway scene gets a clone. Start is
         // rebased because SceneCompositor only collects elements whose Range contains the time.
-        if (Clone(element, typeof(Element)) is not Element copy)
-            return null;
+        return RenderElements([element], default, new PixelSize(PreviewWidth, PreviewHeight));
+    }
 
-        copy.Start = TimeSpan.Zero;
-        TimeSpan time = copy.Length > TimeSpan.Zero
-            ? copy.Length / 2
+    private static byte[]? RenderElements(
+        IReadOnlyList<Element> elements,
+        PixelSize requestedFrameSize,
+        PixelSize outputSize,
+        CancellationToken cancellationToken = default)
+    {
+        var copies = new List<Element>(elements.Count);
+        foreach (Element element in elements)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (Clone(element, typeof(Element)) is not Element copy)
+                return null;
+            copy.Start = TimeSpan.Zero;
+            copies.Add(copy);
+        }
+        if (copies.Count == 0) return null;
+        cancellationToken.ThrowIfCancellationRequested();
+
+        TimeSpan duration = copies.Select(item => item.Length)
+            .Where(item => item > TimeSpan.Zero).DefaultIfEmpty(TimeSpan.Zero).Min();
+        TimeSpan time = duration > TimeSpan.Zero
+            ? duration / 2
             : TimeSpan.Zero;
 
         // The element's sizes are authored against its own scene's frame — a caption is a 355pt
         // glyph in a 1920x1080 project — so the preview scene has to keep that frame for layout to
         // resolve the way it did there.
-        PixelSize frameSize = ResolveFrameSize(element);
+        PixelSize frameSize = requestedFrameSize.Width > 0 && requestedFrameSize.Height > 0
+            ? requestedFrameSize : ResolveFrameSize(elements[0]);
 
         // Scene.Children_CollectionChanged relates each element's path to the scene's own, so both
         // need a Uri even though this scene is never written. The paths are synthetic; nothing on
@@ -107,11 +155,14 @@ public static class ObjectTemplatePreviewRenderer
         string directory = Path.Combine(Path.GetTempPath(), "beutl-template-preview");
         var scene = new Scene(frameSize.Width, frameSize.Height, string.Empty)
         {
-            Duration = copy.Length > TimeSpan.Zero ? copy.Length : TimeSpan.FromSeconds(1),
+            Duration = duration > TimeSpan.Zero ? duration : TimeSpan.FromSeconds(1),
             Uri = ObjectTemplateItem.ToFileUri(Path.Combine(directory, "preview.scene"))
         };
-        copy.Uri = ObjectTemplateItem.ToFileUri(Path.Combine(directory, $"{copy.Id}.belm"));
-        scene.Children.Add(copy);
+        foreach (Element copy in copies)
+        {
+            copy.Uri = ObjectTemplateItem.ToFileUri(Path.Combine(directory, $"{copy.Id}.belm"));
+            scene.Children.Add(copy);
+        }
 
         // The compositor, not a hand-rolled walk, is what resolves the flow operators an element
         // may carry (DrawableGroup / DrawableDecorator populate their children from the flow).
@@ -121,7 +172,8 @@ public static class ObjectTemplatePreviewRenderer
 
         return RenderResources(
             [.. frame.Objects.OfType<Drawable.Resource>()],
-            frameSize.ToSize(1));
+            frameSize.ToSize(1),
+            outputSize);
     }
 
     // Read from the live element: the clone is detached and can no longer reach its scene. A
@@ -155,7 +207,10 @@ public static class ObjectTemplatePreviewRenderer
             TargetDomain = new Rect(default, availableSize)
         };
         using var resource = drawable.ToResource(context);
-        return RenderResources([resource], availableSize);
+        return RenderResources(
+            [resource],
+            availableSize,
+            new PixelSize(PreviewWidth, PreviewHeight));
     }
 
     /// <summary>
@@ -168,7 +223,10 @@ public static class ObjectTemplatePreviewRenderer
     /// tall. <paramref name="availableSize"/> still has to be the authored frame, because that is
     /// what alignment resolves against. The resources belong to the caller.
     /// </remarks>
-    private static byte[]? RenderResources(IReadOnlyList<Drawable.Resource> resources, Size availableSize)
+    private static byte[]? RenderResources(
+        IReadOnlyList<Drawable.Resource> resources,
+        Size availableSize,
+        PixelSize outputSize)
     {
         if (resources.Count == 0)
             return null;
@@ -178,7 +236,7 @@ public static class ObjectTemplatePreviewRenderer
             return null;
 
         float scale = Math.Clamp(
-            MathF.Min(PreviewWidth / bounds.Width, PreviewHeight / bounds.Height),
+            MathF.Min(outputSize.Width / bounds.Width, outputSize.Height / bounds.Height),
             float.Epsilon,
             MaxPreviewScale);
         scale = RenderScaleUtilities.SanitizeOutputScale(scale);
@@ -260,6 +318,19 @@ public static class ObjectTemplatePreviewRenderer
     }
 
     private static Size AvailableSize => new(PreviewWidth, PreviewHeight);
+
+    private static void ValidateOutputSize(PixelSize outputSize)
+    {
+        if (outputSize.Width <= 0 || outputSize.Height <= 0
+            || outputSize.Width > MaxRenderDimension
+            || outputSize.Height > MaxRenderDimension)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(outputSize),
+                outputSize,
+                $"Preview output must be positive and no larger than {MaxRenderDimension}x{MaxRenderDimension}.");
+        }
+    }
 
     // Assigning the live object to a fresh shape would tear it out of the edited scene's hierarchy,
     // so the sample shape only ever receives a detached copy.

--- a/src/Beutl.Extensibility/IEditorContextServices.cs
+++ b/src/Beutl.Extensibility/IEditorContextServices.cs
@@ -9,15 +9,18 @@ namespace Beutl.Extensibility;
 /// </summary>
 public interface IEditorContextServices
 {
-    /// <summary>Gets the host's extension provider, for querying other registered extensions.</summary>
+    /// <summary>
+    /// Gets the host's metadata and lease provider for querying other registered extensions.
+    /// Executable extension instances must not be retained beyond their lease.
+    /// </summary>
     IExtensionProvider ExtensionProvider { get; }
 
     /// <summary>
     /// Resolves a host-provided service of type <typeparamref name="T"/> by type. This is the
     /// escape hatch for capabilities that live downstream of <c>Beutl.Extensibility</c> (for example
     /// the host's editor service), letting an extension reach them without downcasting to the host's
-    /// concrete implementation of <see cref="IEditorContextServices"/>. Implementers must honor this
-    /// by-type lookup rather than assume the concrete host type.
+    /// concrete implementation of <see cref="IEditorContextServices"/>. The concrete extension
+    /// registry is intentionally not resolvable through this method; use <see cref="ExtensionProvider"/>.
     /// </summary>
     /// <typeparam name="T">The reference type of the requested service.</typeparam>
     /// <param name="service">The resolved service when the method returns <see langword="true"/>.</param>

--- a/src/Beutl.Extensibility/IExtensionProvider.cs
+++ b/src/Beutl.Extensibility/IExtensionProvider.cs
@@ -1,21 +1,63 @@
-﻿using Beutl.Collections;
+﻿namespace Beutl.Extensibility;
 
-namespace Beutl.Extensibility;
+public readonly record struct ExtensionId(Guid Value)
+{
+    public override string ToString() => Value.ToString("N");
+}
 
 /// <summary>
-/// A read-only view over the registered extensions. Exposed to extension authors (for example
-/// through <see cref="IEditorContextServices"/>) so they can query other extensions without
-/// referencing the host's concrete extension provider implementation.
+/// Describes a registered extension without retaining its package-owned instance or type.
+/// </summary>
+public sealed class ExtensionDescriptor
+{
+    public ExtensionDescriptor(ExtensionId id, string typeName)
+    {
+        if (id.Value == Guid.Empty)
+            throw new ArgumentException("An extension identifier is required.", nameof(id));
+        ArgumentException.ThrowIfNullOrWhiteSpace(typeName);
+
+        Id = id;
+        TypeName = typeName.Trim();
+    }
+
+    public ExtensionId Id { get; }
+
+    public string TypeName { get; }
+}
+
+/// <summary>
+/// Keeps one package-owned extension alive for an operation. Dispose the lease when no further
+/// extension code can execute or be retained by the operation.
+/// </summary>
+public interface IExtensionLease<out TExtension> : IDisposable
+    where TExtension : Extension
+{
+    TExtension Extension { get; }
+}
+
+/// <summary>
+/// A read-only, lease-backed view over the registered extensions. Enumeration returns copied
+/// metadata only; executable package instances are available solely through explicit leases.
 /// </summary>
 public interface IExtensionProvider
 {
-    /// <summary>Gets every registered extension.</summary>
-    ICoreReadOnlyList<Extension> AllExtensions { get; }
+    /// <summary>
+    /// Occurs after the registered extension metadata changes. Handlers should re-read
+    /// <see cref="Extensions"/> or <see cref="GetDescriptors{TExtension}"/>, return promptly,
+    /// and unsubscribe before their package is unloaded.
+    /// </summary>
+    event EventHandler? ExtensionsChanged;
 
-    /// <summary>Gets all registered extensions assignable to <typeparamref name="TExtension"/>.</summary>
-    TExtension[] GetExtensions<TExtension>()
+    /// <summary>Gets metadata for every registered extension.</summary>
+    IReadOnlyList<ExtensionDescriptor> Extensions { get; }
+
+    /// <summary>Gets metadata for extensions assignable to <typeparamref name="TExtension"/>.</summary>
+    IReadOnlyList<ExtensionDescriptor> GetDescriptors<TExtension>()
         where TExtension : Extension;
 
-    /// <summary>Finds the editor extension that supports <paramref name="file"/>, or <see langword="null"/>.</summary>
-    EditorExtension? MatchEditorExtension(string file);
+    /// <summary>Acquires the extension identified by <paramref name="id"/> for one operation.</summary>
+    bool TryAcquire<TExtension>(
+        ExtensionId id,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IExtensionLease<TExtension>? lease)
+        where TExtension : Extension;
 }

--- a/src/Beutl.Language/CommandNames.ja.resx
+++ b/src/Beutl.Language/CommandNames.ja.resx
@@ -193,7 +193,4 @@
   <data name="ApplyTemplate" xml:space="preserve">
     <value>テンプレートを適用</value>
   </data>
-  <data name="AddElementFromTemplate" xml:space="preserve">
-    <value>テンプレートから要素を追加</value>
-  </data>
 </root>

--- a/src/Beutl.Language/CommandNames.resx
+++ b/src/Beutl.Language/CommandNames.resx
@@ -197,7 +197,4 @@
   <data name="ApplyTemplate" xml:space="preserve">
     <value>Apply Template</value>
   </data>
-  <data name="AddElementFromTemplate" xml:space="preserve">
-    <value>Add Element from Template</value>
-  </data>
 </root>

--- a/src/Beutl.Language/SettingsStrings.ja.resx
+++ b/src/Beutl.Language/SettingsStrings.ja.resx
@@ -666,4 +666,80 @@
   <data name="VersionControl_LargeMediaWarningThresholdMb_Description" xml:space="preserve">
     <value>Git LFS を使わず、このサイズ以上のメディアをコミットする前に警告します</value>
   </data>
+  <data name="AiPlan" xml:space="preserve">
+    <value>AI プラン</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_Plan" xml:space="preserve">
+    <value>プラン</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_Pro" xml:space="preserve">
+    <value>Pro</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_Free" xml:space="preserve">
+    <value>無料</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_SubscriptionStatus" xml:space="preserve">
+    <value>サブスクリプション状態</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_SubscriptionStatus_Active" xml:space="preserve">
+    <value>有効</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_SubscriptionStatus_Canceled" xml:space="preserve">
+    <value>解約済み</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_SubscriptionStatus_CancelScheduled" xml:space="preserve">
+    <value>解約予定</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_CancelScheduledNotice" xml:space="preserve">
+    <value>解約を受け付けました。{0}まではProの機能を利用できます。</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_SubscriptionStatus_ActionRequired" xml:space="preserve">
+    <value>お支払いの確認が必要です</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_MonthlyUsage" xml:space="preserve">
+    <value>今月の使用量</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_MonthlyRemaining" xml:space="preserve">
+    <value>今月の残り</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_AdditionalCredits" xml:space="preserve">
+    <value>追加クレジット</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_AdditionalCreditDebt" xml:space="preserve">
+    <value>未精算の使用済みクレジット</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_ManageAndTopUp" xml:space="preserve">
+    <value>管理 / 追加購入</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_JoinPro" xml:space="preserve">
+    <value>Pro に加入</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_Manage_Description" xml:space="preserve">
+    <value>今月の AI 使用量を確認し、プランや追加クレジットを管理します。</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_LoadFailed" xml:space="preserve">
+    <value>AI プラン情報の読み込みに失敗しました。</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_Loading" xml:space="preserve">
+    <value>AIプランを読み込んでいます…</value>
+    <comment/>
+  </data>
 </root>

--- a/src/Beutl.Language/SettingsStrings.resx
+++ b/src/Beutl.Language/SettingsStrings.resx
@@ -670,4 +670,80 @@
   <data name="VersionControl_LargeMediaWarningThresholdMb_Description" xml:space="preserve">
     <value>Warn before committing media at or above this size without Git LFS</value>
   </data>
+  <data name="AiPlan" xml:space="preserve">
+    <value>AI plan</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_Plan" xml:space="preserve">
+    <value>Plan</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_Pro" xml:space="preserve">
+    <value>Pro</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_Free" xml:space="preserve">
+    <value>Free</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_SubscriptionStatus" xml:space="preserve">
+    <value>Subscription status</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_SubscriptionStatus_Active" xml:space="preserve">
+    <value>Active</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_SubscriptionStatus_Canceled" xml:space="preserve">
+    <value>Canceled</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_SubscriptionStatus_CancelScheduled" xml:space="preserve">
+    <value>Cancels at period end</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_CancelScheduledNotice" xml:space="preserve">
+    <value>Your cancellation is scheduled. Pro features stay available until {0}.</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_SubscriptionStatus_ActionRequired" xml:space="preserve">
+    <value>Payment action required</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_MonthlyUsage" xml:space="preserve">
+    <value>Monthly usage</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_MonthlyRemaining" xml:space="preserve">
+    <value>Monthly remaining</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_AdditionalCredits" xml:space="preserve">
+    <value>Additional credits</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_AdditionalCreditDebt" xml:space="preserve">
+    <value>Credits awaiting settlement</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_ManageAndTopUp" xml:space="preserve">
+    <value>Manage / top up</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_JoinPro" xml:space="preserve">
+    <value>Join Pro</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_Manage_Description" xml:space="preserve">
+    <value>View monthly AI usage and manage your plan or additional credits.</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_LoadFailed" xml:space="preserve">
+    <value>Failed to load the AI plan information.</value>
+    <comment/>
+  </data>
+  <data name="AiPlan_Loading" xml:space="preserve">
+    <value>Loading AI plan…</value>
+    <comment/>
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.es.resx
+++ b/src/Beutl.Language/Strings.es.resx
@@ -1576,4 +1576,55 @@ Ejemplo: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
   <data name="Materials" xml:space="preserve">
     <value>Materiales</value>
   </data>
+  <data name="AiPromptRequired" xml:space="preserve">
+    <value>Escribe una indicación.</value>
+  </data>
+  <data name="AiPromptTooLongFormat" xml:space="preserve">
+    <value>La indicación final no puede superar los {0} caracteres.</value>
+  </data>
+  <data name="AiImageGenerationIdle" xml:space="preserve">
+    <value>Describe la imagen y haz clic en Generar.</value>
+  </data>
+  <data name="AiImageEditIdle" xml:space="preserve">
+    <value>Elige una imagen y una tarea, y haz clic en Ejecutar.</value>
+  </data>
+  <data name="AiEditSourceImage" xml:space="preserve">
+    <value>Imagen de origen</value>
+  </data>
+  <data name="AiEditNoSourceSelected" xml:space="preserve">
+    <value>Sin seleccionar</value>
+  </data>
+  <data name="AiReferenceImageHeader" xml:space="preserve">
+    <value>Imágenes de referencia (opcional)</value>
+  </data>
+  <data name="AiVideoFrameGuidanceHeader" xml:space="preserve">
+    <value>Guía de fotogramas (opcional)</value>
+  </data>
+  <data name="AiSubtitle_CueListEmpty" xml:space="preserve">
+    <value>Transcribe o importa subtítulos y las entradas aparecerán aquí.</value>
+  </data>
+  <data name="AiSubtitle_LineWrapping" xml:space="preserve">
+    <value>Ajuste de línea</value>
+  </data>
+  <data name="AiSubtitle_CueEditing" xml:space="preserve">
+    <value>Entradas</value>
+  </data>
+  <data name="AiSubtitle_CaptionsFile" xml:space="preserve">
+    <value>Archivo de subtítulos</value>
+  </data>
+  <data name="AiJobCenter_DeleteTitleFormat" xml:space="preserve">
+    <value>¿Eliminar «{0}»?</value>
+  </data>
+  <data name="TimeAgoJustNow" xml:space="preserve">
+    <value>Ahora mismo</value>
+  </data>
+  <data name="TimeAgoMinutesFormat" xml:space="preserve">
+    <value>hace {0} min</value>
+  </data>
+  <data name="TimeAgoHoursFormat" xml:space="preserve">
+    <value>hace {0} h</value>
+  </data>
+  <data name="TimeAgoDaysFormat" xml:space="preserve">
+    <value>hace {0} d</value>
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -1570,6 +1570,603 @@ GetProperty&lt;T&gt;("path") または GetProperty&lt;T&gt;(guid, "propertyName"
   <data name="ClickBrowse" xml:space="preserve">
     <value>参照をクリック...</value>
   </data>
+  <data name="Ai" xml:space="preserve">
+    <value>AI</value>
+  </data>
+  <data name="AiGenerateImage" xml:space="preserve">
+    <value>画像を生成</value>
+  </data>
+  <data name="AiImageGeneration" xml:space="preserve">
+    <value>AI 画像生成</value>
+  </data>
+  <data name="AiPrompt" xml:space="preserve">
+    <value>プロンプト</value>
+  </data>
+  <data name="AiPrompt_Placeholder" xml:space="preserve">
+    <value>生成したい画像の説明を入力...</value>
+  </data>
+  <data name="AiAspectRatio" xml:space="preserve">
+    <value>アスペクト比</value>
+  </data>
+  <data name="AiBackground" xml:space="preserve">
+    <value>背景</value>
+  </data>
+  <data name="AiBackgroundAuto" xml:space="preserve">
+    <value>モデルにまかせる</value>
+  </data>
+  <data name="AiBackgroundOpaque" xml:space="preserve">
+    <value>不透明</value>
+  </data>
+  <data name="AiBackgroundTransparent" xml:space="preserve">
+    <value>透過</value>
+  </data>
+  <data name="AiGenerateAudio" xml:space="preserve">
+    <value>音声を生成する</value>
+  </data>
+  <data name="AiGenerate" xml:space="preserve">
+    <value>生成</value>
+  </data>
+  <data name="AiGenerating" xml:space="preserve">
+    <value>生成中...</value>
+  </data>
+  <data name="AiAddToScene" xml:space="preserve">
+    <value>シーンに追加</value>
+  </data>
+  <data name="AiSaveToFile" xml:space="preserve">
+    <value>ファイルに保存</value>
+  </data>
+  <data name="AiMonthlyUsage" xml:space="preserve">
+    <value>今月の使用量: {0}%</value>
+  </data>
+  <data name="AiMonthlyUsageRemaining" xml:space="preserve">
+    <value>今月の利用枠はあと{0}%です</value>
+  </data>
+  <data name="AiAdditionalCredits" xml:space="preserve">
+    <value>購入済みクレジット: {0}</value>
+  </data>
+  <data name="AiAdditionalCreditDebt" xml:space="preserve">
+    <value>返金または異議申立てにより、使用済みのクレジット分が未精算です。次のクレジット購入分が充当されます。</value>
+  </data>
+  <data name="AiProRequired" xml:space="preserve">
+    <value>AI 機能を利用するには有効な Pro プランが必要です。</value>
+  </data>
+  <data name="AiJoinPro" xml:space="preserve">
+    <value>Pro に加入</value>
+  </data>
+  <data name="AiUsageLimitExceeded" xml:space="preserve">
+    <value>このリクエストに必要な使用量が、今月の残り利用枠と追加クレジットの合計を超えています。続行するには追加クレジットを購入してください。</value>
+  </data>
+  <data name="AiFileTooLarge" xml:space="preserve">
+    <value>選択したファイルが大きすぎます。小さいファイルを選ぶか、短いシーン範囲を文字起こししてください。</value>
+  </data>
+  <data name="AiProviderError" xml:space="preserve">
+    <value>AIプロバイダーが処理を完了できませんでした。確保した利用量は返却済みのため、安全に再実行できます。</value>
+  </data>
+  <data name="AiAuthenticationRequired" xml:space="preserve">
+    <value>AI 機能を利用するにはサインインが必要です。</value>
+  </data>
+  <data name="AiRequestInProgress" xml:space="preserve">
+    <value>同じリクエストがまだサーバーで処理中です。少し待ってからもう一度実行すると、その結果を受け取れます (二重に課金されません)。</value>
+  </data>
+  <data name="AiRequestChanged" xml:space="preserve">
+    <value>この依頼を送った名前は、別の依頼のものです。内容を元に戻すと支払い済みの結果を取り戻せます。いまの内容のまま送り直すと、新しい依頼になります。</value>
+  </data>
+  <data name="AiRequestWasDeleted" xml:space="preserve">
+    <value>このリクエストは削除済みのため、結果を取り出せません。途中結果を破棄してから実行し直してください。</value>
+  </data>
+  <data name="AiModelDoesNotSupportRequest" xml:space="preserve">
+    <value>選択したモデルはこの内容に対応していません。モデルか設定を変更してやり直してください。</value>
+  </data>
+  <data name="AiResultUnavailable" xml:space="preserve">
+    <value>結果を読み出せませんでした。もう一度実行してください。同じリクエストとして問い合わせるため、支払い済みの分が二重に請求されることはありません。</value>
+  </data>
+  <data name="AiResultDownloadFailed" xml:space="preserve">
+    <value>生成は完了しています (課金済み) が、結果を取得できませんでした。ジョブ履歴から取得してください。</value>
+  </data>
+  <data name="AiUnexpectedError" xml:space="preserve">
+    <value>リクエストが中断されました。再実行する前に、AIジョブに完了済みの結果がないか確認してください。</value>
+  </data>
+  <data name="AiImageSaved" xml:space="preserve">
+    <value>画像を保存しました。</value>
+  </data>
+  <data name="AiImageAddedToScene" xml:space="preserve">
+    <value>画像をシーンに追加しました。</value>
+  </data>
+  <data name="AiGenerateSubtitles" xml:space="preserve">
+    <value>字幕を生成</value>
+  </data>
+  <data name="AiSubtitle" xml:space="preserve">
+    <value>AI字幕</value>
+  </data>
+  <data name="AiSubtitle_AudioSource" xml:space="preserve">
+    <value>音声ソース</value>
+  </data>
+  <data name="AiSubtitle_Template" xml:space="preserve">
+    <value>テキストテンプレート</value>
+  </data>
+  <data name="AiSubtitle_DefaultTemplate" xml:space="preserve">
+    <value>既定</value>
+  </data>
+  <data name="AiSubtitle_TemplateDescription" xml:space="preserve">
+    <value>保存済みのTextBlockテンプレートが表示されます。書式、エフェクト、アニメーション、配置がすべての字幕に適用されます。</value>
+  </data>
+  <data name="AiSubtitle_Transcribe" xml:space="preserve">
+    <value>文字起こし</value>
+  </data>
+  <data name="AiSubtitle_Transcribing" xml:space="preserve">
+    <value>文字起こし中…</value>
+  </data>
+  <data name="AiSubtitle_AddToScene" xml:space="preserve">
+    <value>字幕をシーンに追加</value>
+  </data>
+  <data name="AiSubtitle_HistoryOverwritePrompt" xml:space="preserve">
+    <value>このタブの字幕を選択した履歴の結果で置き換えますか？現在の字幕はまだ保存されていません。</value>
+  </data>
+  <data name="AiSubtitle_HistoryOverwriteApply" xml:space="preserve">
+    <value>字幕を置き換える</value>
+  </data>
+  <data name="AiSubtitleAddedToScene" xml:space="preserve">
+    <value>字幕をシーンに追加しました。</value>
+  </data>
+  <data name="AiEditImage" xml:space="preserve">
+    <value>画像を編集</value>
+  </data>
+  <data name="AiImageEdit" xml:space="preserve">
+    <value>AI画像編集</value>
+  </data>
+  <data name="AiEditTask" xml:space="preserve">
+    <value>タスク</value>
+  </data>
+  <data name="AiEditRemoveBackground" xml:space="preserve">
+    <value>背景除去</value>
+  </data>
+  <data name="AiEditUpscale" xml:space="preserve">
+    <value>アップスケール</value>
+  </data>
+  <data name="AiEditBrowse" xml:space="preserve">
+    <value>参照...</value>
+  </data>
+  <data name="AiEditRun" xml:space="preserve">
+    <value>実行</value>
+  </data>
+  <data name="AiEditSelectSource" xml:space="preserve">
+    <value>先に画像ファイルを選択してください。</value>
+  </data>
+  <data name="AiGenerateVideo" xml:space="preserve">
+    <value>動画を生成</value>
+  </data>
+  <data name="AiVideoGeneration" xml:space="preserve">
+    <value>AI動画生成</value>
+  </data>
+  <data name="AiVideoPrompt_Placeholder" xml:space="preserve">
+    <value>生成したい動画を説明してください...</value>
+  </data>
+  <data name="AiVideoDuration" xml:space="preserve">
+    <value>長さ</value>
+  </data>
+  <data name="AiVideoResolution" xml:space="preserve">
+    <value>解像度</value>
+  </data>
+  <data name="AiVideoSeconds" xml:space="preserve">
+    <value>秒</value>
+  </data>
+  <data name="AiVideoSubmitting" xml:space="preserve">
+    <value>動画生成ジョブを送信中...</value>
+  </data>
+  <data name="AiVideoIdle" xml:space="preserve">
+    <value>動画の説明を入力して「生成」をクリックしてください。</value>
+  </data>
+  <data name="AiVideoProcessing" xml:space="preserve">
+    <value>動画を生成中... 数分かかる場合があります。</value>
+  </data>
+  <data name="AiVideoCompleted" xml:space="preserve">
+    <value>動画が生成されました。</value>
+  </data>
+  <data name="AiVideoFailed" xml:space="preserve">
+    <value>動画の生成に失敗しました。</value>
+  </data>
+  <data name="AiVideoJobLimitReached" xml:space="preserve">
+    <value>進行中の動画生成ジョブがあります。完了するまでお待ちください。</value>
+  </data>
+  <data name="AiVideoAddedToScene" xml:space="preserve">
+    <value>動画をシーンに追加しました。</value>
+  </data>
+  <data name="AiVideoSaved" xml:space="preserve">
+    <value>動画を保存しました。</value>
+  </data>
+  <data name="AiVideoWaitStopped" xml:space="preserve">
+    <value>ローカルでの待機を停止しました。サーバー側のジョブはAIジョブ履歴から確認できます。</value>
+  </data>
+  <data name="AiClearFrame" xml:space="preserve">
+    <value>フレームを解除</value>
+  </data>
+  <data name="AiJobCenter" xml:space="preserve">
+    <value>AIジョブ</value>
+  </data>
+  <data name="AiJobCenter_Description" xml:space="preserve">
+    <value>編集を止めずに生成状況を確認し、結果の再利用やシーンへの追加ができます。</value>
+  </data>
+  <data name="AiJobCenter_Empty" xml:space="preserve">
+    <value>AIジョブはまだありません。生成した画像、字幕、動画がここに表示されます。</value>
+  </data>
+  <data name="AiJobCenter_LoadFailed" xml:space="preserve">
+    <value>AIジョブ履歴を読み込めませんでした。</value>
+  </data>
+  <data name="AiJobCenter_LoadMore" xml:space="preserve">
+    <value>さらに読み込む</value>
+  </data>
+  <data name="AiJobCenter_StatusQueued" xml:space="preserve">
+    <value>待機中</value>
+  </data>
+  <data name="AiJobCenter_StatusRunning" xml:space="preserve">
+    <value>処理中</value>
+  </data>
+  <data name="AiJobCenter_StatusSucceeded" xml:space="preserve">
+    <value>完了</value>
+  </data>
+  <data name="AiJobCenter_StatusFailed" xml:space="preserve">
+    <value>失敗・利用量返却済み</value>
+  </data>
+  <data name="AiJobCenter_StatusCanceled" xml:space="preserve">
+    <value>キャンセル済み</value>
+  </data>
+  <data name="AiJobCenter_NoDescription" xml:space="preserve">
+    <value>説明なし</value>
+  </data>
+  <data name="AiJobCenter_TranslationSummary" xml:space="preserve">
+    <value>{0}への字幕翻訳</value>
+  </data>
+  <data name="AiJobCenter_UsageFormat" xml:space="preserve">
+    <value>利用量 {0}</value>
+  </data>
+  <data name="AiJobCenter_Retry" xml:space="preserve">
+    <value>再実行</value>
+  </data>
+  <data name="AiJobCenter_RetryTitle" xml:space="preserve">
+    <value>AIジョブを再実行しますか？</value>
+  </data>
+  <data name="AiJobCenter_CheckingRetryCost" xml:space="preserve">
+    <value>現在の利用量見積もりを確認しています…</value>
+  </data>
+  <data name="AiJobCenter_RetryConfirmation" xml:space="preserve">
+    <value>新しいジョブを作成し、利用枠を再度使用します。元の結果は保持されます。</value>
+  </data>
+  <data name="AiJobCenter_RetryFailed" xml:space="preserve">
+    <value>AIジョブを再実行できませんでした。元の設定は保持されています。</value>
+  </data>
+  <data name="AiJobCenter_DeleteTitle" xml:space="preserve">
+    <value>このAI履歴を削除しますか？</value>
+  </data>
+  <data name="AiJobCenter_DeleteConfirmation" xml:space="preserve">
+    <value>サーバー上のコピー、プロンプト、生成結果を削除します。すでにプロジェクトへ追加した素材は残ります。</value>
+  </data>
+  <data name="AiJobCenter_DeleteFailed" xml:space="preserve">
+    <value>AI履歴を削除できませんでした。</value>
+  </data>
+  <data name="AiJobCenter_AddFailed" xml:space="preserve">
+    <value>生成結果をシーンに追加できませんでした。</value>
+  </data>
+  <data name="AiJobCenter_AddedToScene" xml:space="preserve">
+    <value>生成結果をシーンに追加しました。</value>
+  </data>
+  <data name="AiJobCenter_CompletedNotification" xml:space="preserve">
+    <value>{0}が完了しました。AIジョブで結果を確認・追加できます。</value>
+  </data>
+  <data name="AiJobCenter_FailedNotification" xml:space="preserve">
+    <value>{0}に失敗しました。確保した利用量は返却済みで、AIジョブから再実行できます。</value>
+  </data>
+  <data name="AiJobCenter_CanceledNotification" xml:space="preserve">
+    <value>{0}はキャンセルされました。結果は作成されていません。</value>
+  </data>
+  <data name="AiEstimatedUsage" xml:space="preserve">
+    <value>月間利用枠を使用します</value>
+  </data>
+  <data name="AiModel" xml:space="preserve">
+    <value>モデル</value>
+  </data>
+  <data name="AiModelUnavailable" xml:space="preserve">
+    <value>このリクエストで使ったモデルは現在提供されていません。新しいリクエストで別のモデルを選んでください。</value>
+  </data>
+  <data name="AiModelCostLow" xml:space="preserve">
+    <value>割当の消費が少なめ</value>
+  </data>
+  <data name="AiModelCostMedium" xml:space="preserve">
+    <value>割当の消費は標準</value>
+  </data>
+  <data name="AiModelCostHigh" xml:space="preserve">
+    <value>割当の消費が多め</value>
+  </data>
+  <data name="AiModelUnaffordable" xml:space="preserve">
+    <value>残りが足りません</value>
+  </data>
+  <data name="AiPricingUnavailable" xml:space="preserve">
+    <value>正式な料金情報を取得できません。有料操作を始める前に再接続してください。</value>
+  </data>
+  <data name="AiEstimatedUsageMonthly" xml:space="preserve">
+    <value>月間利用枠の範囲内です。</value>
+  </data>
+  <data name="AiEstimatedUsageTopUp" xml:space="preserve">
+    <value>月間利用枠を使い切っているため、購入済みのクレジットを使用します。</value>
+  </data>
+  <data name="AiEstimatedUsageInsufficient" xml:space="preserve">
+    <value>利用枠とクレジットが不足しています。開始前にクレジットを追加してください。</value>
+  </data>
+  <data name="AiSubtitle_SceneMix" xml:space="preserve">
+    <value>シーン全体の音声（指定範囲）</value>
+  </data>
+  <data name="AiSubtitle_Range" xml:space="preserve">
+    <value>シーン範囲</value>
+  </data>
+  <data name="AiSubtitle_SourceLanguage" xml:space="preserve">
+    <value>音声の言語</value>
+  </data>
+  <data name="AiSubtitle_TargetLanguage" xml:space="preserve">
+    <value>翻訳先</value>
+  </data>
+  <data name="AiLanguageAuto" xml:space="preserve">
+    <value>自動検出</value>
+  </data>
+  <data name="AiSubtitle_DetectedLanguage" xml:space="preserve">
+    <value>検出された言語: {0}</value>
+  </data>
+  <data name="AiSubtitle_RunCannotBeRecorded" xml:space="preserve">
+    <value>この実行を書き留められないため、開始できません。課金された直後にセッションが終わると、その依頼をもう一度取りに行けなくなります。このシーンをもう一方の字幕タブで開いている場合は閉じてから、もう一度お試しください。</value>
+  </data>
+  <data name="AiSubtitle_NoAudioInRange" xml:space="preserve">
+    <value>選択したシーン範囲に音声がありません。</value>
+  </data>
+  <data name="AiSubtitle_InvalidRange" xml:space="preserve">
+    <value>終了位置が開始位置より後になるよう、有効なシーン範囲を入力してください。</value>
+  </data>
+  <data name="AiSubtitle_Import" xml:space="preserve">
+    <value>字幕を読み込む</value>
+  </data>
+  <data name="AiSubtitle_Export" xml:space="preserve">
+    <value>字幕を書き出す</value>
+  </data>
+  <data name="AiSubtitle_LossySrtExportTitle" xml:space="preserve">
+    <value>字幕メタデータを除いてSRTを書き出しますか？</value>
+  </data>
+  <data name="AiSubtitle_LossySrtExportMessage" xml:space="preserve">
+    <value>SRTには話者、言語、構造化された字幕メタデータを保存できません。時間と本文だけを残して書き出します。続行しますか？</value>
+  </data>
+  <data name="AiSubtitle_ImportFailed" xml:space="preserve">
+    <value>字幕ファイルを読み込めませんでした。</value>
+  </data>
+  <data name="AiSubtitle_ExportFailed" xml:space="preserve">
+    <value>字幕ファイルを書き出せませんでした。</value>
+  </data>
+  <data name="AiSubtitle_Exported" xml:space="preserve">
+    <value>字幕ファイルを書き出しました。</value>
+  </data>
+  <data name="AiSubtitle_CaptionFiles" xml:space="preserve">
+    <value>字幕ファイル（SRT、WebVTT、ASS）</value>
+  </data>
+  <data name="AiSubtitle_AddCue" xml:space="preserve">
+    <value>字幕を追加</value>
+  </data>
+  <data name="AiSubtitle_DeleteCue" xml:space="preserve">
+    <value>字幕を削除</value>
+  </data>
+  <data name="AiSubtitle_SplitCue" xml:space="preserve">
+    <value>再生位置で分割</value>
+  </data>
+  <data name="AiSubtitle_MergeCue" xml:space="preserve">
+    <value>次と結合</value>
+  </data>
+  <data name="AiSubtitle_WrapCues" xml:space="preserve">
+    <value>行を折り返す</value>
+  </data>
+  <data name="AiSubtitle_MaxLineLength" xml:space="preserve">
+    <value>1行の文字数</value>
+  </data>
+  <data name="AiSubtitle_MaxLineCount" xml:space="preserve">
+    <value>字幕ごとの行数</value>
+  </data>
+  <data name="AiSubtitle_CueStart" xml:space="preserve">
+    <value>開始</value>
+  </data>
+  <data name="AiSubtitle_CueEnd" xml:space="preserve">
+    <value>終了</value>
+  </data>
+  <data name="AiSubtitle_Speaker" xml:space="preserve">
+    <value>話者</value>
+  </data>
+  <data name="AiSubtitle_Language" xml:space="preserve">
+    <value>言語</value>
+  </data>
+  <data name="AiSubtitle_Text" xml:space="preserve">
+    <value>字幕テキスト</value>
+  </data>
+  <data name="AiSubtitle_InvalidTiming" xml:space="preserve">
+    <value>開始・終了時刻が無効な字幕があります。</value>
+  </data>
+  <data name="AiSubtitle_ValidationIssues" xml:space="preserve">
+    <value>修正が必要な字幕の問題が{0}件あります。時刻、順序、行数を確認してください。</value>
+  </data>
+  <data name="AiSubtitle_OverlapWarning" xml:space="preserve">
+    <value>重なっている字幕があります。追加はできますが、同時に表示される場合があります。</value>
+  </data>
+  <data name="AiSubtitle_Translate" xml:space="preserve">
+    <value>字幕を翻訳</value>
+  </data>
+  <data name="AiSubtitle_TemplatePreview" xml:space="preserve">
+    <value>テンプレートのプレビュー（簡易表示）</value>
+  </data>
+  <data name="AiSubtitle_PreviewSample" xml:space="preserve">
+    <value>字幕のプレビュー</value>
+  </data>
+  <data name="AiPreviewMode" xml:space="preserve">
+    <value>プレビュー</value>
+  </data>
+  <data name="AiPreviewResult" xml:space="preserve">
+    <value>生成結果</value>
+  </data>
+  <data name="AiPreviewOriginal" xml:space="preserve">
+    <value>元画像</value>
+  </data>
+  <data name="AiPreviewSideBySide" xml:space="preserve">
+    <value>並べて比較</value>
+  </data>
+  <data name="AiEditSourcePreviewFailed" xml:space="preserve">
+    <value>選択した画像をプレビューできませんでした。対応している別の画像を選択してください。</value>
+  </data>
+  <data name="AiPromptDetails" xml:space="preserve">
+    <value>プロンプトの詳細</value>
+  </data>
+  <data name="AiPromptStyle" xml:space="preserve">
+    <value>スタイル</value>
+  </data>
+  <data name="AiPromptStylePlaceholder" xml:space="preserve">
+    <value>例：映画風、水彩、フォトリアル</value>
+  </data>
+  <data name="AiPromptComposition" xml:space="preserve">
+    <value>構図・カメラ</value>
+  </data>
+  <data name="AiPromptCompositionPlaceholder" xml:space="preserve">
+    <value>例：クローズアップ、広角、柔らかな逆光</value>
+  </data>
+  <data name="AiPromptMotion" xml:space="preserve">
+    <value>動き</value>
+  </data>
+  <data name="AiPromptMotionPlaceholder" xml:space="preserve">
+    <value>例：ゆっくり寄るカメラ、自然な被写体の動き</value>
+  </data>
+  <data name="AiPromptAvoid" xml:space="preserve">
+    <value>避けたい要素</value>
+  </data>
+  <data name="AiPromptAvoidPlaceholder" xml:space="preserve">
+    <value>例：文字、ロゴ、ちらつき、手ぶれ</value>
+  </data>
+  <data name="AiVideoFrameGuidance" xml:space="preserve">
+    <value>フレーム指定</value>
+  </data>
+  <data name="AiVideoFrameGuidanceDescription" xml:space="preserve">
+    <value>最初のフレームから既存の構図を動かしたり、最後のフレームも指定してトランジションを生成できます。画像は生成を実行したときだけアップロードされます。</value>
+  </data>
+  <data name="AiVideoUseCurrentFrame" xml:space="preserve">
+    <value>現在のシーンフレームを使用</value>
+  </data>
+  <data name="AiVideoFirstFrame" xml:space="preserve">
+    <value>最初のフレーム</value>
+  </data>
+  <data name="AiVideoLastFrame" xml:space="preserve">
+    <value>最後のフレーム</value>
+  </data>
+  <data name="AiVideoBrowseFirstFrame" xml:space="preserve">
+    <value>最初のフレームを選択</value>
+  </data>
+  <data name="AiVideoClearFirstFrame" xml:space="preserve">
+    <value>最初のフレームをクリア</value>
+  </data>
+  <data name="AiVideoBrowseLastFrame" xml:space="preserve">
+    <value>最後のフレームを選択</value>
+  </data>
+  <data name="AiVideoClearLastFrame" xml:space="preserve">
+    <value>最後のフレームをクリア</value>
+  </data>
+  <data name="AiVideoFrameCaptureFailed" xml:space="preserve">
+    <value>現在のシーンフレームを取得できませんでした。プレビューのエラーを解消するか、画像ファイルを選択してください。</value>
+  </data>
+  <data name="AiVideoOpenPreview" xml:space="preserve">
+    <value>プレビューを開く</value>
+  </data>
+  <data name="AiVideoPreviewOpenFailed" xml:space="preserve">
+    <value>生成した動画を既定のメディアプレイヤーで開けませんでした。</value>
+  </data>
+  <data name="AiPromptLibraryPrivacy" xml:space="preserve">
+    <value>最近のプロンプトはこのセッション中だけメモリに保持します。名前を付けたテンプレートとピン留めしたプロンプトだけをローカルに保存します。</value>
+  </data>
+  <data name="AiOptional" xml:space="preserve">
+    <value>任意</value>
+  </data>
+  <data name="AiPromptHistory" xml:space="preserve">
+    <value>プロンプト履歴</value>
+  </data>
+  <data name="AiPromptHistoryEmpty" xml:space="preserve">
+    <value>まだ実行したプロンプトはありません。</value>
+  </data>
+  <data name="AiPromptTemplates" xml:space="preserve">
+    <value>プロンプトテンプレート</value>
+  </data>
+  <data name="AiPromptTemplatesEmpty" xml:space="preserve">
+    <value>保存されたテンプレートはありません。</value>
+  </data>
+  <data name="AiPromptSeed" xml:space="preserve">
+    <value>シード値</value>
+  </data>
+  <data name="AiPromptSeedPlaceholder" xml:space="preserve">
+    <value>毎回ランダム</value>
+  </data>
+  <data name="AiReferenceImage" xml:space="preserve">
+    <value>参照画像</value>
+  </data>
+  <data name="AiReferenceImageDescription" xml:space="preserve">
+    <value>既存の画像をもとに生成します。画像は生成を実行したときだけアップロードされます。</value>
+  </data>
+  <data name="AiClearReferenceImage" xml:space="preserve">
+    <value>参照画像をすべて解除</value>
+  </data>
+  <data name="AiReferenceImageCount" xml:space="preserve">
+    <value>{0} / {1} 枚</value>
+  </data>
+  <data name="AiRemoveReferenceImage" xml:space="preserve">
+    <value>外す</value>
+  </data>
+  <data name="AiPromptApply" xml:space="preserve">
+    <value>適用</value>
+  </data>
+  <data name="AiPromptPin" xml:space="preserve">
+    <value>ピン留め／解除</value>
+  </data>
+  <data name="AiPromptTemplateName" xml:space="preserve">
+    <value>テンプレート名</value>
+  </data>
+  <data name="AiPromptSaveTemplate" xml:space="preserve">
+    <value>テンプレートを保存</value>
+  </data>
+  <data name="AiPromptClearRecent" xml:space="preserve">
+    <value>最近のプロンプトを消去</value>
+  </data>
+  <data name="AiPromptTemplateInvalid" xml:space="preserve">
+    <value>テンプレート名とプロンプトの両方を入力してから保存してください。</value>
+  </data>
+  <data name="AiEditRestyle" xml:space="preserve">
+    <value>参照画像からスタイル変更</value>
+  </data>
+  <data name="AiEditRemoveObject" xml:space="preserve">
+    <value>オブジェクトを削除</value>
+  </data>
+  <data name="AiEditOutpaint" xml:space="preserve">
+    <value>キャンバスを拡張（アウトペイント）</value>
+  </data>
+  <data name="AiEditRestylePrompt" xml:space="preserve">
+    <value>変更後のスタイルと、維持したい要素を記述してください。</value>
+  </data>
+  <data name="AiEditRemoveObjectPrompt" xml:space="preserve">
+    <value>削除する対象と、削除後の領域をどう埋めるか記述してください。</value>
+  </data>
+  <data name="AiEditOutpaintPrompt" xml:space="preserve">
+    <value>元画像の外側へどのような風景や内容を続けるか記述してください。</value>
+  </data>
+  <data name="AiEditOutpaintExpansion" xml:space="preserve">
+    <value>各辺の拡張量</value>
+  </data>
+  <data name="AiSubtitle_PartialTranslationAvailable" xml:space="preserve">
+    <value>翻訳は{1}バッチ中{0}バッチまで完了しています。課金済みの途中結果を今すぐ使用するか、もう一度「翻訳」を実行すると完了済みバッチを再処理せずに続行できます。</value>
+  </data>
+  <data name="AiSubtitle_PartialTranscriptionAvailable" xml:space="preserve">
+    <value>文字起こしは{1}チャンク中{0}チャンクまで完了しています。課金済みの途中結果を今すぐ使用するか、もう一度「文字起こし」を実行すると完了済みチャンクを再処理せずに続行できます。</value>
+  </data>
+  <data name="AiSubtitle_UsePartialResult" xml:space="preserve">
+    <value>途中結果を使用</value>
+  </data>
+  <data name="AiSubtitle_DiscardPartialResult" xml:space="preserve">
+    <value>途中結果を破棄</value>
+  </data>
+  <data name="AiSubtitle_CompletedResultAvailable" xml:space="preserve">
+    <value>処理中に入力元または字幕が変更されましたが、課金済みのAI結果は完了しています。内容を確認し、準備ができたら復旧可能な結果を適用してください。</value>
+  </data>
   <data name="Materials" xml:space="preserve">
     <value>素材</value>
   </data>
@@ -1906,5 +2503,77 @@ GetProperty&lt;T&gt;("path") または GetProperty&lt;T&gt;(guid, "propertyName"
   </data>
   <data name="VersionControl_WorktreeOperationInProgress" xml:space="preserve">
     <value>バージョン管理がプロジェクトファイルを更新しています。処理の完了後に再試行してください。</value>
+  </data>
+  <data name="AiPromptRequired" xml:space="preserve">
+    <value>プロンプトを入力してください。</value>
+  </data>
+  <data name="AiPromptTooLongFormat" xml:space="preserve">
+    <value>組み立て後のプロンプトは {0} 文字以内にしてください。</value>
+  </data>
+  <data name="AiImageGenerationIdle" xml:space="preserve">
+    <value>画像の説明を入力して「生成」をクリックしてください。</value>
+  </data>
+  <data name="AiImageEditIdle" xml:space="preserve">
+    <value>画像とタスクを選んで「実行」をクリックしてください。</value>
+  </data>
+  <data name="AiEditSourceImage" xml:space="preserve">
+    <value>元画像</value>
+  </data>
+  <data name="AiEditNoSourceSelected" xml:space="preserve">
+    <value>未選択</value>
+  </data>
+  <data name="AiReferenceImageHeader" xml:space="preserve">
+    <value>参照画像（任意）</value>
+  </data>
+  <data name="AiVideoFrameGuidanceHeader" xml:space="preserve">
+    <value>フレーム指定（任意）</value>
+  </data>
+  <data name="AiPendingRequest" xml:space="preserve">
+    <value>保留中の AI リクエスト</value>
+  </data>
+  <data name="AiRecoverRequest" xml:space="preserve">
+    <value>復元</value>
+  </data>
+  <data name="AiAbandonRequest" xml:space="preserve">
+    <value>破棄</value>
+  </data>
+  <data name="AiSubtitle_CueListEmpty" xml:space="preserve">
+    <value>文字起こしまたは字幕の読み込みを行うと、ここにキューが並びます。</value>
+  </data>
+  <data name="AiSubtitle_LineWrapping" xml:space="preserve">
+    <value>行の折り返し</value>
+  </data>
+  <data name="AiSubtitle_CueEditing" xml:space="preserve">
+    <value>キュー</value>
+  </data>
+  <data name="AiSubtitle_Edit" xml:space="preserve">
+    <value>字幕編集</value>
+  </data>
+  <data name="AiSubtitle_TranscribeDescription" xml:space="preserve">
+    <value>音声ソースを選び、時間情報付きの字幕を作成します。</value>
+  </data>
+  <data name="AiSubtitle_EditDescription" xml:space="preserve">
+    <value>タイミングと本文を確認し、見た目を選んで字幕をシーンに追加します。</value>
+  </data>
+  <data name="AiSubtitle_TranslateDescription" xml:space="preserve">
+    <value>現在の字幕を別の言語に翻訳します。</value>
+  </data>
+  <data name="AiSubtitle_CaptionsFile" xml:space="preserve">
+    <value>字幕ファイル</value>
+  </data>
+  <data name="AiJobCenter_DeleteTitleFormat" xml:space="preserve">
+    <value>「{0}」を削除しますか？</value>
+  </data>
+  <data name="TimeAgoJustNow" xml:space="preserve">
+    <value>たった今</value>
+  </data>
+  <data name="TimeAgoMinutesFormat" xml:space="preserve">
+    <value>{0} 分前</value>
+  </data>
+  <data name="TimeAgoHoursFormat" xml:space="preserve">
+    <value>{0} 時間前</value>
+  </data>
+  <data name="TimeAgoDaysFormat" xml:space="preserve">
+    <value>{0} 日前</value>
   </data>
 </root>

--- a/src/Beutl.Language/Strings.ko-KR.resx
+++ b/src/Beutl.Language/Strings.ko-KR.resx
@@ -1576,4 +1576,55 @@ GetProperty&lt;T&gt;("path") 또는 GetProperty&lt;T&gt;(guid, "propertyName")
   <data name="Materials" xml:space="preserve">
     <value>소재</value>
   </data>
+  <data name="AiPromptRequired" xml:space="preserve">
+    <value>프롬프트를 입력하세요.</value>
+  </data>
+  <data name="AiPromptTooLongFormat" xml:space="preserve">
+    <value>최종 프롬프트는 {0}자를 넘을 수 없습니다.</value>
+  </data>
+  <data name="AiImageGenerationIdle" xml:space="preserve">
+    <value>이미지를 설명하고 생성을 클릭하세요.</value>
+  </data>
+  <data name="AiImageEditIdle" xml:space="preserve">
+    <value>이미지와 작업을 선택한 뒤 실행을 클릭하세요.</value>
+  </data>
+  <data name="AiEditSourceImage" xml:space="preserve">
+    <value>원본 이미지</value>
+  </data>
+  <data name="AiEditNoSourceSelected" xml:space="preserve">
+    <value>선택 안 함</value>
+  </data>
+  <data name="AiReferenceImageHeader" xml:space="preserve">
+    <value>참조 이미지(선택 사항)</value>
+  </data>
+  <data name="AiVideoFrameGuidanceHeader" xml:space="preserve">
+    <value>프레임 지정(선택 사항)</value>
+  </data>
+  <data name="AiSubtitle_CueListEmpty" xml:space="preserve">
+    <value>문자 변환하거나 자막을 가져오면 큐가 여기에 표시됩니다.</value>
+  </data>
+  <data name="AiSubtitle_LineWrapping" xml:space="preserve">
+    <value>줄 바꿈</value>
+  </data>
+  <data name="AiSubtitle_CueEditing" xml:space="preserve">
+    <value>큐</value>
+  </data>
+  <data name="AiSubtitle_CaptionsFile" xml:space="preserve">
+    <value>자막 파일</value>
+  </data>
+  <data name="AiJobCenter_DeleteTitleFormat" xml:space="preserve">
+    <value>“{0}”을(를) 삭제할까요?</value>
+  </data>
+  <data name="TimeAgoJustNow" xml:space="preserve">
+    <value>방금</value>
+  </data>
+  <data name="TimeAgoMinutesFormat" xml:space="preserve">
+    <value>{0}분 전</value>
+  </data>
+  <data name="TimeAgoHoursFormat" xml:space="preserve">
+    <value>{0}시간 전</value>
+  </data>
+  <data name="TimeAgoDaysFormat" xml:space="preserve">
+    <value>{0}일 전</value>
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -1576,6 +1576,603 @@ Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
   <data name="ClickBrowse" xml:space="preserve">
     <value>Click Browse...</value>
   </data>
+  <data name="Ai" xml:space="preserve">
+    <value>AI</value>
+  </data>
+  <data name="AiGenerateImage" xml:space="preserve">
+    <value>Generate image</value>
+  </data>
+  <data name="AiImageGeneration" xml:space="preserve">
+    <value>AI image generation</value>
+  </data>
+  <data name="AiPrompt" xml:space="preserve">
+    <value>Prompt</value>
+  </data>
+  <data name="AiPrompt_Placeholder" xml:space="preserve">
+    <value>Describe the image you want to generate...</value>
+  </data>
+  <data name="AiAspectRatio" xml:space="preserve">
+    <value>Aspect ratio</value>
+  </data>
+  <data name="AiBackground" xml:space="preserve">
+    <value>Background</value>
+  </data>
+  <data name="AiBackgroundAuto" xml:space="preserve">
+    <value>Leave it to the model</value>
+  </data>
+  <data name="AiBackgroundOpaque" xml:space="preserve">
+    <value>Opaque</value>
+  </data>
+  <data name="AiBackgroundTransparent" xml:space="preserve">
+    <value>Transparent</value>
+  </data>
+  <data name="AiGenerateAudio" xml:space="preserve">
+    <value>Generate audio</value>
+  </data>
+  <data name="AiGenerate" xml:space="preserve">
+    <value>Generate</value>
+  </data>
+  <data name="AiGenerating" xml:space="preserve">
+    <value>Generating...</value>
+  </data>
+  <data name="AiAddToScene" xml:space="preserve">
+    <value>Add to scene</value>
+  </data>
+  <data name="AiSaveToFile" xml:space="preserve">
+    <value>Save to file</value>
+  </data>
+  <data name="AiMonthlyUsage" xml:space="preserve">
+    <value>Monthly usage: {0}%</value>
+  </data>
+  <data name="AiMonthlyUsageRemaining" xml:space="preserve">
+    <value>{0}% of this month's allowance remaining</value>
+  </data>
+  <data name="AiAdditionalCredits" xml:space="preserve">
+    <value>Purchased credits: {0}</value>
+  </data>
+  <data name="AiAdditionalCreditDebt" xml:space="preserve">
+    <value>A refund or dispute reversed credits you had already spent. Your next credit purchase covers this first.</value>
+  </data>
+  <data name="AiProRequired" xml:space="preserve">
+    <value>An active Pro plan is required to use AI features.</value>
+  </data>
+  <data name="AiJoinPro" xml:space="preserve">
+    <value>Join Pro</value>
+  </data>
+  <data name="AiUsageLimitExceeded" xml:space="preserve">
+    <value>This request exceeds your remaining monthly allowance and additional credits. Top up additional credits to continue.</value>
+  </data>
+  <data name="AiFileTooLarge" xml:space="preserve">
+    <value>The selected file is too large. Choose a smaller file or transcribe a shorter scene range.</value>
+  </data>
+  <data name="AiProviderError" xml:space="preserve">
+    <value>The AI provider could not finish the request. Reserved usage was restored; you can safely retry.</value>
+  </data>
+  <data name="AiAuthenticationRequired" xml:space="preserve">
+    <value>Sign in to use AI features.</value>
+  </data>
+  <data name="AiRequestInProgress" xml:space="preserve">
+    <value>The same request is still running on the server. Wait a moment and run it again — the result it produces will be used rather than paid for twice.</value>
+  </data>
+  <data name="AiRequestChanged" xml:space="preserve">
+    <value>The name this request was sent under belongs to a different request. Put the request back as it was to collect what it already paid for, or send it again as it is to start a new one.</value>
+  </data>
+  <data name="AiRequestWasDeleted" xml:space="preserve">
+    <value>This request was deleted, so its result can no longer be recovered. Discard the partial result and run it again.</value>
+  </data>
+  <data name="AiModelDoesNotSupportRequest" xml:space="preserve">
+    <value>The chosen model does not support this request. Change the model or the options and try again.</value>
+  </data>
+  <data name="AiResultUnavailable" xml:space="preserve">
+    <value>The result could not be read just now. Run it again — the same request is asked for, so what has already been paid for is not paid for twice.</value>
+  </data>
+  <data name="AiResultDownloadFailed" xml:space="preserve">
+    <value>The result was produced and has been charged for, but it could not be downloaded. Open the job history to fetch it.</value>
+  </data>
+  <data name="AiUnexpectedError" xml:space="preserve">
+    <value>Something interrupted the request. Check AI jobs for a completed result before retrying.</value>
+  </data>
+  <data name="AiImageSaved" xml:space="preserve">
+    <value>The image was saved.</value>
+  </data>
+  <data name="AiImageAddedToScene" xml:space="preserve">
+    <value>The image was added to the scene.</value>
+  </data>
+  <data name="AiGenerateSubtitles" xml:space="preserve">
+    <value>Generate subtitles</value>
+  </data>
+  <data name="AiSubtitle" xml:space="preserve">
+    <value>AI subtitles</value>
+  </data>
+  <data name="AiSubtitle_AudioSource" xml:space="preserve">
+    <value>Audio source</value>
+  </data>
+  <data name="AiSubtitle_Template" xml:space="preserve">
+    <value>Text template</value>
+  </data>
+  <data name="AiSubtitle_DefaultTemplate" xml:space="preserve">
+    <value>Default</value>
+  </data>
+  <data name="AiSubtitle_TemplateDescription" xml:space="preserve">
+    <value>Saved TextBlock templates appear here. Their formatting, effects, animation, and placement are applied to every subtitle.</value>
+  </data>
+  <data name="AiSubtitle_Transcribe" xml:space="preserve">
+    <value>Transcribe</value>
+  </data>
+  <data name="AiSubtitle_Transcribing" xml:space="preserve">
+    <value>Transcribing…</value>
+  </data>
+  <data name="AiSubtitle_AddToScene" xml:space="preserve">
+    <value>Add subtitles to scene</value>
+  </data>
+  <data name="AiSubtitle_HistoryOverwritePrompt" xml:space="preserve">
+    <value>Replace the captions in this tab with the selected history result? The current captions are not saved yet.</value>
+  </data>
+  <data name="AiSubtitle_HistoryOverwriteApply" xml:space="preserve">
+    <value>Replace captions</value>
+  </data>
+  <data name="AiSubtitleAddedToScene" xml:space="preserve">
+    <value>The subtitles were added to the scene.</value>
+  </data>
+  <data name="AiEditImage" xml:space="preserve">
+    <value>Edit image</value>
+  </data>
+  <data name="AiImageEdit" xml:space="preserve">
+    <value>AI image editing</value>
+  </data>
+  <data name="AiEditTask" xml:space="preserve">
+    <value>Task</value>
+  </data>
+  <data name="AiEditRemoveBackground" xml:space="preserve">
+    <value>Remove background</value>
+  </data>
+  <data name="AiEditUpscale" xml:space="preserve">
+    <value>Upscale</value>
+  </data>
+  <data name="AiEditBrowse" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="AiEditRun" xml:space="preserve">
+    <value>Run</value>
+  </data>
+  <data name="AiEditSelectSource" xml:space="preserve">
+    <value>Select an image file first.</value>
+  </data>
+  <data name="AiGenerateVideo" xml:space="preserve">
+    <value>Generate video</value>
+  </data>
+  <data name="AiVideoGeneration" xml:space="preserve">
+    <value>AI video generation</value>
+  </data>
+  <data name="AiVideoPrompt_Placeholder" xml:space="preserve">
+    <value>Describe the video you want to generate...</value>
+  </data>
+  <data name="AiVideoDuration" xml:space="preserve">
+    <value>Duration</value>
+  </data>
+  <data name="AiVideoResolution" xml:space="preserve">
+    <value>Resolution</value>
+  </data>
+  <data name="AiVideoSeconds" xml:space="preserve">
+    <value>seconds</value>
+  </data>
+  <data name="AiVideoSubmitting" xml:space="preserve">
+    <value>Submitting the video generation job...</value>
+  </data>
+  <data name="AiVideoIdle" xml:space="preserve">
+    <value>Describe the video and click Generate.</value>
+  </data>
+  <data name="AiVideoProcessing" xml:space="preserve">
+    <value>Generating the video... This may take a few minutes.</value>
+  </data>
+  <data name="AiVideoCompleted" xml:space="preserve">
+    <value>The video has been generated.</value>
+  </data>
+  <data name="AiVideoFailed" xml:space="preserve">
+    <value>The video generation failed.</value>
+  </data>
+  <data name="AiVideoJobLimitReached" xml:space="preserve">
+    <value>A video generation job is already in progress. Please wait for it to complete.</value>
+  </data>
+  <data name="AiVideoAddedToScene" xml:space="preserve">
+    <value>The video was added to the scene.</value>
+  </data>
+  <data name="AiVideoSaved" xml:space="preserve">
+    <value>The video was saved.</value>
+  </data>
+  <data name="AiClearFrame" xml:space="preserve">
+    <value>Clear frame</value>
+  </data>
+  <data name="AiJobCenter" xml:space="preserve">
+    <value>AI jobs</value>
+  </data>
+  <data name="AiJobCenter_Description" xml:space="preserve">
+    <value>Track, reuse, and add generated results without blocking your editing workflow.</value>
+  </data>
+  <data name="AiJobCenter_Empty" xml:space="preserve">
+    <value>No AI jobs yet. Generated images, subtitles, and videos will appear here.</value>
+  </data>
+  <data name="AiJobCenter_LoadFailed" xml:space="preserve">
+    <value>Failed to load AI job history.</value>
+  </data>
+  <data name="AiJobCenter_LoadMore" xml:space="preserve">
+    <value>Load more</value>
+  </data>
+  <data name="AiJobCenter_StatusQueued" xml:space="preserve">
+    <value>Queued</value>
+  </data>
+  <data name="AiJobCenter_StatusRunning" xml:space="preserve">
+    <value>Processing</value>
+  </data>
+  <data name="AiJobCenter_StatusSucceeded" xml:space="preserve">
+    <value>Completed</value>
+  </data>
+  <data name="AiJobCenter_StatusFailed" xml:space="preserve">
+    <value>Failed · usage restored</value>
+  </data>
+  <data name="AiJobCenter_StatusCanceled" xml:space="preserve">
+    <value>Canceled</value>
+  </data>
+  <data name="AiJobCenter_NoDescription" xml:space="preserve">
+    <value>No description</value>
+  </data>
+  <data name="AiJobCenter_TranslationSummary" xml:space="preserve">
+    <value>Subtitle translation to {0}</value>
+  </data>
+  <data name="AiJobCenter_UsageFormat" xml:space="preserve">
+    <value>Usage {0}</value>
+  </data>
+  <data name="AiJobCenter_Retry" xml:space="preserve">
+    <value>Retry</value>
+  </data>
+  <data name="AiJobCenter_RetryTitle" xml:space="preserve">
+    <value>Retry AI job?</value>
+  </data>
+  <data name="AiJobCenter_CheckingRetryCost" xml:space="preserve">
+    <value>Checking the current usage estimate…</value>
+  </data>
+  <data name="AiJobCenter_RetryConfirmation" xml:space="preserve">
+    <value>This creates a new job and uses your allowance again. The original result is preserved.</value>
+  </data>
+  <data name="AiJobCenter_RetryFailed" xml:space="preserve">
+    <value>Failed to retry the AI job. Its original settings are still available.</value>
+  </data>
+  <data name="AiJobCenter_DeleteTitle" xml:space="preserve">
+    <value>Delete this AI history item?</value>
+  </data>
+  <data name="AiJobCenter_DeleteConfirmation" xml:space="preserve">
+    <value>The server copy, prompt, and generated output will be removed. Items already added to the project are kept.</value>
+  </data>
+  <data name="AiJobCenter_DeleteFailed" xml:space="preserve">
+    <value>Failed to delete the AI history item.</value>
+  </data>
+  <data name="AiJobCenter_AddFailed" xml:space="preserve">
+    <value>Failed to add the generated result to the scene.</value>
+  </data>
+  <data name="AiJobCenter_AddedToScene" xml:space="preserve">
+    <value>The generated result was added to the scene.</value>
+  </data>
+  <data name="AiJobCenter_CompletedNotification" xml:space="preserve">
+    <value>{0} is ready. Open AI jobs to review or add the result.</value>
+  </data>
+  <data name="AiJobCenter_FailedNotification" xml:space="preserve">
+    <value>{0} failed. Reserved usage was restored; you can retry from AI jobs.</value>
+  </data>
+  <data name="AiJobCenter_CanceledNotification" xml:space="preserve">
+    <value>{0} was canceled. No result was created.</value>
+  </data>
+  <data name="AiEstimatedUsage" xml:space="preserve">
+    <value>Uses your monthly allowance</value>
+  </data>
+  <data name="AiModel" xml:space="preserve">
+    <value>Model</value>
+  </data>
+  <data name="AiModelUnavailable" xml:space="preserve">
+    <value>The model this request used is no longer offered. Start a new request to choose another one.</value>
+  </data>
+  <data name="AiModelCostLow" xml:space="preserve">
+    <value>Uses less of the allowance</value>
+  </data>
+  <data name="AiModelCostMedium" xml:space="preserve">
+    <value>Uses about the usual</value>
+  </data>
+  <data name="AiModelCostHigh" xml:space="preserve">
+    <value>Uses more of the allowance</value>
+  </data>
+  <data name="AiModelUnaffordable" xml:space="preserve">
+    <value>Not enough remaining</value>
+  </data>
+  <data name="AiPricingUnavailable" xml:space="preserve">
+    <value>Authoritative pricing is unavailable. Reconnect before starting this paid operation.</value>
+  </data>
+  <data name="AiEstimatedUsageMonthly" xml:space="preserve">
+    <value>Covered by your monthly allowance.</value>
+  </data>
+  <data name="AiEstimatedUsageTopUp" xml:space="preserve">
+    <value>Your monthly allowance is used up, so purchased credits will be used.</value>
+  </data>
+  <data name="AiEstimatedUsageInsufficient" xml:space="preserve">
+    <value>Not enough allowance or credits remaining. Add credits before starting.</value>
+  </data>
+  <data name="AiSubtitle_SceneMix" xml:space="preserve">
+    <value>Scene mix (selected range)</value>
+  </data>
+  <data name="AiSubtitle_Range" xml:space="preserve">
+    <value>Scene range</value>
+  </data>
+  <data name="AiSubtitle_SourceLanguage" xml:space="preserve">
+    <value>Spoken language</value>
+  </data>
+  <data name="AiSubtitle_TargetLanguage" xml:space="preserve">
+    <value>Translate to</value>
+  </data>
+  <data name="AiLanguageAuto" xml:space="preserve">
+    <value>Detect automatically</value>
+  </data>
+  <data name="AiSubtitle_DetectedLanguage" xml:space="preserve">
+    <value>Detected language: {0}</value>
+  </data>
+  <data name="AiSubtitle_RunCannotBeRecorded" xml:space="preserve">
+    <value>This run cannot be written down, so it cannot be started: a request charged for and then lost with the session could not be asked for again. Close the other subtitle tab for this scene and try again.</value>
+  </data>
+  <data name="AiSubtitle_NoAudioInRange" xml:space="preserve">
+    <value>No audio was found in the selected scene range.</value>
+  </data>
+  <data name="AiSubtitle_InvalidRange" xml:space="preserve">
+    <value>Enter a valid scene range where the end is after the start.</value>
+  </data>
+  <data name="AiSubtitle_Import" xml:space="preserve">
+    <value>Import captions</value>
+  </data>
+  <data name="AiSubtitle_Export" xml:space="preserve">
+    <value>Export captions</value>
+  </data>
+  <data name="AiSubtitle_LossySrtExportTitle" xml:space="preserve">
+    <value>Export SRT without caption metadata?</value>
+  </data>
+  <data name="AiSubtitle_LossySrtExportMessage" xml:space="preserve">
+    <value>SRT cannot store speaker, language, or structured caption metadata. Exporting will keep only timing and text. Continue?</value>
+  </data>
+  <data name="AiSubtitle_ImportFailed" xml:space="preserve">
+    <value>The caption file could not be imported.</value>
+  </data>
+  <data name="AiSubtitle_ExportFailed" xml:space="preserve">
+    <value>The caption file could not be exported.</value>
+  </data>
+  <data name="AiSubtitle_Exported" xml:space="preserve">
+    <value>The caption file was exported.</value>
+  </data>
+  <data name="AiSubtitle_CaptionFiles" xml:space="preserve">
+    <value>Caption files (SRT, WebVTT, ASS)</value>
+  </data>
+  <data name="AiSubtitle_AddCue" xml:space="preserve">
+    <value>Add cue</value>
+  </data>
+  <data name="AiSubtitle_DeleteCue" xml:space="preserve">
+    <value>Delete cue</value>
+  </data>
+  <data name="AiSubtitle_SplitCue" xml:space="preserve">
+    <value>Split at playhead</value>
+  </data>
+  <data name="AiSubtitle_MergeCue" xml:space="preserve">
+    <value>Merge next</value>
+  </data>
+  <data name="AiSubtitle_WrapCues" xml:space="preserve">
+    <value>Wrap lines</value>
+  </data>
+  <data name="AiSubtitle_MaxLineLength" xml:space="preserve">
+    <value>Characters per line</value>
+  </data>
+  <data name="AiSubtitle_MaxLineCount" xml:space="preserve">
+    <value>Lines per cue</value>
+  </data>
+  <data name="AiSubtitle_CueStart" xml:space="preserve">
+    <value>Start</value>
+  </data>
+  <data name="AiSubtitle_CueEnd" xml:space="preserve">
+    <value>End</value>
+  </data>
+  <data name="AiSubtitle_Speaker" xml:space="preserve">
+    <value>Speaker</value>
+  </data>
+  <data name="AiSubtitle_Language" xml:space="preserve">
+    <value>Language</value>
+  </data>
+  <data name="AiSubtitle_Text" xml:space="preserve">
+    <value>Caption text</value>
+  </data>
+  <data name="AiSubtitle_InvalidTiming" xml:space="preserve">
+    <value>One or more cues have invalid start or end times.</value>
+  </data>
+  <data name="AiSubtitle_ValidationIssues" xml:space="preserve">
+    <value>{0} caption issues need attention. Check timing, order, and line limits.</value>
+  </data>
+  <data name="AiSubtitle_OverlapWarning" xml:space="preserve">
+    <value>Some captions overlap. They can still be added, but may appear at the same time.</value>
+  </data>
+  <data name="AiSubtitle_Translate" xml:space="preserve">
+    <value>Translate captions</value>
+  </data>
+  <data name="AiSubtitle_TemplatePreview" xml:space="preserve">
+    <value>Template preview (approximate)</value>
+  </data>
+  <data name="AiSubtitle_PreviewSample" xml:space="preserve">
+    <value>Your subtitle preview</value>
+  </data>
+  <data name="AiPreviewMode" xml:space="preserve">
+    <value>Preview</value>
+  </data>
+  <data name="AiPreviewResult" xml:space="preserve">
+    <value>Result</value>
+  </data>
+  <data name="AiPreviewOriginal" xml:space="preserve">
+    <value>Original</value>
+  </data>
+  <data name="AiPreviewSideBySide" xml:space="preserve">
+    <value>Side by side</value>
+  </data>
+  <data name="AiEditSourcePreviewFailed" xml:space="preserve">
+    <value>The selected image could not be previewed. Choose another supported image.</value>
+  </data>
+  <data name="AiPromptDetails" xml:space="preserve">
+    <value>Prompt details</value>
+  </data>
+  <data name="AiPromptStyle" xml:space="preserve">
+    <value>Style</value>
+  </data>
+  <data name="AiPromptStylePlaceholder" xml:space="preserve">
+    <value>e.g. cinematic, watercolor, photorealistic</value>
+  </data>
+  <data name="AiPromptComposition" xml:space="preserve">
+    <value>Composition and camera</value>
+  </data>
+  <data name="AiPromptCompositionPlaceholder" xml:space="preserve">
+    <value>e.g. close-up, wide angle, soft backlight</value>
+  </data>
+  <data name="AiPromptMotion" xml:space="preserve">
+    <value>Motion</value>
+  </data>
+  <data name="AiPromptMotionPlaceholder" xml:space="preserve">
+    <value>e.g. slow camera push-in, natural subject movement</value>
+  </data>
+  <data name="AiPromptAvoid" xml:space="preserve">
+    <value>Avoid</value>
+  </data>
+  <data name="AiPromptAvoidPlaceholder" xml:space="preserve">
+    <value>e.g. text, logos, flicker, camera shake</value>
+  </data>
+  <data name="AiVideoFrameGuidance" xml:space="preserve">
+    <value>Frame guidance</value>
+  </data>
+  <data name="AiVideoFrameGuidanceDescription" xml:space="preserve">
+    <value>Use a first frame to animate an existing composition, or add a last frame to generate a transition. Images are uploaded only when you generate.</value>
+  </data>
+  <data name="AiVideoUseCurrentFrame" xml:space="preserve">
+    <value>Use current scene frame</value>
+  </data>
+  <data name="AiVideoFirstFrame" xml:space="preserve">
+    <value>First frame</value>
+  </data>
+  <data name="AiVideoLastFrame" xml:space="preserve">
+    <value>Last frame</value>
+  </data>
+  <data name="AiVideoBrowseFirstFrame" xml:space="preserve">
+    <value>Browse for first frame</value>
+  </data>
+  <data name="AiVideoClearFirstFrame" xml:space="preserve">
+    <value>Clear first frame</value>
+  </data>
+  <data name="AiVideoBrowseLastFrame" xml:space="preserve">
+    <value>Browse for last frame</value>
+  </data>
+  <data name="AiVideoClearLastFrame" xml:space="preserve">
+    <value>Clear last frame</value>
+  </data>
+  <data name="AiVideoFrameCaptureFailed" xml:space="preserve">
+    <value>The current scene frame could not be captured. Fix preview errors or choose an image file.</value>
+  </data>
+  <data name="AiVideoOpenPreview" xml:space="preserve">
+    <value>Open preview</value>
+  </data>
+  <data name="AiVideoPreviewOpenFailed" xml:space="preserve">
+    <value>The generated video could not be opened in the default media player.</value>
+  </data>
+  <data name="AiPromptLibraryPrivacy" xml:space="preserve">
+    <value>Recent prompts stay in memory for this session. Only named templates and prompts you pin are saved locally.</value>
+  </data>
+  <data name="AiOptional" xml:space="preserve">
+    <value>Optional</value>
+  </data>
+  <data name="AiPromptHistory" xml:space="preserve">
+    <value>Prompt history</value>
+  </data>
+  <data name="AiPromptHistoryEmpty" xml:space="preserve">
+    <value>No prompts have been run yet.</value>
+  </data>
+  <data name="AiPromptTemplates" xml:space="preserve">
+    <value>Prompt templates</value>
+  </data>
+  <data name="AiPromptTemplatesEmpty" xml:space="preserve">
+    <value>No templates saved yet.</value>
+  </data>
+  <data name="AiPromptSeed" xml:space="preserve">
+    <value>Seed</value>
+  </data>
+  <data name="AiPromptSeedPlaceholder" xml:space="preserve">
+    <value>Random every time</value>
+  </data>
+  <data name="AiReferenceImage" xml:space="preserve">
+    <value>Reference images</value>
+  </data>
+  <data name="AiReferenceImageDescription" xml:space="preserve">
+    <value>Guide the generation with existing pictures. They are uploaded only when you generate.</value>
+  </data>
+  <data name="AiClearReferenceImage" xml:space="preserve">
+    <value>Clear references</value>
+  </data>
+  <data name="AiReferenceImageCount" xml:space="preserve">
+    <value>{0} of {1} used</value>
+  </data>
+  <data name="AiRemoveReferenceImage" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="AiPromptApply" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="AiPromptPin" xml:space="preserve">
+    <value>Pin / unpin</value>
+  </data>
+  <data name="AiPromptTemplateName" xml:space="preserve">
+    <value>Template name</value>
+  </data>
+  <data name="AiPromptSaveTemplate" xml:space="preserve">
+    <value>Save template</value>
+  </data>
+  <data name="AiPromptClearRecent" xml:space="preserve">
+    <value>Clear recent prompts</value>
+  </data>
+  <data name="AiPromptTemplateInvalid" xml:space="preserve">
+    <value>Enter both a template name and a prompt before saving.</value>
+  </data>
+  <data name="AiVideoWaitStopped" xml:space="preserve">
+    <value>Local waiting stopped. The server job remains available in AI job history.</value>
+  </data>
+  <data name="AiEditRestyle" xml:space="preserve">
+    <value>Restyle with a reference</value>
+  </data>
+  <data name="AiEditRemoveObject" xml:space="preserve">
+    <value>Remove an object</value>
+  </data>
+  <data name="AiEditOutpaint" xml:space="preserve">
+    <value>Expand canvas (outpaint)</value>
+  </data>
+  <data name="AiEditRestylePrompt" xml:space="preserve">
+    <value>Describe the target style while noting details that must stay unchanged.</value>
+  </data>
+  <data name="AiEditRemoveObjectPrompt" xml:space="preserve">
+    <value>Describe the object to remove and how the cleared area should look.</value>
+  </data>
+  <data name="AiEditOutpaintPrompt" xml:space="preserve">
+    <value>Describe what should continue beyond the original image.</value>
+  </data>
+  <data name="AiEditOutpaintExpansion" xml:space="preserve">
+    <value>Expansion on each edge</value>
+  </data>
+  <data name="AiSubtitle_PartialTranslationAvailable" xml:space="preserve">
+    <value>Translation completed for {0} of {1} batches. You can use the paid partial result now, or run Translate again to continue without processing completed batches again.</value>
+  </data>
+  <data name="AiSubtitle_PartialTranscriptionAvailable" xml:space="preserve">
+    <value>Transcription completed for {0} of {1} audio chunks. You can use the paid partial result now, or run Transcribe again to continue without processing completed chunks again.</value>
+  </data>
+  <data name="AiSubtitle_UsePartialResult" xml:space="preserve">
+    <value>Use partial result</value>
+  </data>
+  <data name="AiSubtitle_DiscardPartialResult" xml:space="preserve">
+    <value>Discard partial result</value>
+  </data>
+  <data name="AiSubtitle_CompletedResultAvailable" xml:space="preserve">
+    <value>The paid AI result is ready, but the source or captions changed while it was running. Review and apply the recoverable result when you are ready.</value>
+  </data>
   <data name="Materials" xml:space="preserve">
     <value>Materials</value>
   </data>
@@ -1912,5 +2509,77 @@ Resolve the conflicts with an external Git tool before editing. The project may 
   </data>
   <data name="VersionControl_WorktreeOperationInProgress" xml:space="preserve">
     <value>Project files are being updated by version control. Wait for the operation to finish, then try again.</value>
+  </data>
+  <data name="AiPromptRequired" xml:space="preserve">
+    <value>Enter a prompt.</value>
+  </data>
+  <data name="AiPromptTooLongFormat" xml:space="preserve">
+    <value>The final composed prompt cannot exceed {0} characters.</value>
+  </data>
+  <data name="AiImageGenerationIdle" xml:space="preserve">
+    <value>Describe the image and click Generate.</value>
+  </data>
+  <data name="AiImageEditIdle" xml:space="preserve">
+    <value>Choose an image and a task, then click Run.</value>
+  </data>
+  <data name="AiEditSourceImage" xml:space="preserve">
+    <value>Source image</value>
+  </data>
+  <data name="AiEditNoSourceSelected" xml:space="preserve">
+    <value>Not selected</value>
+  </data>
+  <data name="AiReferenceImageHeader" xml:space="preserve">
+    <value>Reference images (optional)</value>
+  </data>
+  <data name="AiVideoFrameGuidanceHeader" xml:space="preserve">
+    <value>Frame guidance (optional)</value>
+  </data>
+  <data name="AiPendingRequest" xml:space="preserve">
+    <value>Pending AI request</value>
+  </data>
+  <data name="AiRecoverRequest" xml:space="preserve">
+    <value>Recover</value>
+  </data>
+  <data name="AiAbandonRequest" xml:space="preserve">
+    <value>Abandon</value>
+  </data>
+  <data name="AiSubtitle_CueListEmpty" xml:space="preserve">
+    <value>Transcribe or import captions, and the cues appear here.</value>
+  </data>
+  <data name="AiSubtitle_LineWrapping" xml:space="preserve">
+    <value>Line wrapping</value>
+  </data>
+  <data name="AiSubtitle_CueEditing" xml:space="preserve">
+    <value>Cues</value>
+  </data>
+  <data name="AiSubtitle_Edit" xml:space="preserve">
+    <value>Edit captions</value>
+  </data>
+  <data name="AiSubtitle_TranscribeDescription" xml:space="preserve">
+    <value>Choose an audio source and create timed captions.</value>
+  </data>
+  <data name="AiSubtitle_EditDescription" xml:space="preserve">
+    <value>Review timing and text, choose an appearance, then add the captions to the scene.</value>
+  </data>
+  <data name="AiSubtitle_TranslateDescription" xml:space="preserve">
+    <value>Translate the current captions into another language.</value>
+  </data>
+  <data name="AiSubtitle_CaptionsFile" xml:space="preserve">
+    <value>Captions file</value>
+  </data>
+  <data name="AiJobCenter_DeleteTitleFormat" xml:space="preserve">
+    <value>Delete “{0}”?</value>
+  </data>
+  <data name="TimeAgoJustNow" xml:space="preserve">
+    <value>Just now</value>
+  </data>
+  <data name="TimeAgoMinutesFormat" xml:space="preserve">
+    <value>{0} min ago</value>
+  </data>
+  <data name="TimeAgoHoursFormat" xml:space="preserve">
+    <value>{0} h ago</value>
+  </data>
+  <data name="TimeAgoDaysFormat" xml:space="preserve">
+    <value>{0} d ago</value>
   </data>
 </root>

--- a/src/Beutl.Language/Strings.zh-CN.resx
+++ b/src/Beutl.Language/Strings.zh-CN.resx
@@ -1576,4 +1576,55 @@ GetProperty&lt;T&gt;("path") 或 GetProperty&lt;T&gt;(guid, "propertyName")
   <data name="Materials" xml:space="preserve">
     <value>素材</value>
   </data>
+  <data name="AiPromptRequired" xml:space="preserve">
+    <value>请输入提示词。</value>
+  </data>
+  <data name="AiPromptTooLongFormat" xml:space="preserve">
+    <value>最终组合的提示词不能超过 {0} 个字符。</value>
+  </data>
+  <data name="AiImageGenerationIdle" xml:space="preserve">
+    <value>描述图像并点击“生成”。</value>
+  </data>
+  <data name="AiImageEditIdle" xml:space="preserve">
+    <value>选择图像和任务，然后点击“运行”。</value>
+  </data>
+  <data name="AiEditSourceImage" xml:space="preserve">
+    <value>源图像</value>
+  </data>
+  <data name="AiEditNoSourceSelected" xml:space="preserve">
+    <value>未选择</value>
+  </data>
+  <data name="AiReferenceImageHeader" xml:space="preserve">
+    <value>参考图像（可选）</value>
+  </data>
+  <data name="AiVideoFrameGuidanceHeader" xml:space="preserve">
+    <value>帧引导（可选）</value>
+  </data>
+  <data name="AiSubtitle_CueListEmpty" xml:space="preserve">
+    <value>进行转写或导入字幕后，字幕条目会显示在这里。</value>
+  </data>
+  <data name="AiSubtitle_LineWrapping" xml:space="preserve">
+    <value>换行</value>
+  </data>
+  <data name="AiSubtitle_CueEditing" xml:space="preserve">
+    <value>字幕条目</value>
+  </data>
+  <data name="AiSubtitle_CaptionsFile" xml:space="preserve">
+    <value>字幕文件</value>
+  </data>
+  <data name="AiJobCenter_DeleteTitleFormat" xml:space="preserve">
+    <value>要删除“{0}”吗？</value>
+  </data>
+  <data name="TimeAgoJustNow" xml:space="preserve">
+    <value>刚刚</value>
+  </data>
+  <data name="TimeAgoMinutesFormat" xml:space="preserve">
+    <value>{0} 分钟前</value>
+  </data>
+  <data name="TimeAgoHoursFormat" xml:space="preserve">
+    <value>{0} 小时前</value>
+  </data>
+  <data name="TimeAgoDaysFormat" xml:space="preserve">
+    <value>{0} 天前</value>
+  </data>
 </root>

--- a/src/Beutl.PackageTools.UI/Services/AsyncOperationLifetime.cs
+++ b/src/Beutl.PackageTools.UI/Services/AsyncOperationLifetime.cs
@@ -1,15 +1,19 @@
-﻿namespace Beutl.PackageTools.UI.Services;
+﻿using Beutl.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace Beutl.PackageTools.UI.Services;
 
 /// <summary>
 /// Owns asynchronous work that must finish before its backing resources are disposed.
 /// </summary>
 internal sealed class AsyncOperationLifetime : IAsyncDisposable
 {
+    private static readonly ILogger s_logger = Log.CreateLogger<AsyncOperationLifetime>();
     private readonly object _gate = new();
     private readonly CancellationTokenSource _lifetimeCancellation = new();
     private readonly Action _cancelPendingRequests;
     private readonly Func<ValueTask> _disposeResources;
-    private readonly long _drainDeadlineMilliseconds;
+    private readonly TimeSpan _shutdownDeadline;
     private readonly HashSet<Task> _operations = [];
     private Task? _disposeTask;
     private bool _stopping;
@@ -17,13 +21,15 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
     public AsyncOperationLifetime(
         Action cancelPendingRequests,
         Func<ValueTask> disposeResources,
-        long drainDeadlineMilliseconds = 30_000)
+        TimeSpan? shutdownDeadline = null)
     {
         _cancelPendingRequests = cancelPendingRequests
             ?? throw new ArgumentNullException(nameof(cancelPendingRequests));
         _disposeResources = disposeResources
             ?? throw new ArgumentNullException(nameof(disposeResources));
-        _drainDeadlineMilliseconds = drainDeadlineMilliseconds;
+        _shutdownDeadline = shutdownDeadline ?? TimeSpan.FromSeconds(30);
+        if (_shutdownDeadline <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(shutdownDeadline));
     }
 
     public Task RunAsync(
@@ -61,9 +67,7 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
         lock (_gate)
         {
             _stopping = true;
-            // Publish the disposal task before cancellation so re-entrant callbacks
-            // observe the original teardown.
-            if (_disposeTask == null)
+            if (_disposeTask is null)
             {
                 proxy = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 _disposeTask = proxy.Task;
@@ -71,20 +75,29 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
             disposeTask = _disposeTask;
         }
 
-        if (proxy != null)
+        if (proxy is not null)
         {
-            _ = RunDisposeCoreAsync(proxy);
+            Task teardown = Task.Run(DisposeCoreAsync);
+            _ = CompleteDisposeAsync(proxy, teardown);
         }
 
         return new ValueTask(disposeTask);
     }
 
-    private async Task RunDisposeCoreAsync(TaskCompletionSource proxy)
+    private async Task CompleteDisposeAsync(TaskCompletionSource proxy, Task teardown)
     {
         try
         {
-            await DisposeCoreAsync().ConfigureAwait(false);
+            await teardown.WaitAsync(_shutdownDeadline).ConfigureAwait(false);
             proxy.TrySetResult();
+        }
+        catch (TimeoutException)
+        {
+            s_logger.LogWarning(
+                "Package-tools shutdown exceeded {Deadline}; cleanup will continue after callbacks and operations drain.",
+                _shutdownDeadline);
+            proxy.TrySetResult();
+            _ = ObserveDeferredTeardownAsync(teardown);
         }
         catch (Exception ex)
         {
@@ -97,6 +110,7 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
         Action? completion,
         CancellationTokenSource linkedCancellation)
     {
+        // Ensure the task is registered before a synchronously completing operation can remove it.
         await Task.Yield();
         try
         {
@@ -105,7 +119,7 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
             {
                 lock (_gate)
                 {
-                    if (!_stopping)
+                    if (!_stopping && !linkedCancellation.IsCancellationRequested)
                     {
                         completion();
                     }
@@ -120,11 +134,10 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
 
     private async Task DisposeCoreAsync()
     {
-        long deadline = Environment.TickCount64 + _drainDeadlineMilliseconds;
         Exception? cancellationFailure = null;
         try
         {
-            _lifetimeCancellation.Cancel();
+            _cancelPendingRequests();
         }
         catch (Exception ex)
         {
@@ -133,8 +146,10 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
 
         try
         {
-            // Run independently so a throwing callback cannot skip cancelling pending requests.
-            _cancelPendingRequests();
+            // Run independently so a throwing pending-request callback cannot skip lifetime
+            // cancellation. Pending requests are canceled first so observers of the lifetime token
+            // cannot resume before both cancellation channels have been signaled.
+            _lifetimeCancellation.Cancel();
         }
         catch (Exception ex)
         {
@@ -143,53 +158,67 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
 
         try
         {
-            while (Environment.TickCount64 < deadline)
-            {
-                Task[] operations;
-                lock (_gate)
-                {
-                    operations = _operations.ToArray();
-                }
-
-                if (operations.Length == 0)
-                    break;
-
-                try
-                {
-                    long remaining = deadline - Environment.TickCount64;
-                    if (remaining <= 0)
-                        break;
-
-                    await Task.WhenAll(operations).WaitAsync(TimeSpan.FromMilliseconds(remaining)).ConfigureAwait(false);
-                }
-                catch
-                {
-                    // Awaiting observes operation failures. Each owner reports its own operation error;
-                    // resource teardown must still run after every task has drained.
-                }
-
-                lock (_gate)
-                {
-                    _operations.RemoveWhere(task => task.IsCompleted);
-                }
-            }
+            await DrainOperationsAsync().ConfigureAwait(false);
         }
         finally
         {
-            try
-            {
-                await _disposeResources();
-            }
-            finally
-            {
-                _lifetimeCancellation.Dispose();
-            }
+            await DisposeResourcesAsync().ConfigureAwait(false);
         }
 
-        if (cancellationFailure != null)
-        {
+        if (cancellationFailure is not null)
             throw cancellationFailure;
+    }
+
+    private async Task DrainOperationsAsync()
+    {
+        while (true)
+        {
+            Task[] operations;
+            lock (_gate)
+            {
+                operations = _operations.ToArray();
+            }
+
+            if (operations.Length == 0)
+                return;
+
+            try
+            {
+                await Task.WhenAll(operations).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Owners report operation failures. Disposal only needs to observe them.
+            }
+
+            lock (_gate)
+            {
+                _operations.RemoveWhere(task => task.IsCompleted);
+            }
         }
     }
 
+    private static async Task ObserveDeferredTeardownAsync(Task teardown)
+    {
+        try
+        {
+            await teardown.ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            s_logger.LogWarning(ex, "Deferred package-tools resource cleanup failed.");
+        }
+    }
+
+    private async Task DisposeResourcesAsync()
+    {
+        try
+        {
+            await _disposeResources().ConfigureAwait(false);
+        }
+        finally
+        {
+            _lifetimeCancellation.Dispose();
+        }
+    }
 }

--- a/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
@@ -2522,19 +2522,23 @@ public class Scene : ProjectItem, INotifyEdited
         // .scene ファイル自身を指すため、そのまま使うと _excludeElements に "../foo.belm"
         // のような不正パスが入り、Deserialize 側 (Path.GetDirectoryName を使用) と整合せず
         // 除外パターンが効かない。結果として削除した Element が再読み込みで復活する。
-        string dirPath = Path.GetDirectoryName(Uri!.LocalPath)!;
+        string? dirPath = Uri is { IsFile: true } sceneUri
+            ? Path.GetDirectoryName(sceneUri.LocalPath)
+            : null;
         if (e.Action == NotifyCollectionChangedAction.Remove
             && e.OldItems != null)
         {
             foreach (Element item in e.OldItems.OfType<Element>())
             {
-                string itemPath = item.Uri!.LocalPath;
-                string rel = NormalizeElementPatternForStorage(
-                    Path.GetRelativePath(dirPath, itemPath));
-
-                if (!_excludeElements.Contains(rel) && File.Exists(itemPath))
+                if (dirPath is not null && item.Uri is { IsFile: true } itemUri)
                 {
-                    _excludeElements.Add(rel);
+                    string itemPath = itemUri.LocalPath;
+                    string rel = NormalizeElementPatternForStorage(
+                        Path.GetRelativePath(dirPath, itemPath));
+                    if (!_excludeElements.Contains(rel) && File.Exists(itemPath))
+                    {
+                        _excludeElements.Add(rel);
+                    }
                 }
 
                 affectedRange.Add(item.Range);
@@ -2545,13 +2549,15 @@ public class Scene : ProjectItem, INotifyEdited
         {
             foreach (Element item in e.NewItems.OfType<Element>())
             {
-                string itemPath = item.Uri!.LocalPath;
-                string rel = NormalizeElementPatternForStorage(
-                    Path.GetRelativePath(dirPath, itemPath));
-
-                if (_excludeElements.Contains(rel) && File.Exists(itemPath))
+                if (dirPath is not null && item.Uri is { IsFile: true } itemUri)
                 {
-                    _excludeElements.Remove(rel);
+                    string itemPath = itemUri.LocalPath;
+                    string rel = NormalizeElementPatternForStorage(
+                        Path.GetRelativePath(dirPath, itemPath));
+                    if (_excludeElements.Contains(rel) && File.Exists(itemPath))
+                    {
+                        _excludeElements.Remove(rel);
+                    }
                 }
 
                 affectedRange.Add(item.Range);

--- a/src/Beutl/App.axaml.cs
+++ b/src/Beutl/App.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Input.Platform;
 using Avalonia.Markup.Xaml;
+using Avalonia.Platform;
 using Avalonia.Styling;
 using Avalonia.Threading;
 using Beutl.Api.Services;
@@ -28,6 +29,13 @@ namespace Beutl;
 
 public sealed class App : Application
 {
+    private static readonly string[] s_bundledEngineFonts =
+    [
+        "NotoSansJP-Regular.ttf",
+        "NotoSansJP-Medium.ttf",
+        "NotoSansJP-SemiBold.ttf",
+        "NotoSansJP-Bold.ttf",
+    ];
     private static readonly ILogger s_logger = Log.CreateLogger<App>();
     private readonly TaskCompletionSource _windowOpenTcs = new();
     private FluentAvaloniaTheme? _theme;
@@ -38,10 +46,6 @@ public sealed class App : Application
 
     public override void Initialize()
     {
-        _startUp = GetMainViewModel().RunStartupTask();
-        _sideloadExtensionTask = _startUp.GetTask<LoadSideloadExtensionTask>();
-        _startUp.WaitAll().ContinueWith(_ => _startUp = null);
-
         using Activity? activity = Telemetry.StartActivity("App.Initialize");
 
         FAUISettings.SetAnimationsEnabledAtAppLevel(true);
@@ -53,6 +57,10 @@ public sealed class App : Application
         GraphicsContextFactory.SelectGpuByName(config.GraphicsConfig.SelectedGpuName);
 
         AvaloniaXamlLoader.Load(this);
+        RegisterBundledEngineFonts();
+        _startUp = GetMainViewModel().RunStartupTask();
+        _sideloadExtensionTask = _startUp.GetTask<LoadSideloadExtensionTask>();
+        _startUp.WaitAll().ContinueWith(_ => _startUp = null);
         Resources["PaletteColors"] = AppHelpers.GetPaletteColors();
         ApplyDockStringOverrides();
 
@@ -66,6 +74,16 @@ public sealed class App : Application
         if (!OperatingSystem.IsWindows())
         {
             _theme.RemoveRange(1, _theme.Count - 1);
+        }
+    }
+
+    internal static void RegisterBundledEngineFonts()
+    {
+        foreach (string fileName in s_bundledEngineFonts)
+        {
+            using Stream stream = AssetLoader.Open(
+                new Uri($"avares://Beutl.Controls/Assets/Fonts/{fileName}"));
+            Media.FontManager.Instance.AddFont(stream);
         }
     }
 

--- a/src/Beutl/Pages/SettingsPages/AccountSettingsPage.axaml.cs
+++ b/src/Beutl/Pages/SettingsPages/AccountSettingsPage.axaml.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using Beutl.ViewModels.SettingsPages;
 
 using Reactive.Bindings.Extensions;
@@ -8,6 +9,8 @@ namespace Beutl.Pages.SettingsPages;
 
 public sealed partial class AccountSettingsPage : UserControl
 {
+    private TopLevel? _topLevel;
+
     public AccountSettingsPage()
     {
         InitializeComponent();
@@ -29,5 +32,33 @@ public sealed partial class AccountSettingsPage : UserControl
             .Take(1)
             .ObserveOnUIDispatcher()
             .Subscribe(_ => settingsContainer.Content = new AccountSettingsScreen());
+    }
+
+    // The AI plan is managed in a browser. Reload the plan state once the app
+    // window is focused again so a change made there is reflected here.
+    protected override void OnLoaded(RoutedEventArgs e)
+    {
+        base.OnLoaded(e);
+        _topLevel = TopLevel.GetTopLevel(this);
+        if (_topLevel is WindowBase window)
+        {
+            window.Activated += OnWindowActivated;
+        }
+    }
+
+    protected override void OnUnloaded(RoutedEventArgs e)
+    {
+        base.OnUnloaded(e);
+        if (_topLevel is WindowBase window)
+        {
+            window.Activated -= OnWindowActivated;
+        }
+
+        _topLevel = null;
+    }
+
+    private void OnWindowActivated(object? sender, EventArgs e)
+    {
+        (DataContext as AccountSettingsPageViewModel)?.NotifyReturnedToApplication();
     }
 }

--- a/src/Beutl/Pages/SettingsPages/AccountSettingsScreen.axaml
+++ b/src/Beutl/Pages/SettingsPages/AccountSettingsScreen.axaml
@@ -22,12 +22,12 @@
                     Orientation="Vertical"
                     Spacing="4">
             <Grid Margin="0,32,0,0" ColumnDefinitions="Auto,16,Auto,*">
-                <!--  プロフィール画像  -->
+                <!-- Profile image -->
                 <Border Width="64"
                         Height="64"
                         Background="{DynamicResource ControlSolidFillColorDefaultBrush}"
                         CornerRadius="32"
-                        IsVisible="{Binding ProfileImage.Value, Converter={x:Static StringConverters.IsNullOrEmpty}}">
+                        IsVisible="{CompiledBinding ProfileImage.Value, Converter={x:Static StringConverters.IsNullOrEmpty}}">
 
                     <icons:FluentIcon VerticalAlignment="Center"
                                       FontSize="30"
@@ -35,8 +35,8 @@
                 </Border>
                 <asyncImage:AdvancedImage Width="64"
                                           Height="64"
-                                          IsVisible="{Binding ProfileImage.Value, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
-                                          Source="{Binding ProfileImage.Value}">
+                                          IsVisible="{CompiledBinding ProfileImage.Value, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                                          Source="{CompiledBinding ProfileImage.Value}">
                     <asyncImage:AdvancedImage.Clip>
                         <EllipseGeometry Center="32,32"
                                          RadiusX="32"
@@ -46,20 +46,20 @@
                 </asyncImage:AdvancedImage>
 
                 <StackPanel Grid.Column="2" VerticalAlignment="Center">
-                    <!--  名前表示  -->
-                    <TextBlock Classes="SubtitleTextBlockStyle" Text="{Binding DisplayName.Value}" />
+                    <!-- Display name -->
+                    <TextBlock Classes="SubtitleTextBlockStyle" Text="{CompiledBinding DisplayName.Value}" />
 
-                    <!--  識別可能な名前  -->
+                    <!-- Account name -->
                     <TextBlock Classes="CaptionTextBlockStyle"
                                Opacity="0.8"
-                               Text="{Binding Name.Value}" />
+                               Text="{CompiledBinding Name.Value}" />
                 </StackPanel>
 
                 <Button Grid.Column="3"
                         Padding="8"
                         HorizontalAlignment="Right"
                         VerticalAlignment="Center"
-                        Command="{Binding SignOut}"
+                        Command="{CompiledBinding SignOut}"
                         Theme="{StaticResource TransparentButton}">
                     <Grid ColumnDefinitions="Auto,8,Auto">
                         <icons:FluentIcon FontSize="20" Icon="SignOut" />
@@ -74,12 +74,75 @@
             <ctrls:OptionsDisplayItem Margin="0,24,0,0"
                                       Header="{x:Static lang:SettingsStrings.ChangeAccountSettings}"
                                       Navigates="True"
-                                      NavigationCommand="{Binding OpenAccountSettings}">
+                                      NavigationCommand="{CompiledBinding OpenAccountSettings}">
 
                 <ctrls:OptionsDisplayItem.Icon>
                     <icons:FluentIcon Icon="Open" />
                 </ctrls:OptionsDisplayItem.Icon>
             </ctrls:OptionsDisplayItem>
+
+            <ctrls:OptionsDisplayItem Margin="0,24,0,0"
+                                      Clickable="False"
+                                      Description="{x:Static lang:SettingsStrings.AiPlan_Manage_Description}"
+                                      Header="{x:Static lang:SettingsStrings.AiPlan}">
+
+                <ctrls:OptionsDisplayItem.Icon>
+                    <icons:FluentIcon Icon="SparkleCircle" />
+                </ctrls:OptionsDisplayItem.Icon>
+                <ctrls:OptionsDisplayItem.ActionButton>
+                    <Button Command="{CompiledBinding OpenAiPlan}"
+                            Content="{CompiledBinding AiPlanActionText.Value}" />
+                </ctrls:OptionsDisplayItem.ActionButton>
+            </ctrls:OptionsDisplayItem>
+
+            <TextBlock Margin="32,8,0,0"
+                       AutomationProperties.LiveSetting="Polite"
+                       AutomationProperties.Name="{x:Static lang:SettingsStrings.AiPlan_Loading}"
+                       IsVisible="{CompiledBinding IsAiPlanLoading.Value}"
+                       Text="{x:Static lang:SettingsStrings.AiPlan_Loading}" />
+            <TextBlock Margin="32,8,0,0"
+                       AutomationProperties.LiveSetting="Assertive"
+                       AutomationProperties.Name="{CompiledBinding AiPlanError.Value}"
+                       Foreground="{DynamicResource SystemFillColorCautionBrush}"
+                       IsVisible="{CompiledBinding AiPlanError.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
+                       Text="{CompiledBinding AiPlanError.Value}"
+                       TextWrapping="Wrap" />
+
+            <StackPanel Margin="32,8,0,0"
+                        IsVisible="{CompiledBinding Usage.HasSnapshot.Value}"
+                        Spacing="8">
+                <Grid ColumnDefinitions="Auto,16,*">
+                    <TextBlock Text="{x:Static lang:SettingsStrings.AiPlan_Plan}" />
+                    <TextBlock Grid.Column="2" Text="{CompiledBinding PlanName.Value}" />
+                </Grid>
+                <Grid ColumnDefinitions="Auto,16,*"
+                      IsVisible="{CompiledBinding SubscriptionStatus.Value, Converter={x:Static ObjectConverters.IsNotNull}}">
+                    <TextBlock Text="{x:Static lang:SettingsStrings.AiPlan_SubscriptionStatus}" />
+                    <TextBlock Grid.Column="2" Text="{CompiledBinding SubscriptionStatus.Value}" />
+                </Grid>
+                <TextBlock Foreground="{DynamicResource SystemFillColorCautionBrush}"
+                           IsVisible="{CompiledBinding HasCancelScheduledNotice.Value}"
+                           Text="{CompiledBinding CancelScheduledNotice.Value}"
+                           TextWrapping="Wrap" />
+                <StackPanel Spacing="4">
+                    <TextBlock Text="{CompiledBinding Usage.MonthlyUsageText.Value}" />
+                    <ProgressBar Maximum="100"
+                                 Minimum="0"
+                                 AutomationProperties.Name="{CompiledBinding Usage.MonthlyUsageText.Value}"
+                                 Value="{CompiledBinding Usage.UsagePercent.Value}" />
+                    <TextBlock Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                               Text="{CompiledBinding Usage.MonthlyRemainingText.Value}"
+                               TextWrapping="Wrap" />
+                    <TextBlock Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                               IsVisible="{CompiledBinding Usage.HasAdditionalCredits.Value}"
+                               Text="{CompiledBinding Usage.AdditionalCreditsText.Value}"
+                               TextWrapping="Wrap" />
+                    <TextBlock Foreground="{DynamicResource SystemFillColorCautionBrush}"
+                               IsVisible="{CompiledBinding Usage.HasAdditionalCreditDebt.Value}"
+                               Text="{CompiledBinding Usage.AdditionalCreditDebtText.Value}"
+                               TextWrapping="Wrap" />
+                </StackPanel>
+            </StackPanel>
         </StackPanel>
 
 

--- a/src/Beutl/Services/AI/AiCaptionHistoryResult.cs
+++ b/src/Beutl/Services/AI/AiCaptionHistoryResult.cs
@@ -1,0 +1,350 @@
+﻿using System.Text.Json;
+using Beutl.Api.Services;
+
+namespace Beutl.Services.AI;
+
+internal sealed record AiCaptionHistoryResult(
+    AiJobId JobId,
+    AiTranscriptionSegment[] Segments,
+    string? Language);
+
+internal static class AiCaptionHistoryResultParser
+{
+    public const int MaximumResultBytes = 8 * 1024 * 1024;
+    private const int MaximumSegmentCount = 10_000;
+    private const int MaximumTextLength = 100_000;
+
+    public static bool TryParse(
+        ReadOnlySpan<byte> bytes,
+        string expectedKind,
+        AiJobId jobId,
+        out AiCaptionHistoryResult? result)
+    {
+        result = null;
+        if (bytes.IsEmpty || bytes.Length > MaximumResultBytes)
+            return false;
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(bytes.ToArray(), new JsonDocumentOptions
+            {
+                MaxDepth = 16,
+                AllowTrailingCommas = false,
+                CommentHandling = JsonCommentHandling.Disallow,
+            });
+            JsonElement root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object
+                || !TryGetInt32(root, "version", out int version)
+                || version != 1
+                || !TryGetString(root, "kind", out string? kind)
+                || !string.Equals(kind, expectedKind, StringComparison.Ordinal)
+                || !root.TryGetProperty("segments", out JsonElement segments)
+                || segments.ValueKind != JsonValueKind.Array
+                || segments.GetArrayLength() is <= 0 or > MaximumSegmentCount)
+            {
+                return false;
+            }
+
+            return kind switch
+            {
+                "stt" => TryParseTranscription(root, segments, jobId, out result),
+                "translation" => TryParseTranslation(root, segments, jobId, out result),
+                _ => false,
+            };
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryParseTranscription(
+        JsonElement root,
+        JsonElement segments,
+        AiJobId jobId,
+        out AiCaptionHistoryResult? result)
+    {
+        result = null;
+        string? language = TryGetOptionalString(root, "language");
+        var parsed = new List<AiTranscriptionSegment>(segments.GetArrayLength());
+        foreach (JsonElement segment in segments.EnumerateArray())
+        {
+            if (!TryGetTimeRange(segment, out double start, out double end)
+                || !TryGetString(segment, "text", out string? text)
+                || string.IsNullOrWhiteSpace(text)
+                || text.Length > MaximumTextLength)
+            {
+                return false;
+            }
+            parsed.Add(new AiTranscriptionSegment
+            {
+                Start = start,
+                End = end,
+                Text = text,
+            });
+        }
+
+        result = new AiCaptionHistoryResult(
+            jobId,
+            parsed.ToArray(),
+            language);
+        return true;
+    }
+
+    private static bool TryParseTranslation(
+        JsonElement root,
+        JsonElement segments,
+        AiJobId jobId,
+        out AiCaptionHistoryResult? result)
+    {
+        result = null;
+        string? targetLanguage = TryGetOptionalString(root, "targetLanguage");
+        if (targetLanguage is null)
+        {
+            return false;
+        }
+        var groups = new Dictionary<string, TranslationGroup>(StringComparer.Ordinal);
+        var untimed = new List<(int Sequence, string Text)>();
+        int sequence = 0;
+        foreach (JsonElement segment in segments.EnumerateArray())
+        {
+            if (segment.ValueKind != JsonValueKind.Object
+                || !TryGetString(segment, "text", out string? text)
+                || string.IsNullOrWhiteSpace(text)
+                || text.Length > MaximumTextLength)
+            {
+                return false;
+            }
+
+            int segmentSequence = sequence++;
+            if (!segment.TryGetProperty("context", out JsonElement context)
+                || context.ValueKind == JsonValueKind.Null)
+            {
+                untimed.Add((segmentSequence, text));
+                continue;
+            }
+
+            if (context.ValueKind != JsonValueKind.Object
+                || !TryGetString(context, "groupId", out string? groupId)
+                || string.IsNullOrWhiteSpace(groupId)
+                || groupId.Length > 64
+                || !TryGetInt32(context, "partIndex", out int partIndex)
+                || partIndex is < 0 or >= MaximumSegmentCount
+                || !TryGetTimeRange(context, out double start, out double end))
+            {
+                return false;
+            }
+
+            if (!groups.TryGetValue(groupId, out TranslationGroup? group))
+            {
+                group = new TranslationGroup(segmentSequence, start, end);
+                groups.Add(groupId, group);
+            }
+            else if (group.Start != start || group.End != end)
+            {
+                return false;
+            }
+            if (!group.Parts.TryAdd(partIndex, text))
+                return false;
+        }
+
+        if (groups.Count == 0)
+            return TryParseUntimedTranslation(segments, jobId, targetLanguage, out result);
+
+        var parsed = new List<AiTranscriptionSegment>(groups.Count + untimed.Count);
+        foreach (TranslationGroup group in groups.Values
+                     .OrderBy(group => group.Start)
+                     .ThenBy(group => group.Sequence))
+        {
+            int expectedPart = group.Parts.Keys.First();
+            var text = new System.Text.StringBuilder();
+            foreach ((int partIndex, string part) in group.Parts)
+            {
+                if (partIndex != expectedPart++)
+                    return false;
+                text.Append(part);
+            }
+            parsed.Add(new AiTranscriptionSegment
+            {
+                Start = group.Start,
+                End = group.End,
+                Text = text.ToString(),
+            });
+        }
+
+        // Optional context is a per-segment contract. Keep every exact timed range,
+        // then place context-free results after the last known cue so synthesized
+        // ranges can neither overlap nor reorder the timed material.
+        double nextUntimedStart = parsed.Max(segment => segment.End);
+        foreach ((_, string text) in untimed.OrderBy(item => item.Sequence))
+        {
+            parsed.Add(new AiTranscriptionSegment
+            {
+                Start = nextUntimedStart,
+                End = nextUntimedStart + s_untimedSegmentDuration.TotalSeconds,
+                Text = text,
+            });
+            nextUntimedStart += s_untimedSegmentDuration.TotalSeconds;
+        }
+
+        result = new AiCaptionHistoryResult(
+            jobId,
+            parsed.ToArray(),
+            targetLanguage);
+        return true;
+    }
+
+    // Positive, non-overlapping ranges keep every placeholder cue editable in the UI.
+    private static readonly TimeSpan s_untimedSegmentDuration = TimeSpan.FromSeconds(1);
+
+    private static bool TryParseUntimedTranslation(
+        JsonElement segments,
+        AiJobId jobId,
+        string targetLanguage,
+        out AiCaptionHistoryResult? result)
+    {
+        result = null;
+        var parsed = new List<AiTranscriptionSegment>(segments.GetArrayLength());
+        int index = 0;
+        foreach (JsonElement segment in segments.EnumerateArray())
+        {
+            if (segment.ValueKind != JsonValueKind.Object
+                || !TryGetString(segment, "text", out string? text)
+                || string.IsNullOrWhiteSpace(text)
+                || text.Length > MaximumTextLength)
+            {
+                return false;
+            }
+
+            double start = index * s_untimedSegmentDuration.TotalSeconds;
+            parsed.Add(new AiTranscriptionSegment
+            {
+                Start = start,
+                End = start + s_untimedSegmentDuration.TotalSeconds,
+                Text = text,
+            });
+            index++;
+        }
+
+        result = new AiCaptionHistoryResult(jobId, parsed.ToArray(), targetLanguage);
+        return true;
+    }
+
+    private static bool TryGetTimeRange(
+        JsonElement element,
+        out double start,
+        out double end)
+    {
+        start = default;
+        end = default;
+        return element.ValueKind == JsonValueKind.Object
+            && element.TryGetProperty("start", out JsonElement startElement)
+            && startElement.TryGetDouble(out start)
+            && double.IsFinite(start)
+            && start >= 0
+            && IsTimeSpanRepresentable(start)
+            && element.TryGetProperty("end", out JsonElement endElement)
+            && endElement.TryGetDouble(out end)
+            && double.IsFinite(end)
+            && IsTimeSpanRepresentable(end)
+            && end > start;
+    }
+
+    private static bool IsTimeSpanRepresentable(double seconds)
+    {
+        try
+        {
+            _ = TimeSpan.FromSeconds(seconds);
+            return true;
+        }
+        catch (OverflowException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryGetInt32(JsonElement element, string name, out int value)
+    {
+        value = default;
+        return element.TryGetProperty(name, out JsonElement property)
+            && property.ValueKind == JsonValueKind.Number
+            && property.TryGetInt32(out value);
+    }
+
+    private static bool TryGetString(JsonElement element, string name, out string? value)
+    {
+        value = null;
+        return element.TryGetProperty(name, out JsonElement property)
+            && property.ValueKind == JsonValueKind.String
+            && (value = property.GetString()) is not null;
+    }
+
+    private static string? TryGetOptionalString(JsonElement element, string name)
+        => TryGetString(element, name, out string? value)
+            && !string.IsNullOrWhiteSpace(value)
+            && value.Length <= 32
+                ? value.Trim().ToLowerInvariant()
+                : null;
+
+    private sealed class TranslationGroup(int sequence, double start, double end)
+    {
+        public int Sequence { get; } = sequence;
+
+        public double Start { get; } = start;
+
+        public double End { get; } = end;
+
+        public SortedDictionary<int, string> Parts { get; } = [];
+    }
+}
+
+internal sealed class SizeLimitedMemoryStream(int maximumBytes) : MemoryStream
+{
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        EnsureWithinLimit(count);
+        base.Write(buffer, offset, count);
+    }
+
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        EnsureWithinLimit(buffer.Length);
+        base.Write(buffer);
+    }
+
+    public override Task WriteAsync(
+        byte[] buffer,
+        int offset,
+        int count,
+        CancellationToken cancellationToken)
+    {
+        EnsureWithinLimit(count);
+        return base.WriteAsync(buffer, offset, count, cancellationToken);
+    }
+
+    public override ValueTask WriteAsync(
+        ReadOnlyMemory<byte> buffer,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureWithinLimit(buffer.Length);
+        return base.WriteAsync(buffer, cancellationToken);
+    }
+
+    public override void WriteByte(byte value)
+    {
+        EnsureWithinLimit(1);
+        base.WriteByte(value);
+    }
+
+    private void EnsureWithinLimit(int additionalBytes)
+    {
+        if (maximumBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maximumBytes));
+        if (additionalBytes < 0 || Position > maximumBytes - additionalBytes)
+            throw new InvalidDataException("The AI result exceeds the supported size.");
+    }
+}

--- a/src/Beutl/Services/AI/AiCaptionSceneImporter.cs
+++ b/src/Beutl/Services/AI/AiCaptionSceneImporter.cs
@@ -1,0 +1,58 @@
+﻿using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Editor.Services.Captions;
+using Beutl.Graphics;
+using Beutl.ProjectSystem;
+
+namespace Beutl.Services.AI;
+
+internal readonly record struct CaptionSceneImportResult(
+    bool IsSuccess,
+    ElementAddFailureId? FailureId);
+
+internal static class AiCaptionSceneImporter
+{
+    public static async Task<CaptionSceneImportResult> AddAsync(
+        Scene scene,
+        IElementAdder adder,
+        CaptionDocument document,
+        ICaptionTemplateProvider templates,
+        CaptionTemplateId templateId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+        ArgumentNullException.ThrowIfNull(adder);
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(templates);
+
+        using ICaptionTemplateLease template = templates.Acquire(templateId);
+        int layer = scene.Children
+            .Select(item => item.ZIndex)
+            .DefaultIfEmpty(-1)
+            .Max() + 1;
+        Point defaultPosition = new(0, scene.FrameSize.Height * 0.35f);
+        var context = new CaptionElementContext(
+            layer,
+            Beutl.Language.Strings.AiSubtitle,
+            defaultPosition);
+        var descriptions = new List<ElementDescription>(document.Count);
+        foreach (CaptionCue cue in document.Cues)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            descriptions.AddRange(template.CreateElements(cue, context));
+        }
+        ElementAddResult? result = null;
+        try
+        {
+            result = await adder.AddAsync(descriptions, cancellationToken);
+            return new CaptionSceneImportResult(result.IsSuccess, result.Failure?.Id);
+        }
+        finally
+        {
+            // ElementAddResult retains its input descriptions, whose source factories may belong
+            // to a collectible package. Clear both references before releasing the template lease.
+            result = null;
+            descriptions.Clear();
+        }
+    }
+}

--- a/src/Beutl/Services/AI/AiErrorMessage.cs
+++ b/src/Beutl/Services/AI/AiErrorMessage.cs
@@ -1,0 +1,15 @@
+﻿using Beutl.Language;
+
+namespace Beutl.Services.AI;
+
+internal static class AiErrorMessage
+{
+    public static string? Localize(string? value)
+        => string.IsNullOrWhiteSpace(value)
+            ? null
+            : value.Trim() switch
+            {
+                "aiProviderError" => Strings.AiProviderError,
+                { } error => error,
+            };
+}

--- a/src/Beutl/Services/AI/AiImageDecodeValidator.cs
+++ b/src/Beutl/Services/AI/AiImageDecodeValidator.cs
@@ -1,0 +1,73 @@
+﻿using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.Services.AI;
+
+internal static class AiImageDecodeValidator
+{
+    internal const int MaxDimension = 8_192;
+    internal const long MaxPixels = 16_777_216;
+    internal const long MaxDecodedBytes = 64L * 1024 * 1024;
+
+    public static void ValidateEncoded(Stream encoded, long maxEncodedBytes)
+    {
+        ArgumentNullException.ThrowIfNull(encoded);
+        if (maxEncodedBytes < 0)
+            throw new ArgumentOutOfRangeException(nameof(maxEncodedBytes));
+        if (!encoded.CanSeek)
+            throw new InvalidDataException("AI image data must be seekable before decoding.");
+
+        long origin = encoded.Position;
+        try
+        {
+            if (encoded.Length - origin > maxEncodedBytes)
+                throw new InvalidDataException("The AI image is too large.");
+            using SKData data = SKData.Create(encoded)
+                ?? throw new InvalidDataException("Failed to inspect the AI image.");
+            using SKCodec codec = SKCodec.Create(data)
+                ?? throw new InvalidDataException("Failed to inspect the AI image.");
+            Validate(codec.Info);
+        }
+        finally
+        {
+            encoded.Position = origin;
+        }
+    }
+
+    private static FileStream OpenValidatedFile(string path, long maxEncodedBytes)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        FileStream stream = File.OpenRead(path);
+        try
+        {
+            ValidateEncoded(stream, maxEncodedBytes);
+            stream.Position = 0;
+            return stream;
+        }
+        catch
+        {
+            stream.Dispose();
+            throw;
+        }
+    }
+
+    public static void Validate(SKImageInfo info)
+        => ValidateDimensions(info.Width, info.Height);
+
+    public static void ValidateDimensions(int width, int height)
+    {
+        if (width <= 0 || height <= 0
+            || width > MaxDimension || height > MaxDimension
+            || (long)width * height > MaxPixels
+            || (long)width * height * 4 > MaxDecodedBytes)
+        {
+            throw new InvalidDataException("The AI image dimensions are unsupported.");
+        }
+    }
+
+    public static Bitmap LoadValidatedBitmap(string path, long maxEncodedBytes)
+    {
+        using FileStream stream = OpenValidatedFile(path, maxEncodedBytes);
+        return Bitmap.FromStream(stream);
+    }
+}

--- a/src/Beutl/Services/AI/AiJobCompletionNotifier.cs
+++ b/src/Beutl/Services/AI/AiJobCompletionNotifier.cs
@@ -1,0 +1,124 @@
+﻿using Beutl.Api.Services;
+using Beutl.Editor.Services.AI;
+using Beutl.Language;
+using Beutl.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace Beutl.Services.AI;
+
+internal sealed class AiJobCompletionNotifier : IDisposable
+{
+    private readonly Action _openJobCenter;
+    private readonly IAiJobKindRegistry _jobKinds;
+    private readonly AiJobResultRegistry _resultHandlers;
+    private readonly IDisposable _subscription;
+    private readonly ILogger _logger = Log.CreateLogger<AiJobCompletionNotifier>();
+    private Dictionary<AiJobId, AiJobStatusSemantics> _knownStatuses = [];
+    private bool _hasBaseline;
+
+    public AiJobCompletionNotifier(
+        IObservable<AiJobMonitorSnapshot> snapshots,
+        IAiJobKindRegistry jobKinds,
+        AiJobResultRegistry resultHandlers,
+        Action openJobCenter)
+    {
+        ArgumentNullException.ThrowIfNull(snapshots);
+        ArgumentNullException.ThrowIfNull(openJobCenter);
+
+        _jobKinds = jobKinds ?? throw new ArgumentNullException(nameof(jobKinds));
+        _resultHandlers = resultHandlers ?? throw new ArgumentNullException(nameof(resultHandlers));
+        _openJobCenter = openJobCenter;
+        _subscription = snapshots.Subscribe(ProcessSnapshot);
+    }
+
+    public void Dispose() => _subscription.Dispose();
+
+    internal void ProcessSnapshot(AiJobMonitorSnapshot snapshot)
+    {
+        if (snapshot.Error is AuthenticationRequiredException
+            || snapshot.IsLoading && snapshot.Jobs.IsEmpty)
+        {
+            _knownStatuses.Clear();
+            _hasBaseline = false;
+            return;
+        }
+
+        if (snapshot.IsLoading || snapshot.Error is not null)
+            return;
+
+        var currentStatuses = new Dictionary<AiJobId, AiJobStatusSemantics>();
+        foreach (AiJob job in snapshot.Jobs)
+        {
+            try
+            {
+                currentStatuses[job.Id] = _jobKinds.GetStatus(job);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to resolve AI job status for {JobId}.", job.Id);
+                currentStatuses[job.Id] = AiJobStatusSemantics.Unknown;
+            }
+        }
+
+        if (!_hasBaseline)
+        {
+            _knownStatuses = currentStatuses;
+            _hasBaseline = true;
+            return;
+        }
+
+        foreach (AiJob job in snapshot.Jobs)
+        {
+            if (!_knownStatuses.TryGetValue(job.Id, out AiJobStatusSemantics oldStatus)
+                || oldStatus.IsTerminal
+                || !currentStatuses[job.Id].IsTerminal)
+            {
+                continue;
+            }
+
+            ShowCompletion(job, currentStatuses[job.Id]);
+        }
+
+        _knownStatuses = currentStatuses;
+    }
+
+    private void ShowCompletion(AiJob job, AiJobStatusSemantics status)
+    {
+        if (!_resultHandlers.TryAcquireCompletionPresenter(
+                job.Kind,
+                out IAiJobCompletionPresenterLease? lease))
+            return;
+
+        using (lease)
+        {
+            try
+            {
+                AiJobCompletionPresentation? completion = lease.Presenter.CreateCompletion(
+                    job,
+                    status);
+                if (completion is null)
+                    return;
+
+                NotificationService.Show(
+                    completion.Title,
+                    completion.Message,
+                    ToNotificationType(completion.Notification),
+                    completion.Expiration,
+                    actions: [new NotificationAction(Strings.AiJobCenter, _openJobCenter)]);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "AI job completion handler failed for {JobId}.", job.Id);
+            }
+        }
+    }
+
+    private static NotificationType ToNotificationType(AiJobNotificationKind notification)
+        => notification switch
+        {
+            AiJobNotificationKind.Information => NotificationType.Information,
+            AiJobNotificationKind.Success => NotificationType.Success,
+            AiJobNotificationKind.Warning => NotificationType.Warning,
+            _ => throw new ArgumentOutOfRangeException(nameof(notification)),
+        };
+}

--- a/src/Beutl/Services/AI/AiJobResultHandlers.cs
+++ b/src/Beutl/Services/AI/AiJobResultHandlers.cs
@@ -1,0 +1,436 @@
+﻿using System.Text.Json;
+using Beutl.Api.Services;
+using Beutl.Editor.Services;
+using Beutl.Editor.Services.AI;
+using Beutl.Editor.Services.Captions;
+using Beutl.Extensibility;
+using Beutl.Graphics;
+using Beutl.Language;
+using Beutl.Media;
+using Beutl.ProjectSystem;
+
+namespace Beutl.Services.AI;
+
+internal interface IAiCaptionResultPresenter
+{
+    bool TryPresentCaptionResult(AiCaptionHistoryResult result);
+}
+
+internal sealed class AiJobResultContext(
+    IAiJobResultEditorContext editor,
+    IAuthenticatedContentService content,
+    Action<AiCaptionHistoryResult>? openCaptionResult) : IAiJobResultContext, IAiCaptionResultPresenter
+{
+    private readonly IAiJobResultEditorContext _editor = editor ?? throw new ArgumentNullException(nameof(editor));
+    private readonly IAuthenticatedContentService _content = content ?? throw new ArgumentNullException(nameof(content));
+
+    public IAiJobResultEditorContext Editor => _editor;
+
+    public Task<AiContentDownload> CopyContentToAsync(
+        Uri contentUri,
+        Stream destination,
+        CancellationToken cancellationToken)
+        => _content.CopyToAsync(contentUri, destination, cancellationToken);
+
+    public bool TryPresentCaptionResult(AiCaptionHistoryResult result)
+    {
+        if (openCaptionResult is null)
+            return false;
+
+        openCaptionResult(result);
+        return true;
+    }
+}
+
+internal static class BuiltInAiJobResultCapabilities
+{
+    public static AiJobResultRegistry CreateRegistry(
+        IExtensionRegistry? extensionProvider = null,
+        Action<AiJobResultExtensionFailure>? reportFailure = null)
+    {
+        (AiJobKindId Kind, BuiltInAiJobResultCapability Capability)[] capabilities =
+        [
+            (
+                AiJobKinds.Image,
+                new ImageAiJobResultCapabilities(
+                    () => Strings.AiImageGeneration,
+                    _ => AiOperations.ImageGeneration.Value)),
+            (
+                AiJobKinds.ImageEdit,
+                new ImageAiJobResultCapabilities(
+                    () => Strings.AiImageEdit,
+                    GetImageEditOperation)),
+            (
+                AiJobKinds.Transcription,
+                new CaptionAiJobResultCapabilities(() => Strings.AiSubtitle)),
+            (
+                AiJobKinds.CaptionTranslation,
+                new CaptionAiJobResultCapabilities(
+                    () => Strings.AiSubtitle,
+                    useTargetLanguageAsFallback: true)),
+            (
+                AiJobKinds.Video,
+                new VideoAiJobResultCapabilities()),
+        ];
+
+        return new AiJobResultRegistry(
+            capabilities.Select(item => new AiJobPresentationRegistration(
+                item.Kind,
+                item.Capability)),
+            capabilities.Select(item => new AiJobCompletionRegistration(
+                item.Kind,
+                item.Capability)),
+            capabilities.Select(item => new AiJobResultApplicatorRegistration(
+                item.Kind,
+                item.Capability)),
+            extensionProvider,
+            reportFailure);
+    }
+
+    private static string GetImageEditOperation(AiJob job)
+    {
+        string? task = AiJobResultInput.GetString(job, "task");
+        return task is null
+            ? "image.edit"
+            : $"image.edit.{task.Replace('_', '.')}";
+    }
+}
+
+internal abstract class BuiltInAiJobResultCapability(
+    Func<string> getKindDisplayName,
+    bool useTargetLanguageAsFallback = false) :
+    IAiJobPresenter,
+    IAiJobCompletionPresenter,
+    IAiJobResultApplicator
+{
+    protected virtual bool HasImagePreview => false;
+
+    private static readonly IReadOnlyDictionary<string, Func<string>> s_statusDisplayNames =
+        new Dictionary<string, Func<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            [AiJobStatuses.Queued.Value] = () => Strings.AiJobCenter_StatusQueued,
+            [AiJobStatuses.Running.Value] = () => Strings.AiJobCenter_StatusRunning,
+            [AiJobStatuses.Finalizing.Value] = () => Strings.AiJobCenter_StatusRunning,
+            [AiJobStatuses.Succeeded.Value] = () => Strings.AiJobCenter_StatusSucceeded,
+            [AiJobStatuses.Failed.Value] = () => Strings.AiJobCenter_StatusFailed,
+            [AiJobStatuses.Canceled.Value] = () => Strings.AiJobCenter_StatusCanceled,
+        };
+
+    public AiJobPresentation Present(AiJob job, AiJobStatusSemantics status)
+    {
+        string? prompt = AiJobResultInput.GetString(job, "prompt");
+        string? language = AiJobResultInput.GetString(job, "targetLanguage")
+            ?? AiJobResultInput.GetString(job, "language");
+        string summary = prompt
+            ?? AiJobResultInput.GetString(job, "filename")
+            ?? (useTargetLanguageAsFallback && language is not null
+                ? string.Format(Strings.AiJobCenter_TranslationSummary, language)
+                : Strings.AiJobCenter_NoDescription);
+        string normalizedStatus = job.Status.Value.Trim();
+        string statusDisplayName = s_statusDisplayNames.TryGetValue(
+            normalizedStatus,
+            out Func<string>? getStatusDisplayName)
+            ? getStatusDisplayName()
+            : normalizedStatus;
+
+        var details = new List<string>();
+        AddIfPresent(details, AiJobResultInput.GetString(job, "size"));
+        if (AiJobResultInput.GetInt32(job, "durationSeconds") is { } durationSeconds)
+        {
+            details.Add($"{durationSeconds} {Strings.AiVideoSeconds}");
+        }
+        AddIfPresent(details, AiJobResultInput.GetString(job, "resolution"));
+        AddIfPresent(details, language);
+
+        return new AiJobPresentation(
+            getKindDisplayName(),
+            statusDisplayName,
+            summary,
+            string.Join(" · ", details),
+            status.Outcome == AiJobOutcomes.Failed,
+            HasImagePreview);
+    }
+
+    public AiJobCompletionPresentation? CreateCompletion(
+        AiJob job,
+        AiJobStatusSemantics status)
+    {
+        if (!status.IsTerminal)
+            return null;
+
+        if (status.Outcome == AiJobOutcomes.Succeeded)
+        {
+            return new AiJobCompletionPresentation(
+                Strings.AiJobCenter,
+                string.Format(
+                    Strings.AiJobCenter_CompletedNotification,
+                    getKindDisplayName()),
+                AiJobNotificationKind.Success,
+                TimeSpan.FromSeconds(15));
+        }
+
+        if (status.Outcome == AiJobOutcomes.Failed)
+        {
+            return new AiJobCompletionPresentation(
+                Strings.AiJobCenter,
+                string.Format(
+                    Strings.AiJobCenter_FailedNotification,
+                    getKindDisplayName()),
+                AiJobNotificationKind.Warning,
+                TimeSpan.FromSeconds(20));
+        }
+
+        if (status.Outcome == AiJobOutcomes.Canceled)
+        {
+            return new AiJobCompletionPresentation(
+                Strings.AiJobCenter,
+                string.Format(
+                    Strings.AiJobCenter_CanceledNotification,
+                    getKindDisplayName()),
+                AiJobNotificationKind.Information,
+                TimeSpan.FromSeconds(15));
+        }
+
+        return null;
+    }
+
+    public virtual bool CanApply(AiJob job, AiJobStatusSemantics status)
+        => status.Outcome == AiJobOutcomes.Succeeded && job.ContentUri is not null;
+
+    public abstract Task ApplyAsync(
+        AiJob job,
+        IAiJobResultContext context,
+        CancellationToken cancellationToken);
+
+    protected static void ShowImportResult(ElementAddResult result)
+    {
+        if (result.Failure is LockedElementLayerFailure)
+        {
+            NotificationService.ShowWarning(Strings.Lock, Strings.LayerIsLocked);
+        }
+        else if (!result.IsSuccess)
+        {
+            throw new InvalidOperationException(
+                $"Failed to add the AI job result: {result.Failure?.Id}.",
+                result.Failure?.Exception);
+        }
+        else
+        {
+            NotificationService.ShowSuccess(Strings.AiJobCenter, Strings.AiJobCenter_AddedToScene);
+        }
+    }
+
+    private static void AddIfPresent(List<string> values, string? value)
+    {
+        if (value is not null)
+        {
+            values.Add(value);
+        }
+    }
+}
+
+internal sealed class ImageAiJobResultCapabilities : BuiltInAiJobResultCapability
+{
+    private readonly Func<string> _getDisplayName;
+    private readonly Func<AiJob, string> _getOperation;
+
+    protected override bool HasImagePreview => true;
+
+    public ImageAiJobResultCapabilities(
+        Func<string> getDisplayName,
+        Func<AiJob, string> getOperation)
+        : base(getDisplayName)
+    {
+        _getDisplayName = getDisplayName ?? throw new ArgumentNullException(nameof(getDisplayName));
+        _getOperation = getOperation ?? throw new ArgumentNullException(nameof(getOperation));
+    }
+
+    public override async Task ApplyAsync(
+        AiJob job,
+        IAiJobResultContext context,
+        CancellationToken cancellationToken)
+    {
+        using var content = new SizeLimitedMemoryStream(
+            checked((int)AiRequestLimits.MaxImageUploadBytes));
+        await context.CopyContentToAsync(job.ContentUri!, content, cancellationToken);
+        content.Position = 0;
+        AiImageDecodeValidator.ValidateEncoded(content, AiRequestLimits.MaxImageUploadBytes);
+        using Bitmap bitmap = Bitmap.FromStream(content);
+
+        IAiJobResultEditorContext editor = context.Editor;
+        TimeSpan start = editor.CurrentTime;
+        var importer = new AiResultImporter(editor.Scene, editor.ElementAdder);
+        ElementAddResult result = await importer.ImportImageAsync(
+            bitmap,
+            new AiResultImportOptions(
+                start,
+                TimeSpan.FromSeconds(5),
+                editor.GetNextLayer(start),
+                _getDisplayName()),
+            cancellationToken);
+        ShowImportResult(result);
+    }
+}
+
+internal sealed class VideoAiJobResultCapabilities()
+    : BuiltInAiJobResultCapability(() => Strings.AiVideoGeneration)
+{
+    public override async Task ApplyAsync(
+        AiJob job,
+        IAiJobResultContext context,
+        CancellationToken cancellationToken)
+    {
+        (string temporaryContentPath, FileStream destination) = AiTemporaryFileStore.Create(
+            "downloads",
+            "job-video",
+            ".download");
+        try
+        {
+            AiContentDownload download;
+            await using (destination)
+            {
+                using Stream boundedDestination =
+                    AiVideoResultDownload.CreateBoundedStream(destination);
+                download = await context.CopyContentToAsync(
+                    job.ContentUri!,
+                    boundedDestination,
+                    cancellationToken);
+            }
+            AiContentMetadata? metadata = AiContentMetadata.Combine(
+                job.ContentMetadata,
+                download.Metadata);
+            string extension = metadata?.GetFileExtension(".mp4", "video") ?? ".mp4";
+
+            int? durationSeconds = AiJobResultInput.GetInt32(job, "durationSeconds");
+            IAiJobResultEditorContext editor = context.Editor;
+            TimeSpan start = editor.CurrentTime;
+            var importer = new AiResultImporter(editor.Scene, editor.ElementAdder);
+            ElementAddResult result = await importer.ImportVideoAsync(
+                temporaryContentPath,
+                extension,
+                new AiResultImportOptions(
+                    start,
+                    TimeSpan.FromSeconds(durationSeconds ?? 6),
+                    editor.GetNextLayer(start),
+                    Strings.AiVideoGeneration),
+                cancellationToken);
+            ShowImportResult(result);
+        }
+        finally
+        {
+            TryDelete(temporaryContentPath);
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch
+        {
+        }
+    }
+}
+
+internal sealed class CaptionAiJobResultCapabilities(
+    Func<string> getKindDisplayName,
+    bool useTargetLanguageAsFallback = false)
+    : BuiltInAiJobResultCapability(getKindDisplayName, useTargetLanguageAsFallback)
+{
+    public override async Task ApplyAsync(
+        AiJob job,
+        IAiJobResultContext context,
+        CancellationToken cancellationToken)
+    {
+        AiCaptionHistoryResult recovered = await DownloadAsync(job, context, cancellationToken);
+        if (context is IAiCaptionResultPresenter presenter
+            && presenter.TryPresentCaptionResult(recovered))
+        {
+            return;
+        }
+
+        var document = new CaptionDocument(recovered.Segments.Select(segment => new CaptionCue(
+            TimeSpan.FromSeconds(segment.Start),
+            TimeSpan.FromSeconds(segment.End),
+            segment.Text,
+            language: recovered.Language)));
+        CaptionTemplateRegistrationSet template =
+            CaptionPresentationDefaults.CreateDefaultText(Strings.AiSubtitle_DefaultTemplate);
+        await using var templates = new CaptionTemplateRegistry(
+            [template.DescriptorRegistration],
+            [template.ElementFactoryRegistration],
+            [template.PlacementPolicyRegistration]);
+        CaptionSceneImportResult result = await AiCaptionSceneImporter.AddAsync(
+            context.Editor.Scene,
+            context.Editor.ElementAdder,
+            document,
+            templates,
+            CaptionTemplateIds.DefaultText,
+            cancellationToken);
+        if (result.IsSuccess)
+        {
+            NotificationService.ShowSuccess(Strings.AiJobCenter, Strings.AiJobCenter_AddedToScene);
+        }
+        else if (result.FailureId == ElementAddFailureIds.LockedLayer)
+        {
+            NotificationService.ShowWarning(Strings.Lock, Strings.LayerIsLocked);
+        }
+        else
+        {
+            throw new InvalidOperationException(
+                $"Failed to add the AI caption result: {result.FailureId}.");
+        }
+    }
+
+    private static async Task<AiCaptionHistoryResult> DownloadAsync(
+        AiJob job,
+        IAiJobResultContext context,
+        CancellationToken cancellationToken)
+    {
+        using var content = new SizeLimitedMemoryStream(
+            AiCaptionHistoryResultParser.MaximumResultBytes);
+        await context.CopyContentToAsync(job.ContentUri!, content, cancellationToken);
+        if (!AiCaptionHistoryResultParser.TryParse(
+                content.GetBuffer().AsSpan(0, checked((int)content.Length)),
+                job.Kind.Value,
+                job.Id,
+                out AiCaptionHistoryResult? result)
+            || result is null)
+        {
+            throw new InvalidDataException("The AI caption history result is invalid.");
+        }
+
+        return result;
+    }
+}
+
+internal static class AiJobResultInput
+{
+    public static string? GetString(AiJob job, string propertyName)
+    {
+        if (job.InputParameters is not { ValueKind: JsonValueKind.Object } input
+            || !input.TryGetProperty(propertyName, out JsonElement value)
+            || value.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        string? text = value.GetString();
+        return string.IsNullOrWhiteSpace(text) ? null : text.Trim();
+    }
+
+    public static int? GetInt32(AiJob job, string propertyName)
+    {
+        if (job.InputParameters is not { ValueKind: JsonValueKind.Object } input
+            || !input.TryGetProperty(propertyName, out JsonElement value)
+            || value.ValueKind != JsonValueKind.Number
+            || !value.TryGetInt32(out int result))
+        {
+            return null;
+        }
+
+        return result;
+    }
+}

--- a/src/Beutl/Services/AI/AiJobResultHandlers.cs
+++ b/src/Beutl/Services/AI/AiJobResultHandlers.cs
@@ -13,13 +13,13 @@ namespace Beutl.Services.AI;
 
 internal interface IAiCaptionResultPresenter
 {
-    bool TryPresentCaptionResult(AiCaptionHistoryResult result);
+    Task<bool> TryPresentCaptionResultAsync(AiCaptionHistoryResult result);
 }
 
 internal sealed class AiJobResultContext(
     IAiJobResultEditorContext editor,
     IAuthenticatedContentService content,
-    Action<AiCaptionHistoryResult>? openCaptionResult) : IAiJobResultContext, IAiCaptionResultPresenter
+    Func<AiCaptionHistoryResult, Task<bool>>? openCaptionResult) : IAiJobResultContext, IAiCaptionResultPresenter
 {
     private readonly IAiJobResultEditorContext _editor = editor ?? throw new ArgumentNullException(nameof(editor));
     private readonly IAuthenticatedContentService _content = content ?? throw new ArgumentNullException(nameof(content));
@@ -32,13 +32,11 @@ internal sealed class AiJobResultContext(
         CancellationToken cancellationToken)
         => _content.CopyToAsync(contentUri, destination, cancellationToken);
 
-    public bool TryPresentCaptionResult(AiCaptionHistoryResult result)
+    public Task<bool> TryPresentCaptionResultAsync(AiCaptionHistoryResult result)
     {
         if (openCaptionResult is null)
-            return false;
-
-        openCaptionResult(result);
-        return true;
+            return Task.FromResult(false);
+        return openCaptionResult(result);
     }
 }
 
@@ -345,12 +343,14 @@ internal sealed class CaptionAiJobResultCapabilities(
         CancellationToken cancellationToken)
     {
         AiCaptionHistoryResult recovered = await DownloadAsync(job, context, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
         if (context is IAiCaptionResultPresenter presenter
-            && presenter.TryPresentCaptionResult(recovered))
+            && await presenter.TryPresentCaptionResultAsync(recovered))
         {
             return;
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
         var document = new CaptionDocument(recovered.Segments.Select(segment => new CaptionCue(
             TimeSpan.FromSeconds(segment.Start),
             TimeSpan.FromSeconds(segment.End),

--- a/src/Beutl/Services/AI/AiOperationAvailabilityTracker.cs
+++ b/src/Beutl/Services/AI/AiOperationAvailabilityTracker.cs
@@ -1,0 +1,152 @@
+﻿using Avalonia.Threading;
+using Beutl.Api.Services;
+using Reactive.Bindings;
+
+namespace Beutl.Services.AI;
+
+internal sealed class AiOperationAvailabilityTracker : IDisposable
+{
+    private readonly IAiOperationAvailabilityService _service;
+    private readonly CancellationToken _lifetimeToken;
+    private readonly TimeSpan _debounce;
+    private readonly object _gate = new();
+    private CancellationTokenSource? _requestCts;
+    private long _revision;
+    private bool _disposed;
+
+    public AiOperationAvailabilityTracker(
+        IAiOperationAvailabilityService service,
+        CancellationToken lifetimeToken,
+        TimeSpan? debounce = null)
+    {
+        _service = service ?? throw new ArgumentNullException(nameof(service));
+        _lifetimeToken = lifetimeToken;
+        _debounce = debounce ?? TimeSpan.FromMilliseconds(250);
+        if (_debounce < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(debounce));
+    }
+
+    /// <summary>
+    /// What the server last said. A check that is pending, was never asked, or
+    /// failed leaves this <see cref="AiOperationAvailabilityState.Unknown"/> —
+    /// the caller must not read that as a refusal.
+    /// </summary>
+    public ReactivePropertySlim<AiOperationAvailabilityState> State { get; } =
+        new(AiOperationAvailabilityState.Unknown);
+
+    internal Task? CurrentCheck { get; private set; }
+
+    public void Check(AiOperationAvailabilityRequest? request)
+    {
+        CancellationTokenSource? previous;
+        CancellationTokenSource? current = null;
+        long revision;
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+
+            previous = _requestCts;
+            revision = ++_revision;
+            if (request is not null && !_lifetimeToken.IsCancellationRequested)
+            {
+                current = CancellationTokenSource.CreateLinkedTokenSource(_lifetimeToken);
+                _requestCts = current;
+            }
+            else
+            {
+                _requestCts = null;
+            }
+        }
+
+        previous?.Cancel();
+        previous?.Dispose();
+        Publish(revision, AiOperationAvailabilityState.Unknown);
+        CurrentCheck = current is null
+            ? null
+            : CheckCoreAsync(request!, revision, current);
+    }
+
+    public void Refresh(AiOperationAvailabilityRequest? request) => Check(request);
+
+    public async Task<bool> CheckNowAsync(
+        AiOperationAvailabilityRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return await _service.CheckAsync(request, cancellationToken);
+    }
+
+    private async Task CheckCoreAsync(
+        AiOperationAvailabilityRequest request,
+        long revision,
+        CancellationTokenSource requestCts)
+    {
+        AiOperationAvailabilityState state = AiOperationAvailabilityState.Unknown;
+        try
+        {
+            if (_debounce > TimeSpan.Zero)
+                await Task.Delay(_debounce, requestCts.Token);
+            state = await _service.CheckAsync(request, requestCts.Token)
+                ? AiOperationAvailabilityState.Available
+                : AiOperationAvailabilityState.Unavailable;
+        }
+        catch (OperationCanceledException) when (requestCts.IsCancellationRequested)
+        {
+            return;
+        }
+        catch
+        {
+            // A check that could not be made has not refused anything. The
+            // authoritative check still runs before the paid request is sent.
+        }
+        finally
+        {
+            lock (_gate)
+            {
+                if (ReferenceEquals(_requestCts, requestCts))
+                    _requestCts = null;
+            }
+
+            requestCts.Dispose();
+        }
+
+        Publish(revision, state);
+    }
+
+    private void Publish(long revision, AiOperationAvailabilityState state)
+    {
+        void Apply()
+        {
+            lock (_gate)
+            {
+                if (_disposed || revision != _revision)
+                    return;
+                State.Value = state;
+            }
+        }
+
+        if (Dispatcher.UIThread.CheckAccess())
+            Apply();
+        else
+            Dispatcher.UIThread.Post(Apply);
+    }
+
+    public void Dispose()
+    {
+        CancellationTokenSource? source;
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            _revision++;
+            source = _requestCts;
+            _requestCts = null;
+        }
+
+        source?.Cancel();
+        source?.Dispose();
+        State.Dispose();
+    }
+}

--- a/src/Beutl/Services/AI/AiOutstandingRequests.cs
+++ b/src/Beutl/Services/AI/AiOutstandingRequests.cs
@@ -1,0 +1,63 @@
+﻿using Beutl.Api.Services;
+
+namespace Beutl.Services.AI;
+
+/// <summary>
+/// What each request still waiting to be collected was made of.
+/// </summary>
+/// <remarks>
+/// The image editor's five tasks are five operations with five model lists and
+/// five prices, so a name outstanding on one says nothing about a request built
+/// on another. Holding every outstanding request, rather than only the last
+/// one, is what lets the screen answer that for the task on show while another
+/// task's request is still uncollected.
+/// </remarks>
+internal sealed class AiOutstandingRequests
+{
+    // Keep requests in dispatch order. A task can have more than one uncollected request; choosing
+    // an arbitrary one in that case would make the model shown after reopening vary by call.
+    private readonly List<(string Key, string?[] Request)> _held = [];
+
+    public void Remember(AiRequestName name, string?[] request)
+    {
+        if (string.IsNullOrEmpty(name.Key))
+            return;
+        Forget(name);
+        _held.Add((name.Key, request));
+    }
+
+    public void Forget(AiRequestName name)
+    {
+        if (!string.IsNullOrEmpty(name.Key))
+            _held.RemoveAll(held => string.Equals(held.Key, name.Key, StringComparison.Ordinal));
+    }
+
+    /// <summary>Every request being held, oldest first.</summary>
+    public IEnumerable<string?[]> All() => _held.Select(held => held.Request);
+
+    /// <summary>Whether any request being held matches <paramref name="predicate"/>.</summary>
+    public bool Any(Func<string?[], bool> predicate)
+        => _held.Exists(held => predicate(held.Request));
+
+    /// <summary>
+    /// The most recently sent request being held that matches
+    /// <paramref name="predicate"/>. Reading what it was sent with is how a list
+    /// fetched later lands on the model that request named, rather than on
+    /// whichever the account can afford today — and the newest is the one the
+    /// screen was last showing, so coming back lands where it was left.
+    /// </summary>
+    public bool TryFind(Func<string?[], bool> predicate, out string?[] request)
+    {
+        for (int index = _held.Count - 1; index >= 0; index--)
+        {
+            if (predicate(_held[index].Request))
+            {
+                request = _held[index].Request;
+                return true;
+            }
+        }
+
+        request = [];
+        return false;
+    }
+}

--- a/src/Beutl/Services/AI/AiRequestKey.cs
+++ b/src/Beutl/Services/AI/AiRequestKey.cs
@@ -1,0 +1,1018 @@
+﻿using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using Beutl.Api.Services;
+using Reactive.Bindings;
+
+namespace Beutl.Services.AI;
+
+/// <summary>
+/// A request's name, and whether it has been sent under that name before.
+/// </summary>
+/// <remarks>
+/// A repeat may be answered by the job the first attempt already reserved, and
+/// the server looks that job up before it looks at what the account can afford.
+/// A caller that checks the balance itself must not check it for a repeat, or
+/// it refuses to collect something already bought — most visibly when the
+/// request that emptied the balance is the one being collected.
+/// </remarks>
+internal readonly record struct AiRequestName(string Key, bool IsRepeat);
+
+/// <summary>
+/// Which refusals happened before the server reserved anything.
+/// </summary>
+internal static class AiRequestOutcome
+{
+    /// <summary>
+    /// Whether this failure authoritatively proves that the name is not the route back to a job.
+    /// Authentication is checked before the server looks up an idempotency key, so a first attempt
+    /// may be withdrawn only when its current request is known not to have been reserved. A repeat
+    /// keeps its name because the same authentication refusal says nothing about an older job.
+    /// An outer upload-size rejection has the same repeat boundary. The remaining refusals are
+    /// returned only after the server finds no job under the key.
+    /// </summary>
+    public static bool CanWithdraw(AiRequestName name, Exception exception)
+    {
+        bool preLookupRefusal = exception is AiFileTooLargeException
+            || exception is AuthenticationRequiredException
+            {
+                CurrentAttemptReservationIsKnownAbsent: true,
+            };
+        if (!name.IsRepeat && preLookupRefusal)
+        {
+            return true;
+        }
+
+        return exception is AiPlanRequiredException
+            or AiUsageLimitExceededException
+            or AiJobLimitReachedException
+            or AiModelUnavailableException
+            or AiModelDoesNotSupportRequestException;
+    }
+}
+
+/// <summary>
+/// Names the requests of one metered AI attempt, so that repeating a request
+/// whose answer never arrived recovers what it may already have paid for
+/// instead of buying it again.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The server charges an operation when it accepts it, and answers a repeat of
+/// a key it has already seen with the job that key created — the finished
+/// result, or a refusal while it is still running. Neither charges twice, so a
+/// request whose outcome the client never learned has to go back out under the
+/// key it first used. A request made of anything else is a different request
+/// and takes a different key: the server refuses a key that comes back with a
+/// different fingerprint behind it, which is why every part that identifies the
+/// request is passed to <see cref="NameFor(ReadOnlySpan{string})"/>.
+/// </para>
+/// <para>
+/// Once the server has settled a job — a result, or a failure it owns and has
+/// refunded — the key that named it is spent. It would keep answering with that
+/// settled job, so asking for anything more has to be a new request:
+/// <see cref="Retire(AiRequestName)"/> says one request was settled, and
+/// <see cref="Retire()"/> says the whole run was. A name the server made no job
+/// under is not settled but spent for nothing, and
+/// <see cref="Withdraw(AiRequestName)"/> takes it back.
+/// </para>
+/// </remarks>
+internal sealed class AiRequestKey : IDisposable
+{
+    private readonly Lock _gate = new();
+    // The names issued and the requests they represent. Only unsettled requests remain here.
+    private readonly Dictionary<string, string> _outstanding = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, string> _outstandingAccounts = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, string> _outstandingOperations = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, AiRequestRecoveryLease> _claims = new(StringComparer.Ordinal);
+    // A settled request cannot be sent again under the same name. A repeated request uses the
+    // next generation name; when no generation exists, generation 0 keeps the original shape.
+    private readonly Dictionary<string, int> _generations = new(StringComparer.Ordinal);
+    private readonly ReactivePropertySlim<bool> _hasOutstandingName = new(false);
+    private readonly AiRequestRecoveryContext? _recoveryContext;
+    private readonly string? _operation;
+    private string _seed;
+    private bool _resumedAttemptPending;
+    private bool _disposed;
+
+    internal Action? BeforeAbandonPersistedRemoval { get; set; }
+
+    public AiRequestKey(string? seed = null, bool namePending = false,
+        AiRequestRecoveryContext? recoveryContext = null, string? operation = null)
+    {
+        _recoveryContext = recoveryContext;
+        _operation = operation;
+        _seed = string.IsNullOrEmpty(seed) ? NewSeed() : seed;
+        // Among executions restored from recovery, only those that ended immediately after
+        // dispatch still hold a name. The recovery record tells us whether that happened; a
+        // seed alone is not enough because unreserved and refunded requests also retain seeds.
+        bool resumedSeed = !string.IsNullOrEmpty(seed) && namePending;
+        bool hasDurableRecovery = false;
+        if (_recoveryContext?.TryGetIdentity() is { } identity
+            && !string.IsNullOrWhiteSpace(operation))
+        {
+            try
+            {
+                hasDurableRecovery = _recoveryContext.Store.HasAny(identity.AccountId, operation);
+            }
+            catch (InvalidDataException)
+            {
+                // A corrupt or locked store must not be treated as an empty
+                // store. Remember the failure so the first new request fails
+                // closed instead of buying work without a durable recovery row.
+            }
+        }
+        // A paid request may have exhausted the current balance. Publish only
+        // command reachability here; NameFor marks repeat only after the exact
+        // fingerprint is found, so an unrelated input cannot skip preflight.
+        _hasOutstandingName.Value = resumedSeed || hasDurableRecovery;
+        // A restored execution knows its name but not which request was sent, so treat only the
+        // first name handed out again as a repeat dispatch.
+        _resumedAttemptPending = resumedSeed;
+        if (_recoveryContext is not null)
+            _recoveryContext.IdentityChanged += RefreshIdentity;
+    }
+
+    /// <summary>
+    /// What the current keys are derived from. Held with the rest of a resumable
+    /// run's state so a request resumed in another session is sent under the key
+    /// it was first sent under.
+    /// </summary>
+    public string Seed
+    {
+        get
+        {
+            lock (_gate)
+                return _seed;
+        }
+    }
+
+    public static string NewSeed() => Guid.NewGuid().ToString("N");
+
+    internal bool HasDurableRecovery => _recoveryContext is not null;
+
+    internal string? CurrentAccountId => _recoveryContext?.TryGetIdentity()?.AccountId;
+
+    /// <summary>
+    /// Whether a name has been handed out that the server has not been seen to
+    /// settle.
+    /// </summary>
+    /// <remarks>
+    /// While this holds, asking again may be answered by a job already paid
+    /// for. The server looks that job up before it looks at the balance, so a
+    /// caller that gates on the balance itself has to leave the way open — most
+    /// of all when the request being collected is the one that emptied it.
+    /// </remarks>
+    public IReadOnlyReactiveProperty<bool> HasOutstandingName
+    {
+        get
+        {
+            RefreshIdentity();
+            return _hasOutstandingName;
+        }
+    }
+
+    private void RefreshIdentity()
+    {
+        if (_disposed) return;
+        bool has = false;
+        lock (_gate)
+        {
+            // The key is still useful without durable recovery (unit callers and
+            // the pre-recovery subtitle flow use that mode). In that case the
+            // in-memory map is the complete source of truth.
+            if (_recoveryContext is null)
+            {
+                has = _outstanding.Count > 0 || _resumedAttemptPending;
+            }
+            else
+            {
+                string? account = _recoveryContext?.TryGetIdentity()?.AccountId;
+                has = _resumedAttemptPending
+                    || account is not null && _outstandingAccounts.Values.Any(value => value == account);
+                if (!has && account is not null && !string.IsNullOrWhiteSpace(_operation))
+                {
+                    try
+                    {
+                        has = _recoveryContext!.Store.HasAny(account, _operation);
+                    }
+                    catch (InvalidDataException)
+                    {
+                    }
+                }
+            }
+        }
+        _hasOutstandingName.Value = has;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        if (_recoveryContext is not null)
+            _recoveryContext.IdentityChanged -= RefreshIdentity;
+        foreach (AiRequestRecoveryLease claim in _claims.Values)
+            claim.Dispose();
+        _claims.Clear();
+        _hasOutstandingName.Dispose();
+    }
+
+    /// <summary>
+    /// The key for a request identified by <paramref name="parts"/>. The server
+    /// holds a key to printable ASCII and to 255 characters, which this is.
+    /// </summary>
+    public string For(params ReadOnlySpan<string?> parts) => NameFor(parts).Key;
+
+    /// <summary>
+    /// The key for a request identified by <paramref name="parts"/>, and
+    /// whether it has been handed out since the last settlement.
+    /// </summary>
+    public AiRequestName NameFor(params ReadOnlySpan<string?> parts)
+    {
+        string operation = ResolveOperation(parts);
+        return Remember(Fingerprint(parts), operation, ResolveModel(operation, parts));
+    }
+
+    /// <summary>
+    /// Names and durably records a form request in one call. The key-only
+    /// overload remains useful for non-form callers, while the dialog VMs use
+    /// this overload so a crash cannot leave a paid key without its inputs.
+    /// </summary>
+    internal AiRequestName NameFor(
+        ReadOnlySpan<string?> parts,
+        AiRequestFormSnapshot form,
+        IReadOnlyList<AiRequestRecoverySource>? sources = null)
+    {
+        ArgumentNullException.ThrowIfNull(form);
+        string operation = ResolveOperation(parts);
+        return Remember(
+            Fingerprint(parts),
+            operation,
+            ResolveModel(operation, parts),
+            form,
+            sources);
+    }
+
+    /// <summary>
+    /// The key for the <paramref name="pieceIndex"/>th piece of a request sent
+    /// in pieces, each of which is charged and recovered on its own.
+    /// </summary>
+    public string For(int pieceIndex, params ReadOnlySpan<string?> parts)
+        => NameFor(pieceIndex, parts).Key;
+
+    public AiRequestName NameFor(int pieceIndex, params ReadOnlySpan<string?> parts)
+    {
+        string operation = ResolveOperation(parts);
+        return Remember(
+            $"{Fingerprint(parts)}-{pieceIndex.ToString(CultureInfo.InvariantCulture)}",
+            operation,
+            ResolveModel(operation, parts));
+    }
+
+    public bool HasPersistedFor(AiOperationId operation)
+        => _recoveryContext?.TryGetIdentity() is { } identity
+            && _recoveryContext.Store.HasAny(identity.AccountId, operation.Value);
+
+    public IReadOnlyList<AiModelId> PersistedModels(AiOperationId operation)
+        => _recoveryContext?.TryGetIdentity() is { } identity
+            ? _recoveryContext.Store.ModelsFor(identity.AccountId, operation.Value)
+                .Select(model => new AiModelId(model))
+                .ToArray()
+            : [];
+
+    public AiModelId? PreferredPersistedModel(AiOperationId operation)
+    {
+        if (_recoveryContext?.TryGetIdentity() is not { } identity)
+            return null;
+        IReadOnlyList<AiPendingAttempt> attempts = _recoveryContext.Store.PendingFor(
+            identity.AccountId,
+            operation.Value);
+        // A preferred model is safe only when there is exactly one pending
+        // attempt and that attempt explicitly named a model. Returning a model
+        // from one of several rows would bind a different form to it.
+        if (attempts.Count != 1 || attempts[0].Model is null)
+            return null;
+        return attempts[0].Model is { } model ? new AiModelId(model) : null;
+    }
+
+    public bool HasExplicitNullPersistedModel(AiOperationId operation)
+        => _recoveryContext?.TryGetIdentity() is { } identity
+            && _recoveryContext.Store.PendingFor(identity.AccountId, operation.Value)
+                .Count == 1
+            && _recoveryContext.Store.HasModelless(identity.AccountId, operation.Value);
+
+    internal IReadOnlyList<AiPendingAttempt> PendingAttempts(AiOperationId operation)
+        => _recoveryContext?.PendingFor(operation.Value)
+            ?? Array.Empty<AiPendingAttempt>();
+
+    internal IReadOnlyList<string> ResolveSources(AiPendingAttempt attempt)
+    {
+        if (_recoveryContext is null)
+            throw new InvalidDataException("AI request recovery is not configured.");
+        return _recoveryContext.Store.ResolveSources(attempt);
+    }
+
+    internal byte[] ReadSourceBytes(AiRequestRecoverySource source)
+    {
+        if (_recoveryContext is null)
+            throw new InvalidDataException("AI request recovery is not configured.");
+        return _recoveryContext.Store.ReadSourceBytes(source);
+    }
+
+    internal AiRequestRecoverySource CreateDurableSource(
+        string role,
+        string name,
+        ReadOnlySpan<byte> content,
+        string? elementId = null)
+    {
+        if (_recoveryContext is null)
+            throw new InvalidDataException("AI request recovery is not configured.");
+        return _recoveryContext.Store.CreateDurableSource(role, name, content, elementId);
+    }
+
+    internal void CleanupUncommittedSources(IEnumerable<AiRequestRecoverySource> sources)
+    {
+        if (_recoveryContext is not null)
+            _recoveryContext.Store.DeleteUncommittedSources(sources);
+    }
+
+    internal AiRequestRecoveryLease? TryClaim(AiRequestName name)
+    {
+        if (_recoveryContext is null || string.IsNullOrEmpty(name.Key))
+            return null;
+        lock (_gate)
+        {
+            if (!_outstanding.TryGetValue(name.Key, out string? request)
+                || !_outstandingAccounts.TryGetValue(name.Key, out string? account)
+                || !_outstandingOperations.TryGetValue(name.Key, out string? operation))
+                return null;
+            AiPendingAttempt? current = _recoveryContext.Store.Find(account, operation, request);
+            if (current is null || !StringComparer.Ordinal.Equals(current.Key, name.Key))
+                throw new InvalidDataException("AI request recovery attempt is stale.");
+
+            // An unknown result leaves the dispatched fence durable so another
+            // process cannot overlap the provider call. Keep this process's
+            // exact owner on an immediate retry instead of asking the store for
+            // a competing claim that it must (correctly) reject.
+            if (_claims.GetValueOrDefault(name.Key) is { } localClaim
+                && localClaim.WasDispatched)
+            {
+                if (localClaim.Reacquire())
+                    return localClaim;
+
+                // The old owner may have expired and been replaced after a
+                // process restart. Drop only this local handle, then let the
+                // store's owner-token CAS decide whether a fresh claim is safe.
+                _claims.Remove(name.Key);
+            }
+
+            AiRequestRecoveryLease? claim = _recoveryContext.Store.Claim(account, operation, request, name.Key);
+            if (claim is null)
+                return null;
+            _claims[name.Key] = claim;
+            return claim;
+        }
+    }
+
+    internal void MarkClaimDispatched(AiRequestRecoveryLease? claim)
+    {
+        if (claim is not null && !claim.MarkDispatched())
+            throw new InvalidDataException("AI recovery dispatch fence could not be persisted.");
+    }
+
+    internal AiPendingAttempt? FindPending(
+        AiOperationId operation,
+        ReadOnlySpan<string?> parts)
+    {
+        if (_recoveryContext?.TryGetIdentity() is not { } identity)
+            return null;
+        return _recoveryContext.Store.Find(
+            identity.AccountId,
+            ResolveOperation(parts),
+            Fingerprint(parts));
+    }
+
+    internal bool MatchesPending(AiPendingAttempt attempt, ReadOnlySpan<string?> parts)
+        => _recoveryContext?.TryGetIdentity() is { } identity
+            && StringComparer.Ordinal.Equals(identity.AccountId, attempt.AccountId)
+            && string.Equals(
+                attempt.Fingerprint,
+                Fingerprint(parts),
+                StringComparison.Ordinal)
+            && string.Equals(attempt.Operation, ResolveOperation(parts), StringComparison.Ordinal);
+
+    internal bool IsCurrentPending(AiPendingAttempt attempt)
+    {
+        if (_recoveryContext?.TryGetIdentity() is not { } identity
+            || !StringComparer.Ordinal.Equals(identity.AccountId, attempt.AccountId))
+        {
+            return false;
+        }
+
+        AiPendingAttempt? current = _recoveryContext.Store.Find(
+            attempt.AccountId,
+            attempt.Operation,
+            attempt.Fingerprint);
+        return current is not null
+            && StringComparer.Ordinal.Equals(current.Key, attempt.Key);
+    }
+
+    internal void PersistForm(
+        AiRequestName name,
+        AiRequestFormSnapshot form,
+        IReadOnlyList<AiRequestRecoverySource>? sources = null)
+    {
+        if (_recoveryContext is null || string.IsNullOrEmpty(name.Key))
+            return;
+        ArgumentNullException.ThrowIfNull(form);
+        lock (_gate)
+        {
+            if (!_outstanding.TryGetValue(name.Key, out string? request)
+                || !_outstandingAccounts.TryGetValue(name.Key, out string? account)
+                || !_outstandingOperations.TryGetValue(name.Key, out string? operation))
+            {
+                throw new InvalidOperationException("The AI request name is not outstanding.");
+            }
+
+            AiPendingAttempt? existing = _recoveryContext.Store.Find(account, operation, request);
+            if (existing is null)
+                throw new InvalidDataException("The AI recovery row is missing.");
+            if (!_recoveryContext.Store.TryUpdateForm(
+                    account,
+                    operation,
+                    request,
+                    existing.Key,
+                    form,
+                    sources))
+            {
+                throw new InvalidDataException("The AI recovery row changed while updating form state.");
+            }
+        }
+    }
+
+    internal void Abandon(AiPendingAttempt attempt)
+    {
+        if (_recoveryContext is null)
+            return;
+        if (!StringComparer.Ordinal.Equals(CurrentAccountId, attempt.AccountId))
+            throw new AuthenticationRequiredException();
+        lock (_gate)
+        {
+            // Resolve the exact issued entry, including account and operation.
+            // A fingerprint is scoped to both, so matching it alone can remove
+            // another account's pending attempt after an account switch.
+            string? key = null;
+            foreach (KeyValuePair<string, string> pair in _outstanding)
+            {
+                if (pair.Value == attempt.Fingerprint
+                    && _outstandingAccounts.GetValueOrDefault(pair.Key) == attempt.AccountId
+                    && _outstandingOperations.GetValueOrDefault(pair.Key) == attempt.Operation)
+                {
+                    key = pair.Key;
+                    break;
+                }
+            }
+            AiPendingAttempt? persisted = _recoveryContext.Store.Find(
+                attempt.AccountId,
+                attempt.Operation,
+                attempt.Fingerprint);
+            if (persisted is not null
+                && !StringComparer.Ordinal.Equals(persisted.Key, attempt.Key))
+            {
+                throw new InvalidDataException("AI recovery key does not match the pending attempt.");
+            }
+            bool removed = persisted is null && key is not null;
+            if (persisted is not null)
+            {
+                BeforeAbandonPersistedRemoval?.Invoke();
+                removed = _recoveryContext.Abandon(attempt);
+                if (!removed)
+                {
+                    AiPendingAttempt? current = _recoveryContext.Store.Find(
+                        attempt.AccountId,
+                        attempt.Operation,
+                        attempt.Fingerprint);
+                    if (current is null)
+                    {
+                        removed = true;
+                    }
+                    else
+                    {
+                        throw new InvalidDataException(
+                            StringComparer.Ordinal.Equals(current.Key, attempt.Key)
+                                ? "The AI recovery attempt has an active dispatch fence and cannot be abandoned."
+                                : "The AI recovery attempt changed while it was being abandoned.");
+                    }
+                }
+            }
+            if (removed)
+            {
+                string generationIdentity =
+                    $"{attempt.AccountId}\n{attempt.Operation}\n{attempt.Fingerprint}";
+                int durableGeneration = persisted is null
+                    ? _recoveryContext.Store.AdvanceGeneration(
+                        attempt.AccountId,
+                        attempt.Operation,
+                        attempt.Fingerprint)
+                    : _recoveryContext.Store.GetGeneration(
+                        attempt.AccountId,
+                        attempt.Operation,
+                        attempt.Fingerprint);
+                _generations[generationIdentity] = Math.Max(
+                    _generations.GetValueOrDefault(generationIdentity) + 1,
+                    durableGeneration);
+                if (key is not null)
+                {
+                    _outstanding.Remove(key);
+                    _outstandingAccounts.Remove(key);
+                    _outstandingOperations.Remove(key);
+                }
+            }
+        }
+        RefreshIdentity();
+    }
+
+    public IDisposable EnterAuthenticatedScope(AiRequestName name)
+    {
+        if (_recoveryContext is null)
+            return EmptyDisposable.Instance;
+        string account;
+        lock (_gate)
+        {
+            account = _outstandingAccounts.GetValueOrDefault(name.Key)
+                ?? throw new InvalidOperationException("The AI request name is not outstanding.");
+        }
+        return _recoveryContext.Enter(account);
+    }
+
+    /// <summary>
+    /// Identifies a file the way the server does: by the name it arrives under
+    /// and by its bytes.
+    /// </summary>
+    /// <remarks>
+    /// Anything else drifts from what the server calls the same request. Its
+    /// path would make a file moved between folders a new request, and its
+    /// modified time would do the same for a file merely touched — both would
+    /// buy the same work a second time. Reading the bytes is what the upload is
+    /// about to do anyway.
+    /// </remarks>
+    public static string FileStamp(string? filePath)
+    {
+        if (string.IsNullOrEmpty(filePath))
+            return string.Empty;
+
+        try
+        {
+            using FileStream stream = File.OpenRead(filePath);
+            return FileStamp(Path.GetFileName(filePath), SHA256.HashData(stream));
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Unreadable here means the upload is about to fail anyway; the path
+            // alone still tells two different files apart.
+            return filePath;
+        }
+    }
+
+    /// <summary>
+    /// Identifies bytes already in hand, sent under <paramref name="fileName"/>.
+    /// </summary>
+    /// <remarks>
+    /// Reading the file once and naming that reading is the only way the name
+    /// is sure to belong to what goes out: read for the name and read again to
+    /// send, and a file rewritten in between is recorded under a name that
+    /// describes something else.
+    /// </remarks>
+    public static string FileStamp(string fileName, ReadOnlySpan<byte> content)
+        => string.Create(
+            CultureInfo.InvariantCulture,
+            $"{fileName}:{Convert.ToHexString(SHA256.HashData(content))}");
+
+    /// <summary>
+    /// Identifies bytes by the bytes alone, for an upload the server takes no
+    /// name from.
+    /// </summary>
+    /// <remarks>
+    /// A video's frames are identified by their contents and their type, never
+    /// by what the file was called: a frame is a picture, and the name it
+    /// reached disk under says nothing about the request. Naming it here would
+    /// make the same picture two requests — a frame captured from the scene
+    /// lands in a file named for uniqueness, so capturing it again to retry an
+    /// interrupted run would buy that run a second time.
+    /// </remarks>
+    public static string ContentStamp(ReadOnlySpan<byte> content)
+        => Convert.ToHexString(SHA256.HashData(content));
+
+    /// <summary>
+    /// Says the server settled the job this one name made. Only that request
+    /// starts again under a fresh name.
+    /// </summary>
+    /// <remarks>
+    /// Settling the whole run instead would throw away the names of every other
+    /// request still waiting to be collected: a run that finishes a second
+    /// request while a first one is still outstanding would leave the first
+    /// unreachable, and asking for it again would buy it a second time.
+    /// </remarks>
+    public bool Retire(AiRequestName name)
+    {
+        if (string.IsNullOrEmpty(name.Key))
+            return false;
+
+        bool anyLeft;
+        bool retired = false;
+        lock (_gate)
+        {
+            if (_outstanding.Remove(name.Key, out string? request))
+            {
+                string? issuedAccount = _outstandingAccounts.GetValueOrDefault(name.Key);
+                string? issuedOperation = _outstandingOperations.GetValueOrDefault(name.Key);
+                AiRequestRecoveryLease? claim = _claims.GetValueOrDefault(name.Key);
+                string generationIdentity = _recoveryContext is null
+                    ? request
+                    : $"{issuedAccount}\n{issuedOperation}\n{request}";
+                bool removedPersisted = RemovePersisted(
+                    request,
+                    issuedAccount,
+                    issuedOperation,
+                    name.Key,
+                    settle: true,
+                    claim?.OwnerToken,
+                    claim?.Generation);
+                if (!removedPersisted && _recoveryContext is not null)
+                {
+                    // Another process already changed the row. Do not let a
+                    // stale local completion advance or delete that owner.
+                    _outstanding[name.Key] = request;
+                    if (issuedAccount is not null)
+                        _outstandingAccounts[name.Key] = issuedAccount;
+                    if (issuedOperation is not null)
+                        _outstandingOperations[name.Key] = issuedOperation;
+                    return false;
+                }
+                _generations[generationIdentity] =
+                    _generations.GetValueOrDefault(generationIdentity) + 1;
+                _outstandingAccounts.Remove(name.Key);
+                _outstandingOperations.Remove(name.Key);
+                claim?.Dispose();
+                _claims.Remove(name.Key);
+                retired = true;
+            }
+
+            anyLeft = HasCurrentOutstandingInMemory() || HasDurableOutstanding();
+        }
+
+        if (!anyLeft)
+            _hasOutstandingName.Value = false;
+        return retired;
+    }
+
+    /// <summary>
+    /// Says every request of this run is settled, and the next one starts under
+    /// a seed of its own.
+    /// </summary>
+    public bool Retire()
+    {
+        bool retired;
+        lock (_gate)
+        {
+            if (_recoveryContext is not null)
+            {
+                if (_recoveryContext.TryGetIdentity() is not { } identity
+                    || string.IsNullOrWhiteSpace(_operation))
+                    return false;
+                retired = _recoveryContext.Store.SettleMany(
+                    identity.AccountId,
+                    _operation,
+                    _outstanding.Select(pair =>
+                        new AiPendingAttempt(
+                            _outstandingAccounts[pair.Key],
+                            _outstandingOperations[pair.Key],
+                            pair.Value,
+                            pair.Key)))
+                    || (_outstanding.Count == 0 && !HasDurableOutstanding());
+            }
+            else
+            {
+                retired = true;
+            }
+            if (!retired)
+                return false;
+            _seed = NewSeed();
+            _outstanding.Clear();
+            _outstandingAccounts.Clear();
+            _outstandingOperations.Clear();
+            _generations.Clear();
+            // Nothing under the new seed has been paid for.
+            _resumedAttemptPending = false;
+        }
+
+        _hasOutstandingName.Value = false;
+        return true;
+    }
+
+    /// <summary>
+    /// Forgets a name the server made no job under, so it stops counting as
+    /// outstanding and the same request may go out under it again.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A name is handed out before the request goes out, and some refusals
+    /// happen before anything is reserved: the client's own balance check, and
+    /// the server's answers about the plan, the sign-in, the size of an upload
+    /// and whether a model can serve the request at all — every one of which it
+    /// decides after looking the name up and finding nothing. Leaving such a
+    /// name outstanding pins the run to the model it named and keeps the way
+    /// back to a job open that was never made.
+    /// </para>
+    /// <para>
+    /// Call this only where the server has been heard to reserve nothing, or
+    /// where the request never left. A name withdrawn while the job it made is
+    /// still out there is a job that will be bought again.
+    /// </para>
+    /// </remarks>
+    public bool Withdraw(AiRequestName name)
+        => WithdrawCore(name, ownerAuthorizedDispatched: false);
+
+    /// <summary>
+    /// Withdraws a name after the server authoritatively reported that no
+    /// reservation was made, including when the provider call had already
+    /// been marked dispatched.
+    /// </summary>
+    /// <remarks>
+    /// A dispatched recovery row is a paid-job fence. Only the process that
+    /// still holds the exact live dispatch lease may use this path; ordinary
+    /// withdrawal and cross-process abandon remain fail-closed.
+    /// </remarks>
+    internal bool WithdrawAfterNoReservation(AiRequestName name)
+        => WithdrawCore(name, ownerAuthorizedDispatched: true);
+
+    private bool WithdrawCore(AiRequestName name, bool ownerAuthorizedDispatched)
+    {
+        if (string.IsNullOrEmpty(name.Key))
+            return false;
+
+        bool anyLeft;
+        bool withdrawn = false;
+        lock (_gate)
+        {
+            if (_outstanding.Remove(name.Key, out string? request))
+            {
+                string? issuedAccount = _outstandingAccounts.GetValueOrDefault(name.Key);
+                string? issuedOperation = _outstandingOperations.GetValueOrDefault(name.Key);
+                AiRequestRecoveryLease? claim = _claims.GetValueOrDefault(name.Key);
+                bool exactDispatchedOwner = ownerAuthorizedDispatched
+                    && claim is { IsDispatched: true };
+                // A pre-dispatch refusal may still be withdrawn by the claim
+                // owner. Once dispatch is persisted, however, the owner proof
+                // is accepted only through WithdrawAfterNoReservation.
+                bool exactPredispatchOwner = claim is not null
+                    && !claim.WasDispatched;
+                bool authorizedOwner = exactDispatchedOwner || exactPredispatchOwner;
+                bool removedPersisted = RemovePersisted(
+                    request,
+                    issuedAccount,
+                    issuedOperation,
+                    name.Key,
+                    settle: false,
+                    authorizedOwner ? claim!.OwnerToken : null,
+                    authorizedOwner ? claim!.Generation : null,
+                    exactDispatchedOwner);
+                if (!removedPersisted && _recoveryContext is not null)
+                {
+                    _outstanding[name.Key] = request;
+                    if (issuedAccount is not null)
+                        _outstandingAccounts[name.Key] = issuedAccount;
+                    if (issuedOperation is not null)
+                        _outstandingOperations[name.Key] = issuedOperation;
+                    return false;
+                }
+                _outstandingAccounts.Remove(name.Key);
+                _outstandingOperations.Remove(name.Key);
+                claim?.Dispose();
+                _claims.Remove(name.Key);
+                withdrawn = true;
+            }
+            anyLeft = HasCurrentOutstandingInMemory() || HasDurableOutstanding();
+        }
+
+        if (!anyLeft)
+            _hasOutstandingName.Value = false;
+        return withdrawn;
+    }
+
+    private AiRequestName Remember(
+        string request,
+        string operation,
+        string? model,
+        AiRequestFormSnapshot? form = null,
+        IReadOnlyList<AiRequestRecoverySource>? sources = null)
+    {
+        AiAuthenticatedRequestIdentity? authenticated = _recoveryContext?.GetRequiredIdentity();
+        string? account = authenticated?.AccountId;
+        AiRequestName name;
+        bool hasOutstanding;
+        lock (_gate)
+        {
+            if (_recoveryContext is not null)
+            {
+                if (operation.Length == 0)
+                    throw new InvalidOperationException("An AI request operation is required for durable recovery.");
+                try
+                {
+                    AiPendingAttempt? persisted = _recoveryContext.Store.Find(account!, operation, request);
+                    if (persisted is not null)
+                    {
+                        string persistedKey = persisted.Key;
+                        string[] staleKeys = _outstanding
+                            .Where(pair => pair.Key != persistedKey
+                                && pair.Value == request
+                                && _outstandingAccounts.GetValueOrDefault(pair.Key) == account
+                                && _outstandingOperations.GetValueOrDefault(pair.Key) == operation)
+                            .Select(static pair => pair.Key)
+                            .ToArray();
+                        foreach (string staleKey in staleKeys)
+                        {
+                            _outstanding.Remove(staleKey);
+                            _outstandingAccounts.Remove(staleKey);
+                            _outstandingOperations.Remove(staleKey);
+                            if (_claims.Remove(staleKey, out AiRequestRecoveryLease? staleClaim))
+                                staleClaim.Dispose();
+                        }
+                        if (!_outstanding.ContainsKey(persistedKey))
+                        {
+                            _outstanding[persistedKey] = request;
+                            _outstandingAccounts[persistedKey] = account!;
+                            _outstandingOperations[persistedKey] = operation;
+                        }
+                        if (form is not null && !persisted.HasCanonicalForm)
+                        {
+                            _recoveryContext.Store.WriteOrGet(
+                                persisted with { Form = form, Sources = sources });
+                        }
+                        else if (sources is not null)
+                        {
+                            // The caller may have prepared fresh durable copies
+                            // while racing with another request that committed the
+                            // same identity. Keep the committed row's copies and
+                            // remove only the newly unreferenced ones.
+                            _recoveryContext.Store.DeleteUncommittedSources(sources);
+                        }
+                        _hasOutstandingName.Value = true;
+                        return new AiRequestName(persistedKey, true);
+                    }
+                }
+                catch
+                {
+                    if (sources is not null)
+                        _recoveryContext.Store.DeleteUncommittedSources(sources);
+                    throw;
+                }
+            }
+            string generationIdentity = _recoveryContext is null
+                ? request
+                : $"{account}\n{operation}\n{request}";
+            int generation = _generations.GetValueOrDefault(generationIdentity);
+            if (_recoveryContext is not null)
+            {
+                generation = Math.Max(
+                    generation,
+                    _recoveryContext.Store.GetGeneration(account!, operation, request));
+            }
+            // Generation 0 keeps the shape used before generations existed. Both the seed in
+            // recovery and the name retained by the server continue to work unchanged.
+            string keyBase = _recoveryContext is null
+                ? $"{_seed}-{request}"
+                : $"{_seed}-{request}-{ScopeFingerprint(account!, operation)}";
+            string key = generation == 0
+                ? keyBase
+                : $"{keyBase}-r{generation.ToString(CultureInfo.InvariantCulture)}";
+            if (_outstanding.ContainsKey(key))
+                return new AiRequestName(key, true);
+            bool resumed = _resumedAttemptPending;
+            _resumedAttemptPending = false;
+            name = new AiRequestName(key, resumed);
+            // Durable state is committed before exposing the name in memory.
+            if (_recoveryContext is not null)
+            {
+                string persistedKey;
+                try
+                {
+                    persistedKey = _recoveryContext.Store.WriteOrGet(
+                        new AiPendingAttempt(account!, operation, request, key, model, form, sources)).Key;
+                }
+                catch
+                {
+                    if (sources is not null)
+                        _recoveryContext.Store.DeleteUncommittedSources(sources);
+                    throw;
+                }
+                if (!string.Equals(persistedKey, key, StringComparison.Ordinal))
+                {
+                    key = persistedKey;
+                    name = new AiRequestName(key, true);
+                }
+            }
+            _outstanding[key] = request;
+            if (account is not null)
+                _outstandingAccounts[key] = account;
+            _outstandingOperations[key] = operation;
+            hasOutstanding = true;
+        }
+        if (hasOutstanding)
+            _hasOutstandingName.Value = true;
+        return name;
+    }
+
+    private bool RemovePersisted(
+        string request,
+        string? issuedAccount,
+        string? issuedOperation,
+        string key,
+        bool settle,
+        string? ownerToken = null,
+        int? generation = null,
+        bool ownerAuthorizedDispatched = false)
+    {
+        if (_recoveryContext is null)
+            return true;
+        string? account = issuedAccount ?? _recoveryContext.TryGetIdentity()?.AccountId;
+        string operation = issuedOperation ?? _operation
+            ?? throw new InvalidOperationException("An AI request operation is required for durable recovery.");
+        if (account is null)
+            return false;
+        bool removed = settle
+            ? _recoveryContext.Store.TrySettle(account, operation, request, key, ownerToken, generation)
+            : ownerAuthorizedDispatched
+                ? _recoveryContext.Store.TryWithdrawAfterNoReservation(
+                    account,
+                    operation,
+                    request,
+                    key,
+                    ownerToken ?? throw new InvalidOperationException("A dispatched withdrawal requires an owner token."),
+                    generation ?? throw new InvalidOperationException("A dispatched withdrawal requires a generation."))
+                : _recoveryContext.Store.TryWithdraw(account, operation, request, key, ownerToken, generation);
+        return removed;
+    }
+
+    private bool HasDurableOutstanding()
+        => _recoveryContext?.TryGetIdentity() is { } identity
+            && !string.IsNullOrWhiteSpace(_operation)
+            && _recoveryContext.Store.HasAny(identity.AccountId, _operation);
+
+    private bool HasCurrentOutstandingInMemory()
+    {
+        string? account = _recoveryContext?.TryGetIdentity()?.AccountId;
+        return account is null
+            ? _outstanding.Count > 0
+            : _outstandingAccounts.Values.Any(value => value == account);
+    }
+
+    private string ResolveOperation(ReadOnlySpan<string?> parts)
+    {
+        if (_operation is null)
+            return string.Empty;
+        if (_operation == "image.edit" && parts.Length > 0 && !string.IsNullOrWhiteSpace(parts[0]))
+        {
+            // The edit task is the first request part; include it in the
+            // durable identity so different edit tools never collide.
+            string task = parts[0]!.Trim();
+            return $"image.edit.{task}";
+        }
+        return _operation;
+    }
+
+    private static string? ResolveModel(string operation, ReadOnlySpan<string?> parts)
+    {
+        int index = operation switch
+        {
+            "image.generate" => 4,
+            "video.generate" => 6,
+            _ when operation.StartsWith("image.edit.", StringComparison.Ordinal) => 2,
+            _ => -1,
+        };
+        return index >= 0 && index < parts.Length ? parts[index] : null;
+    }
+
+    // Length-prefixed so that no arrangement of parts can read as another one.
+    private static string Fingerprint(ReadOnlySpan<string?> parts)
+    {
+        var builder = new StringBuilder();
+        foreach (string? part in parts)
+        {
+            builder.Append(part?.Length ?? -1)
+                .Append(':')
+                .Append(part)
+                .Append('\u001f');
+        }
+
+        return Convert
+            .ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(builder.ToString())).AsSpan(0, 8))
+            .ToLowerInvariant();
+    }
+
+    private static string ScopeFingerprint(string account, string operation)
+        => Convert
+            .ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes($"{account}\u001f{operation}"))
+                .AsSpan(0, 8))
+            .ToLowerInvariant();
+}

--- a/src/Beutl/Services/AI/AiResultImageLease.cs
+++ b/src/Beutl/Services/AI/AiResultImageLease.cs
@@ -1,0 +1,10 @@
+﻿using Beutl.Media;
+using Beutl.Media.Source;
+
+namespace Beutl.Services.AI;
+
+internal static class AiResultImageLease
+{
+    public static Ref<Bitmap>? Acquire(Ref<Bitmap>? image)
+        => image?.TryClone();
+}

--- a/src/Beutl/Services/AI/AiResultImporter.cs
+++ b/src/Beutl/Services/AI/AiResultImporter.cs
@@ -1,0 +1,355 @@
+﻿using System.Buffers.Binary;
+using Beutl.Api.Services;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Graphics;
+using Beutl.Logging;
+using Beutl.Media;
+using Beutl.Media.Decoding;
+using Beutl.Media.Source;
+using Beutl.ProjectSystem;
+using Microsoft.Extensions.Logging;
+
+namespace Beutl.Services.AI;
+
+internal sealed record AiResultImportOptions(
+    TimeSpan Start,
+    TimeSpan Length,
+    int Layer,
+    string Name);
+
+internal sealed class AiResultImporter
+{
+    private static readonly ILogger s_logger = Log.CreateLogger<AiResultImporter>();
+    private readonly Scene _scene;
+    private readonly IElementAdder _elementAdder;
+    private readonly Func<string, CancellationToken, Task> _validateVideo;
+
+    public AiResultImporter(
+        Scene scene,
+        IElementAdder elementAdder,
+        Func<string, CancellationToken, Task>? validateVideo = null)
+    {
+        _scene = scene ?? throw new ArgumentNullException(nameof(scene));
+        _elementAdder = elementAdder ?? throw new ArgumentNullException(nameof(elementAdder));
+        _validateVideo = validateVideo ?? ValidateVideoAsync;
+    }
+
+    public async Task<ElementAddResult> ImportImageAsync(
+        Bitmap bitmap,
+        AiResultImportOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(bitmap);
+        ArgumentNullException.ThrowIfNull(options);
+
+        string path = await StageAsync(
+            ".png",
+            stream =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!bitmap.Save(stream, EncodedImageFormat.Png))
+                    throw new IOException("Failed to encode the AI image as PNG.");
+                return Task.CompletedTask;
+            },
+            cancellationToken);
+        return await AddStagedResultAsync(path, options, cancellationToken);
+    }
+
+    public async Task<ElementAddResult> ImportImageAsync(
+        ReadOnlyMemory<byte> bytes,
+        AiResultImportOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        if (bytes.Length > AiRequestLimits.MaxImageUploadBytes)
+            throw new InvalidDataException("AI image data is too large.");
+        using var stream = new MemoryStream(bytes.ToArray(), writable: false);
+        AiImageDecodeValidator.ValidateEncoded(stream, AiRequestLimits.MaxImageUploadBytes);
+        using Bitmap bitmap = Bitmap.FromStream(stream);
+        return await ImportImageAsync(bitmap, options, cancellationToken);
+    }
+
+    public Task<ElementAddResult> ImportVideoAsync(
+        ReadOnlyMemory<byte> bytes,
+        AiResultImportOptions options,
+        CancellationToken cancellationToken = default)
+        => ImportVideoCoreAsync(
+            async stream =>
+            {
+                await stream.WriteAsync(bytes, cancellationToken);
+            },
+            ".mp4",
+            options,
+            cancellationToken);
+
+    public Task<ElementAddResult> ImportVideoAsync(
+        string sourcePath,
+        AiResultImportOptions options,
+        CancellationToken cancellationToken = default)
+        => ImportVideoAsync(
+            sourcePath,
+            Path.GetExtension(sourcePath),
+            options,
+            cancellationToken);
+
+    public Task<ElementAddResult> ImportVideoAsync(
+        string sourcePath,
+        string extension,
+        AiResultImportOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourcePath);
+        return ImportVideoCoreAsync(
+            async destination =>
+            {
+                await using FileStream source = File.OpenRead(sourcePath);
+                await source.CopyToAsync(destination, cancellationToken);
+            },
+            extension,
+            options,
+            cancellationToken);
+    }
+
+    private async Task<ElementAddResult> ImportVideoCoreAsync(
+        Func<Stream, Task> writer,
+        string extension,
+        AiResultImportOptions options,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        string normalizedExtension = NormalizeVideoExtension(extension);
+        string path = await StageAsync(normalizedExtension, writer, cancellationToken);
+        try
+        {
+            await _validateVideo(path, cancellationToken);
+            return await AddStagedResultAsync(path, options, cancellationToken);
+        }
+        catch
+        {
+            TryDelete(path);
+            throw;
+        }
+    }
+
+    private static Task ValidateVideoAsync(string path, CancellationToken cancellationToken)
+    {
+        ValidateVideoContainerSignature(path);
+        return Task.Run(() =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                using MediaReader reader = MediaReader.Open(
+                    path,
+                    new MediaOptions(MediaMode.Video) { PreferProxy = false });
+                Ref<Bitmap>? firstFrame = null;
+                try
+                {
+                    if (!reader.HasVideo
+                        || !reader.ReadVideo(0, out firstFrame)
+                        || firstFrame?.Value is null)
+                    {
+                        throw new InvalidDataException(
+                            "The AI video result does not contain a decodable video frame.");
+                    }
+                }
+                finally
+                {
+                    firstFrame?.Dispose();
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (InvalidDataException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidDataException(
+                    "The AI video result could not be decoded.",
+                    ex);
+            }
+        }, cancellationToken);
+    }
+
+    internal static void ValidateVideoContainerSignature(string path)
+    {
+        using FileStream stream = File.OpenRead(path);
+        string extension = Path.GetExtension(path);
+        if (extension is ".mp4" or ".mov")
+        {
+            ValidateIsoBaseMediaFile(stream);
+            return;
+        }
+
+        Span<byte> header = stackalloc byte[4];
+        try
+        {
+            stream.ReadExactly(header);
+        }
+        catch (EndOfStreamException ex)
+        {
+            throw new InvalidDataException("The AI video result is truncated.", ex);
+        }
+
+        if (header[0] != 0x1a
+            || header[1] != 0x45
+            || header[2] != 0xdf
+            || header[3] != 0xa3)
+        {
+            throw new InvalidDataException(
+                "The AI video result does not match its declared container format.");
+        }
+    }
+
+    private static void ValidateIsoBaseMediaFile(Stream stream)
+    {
+        const int maximumBoxesToInspect = 4096;
+        Span<byte> header = stackalloc byte[16];
+        long length = stream.Length;
+        for (int boxIndex = 0; boxIndex < maximumBoxesToInspect && stream.Position < length; boxIndex++)
+        {
+            long remaining = length - stream.Position;
+            if (remaining < 8)
+                throw new InvalidDataException("The AI video result has a truncated MP4 box header.");
+
+            stream.ReadExactly(header[..8]);
+            ulong boxSize = BinaryPrimitives.ReadUInt32BigEndian(header[..4]);
+            int headerSize = 8;
+            if (boxSize == 1)
+            {
+                if (remaining < 16)
+                {
+                    throw new InvalidDataException(
+                        "The AI video result has a truncated extended MP4 box header.");
+                }
+
+                stream.ReadExactly(header[8..16]);
+                boxSize = BinaryPrimitives.ReadUInt64BigEndian(header[8..16]);
+                headerSize = 16;
+            }
+            else if (boxSize == 0)
+            {
+                boxSize = (ulong)remaining;
+            }
+
+            if (boxSize < (ulong)headerSize || boxSize > (ulong)remaining)
+                throw new InvalidDataException("The AI video result has an invalid MP4 box size.");
+
+            ReadOnlySpan<byte> type = header[4..8];
+            bool isFileType = type.SequenceEqual("ftyp"u8)
+                && boxSize >= (ulong)(headerSize + 8);
+            if (isFileType || type.SequenceEqual("moov"u8) || type.SequenceEqual("mdat"u8))
+                return;
+
+            stream.Seek(checked((long)boxSize - headerSize), SeekOrigin.Current);
+        }
+
+        throw new InvalidDataException(
+            "The AI video result does not match its declared container format.");
+    }
+
+    private async Task<ElementAddResult> AddStagedResultAsync(
+        string path,
+        AiResultImportOptions options,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            ElementAddResult result = await _elementAdder.AddAsync(
+            [
+                new ElementDescription(
+                    options.Start,
+                    options.Length,
+                    options.Layer,
+                    new ElementSource.File(path),
+                    options.Name),
+            ], cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                TryDelete(path);
+            }
+
+            return result;
+        }
+        catch
+        {
+            TryDelete(path);
+            throw;
+        }
+    }
+
+    private async Task<string> StageAsync(
+        string extension,
+        Func<Stream, Task> writer,
+        CancellationToken cancellationToken)
+    {
+        string directory = GetResourceDirectory();
+        Directory.CreateDirectory(directory);
+
+        string destinationPath = Path.Combine(directory, $"{Guid.NewGuid():N}{extension}");
+        string temporaryPath = Path.Combine(directory, $".{Guid.NewGuid():N}.tmp");
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var streamOptions = new FileStreamOptions
+            {
+                Mode = FileMode.CreateNew,
+                Access = FileAccess.Write,
+                Share = FileShare.None,
+                BufferSize = 81920,
+                Options = FileOptions.Asynchronous | FileOptions.SequentialScan,
+            };
+            if (!OperatingSystem.IsWindows())
+                streamOptions.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+            await using (var stream = new FileStream(temporaryPath, streamOptions))
+            {
+                await writer(stream);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+            File.Move(temporaryPath, destinationPath);
+            return destinationPath;
+        }
+        finally
+        {
+            TryDelete(temporaryPath);
+        }
+    }
+
+    internal static string GetUnsavedSceneDirectory(Guid sceneId)
+        => UnsavedSceneStorage.GetDirectory(sceneId);
+
+    private string GetResourceDirectory()
+    {
+        string projectDirectory = _scene.Uri?.LocalPath is { } scenePath
+            ? Path.GetDirectoryName(scenePath)!
+            : GetUnsavedSceneDirectory(_scene.Id);
+        return Path.Combine(projectDirectory, "resources", "ai");
+    }
+
+    private static string NormalizeVideoExtension(string extension)
+    {
+        string normalized = string.IsNullOrWhiteSpace(extension)
+            ? ".mp4"
+            : extension.StartsWith('.') ? extension.ToLowerInvariant() : $".{extension.ToLowerInvariant()}";
+        return normalized is ".mp4" or ".webm" or ".mov" or ".mkv"
+            ? normalized
+            : throw new ArgumentException("The AI video format is unsupported.", nameof(extension));
+    }
+
+    private void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (Exception ex)
+        {
+            s_logger.LogWarning(ex, "Failed to remove unused AI project resource {Path}.", path);
+        }
+    }
+}

--- a/src/Beutl/Services/AI/AiTemporaryFileStore.cs
+++ b/src/Beutl/Services/AI/AiTemporaryFileStore.cs
@@ -1,0 +1,324 @@
+﻿namespace Beutl.Services.AI;
+
+internal static class AiTemporaryFileStore
+{
+    internal static readonly TimeSpan StaleAge = TimeSpan.FromDays(1);
+    private const UnixFileMode DirectoryMode = UnixFileMode.UserRead
+        | UnixFileMode.UserWrite
+        | UnixFileMode.UserExecute;
+    private const UnixFileMode FileMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+    private const string SessionLockName = ".lock";
+    private static readonly TimeSpan s_coordinationLockTimeout = TimeSpan.FromSeconds(30);
+    private static readonly object s_gate = new();
+    private static readonly HashSet<string> s_cleanedDirectories = new(StringComparer.Ordinal);
+    private static readonly string s_sessionId = Guid.NewGuid().ToString("N");
+    private static readonly Dictionary<string, FileStream> s_sessionLocks =
+        new(StringComparer.Ordinal);
+
+    internal static Action<string>? BeforeSessionClaim { get; set; }
+
+    internal static Action<string>? BeforeSessionCleanup { get; set; }
+
+    public static string RootDirectory => Path.Combine(
+        BeutlEnvironment.GetHomeDirectoryPath(),
+        "tmp",
+        "ai");
+
+    public static (string Path, FileStream Stream) Create(
+        string category,
+        string prefix,
+        string extension)
+    {
+        string categoryRoot = GetCategoryRootDirectory(category);
+        string directory = Path.Combine(categoryRoot, s_sessionId);
+        string normalizedPrefix = NormalizeComponent(prefix, nameof(prefix));
+        string normalizedExtension = NormalizeExtension(extension);
+        EnsurePrivateDirectory(categoryRoot);
+        using (AcquireCoordinationLock(categoryRoot))
+        {
+            EnsurePrivateDirectory(directory);
+            BeforeSessionClaim?.Invoke(directory);
+            HoldSession(directory);
+        }
+        CleanAbandonedSessionsOnce(
+            categoryRoot,
+            DateTimeOffset.UtcNow);
+
+        while (true)
+        {
+            string path = Path.Combine(
+                directory,
+                $"{normalizedPrefix}-{Guid.NewGuid():N}{normalizedExtension}");
+            try
+            {
+                var options = new FileStreamOptions
+                {
+                    Mode = System.IO.FileMode.CreateNew,
+                    Access = FileAccess.Write,
+                    Share = FileShare.None,
+                    BufferSize = 81920,
+                    Options = FileOptions.Asynchronous | FileOptions.SequentialScan,
+                };
+                if (!OperatingSystem.IsWindows())
+                    options.UnixCreateMode = FileMode;
+                var stream = new FileStream(path, options);
+                try
+                {
+                    EnsurePrivateFile(path);
+                    return (path, stream);
+                }
+                catch
+                {
+                    stream.Dispose();
+                    try
+                    {
+                        File.Delete(path);
+                    }
+                    catch
+                    {
+                    }
+                    throw;
+                }
+            }
+            catch (IOException) when (File.Exists(path))
+            {
+            }
+        }
+    }
+
+    /// <summary>
+    /// Where this process writes. Every process keeps its own directory, so
+    /// clearing up after one that exited can never take a file another is
+    /// still using.
+    /// </summary>
+    internal static string GetCategoryDirectory(string category)
+        => Path.Combine(GetCategoryRootDirectory(category), s_sessionId);
+
+    internal static string GetCategoryRootDirectory(string category)
+        => Path.Combine(RootDirectory, NormalizeComponent(category, nameof(category)));
+
+    /// <summary>
+    /// Clears up after sessions that are over. A session directory whose lock
+    /// is still held belongs to a process that is still running, and nothing in
+    /// it is removed however old it looks.
+    /// </summary>
+    internal static void CleanAbandonedSessions(string categoryRoot, DateTimeOffset now)
+        => CleanAbandonedSessions(categoryRoot, now, s_sessionId);
+
+    internal static void CleanAbandonedSessions(
+        string categoryRoot,
+        DateTimeOffset now,
+        string currentSessionId)
+    {
+        if (!Directory.Exists(categoryRoot))
+            return;
+
+        var claimedSessions = new List<(string Directory, FileStream Claim)>();
+        using (FileStream coordinationLock = AcquireCoordinationLock(categoryRoot))
+        {
+            foreach (string session in Directory.EnumerateDirectories(categoryRoot))
+            {
+                if (string.Equals(Path.GetFileName(session), currentSessionId, StringComparison.Ordinal))
+                    continue;
+
+                try
+                {
+                    claimedSessions.Add((session, OpenSessionLock(session)));
+                }
+                catch (IOException)
+                {
+                    // Held by a live process.
+                }
+                catch (UnauthorizedAccessException)
+                {
+                }
+            }
+        }
+
+        try
+        {
+            // Files written directly here belong to a version that had no sessions.
+            CleanStaleFiles(categoryRoot, now);
+            foreach ((string session, FileStream claim) in claimedSessions)
+            {
+                BeforeSessionCleanup?.Invoke(session);
+                CleanStaleFiles(session, now);
+                claim.Dispose();
+                TryRemoveFinishedSession(session);
+            }
+        }
+        finally
+        {
+            foreach ((_, FileStream claim) in claimedSessions)
+                claim.Dispose();
+        }
+    }
+
+    internal static void CleanStaleFiles(string directory, DateTimeOffset now)
+    {
+        if (!Directory.Exists(directory))
+            return;
+
+        foreach (string path in Directory.EnumerateFiles(directory))
+        {
+            if (string.Equals(Path.GetFileName(path), SessionLockName, StringComparison.Ordinal))
+                continue;
+
+            try
+            {
+                if (now - File.GetLastWriteTimeUtc(path) >= StaleAge)
+                    File.Delete(path);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+
+    internal static void EnsurePrivateDirectory(string directory)
+    {
+        Directory.CreateDirectory(directory);
+        if (OperatingSystem.IsWindows())
+            return;
+
+        // Every level down from the root, so a category or session directory
+        // created along the way is no more readable than the root itself.
+        File.SetUnixFileMode(RootDirectory, DirectoryMode);
+        for (string? current = directory;
+             current is not null
+             && current.StartsWith(RootDirectory, StringComparison.Ordinal)
+             && !string.Equals(current, RootDirectory, StringComparison.Ordinal);
+             current = Path.GetDirectoryName(current))
+        {
+            File.SetUnixFileMode(current, DirectoryMode);
+        }
+    }
+
+    internal static void EnsurePrivateFile(string path)
+    {
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(path, FileMode);
+    }
+
+    private static void CleanAbandonedSessionsOnce(string categoryRoot, DateTimeOffset now)
+    {
+        lock (s_gate)
+        {
+            if (!s_cleanedDirectories.Add(categoryRoot))
+                return;
+        }
+        CleanAbandonedSessions(categoryRoot, now);
+    }
+
+    // Held for as long as this process runs. Another process reads the lock it
+    // cannot take as "the owner is still here".
+    private static void HoldSession(string sessionDirectory)
+    {
+        lock (s_gate)
+        {
+            if (s_sessionLocks.ContainsKey(sessionDirectory))
+                return;
+
+            s_sessionLocks[sessionDirectory] = OpenSessionLock(sessionDirectory);
+        }
+    }
+
+    private static FileStream OpenSessionLock(string sessionDirectory)
+        => OpenExclusiveLock(Path.Combine(sessionDirectory, SessionLockName));
+
+    private static FileStream AcquireCoordinationLock(string categoryRoot)
+    {
+        string path = Path.Combine(categoryRoot, SessionLockName);
+        DateTimeOffset deadline = DateTimeOffset.UtcNow + s_coordinationLockTimeout;
+        IOException? lastFailure = null;
+        do
+        {
+            try
+            {
+                return OpenExclusiveLock(path);
+            }
+            catch (IOException ex)
+            {
+                lastFailure = ex;
+                Thread.Sleep(10);
+            }
+        }
+        while (DateTimeOffset.UtcNow < deadline);
+
+        throw new IOException(
+            $"Could not coordinate AI temporary-file sessions in '{categoryRoot}'.",
+            lastFailure);
+    }
+
+    private static FileStream OpenExclusiveLock(string path)
+    {
+        var options = new FileStreamOptions
+        {
+            Mode = System.IO.FileMode.OpenOrCreate,
+            Access = FileAccess.ReadWrite,
+            Share = FileShare.None,
+        };
+        if (!OperatingSystem.IsWindows())
+            options.UnixCreateMode = FileMode;
+
+        var stream = new FileStream(path, options);
+        try
+        {
+            EnsurePrivateFile(path);
+            return stream;
+        }
+        catch
+        {
+            stream.Dispose();
+            throw;
+        }
+    }
+
+    private static void TryRemoveFinishedSession(string sessionDirectory)
+    {
+        try
+        {
+            if (Directory.EnumerateFileSystemEntries(sessionDirectory)
+                .Any(entry => !string.Equals(
+                    Path.GetFileName(entry),
+                    SessionLockName,
+                    StringComparison.Ordinal)))
+            {
+                return;
+            }
+
+            File.Delete(Path.Combine(sessionDirectory, SessionLockName));
+            Directory.Delete(sessionDirectory);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private static string NormalizeComponent(string value, string parameterName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value, parameterName);
+        string normalized = value.Trim();
+        if (normalized.Length > 64
+            || normalized.Any(character => !char.IsAsciiLetterOrDigit(character) && character != '-'))
+        {
+            throw new ArgumentException("The temporary-file component is invalid.", parameterName);
+        }
+        return normalized;
+    }
+
+    private static string NormalizeExtension(string extension)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(extension);
+        string normalized = extension.StartsWith('.') ? extension : $".{extension}";
+        if (normalized.Length is < 2 or > 11
+            || normalized.Skip(1).Any(character => !char.IsAsciiLetterOrDigit(character)))
+        {
+            throw new ArgumentException("The temporary-file extension is invalid.", nameof(extension));
+        }
+        return normalized.ToLowerInvariant();
+    }
+}

--- a/src/Beutl/Services/AI/AiUploadBytes.cs
+++ b/src/Beutl/Services/AI/AiUploadBytes.cs
@@ -1,0 +1,53 @@
+﻿using Beutl.Api.Services;
+
+namespace Beutl.Services.AI;
+
+/// <summary>
+/// Reading a file that is about to be uploaded, without letting it decide how
+/// much memory that takes.
+/// </summary>
+/// <remarks>
+/// A request is named by what its file contains, so the bytes have to be in
+/// hand before the request goes out. What is on disk can have changed since it
+/// was chosen, though — the same path can hold something enormous by the time
+/// it is read — and the size the request is allowed is known up front. Reading
+/// past it serves no purpose and is how a picture picked at ten megabytes turns
+/// into a process with none left.
+/// </remarks>
+internal static class AiUploadBytes
+{
+    public static async Task<byte[]> ReadWithinAsync(
+        string path,
+        long limit,
+        CancellationToken cancellationToken)
+    {
+        await using FileStream stream = new(
+            path,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 81920,
+            FileOptions.Asynchronous | FileOptions.SequentialScan);
+        if (stream.Length > limit)
+            throw new AiFileTooLargeException();
+
+        // Read to one byte past the limit rather than trusting the length: a
+        // file being written to grows between the two.
+        var buffer = new MemoryStream(capacity: (int)Math.Min(stream.Length, limit));
+        byte[] chunk = new byte[81920];
+        long read = 0;
+        while (true)
+        {
+            int count = await stream.ReadAsync(chunk, cancellationToken);
+            if (count == 0)
+                break;
+
+            read += count;
+            if (read > limit)
+                throw new AiFileTooLargeException();
+            buffer.Write(chunk, 0, count);
+        }
+
+        return buffer.ToArray();
+    }
+}

--- a/src/Beutl/Services/AI/AiVideoResultDownload.cs
+++ b/src/Beutl/Services/AI/AiVideoResultDownload.cs
@@ -1,0 +1,110 @@
+﻿namespace Beutl.Services.AI;
+
+internal static class AiVideoResultDownload
+{
+    // The API accepts at most 60 seconds. This still permits an encoded bitrate above 68 Mbit/s
+    // while bounding a malformed or non-terminating response well below the whole disk.
+    internal const long MaximumBytes = 512L * 1024 * 1024;
+
+    public static Stream CreateBoundedStream(
+        Stream destination,
+        long maximumBytes = MaximumBytes)
+    {
+        ArgumentNullException.ThrowIfNull(destination);
+        if (!destination.CanWrite)
+            throw new ArgumentException("The destination stream must be writable.", nameof(destination));
+        if (maximumBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maximumBytes));
+
+        return new BoundedWriteStream(destination, maximumBytes);
+    }
+
+    private sealed class BoundedWriteStream(Stream destination, long maximumBytes) : Stream
+    {
+        private long _written;
+
+        public override bool CanRead => false;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => destination.CanWrite;
+
+        public override long Length => _written;
+
+        public override long Position
+        {
+            get => _written;
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => destination.Flush();
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+            => destination.FlushAsync(cancellationToken);
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin)
+            => throw new NotSupportedException();
+
+        public override void SetLength(long value)
+            => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            EnsureCapacity(count);
+            destination.Write(buffer, offset, count);
+            _written += count;
+        }
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            EnsureCapacity(buffer.Length);
+            destination.Write(buffer);
+            _written += buffer.Length;
+        }
+
+        public override async Task WriteAsync(
+            byte[] buffer,
+            int offset,
+            int count,
+            CancellationToken cancellationToken)
+        {
+            EnsureCapacity(count);
+            await destination.WriteAsync(buffer.AsMemory(offset, count), cancellationToken);
+            _written += count;
+        }
+
+        public override async ValueTask WriteAsync(
+            ReadOnlyMemory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            EnsureCapacity(buffer.Length);
+            await destination.WriteAsync(buffer, cancellationToken);
+            _written += buffer.Length;
+        }
+
+        public override void WriteByte(byte value)
+        {
+            EnsureCapacity(1);
+            destination.WriteByte(value);
+            _written++;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            // The caller owns the staging file stream. This wrapper only bounds writes.
+            base.Dispose(disposing);
+        }
+
+        private void EnsureCapacity(int count)
+        {
+            if (count < 0 || count > maximumBytes - _written)
+            {
+                throw new InvalidDataException(
+                    $"The AI video result exceeds the {maximumBytes}-byte download limit.");
+            }
+        }
+    }
+}

--- a/src/Beutl/Services/AI/CaptionDraftStore.cs
+++ b/src/Beutl/Services/AI/CaptionDraftStore.cs
@@ -94,7 +94,10 @@ internal sealed record CaptionSourceTranscriptionResume(
     string RequestKeyModel = "",
     // Whether the draft ended while holding a dispatched but unsettled name. A seed alone cannot
     // answer this because unreserved and refunded requests also retain seeds.
-    bool RequestKeyNamePending = false);
+    bool RequestKeyNamePending = false,
+    // The canonical start of the selected source window. Together with TotalSamples this identifies
+    // the exact audio submitted for this run. Null marks a legacy draft that cannot safely resume.
+    long? SourceStartSamples = null);
 
 internal sealed record CaptionDraft(
     int Version,
@@ -724,6 +727,7 @@ internal sealed class FileCaptionDraftStore : ICaptionDraftStore
             && resume.FileLength > 0
             && resume.LastWriteTimeUtcTicks >= 0
             && resume.LastWriteTimeUtcTicks <= DateTime.MaxValue.Ticks
+            && resume.SourceStartSamples is null or >= 0
             && resume.Segments.All(segment => segment is not null
                 && double.IsFinite(segment.Start)
                 && double.IsFinite(segment.End)

--- a/src/Beutl/Services/AI/CaptionDraftStore.cs
+++ b/src/Beutl/Services/AI/CaptionDraftStore.cs
@@ -368,11 +368,26 @@ internal sealed class FileCaptionDraftStore : ICaptionDraftStore
                     return CaptionDraftReadResult.Absent;
                 }
 
+                bool recordsNamePending = RecordsNamePending(bytes, envelope.Version);
                 CaptionDraft draft = Migrate(
                     envelope.Draft,
                     envelope.Version,
-                    RecordsNamePending(bytes, envelope.Version));
-                CaptionDraftEntry[] recoveries = envelope.Recoveries ?? [];
+                    recordsNamePending);
+                CaptionDraftEntry[] storedRecoveries = envelope.Recoveries ?? [];
+                var recoveries = new CaptionDraftEntry[storedRecoveries.Length];
+                for (int index = 0; index < storedRecoveries.Length; index++)
+                {
+                    CaptionDraftEntry? recovery = storedRecoveries[index];
+                    if (recovery is null)
+                    {
+                        DeleteInvalidFile(storagePath);
+                        return CaptionDraftReadResult.Absent;
+                    }
+                    recoveries[index] = new CaptionDraftEntry(
+                        recovery.JobId,
+                        Migrate(recovery.Draft, envelope.Version, recordsNamePending),
+                        recovery.Recoveries);
+                }
                 var entry = new CaptionDraftEntry(envelope.JobId, draft, recoveries);
                 if (!IsValid(entry))
                 {

--- a/src/Beutl/Services/AI/CaptionDraftStore.cs
+++ b/src/Beutl/Services/AI/CaptionDraftStore.cs
@@ -1,0 +1,863 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Beutl.Api.Services;
+using Beutl.ProjectSystem;
+
+namespace Beutl.Services.AI;
+
+internal enum CaptionDraftKind
+{
+    Translation,
+    Transcription,
+}
+
+internal sealed record StoredCaptionCue(
+    long StartTicks,
+    long EndTicks,
+    string Text,
+    string? Speaker,
+    string? Language,
+    Dictionary<string, string> Metadata);
+
+internal sealed record CaptionTranslationResume(
+    StoredCaptionCue[] SourceCues,
+    string? SourceLanguage,
+    string? SelectedSourceLanguage,
+    string TargetLanguage,
+    Dictionary<string, string> TranslatedPieces,
+    int CompletedBatchCount,
+    // What the batches of this run were named to the server. Kept so that a run
+    // resumed in a later session asks for the translations it already paid for
+    // rather than buying them again. Empty in a draft written before this was
+    // recorded, which resumes as a run of its own.
+    string RequestKeySeed = "",
+    // The model those names were built from. A run resumed on another model
+    // would name its unfinished batches differently and buy them again, so the
+    // picker is put back on this one.
+    string RequestKeyModel = "",
+    // Whether the draft ended while holding a dispatched but unsettled name. A seed alone cannot
+    // answer this because unreserved and refunded requests also retain seeds. Confusing them would
+    // restore unpaid work as an already-paid recovery.
+    bool RequestKeyNamePending = false,
+    int MaxSegments = 0,
+    int MaxCharacters = 0,
+    int MaxRequestBytes = 0);
+
+internal sealed record CaptionSceneTranscriptionResume(
+    Guid SceneId,
+    string? Language,
+    TimeSpan RangeStart,
+    TimeSpan Duration,
+    TimeSpan ChunkDuration,
+    int ChunkCount,
+    AiTranscriptionSegment[] Segments,
+    string? DetectedLanguage,
+    int CompletedChunkCount,
+    // What the chunks of this run were named to the server. Scene audio is
+    // composed rather than read from a file, so nothing written down proves it
+    // is still the same audio — the server's own fingerprint does. A chunk
+    // asked for again under this seed is answered from the job it made when the
+    // audio matches, and refused as a different request when it does not, which
+    // is where the run starts over.
+    string RequestKeySeed = "",
+    string RequestKeyModel = "",
+    bool RequestKeyNamePending = false,
+    // A random identifier shared only by scene-mix operations created by one dialog lifetime.
+    // Completed chunks cannot be validated against edited audio, so a partial run may continue
+    // only while this identifier still matches. A zero-completion pending request remains safe to
+    // retry because the server validates that chunk's audio fingerprint.
+    Guid AudioSessionId = default);
+
+internal sealed record CaptionSourceTranscriptionResume(
+    string FilePath,
+    Guid ElementId,
+    long FileLength,
+    long LastWriteTimeUtcTicks,
+    string? Language,
+    int SampleRate,
+    long TotalSamples,
+    int ChunkSamples,
+    int ChunkCount,
+    AiTranscriptionSegment[] Segments,
+    string? DetectedLanguage,
+    int CompletedChunkCount,
+    // What the chunks of this run were named to the server. Kept so that a run
+    // resumed in a later session asks for the transcriptions it already paid
+    // for rather than buying them again. Empty in a draft written before this
+    // was recorded, which resumes as a run of its own.
+    string RequestKeySeed = "",
+    // The model those names were built from. A run resumed on another model
+    // would name its unfinished chunks differently and buy them again, so the
+    // picker is put back on this one.
+    string RequestKeyModel = "",
+    // Whether the draft ended while holding a dispatched but unsettled name. A seed alone cannot
+    // answer this because unreserved and refunded requests also retain seeds.
+    bool RequestKeyNamePending = false);
+
+internal sealed record CaptionDraft(
+    int Version,
+    StoredCaptionCue[] Cues,
+    string? Language,
+    AiTranscriptionSegment[]? Segments,
+    CaptionDraftKind Kind,
+    int CompletedSteps,
+    int TotalSteps,
+    CaptionTranslationResume? TranslationResume,
+    CaptionSceneTranscriptionResume? SceneTranscriptionResume,
+    CaptionSourceTranscriptionResume? SourceTranscriptionResume = null);
+
+internal sealed record CaptionDraftScope
+{
+    [JsonConstructor]
+    public CaptionDraftScope(
+        string userId,
+        Guid projectId,
+        Guid sceneId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+        if (projectId == Guid.Empty)
+            throw new ArgumentException("A project identifier is required.", nameof(projectId));
+        if (sceneId == Guid.Empty)
+            throw new ArgumentException("A scene identifier is required.", nameof(sceneId));
+
+        string normalizedUserId = userId.Trim();
+        if (normalizedUserId.Length > 256)
+            throw new ArgumentException("The user identifier is too long.", nameof(userId));
+
+        UserId = normalizedUserId;
+        ProjectId = projectId;
+        SceneId = sceneId;
+    }
+
+    public string UserId { get; }
+
+    public Guid ProjectId { get; }
+
+    public Guid SceneId { get; }
+}
+
+internal sealed record CaptionDraftEntry
+{
+    public CaptionDraftEntry(
+        string? jobId,
+        CaptionDraft draft,
+        CaptionDraftEntry[]? recoveries = null)
+    {
+        string? normalizedJobId = string.IsNullOrWhiteSpace(jobId) ? null : jobId.Trim();
+        if (normalizedJobId?.Length > 256)
+            throw new ArgumentException("The job identifier is too long.", nameof(jobId));
+
+        JobId = normalizedJobId;
+        Draft = draft ?? throw new ArgumentNullException(nameof(draft));
+        Recoveries = recoveries ?? [];
+    }
+
+    public string? JobId { get; }
+
+    public CaptionDraft Draft { get; }
+
+    public CaptionDraftEntry[] Recoveries { get; }
+}
+
+/// <summary>What came of looking for a scope's draft.</summary>
+internal enum CaptionDraftReadOutcome
+{
+    /// <summary>Nothing is stored for this scope, and nothing was.</summary>
+    Absent,
+
+    /// <summary>
+    /// Something may be stored and could not be read. Never the same as absent:
+    /// writing over what could not be read destroys whatever it held, which may
+    /// be the only way back to something already paid for.
+    /// </summary>
+    Unreadable,
+
+    /// <summary>A draft was read.</summary>
+    Read,
+}
+
+internal readonly record struct CaptionDraftReadResult(
+    CaptionDraftReadOutcome Outcome,
+    CaptionDraftEntry? Entry)
+{
+    public static readonly CaptionDraftReadResult Absent = new(CaptionDraftReadOutcome.Absent, null);
+
+    public static readonly CaptionDraftReadResult Unreadable =
+        new(CaptionDraftReadOutcome.Unreadable, null);
+}
+
+internal interface ICaptionDraftSession : IDisposable
+{
+    CaptionDraftScope Scope { get; }
+
+    CaptionDraftReadResult Read();
+
+    void Save(CaptionDraftEntry entry);
+
+    void Delete();
+}
+
+internal interface ICaptionDraftStore
+{
+    bool TryOpen(
+        CaptionDraftScope scope,
+        [NotNullWhen(true)] out ICaptionDraftSession? session);
+}
+
+internal sealed class FileCaptionDraftStore : ICaptionDraftStore
+{
+    private const int UnixLockExclusive = 2;
+    private const int UnixLockNonBlocking = 4;
+    // Version 2 records what a run's requests were named before its first piece
+    // comes back; version 3 records whether one of those names was outstanding;
+    // version 4 retains more than one paid recovery for a scene.
+    internal const int CurrentVersion = 5;
+    // Read old drafts too. Only their request-name fields are ambiguous, so normalize those fields
+    // rather than discarding already-paid results.
+    internal const int OldestSupportedVersion = 1;
+    internal const int MaximumStorageBytes = 8 * 1024 * 1024;
+    internal const int MaximumRetainedRecoveries = 63;
+    private const int MaximumCueCount = 10_000;
+    private const int MaximumCueTextLength = 100_000;
+
+    private static readonly JsonSerializerOptions s_jsonOptions = CreateJsonOptions();
+    private readonly Dictionary<CaptionDraftScope, Guid> _leases = [];
+    private readonly object _gate = new();
+
+    public FileCaptionDraftStore(string storageDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(storageDirectory))
+            throw new ArgumentException("A storage directory is required.", nameof(storageDirectory));
+
+        StorageDirectory = Path.GetFullPath(storageDirectory);
+        if (File.Exists(StorageDirectory))
+            throw new ArgumentException("The storage path must identify a directory.", nameof(storageDirectory));
+    }
+
+    public string StorageDirectory { get; }
+
+    public bool TryOpen(
+        CaptionDraftScope scope,
+        [NotNullWhen(true)] out ICaptionDraftSession? session)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+        lock (_gate)
+        {
+            if (_leases.ContainsKey(scope))
+            {
+                session = null;
+                return false;
+            }
+
+            // Another Beutl process may open the same scene for the same account. If both write,
+            // one can overwrite the other's paid request name and force a repurchase on restart.
+            // Keep the file open without sharing so only the process that acquired it may write.
+            FileStream? lockFile = TryTakeLockFile(scope);
+            if (lockFile is null)
+            {
+                session = null;
+                return false;
+            }
+
+            Guid leaseId = Guid.NewGuid();
+            _leases.Add(scope, leaseId);
+            session = new Session(this, scope, leaseId, lockFile);
+            return true;
+        }
+    }
+
+    private FileStream? TryTakeLockFile(CaptionDraftScope scope)
+    {
+        FileStream? lockFile = null;
+        try
+        {
+            Directory.CreateDirectory(StorageDirectory);
+            bool useUnixFileLock = OperatingSystem.IsLinux() || OperatingSystem.IsMacOS();
+            lockFile = new FileStream(
+                GetStoragePath(scope) + ".lock",
+                FileMode.OpenOrCreate,
+                FileAccess.ReadWrite,
+                useUnixFileLock ? FileShare.ReadWrite : FileShare.None,
+                bufferSize: 1,
+                FileOptions.None);
+            if (useUnixFileLock
+                && Flock(lockFile.SafeFileHandle, UnixLockExclusive | UnixLockNonBlocking) != 0)
+            {
+                lockFile.Dispose();
+                return null;
+            }
+
+            // Keep the reusable empty file named. Unlinking it while or immediately after the
+            // lease is held lets another process lock a different inode at the same path.
+            return lockFile;
+        }
+        catch (IOException)
+        {
+            lockFile?.Dispose();
+            // Another process owns the draft.
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            lockFile?.Dispose();
+            return null;
+        }
+    }
+
+    [System.Runtime.InteropServices.DllImport("libc", EntryPoint = "flock", SetLastError = true)]
+    private static extern int Flock(
+        Microsoft.Win32.SafeHandles.SafeFileHandle fileHandle,
+        int operation);
+
+    internal string GetStoragePath(CaptionDraftScope scope)
+    {
+        byte[] identity = JsonSerializer.SerializeToUtf8Bytes(scope, s_jsonOptions);
+        string fileName = Convert.ToHexString(SHA256.HashData(identity)) + ".json";
+        return Path.Combine(StorageDirectory, fileName);
+    }
+
+    private CaptionDraftReadResult Read(CaptionDraftScope scope, Guid leaseId)
+    {
+        lock (_gate)
+        {
+            EnsureLease(scope, leaseId);
+            string storagePath = GetStoragePath(scope);
+            DeleteStaleTemporaryFiles(storagePath);
+            if (!File.Exists(storagePath))
+                return CaptionDraftReadResult.Absent;
+
+            byte[] bytes;
+            try
+            {
+                var info = new FileInfo(storagePath);
+                if (info.Length is <= 0 or > MaximumStorageBytes)
+                {
+                    DeleteInvalidFile(storagePath);
+                    return CaptionDraftReadResult.Absent;
+                }
+
+                bytes = File.ReadAllBytes(storagePath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Unreadable is not absent. Do not delete or overwrite a draft that may contain
+                // an already-paid request name.
+                return CaptionDraftReadResult.Unreadable;
+            }
+
+            try
+            {
+                CaptionDraftEnvelope? envelope = JsonSerializer.Deserialize<CaptionDraftEnvelope>(
+                    bytes,
+                    s_jsonOptions);
+                // A newer version wrote this draft. It is unreadable, not corrupt; deleting it
+                // after downgrading would lose paid request names even after upgrading again.
+                if (envelope is not null && envelope.Version > CurrentVersion)
+                    return CaptionDraftReadResult.Unreadable;
+
+                if (envelope is null
+                    || envelope.Version < OldestSupportedVersion
+                    || envelope.Scope != scope)
+                {
+                    DeleteInvalidFile(storagePath);
+                    return CaptionDraftReadResult.Absent;
+                }
+
+                CaptionDraft draft = Migrate(
+                    envelope.Draft,
+                    envelope.Version,
+                    RecordsNamePending(bytes, envelope.Version));
+                CaptionDraftEntry[] recoveries = envelope.Recoveries ?? [];
+                var entry = new CaptionDraftEntry(envelope.JobId, draft, recoveries);
+                if (!IsValid(entry))
+                {
+                    DeleteInvalidFile(storagePath);
+                    return CaptionDraftReadResult.Absent;
+                }
+                return new CaptionDraftReadResult(
+                    CaptionDraftReadOutcome.Read,
+                    entry);
+            }
+            catch (Exception ex) when (ex is JsonException
+                or NotSupportedException
+                or ArgumentException)
+            {
+                // The document was readable but is not a valid draft, so it may be removed.
+                DeleteInvalidFile(storagePath);
+                return CaptionDraftReadResult.Absent;
+            }
+        }
+    }
+
+    private void Save(CaptionDraftScope scope, Guid leaseId, CaptionDraftEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        if (!IsValid(entry))
+            throw new ArgumentException("The caption draft is invalid.", nameof(entry));
+
+        lock (_gate)
+        {
+            EnsureLease(scope, leaseId);
+            string storagePath = GetStoragePath(scope);
+            DeleteStaleTemporaryFiles(storagePath);
+            var envelope = new CaptionDraftEnvelope(
+                CurrentVersion,
+                scope,
+                entry.JobId,
+                entry.Draft,
+                entry.Recoveries);
+            byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(envelope, s_jsonOptions);
+            if (bytes.Length > MaximumStorageBytes)
+                throw new InvalidOperationException("The caption draft exceeds the storage limit.");
+
+            if (OperatingSystem.IsWindows())
+                Directory.CreateDirectory(StorageDirectory);
+            else
+                Directory.CreateDirectory(
+                    StorageDirectory,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            string temporaryPath = storagePath + $".{Guid.NewGuid():N}.tmp";
+            try
+            {
+                var options = new FileStreamOptions
+                {
+                    Mode = FileMode.CreateNew,
+                    Access = FileAccess.Write,
+                    Share = FileShare.None,
+                    Options = FileOptions.WriteThrough,
+                };
+                if (!OperatingSystem.IsWindows())
+                    options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+                using (FileStream stream = new(temporaryPath, options))
+                {
+                    stream.Write(bytes);
+                    stream.Flush(flushToDisk: true);
+                }
+                File.Move(temporaryPath, storagePath, overwrite: true);
+                RestrictFileAccess(storagePath);
+            }
+            finally
+            {
+                try
+                {
+                    File.Delete(temporaryPath);
+                }
+                catch (IOException)
+                {
+                }
+                catch (UnauthorizedAccessException)
+                {
+                }
+            }
+        }
+    }
+
+    private void Delete(CaptionDraftScope scope, Guid leaseId)
+    {
+        lock (_gate)
+        {
+            EnsureLease(scope, leaseId);
+            File.Delete(GetStoragePath(scope));
+        }
+    }
+
+    private void Release(CaptionDraftScope scope, Guid leaseId)
+    {
+        lock (_gate)
+        {
+            if (_leases.TryGetValue(scope, out Guid currentLease) && currentLease == leaseId)
+            {
+                _leases.Remove(scope);
+            }
+        }
+    }
+
+    private void EnsureLease(CaptionDraftScope scope, Guid leaseId)
+    {
+        if (!_leases.TryGetValue(scope, out Guid currentLease) || currentLease != leaseId)
+            throw new InvalidOperationException("The caption draft session no longer owns this scope.");
+    }
+
+    private static JsonSerializerOptions CreateJsonOptions()
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false,
+        };
+        options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase, false));
+        return options;
+    }
+
+    // Version 1 spans the period after seeds were stored but before models were stored. A seed
+    // without a model is indistinguishable from a request that intentionally omitted the model;
+    // guessing wrong would rename and repurchase already-paid chunks.
+    //
+    // Only the name is ambiguous, so drop the name while preserving paid results; unsent chunks
+    // are then priced as new work. This flag records whether the draft actually stored its
+    // pending-name state. Version 2 contains documents from before and after that field was added,
+    // and a stored false is otherwise indistinguishable from a missing false.
+    private static bool RecordsNamePending(byte[] bytes, int version)
+    {
+        if (version != 2)
+            return false;
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(bytes);
+            if (!document.RootElement.TryGetProperty("draft", out JsonElement draft))
+                return false;
+
+            foreach (string resume in
+                (string[])["translationResume", "sourceTranscriptionResume", "sceneTranscriptionResume"])
+            {
+                if (draft.TryGetProperty(resume, out JsonElement element)
+                    && element.ValueKind == JsonValueKind.Object
+                    && element.TryGetProperty("requestKeyNamePending", out _))
+                {
+                    return true;
+                }
+            }
+        }
+        catch (JsonException)
+        {
+        }
+
+        return false;
+    }
+
+    private static CaptionDraft Migrate(CaptionDraft draft, int version, bool recordsNamePending)
+    {
+        if (version >= CurrentVersion)
+            return draft;
+
+        if (version >= 3)
+            return draft with { Version = CurrentVersion };
+
+        // Honor an explicitly stored value. A missing value came from version 2 before the field
+        // existed, where a seed means the draft held a name.
+        if (version == 2 && recordsNamePending)
+            return draft with { Version = CurrentVersion };
+
+        // Version 2 did not store whether a name remained pending. Reading that as false would
+        // make a run with an unanswered first chunk unrecoverable and charge again. Version 2 also
+        // did not settle names after each returned chunk, so a seed is treated as a held name. If
+        // that guess is too cautious and the server finds nothing, it simply handles a normal new charge.
+        if (version == 2)
+        {
+            return draft with
+            {
+                Version = CurrentVersion,
+                TranslationResume = draft.TranslationResume is { } pendingTranslation
+                    ? pendingTranslation with
+                    {
+                        RequestKeyNamePending =
+                            !string.IsNullOrEmpty(pendingTranslation.RequestKeySeed),
+                    }
+                    : null,
+                SourceTranscriptionResume =
+                    draft.SourceTranscriptionResume is { } pendingSource
+                        ? pendingSource with
+                        {
+                            RequestKeyNamePending =
+                                !string.IsNullOrEmpty(pendingSource.RequestKeySeed),
+                        }
+                        : null,
+                SceneTranscriptionResume =
+                    draft.SceneTranscriptionResume is { } pendingScene
+                        ? pendingScene with
+                        {
+                            RequestKeyNamePending =
+                                !string.IsNullOrEmpty(pendingScene.RequestKeySeed),
+                        }
+                        : null,
+            };
+        }
+
+        return draft with
+        {
+            Version = CurrentVersion,
+            TranslationResume = draft.TranslationResume is { } translation
+                ? translation with
+                {
+                    RequestKeySeed = string.Empty,
+                    RequestKeyModel = string.Empty,
+                    RequestKeyNamePending = false,
+                }
+                : null,
+            SourceTranscriptionResume = draft.SourceTranscriptionResume is { } source
+                ? source with
+                {
+                    RequestKeySeed = string.Empty,
+                    RequestKeyModel = string.Empty,
+                    RequestKeyNamePending = false,
+                }
+                : null,
+            SceneTranscriptionResume = draft.SceneTranscriptionResume is { } scene
+                ? scene with
+                {
+                    RequestKeySeed = string.Empty,
+                    RequestKeyModel = string.Empty,
+                    RequestKeyNamePending = false,
+                }
+                : null,
+        };
+    }
+
+    private static bool IsValid(CaptionDraft draft)
+    {
+        if (draft.Version != CurrentVersion
+            || draft.Cues is null
+            || draft.Cues.Length > MaximumCueCount
+            || draft.Cues.Any(cue => cue is null
+                || cue.Text is null
+                || cue.Text.Length > MaximumCueTextLength
+                || cue.StartTicks < 0
+                || cue.EndTicks <= cue.StartTicks
+                || cue.Metadata is null
+                || cue.Metadata.Any(pair =>
+                    string.IsNullOrWhiteSpace(pair.Key) || pair.Value is null))
+            // Nothing finished yet is a run worth keeping: it holds the names
+            // its first pieces were sent under, which is what makes them
+            // collectable rather than something to buy a second time.
+            || draft.CompletedSteps < 0
+            || draft.TotalSteps < draft.CompletedSteps)
+        {
+            return false;
+        }
+
+        return draft.Kind switch
+        {
+            CaptionDraftKind.Translation => draft.Cues.Length > 0
+                && IsValid(draft.TranslationResume)
+                && draft.SceneTranscriptionResume is null
+                && draft.SourceTranscriptionResume is null,
+            CaptionDraftKind.Transcription => IsValidTranscriptionDraft(draft),
+            _ => false,
+        };
+    }
+
+    private static bool IsValid(CaptionDraftEntry entry)
+        => IsValid(entry.Draft)
+            && entry.Recoveries is { Length: <= MaximumRetainedRecoveries }
+            && entry.Recoveries.All(recovery => recovery is not null
+                && recovery.Recoveries.Length == 0
+                && IsValid(recovery.Draft));
+
+    private static bool IsValidTranscriptionDraft(CaptionDraft draft)
+        => draft.TranslationResume is null
+            && draft.Segments is not null
+            && (IsValid(draft.SceneTranscriptionResume)
+                && draft.SourceTranscriptionResume is null
+                || IsValid(draft.SourceTranscriptionResume)
+                && draft.SceneTranscriptionResume is null
+                || draft.SceneTranscriptionResume is null
+                && draft.SourceTranscriptionResume is null
+                && draft.CompletedSteps == draft.TotalSteps);
+
+    private static bool IsValid(CaptionTranslationResume? resume)
+        => resume is
+        {
+            SourceCues.Length: > 0 and <= MaximumCueCount,
+            CompletedBatchCount: >= 0,
+        }
+            && !string.IsNullOrWhiteSpace(resume.TargetLanguage)
+            && (resume.MaxSegments == 0
+                && resume.MaxCharacters == 0
+                && resume.MaxRequestBytes == 0
+                || resume.MaxSegments > 0
+                && resume.MaxCharacters > 0
+                && resume.MaxRequestBytes > 0)
+            && resume.SourceCues.All(cue => cue is not null
+                && cue.Text is not null
+                && cue.Text.Length <= MaximumCueTextLength
+                && cue.StartTicks >= 0
+                && cue.EndTicks > cue.StartTicks
+                && cue.Metadata is not null)
+            && resume.TranslatedPieces is not null
+            && (resume.CompletedBatchCount > 0) == (resume.TranslatedPieces.Count > 0)
+            && resume.TranslatedPieces.All(pair =>
+                !string.IsNullOrWhiteSpace(pair.Key)
+                && !string.IsNullOrWhiteSpace(pair.Value)
+                && pair.Value.Length <= MaximumCueTextLength);
+
+    private static bool IsValid(CaptionSceneTranscriptionResume? resume)
+        => resume is
+        {
+            ChunkCount: > 0,
+            CompletedChunkCount: >= 0,
+            Duration: { } duration,
+            ChunkDuration: { } chunkDuration,
+            Segments: not null,
+        }
+            && resume.CompletedChunkCount <= resume.ChunkCount
+            && resume.SceneId != Guid.Empty
+            && duration > TimeSpan.Zero
+            && chunkDuration > TimeSpan.Zero
+            && resume.Segments.All(segment => segment is not null
+                && double.IsFinite(segment.Start)
+                && double.IsFinite(segment.End)
+                && segment.End > segment.Start
+                && segment.Text is not null
+                && segment.Text.Length <= MaximumCueTextLength);
+
+    private static bool IsValid(CaptionSourceTranscriptionResume? resume)
+        => resume is
+        {
+            SampleRate: > 0,
+            TotalSamples: > 0 and <= int.MaxValue,
+            ChunkSamples: > 0,
+            ChunkCount: > 0,
+            CompletedChunkCount: >= 0,
+            Segments: not null,
+        }
+            && resume.CompletedChunkCount <= resume.ChunkCount
+            && (resume.CompletedChunkCount == resume.ChunkCount
+                || resume.TotalSamples > (long)resume.ChunkSamples
+                    * resume.CompletedChunkCount)
+            && resume.ChunkCount == checked((int)Math.Ceiling(
+                resume.TotalSamples / (double)resume.ChunkSamples))
+            && !string.IsNullOrWhiteSpace(resume.FilePath)
+            && Path.IsPathFullyQualified(resume.FilePath)
+            && resume.FileLength > 0
+            && resume.LastWriteTimeUtcTicks >= 0
+            && resume.LastWriteTimeUtcTicks <= DateTime.MaxValue.Ticks
+            && resume.Segments.All(segment => segment is not null
+                && double.IsFinite(segment.Start)
+                && double.IsFinite(segment.End)
+                && segment.End > segment.Start
+                && segment.Text is not null
+                && segment.Text.Length <= MaximumCueTextLength);
+
+    private static void DeleteInvalidFile(string storagePath)
+    {
+        try
+        {
+            File.Delete(storagePath);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private static void DeleteStaleTemporaryFiles(string storagePath)
+    {
+        string? directory = Path.GetDirectoryName(storagePath);
+        if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
+            return;
+
+        string pattern = Path.GetFileName(storagePath) + ".*.tmp";
+        try
+        {
+            foreach (string path in Directory.EnumerateFiles(directory, pattern))
+            {
+                try
+                {
+                    if (File.GetLastWriteTimeUtc(path) > DateTime.UtcNow.AddHours(-1))
+                        continue;
+                    File.Delete(path);
+                }
+                catch (IOException)
+                {
+                }
+                catch (UnauthorizedAccessException)
+                {
+                }
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private static void RestrictFileAccess(string path)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        try
+        {
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+        catch (PlatformNotSupportedException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    private sealed record CaptionDraftEnvelope(
+        int Version,
+        CaptionDraftScope Scope,
+        string? JobId,
+        CaptionDraft Draft,
+        CaptionDraftEntry[]? Recoveries = null);
+
+    private sealed class Session(
+        FileCaptionDraftStore owner,
+        CaptionDraftScope scope,
+        Guid leaseId,
+        FileStream lockFile) : ICaptionDraftSession
+    {
+        private FileCaptionDraftStore? _owner = owner;
+
+        public CaptionDraftScope Scope { get; } = scope;
+
+        public CaptionDraftReadResult Read()
+            => GetOwner().Read(Scope, leaseId);
+
+        public void Save(CaptionDraftEntry entry)
+            => GetOwner().Save(Scope, leaseId, entry);
+
+        public void Delete()
+            => GetOwner().Delete(Scope, leaseId);
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _owner, null) is not { } owner)
+                return;
+
+            owner.Release(Scope, leaseId);
+            try
+            {
+                lockFile.Dispose();
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+
+        private FileCaptionDraftStore GetOwner()
+            => Volatile.Read(ref _owner)
+                ?? throw new ObjectDisposedException(nameof(ICaptionDraftSession));
+    }
+}
+
+internal static class CaptionDraftStoreProvider
+{
+    private static readonly Lazy<ICaptionDraftStore> s_current = new(() =>
+        new FileCaptionDraftStore(Path.Combine(
+            BeutlEnvironment.GetHomeDirectoryPath(),
+            "ai-caption-drafts")));
+    private static ICaptionDraftStore? s_override;
+
+    public static ICaptionDraftStore Current => Volatile.Read(ref s_override) ?? s_current.Value;
+
+    internal static void SetCurrentForTesting(ICaptionDraftStore? store)
+        => Volatile.Write(ref s_override, store);
+}

--- a/src/Beutl/Services/AI/CaptionPresentationDefaults.cs
+++ b/src/Beutl/Services/AI/CaptionPresentationDefaults.cs
@@ -1,0 +1,16 @@
+﻿using Beutl.Editor.Services.Captions;
+using Beutl.Media;
+
+namespace Beutl.Services.AI;
+
+internal static class CaptionPresentationDefaults
+{
+    internal const string FontFamilyName = "Noto Sans JP";
+
+    internal static FontFamily FontFamily { get; } = new(FontFamilyName);
+
+    internal static DefaultTextCaptionElementFactory ElementFactory { get; } = new(FontFamily);
+
+    internal static CaptionTemplateRegistrationSet CreateDefaultText(string name)
+        => CaptionTemplateDefaults.CreateDefaultText(name, ElementFactory);
+}

--- a/src/Beutl/Services/AI/CaptionTemplatePreviewRenderer.cs
+++ b/src/Beutl/Services/AI/CaptionTemplatePreviewRenderer.cs
@@ -1,0 +1,28 @@
+﻿using Beutl.Editor.Services;
+using Beutl.Media;
+using Beutl.ProjectSystem;
+
+namespace Beutl.Services.AI;
+
+internal static class CaptionTemplatePreviewRenderer
+{
+    private static readonly PixelSize s_outputSize = new(1024, 576);
+
+    public static async ValueTask<byte[]?> RenderPngAsync(
+        IReadOnlyList<Element> elements,
+        Beutl.Media.PixelSize frameSize,
+        CancellationToken cancellationToken)
+    {
+        if (elements.Count == 0 || frameSize.Width <= 0 || frameSize.Height <= 0)
+            return null;
+
+        // Render captions at 4x the object-template thumbnail density. The UI scales this bitmap
+        // down to its display size, preserving glyph detail that would otherwise be lost at 256x144.
+        return await ObjectTemplatePreviewRenderer.RenderElementsPngAsync(
+                elements,
+                frameSize,
+                s_outputSize,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Beutl/Services/AI/FileAiRequestRecoveryStore.cs
+++ b/src/Beutl/Services/AI/FileAiRequestRecoveryStore.cs
@@ -1,0 +1,2229 @@
+﻿using System.ComponentModel;
+using System.Diagnostics;
+using System.Reactive.Linq;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Beutl.Api.Objects;
+using Beutl.Api.Services;
+
+namespace Beutl.Services.AI;
+
+/// <summary>
+/// A source referenced by a pending paid request. The row contains only a
+/// locator and a content stamp; the content itself is kept in a private
+/// recovery copy only when the original locator is process-local.
+/// </summary>
+internal sealed record AiRequestRecoverySource(
+    string Role,
+    string? Path,
+    string Name,
+    string ContentHash,
+    long Length,
+    string? DurableFile = null,
+    string? ElementId = null)
+{
+    [JsonIgnore]
+    public bool IsDurable => !string.IsNullOrEmpty(DurableFile);
+}
+
+/// <summary>
+/// Canonical form state needed to rebuild one request after a process restart.
+/// Nullable members are intentional: each form uses a different subset, while
+/// an explicit null model is represented by <see cref="AiPendingAttempt.Model"/>
+/// rather than by an absent recovery row.
+/// </summary>
+internal sealed record AiRequestFormSnapshot(
+    string? Prompt = null,
+    string? Style = null,
+    string? Composition = null,
+    string? Motion = null,
+    string? Exclusions = null,
+    string? Task = null,
+    string? AspectRatio = null,
+    string? Background = null,
+    int? Seed = null,
+    int? DurationSeconds = null,
+    string? Resolution = null,
+    bool? GenerateAudio = null,
+    int? OutpaintExpansionPercent = null,
+    int? MaxReferenceImages = null,
+    long? MaxReferenceTotalBytes = null,
+    bool? SupportsReferenceImage = null,
+    bool? SupportsSeed = null,
+    bool? HasBackgroundChoice = null,
+    bool? SupportsAudio = null,
+    bool? SupportsFirstFrame = null,
+    bool? SupportsLastFrame = null,
+    string? SourceName = null,
+    bool? SourceIsPrepared = null,
+    string? SourceElementId = null,
+    string? FirstFrameElementId = null,
+    string? LastFrameElementId = null);
+
+/// <summary>
+/// The complete durable identity of a request whose server outcome is not yet
+/// known. This is deliberately an internal domain record: API request DTOs do
+/// not own recovery state and therefore cannot accidentally serialize it.
+/// </summary>
+internal sealed record AiPendingAttempt(
+    string AccountId,
+    string Operation,
+    string Fingerprint,
+    string Key,
+    string? Model = null,
+    AiRequestFormSnapshot? Form = null,
+    IReadOnlyList<AiRequestRecoverySource>? Sources = null)
+{
+    [JsonIgnore]
+    public IReadOnlyList<AiRequestRecoverySource> EffectiveSources
+        => Sources ?? Array.Empty<AiRequestRecoverySource>();
+
+    [JsonIgnore]
+    public bool HasCanonicalForm => Form is not null;
+
+    [JsonIgnore]
+    public string DisplayName
+    {
+        get
+        {
+            string operation = Operation switch
+            {
+                "image.generate" => "Image generation",
+                "video.generate" => "Video generation",
+                _ when Operation.StartsWith("image.edit.", StringComparison.Ordinal)
+                    => "Image edit",
+                _ => "AI request",
+            };
+            return Model is { Length: > 0 }
+                ? $"{operation} ({Model})"
+                : $"{operation} (default model)";
+        }
+    }
+}
+
+internal sealed class AiRequestRecoveryLease : IDisposable
+{
+    private readonly FileAiRequestRecoveryStore _store;
+    private const int ActiveState = 0;
+    private const int DispatchingState = 1;
+    private const int DispatchedState = 2;
+    private const int ReleasedState = 3;
+    private int _state;
+    private int _everDispatched;
+    private Timer? _renewalTimer;
+    private int _renewing;
+    private static readonly TimeSpan RenewalCadence = TimeSpan.FromMinutes(5);
+
+    internal Action? BeforeReacquirePublish { get; set; }
+
+    internal Action? BeforeDispatchCompareExchange { get; set; }
+
+    internal AiRequestRecoveryLease(
+        FileAiRequestRecoveryStore store,
+        string accountId,
+        string operation,
+        string fingerprint,
+        string key,
+        int generation,
+        string ownerToken,
+        bool dispatched = false)
+    {
+        _store = store;
+        AccountId = accountId;
+        Operation = operation;
+        Fingerprint = fingerprint;
+        Key = key;
+        Generation = generation;
+        OwnerToken = ownerToken;
+        _state = dispatched ? DispatchedState : ActiveState;
+        _everDispatched = dispatched ? 1 : 0;
+        if (dispatched)
+            StartRenewalTimer();
+    }
+
+    internal string AccountId { get; }
+
+    internal string Operation { get; }
+
+    internal string Fingerprint { get; }
+
+    internal string Key { get; }
+
+    internal int Generation { get; }
+
+    internal string OwnerToken { get; }
+
+    internal bool IsDispatched => Volatile.Read(ref _state) == DispatchedState;
+
+    internal bool IsReleased => Volatile.Read(ref _state) == ReleasedState;
+
+    internal bool WasDispatched => Volatile.Read(ref _everDispatched) != 0;
+
+    internal bool MarkDispatched()
+    {
+        SpinWait spinner = new();
+        bool compareHookInvoked = false;
+        while (true)
+        {
+            int state = Volatile.Read(ref _state);
+            if (state == DispatchedState)
+                return true;
+            if (state == DispatchingState)
+            {
+                spinner.SpinOnce();
+                continue;
+            }
+            if (state != ActiveState)
+                return false;
+            if (!compareHookInvoked)
+            {
+                BeforeDispatchCompareExchange?.Invoke();
+                compareHookInvoked = true;
+            }
+            if (Interlocked.CompareExchange(ref _state, DispatchingState, ActiveState) != ActiveState)
+                continue;
+            break;
+        }
+
+        bool persisted;
+        try
+        {
+            persisted = _store.MarkClaimDispatched(this);
+        }
+        catch
+        {
+            Volatile.Write(ref _state, ActiveState);
+            throw;
+        }
+        if (!persisted)
+        {
+            Volatile.Write(ref _state, ActiveState);
+            return false;
+        }
+
+        StartRenewalTimer();
+        Volatile.Write(ref _everDispatched, 1);
+        if (Interlocked.CompareExchange(ref _state, DispatchedState, DispatchingState)
+            != DispatchingState)
+        {
+            Interlocked.Exchange(ref _renewalTimer, null)?.Dispose();
+            return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Extends the durable dispatched fence. Call on a cadence shorter than
+    /// <see cref="FileAiRequestRecoveryStore.ClaimLifetime"/> while provider
+    /// work is active; returns false after expiry, settle, or owner loss.
+    /// </summary>
+    internal bool Renew()
+        => Volatile.Read(ref _state) == DispatchedState
+            && _store.RenewClaim(this);
+
+    /// <summary>
+    /// Reacquires this process's own dispatched fence after an unknown result.
+    /// The owner token is part of the compare-and-swap, so another process can
+    /// never take over through this path.
+    /// </summary>
+    internal bool Reacquire()
+    {
+        int state = Volatile.Read(ref _state);
+        if (Volatile.Read(ref _everDispatched) == 0
+            || state == DispatchingState)
+            return false;
+
+        if (state != DispatchedState
+            && Interlocked.CompareExchange(ref _state, DispatchingState, ReleasedState)
+                != ReleasedState)
+            return false;
+        if (state == DispatchedState
+            && Interlocked.CompareExchange(ref _state, DispatchingState, DispatchedState)
+                != DispatchedState)
+            return false;
+
+        try
+        {
+            bool reacquired = _store.ReacquireClaim(this);
+            if (reacquired)
+            {
+                StartRenewalTimer();
+                BeforeReacquirePublish?.Invoke();
+                if (Interlocked.CompareExchange(ref _state, DispatchedState, DispatchingState)
+                    != DispatchingState)
+                {
+                    Interlocked.Exchange(ref _renewalTimer, null)?.Dispose();
+                    return false;
+                }
+            }
+            else
+            {
+                Volatile.Write(ref _state, ReleasedState);
+                Interlocked.Exchange(ref _renewalTimer, null)?.Dispose();
+            }
+            return reacquired;
+        }
+        catch
+        {
+            // A failed lock/read/write must not strand the lease in the
+            // transitional state. Dispose must remain terminating.
+            Volatile.Write(ref _state, ReleasedState);
+            Interlocked.Exchange(ref _renewalTimer, null)?.Dispose();
+            throw;
+        }
+    }
+
+    private void StartRenewalTimer()
+    {
+        Timer? timer = _renewalTimer;
+        if (timer is null)
+        {
+            timer = new Timer(
+                static state => ((AiRequestRecoveryLease)state!).RenewTick(),
+                this,
+                Timeout.InfiniteTimeSpan,
+                Timeout.InfiniteTimeSpan);
+            Timer? previous = Interlocked.CompareExchange(ref _renewalTimer, timer, null);
+            if (previous is not null)
+            {
+                timer.Dispose();
+                timer = previous;
+            }
+        }
+        timer.Change(RenewalCadence, RenewalCadence);
+    }
+
+    private void RenewTick()
+    {
+        if (Volatile.Read(ref _state) != DispatchedState
+            || Interlocked.Exchange(ref _renewing, 1) != 0)
+            return;
+        try
+        {
+            if (!Renew())
+                _renewalTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceWarning("AI recovery claim renewal failed: {0}", ex.Message);
+        }
+        finally
+        {
+            Volatile.Write(ref _renewing, 0);
+        }
+    }
+
+    public void Dispose()
+    {
+        while (true)
+        {
+            int state = Volatile.Read(ref _state);
+            if (state == ReleasedState)
+                return;
+            if (state == DispatchingState)
+            {
+                Thread.Yield();
+                continue;
+            }
+            if (Interlocked.CompareExchange(ref _state, ReleasedState, state) == state)
+                break;
+        }
+
+        Timer? timer = Interlocked.Exchange(ref _renewalTimer, null);
+        timer?.Dispose();
+        _store.ReleaseClaim(this, force: false);
+    }
+}
+
+/// <summary>Atomic, bounded local storage for unresolved metered AI attempts.</summary>
+internal sealed class FileAiRequestRecoveryStore : IDisposable
+{
+    // Keep the version at one so rows written by the previous key-only store
+    // remain readable. They are intentionally marked as lacking a form and can
+    // never be silently replayed as a newly shaped request.
+    private const int Version = 1;
+    private const int MaximumBytes = 1024 * 1024;
+    private const int MaximumRecords = 256;
+    private const int MaximumSourcesPerRecord = 16;
+    private const int MaximumPromptLength = 32_000;
+    private const int MaximumScalarLength = 4_096;
+    private const int MaximumPathLength = 4_096;
+    private const long MaximumSourceBytes = 256L * 1024 * 1024;
+    private static readonly TimeSpan OrphanSourceAge = TimeSpan.FromHours(1);
+    private const string SourceDirectoryName = "ai-request-recovery-sources";
+    private const int MaximumGenerationEntries = 1_024;
+    private const int MaximumClaims = 256;
+    private static readonly TimeSpan ClaimLifetime = TimeSpan.FromMinutes(15);
+
+    private readonly object _gate = new();
+    private readonly HashSet<string> _newSourceFiles = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, FileStream> _pendingPublicationMarkers = new(StringComparer.Ordinal);
+    private readonly string _path;
+    private readonly string _sourceDirectory;
+    private readonly string _generationPath;
+    private readonly string _claimPath;
+    private readonly Func<DateTimeOffset> _utcNow;
+    private string LockPath => _path + ".lock";
+
+    public FileAiRequestRecoveryStore(
+        string storageDirectory,
+        Func<DateTimeOffset>? utcNow = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(storageDirectory);
+        string fullDirectory = Path.GetFullPath(storageDirectory);
+        Directory.CreateDirectory(fullDirectory);
+        RestrictDirectory(fullDirectory);
+        _path = Path.Combine(fullDirectory, "ai-request-recovery.json");
+        _sourceDirectory = Path.Combine(fullDirectory, SourceDirectoryName);
+        _generationPath = Path.Combine(fullDirectory, "ai-request-recovery-generations.json");
+        _claimPath = Path.Combine(fullDirectory, "ai-request-recovery-claims.json");
+        _utcNow = utcNow ?? (() => DateTimeOffset.UtcNow);
+        Directory.CreateDirectory(_sourceDirectory);
+        RestrictDirectory(_sourceDirectory);
+        SweepStoreTemporaryFiles(fullDirectory);
+        SweepOrphanedSources();
+    }
+
+    internal string StoragePath => _path;
+
+    internal string SourceDirectory => _sourceDirectory;
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            foreach (FileStream marker in _pendingPublicationMarkers.Values)
+                marker.Dispose();
+            _pendingPublicationMarkers.Clear();
+        }
+    }
+
+    internal int GetGeneration(string accountId, string operation, string fingerprint)
+    {
+        ValidateIdentity(accountId, operation, fingerprint);
+        lock (_gate)
+        {
+            using FileStream lease = AcquireLock();
+            return LoadGenerations().FirstOrDefault(entry =>
+                entry.AccountId == accountId
+                && entry.Operation == operation
+                && entry.Fingerprint == fingerprint)?.Generation ?? 0;
+        }
+    }
+
+    internal int AdvanceGeneration(string accountId, string operation, string fingerprint)
+    {
+        ValidateIdentity(accountId, operation, fingerprint);
+        lock (_gate)
+        {
+            using FileStream lease = AcquireLock();
+            return AdvanceGenerationCore(accountId, operation, fingerprint);
+        }
+    }
+
+    internal static AiRequestRecoverySource CreateExternalSource(
+        string role,
+        string path,
+        string name,
+        ReadOnlySpan<byte> content,
+        string? elementId = null)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("A source path is required.", nameof(path));
+        return new AiRequestRecoverySource(
+            role,
+            path,
+            name,
+            Convert.ToHexString(SHA256.HashData(content)),
+            content.Length,
+            DurableFile: null,
+            elementId);
+    }
+
+    internal AiPendingAttempt? Find(string accountId, string operation, string fingerprint)
+    {
+        lock (_gate)
+        {
+            ValidateIdentity(accountId, operation, fingerprint);
+            using FileStream lease = AcquireLock();
+            return Load().FirstOrDefault(x => x.AccountId == accountId
+                && x.Operation == operation
+                && x.Fingerprint == fingerprint);
+        }
+    }
+
+    internal bool TryUpdateForm(
+        string accountId,
+        string operation,
+        string fingerprint,
+        string key,
+        AiRequestFormSnapshot form,
+        IReadOnlyList<AiRequestRecoverySource>? sources)
+    {
+        lock (_gate)
+        {
+            ValidateIdentity(accountId, operation, fingerprint);
+            using FileStream lease = AcquireLock();
+            List<AiPendingAttempt> records = Load();
+            int index = records.FindIndex(attempt => attempt.AccountId == accountId
+                && attempt.Operation == operation
+                && attempt.Fingerprint == fingerprint
+                && attempt.Key == key);
+            if (index < 0)
+                return false;
+            records[index] = records[index] with { Form = form, Sources = sources ?? Array.Empty<AiRequestRecoverySource>() };
+            ValidateRecord(records[index]);
+            Save(records);
+            MarkSourcesCommitted(records[index].EffectiveSources);
+            return true;
+        }
+    }
+
+    internal IReadOnlyList<AiPendingAttempt> PendingFor(string accountId, string operation)
+    {
+        ValidateText(accountId, 128, nameof(accountId));
+        ValidateText(operation, 128, nameof(operation));
+        lock (_gate)
+        {
+            using FileStream lease = AcquireLock();
+            return Load()
+                .Where(record => record.AccountId == accountId
+                    && (record.Operation == operation
+                        || record.Operation.StartsWith(operation + ".", StringComparison.Ordinal)))
+                .ToArray();
+        }
+    }
+
+    internal AiPendingAttempt WriteOrGet(AiPendingAttempt attempt)
+    {
+        lock (_gate)
+        {
+            // Keep the on-disk shape unambiguous. A missing source list means
+            // "no sources", never "the parser could not tell"; this also
+            // makes a form without sources round-trip through the strict
+            // current schema.
+            attempt = attempt with { Sources = attempt.Sources ?? Array.Empty<AiRequestRecoverySource>() };
+            ValidateRecord(attempt);
+            using FileStream lease = AcquireLock();
+            List<AiPendingAttempt> records = Load();
+            int existingIndex = records.FindIndex(x => x.AccountId == attempt.AccountId
+                && x.Operation == attempt.Operation
+                && x.Fingerprint == attempt.Fingerprint);
+            if (existingIndex >= 0)
+            {
+                AiPendingAttempt existing = records[existingIndex];
+                // The first key is authoritative. A later call may fill in a
+                // form snapshot after an older key-only row, but can never
+                // replace a durable identity with another key.
+                if (!existing.HasCanonicalForm && attempt.HasCanonicalForm)
+                {
+                    records[existingIndex] = attempt with { Key = existing.Key };
+                    Save(records);
+                    MarkSourcesCommitted(attempt.EffectiveSources);
+                    return records[existingIndex];
+                }
+
+                DeleteUncommittedSourcesCore(attempt.EffectiveSources, records);
+
+                return existing;
+            }
+
+            if (records.Count >= MaximumRecords)
+                throw new InvalidDataException(
+                    "AI request recovery store is full; unresolved attempts were retained.");
+
+            records.Add(attempt);
+            Save(records);
+            MarkSourcesCommitted(attempt.EffectiveSources);
+            return attempt;
+        }
+    }
+
+    internal AiRequestRecoveryLease? Claim(
+        string accountId,
+        string operation,
+        string fingerprint,
+        string key)
+    {
+        ValidateIdentity(accountId, operation, fingerprint);
+        if (!IsPrintable(key, 255))
+            throw new InvalidDataException("AI request recovery key is invalid.");
+        lock (_gate)
+        {
+            using FileStream lease = AcquireLock();
+            AiPendingAttempt? current = Load().FirstOrDefault(attempt =>
+                attempt.AccountId == accountId
+                && attempt.Operation == operation
+                && attempt.Fingerprint == fingerprint);
+            if (current is null || !StringComparer.Ordinal.Equals(current.Key, key))
+                throw new InvalidDataException("AI request recovery attempt is stale.");
+
+            int generation = GetGenerationCore(accountId, operation, fingerprint);
+            List<AiRequestRecoveryClaim> claims = LoadClaims();
+            DateTimeOffset now = _utcNow();
+            // A dispatched claim is a durable paid-job fence. Expiry controls
+            // renewal only; it cannot make the request abandonable or reusable.
+            claims.RemoveAll(claim => !claim.Dispatched && claim.ExpiresAt <= now);
+            int removedStale = claims.RemoveAll(claim =>
+                claim.AccountId == accountId
+                && claim.Operation == operation
+                && claim.Fingerprint == fingerprint
+                && (claim.Generation != generation
+                    || !StringComparer.Ordinal.Equals(claim.Key, key)));
+            AiRequestRecoveryClaim? existingClaim = claims.FirstOrDefault(claim =>
+                claim.AccountId == accountId
+                && claim.Operation == operation
+                && claim.Fingerprint == fingerprint);
+            if (existingClaim is not null
+                && existingClaim.Dispatched
+                && existingClaim.ExpiresAt <= now)
+            {
+                // The renewal TTL has elapsed, but a dispatched provider call
+                // remains fenced. Atomically hand the durable fence to the
+                // recovering process, preserving key and generation while
+                // fencing the old owner token.
+                string adoptedOwner = $"{Guid.NewGuid():N}";
+                claims[claims.IndexOf(existingClaim)] = existingClaim with
+                {
+                    OwnerToken = adoptedOwner,
+                    ExpiresAt = now.Add(ClaimLifetime),
+                };
+                SaveClaims(claims);
+                return new AiRequestRecoveryLease(
+                    this,
+                    accountId,
+                    operation,
+                    fingerprint,
+                    key,
+                    generation,
+                    adoptedOwner,
+                    dispatched: true);
+            }
+            if (existingClaim is not null)
+            {
+                if (removedStale > 0)
+                    SaveClaims(claims);
+                return null;
+            }
+            if (claims.Count >= MaximumClaims)
+            {
+                // Expired non-dispatched claims were removed above. Dispatched
+                // fences are retained for exact-key adoption and cannot be
+                // evicted while they may own a provider call.
+                throw new InvalidDataException("AI request recovery claims are full.");
+            }
+
+            string owner = $"{Guid.NewGuid():N}";
+            claims.Add(new AiRequestRecoveryClaim(
+                accountId,
+                operation,
+                fingerprint,
+                key,
+                generation,
+                owner,
+                now.Add(ClaimLifetime),
+                Dispatched: false));
+            SaveClaims(claims);
+            return new AiRequestRecoveryLease(
+                this,
+                accountId,
+                operation,
+                fingerprint,
+                key,
+                generation,
+                owner);
+        }
+    }
+
+    /// <summary>Persists the dispatch fence and extends its lease.</summary>
+    internal bool MarkClaimDispatched(AiRequestRecoveryLease claim)
+    {
+        ArgumentNullException.ThrowIfNull(claim);
+        lock (_gate)
+        {
+            using FileStream lease = AcquireLock();
+            List<AiRequestRecoveryClaim> claims = LoadClaims();
+            int index = claims.FindIndex(item => MatchesClaim(item, claim));
+            if (index < 0)
+                return false;
+            DateTimeOffset now = _utcNow();
+            AiRequestRecoveryClaim current = claims[index];
+            if (current.ExpiresAt <= now)
+                return false;
+            claims[index] = current with
+            {
+                Dispatched = true,
+                ExpiresAt = now.Add(ClaimLifetime),
+            };
+            SaveClaims(claims);
+            return true;
+        }
+    }
+
+    /// <summary>Renews a live dispatched claim using owner/generation CAS.</summary>
+    internal bool RenewClaim(AiRequestRecoveryLease claim)
+    {
+        ArgumentNullException.ThrowIfNull(claim);
+        lock (_gate)
+        {
+            using FileStream lease = AcquireLock();
+            List<AiRequestRecoveryClaim> claims = LoadClaims();
+            int index = claims.FindIndex(item => MatchesClaim(item, claim));
+            if (index < 0)
+                return false;
+            DateTimeOffset now = _utcNow();
+            AiRequestRecoveryClaim current = claims[index];
+            if (!current.Dispatched || current.ExpiresAt <= now)
+                return false;
+            claims[index] = current with { ExpiresAt = now.Add(ClaimLifetime) };
+            SaveClaims(claims);
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Renews a dispatched fence using its original owner token, including
+    /// after its TTL elapsed. A competing process may claim an expired fence
+    /// first; in that case the exact-owner match fails closed.
+    /// </summary>
+    internal bool ReacquireClaim(AiRequestRecoveryLease claim)
+    {
+        ArgumentNullException.ThrowIfNull(claim);
+        lock (_gate)
+        {
+            using FileStream lease = AcquireLock();
+            List<AiRequestRecoveryClaim> claims = LoadClaims();
+            int index = claims.FindIndex(item => MatchesClaim(item, claim));
+            if (index < 0)
+                return false;
+            AiRequestRecoveryClaim current = claims[index];
+            if (!current.Dispatched)
+                return false;
+            claims[index] = current with { ExpiresAt = _utcNow().Add(ClaimLifetime) };
+            SaveClaims(claims);
+            return true;
+        }
+    }
+
+    private static bool MatchesClaim(AiRequestRecoveryClaim item, AiRequestRecoveryLease claim)
+        => item.AccountId == claim.AccountId
+            && item.Operation == claim.Operation
+            && item.Fingerprint == claim.Fingerprint
+            && item.Generation == claim.Generation
+            && item.Key == claim.Key
+            && item.OwnerToken == claim.OwnerToken;
+
+    internal void ReleaseClaim(AiRequestRecoveryLease claim, bool force)
+    {
+        lock (_gate)
+        {
+            try
+            {
+                using FileStream lease = AcquireLock();
+                List<AiRequestRecoveryClaim> claims = LoadClaims();
+                int removed = force || !claim.WasDispatched
+                    ? claims.RemoveAll(item =>
+                    item.AccountId == claim.AccountId
+                    && item.Operation == claim.Operation
+                    && item.Fingerprint == claim.Fingerprint
+                    && item.Generation == claim.Generation
+                    && StringComparer.Ordinal.Equals(item.Key, claim.Key)
+                    && StringComparer.Ordinal.Equals(item.OwnerToken, claim.OwnerToken))
+                    : 0;
+                if (removed > 0)
+                    SaveClaims(claims);
+            }
+            catch (Exception ex) when (ex is IOException
+                or UnauthorizedAccessException
+                or InvalidDataException)
+            {
+            }
+        }
+    }
+
+    /// <summary>
+    /// Removes a settled row only when the caller still owns the exact key that
+    /// created it. A stale response from an older generation therefore cannot
+    /// delete a newer row with the same form fingerprint.
+    /// </summary>
+    internal bool TrySettle(
+        string accountId,
+        string operation,
+        string fingerprint,
+        string key,
+        string? ownerToken = null,
+        int? generation = null)
+        => TryRemoveExact(accountId, operation, fingerprint, key, advanceGeneration: true, ownerToken, generation);
+
+    /// <summary>Withdraws a preflight refusal using an exact key CAS.</summary>
+    internal bool TryWithdraw(
+        string accountId,
+        string operation,
+        string fingerprint,
+        string key,
+        string? ownerToken = null,
+        int? generation = null)
+        => TryRemoveExact(accountId, operation, fingerprint, key, advanceGeneration: false, ownerToken, generation);
+
+    /// <summary>
+    /// Withdraws a dispatched request only with the exact owner lease that
+    /// marked provider dispatch, after an authoritative no-reservation result.
+    /// </summary>
+    internal bool TryWithdrawAfterNoReservation(
+        string accountId,
+        string operation,
+        string fingerprint,
+        string key,
+        string ownerToken,
+        int generation)
+        => TryRemoveExact(
+            accountId,
+            operation,
+            fingerprint,
+            key,
+            advanceGeneration: false,
+            ownerToken,
+            generation,
+            requireDispatchedOwner: true);
+
+    internal bool Abandon(AiPendingAttempt attempt)
+    {
+        ArgumentNullException.ThrowIfNull(attempt);
+        lock (_gate)
+        {
+            ValidateRecord(attempt);
+            using FileStream lease = AcquireLock();
+            List<AiPendingAttempt> records = Load();
+            AiPendingAttempt? existing = records.FirstOrDefault(record =>
+                record.AccountId == attempt.AccountId
+                && record.Operation == attempt.Operation
+                && record.Fingerprint == attempt.Fingerprint);
+            if (existing is null)
+                return false;
+            if (!StringComparer.Ordinal.Equals(existing.Key, attempt.Key))
+                return false;
+            List<AiRequestRecoveryClaim> claims = LoadClaims();
+            DateTimeOffset now = _utcNow();
+            if (claims.Any(claim => claim.AccountId == attempt.AccountId
+                && claim.Operation == attempt.Operation
+                && claim.Fingerprint == attempt.Fingerprint
+                && claim.Key == attempt.Key
+                && (claim.Dispatched || claim.ExpiresAt > now)))
+            {
+                // A dispatched request cannot be abandoned by a competing
+                // process. The exact owner (or a later fence adopter) must
+                // settle it; expiry alone is not proof of provider terminality.
+                return false;
+            }
+
+            // Advance the durable generation before publishing row removal. If
+            // the row write fails, the old row remains recoverable; if the
+            // generation write fails, no paid key is discarded.
+            AdvanceGenerationCore(existing.AccountId, existing.Operation, existing.Fingerprint);
+            records.Remove(existing);
+            Save(records);
+            DeleteDurableSources([existing], records);
+            InvalidateClaimsCore(existing.AccountId, existing.Operation, existing.Fingerprint);
+            if (existing.EffectiveSources.Count != 0)
+            {
+                foreach (AiRequestRecoverySource source in existing.EffectiveSources)
+                {
+                    if (source.DurableFile is { } durable)
+                        _newSourceFiles.Remove(durable);
+                }
+            }
+            return true;
+        }
+    }
+
+    private bool TryRemoveExact(
+        string accountId,
+        string operation,
+        string fingerprint,
+        string key,
+        bool advanceGeneration,
+        string? ownerToken = null,
+        int? generation = null,
+        bool requireDispatchedOwner = false)
+    {
+        lock (_gate)
+        {
+            ValidateIdentity(accountId, operation, fingerprint);
+            if (!IsPrintable(key, 255))
+                throw new InvalidDataException("AI request recovery key is invalid.");
+            using FileStream lease = AcquireLock();
+            List<AiPendingAttempt> records = Load();
+            AiPendingAttempt? existing = records.FirstOrDefault(record =>
+                record.AccountId == accountId
+                && record.Operation == operation
+                && record.Fingerprint == fingerprint);
+            if (existing is null || !StringComparer.Ordinal.Equals(existing.Key, key))
+                return false;
+            List<AiRequestRecoveryClaim> claims = LoadClaims();
+            DateTimeOffset now = _utcNow();
+            claims.RemoveAll(claim => !claim.Dispatched && claim.ExpiresAt <= now);
+            AiRequestRecoveryClaim? matchingDispatched = claims.FirstOrDefault(claim =>
+                claim.AccountId == accountId
+                && claim.Operation == operation
+                && claim.Fingerprint == fingerprint
+                && claim.Key == key
+                && claim.Dispatched);
+            if (requireDispatchedOwner && matchingDispatched is null)
+                return false;
+            if (matchingDispatched is not null
+                && (ownerToken is null
+                    || !StringComparer.Ordinal.Equals(matchingDispatched.OwnerToken, ownerToken)
+                    || generation is null
+                    || matchingDispatched.Generation != generation.Value))
+            {
+                // Once provider work was dispatched, only the exact owner can
+                // settle it or withdraw it after an authoritative no-reservation
+                // response. Process loss and lease expiry are not terminality.
+                return false;
+            }
+            if (claims.Any(claim => claim.AccountId == accountId
+                && claim.Operation == operation
+                && claim.Fingerprint == fingerprint
+                && claim.Key == key
+                && (ownerToken is null
+                    || !StringComparer.Ordinal.Equals(claim.OwnerToken, ownerToken)
+                    || generation is not null && claim.Generation != generation.Value)
+                && claim.ExpiresAt > now))
+            {
+                // A live claim belongs to the dispatching process. A stale
+                // response without its owner token cannot settle/withdraw it.
+                return false;
+            }
+
+            if (advanceGeneration)
+                AdvanceGenerationCore(accountId, operation, fingerprint);
+            records.Remove(existing);
+            Save(records);
+            DeleteDurableSources([existing], records);
+            InvalidateClaimsCore(accountId, operation, fingerprint);
+            return true;
+        }
+    }
+
+    private int GetGenerationCore(string accountId, string operation, string fingerprint)
+        => LoadGenerations().FirstOrDefault(entry =>
+            entry.AccountId == accountId
+            && entry.Operation == operation
+            && entry.Fingerprint == fingerprint)?.Generation ?? 0;
+
+    internal bool SettleMany(
+        string accountId,
+        string operation,
+        IEnumerable<AiPendingAttempt> identities)
+    {
+        ArgumentNullException.ThrowIfNull(identities);
+        ValidateText(accountId, 128, nameof(accountId));
+        ValidateText(operation, 128, nameof(operation));
+        AiPendingAttempt[] requested = identities.ToArray();
+        foreach (AiPendingAttempt identity in requested)
+        {
+            ValidateIdentity(identity.AccountId, identity.Operation, identity.Fingerprint);
+            if (!IsPrintable(identity.Key, 255))
+                throw new InvalidDataException("AI request recovery key is invalid.");
+        }
+
+        lock (_gate)
+        {
+            using FileStream lease = AcquireLock();
+            List<AiPendingAttempt> records = Load();
+            AiPendingAttempt[] scoped = records.Where(record =>
+                record.AccountId == accountId
+                && (record.Operation == operation
+                    || record.Operation.StartsWith(operation + ".", StringComparison.Ordinal)))
+                .ToArray();
+            // Whole-run retirement is one CAS over the complete operation
+            // scope. A row that was replaced, or one this process never
+            // materialized, keeps every row and generation unchanged.
+            if (scoped.Length != requested.Length
+                || scoped.Any(record => !requested.Any(identity =>
+                    identity.AccountId == record.AccountId
+                    && identity.Operation == record.Operation
+                    && identity.Fingerprint == record.Fingerprint
+                    && identity.Key == record.Key)))
+            {
+                return false;
+            }
+            AiPendingAttempt[] removed = scoped;
+            if (removed.Length == 0)
+                return false;
+
+            List<AiRequestRecoveryClaim> claims = LoadClaims();
+            if (removed.Any(attempt => claims.Any(claim =>
+                claim.AccountId == attempt.AccountId
+                && claim.Operation == attempt.Operation
+                && claim.Fingerprint == attempt.Fingerprint
+                && claim.Key == attempt.Key
+                && claim.Dispatched)))
+            {
+                // Bulk retirement has no owner-token proof. Never remove a
+                // row whose provider request was dispatched; the exact owner
+                // or a later fence adopter must settle it individually.
+                throw new InvalidDataException(
+                    "A dispatched AI recovery attempt cannot be settled in bulk.");
+            }
+
+            foreach (AiPendingAttempt attempt in removed)
+                AdvanceGenerationCore(attempt.AccountId, attempt.Operation, attempt.Fingerprint);
+
+            records.RemoveAll(record => requested.Any(identity =>
+                identity.AccountId == record.AccountId
+                && identity.Operation == record.Operation
+                && identity.Fingerprint == record.Fingerprint
+                && identity.Key == record.Key));
+            Save(records);
+            foreach (AiPendingAttempt attempt in removed)
+                InvalidateClaimsCore(attempt.AccountId, attempt.Operation, attempt.Fingerprint);
+            foreach (AiPendingAttempt attempt in removed)
+            {
+                foreach (AiRequestRecoverySource source in attempt.EffectiveSources)
+                {
+                    if (source.DurableFile is { } durable)
+                        _newSourceFiles.Remove(durable);
+                }
+            }
+            DeleteDurableSources(removed, records);
+            return true;
+        }
+    }
+
+    internal bool HasAny(string accountId, string operation)
+        => PendingFor(accountId, operation).Count != 0;
+
+    internal IReadOnlyList<string> ModelsFor(string accountId, string operation)
+        => PendingFor(accountId, operation)
+            .Where(record => record.Operation == operation && record.Model is not null)
+            .Select(record => record.Model!)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+    internal bool HasModelless(string accountId, string operation)
+        => PendingFor(accountId, operation)
+            .Any(record => record.Operation == operation && record.Model is null);
+
+    /// <summary>
+    /// Makes a private, process-independent copy for a captured or generated
+    /// source. The JSON row stores only the generated token and its hash.
+    /// </summary>
+    internal AiRequestRecoverySource CreateDurableSource(
+        string role,
+        string name,
+        ReadOnlySpan<byte> content,
+        string? elementId = null)
+    {
+        ValidateSourceMetadata(role, name, content.Length, elementId);
+        string token = $"{Guid.NewGuid():N}.src";
+        string destination = Path.Combine(_sourceDirectory, token);
+        string temporary = destination + $".{Guid.NewGuid():N}.tmp";
+        string marker = destination + ".pending";
+        bool published = false;
+        FileStream? markerLease = null;
+        try
+        {
+            // The marker is durable before the source is published. Startup
+            // sweeping therefore cannot mistake a long row-publication stall
+            // for an orphan until the marker lease expires.
+            var markerOptions = new FileStreamOptions
+            {
+                Mode = FileMode.CreateNew,
+                Access = FileAccess.ReadWrite,
+                Share = FileShare.None,
+                Options = FileOptions.WriteThrough | FileOptions.SequentialScan,
+            };
+            if (!OperatingSystem.IsWindows())
+                markerOptions.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+            markerLease = new FileStream(marker, markerOptions);
+            markerLease.Write(System.Text.Encoding.UTF8.GetBytes(_utcNow().ToString("O")));
+            markerLease.Flush(flushToDisk: true);
+            RestrictFile(marker);
+            EnsureDirectorySynced(_sourceDirectory);
+            WritePrivateBytes(temporary, content);
+            AtomicReplace(temporary, destination, overwrite: false);
+            published = true;
+            RestrictFile(destination);
+            EnsureDirectorySynced(_sourceDirectory);
+            lock (_gate)
+            {
+                _newSourceFiles.Add(token);
+                _pendingPublicationMarkers[token] = markerLease
+                    ?? throw new IOException("AI recovery source publication marker was lost.");
+                markerLease = null;
+            }
+            return new AiRequestRecoverySource(
+                role,
+                Path: null,
+                name,
+                Convert.ToHexString(SHA256.HashData(content)),
+                content.Length,
+                token,
+                elementId);
+        }
+        finally
+        {
+            markerLease?.Dispose();
+            TryDelete(temporary);
+            if (!published)
+                TryDelete(marker);
+        }
+    }
+
+    /// <summary>
+    /// Removes durable files that were written before a row could be
+    /// committed. Only files older than the orphan grace period and not
+    /// referenced by a valid row are removed; a committed copy is never
+    /// guessed at or deleted.
+    /// </summary>
+    internal void DeleteUncommittedSources(IEnumerable<AiRequestRecoverySource> sources)
+    {
+        ArgumentNullException.ThrowIfNull(sources);
+        AiRequestRecoverySource[] requested = sources.ToArray();
+        if (requested.Length == 0)
+            return;
+
+        lock (_gate)
+        {
+            try
+            {
+                using FileStream lease = AcquireLock();
+                List<AiPendingAttempt> records;
+                try
+                {
+                    records = Load();
+                }
+                catch (InvalidDataException)
+                {
+                    // A corrupt index is fail-closed. Orphan cleanup can be retried
+                    // on a later startup once the index is repaired.
+                    return;
+                }
+
+                DeleteUncommittedSourcesCore(requested, records);
+            }
+            catch (Exception ex) when (ex is IOException
+                or UnauthorizedAccessException
+                or InvalidDataException)
+            {
+                // If the cross-process lock is held, only delete copies created
+                // by this store instance and not yet published in a row. A
+                // committed copy is never guessed at or removed. Crashed
+                // processes are handled by the startup orphan sweep.
+                foreach (AiRequestRecoverySource source in requested)
+                {
+                    if (source.DurableFile is { } durable
+                        && _newSourceFiles.Contains(durable))
+                    {
+                        TryDelete(Path.Combine(_sourceDirectory, durable));
+                        TryDelete(Path.Combine(_sourceDirectory, durable + ".pending"));
+                        _newSourceFiles.Remove(durable);
+                    }
+                }
+            }
+        }
+    }
+
+    private void DeleteUncommittedSourcesCore(
+        IEnumerable<AiRequestRecoverySource> requested,
+        IReadOnlyList<AiPendingAttempt> records)
+    {
+        HashSet<string> retained = records
+            .SelectMany(record => record.EffectiveSources)
+            .Where(source => source.DurableFile is not null)
+            .Select(source => source.DurableFile!)
+            .ToHashSet(StringComparer.Ordinal);
+        foreach (AiRequestRecoverySource source in requested)
+        {
+            if (source.DurableFile is { } durable && !retained.Contains(durable))
+            {
+                TryDelete(Path.Combine(_sourceDirectory, durable));
+                if (_pendingPublicationMarkers.Remove(durable, out FileStream? marker))
+                    marker.Dispose();
+                TryDelete(Path.Combine(_sourceDirectory, durable + ".pending"));
+                _newSourceFiles.Remove(durable);
+            }
+        }
+    }
+
+    private void MarkSourcesCommitted(IEnumerable<AiRequestRecoverySource> sources)
+    {
+        foreach (AiRequestRecoverySource source in sources)
+        {
+            if (source.DurableFile is { } durable)
+            {
+                _newSourceFiles.Remove(durable);
+                if (_pendingPublicationMarkers.Remove(durable, out FileStream? marker))
+                    marker.Dispose();
+                TryDelete(Path.Combine(_sourceDirectory, durable + ".pending"));
+            }
+        }
+    }
+
+    private void SweepOrphanedSources()
+    {
+        try
+        {
+            using FileStream lease = AcquireLock();
+            HashSet<string> retained = Load()
+                .SelectMany(record => record.EffectiveSources)
+                .Where(source => source.DurableFile is not null)
+                .Select(source => source.DurableFile!)
+                .ToHashSet(StringComparer.Ordinal);
+            DateTime now = _utcNow().UtcDateTime;
+            foreach (string path in Directory.EnumerateFiles(_sourceDirectory))
+            {
+                string name = Path.GetFileName(path);
+                if (name.EndsWith(".pending", StringComparison.Ordinal))
+                {
+                    // A crash can happen after the publication marker is
+                    // flushed but before the source rename. There is then no
+                    // `.src` entry below to reclaim the marker. Keep a marker
+                    // while its owner is active or inside the grace period;
+                    // once it is old and unlocked, it is an orphan temp file.
+                    string sourcePath = path[..^".pending".Length];
+                    bool sourceExists = File.Exists(sourcePath);
+                    bool markerLocked = IsMarkerLocked(path);
+                    bool markerIsOld = now - File.GetLastWriteTimeUtc(path) >= OrphanSourceAge;
+                    if (sourceExists)
+                    {
+                        // Once the source is referenced by a durable row, a
+                        // stale marker is no longer needed. This closes the
+                        // crash window between row publication and marker
+                        // deletion without touching an unregistered source.
+                        if (retained.Contains(Path.GetFileName(sourcePath))
+                            && !markerLocked
+                            && markerIsOld)
+                        {
+                            TryDelete(path);
+                        }
+                        continue;
+                    }
+
+                    if (markerLocked || !markerIsOld)
+                    {
+                        continue;
+                    }
+
+                    TryDelete(path);
+                    continue;
+                }
+                if (name.Contains(".src.", StringComparison.Ordinal)
+                    && name.EndsWith(".tmp", StringComparison.Ordinal))
+                {
+                    if (now - File.GetLastWriteTimeUtc(path) >= OrphanSourceAge
+                        && !IsMarkerLocked(path))
+                        TryDelete(path);
+                    continue;
+                }
+                if (!name.EndsWith(".src", StringComparison.Ordinal))
+                    continue;
+                if (retained.Contains(name))
+                    continue;
+                DateTime written = File.GetLastWriteTimeUtc(path);
+                string marker = path + ".pending";
+                if (File.Exists(marker)
+                    && (now - File.GetLastWriteTimeUtc(marker) < OrphanSourceAge
+                        || IsMarkerLocked(marker)))
+                    continue;
+                if (now - written >= OrphanSourceAge)
+                {
+                    TryDelete(path);
+                    TryDelete(marker);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException
+            or UnauthorizedAccessException
+            or InvalidDataException)
+        {
+            // Recovery is fail-closed. Never sweep when the index could not be
+            // read, because a source may still be referenced by a valid row.
+        }
+    }
+
+    private static void SweepStoreTemporaryFiles(string directory)
+    {
+        try
+        {
+            DateTime cutoff = DateTime.UtcNow - OrphanSourceAge;
+            foreach (string path in Directory.EnumerateFiles(directory, "*.json.*.tmp"))
+            {
+                if (File.GetLastWriteTimeUtc(path) < cutoff
+                    && !IsMarkerLocked(path))
+                    TryDelete(path);
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Returns the original user-selected source only after checking its name,
+    /// length and bytes. Any failure is false (fail closed), never a fallback
+    /// to a newly named request.
+    /// </summary>
+    internal bool TryResolveSource(AiRequestRecoverySource source, out string? path)
+    {
+        path = null;
+        try
+        {
+            ValidateSource(source);
+            string candidate;
+            if (source.DurableFile is { Length: > 0 } durable)
+            {
+                candidate = Path.Combine(_sourceDirectory, durable);
+                string full = Path.GetFullPath(candidate);
+                if (!IsWithinDirectory(full, _sourceDirectory))
+                    return false;
+            }
+            else if (source.Path is { Length: > 0 } external)
+            {
+                candidate = external;
+            }
+            else
+            {
+                return false;
+            }
+
+            if (!File.Exists(candidate))
+                return false;
+            FileInfo info = new(candidate);
+            if (info.Length != source.Length)
+                return false;
+            using FileStream stream = File.OpenRead(candidate);
+            byte[] hash = SHA256.HashData(stream);
+            if (!CryptographicOperations.FixedTimeEquals(
+                    hash,
+                    Convert.FromHexString(source.ContentHash)))
+            {
+                return false;
+            }
+
+            path = candidate;
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException
+            or UnauthorizedAccessException
+            or ArgumentException
+            or InvalidDataException
+            or FormatException
+            or OverflowException)
+        {
+            path = null;
+            return false;
+        }
+    }
+
+    internal IReadOnlyList<string> ResolveSources(AiPendingAttempt attempt)
+    {
+        ValidateRecord(attempt);
+        var result = new string[attempt.EffectiveSources.Count];
+        for (int index = 0; index < result.Length; index++)
+        {
+            if (!TryResolveSource(attempt.EffectiveSources[index], out string? path)
+                || path is null)
+            {
+                throw new InvalidDataException(
+                    $"AI recovery source '{attempt.EffectiveSources[index].Role}' is unavailable.");
+            }
+
+            result[index] = path;
+        }
+
+        return result;
+    }
+
+    /// <summary>Reads and verifies one source in a single fail-closed operation.</summary>
+    internal byte[] ReadSourceBytes(AiRequestRecoverySource source)
+    {
+        if (!TryResolveSource(source, out string? path) || path is null)
+            throw new InvalidDataException($"AI recovery source '{source.Role}' is unavailable.");
+        try
+        {
+            byte[] bytes = File.ReadAllBytes(path);
+            if (bytes.LongLength != source.Length
+                || !CryptographicOperations.FixedTimeEquals(
+                    SHA256.HashData(bytes),
+                    Convert.FromHexString(source.ContentHash)))
+            {
+                throw new InvalidDataException(
+                    $"AI recovery source '{source.Role}' changed while it was read.");
+            }
+            return bytes;
+        }
+        catch (Exception ex) when (ex is IOException
+            or UnauthorizedAccessException
+            or ArgumentException)
+        {
+            throw new InvalidDataException($"AI recovery source '{source.Role}' is unreadable.", ex);
+        }
+    }
+
+    private List<AiPendingAttempt> Load()
+    {
+        if (!File.Exists(_path))
+            return [];
+
+        try
+        {
+            FileInfo info = new(_path);
+            if (info.Length is <= 0 or > MaximumBytes)
+                throw new InvalidDataException("AI request recovery store has invalid size.");
+
+            using JsonDocument document = JsonDocument.Parse(File.ReadAllBytes(_path));
+            JsonElement root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object
+                || root.EnumerateObject().Count() != 2
+                || !root.TryGetProperty("version", out JsonElement version)
+                || version.ValueKind != JsonValueKind.Number
+                || version.GetInt32() != Version
+                || !root.TryGetProperty("records", out JsonElement recordsElement)
+                || recordsElement.ValueKind != JsonValueKind.Array)
+            {
+                throw new InvalidDataException("Unsupported AI request recovery version.");
+            }
+
+            var result = new List<AiPendingAttempt>();
+            var identities = new HashSet<string>(StringComparer.Ordinal);
+            foreach (JsonElement item in recordsElement.EnumerateArray())
+            {
+                AiPendingAttempt attempt = ParseAttempt(item);
+                ValidateRecord(attempt);
+                string identity = $"{attempt.AccountId}\n{attempt.Operation}\n{attempt.Fingerprint}";
+                if (!identities.Add(identity))
+                    throw new InvalidDataException("Duplicate AI recovery record.");
+                result.Add(attempt);
+                if (result.Count > MaximumRecords)
+                    throw new InvalidDataException("AI request recovery store is full.");
+            }
+
+            return result;
+        }
+        catch (Exception ex) when (ex is IOException
+            or UnauthorizedAccessException
+            or JsonException
+            or InvalidDataException
+            or FormatException
+            or OverflowException)
+        {
+            throw new InvalidDataException("AI request recovery store is unreadable.", ex);
+        }
+    }
+
+    private static AiPendingAttempt ParseAttempt(JsonElement item)
+    {
+        if (item.ValueKind != JsonValueKind.Object)
+            throw new InvalidDataException("Invalid AI recovery record.");
+
+        JsonProperty[] properties = item.EnumerateObject().ToArray();
+        if (properties.Select(property => property.Name).Distinct(StringComparer.Ordinal).Count()
+            != properties.Length)
+        {
+            throw new InvalidDataException("Duplicate AI recovery record property.");
+        }
+        bool legacy = properties.Length == 5
+            && properties.All(property => property.Name is nameof(AiPendingAttempt.AccountId)
+                or nameof(AiPendingAttempt.Operation)
+                or nameof(AiPendingAttempt.Fingerprint)
+                or nameof(AiPendingAttempt.Key)
+                or nameof(AiPendingAttempt.Model));
+        bool current = properties.Length is 6 or 7
+            && properties.All(property => property.Name is nameof(AiPendingAttempt.AccountId)
+                or nameof(AiPendingAttempt.Operation)
+                or nameof(AiPendingAttempt.Fingerprint)
+                or nameof(AiPendingAttempt.Key)
+                or nameof(AiPendingAttempt.Model)
+                or nameof(AiPendingAttempt.Form)
+                or nameof(AiPendingAttempt.Sources));
+        if (!legacy && !current)
+            throw new InvalidDataException("Invalid AI recovery record shape.");
+
+        string account = RequiredString(item, nameof(AiPendingAttempt.AccountId));
+        string operation = RequiredString(item, nameof(AiPendingAttempt.Operation));
+        string fingerprint = RequiredString(item, nameof(AiPendingAttempt.Fingerprint));
+        string key = RequiredString(item, nameof(AiPendingAttempt.Key));
+        string? model = OptionalString(item, nameof(AiPendingAttempt.Model));
+        AiRequestFormSnapshot? form = null;
+        IReadOnlyList<AiRequestRecoverySource>? sources = null;
+        if (current)
+        {
+            if (!item.TryGetProperty(nameof(AiPendingAttempt.Form), out JsonElement formElement)
+                || formElement.ValueKind is not (JsonValueKind.Null or JsonValueKind.Object))
+            {
+                throw new InvalidDataException("Invalid AI recovery form state.");
+            }
+
+            if (formElement.ValueKind == JsonValueKind.Object)
+            {
+                EnsureKnownProperties(
+                    formElement,
+                    FormProperties);
+                form = JsonSerializer.Deserialize<AiRequestFormSnapshot>(formElement.GetRawText())
+                    ?? throw new InvalidDataException("Invalid AI recovery form state.");
+            }
+
+            if (item.TryGetProperty(nameof(AiPendingAttempt.Sources), out JsonElement sourcesElement))
+            {
+                if (sourcesElement.ValueKind != JsonValueKind.Array)
+                    throw new InvalidDataException("Invalid AI recovery sources.");
+                foreach (JsonElement sourceElement in sourcesElement.EnumerateArray())
+                    EnsureKnownProperties(sourceElement, SourceProperties);
+                sources = JsonSerializer.Deserialize<List<AiRequestRecoverySource>>(
+                        sourcesElement.GetRawText())
+                    ?? throw new InvalidDataException("Invalid AI recovery sources.");
+            }
+            else
+            {
+                sources = Array.Empty<AiRequestRecoverySource>();
+            }
+        }
+
+        return new AiPendingAttempt(account, operation, fingerprint, key, model, form, sources);
+    }
+
+    private void Save(List<AiPendingAttempt> records)
+    {
+        if (records.Count > MaximumRecords)
+            throw new InvalidDataException(
+                "AI request recovery store is full; unresolved attempts were retained.");
+
+        byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(
+            new RecoveryDocument(Version, records),
+            SerializerOptions);
+        if (bytes.Length is <= 0 or > MaximumBytes)
+            throw new InvalidDataException("AI request recovery store exceeds its size limit.");
+
+        string temporary = _path + $".{Guid.NewGuid():N}.tmp";
+        try
+        {
+            WritePrivateBytes(temporary, bytes);
+            AtomicReplace(temporary, _path, overwrite: true);
+            RestrictFile(_path);
+            EnsureDirectorySynced(Path.GetDirectoryName(_path)!);
+        }
+        finally
+        {
+            TryDelete(temporary);
+        }
+    }
+
+    private int AdvanceGenerationCore(string accountId, string operation, string fingerprint)
+    {
+        List<AiGenerationEntry> entries = LoadGenerations();
+        int index = entries.FindIndex(entry => entry.AccountId == accountId
+            && entry.Operation == operation
+            && entry.Fingerprint == fingerprint);
+        int next = index >= 0 ? checked(entries[index].Generation + 1) : 1;
+        if (index >= 0)
+            entries[index] = entries[index] with { Generation = next };
+        else
+        {
+            if (entries.Count >= MaximumGenerationEntries)
+            {
+                // Generation entries are tombstones. Prune only identities with
+                // no live pending row or claim; active identities keep their
+                // fence and can never be reused while a stale response exists.
+                HashSet<string> active = Load()
+                    .Select(attempt => $"{attempt.AccountId}\n{attempt.Operation}\n{attempt.Fingerprint}")
+                    .Concat(LoadClaims().Select(claim =>
+                        $"{claim.AccountId}\n{claim.Operation}\n{claim.Fingerprint}"))
+                    .ToHashSet(StringComparer.Ordinal);
+                entries.RemoveAll(entry => !active.Contains(
+                    $"{entry.AccountId}\n{entry.Operation}\n{entry.Fingerprint}"));
+                if (entries.Count >= MaximumGenerationEntries)
+                {
+                    // This can only happen when every slot is active. Keep the
+                    // oldest live fences and reject this new generation rather
+                    // than evicting an active owner.
+                    throw new InvalidDataException("AI request generation store is full with active attempts.");
+                }
+            }
+            entries.Add(new AiGenerationEntry(accountId, operation, fingerprint, next));
+        }
+
+        SaveGenerations(entries);
+        InvalidateClaimsCore(accountId, operation, fingerprint);
+        return next;
+    }
+
+    private void InvalidateClaimsCore(string accountId, string operation, string fingerprint)
+    {
+        List<AiRequestRecoveryClaim> claims = LoadClaims();
+        if (claims.RemoveAll(claim => claim.AccountId == accountId
+            && claim.Operation == operation
+            && claim.Fingerprint == fingerprint) > 0)
+        {
+            SaveClaims(claims);
+        }
+    }
+
+    private List<AiGenerationEntry> LoadGenerations()
+    {
+        if (!File.Exists(_generationPath))
+            return [];
+        try
+        {
+            FileInfo info = new(_generationPath);
+            if (info.Length is <= 0 or > 256 * 1024)
+                throw new InvalidDataException("AI request generation store has invalid size.");
+            using JsonDocument document = JsonDocument.Parse(File.ReadAllBytes(_generationPath));
+            JsonElement root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object
+                || root.EnumerateObject().Count() != 2
+                || !root.TryGetProperty("version", out JsonElement version)
+                || version.ValueKind != JsonValueKind.Number
+                || version.GetInt32() != Version
+                || !root.TryGetProperty("generations", out JsonElement generations)
+                || generations.ValueKind != JsonValueKind.Array)
+            {
+                throw new InvalidDataException("Unsupported AI request generation version.");
+            }
+
+            var result = new List<AiGenerationEntry>();
+            var identities = new HashSet<string>(StringComparer.Ordinal);
+            foreach (JsonElement item in generations.EnumerateArray())
+            {
+                if (item.ValueKind != JsonValueKind.Object)
+                    throw new InvalidDataException("Invalid AI request generation entry.");
+                JsonProperty[] properties = item.EnumerateObject().ToArray();
+                if (properties.Length != 4
+                    || properties.Select(property => property.Name).Distinct(StringComparer.Ordinal).Count() != 4
+                    || properties.Any(property => property.Name is not (nameof(AiGenerationEntry.AccountId)
+                        or nameof(AiGenerationEntry.Operation)
+                        or nameof(AiGenerationEntry.Fingerprint)
+                        or nameof(AiGenerationEntry.Generation))))
+                {
+                    throw new InvalidDataException("Invalid AI request generation shape.");
+                }
+
+                string account = RequiredString(item, nameof(AiGenerationEntry.AccountId));
+                string operation = RequiredString(item, nameof(AiGenerationEntry.Operation));
+                string fingerprint = RequiredString(item, nameof(AiGenerationEntry.Fingerprint));
+                if (!item.TryGetProperty(nameof(AiGenerationEntry.Generation), out JsonElement number)
+                    || number.ValueKind != JsonValueKind.Number
+                    || number.GetInt32() <= 0)
+                {
+                    throw new InvalidDataException("Invalid AI request generation value.");
+                }
+
+                ValidateIdentity(account, operation, fingerprint);
+                var entry = new AiGenerationEntry(account, operation, fingerprint, number.GetInt32());
+                string identity = $"{account}\n{operation}\n{fingerprint}";
+                if (!identities.Add(identity))
+                    throw new InvalidDataException("Duplicate AI request generation entry.");
+                result.Add(entry);
+                if (result.Count > MaximumGenerationEntries)
+                    throw new InvalidDataException("AI request generation store is full.");
+            }
+
+            return result;
+        }
+        catch (Exception ex) when (ex is IOException
+            or UnauthorizedAccessException
+            or JsonException
+            or InvalidDataException
+            or FormatException
+            or OverflowException)
+        {
+            throw new InvalidDataException("AI request generation store is unreadable.", ex);
+        }
+    }
+
+    private void SaveGenerations(List<AiGenerationEntry> entries)
+    {
+        byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(
+            new GenerationDocument(Version, entries),
+            SerializerOptions);
+        if (bytes.Length is <= 0 or > 256 * 1024)
+            throw new InvalidDataException("AI request generation store exceeds its size limit.");
+        string temporary = _generationPath + $".{Guid.NewGuid():N}.tmp";
+        try
+        {
+            WritePrivateBytes(temporary, bytes);
+            AtomicReplace(temporary, _generationPath, overwrite: true);
+            RestrictFile(_generationPath);
+            EnsureDirectorySynced(Path.GetDirectoryName(_generationPath)!);
+        }
+        finally
+        {
+            TryDelete(temporary);
+        }
+    }
+
+    private List<AiRequestRecoveryClaim> LoadClaims()
+    {
+        if (!File.Exists(_claimPath))
+            return [];
+        try
+        {
+            FileInfo info = new(_claimPath);
+            if (info.Length is <= 0 or > 256 * 1024)
+                throw new InvalidDataException("AI recovery claims have invalid size.");
+            using JsonDocument document = JsonDocument.Parse(File.ReadAllBytes(_claimPath));
+            JsonElement root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object
+                || root.EnumerateObject().Count() != 2
+                || !root.TryGetProperty("version", out JsonElement version)
+                || version.GetInt32() != Version
+                || !root.TryGetProperty("claims", out JsonElement claimsElement)
+                || claimsElement.ValueKind != JsonValueKind.Array)
+            {
+                throw new InvalidDataException("Unsupported AI recovery claim version.");
+            }
+
+            List<AiRequestRecoveryClaim>? claims = JsonSerializer.Deserialize<List<AiRequestRecoveryClaim>>(
+                claimsElement.GetRawText(),
+                SerializerOptions);
+            if (claims is null || claims.Count > MaximumClaims)
+                throw new InvalidDataException("AI recovery claim count exceeds its limit.");
+            HashSet<string> identities = new(StringComparer.Ordinal);
+            foreach (AiRequestRecoveryClaim claim in claims)
+            {
+                ValidateIdentity(claim.AccountId, claim.Operation, claim.Fingerprint);
+                if (!IsPrintable(claim.Key, 255)
+                    || claim.Generation < 0
+                    || !IsPrintable(claim.OwnerToken, 128)
+                    || !identities.Add($"{claim.AccountId}\n{claim.Operation}\n{claim.Fingerprint}\n{claim.OwnerToken}"))
+                {
+                    throw new InvalidDataException("AI recovery claim is invalid or duplicated.");
+                }
+            }
+            return claims;
+        }
+        catch (Exception ex) when (ex is IOException
+            or UnauthorizedAccessException
+            or JsonException
+            or InvalidDataException
+            or FormatException
+            or OverflowException)
+        {
+            throw new InvalidDataException("AI recovery claims are unreadable.", ex);
+        }
+    }
+
+    private void SaveClaims(List<AiRequestRecoveryClaim> claims)
+    {
+        byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(
+            new ClaimDocument(Version, claims),
+            SerializerOptions);
+        if (bytes.Length is <= 0 or > 256 * 1024)
+            throw new InvalidDataException("AI recovery claims exceed their size limit.");
+        string temporary = _claimPath + $".{Guid.NewGuid():N}.tmp";
+        try
+        {
+            WritePrivateBytes(temporary, bytes);
+            AtomicReplace(temporary, _claimPath, overwrite: true);
+            RestrictFile(_claimPath);
+            EnsureDirectorySynced(Path.GetDirectoryName(_claimPath)!);
+        }
+        finally
+        {
+            TryDelete(temporary);
+        }
+    }
+
+    private FileStream AcquireLock()
+    {
+        try
+        {
+            var options = new FileStreamOptions
+            {
+                Mode = FileMode.OpenOrCreate,
+                Access = FileAccess.ReadWrite,
+                Share = FileShare.None,
+                Options = FileOptions.WriteThrough,
+            };
+            if (!OperatingSystem.IsWindows())
+                options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+            FileStream stream = new(LockPath, options);
+            RestrictFile(LockPath);
+            return stream;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            throw new InvalidDataException("AI request recovery store is unavailable.", ex);
+        }
+    }
+
+    private void DeleteDurableSources(
+        IEnumerable<AiPendingAttempt> removed,
+        IEnumerable<AiPendingAttempt> remaining)
+    {
+        HashSet<string> retained = remaining
+            .SelectMany(attempt => attempt.EffectiveSources)
+            .Where(source => source.DurableFile is not null)
+            .Select(source => source.DurableFile!)
+            .ToHashSet(StringComparer.Ordinal);
+        foreach (AiPendingAttempt attempt in removed)
+        {
+            foreach (AiRequestRecoverySource source in attempt.EffectiveSources)
+            {
+                if (source.DurableFile is { } durable && !retained.Contains(durable))
+                {
+                    TryDelete(Path.Combine(_sourceDirectory, durable));
+                    if (_pendingPublicationMarkers.Remove(durable, out FileStream? marker))
+                        marker.Dispose();
+                    TryDelete(Path.Combine(_sourceDirectory, durable + ".pending"));
+                }
+            }
+        }
+    }
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = false,
+        PropertyNamingPolicy = null,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    private sealed record RecoveryDocument(int version, IReadOnlyList<AiPendingAttempt> records);
+
+    private sealed record GenerationDocument(int version, IReadOnlyList<AiGenerationEntry> generations);
+
+    private sealed record ClaimDocument(int version, IReadOnlyList<AiRequestRecoveryClaim> claims);
+
+    private sealed record AiGenerationEntry(
+        string AccountId,
+        string Operation,
+        string Fingerprint,
+        int Generation);
+
+    private sealed record AiRequestRecoveryClaim(
+        string AccountId,
+        string Operation,
+        string Fingerprint,
+        string Key,
+        int Generation,
+        string OwnerToken,
+        DateTimeOffset ExpiresAt,
+        bool Dispatched = false);
+
+    private static readonly HashSet<string> FormProperties =
+        [
+            nameof(AiRequestFormSnapshot.Prompt),
+            nameof(AiRequestFormSnapshot.Style),
+            nameof(AiRequestFormSnapshot.Composition),
+            nameof(AiRequestFormSnapshot.Motion),
+            nameof(AiRequestFormSnapshot.Exclusions),
+            nameof(AiRequestFormSnapshot.Task),
+            nameof(AiRequestFormSnapshot.AspectRatio),
+            nameof(AiRequestFormSnapshot.Background),
+            nameof(AiRequestFormSnapshot.Seed),
+            nameof(AiRequestFormSnapshot.DurationSeconds),
+            nameof(AiRequestFormSnapshot.Resolution),
+            nameof(AiRequestFormSnapshot.GenerateAudio),
+            nameof(AiRequestFormSnapshot.OutpaintExpansionPercent),
+            nameof(AiRequestFormSnapshot.MaxReferenceImages),
+            nameof(AiRequestFormSnapshot.MaxReferenceTotalBytes),
+            nameof(AiRequestFormSnapshot.SupportsReferenceImage),
+            nameof(AiRequestFormSnapshot.SupportsSeed),
+            nameof(AiRequestFormSnapshot.HasBackgroundChoice),
+            nameof(AiRequestFormSnapshot.SupportsAudio),
+            nameof(AiRequestFormSnapshot.SupportsFirstFrame),
+            nameof(AiRequestFormSnapshot.SupportsLastFrame),
+            nameof(AiRequestFormSnapshot.SourceName),
+            nameof(AiRequestFormSnapshot.SourceIsPrepared),
+            nameof(AiRequestFormSnapshot.SourceElementId),
+            nameof(AiRequestFormSnapshot.FirstFrameElementId),
+            nameof(AiRequestFormSnapshot.LastFrameElementId),
+        ];
+
+    private static readonly HashSet<string> SourceProperties =
+        [
+            nameof(AiRequestRecoverySource.Role),
+            nameof(AiRequestRecoverySource.Path),
+            nameof(AiRequestRecoverySource.Name),
+            nameof(AiRequestRecoverySource.ContentHash),
+            nameof(AiRequestRecoverySource.Length),
+            nameof(AiRequestRecoverySource.DurableFile),
+            nameof(AiRequestRecoverySource.ElementId),
+        ];
+
+    private static void EnsureKnownProperties(JsonElement element, HashSet<string> known)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+            throw new InvalidDataException("Invalid AI recovery object.");
+        HashSet<string> names = new(StringComparer.Ordinal);
+        foreach (JsonProperty property in element.EnumerateObject())
+        {
+            if (!known.Contains(property.Name) || !names.Add(property.Name))
+                throw new InvalidDataException("Unknown or duplicate AI recovery property.");
+        }
+    }
+
+    private static string RequiredString(JsonElement item, string property)
+    {
+        if (!item.TryGetProperty(property, out JsonElement element)
+            || element.ValueKind != JsonValueKind.String
+            || element.GetString() is not { } value)
+        {
+            throw new InvalidDataException($"AI recovery property '{property}' is invalid.");
+        }
+
+        return value;
+    }
+
+    private static string? OptionalString(JsonElement item, string property)
+    {
+        if (!item.TryGetProperty(property, out JsonElement element))
+            throw new InvalidDataException($"AI recovery property '{property}' is missing.");
+        return element.ValueKind switch
+        {
+            JsonValueKind.Null => null,
+            JsonValueKind.String => element.GetString(),
+            _ => throw new InvalidDataException($"AI recovery property '{property}' is invalid."),
+        };
+    }
+
+    private static void ValidateIdentity(string accountId, string operation, string fingerprint)
+    {
+        ValidateText(accountId, 128, nameof(accountId));
+        ValidateText(operation, 128, nameof(operation));
+        ValidateText(fingerprint, 128, nameof(fingerprint));
+    }
+
+    private static void ValidateRecord(AiPendingAttempt attempt)
+    {
+        ValidateIdentity(attempt.AccountId, attempt.Operation, attempt.Fingerprint);
+        if (!IsPrintable(attempt.Key, 255))
+            throw new InvalidDataException("AI request recovery key is invalid.");
+        if (attempt.Model is not null && !IsPrintable(attempt.Model, 256))
+            throw new InvalidDataException("AI request recovery model is invalid.");
+
+        if (attempt.Form is { } form)
+        {
+            ValidateOptionalMultilineText(form.Prompt, MaximumPromptLength, nameof(form.Prompt));
+            ValidateOptionalMultilineText(form.Style, MaximumPromptLength, nameof(form.Style));
+            ValidateOptionalMultilineText(form.Composition, MaximumPromptLength, nameof(form.Composition));
+            ValidateOptionalMultilineText(form.Motion, MaximumPromptLength, nameof(form.Motion));
+            ValidateOptionalMultilineText(form.Exclusions, MaximumPromptLength, nameof(form.Exclusions));
+            ValidateOptionalText(form.Task, MaximumScalarLength, nameof(form.Task));
+            ValidateOptionalText(form.AspectRatio, MaximumScalarLength, nameof(form.AspectRatio));
+            ValidateOptionalText(form.Background, MaximumScalarLength, nameof(form.Background));
+            ValidateOptionalText(form.Resolution, MaximumScalarLength, nameof(form.Resolution));
+            ValidateOptionalText(form.SourceName, MaximumScalarLength, nameof(form.SourceName));
+            if (form.MaxReferenceImages is < 0 or > AiRequestLimits.MaxImageReferences
+                || form.MaxReferenceTotalBytes is <= 0 or > MaximumSourceBytes)
+                throw new InvalidDataException("AI recovery capability snapshot is invalid.");
+            ValidateOptionalText(form.SourceElementId, MaximumScalarLength, nameof(form.SourceElementId));
+            ValidateOptionalText(form.FirstFrameElementId, MaximumScalarLength, nameof(form.FirstFrameElementId));
+            ValidateOptionalText(form.LastFrameElementId, MaximumScalarLength, nameof(form.LastFrameElementId));
+            if (form.Seed is < AiRequestLimits.MinSeed or > AiRequestLimits.MaxSeed
+                || form.DurationSeconds is < 1 or > 300
+                || form.OutpaintExpansionPercent is < 1 or > 100)
+            {
+                throw new InvalidDataException("AI recovery scalar parameter is invalid.");
+            }
+        }
+
+        IReadOnlyList<AiRequestRecoverySource> sources = attempt.EffectiveSources;
+        if (sources.Count > MaximumSourcesPerRecord)
+            throw new InvalidDataException("AI recovery source count exceeds its limit.");
+        foreach (AiRequestRecoverySource source in sources)
+            ValidateSource(source);
+    }
+
+    private static void ValidateSource(AiRequestRecoverySource source)
+    {
+        ValidateSourceMetadata(source.Role, source.Name, source.Length, source.ElementId);
+        if (source.Path is { } path)
+        {
+            if (path.Length > MaximumPathLength || path.IndexOf('\0') >= 0)
+                throw new InvalidDataException("AI recovery source path is invalid.");
+        }
+
+        if (source.DurableFile is { } durable
+            && (!IsPrintable(durable, 96)
+                || durable.Contains('/')
+                || durable.Contains('\\')
+                || !durable.EndsWith(".src", StringComparison.Ordinal)))
+        {
+            throw new InvalidDataException("AI recovery durable source locator is invalid.");
+        }
+
+        if (source.Path is null && source.DurableFile is null)
+            throw new InvalidDataException("AI recovery source has no locator.");
+        if (string.IsNullOrEmpty(source.ContentHash)
+            || source.ContentHash.Length != 64
+            || !source.ContentHash.All(Uri.IsHexDigit))
+        {
+            throw new InvalidDataException("AI recovery source hash is invalid.");
+        }
+    }
+
+    private static void ValidateSourceMetadata(
+        string role,
+        string name,
+        long length,
+        string? elementId)
+    {
+        ValidateText(role, 128, nameof(role));
+        ValidateText(name, 256, nameof(name));
+        if (length is < 0 or > MaximumSourceBytes)
+            throw new InvalidDataException("AI recovery source length is invalid.");
+        if (elementId is not null)
+            ValidateText(elementId, MaximumScalarLength, nameof(elementId));
+    }
+
+    private static void ValidateOptionalText(string? value, int maxLength, string name)
+    {
+        if (value is { Length: > 0 })
+            ValidateText(value, maxLength, name);
+    }
+
+    private static void ValidateOptionalMultilineText(string? value, int maxLength, string name)
+    {
+        if (value is null)
+            return;
+        if (value.Length > maxLength
+            || value.Any(character => char.IsControl(character)
+                && character is not ('\r' or '\n' or '\t')))
+        {
+            throw new InvalidDataException($"AI request recovery {name} is invalid.");
+        }
+    }
+
+    private static void ValidateText(string value, int maxLength, string name)
+    {
+        if (string.IsNullOrEmpty(value)
+            || value.Length > maxLength
+            || value.Any(char.IsControl))
+        {
+            throw new InvalidDataException($"AI request recovery {name} is invalid.");
+        }
+    }
+
+    private static bool IsPrintable(string value, int maxLength)
+        => value.Length > 0
+            && value.Length <= maxLength
+            && value.All(character => character is >= '\x20' and <= '\x7e');
+
+    private static void WritePrivateBytes(string path, ReadOnlySpan<byte> bytes)
+    {
+        var options = new FileStreamOptions
+        {
+            Mode = FileMode.CreateNew,
+            Access = FileAccess.Write,
+            Share = FileShare.None,
+            Options = FileOptions.WriteThrough | FileOptions.SequentialScan,
+        };
+        if (!OperatingSystem.IsWindows())
+            options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        using FileStream stream = new(path, options);
+        stream.Write(bytes);
+        stream.Flush(flushToDisk: true);
+        RestrictFile(path);
+    }
+
+    private static void AtomicReplace(string temporary, string destination, bool overwrite)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            File.Move(temporary, destination, overwrite);
+            return;
+        }
+        const uint replace = 0x1;
+        const uint writeThrough = 0x8;
+        if (!MoveFileEx(temporary, destination, writeThrough | (overwrite ? replace : 0)))
+            throw new IOException("Atomic recovery-file replacement failed.", new Win32Exception(Marshal.GetLastWin32Error()));
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool MoveFileEx(string existingFileName, string newFileName, uint flags);
+
+    /// <summary>
+    /// Flushes directory metadata after rename on Unix. Windows provides no
+    /// portable directory fsync; file contents are flushed and rename is
+    /// atomic, but directory-entry durability is delegated to the filesystem.
+    /// </summary>
+    private static void EnsureDirectorySynced(string path)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+        int fd = UnixOpen(path, 0);
+        if (fd < 0)
+            throw new IOException($"Unable to open directory for durability sync (errno {Marshal.GetLastWin32Error()}).");
+        try
+        {
+            if (UnixFsync(fd) != 0)
+                throw new IOException($"Unable to fsync directory (errno {Marshal.GetLastWin32Error()}).");
+        }
+        finally
+        {
+            if (UnixClose(fd) != 0)
+                throw new IOException($"Unable to close synced directory (errno {Marshal.GetLastWin32Error()}).");
+        }
+    }
+
+    private static bool IsMarkerLocked(string path)
+    {
+        try
+        {
+            using FileStream stream = new(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            return false;
+        }
+        catch (IOException)
+        {
+            return true;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return true;
+        }
+    }
+
+    [DllImport("libc", EntryPoint = "open", SetLastError = true)]
+    private static extern int UnixOpen(string path, int flags);
+
+    [DllImport("libc", EntryPoint = "fsync", SetLastError = true)]
+    private static extern int UnixFsync(int fd);
+
+    [DllImport("libc", EntryPoint = "close", SetLastError = true)]
+    private static extern int UnixClose(int fd);
+
+    private static bool IsWithinDirectory(string path, string directory)
+    {
+        string fullPath = Path.GetFullPath(path);
+        string fullDirectory = Path.GetFullPath(directory)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+        return fullPath.StartsWith(fullDirectory, StringComparison.Ordinal);
+    }
+
+    private static void RestrictDirectory(string path)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(
+                path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
+    private static void RestrictFile(string path)
+    {
+        if (!OperatingSystem.IsWindows() && File.Exists(path))
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+        }
+    }
+}
+
+internal sealed class AiRequestRecoveryContext : IDisposable
+{
+    private readonly FileAiRequestRecoveryStore _store;
+    private readonly Func<AiAuthenticatedRequestIdentity?> _identityProvider;
+    private readonly IDisposable? _identitySubscription;
+    private string? _lastAccount;
+
+    public event Action? IdentityChanged;
+
+    public AiRequestRecoveryContext(
+        FileAiRequestRecoveryStore store,
+        Func<AiAuthenticatedRequestIdentity?> identityProvider,
+        IObservable<AiAuthenticatedRequestIdentity?>? identityChanges = null)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _identityProvider = identityProvider ?? throw new ArgumentNullException(nameof(identityProvider));
+        _identitySubscription = identityChanges?.Subscribe(_ => RefreshIdentity());
+    }
+
+    public FileAiRequestRecoveryStore Store => _store;
+
+    public AiAuthenticatedRequestIdentity GetRequiredIdentity()
+    {
+        AiAuthenticatedRequestIdentity identity = _identityProvider()
+            ?? throw new AuthenticationRequiredException();
+        if (string.IsNullOrWhiteSpace(identity.AccountId)
+            || identity.User is { } user
+                && !StringComparer.Ordinal.Equals(user.Profile.Id, identity.AccountId))
+        {
+            throw new AuthenticationRequiredException();
+        }
+
+        return identity;
+    }
+
+    public AiAuthenticatedRequestIdentity? TryGetIdentity()
+    {
+        AiAuthenticatedRequestIdentity? current = _identityProvider();
+        if (current is { } identity
+            && (string.IsNullOrWhiteSpace(identity.AccountId)
+                || identity.User is { } user
+                    && !StringComparer.Ordinal.Equals(user.Profile.Id, identity.AccountId)))
+        {
+            current = null;
+        }
+
+        string? account = current?.AccountId;
+        if (!StringComparer.Ordinal.Equals(account, _lastAccount))
+        {
+            _lastAccount = account;
+            try
+            {
+                foreach (Action handler in IdentityChanged?.GetInvocationList().Cast<Action>()
+                    ?? Array.Empty<Action>())
+                {
+                    try
+                    {
+                        handler();
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        return current;
+    }
+
+    public void RefreshIdentity() => _ = TryGetIdentity();
+
+    public IReadOnlyList<AiPendingAttempt> PendingFor(string operation)
+        => TryGetIdentity() is { } identity
+            ? _store.PendingFor(identity.AccountId, operation)
+            : Array.Empty<AiPendingAttempt>();
+
+    public bool Abandon(AiPendingAttempt attempt)
+    {
+        AiAuthenticatedRequestIdentity identity = GetRequiredIdentity();
+        if (!StringComparer.Ordinal.Equals(identity.AccountId, attempt.AccountId))
+            throw new AuthenticationRequiredException();
+        return _store.Abandon(attempt);
+    }
+
+    public void Dispose()
+    {
+        _identitySubscription?.Dispose();
+        _store.Dispose();
+    }
+
+    public IDisposable Enter(string issuedAccountId)
+    {
+        AiAuthenticatedRequestIdentity current = GetRequiredIdentity();
+        if (!StringComparer.Ordinal.Equals(current.AccountId, issuedAccountId))
+            throw new AuthenticationRequiredException();
+        return current.User is null
+            ? EmptyDisposable.Instance
+            : AiAuthenticatedRequestScope.Enter(current.User);
+    }
+}

--- a/src/Beutl/Services/AI/IPromptLibrary.cs
+++ b/src/Beutl/Services/AI/IPromptLibrary.cs
@@ -1,0 +1,83 @@
+﻿namespace Beutl.Services.AI;
+
+internal interface IPromptLibrary
+{
+    string StoragePath { get; }
+
+    bool RetainRecentPromptText { get; }
+
+    string? RecoveredCorruptFilePath { get; }
+
+    IReadOnlyList<PromptHistoryEntry> History { get; }
+
+    IReadOnlyList<PromptTemplate> Templates { get; }
+
+    PromptHistoryEntry Record(PromptTaskKind taskKind, string prompt);
+
+    PromptTemplate SaveTemplate(string name, PromptTaskKind taskKind, string prompt);
+
+    bool SetHistoryPinned(Guid id, bool isPinned);
+
+    bool SetTemplatePinned(Guid id, bool isPinned);
+
+    bool DeleteHistory(Guid id);
+
+    bool DeleteTemplate(Guid id);
+
+    void ClearHistory();
+
+    void ClearTemplates();
+
+    void ClearAll();
+}
+
+/// <summary>
+/// Publishes committed prompt-library changes without making observation part of the storage
+/// contract required by simple or read-only implementations.
+/// </summary>
+internal interface IPromptLibraryChangeSource
+{
+    IDisposable SubscribeChanged(Action callback);
+}
+
+internal static class PromptLibraryChangeHub
+{
+    private static event Action<string>? Changed;
+
+    public static IDisposable Subscribe(Action<string> callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        Changed += callback;
+        return new Subscription(callback);
+    }
+
+    public static void Publish(string storagePath)
+    {
+        foreach (Action<string> callback in Changed?.GetInvocationList().Cast<Action<string>>()
+            ?? Array.Empty<Action<string>>())
+        {
+            try
+            {
+                callback(storagePath);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Trace.TraceWarning(
+                    "A prompt-library change observer failed: {0}",
+                    ex.Message);
+            }
+        }
+    }
+
+    private sealed class Subscription(Action<string> callback) : IDisposable
+    {
+        private Action<string>? _callback = callback;
+
+        public void Dispose()
+        {
+            Action<string>? callback = Interlocked.Exchange(ref _callback, null);
+            if (callback is not null)
+                Changed -= callback;
+        }
+    }
+}

--- a/src/Beutl/Services/AI/PersistentPromptLibrary.cs
+++ b/src/Beutl/Services/AI/PersistentPromptLibrary.cs
@@ -518,13 +518,12 @@ internal sealed class PersistentPromptLibrary : IPromptLibrary, IPromptLibraryCh
 
         items.Sort((left, right) => right.LastUsedAtUtc.CompareTo(left.LastUsedAtUtc));
         var coalesced = new List<PromptHistoryEntry>(items.Count);
+        var historyIndex = new Dictionary<(PromptTaskKind Kind, string Prompt), int>();
         foreach (PromptHistoryEntry item in items)
         {
-            int index = coalesced.FindIndex(existing =>
-                existing.TaskKind == item.TaskKind
-                && string.Equals(existing.Prompt, item.Prompt, StringComparison.Ordinal));
-            if (index < 0)
+            if (!historyIndex.TryGetValue((item.TaskKind, item.Prompt), out int index))
             {
+                historyIndex.Add((item.TaskKind, item.Prompt), coalesced.Count);
                 coalesced.Add(item);
                 continue;
             }

--- a/src/Beutl/Services/AI/PersistentPromptLibrary.cs
+++ b/src/Beutl/Services/AI/PersistentPromptLibrary.cs
@@ -1,0 +1,947 @@
+﻿using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Beutl.Services.AI;
+
+internal sealed class PersistentPromptLibrary : IPromptLibrary, IPromptLibraryChangeSource
+{
+    internal const int CurrentStorageVersion = 2;
+    private const int LegacyMaxPromptLength = 32_768;
+    // Templates model prompts that can be sent to the paid API. Keeping oversized text here
+    // would create reusable entries that can never pass final request validation.
+    internal const int MaxPromptLength = Beutl.Api.Services.AiRequestLimits.MaxPromptLength;
+    internal const int MaxTemplateNameLength = 128;
+    private const int WriteLockTimeoutMilliseconds = 2_000;
+
+    private static readonly JsonSerializerOptions s_jsonOptions = CreateJsonOptions();
+
+    private readonly object _gate = new();
+    private readonly PromptLibraryOptions _options;
+    private readonly Action<string, string> _replaceFile;
+    private readonly Action? _beforeNormalizationWriteLock;
+    private readonly Action? _beforeCorruptionWriteLock;
+    private readonly TimeProvider _timeProvider;
+    private readonly string _lockPath;
+    private List<PromptHistoryEntry> _history = [];
+    private List<PromptTemplate> _templates = [];
+
+    public PersistentPromptLibrary(
+        string storagePath,
+        PromptLibraryOptions? options = null,
+        TimeProvider? timeProvider = null,
+        Action<string, string>? replaceFile = null,
+        Action? beforeNormalizationWriteLock = null,
+        Action? beforeCorruptionWriteLock = null)
+    {
+        if (string.IsNullOrWhiteSpace(storagePath))
+        {
+            throw new ArgumentException("A storage file path is required.", nameof(storagePath));
+        }
+
+        StoragePath = Path.GetFullPath(storagePath);
+        if (string.IsNullOrEmpty(Path.GetFileName(StoragePath)) || Directory.Exists(StoragePath))
+        {
+            throw new ArgumentException("The storage path must identify a file.", nameof(storagePath));
+        }
+
+        _options = options ?? new PromptLibraryOptions();
+        ValidateOptions(_options);
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _lockPath = StoragePath + ".lock";
+        _replaceFile = replaceFile ?? ReplaceFile;
+        _beforeNormalizationWriteLock = beforeNormalizationWriteLock;
+        _beforeCorruptionWriteLock = beforeCorruptionWriteLock;
+
+        if (File.Exists(StoragePath))
+        {
+            Load();
+        }
+    }
+
+    public string StoragePath { get; }
+
+    public bool RetainRecentPromptText => _options.RetainRecentPromptText;
+
+    public string? RecoveredCorruptFilePath { get; private set; }
+
+    public IReadOnlyList<PromptHistoryEntry> History
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _history.ToArray();
+            }
+        }
+    }
+
+    public IReadOnlyList<PromptTemplate> Templates
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _templates.ToArray();
+            }
+        }
+    }
+
+    public IDisposable SubscribeChanged(Action callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        return PromptLibraryChangeHub.Subscribe(path =>
+        {
+            if (StringComparer.Ordinal.Equals(StoragePath, path))
+                callback();
+        });
+    }
+
+    public PromptHistoryEntry Record(PromptTaskKind taskKind, string prompt)
+    {
+        ValidateTaskKind(taskKind);
+        string normalizedPrompt = NormalizePrompt(prompt, nameof(prompt));
+
+        PromptHistoryEntry entry;
+        lock (_gate)
+        {
+            using FileStream writeLock = BeginWrite();
+            ReloadForWrite();
+            List<PromptHistoryEntry> history = [.. _history];
+            DateTimeOffset now = _timeProvider.GetUtcNow().ToUniversalTime();
+            int index = history.FindIndex(item =>
+                item.TaskKind == taskKind
+                && string.Equals(item.Prompt, normalizedPrompt, StringComparison.Ordinal));
+
+            if (index >= 0)
+            {
+                PromptHistoryEntry existing = history[index];
+                entry = existing with
+                {
+                    LastUsedAtUtc = now,
+                    UseCount = IncrementSaturating(existing.UseCount),
+                };
+                history.RemoveAt(index);
+            }
+            else
+            {
+                entry = new PromptHistoryEntry(
+                    Guid.NewGuid(),
+                    taskKind,
+                    normalizedPrompt,
+                    now,
+                    1,
+                    false);
+            }
+
+            history.Insert(0, entry);
+            TrimRecentHistory(history);
+            Commit(history, [.. _templates], writeLock);
+        }
+        PublishChanged();
+        return entry;
+    }
+
+    public PromptTemplate SaveTemplate(string name, PromptTaskKind taskKind, string prompt)
+    {
+        ValidateTaskKind(taskKind);
+        string normalizedName = NormalizeTemplateName(name);
+        string normalizedPrompt = NormalizePrompt(prompt, nameof(prompt));
+
+        PromptTemplate template;
+        lock (_gate)
+        {
+            using FileStream writeLock = BeginWrite();
+            ReloadForWrite();
+            List<PromptTemplate> templates = [.. _templates];
+            DateTimeOffset now = _timeProvider.GetUtcNow().ToUniversalTime();
+            int index = templates.FindIndex(item =>
+                item.TaskKind == taskKind
+                && string.Equals(item.Name, normalizedName, StringComparison.OrdinalIgnoreCase));
+
+            if (index >= 0)
+            {
+                PromptTemplate existing = templates[index];
+                template = existing with
+                {
+                    Name = normalizedName,
+                    Prompt = normalizedPrompt,
+                    UpdatedAtUtc = now,
+                };
+                templates.RemoveAt(index);
+            }
+            else
+            {
+                template = new PromptTemplate(
+                    Guid.NewGuid(),
+                    normalizedName,
+                    taskKind,
+                    normalizedPrompt,
+                    now,
+                    now,
+                    false);
+            }
+
+            templates.Insert(0, template);
+            Commit([.. _history], templates, writeLock);
+        }
+        PublishChanged();
+        return template;
+    }
+
+    public bool SetHistoryPinned(Guid id, bool isPinned)
+    {
+        lock (_gate)
+        {
+            using FileStream writeLock = BeginWrite();
+            ReloadForWrite();
+            List<PromptHistoryEntry> history = [.. _history];
+            int index = history.FindIndex(item => item.Id == id);
+            if (index < 0 || history[index].IsPinned == isPinned)
+            {
+                return false;
+            }
+
+            history[index] = history[index] with { IsPinned = isPinned };
+            TrimRecentHistory(history);
+            Commit(history, [.. _templates], writeLock);
+        }
+        PublishChanged();
+        return true;
+    }
+
+    public bool SetTemplatePinned(Guid id, bool isPinned)
+    {
+        lock (_gate)
+        {
+            using FileStream writeLock = BeginWrite();
+            ReloadForWrite();
+            List<PromptTemplate> templates = [.. _templates];
+            int index = templates.FindIndex(item => item.Id == id);
+            if (index < 0 || templates[index].IsPinned == isPinned)
+            {
+                return false;
+            }
+
+            templates[index] = templates[index] with { IsPinned = isPinned };
+            Commit([.. _history], templates, writeLock);
+        }
+        PublishChanged();
+        return true;
+    }
+
+    public bool DeleteHistory(Guid id)
+    {
+        lock (_gate)
+        {
+            using FileStream writeLock = BeginWrite();
+            ReloadForWrite();
+            List<PromptHistoryEntry> history = [.. _history];
+            int index = history.FindIndex(item => item.Id == id);
+            if (index < 0)
+            {
+                return false;
+            }
+
+            history.RemoveAt(index);
+            Commit(history, [.. _templates], writeLock);
+        }
+        PublishChanged();
+        return true;
+    }
+
+    public bool DeleteTemplate(Guid id)
+    {
+        lock (_gate)
+        {
+            using FileStream writeLock = BeginWrite();
+            ReloadForWrite();
+            List<PromptTemplate> templates = [.. _templates];
+            int index = templates.FindIndex(item => item.Id == id);
+            if (index < 0)
+            {
+                return false;
+            }
+
+            templates.RemoveAt(index);
+            Commit([.. _history], templates, writeLock);
+        }
+        PublishChanged();
+        return true;
+    }
+
+    public void ClearHistory()
+    {
+        bool changed = false;
+        lock (_gate)
+        {
+            using FileStream writeLock = BeginWrite();
+            ReloadForWrite();
+            if (_history.Count > 0)
+            {
+                Commit([], [.. _templates], writeLock);
+                changed = true;
+            }
+        }
+        if (changed)
+            PublishChanged();
+    }
+
+    public void ClearTemplates()
+    {
+        bool changed = false;
+        lock (_gate)
+        {
+            using FileStream writeLock = BeginWrite();
+            ReloadForWrite();
+            if (_templates.Count > 0)
+            {
+                Commit([.. _history], [], writeLock);
+                changed = true;
+            }
+        }
+        if (changed)
+            PublishChanged();
+    }
+
+    public void ClearAll()
+    {
+        bool changed = false;
+        lock (_gate)
+        {
+            using FileStream writeLock = BeginWrite();
+            ReloadForWrite();
+            if (_history.Count > 0 || _templates.Count > 0)
+            {
+                Commit([], [], writeLock);
+                changed = true;
+            }
+        }
+        if (changed)
+            PublishChanged();
+    }
+
+    private static JsonSerializerOptions CreateJsonOptions()
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true,
+        };
+        options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase, false));
+        return options;
+    }
+
+    private static void ValidateOptions(PromptLibraryOptions options)
+    {
+        if (options.MaxRecentItems is < 1 or > PromptLibraryOptions.MaximumMaxRecentItems)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options),
+                options.MaxRecentItems,
+                $"MaxRecentItems must be between 1 and {PromptLibraryOptions.MaximumMaxRecentItems}.");
+        }
+    }
+
+    private static void ValidateTaskKind(PromptTaskKind taskKind)
+    {
+        if (!Enum.IsDefined(typeof(PromptTaskKind), taskKind))
+        {
+            throw new ArgumentOutOfRangeException(nameof(taskKind));
+        }
+    }
+
+    private static string NormalizePrompt(string prompt, string parameterName)
+    {
+        string normalized = NormalizePromptText(prompt, parameterName);
+
+        if (normalized.Length > MaxPromptLength)
+        {
+            throw new ArgumentException(
+                $"The prompt cannot exceed {MaxPromptLength} characters.",
+                parameterName);
+        }
+
+        return normalized;
+    }
+
+    private static string NormalizePromptText(string prompt, string parameterName)
+    {
+        ArgumentNullException.ThrowIfNull(prompt, parameterName);
+        string normalized = prompt
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n')
+            .Trim();
+        if (normalized.Length == 0)
+            throw new ArgumentException("A prompt is required.", parameterName);
+
+        return normalized;
+    }
+
+    private static string NormalizeTemplateName(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        string normalized = name.Trim();
+        if (normalized.Length == 0)
+        {
+            throw new ArgumentException("A template name is required.", nameof(name));
+        }
+
+        if (normalized.Length > MaxTemplateNameLength)
+        {
+            throw new ArgumentException(
+                $"The template name cannot exceed {MaxTemplateNameLength} characters.",
+                nameof(name));
+        }
+
+        if (normalized.Any(char.IsControl))
+        {
+            throw new ArgumentException("The template name cannot contain control characters.", nameof(name));
+        }
+
+        return normalized;
+    }
+
+    private static int IncrementSaturating(int value) => value == int.MaxValue ? value : value + 1;
+
+    private static int AddSaturating(int left, int right) =>
+        left > int.MaxValue - right ? int.MaxValue : left + right;
+
+    private void Load()
+    {
+        try
+        {
+            using FileStream stream = File.OpenRead(StoragePath);
+            StorageDocument document = JsonSerializer.Deserialize<StorageDocument>(stream, s_jsonOptions)
+                ?? throw new InvalidDataException("The prompt library document is empty.");
+
+            if (document.Version > CurrentStorageVersion)
+            {
+                throw new NotSupportedException(
+                    $"Prompt library version {document.Version} is newer than supported version {CurrentStorageVersion}.");
+            }
+
+            if (document.Version < 1)
+            {
+                throw new InvalidDataException($"Unsupported prompt library version {document.Version}.");
+            }
+
+            if (document.History is null || document.Templates is null)
+            {
+                throw new InvalidDataException("The prompt library collections are missing.");
+            }
+
+            var ids = new HashSet<Guid>();
+            bool migrateLegacyPrompts = document.Version == 1;
+            List<PromptHistoryEntry> history = LoadHistory(
+                document.History,
+                ids,
+                migrateLegacyPrompts,
+                out bool historyChanged);
+            List<PromptTemplate> templates = LoadTemplates(
+                document.Templates,
+                ids,
+                migrateLegacyPrompts,
+                out bool templatesChanged);
+
+            bool retentionChanged = false;
+            if (!_options.RetainRecentPromptText)
+            {
+                retentionChanged = history.RemoveAll(item => !item.IsPinned) > 0;
+            }
+
+            int historyCount = history.Count;
+            TrimRecentHistory(history);
+            bool trimChanged = history.Count != historyCount;
+
+            _history = history;
+            _templates = templates;
+
+            if (migrateLegacyPrompts
+                || historyChanged
+                || templatesChanged
+                || retentionChanged
+                || trimChanged)
+            {
+                // The file may change after the initial read and before this process can
+                // acquire the cross-process writer lock. Reload and normalize the winner
+                // under that lock rather than publishing this stale snapshot.
+                _beforeNormalizationWriteLock?.Invoke();
+                using FileStream writeLock = BeginWrite();
+                if (ReloadForWrite())
+                {
+                    WriteDocument(_history, _templates, writeLock);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidDataException)
+        {
+            RecoverFromCorruption();
+        }
+    }
+
+    private static List<PromptHistoryEntry> LoadHistory(
+        IReadOnlyCollection<StoredHistoryEntry> storedItems,
+        HashSet<Guid> ids,
+        bool migrateLegacyPrompts,
+        out bool changed)
+    {
+        var items = new List<PromptHistoryEntry>(storedItems.Count);
+        changed = false;
+
+        foreach (StoredHistoryEntry stored in storedItems)
+        {
+            ValidateStoredId(stored.Id, ids);
+            PromptTaskKind taskKind = ValidateStoredTaskKind(stored.TaskKind);
+            string? prompt = NormalizeStoredPrompt(stored.Prompt, migrateLegacyPrompts);
+            if (stored.LastUsedAtUtc is not { } lastUsedAtUtc || stored.UseCount < 1)
+            {
+                throw new InvalidDataException("A prompt history entry has invalid usage data.");
+            }
+            if (prompt is null)
+            {
+                changed = true;
+                continue;
+            }
+
+            DateTimeOffset normalizedTimestamp = lastUsedAtUtc.ToUniversalTime();
+            changed |= !string.Equals(stored.Prompt, prompt, StringComparison.Ordinal)
+                || stored.LastUsedAtUtc != normalizedTimestamp;
+            items.Add(new PromptHistoryEntry(
+                stored.Id,
+                taskKind,
+                prompt,
+                normalizedTimestamp,
+                stored.UseCount,
+                stored.IsPinned));
+        }
+
+        items.Sort((left, right) => right.LastUsedAtUtc.CompareTo(left.LastUsedAtUtc));
+        var coalesced = new List<PromptHistoryEntry>(items.Count);
+        foreach (PromptHistoryEntry item in items)
+        {
+            int index = coalesced.FindIndex(existing =>
+                existing.TaskKind == item.TaskKind
+                && string.Equals(existing.Prompt, item.Prompt, StringComparison.Ordinal));
+            if (index < 0)
+            {
+                coalesced.Add(item);
+                continue;
+            }
+
+            PromptHistoryEntry existing = coalesced[index];
+            coalesced[index] = existing with
+            {
+                UseCount = AddSaturating(existing.UseCount, item.UseCount),
+                IsPinned = existing.IsPinned || item.IsPinned,
+            };
+            changed = true;
+        }
+
+        return coalesced;
+    }
+
+    private static List<PromptTemplate> LoadTemplates(
+        IReadOnlyCollection<StoredTemplate> storedItems,
+        HashSet<Guid> ids,
+        bool migrateLegacyPrompts,
+        out bool changed)
+    {
+        var items = new List<PromptTemplate>(storedItems.Count);
+        changed = false;
+
+        foreach (StoredTemplate stored in storedItems)
+        {
+            ValidateStoredId(stored.Id, ids);
+            PromptTaskKind taskKind = ValidateStoredTaskKind(stored.TaskKind);
+            string name = NormalizeStoredTemplateName(stored.Name);
+            string? prompt = NormalizeStoredPrompt(stored.Prompt, migrateLegacyPrompts);
+            if (stored.CreatedAtUtc is not { } createdAtUtc
+                || stored.UpdatedAtUtc is not { } updatedAtUtc
+                || createdAtUtc > updatedAtUtc)
+            {
+                throw new InvalidDataException("A prompt template has invalid timestamps.");
+            }
+            if (prompt is null)
+            {
+                changed = true;
+                continue;
+            }
+
+            DateTimeOffset normalizedCreatedAt = createdAtUtc.ToUniversalTime();
+            DateTimeOffset normalizedUpdatedAt = updatedAtUtc.ToUniversalTime();
+            changed |= !string.Equals(stored.Name, name, StringComparison.Ordinal)
+                || !string.Equals(stored.Prompt, prompt, StringComparison.Ordinal)
+                || stored.CreatedAtUtc != normalizedCreatedAt
+                || stored.UpdatedAtUtc != normalizedUpdatedAt;
+            items.Add(new PromptTemplate(
+                stored.Id,
+                name,
+                taskKind,
+                prompt,
+                normalizedCreatedAt,
+                normalizedUpdatedAt,
+                stored.IsPinned));
+        }
+
+        items.Sort((left, right) => right.UpdatedAtUtc.CompareTo(left.UpdatedAtUtc));
+        var coalesced = new List<PromptTemplate>(items.Count);
+        foreach (PromptTemplate item in items)
+        {
+            int index = coalesced.FindIndex(existing =>
+                existing.TaskKind == item.TaskKind
+                && string.Equals(existing.Name, item.Name, StringComparison.OrdinalIgnoreCase));
+            if (index < 0)
+            {
+                coalesced.Add(item);
+                continue;
+            }
+
+            PromptTemplate existing = coalesced[index];
+            coalesced[index] = existing with
+            {
+                CreatedAtUtc = existing.CreatedAtUtc < item.CreatedAtUtc
+                    ? existing.CreatedAtUtc
+                    : item.CreatedAtUtc,
+                IsPinned = existing.IsPinned || item.IsPinned,
+            };
+            changed = true;
+        }
+
+        return coalesced;
+    }
+
+    private static void ValidateStoredId(Guid id, HashSet<Guid> ids)
+    {
+        if (id == Guid.Empty || !ids.Add(id))
+        {
+            throw new InvalidDataException("A prompt library item has an invalid or duplicate ID.");
+        }
+    }
+
+    private static PromptTaskKind ValidateStoredTaskKind(PromptTaskKind? taskKind)
+    {
+        if (taskKind is not { } value || !Enum.IsDefined(typeof(PromptTaskKind), value))
+        {
+            throw new InvalidDataException("A prompt library item has an invalid task kind.");
+        }
+
+        return value;
+    }
+
+    private static string? NormalizeStoredPrompt(string? prompt, bool migrateLegacyPrompt)
+    {
+        try
+        {
+            string normalized = NormalizePromptText(prompt!, nameof(prompt));
+            int maximumLength = migrateLegacyPrompt
+                ? LegacyMaxPromptLength
+                : MaxPromptLength;
+            if (normalized.Length > maximumLength)
+            {
+                throw new ArgumentException(
+                    $"The prompt cannot exceed {maximumLength} characters.",
+                    nameof(prompt));
+            }
+            // Version 1 permitted larger prompts. Drop only an entry that the
+            // paid API can no longer submit, rather than treating its siblings
+            // as corrupt or silently changing the prompt's meaning.
+            return migrateLegacyPrompt && normalized.Length > MaxPromptLength
+                ? null
+                : normalized;
+        }
+        catch (ArgumentException ex)
+        {
+            throw new InvalidDataException("A stored prompt is invalid.", ex);
+        }
+    }
+
+    private static string NormalizeStoredTemplateName(string? name)
+    {
+        try
+        {
+            return NormalizeTemplateName(name!);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new InvalidDataException("A stored template name is invalid.", ex);
+        }
+    }
+
+    private void TrimRecentHistory(List<PromptHistoryEntry> history)
+    {
+        int recentCount = 0;
+        for (int i = 0; i < history.Count; i++)
+        {
+            if (history[i].IsPinned)
+            {
+                continue;
+            }
+
+            recentCount++;
+            if (recentCount > _options.MaxRecentItems)
+            {
+                history.RemoveAt(i);
+                i--;
+            }
+        }
+    }
+
+    private FileStream BeginWrite()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(StoragePath)!);
+        long deadline = Environment.TickCount64 + WriteLockTimeoutMilliseconds;
+        while (true)
+        {
+            try
+            {
+                return new FileStream(
+                    _lockPath,
+                    new FileStreamOptions
+                    {
+                        Mode = FileMode.OpenOrCreate,
+                        Access = FileAccess.ReadWrite,
+                        Share = FileShare.None,
+                        BufferSize = 1,
+                        Options = FileOptions.WriteThrough,
+                    });
+            }
+            catch (IOException) when (Environment.TickCount64 < deadline)
+            {
+                Thread.Sleep(10);
+            }
+        }
+    }
+
+    // The process lock protects the read-modify-write window. Reload while it is held so a
+    // second library instance does not commit a stale in-memory snapshot over a newer change.
+    private bool ReloadForWrite()
+    {
+        PromptHistoryEntry[] localTransientHistory = _options.RetainRecentPromptText
+            ? []
+            : _history.Where(item => !item.IsPinned).ToArray();
+        if (!File.Exists(StoragePath))
+        {
+            _history = localTransientHistory.ToList();
+            _templates = [];
+            return false;
+        }
+
+        using FileStream stream = File.OpenRead(StoragePath);
+        StorageDocument document = JsonSerializer.Deserialize<StorageDocument>(stream, s_jsonOptions)
+            ?? throw new InvalidDataException("The prompt library document is empty.");
+        if (document.Version > CurrentStorageVersion)
+        {
+            throw new NotSupportedException(
+                $"Prompt library version {document.Version} is newer than supported version {CurrentStorageVersion}.");
+        }
+        if (document.Version < 1
+            || document.History is null
+            || document.Templates is null)
+        {
+            throw new InvalidDataException("The prompt library document is invalid.");
+        }
+
+        var ids = new HashSet<Guid>();
+        List<PromptHistoryEntry> history = LoadHistory(
+            document.History,
+            ids,
+            document.Version == 1,
+            out bool historyChanged);
+        List<PromptTemplate> templates = LoadTemplates(
+            document.Templates,
+            ids,
+            document.Version == 1,
+            out bool templatesChanged);
+        bool retentionChanged = false;
+        if (!_options.RetainRecentPromptText)
+        {
+            retentionChanged = history.RemoveAll(item => !item.IsPinned) > 0;
+            var persistedIds = history.Select(item => item.Id).ToHashSet();
+            history.InsertRange(
+                0,
+                localTransientHistory.Where(item => !persistedIds.Contains(item.Id)));
+        }
+        int historyCount = history.Count;
+        TrimRecentHistory(history);
+        bool trimChanged = history.Count != historyCount;
+        _history = history;
+        _templates = templates;
+        return document.Version == 1
+            || historyChanged
+            || templatesChanged
+            || retentionChanged
+            || trimChanged;
+    }
+
+    private void Commit(
+        List<PromptHistoryEntry> history,
+        List<PromptTemplate> templates,
+        FileStream writeLock)
+    {
+        WriteDocument(history, templates, writeLock);
+        _history = history;
+        _templates = templates;
+    }
+
+    private void PublishChanged()
+        => PromptLibraryChangeHub.Publish(StoragePath);
+
+    private void WriteDocument(
+        IReadOnlyCollection<PromptHistoryEntry> history,
+        IReadOnlyCollection<PromptTemplate> templates,
+        FileStream? writeLock = null)
+    {
+        using FileStream? ownedLock = writeLock is null ? BeginWrite() : null;
+        var document = new StorageDocument
+        {
+            Version = CurrentStorageVersion,
+            History = history
+                .Where(item => _options.RetainRecentPromptText || item.IsPinned)
+                .Select(StoredHistoryEntry.FromModel)
+                .ToList(),
+            Templates = templates.Select(StoredTemplate.FromModel).ToList(),
+        };
+
+        string directory = Path.GetDirectoryName(StoragePath)!;
+        Directory.CreateDirectory(directory);
+        string tempPath = Path.Combine(
+            directory,
+            $".{Path.GetFileName(StoragePath)}.{Guid.NewGuid():N}.tmp");
+
+        try
+        {
+            var streamOptions = new FileStreamOptions
+            {
+                Mode = FileMode.CreateNew,
+                Access = FileAccess.Write,
+                Share = FileShare.None,
+                BufferSize = 4096,
+                Options = FileOptions.WriteThrough,
+            };
+            if (!OperatingSystem.IsWindows())
+            {
+                streamOptions.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+            }
+
+            using (var stream = new FileStream(tempPath, streamOptions))
+            {
+                JsonSerializer.Serialize(stream, document, s_jsonOptions);
+                stream.Flush(true);
+            }
+
+            _replaceFile(tempPath, StoragePath);
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
+    private static void ReplaceFile(string sourcePath, string destinationPath) =>
+        File.Move(sourcePath, destinationPath, true);
+
+    private void RecoverFromCorruption()
+    {
+        _beforeCorruptionWriteLock?.Invoke();
+        using FileStream writeLock = BeginWrite();
+        if (!File.Exists(StoragePath))
+        {
+            _history = [];
+            _templates = [];
+            WriteDocument(_history, _templates, writeLock);
+            return;
+        }
+
+        try
+        {
+            if (ReloadForWrite())
+            {
+                WriteDocument(_history, _templates, writeLock);
+            }
+            return;
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidDataException)
+        {
+            // The current lock owner is responsible for quarantining the corrupt winner below.
+        }
+
+        string timestamp = _timeProvider.GetUtcNow()
+            .ToUniversalTime()
+            .ToString("yyyyMMddHHmmssfff", CultureInfo.InvariantCulture);
+        string recoveryPath;
+        do
+        {
+            recoveryPath = $"{StoragePath}.corrupt-{timestamp}-{Guid.NewGuid():N}";
+        }
+        while (File.Exists(recoveryPath));
+
+        File.Move(StoragePath, recoveryPath);
+        RecoveredCorruptFilePath = recoveryPath;
+        _history = [];
+        _templates = [];
+        WriteDocument(_history, _templates, writeLock);
+    }
+
+    private sealed class StorageDocument
+    {
+        public int Version { get; set; }
+
+        public List<StoredHistoryEntry>? History { get; set; }
+
+        public List<StoredTemplate>? Templates { get; set; }
+    }
+
+    private sealed class StoredHistoryEntry
+    {
+        public Guid Id { get; set; }
+
+        public PromptTaskKind? TaskKind { get; set; }
+
+        public string? Prompt { get; set; }
+
+        public DateTimeOffset? LastUsedAtUtc { get; set; }
+
+        public int UseCount { get; set; }
+
+        public bool IsPinned { get; set; }
+
+        public static StoredHistoryEntry FromModel(PromptHistoryEntry model) => new()
+        {
+            Id = model.Id,
+            TaskKind = model.TaskKind,
+            Prompt = model.Prompt,
+            LastUsedAtUtc = model.LastUsedAtUtc,
+            UseCount = model.UseCount,
+            IsPinned = model.IsPinned,
+        };
+    }
+
+    private sealed class StoredTemplate
+    {
+        public Guid Id { get; set; }
+
+        public string? Name { get; set; }
+
+        public PromptTaskKind? TaskKind { get; set; }
+
+        public string? Prompt { get; set; }
+
+        public DateTimeOffset? CreatedAtUtc { get; set; }
+
+        public DateTimeOffset? UpdatedAtUtc { get; set; }
+
+        public bool IsPinned { get; set; }
+
+        public static StoredTemplate FromModel(PromptTemplate model) => new()
+        {
+            Id = model.Id,
+            Name = model.Name,
+            TaskKind = model.TaskKind,
+            Prompt = model.Prompt,
+            CreatedAtUtc = model.CreatedAtUtc,
+            UpdatedAtUtc = model.UpdatedAtUtc,
+            IsPinned = model.IsPinned,
+        };
+    }
+}

--- a/src/Beutl/Services/AI/PersistentPromptLibrary.cs
+++ b/src/Beutl/Services/AI/PersistentPromptLibrary.cs
@@ -586,13 +586,17 @@ internal sealed class PersistentPromptLibrary : IPromptLibrary, IPromptLibraryCh
 
         items.Sort((left, right) => right.UpdatedAtUtc.CompareTo(left.UpdatedAtUtc));
         var coalesced = new List<PromptTemplate>(items.Count);
+        var indexesByTask = new Dictionary<PromptTaskKind, Dictionary<string, int>>();
         foreach (PromptTemplate item in items)
         {
-            int index = coalesced.FindIndex(existing =>
-                existing.TaskKind == item.TaskKind
-                && string.Equals(existing.Name, item.Name, StringComparison.OrdinalIgnoreCase));
-            if (index < 0)
+            if (!indexesByTask.TryGetValue(item.TaskKind, out Dictionary<string, int>? indexesByName))
             {
+                indexesByName = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                indexesByTask.Add(item.TaskKind, indexesByName);
+            }
+            if (!indexesByName.TryGetValue(item.Name, out int index))
+            {
+                indexesByName.Add(item.Name, coalesced.Count);
                 coalesced.Add(item);
                 continue;
             }

--- a/src/Beutl/Services/AI/PromptLibraryModels.cs
+++ b/src/Beutl/Services/AI/PromptLibraryModels.cs
@@ -1,0 +1,36 @@
+﻿namespace Beutl.Services.AI;
+
+internal enum PromptTaskKind
+{
+    Image,
+    ImageEdit,
+    Video,
+}
+
+internal sealed record PromptHistoryEntry(
+    Guid Id,
+    PromptTaskKind TaskKind,
+    string Prompt,
+    DateTimeOffset LastUsedAtUtc,
+    int UseCount,
+    bool IsPinned);
+
+internal sealed record PromptTemplate(
+    Guid Id,
+    string Name,
+    PromptTaskKind TaskKind,
+    string Prompt,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset UpdatedAtUtc,
+    bool IsPinned);
+
+internal sealed record PromptLibraryOptions
+{
+    public const int DefaultMaxRecentItems = 50;
+    public const int MaximumMaxRecentItems = 500;
+
+    public int MaxRecentItems { get; init; } = DefaultMaxRecentItems;
+
+    // Named templates and pinned history are explicit saves and remain persistent.
+    public bool RetainRecentPromptText { get; init; }
+}

--- a/src/Beutl/Services/AI/PromptLibraryProvider.cs
+++ b/src/Beutl/Services/AI/PromptLibraryProvider.cs
@@ -1,0 +1,268 @@
+﻿using Beutl.Api.Services;
+
+namespace Beutl.Services.AI;
+
+internal static class PromptLibraryProvider
+{
+    private static readonly object s_gate = new();
+    private static readonly Dictionary<string, PersistentPromptLibrary> s_libraries = new(StringComparer.Ordinal);
+    private static string s_root = Path.Combine(BeutlEnvironment.GetHomeDirectoryPath(), "ai-prompts");
+    private static string s_legacy = Path.Combine(BeutlEnvironment.GetHomeDirectoryPath(), "ai-prompts.json");
+    private static string s_migrationMarker = Path.Combine(BeutlEnvironment.GetHomeDirectoryPath(), "ai-prompts.migrated");
+
+    internal static void ConfigureRootForTests(string root)
+    {
+        lock (s_gate)
+        {
+            s_libraries.Clear();
+            s_root = Path.GetFullPath(root);
+            string home = Path.GetDirectoryName(s_root)!;
+            s_legacy = Path.Combine(home, "ai-prompts.json");
+            s_migrationMarker = Path.Combine(home, "ai-prompts.migrated");
+        }
+    }
+
+    internal static void ResetRootAfterTests()
+        => ConfigureRootForTests(Path.Combine(
+            BeutlEnvironment.GetHomeDirectoryPath(),
+            "ai-prompts"));
+
+    public static IPromptLibrary For(AiRequestRecoveryContext context)
+        => new AccountPromptLibrary(context);
+
+    private static (string AccountKey, string StoragePath)? ResolveAccountStorage(
+        AiRequestRecoveryContext context)
+    {
+        string account = context.TryGetIdentity()?.AccountId ?? string.Empty;
+        if (account.Length == 0)
+            return null;
+
+        string accountKey = Convert.ToHexString(
+            System.Security.Cryptography.SHA256.HashData(
+                System.Text.Encoding.UTF8.GetBytes(account)));
+        return (accountKey, Path.Combine(s_root, accountKey + ".json"));
+    }
+
+    private sealed class AccountPromptLibrary(AiRequestRecoveryContext context)
+        : IPromptLibrary, IPromptLibraryChangeSource
+    {
+        private PersistentPromptLibrary? Library
+        {
+            get
+            {
+                if (ResolveAccountStorage(context) is not { } account)
+                    return null;
+                Directory.CreateDirectory(s_root);
+                string accountKey = account.AccountKey;
+                string path = account.StoragePath;
+                lock (s_gate)
+                {
+                    if (s_libraries.TryGetValue(accountKey, out PersistentPromptLibrary? cached))
+                        return cached;
+                    using FileStream migrationLock = AcquireMigrationLock();
+                    string? migrationOwner = ReadMigrationOwner();
+                    if (migrationOwner is null)
+                    {
+                    }
+                    else if (migrationOwner.Length == 0)
+                    {
+                        throw new InvalidDataException("Prompt migration marker is invalid.");
+                    }
+                    else if (migrationOwner is { Length: > 0 }
+                        && !StringComparer.OrdinalIgnoreCase.Equals(migrationOwner, accountKey))
+                    {
+                        if (File.Exists(path))
+                        {
+                            var existing = new PersistentPromptLibrary(path);
+                            s_libraries[accountKey] = existing;
+                            return existing;
+                        }
+                        var isolated = new PersistentPromptLibrary(path);
+                        s_libraries[accountKey] = isolated;
+                        return isolated;
+                    }
+
+                    if (File.Exists(s_legacy) && !File.Exists(path))
+                    {
+                        try
+                        {
+                            if (migrationOwner is null)
+                                WriteMigrationMarker(accountKey);
+                            DurableMove(s_legacy, path, overwrite: false);
+                            migrationOwner = accountKey;
+                        }
+                        catch (IOException ex)
+                        {
+                            throw new IOException("Prompt library legacy migration is pending; retry for the owning account.", ex);
+                        }
+                    }
+                    else if (migrationOwner is not null && migrationOwner.Length > 0
+                        && StringComparer.OrdinalIgnoreCase.Equals(migrationOwner, accountKey)
+                        && !File.Exists(s_legacy) && !File.Exists(path))
+                    {
+                        throw new IOException("Prompt library migration owner data is missing.");
+                    }
+                    else if (migrationOwner is null
+                        && !File.Exists(s_legacy)
+                        && File.Exists(path))
+                    {
+                        try
+                        {
+                            WriteMigrationMarker(accountKey);
+                        }
+                        catch (IOException ex)
+                        {
+                            throw new IOException("Prompt library migration marker publication is pending.", ex);
+                        }
+                    }
+                    else if (migrationOwner is null && File.Exists(s_legacy))
+                    {
+                        throw new IOException("Prompt library legacy migration is unavailable.");
+                    }
+                    var library = new PersistentPromptLibrary(path);
+                    s_libraries[accountKey] = library;
+                    return library;
+                }
+            }
+        }
+
+        private static void WriteMigrationMarker(string accountKey)
+        {
+            string temporary = s_migrationMarker + $".{Guid.NewGuid():N}.tmp";
+            try
+            {
+                var options = new FileStreamOptions
+                {
+                    Mode = FileMode.CreateNew,
+                    Access = FileAccess.Write,
+                    Share = FileShare.None,
+                    Options = FileOptions.WriteThrough,
+                };
+                if (!OperatingSystem.IsWindows())
+                    options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+                using (FileStream stream = new(temporary, options))
+                using (var writer = new StreamWriter(stream, System.Text.Encoding.UTF8, leaveOpen: true))
+                {
+                    writer.Write(accountKey);
+                    writer.Flush();
+                    stream.Flush(flushToDisk: true);
+                }
+                DurableMove(temporary, s_migrationMarker, overwrite: false);
+            }
+            finally
+            {
+                try { File.Delete(temporary); }
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { }
+            }
+        }
+
+        private static FileStream AcquireMigrationLock()
+        {
+            string path = s_migrationMarker + ".lock";
+            try
+            {
+                return new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+            }
+            catch (IOException ex)
+            {
+                throw new IOException("Prompt library migration is busy; retry later.", ex);
+            }
+        }
+
+        private static void DurableMove(string source, string destination, bool overwrite)
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                const uint replace = 0x1;
+                const uint writeThrough = 0x8;
+                if (!MoveFileEx(source, destination, writeThrough | (overwrite ? replace : 0)))
+                    throw new IOException("Prompt migration rename failed.", new System.ComponentModel.Win32Exception(System.Runtime.InteropServices.Marshal.GetLastWin32Error()));
+            }
+            else
+            {
+                File.Move(source, destination, overwrite);
+                SyncDirectory(Path.GetDirectoryName(source)!);
+                string destinationDirectory = Path.GetDirectoryName(destination)!;
+                if (!StringComparer.Ordinal.Equals(
+                        Path.GetFullPath(destinationDirectory),
+                        Path.GetFullPath(Path.GetDirectoryName(source)!)))
+                    SyncDirectory(destinationDirectory);
+            }
+        }
+
+        private static void SyncDirectory(string path)
+        {
+            int fd = UnixOpen(path, 0);
+            if (fd < 0)
+                throw new IOException("Unable to open migration directory.");
+            try
+            {
+                if (UnixFsync(fd) != 0)
+                    throw new IOException("Unable to fsync migration directory.");
+            }
+            finally
+            {
+                _ = UnixClose(fd);
+            }
+        }
+
+        [System.Runtime.InteropServices.DllImport("libc", EntryPoint = "open", SetLastError = true)]
+        private static extern int UnixOpen(string path, int flags);
+
+        [System.Runtime.InteropServices.DllImport("libc", EntryPoint = "fsync", SetLastError = true)]
+        private static extern int UnixFsync(int fd);
+
+        [System.Runtime.InteropServices.DllImport("libc", EntryPoint = "close", SetLastError = true)]
+        private static extern int UnixClose(int fd);
+
+        [System.Runtime.InteropServices.DllImport("kernel32.dll", CharSet = System.Runtime.InteropServices.CharSet.Unicode, SetLastError = true)]
+        [return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)]
+        private static extern bool MoveFileEx(string existingFileName, string newFileName, uint flags);
+
+        private static string? ReadMigrationOwner()
+        {
+            if (!File.Exists(s_migrationMarker))
+                return null;
+            try
+            {
+                string value = File.ReadAllText(s_migrationMarker).Trim();
+                if (value.Length != 64 || value.Any(c => !Uri.IsHexDigit(c)))
+                    throw new InvalidDataException("Prompt migration marker is invalid.");
+                return value;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                throw new IOException("Prompt migration marker cannot be read.", ex);
+            }
+        }
+        public string StoragePath => Library?.StoragePath ?? string.Empty;
+        public bool RetainRecentPromptText => Library?.RetainRecentPromptText ?? false;
+        public string? RecoveredCorruptFilePath => Library?.RecoveredCorruptFilePath;
+        public IReadOnlyList<PromptHistoryEntry> History => Library?.History ?? Array.Empty<PromptHistoryEntry>();
+        public IReadOnlyList<PromptTemplate> Templates => Library?.Templates ?? Array.Empty<PromptTemplate>();
+        public PromptHistoryEntry Record(PromptTaskKind k, string p) => Require().Record(k, p);
+        public PromptTemplate SaveTemplate(string n, PromptTaskKind k, string p) => Require().SaveTemplate(n, k, p);
+        public bool SetHistoryPinned(Guid id, bool value) => Library?.SetHistoryPinned(id, value) ?? false;
+        public bool SetTemplatePinned(Guid id, bool value) => Library?.SetTemplatePinned(id, value) ?? false;
+        public bool DeleteHistory(Guid id) => Library?.DeleteHistory(id) ?? false;
+        public bool DeleteTemplate(Guid id) => Library?.DeleteTemplate(id) ?? false;
+        public void ClearHistory() => Library?.ClearHistory();
+        public void ClearTemplates() => Library?.ClearTemplates();
+        public void ClearAll() => Library?.ClearAll();
+        public IDisposable SubscribeChanged(Action callback)
+        {
+            ArgumentNullException.ThrowIfNull(callback);
+            return PromptLibraryChangeHub.Subscribe(path =>
+            {
+                if (ResolveAccountStorage(context) is { } current
+                    && StringComparer.Ordinal.Equals(current.StoragePath, path))
+                {
+                    callback();
+                }
+            });
+        }
+
+        private PersistentPromptLibrary Require() => Library ?? throw new AuthenticationRequiredException();
+    }
+}

--- a/src/Beutl/Services/AI/RelativeTimeText.cs
+++ b/src/Beutl/Services/AI/RelativeTimeText.cs
@@ -1,0 +1,29 @@
+﻿namespace Beutl.Services.AI;
+
+internal static class RelativeTimeText
+{
+    /// <summary>
+    /// How long ago something happened, worded the way a person looking for the
+    /// one they just made would ask for it. Past a week the calendar date is what
+    /// identifies it, so that is what comes back.
+    /// </summary>
+    public static string Format(DateTimeOffset moment, DateTimeOffset now)
+    {
+        TimeSpan elapsed = now - moment;
+        if (elapsed < TimeSpan.Zero)
+        {
+            elapsed = TimeSpan.Zero;
+        }
+
+        if (elapsed < TimeSpan.FromMinutes(1))
+            return Strings.TimeAgoJustNow;
+        if (elapsed < TimeSpan.FromHours(1))
+            return string.Format(Strings.TimeAgoMinutesFormat, (int)elapsed.TotalMinutes);
+        if (elapsed < TimeSpan.FromDays(1))
+            return string.Format(Strings.TimeAgoHoursFormat, (int)elapsed.TotalHours);
+        if (elapsed < TimeSpan.FromDays(7))
+            return string.Format(Strings.TimeAgoDaysFormat, (int)elapsed.TotalDays);
+
+        return moment.ToLocalTime().ToString("d");
+    }
+}

--- a/src/Beutl/Services/AiPlanCoordinator.cs
+++ b/src/Beutl/Services/AiPlanCoordinator.cs
@@ -1,0 +1,83 @@
+﻿using System.Diagnostics;
+using Beutl.Api;
+using Beutl.Api.Services;
+using Beutl.Configuration;
+
+namespace Beutl.Services;
+
+public interface IAiPlanCoordinator
+{
+    void OpenAccountSettings();
+
+    void OpenAiPlan();
+
+    Task RefreshIfPendingAsync(CancellationToken cancellationToken);
+}
+
+internal sealed class AiPlanCoordinator : IAiPlanCoordinator
+{
+    private readonly IAiEntitlementService _entitlements;
+    private readonly Action<Uri> _openUri;
+    private readonly Func<string> _language;
+    private readonly Uri _portalBaseUri;
+    private int _refreshPending;
+
+    public AiPlanCoordinator(
+        IAiEntitlementService entitlements,
+        Action<Uri>? openUri = null,
+        Func<string>? language = null,
+        Uri? portalBaseUri = null)
+    {
+        _entitlements = entitlements ?? throw new ArgumentNullException(nameof(entitlements));
+        _openUri = openUri ?? OpenWithShell;
+        _language = language ?? (() =>
+            GlobalConfiguration.Instance.ViewConfig.UICulture.TwoLetterISOLanguageName);
+        // The pages opened here belong to the same site the client talks to, so
+        // a build pointed at a local server must not send the user to the live
+        // one to manage a plan that build knows nothing about.
+        _portalBaseUri = portalBaseUri ?? new Uri(BeutlApiApplication.BaseUrl, UriKind.Absolute);
+    }
+
+    public void OpenAccountSettings()
+    {
+        _openUri(new Uri(_portalBaseUri, "account/manage"));
+        Interlocked.Exchange(ref _refreshPending, 1);
+    }
+
+    public void OpenAiPlan()
+    {
+        string language = _language();
+        if (string.IsNullOrWhiteSpace(language))
+            throw new InvalidOperationException("The UI language is unavailable.");
+
+        _openUri(new Uri(
+            _portalBaseUri,
+            $"{Uri.EscapeDataString(language)}/account/manage/ai-plan"));
+        Interlocked.Exchange(ref _refreshPending, 1);
+    }
+
+    public async Task RefreshIfPendingAsync(CancellationToken cancellationToken)
+    {
+        if (Interlocked.Exchange(ref _refreshPending, 0) == 0)
+            return;
+
+        try
+        {
+            await _entitlements.RefreshAsync(cancellationToken);
+        }
+        catch
+        {
+            Interlocked.Exchange(ref _refreshPending, 1);
+            throw;
+        }
+    }
+
+    private static void OpenWithShell(Uri uri)
+    {
+        Process.Start(new ProcessStartInfo(uri.AbsoluteUri)
+        {
+            UseShellExecute = true,
+            Verb = "open",
+        });
+    }
+}

--- a/src/Beutl/Services/AiPlanCoordinator.cs
+++ b/src/Beutl/Services/AiPlanCoordinator.cs
@@ -2,20 +2,34 @@
 using Beutl.Api;
 using Beutl.Api.Services;
 using Beutl.Configuration;
+using Beutl.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace Beutl.Services;
 
 public interface IAiPlanCoordinator
 {
+    /// <summary>Raised once after a pending entitlement refresh completes successfully.</summary>
+    event EventHandler? Refreshed;
+
     void OpenAccountSettings();
 
     void OpenAiPlan();
 
-    Task RefreshIfPendingAsync(CancellationToken cancellationToken);
+    /// <summary>
+    /// Refreshes entitlements after a plan page was opened by this coordinator.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> when this call consumed and completed a pending refresh;
+    /// <see langword="false"/> when no plan refresh was pending.
+    /// </returns>
+    /// <remarks>A failed or cancelled refresh is restored as pending before the exception propagates.</remarks>
+    Task<bool> RefreshIfPendingAsync(CancellationToken cancellationToken);
 }
 
 internal sealed class AiPlanCoordinator : IAiPlanCoordinator
 {
+    private readonly ILogger _logger = Log.CreateLogger<AiPlanCoordinator>();
     private readonly IAiEntitlementService _entitlements;
     private readonly Action<Uri> _openUri;
     private readonly Func<string> _language;
@@ -38,6 +52,8 @@ internal sealed class AiPlanCoordinator : IAiPlanCoordinator
         _portalBaseUri = portalBaseUri ?? new Uri(BeutlApiApplication.BaseUrl, UriKind.Absolute);
     }
 
+    public event EventHandler? Refreshed;
+
     public void OpenAccountSettings()
     {
         _openUri(new Uri(_portalBaseUri, "account/manage"));
@@ -56,10 +72,10 @@ internal sealed class AiPlanCoordinator : IAiPlanCoordinator
         Interlocked.Exchange(ref _refreshPending, 1);
     }
 
-    public async Task RefreshIfPendingAsync(CancellationToken cancellationToken)
+    public async Task<bool> RefreshIfPendingAsync(CancellationToken cancellationToken)
     {
         if (Interlocked.Exchange(ref _refreshPending, 0) == 0)
-            return;
+            return false;
 
         try
         {
@@ -69,6 +85,25 @@ internal sealed class AiPlanCoordinator : IAiPlanCoordinator
         {
             Interlocked.Exchange(ref _refreshPending, 1);
             throw;
+        }
+
+        NotifyRefreshedSafely();
+        return true;
+    }
+
+    private void NotifyRefreshedSafely()
+    {
+        Delegate[] handlers = Refreshed?.GetInvocationList() ?? [];
+        foreach (EventHandler handler in handlers.Cast<EventHandler>())
+        {
+            try
+            {
+                handler(this, EventArgs.Empty);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An AI plan refresh subscriber failed; continuing publication.");
+            }
         }
     }
 

--- a/src/Beutl/Services/AiPromptComposer.cs
+++ b/src/Beutl/Services/AiPromptComposer.cs
@@ -1,0 +1,73 @@
+﻿using Beutl.Api.Services;
+using Beutl.Language;
+
+namespace Beutl.Services;
+
+internal sealed record AiPromptParts(
+    string Main,
+    string? Style = null,
+    string? Composition = null,
+    string? Motion = null,
+    string? Exclusions = null);
+
+internal static class AiPromptComposer
+{
+    public static string Compose(AiPromptParts parts)
+    {
+        ArgumentNullException.ThrowIfNull(parts);
+
+        var sections = new List<string>(5);
+        AddSection(sections, null, parts.Main);
+        AddSection(sections, "Style", parts.Style);
+        AddSection(sections, "Composition", parts.Composition);
+        AddSection(sections, "Motion", parts.Motion);
+        AddSection(sections, "Avoid", parts.Exclusions);
+        string result = string.Join("\n", sections);
+        if (result.Length > AiRequestLimits.MaxPromptLength)
+        {
+            throw new ArgumentException(PromptTooLongMessage, nameof(parts));
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// The reason the parts cannot be sent, worded for the person who typed them,
+    /// or null when they can. The message is built here rather than taken from the
+    /// exception so a caller never shows an exception's text as an explanation.
+    /// </summary>
+    public static string? GetValidationError(AiPromptParts parts)
+    {
+        try
+        {
+            return string.IsNullOrWhiteSpace(Compose(parts))
+                ? Strings.AiPromptRequired
+                : null;
+        }
+        catch (ArgumentException)
+        {
+            return PromptTooLongMessage;
+        }
+    }
+
+    internal static string PromptTooLongMessage
+        => string.Format(Strings.AiPromptTooLongFormat, AiRequestLimits.MaxPromptLength);
+
+    private static void AddSection(List<string> sections, string? label, string? value)
+    {
+        string? normalized = Normalize(value);
+        if (normalized is null)
+            return;
+
+        sections.Add(label is null ? normalized : $"{label}: {normalized}");
+    }
+
+    private static string? Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        return string.Join(
+            " ",
+            value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+    }
+}

--- a/src/Beutl/Services/AiPromptValidation.cs
+++ b/src/Beutl/Services/AiPromptValidation.cs
@@ -1,0 +1,27 @@
+﻿namespace Beutl.Services;
+
+internal static class AiPromptValidation
+{
+    /// <summary>
+    /// Repeats a prompt's validation message, but only once the person has typed
+    /// something. A tab that was just opened has an empty prompt and therefore an
+    /// error, yet nothing has gone wrong: showing it reads as a complaint about
+    /// work not started.
+    /// </summary>
+    public static IObservable<string?> WhileTyping(
+        IObservable<string?> validationError,
+        params IObservable<string>[] promptParts)
+    {
+        ArgumentNullException.ThrowIfNull(validationError);
+        ArgumentNullException.ThrowIfNull(promptParts);
+
+        IObservable<bool> hasTyped = promptParts
+            .Merge()
+            .Where(part => !string.IsNullOrWhiteSpace(part))
+            .Select(_ => true)
+            .Take(1)
+            .StartWith(false);
+
+        return validationError.CombineLatest(hasTyped, (error, typed) => typed ? error : null);
+    }
+}

--- a/src/Beutl/Services/AsyncOperationLifetime.cs
+++ b/src/Beutl/Services/AsyncOperationLifetime.cs
@@ -1,0 +1,556 @@
+﻿using System.Diagnostics;
+using Beutl.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace Beutl.Services;
+
+/// <summary>
+/// Admits asynchronous operations while a view-model is alive, owns their cancellation token,
+/// admits publication before shutdown begins, keeps admitted publication in the
+/// drain, and allows disposal to await every admitted operation. Publication admission and
+/// shutdown are linearized by the gate. If a publication acquires the gate before
+/// <see cref="StopAsync"/> or <see cref="DisposeAsync()"/> marks the lifetime as stopping, its
+/// callback may run after shutdown has started, but remains in the drain until that callback
+/// returns.
+/// </summary>
+internal sealed class AsyncOperationLifetime : IAsyncDisposable
+{
+    private static readonly TimeSpan s_defaultShutdownDeadline = TimeSpan.FromSeconds(30);
+    private static readonly ILogger s_logger = Log.CreateLogger<AsyncOperationLifetime>();
+    private readonly object _gate = new();
+    private readonly TimeSpan _shutdownDeadline;
+    private readonly Action<Exception>? _deferredFailureObserver;
+    private CancellationTokenSource? _cancellation = new();
+    private TaskCompletionSource? _drained;
+    private Task? _stopTask;
+    private TaskCompletionSource? _stopCompletion;
+    private Task? _stopDrainTask;
+    private TaskCompletionSource? _stopDrainCompletion;
+    private Task? _stopCancellationTask;
+    private readonly List<CancellationTokenSource> _deferredOperationCancellations = [];
+    private Exception? _cancellationFailure;
+    private Task? _disposeTask;
+    private int _activeOperations;
+    private int _activePublications;
+    private bool _stopping;
+
+    public AsyncOperationLifetime(
+        TimeSpan? shutdownDeadline = null,
+        Action<Exception>? deferredFailureObserver = null)
+    {
+        _shutdownDeadline = shutdownDeadline ?? s_defaultShutdownDeadline;
+        if (_shutdownDeadline <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(shutdownDeadline));
+        _deferredFailureObserver = deferredFailureObserver;
+    }
+
+    public Operation? TryEnter()
+    {
+        lock (_gate)
+        {
+            if (_stopping || _cancellation is null)
+                return null;
+
+            _activeOperations++;
+            return new Operation(
+                this,
+                CancellationTokenSource.CreateLinkedTokenSource(_cancellation.Token));
+        }
+    }
+
+    public Task StopAsync()
+    {
+        long started = Stopwatch.GetTimestamp();
+        CancellationTokenSource? cancellation = null;
+        Task stopTask;
+        Task? drained = null;
+        bool startCompletion = false;
+        lock (_gate)
+        {
+            if (!_stopping)
+            {
+                _stopping = true;
+                cancellation = _cancellation;
+            }
+
+            if (_stopTask is null)
+            {
+                drained = HasNoActiveWork_NoLock()
+                    ? Task.CompletedTask
+                    : (_drained ??= new TaskCompletionSource(
+                        TaskCreationOptions.RunContinuationsAsynchronously)).Task;
+                _stopCompletion = new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                _stopDrainCompletion = new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                _stopTask = _stopCompletion.Task;
+                _stopDrainTask = _stopDrainCompletion.Task;
+                _stopCancellationTask = CreateCancellationTask(cancellation);
+                startCompletion = true;
+            }
+
+            stopTask = _stopTask;
+        }
+
+        if (startCompletion)
+        {
+            Task cancellationTask = _stopCancellationTask!;
+            if (cancellation is not null)
+            {
+                // Preserve the old synchronous observation that admission has
+                // been cancelled, without running user callbacks on this
+                // thread. CancellationTokenSource marks itself cancelled before
+                // invoking callbacks, so this wait cannot be held by a
+                // reentrant callback.
+                SpinWait.SpinUntil(
+                    () => cancellation.IsCancellationRequested || cancellationTask.IsCompleted,
+                    _shutdownDeadline);
+            }
+            _ = CompleteStopDrainAsync(drained!, cancellationTask);
+            TimeSpan remaining = _shutdownDeadline - Stopwatch.GetElapsedTime(started);
+            _ = CompleteStopProxyAsync(
+                _stopCompletion!,
+                _stopDrainTask!,
+                remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero);
+        }
+
+        return stopTask;
+    }
+
+    private void CancelStop(CancellationTokenSource cancellation)
+    {
+        try
+        {
+            cancellation.Cancel();
+        }
+        catch (Exception ex)
+        {
+            RecordCancellationFailure(ex);
+        }
+    }
+
+    private Task CreateCancellationTask(CancellationTokenSource? cancellation)
+        => cancellation is null
+            ? Task.CompletedTask
+            : Task.Factory.StartNew(
+                () => CancelStop(cancellation),
+                CancellationToken.None,
+                TaskCreationOptions.DenyChildAttach | TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
+
+    private async Task CompleteStopDrainAsync(Task drained, Task cancellationTask)
+    {
+        List<Exception>? failures = null;
+        try
+        {
+            await Task.WhenAll(drained, cancellationTask).ConfigureAwait(false);
+        }
+        catch
+        {
+            AddFailures(drained, ref failures);
+            AddFailures(cancellationTask, ref failures);
+        }
+
+        TaskCompletionSource? completion;
+        Exception? failure;
+        List<CancellationTokenSource>? deferredCancellations;
+        lock (_gate)
+        {
+            completion = _stopDrainCompletion;
+            failure = _cancellationFailure;
+            deferredCancellations = _deferredOperationCancellations.Count == 0
+                ? null
+                : [.. _deferredOperationCancellations];
+            _deferredOperationCancellations.Clear();
+        }
+
+        if (deferredCancellations is not null)
+        {
+            foreach (CancellationTokenSource deferred in deferredCancellations)
+                deferred.Dispose();
+        }
+
+        if (failure is not null)
+        {
+            IEnumerable<Exception> cancellationFailures = failure is AggregateException aggregate
+                ? aggregate.Flatten().InnerExceptions
+                : [failure];
+            foreach (Exception cancellationFailure in cancellationFailures)
+            {
+                if (failures?.Contains(cancellationFailure) != true)
+                    (failures ??= []).Add(cancellationFailure);
+            }
+        }
+
+        if (failures is { Count: 1 })
+            completion?.TrySetException(failures[0]);
+        else if (failures is { Count: > 1 })
+            completion?.TrySetException(new AggregateException(failures));
+        else
+            completion?.TrySetResult();
+    }
+
+    private async Task CompleteStopProxyAsync(
+        TaskCompletionSource completion,
+        Task drain,
+        TimeSpan remaining)
+    {
+        if (remaining <= TimeSpan.Zero)
+        {
+            s_logger.LogWarning(
+                "Asynchronous operation shutdown exceeded {Deadline}; draining will continue.",
+                _shutdownDeadline);
+            completion.TrySetResult();
+            _ = ObserveDeferredStopAsync(drain);
+            return;
+        }
+
+        try
+        {
+            await drain.WaitAsync(remaining).ConfigureAwait(false);
+            if (drain.IsFaulted)
+                completion.TrySetException(drain.Exception!.Flatten().InnerExceptions);
+            else
+                completion.TrySetResult();
+        }
+        catch (TimeoutException)
+        {
+            s_logger.LogWarning(
+                "Asynchronous operation shutdown exceeded {Deadline}; draining will continue.",
+                _shutdownDeadline);
+            completion.TrySetResult();
+            _ = ObserveDeferredStopAsync(drain);
+        }
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
+        }
+    }
+
+    private async Task ObserveDeferredStopAsync(Task drain)
+    {
+        try
+        {
+            await drain.ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            s_logger.LogWarning(ex, "Deferred asynchronous operation shutdown failed.");
+            _deferredFailureObserver?.Invoke(ex);
+        }
+    }
+
+    public ValueTask DisposeAsync()
+        => DisposeAsync(static () => ValueTask.CompletedTask);
+
+    public ValueTask DisposeAsync(Func<ValueTask> disposeResources)
+        => DisposeAsync(static () => { }, disposeResources);
+
+    public ValueTask DisposeAsync(Action cancelAdditionalWork, Func<ValueTask> disposeResources)
+    {
+        ArgumentNullException.ThrowIfNull(cancelAdditionalWork);
+        ArgumentNullException.ThrowIfNull(disposeResources);
+        TaskCompletionSource? proxy = null;
+        Task? drained = null;
+        bool startStopCompletion = false;
+        Task disposeTask;
+        lock (_gate)
+        {
+            if (_disposeTask is null)
+            {
+                proxy = new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                _disposeTask = proxy.Task;
+
+                if (!_stopping)
+                {
+                    _stopping = true;
+                    // The cancellation task is created together with the stop
+                    // state below, before any callback can re-enter.
+                }
+                if (_stopTask is null)
+                {
+                    drained = HasNoActiveWork_NoLock()
+                        ? Task.CompletedTask
+                        : (_drained ??= new TaskCompletionSource(
+                            TaskCreationOptions.RunContinuationsAsynchronously)).Task;
+                    _stopCompletion = new TaskCompletionSource(
+                        TaskCreationOptions.RunContinuationsAsynchronously);
+                    _stopDrainCompletion = new TaskCompletionSource(
+                        TaskCreationOptions.RunContinuationsAsynchronously);
+                    _stopTask = _stopCompletion.Task;
+                    _stopDrainTask = _stopDrainCompletion.Task;
+                    _stopCancellationTask = CreateCancellationTask(_cancellation);
+                    startStopCompletion = true;
+                }
+            }
+
+            disposeTask = _disposeTask;
+        }
+
+        if (proxy is not null)
+        {
+            Task stopDrainTask = _stopDrainTask!;
+            Task teardown = Task.Run(() => DisposeCoreAsync(
+                drained,
+                startStopCompletion,
+                stopDrainTask,
+                cancelAdditionalWork,
+                disposeResources));
+            if (startStopCompletion)
+            {
+                _ = CompleteStopProxyAsync(_stopCompletion!, stopDrainTask, _shutdownDeadline);
+            }
+            _ = CompleteDisposeAsync(proxy, teardown);
+        }
+
+        return new ValueTask(disposeTask);
+    }
+
+    private async Task DisposeCoreAsync(
+        Task? drained,
+        bool startStopCompletion,
+        Task stopDrainTask,
+        Action cancelAdditionalWork,
+        Func<ValueTask> disposeResources)
+    {
+        List<Exception>? failures = null;
+        Task additionalCancellation = Task.Run(cancelAdditionalWork);
+
+        if (startStopCompletion)
+            _ = CompleteStopDrainAsync(drained!, _stopCancellationTask!);
+
+        try
+        {
+            await Task.WhenAll(stopDrainTask, additionalCancellation).ConfigureAwait(false);
+        }
+        catch
+        {
+            AddFailures(stopDrainTask, ref failures);
+            AddFailures(additionalCancellation, ref failures);
+        }
+
+        try
+        {
+            await disposeResources().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            (failures ??= []).Add(ex);
+        }
+
+        CancellationTokenSource? ownedCancellation;
+        lock (_gate)
+        {
+            ownedCancellation = _cancellation;
+            _cancellation = null;
+        }
+        ownedCancellation?.Dispose();
+
+        if (failures is { Count: 1 })
+            throw failures[0];
+        if (failures is { Count: > 1 })
+            throw new AggregateException(failures);
+    }
+
+    private static void AddFailures(Task task, ref List<Exception>? failures)
+    {
+        if (task.Exception is not { } aggregate)
+            return;
+
+        foreach (Exception exception in aggregate.Flatten().InnerExceptions)
+        {
+            if (failures?.Contains(exception) != true)
+                (failures ??= []).Add(exception);
+        }
+    }
+
+    private async Task CompleteDisposeAsync(TaskCompletionSource proxy, Task teardown)
+    {
+        try
+        {
+            await teardown.WaitAsync(_shutdownDeadline).ConfigureAwait(false);
+            proxy.TrySetResult();
+        }
+        catch (TimeoutException)
+        {
+            s_logger.LogWarning(
+                "Asynchronous operation disposal exceeded {Deadline}; resource cleanup will continue.",
+                _shutdownDeadline);
+            proxy.TrySetResult();
+            _ = ObserveDeferredDisposeAsync(teardown);
+        }
+        catch (Exception ex)
+        {
+            proxy.TrySetException(ex);
+        }
+    }
+
+    private async Task ObserveDeferredDisposeAsync(Task teardown)
+    {
+        try
+        {
+            await teardown.ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            s_logger.LogWarning(ex, "Deferred asynchronous operation resource cleanup failed.");
+            _deferredFailureObserver?.Invoke(ex);
+        }
+    }
+
+    private bool TryPublish(Operation operation, Action publication)
+    {
+        ArgumentNullException.ThrowIfNull(publication);
+        lock (operation.PublicationGate)
+        {
+            lock (_gate)
+            {
+                if (_stopping || !operation.CanPublish)
+                    return false;
+
+                // This increment is the publication's linearization point. The operation
+                // gate remains held through the callback, so ClosePublication cannot return
+                // until an already-admitted callback has completed.
+                _activePublications++;
+            }
+
+            try
+            {
+                publication();
+                return true;
+            }
+            finally
+            {
+                ExitPublication();
+            }
+        }
+    }
+
+    private void ExitPublication()
+    {
+        TaskCompletionSource? drained = null;
+        lock (_gate)
+        {
+            if (_activePublications <= 0)
+                return;
+
+            _activePublications--;
+            if (_stopping && HasNoActiveWork_NoLock())
+                drained = _drained;
+        }
+        drained?.TrySetResult();
+    }
+
+    private bool HasNoActiveWork_NoLock()
+        => _activeOperations == 0 && _activePublications == 0;
+
+    private void Exit(CancellationTokenSource operationCancellation)
+    {
+        TaskCompletionSource? drained = null;
+        bool disposeCancellation = true;
+        lock (_gate)
+        {
+            if (_activeOperations <= 0)
+                return;
+
+            _activeOperations--;
+            if (_stopping && _stopCancellationTask is { IsCompleted: false })
+            {
+                _deferredOperationCancellations.Add(operationCancellation);
+                disposeCancellation = false;
+            }
+            if (_stopping && HasNoActiveWork_NoLock())
+            {
+                drained = _drained;
+            }
+        }
+        if (disposeCancellation)
+            operationCancellation.Dispose();
+        drained?.TrySetResult();
+    }
+
+    private void RecordCancellationFailure(Exception exception)
+    {
+        lock (_gate)
+        {
+            _cancellationFailure = _cancellationFailure is null
+                ? exception
+                : new AggregateException(_cancellationFailure, exception);
+        }
+    }
+
+    /// <summary>
+    /// One admitted operation. Its token dies with the view-model, and separately
+    /// with <see cref="Cancel"/>, so a caller can abandon a single long request
+    /// without shutting down everything else the view-model has admitted.
+    /// </summary>
+    internal sealed class Operation : IDisposable
+    {
+        private readonly CancellationTokenSource _cancellation;
+        internal object PublicationGate { get; } = new();
+        private AsyncOperationLifetime? _owner;
+        private int _publicationClosed;
+
+        internal Operation(AsyncOperationLifetime owner, CancellationTokenSource cancellation)
+        {
+            _owner = owner;
+            _cancellation = cancellation;
+            CancellationToken = cancellation.Token;
+        }
+
+        public CancellationToken CancellationToken { get; }
+
+        /// <summary>
+        /// Attempts to admit a publication. The callback is invoked outside the lifetime gate;
+        /// once admitted, it is included in shutdown draining even if it throws.
+        /// </summary>
+        public bool TryPublish(Action publication)
+            => _owner?.TryPublish(this, publication) == true;
+
+        internal bool CanPublish => Volatile.Read(ref _publicationClosed) == 0;
+
+        /// <summary>
+        /// Permanently closes publication for this operation without removing
+        /// it from shutdown draining. Used when an account/session changes
+        /// while non-cooperative remote work may still complete.
+        /// </summary>
+        public void ClosePublication()
+        {
+            Interlocked.Exchange(ref _publicationClosed, 1);
+            lock (PublicationGate)
+            {
+            }
+        }
+
+        public void Cancel()
+        {
+            if (_owner is not { } owner)
+                return;
+
+            try
+            {
+                _cancellation.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+            catch (Exception ex)
+            {
+                owner.RecordCancellationFailure(ex);
+            }
+        }
+
+        public void Dispose()
+        {
+            // Stop new admission without waiting for an already-running
+            // publication. The owner's publication count keeps that callback
+            // in the lifetime drain until it returns.
+            Interlocked.Exchange(ref _publicationClosed, 1);
+            if (Interlocked.Exchange(ref _owner, null) is not { } owner)
+                return;
+
+            owner.Exit(_cancellation);
+        }
+    }
+}

--- a/src/Beutl/Services/EditorContextServices.cs
+++ b/src/Beutl/Services/EditorContextServices.cs
@@ -15,9 +15,11 @@ internal sealed class EditorContextServices(EditorService editorService, Extensi
     public bool TryGetService<T>([NotNullWhen(true)] out T? service)
         where T : class
     {
-        // Resolve by assignability so both the concrete ExtensionProvider and its IExtensionProvider
-        // interface (and the host-internal EditorService) are reachable by type.
-        service = editorService as T ?? extensionProvider as T;
+        // The concrete provider exposes host-only package instances. Extensions receive only the
+        // lease-backed public interface, so TryGetService cannot be used to downcast around it.
+        service = editorService as T;
+        if (service is null && typeof(T) == typeof(IExtensionProvider))
+            service = (T)(object)(IExtensionProvider)extensionProvider;
         return service is not null;
     }
 }

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -112,6 +112,8 @@ public sealed class EditorService
 
     public ICoreList<EditorTabItem> TabItems => _tabItems;
 
+    internal ExtensionProvider ExtensionProvider => _extensionProvider;
+
     public IReactiveProperty<EditorTabItem?> SelectedTabItem { get; } = new ReactivePropertySlim<EditorTabItem?>();
 
     internal IReadOnlyReactiveProperty<IProjectVersionControlService?>

--- a/src/Beutl/Services/IdentityOperationLifetime.cs
+++ b/src/Beutl/Services/IdentityOperationLifetime.cs
@@ -1,0 +1,334 @@
+﻿namespace Beutl.Services;
+
+/// <summary>
+/// Fences asynchronous work which belongs to the current authenticated account.
+/// An operation keeps the account revision it entered with; publication and an
+/// identity switch share the same gate, so a late callback is either admitted
+/// before the switch (and finishes before the switch clears the UI) or rejected
+/// after it. The identity cancellation token is linked to the operation token.
+/// </summary>
+internal sealed class IdentityOperationLifetime : IDisposable
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<long, Generation> _generations = [];
+    private Generation _current;
+    private long _revision;
+    private bool _disposed;
+
+    public IdentityOperationLifetime()
+    {
+        _current = new Generation(0);
+        _generations.Add(0, _current);
+    }
+
+    public Operation? TryEnter(AsyncOperationLifetime.Operation operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                operation.Dispose();
+                return null;
+            }
+            if (_current.ClearPending)
+            {
+                operation.Dispose();
+                return null;
+            }
+
+            Generation generation = _current;
+            generation.Active++;
+            CancellationTokenSource cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                operation.CancellationToken,
+                generation.Cancellation.Token);
+            return new Operation(this, operation, generation, cancellation);
+        }
+    }
+
+    /// <summary>Admits the parent operation and identity revision as one critical section.</summary>
+    public Operation? TryEnter(AsyncOperationLifetime lifetime)
+    {
+        ArgumentNullException.ThrowIfNull(lifetime);
+        lock (_gate)
+        {
+            if (_disposed)
+                return null;
+            if (_current.ClearPending)
+                return null;
+
+            AsyncOperationLifetime.Operation? operation = lifetime.TryEnter();
+            if (operation is null)
+                return null;
+
+            Generation generation = _current;
+            generation.Active++;
+            CancellationTokenSource cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                operation.CancellationToken,
+                generation.Cancellation.Token);
+            return new Operation(this, operation, generation, cancellation);
+        }
+    }
+
+    /// <summary>
+    /// Atomically advances the account revision, cancels work from the old
+    /// revision, and clears account-scoped UI state while publication is fenced.
+    /// </summary>
+    public void Switch(Action clearAccountState)
+    {
+        ArgumentNullException.ThrowIfNull(clearAccountState);
+        Generation? previous = null;
+        try
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                    return;
+
+                previous = _current;
+                previous.Retired = true;
+                previous.Cancelling = true;
+                _revision = checked(_revision + 1);
+                _current = new Generation(_revision);
+                _generations.Add(_revision, _current);
+                // Keep the gate through clearing so no new-generation
+                // operation can publish into state that is about to be reset.
+                clearAccountState();
+            }
+        }
+        finally
+        {
+            if (previous is not null)
+                StartCancellation(previous);
+        }
+    }
+
+    /// <summary>
+    /// Advances the identity fence immediately, then clears UI-owned state on
+    /// the supplied scheduler before admitting work for the new identity.
+    /// </summary>
+    public void SwitchDeferred(
+        Action<Action> scheduleClear,
+        Action clearAccountState,
+        Action? afterClear = null)
+    {
+        ArgumentNullException.ThrowIfNull(scheduleClear);
+        ArgumentNullException.ThrowIfNull(clearAccountState);
+
+        Generation previous;
+        Generation next;
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+
+            previous = _current;
+            previous.Retired = true;
+            previous.Cancelling = true;
+            _revision = checked(_revision + 1);
+            next = new Generation(_revision) { ClearPending = true };
+            _current = next;
+            _generations.Add(_revision, next);
+        }
+
+        try
+        {
+            scheduleClear(() =>
+            {
+                bool cleared = false;
+                lock (_gate)
+                {
+                    if (!_disposed
+                        && ReferenceEquals(_current, next)
+                        && next.ClearPending)
+                    {
+                        try
+                        {
+                            clearAccountState();
+                            cleared = true;
+                        }
+                        finally
+                        {
+                            next.ClearPending = false;
+                        }
+                    }
+                }
+
+                if (cleared)
+                    afterClear?.Invoke();
+            });
+        }
+        finally
+        {
+            StartCancellation(previous);
+        }
+    }
+
+    public void Dispose()
+    {
+        Generation[] generations;
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            generations = _generations.Values.ToArray();
+            foreach (Generation generation in generations)
+            {
+                generation.Retired = true;
+                generation.Cancelling = true;
+            }
+        }
+
+        foreach (Generation generation in generations)
+            StartCancellation(generation);
+    }
+
+    private void StartCancellation(Generation generation)
+    {
+        Task? cancellationTask;
+        lock (_gate)
+        {
+            if (!generation.Cancelling)
+                return;
+            if (generation.CancellationTask is null)
+                generation.CancellationTask = CancelGenerationAsync(generation);
+            cancellationTask = generation.CancellationTask;
+        }
+
+        // CancellationTokenSource marks IsCancellationRequested before invoking
+        // user callbacks. Wait only for that mark, not for callbacks themselves,
+        // so callers observe the fence synchronously without inheriting a stuck
+        // callback's latency.
+        SpinWait.SpinUntil(
+            () => generation.Cancellation.IsCancellationRequested || cancellationTask.IsCompleted,
+            TimeSpan.FromSeconds(1));
+    }
+
+    private async Task CancelGenerationAsync(Generation generation)
+    {
+        try
+        {
+            await Task.Run(generation.Cancellation.Cancel).ConfigureAwait(false);
+        }
+        catch
+        {
+        }
+        finally
+        {
+            lock (_gate)
+            {
+                generation.Cancelling = false;
+                TryRetire_NoLock(generation);
+            }
+        }
+    }
+
+    private bool TryPublish(Operation operation, Action publication)
+    {
+        lock (_gate)
+        {
+            if (_disposed || operation.Closed || !ReferenceEquals(operation.Generation, _current))
+                return false;
+
+            // Keep the identity gate through the underlying publication gate
+            // and callback. Switch() therefore cannot clear state underneath a
+            // callback which has already been admitted.
+            return operation.Parent.TryPublish(publication);
+        }
+    }
+
+    private bool IsCurrent(Operation operation)
+    {
+        lock (_gate)
+            return !_disposed && !operation.Closed && ReferenceEquals(operation.Generation, _current);
+    }
+
+    private void Close(Operation operation)
+    {
+        lock (_gate)
+        {
+            if (operation.Closed)
+                return;
+            operation.Closed = true;
+        }
+    }
+
+    private void Exit(Operation operation)
+    {
+        operation.Cancellation.Dispose();
+        lock (_gate)
+        {
+            if (operation.Generation.Active > 0)
+                operation.Generation.Active--;
+            TryRetire_NoLock(operation.Generation);
+        }
+    }
+
+    private void TryRetire_NoLock(Generation generation)
+    {
+        if (generation.Retired && generation.Active == 0 && !generation.Cancelling
+            && _generations.Remove(generation.Revision))
+        {
+            generation.Cancellation.Dispose();
+        }
+    }
+
+    internal sealed class Generation(long revision)
+    {
+        public long Revision { get; } = revision;
+        public CancellationTokenSource Cancellation { get; } = new();
+        public int Active;
+        public bool Retired;
+        public bool Cancelling;
+        public Task? CancellationTask;
+        public bool ClearPending;
+    }
+
+    internal sealed class Operation : IDisposable
+    {
+        private readonly IdentityOperationLifetime _owner;
+        internal readonly AsyncOperationLifetime.Operation Parent;
+        internal readonly Generation Generation;
+        internal readonly CancellationTokenSource Cancellation;
+        internal bool Closed;
+        private int _disposed;
+
+        internal Operation(
+            IdentityOperationLifetime owner,
+            AsyncOperationLifetime.Operation parent,
+            Generation generation,
+            CancellationTokenSource cancellation)
+        {
+            _owner = owner;
+            Parent = parent;
+            Generation = generation;
+            Cancellation = cancellation;
+            CancellationToken = cancellation.Token;
+        }
+
+        public CancellationToken CancellationToken { get; }
+
+        public bool TryPublish(Action publication)
+            => _owner.TryPublish(this, publication);
+
+        public bool IsCurrent
+            => _owner.IsCurrent(this);
+
+        public void ClosePublication()
+            => _owner.Close(this);
+
+        public void Cancel()
+            => Parent.Cancel();
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                return;
+            _owner.Close(this);
+            _owner.Exit(this);
+            Parent.Dispose();
+        }
+    }
+}

--- a/src/Beutl/Services/PrimitiveImpls/AiWorkspaceTabExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/AiWorkspaceTabExtension.cs
@@ -1,0 +1,61 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Beutl.ViewModels;
+using Beutl.ViewModels.Tools;
+using Beutl.Views.Tools;
+
+namespace Beutl.Services.PrimitiveImpls;
+
+[PrimitiveImpl]
+public sealed class AiWorkspaceTabExtension : ToolTabExtension
+{
+    public static readonly AiWorkspaceTabExtension Instance = new();
+
+    public override string Name => "AI";
+
+    public override string DisplayName => Strings.Ai;
+
+    public override string? Header => Strings.Ai;
+
+    // Several AI tabs can be open at once so two pages can sit side by side. Each
+    // tab keeps its own work, so a second one is a second workbench, not a mirror.
+    public override bool CanMultiple => true;
+
+    public override DockAnchor DefaultAnchor => DockAnchor.Right;
+
+    public override bool OpenByDefault => false;
+
+    public override int DefaultOrder => 90;
+
+    public override bool TryCreateContent(
+        IEditorContext editorContext,
+        [NotNullWhen(true)] out Control? control)
+    {
+        if (editorContext is EditViewModel)
+        {
+            control = new AiWorkspaceView();
+            return true;
+        }
+
+        control = null;
+        return false;
+    }
+
+    public override bool TryCreateContext(
+        IEditorContext editorContext,
+        [NotNullWhen(true)] out IToolContext? context)
+    {
+        if (editorContext is EditViewModel editViewModel
+            && Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime lifetime
+            && lifetime.MainWindow?.DataContext is MainViewModel mainViewModel)
+        {
+            context = mainViewModel.CreateAiWorkspaceViewModel(editViewModel);
+            return true;
+        }
+
+        context = null;
+        return false;
+    }
+}

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -123,10 +123,9 @@ public sealed class SceneEditorExtension : EditorExtension
         // TryCreate* must not throw: when the host does not supply the services EditViewModel needs,
         // fail (return false) rather than pushing nulls into EditViewModel.
         if (obj is Scene scene
-            && services.TryGetService<EditorService>(out EditorService? editorService)
-            && services.TryGetService<ExtensionProvider>(out ExtensionProvider? extensionProvider))
+            && services.TryGetService<EditorService>(out EditorService? editorService))
         {
-            context = new EditViewModel(scene, extensionProvider, editorService);
+            context = new EditViewModel(scene, editorService.ExtensionProvider, editorService);
             return true;
         }
 

--- a/src/Beutl/Services/PropertyEditorService.cs
+++ b/src/Beutl/Services/PropertyEditorService.cs
@@ -30,7 +30,7 @@ public static class PropertyEditorService
     }
 
     public static (IPropertyAdapter[]? Properties, PropertyEditorExtension? Extension) MatchProperty(
-        IReadOnlyList<IPropertyAdapter> properties, IExtensionProvider extensionProvider)
+        IReadOnlyList<IPropertyAdapter> properties, ExtensionProvider extensionProvider)
     {
         ArgumentNullException.ThrowIfNull(extensionProvider);
 

--- a/src/Beutl/Services/StartupTasks/LoadPrimitiveExtensionTask.cs
+++ b/src/Beutl/Services/StartupTasks/LoadPrimitiveExtensionTask.cs
@@ -57,6 +57,7 @@ public sealed class LoadPrimitiveExtensionTask : StartupTask
         EqualizerPropertiesExtension.Instance,
         ScriptEditorExtension.Instance,
         FileBrowserTabExtension.Instance,
+        AiWorkspaceTabExtension.Instance,
         HistoryTabExtension.Instance,
         VersionControlTabExtension.Instance,
         DockLayoutTabExtension.Instance,
@@ -64,7 +65,7 @@ public sealed class LoadPrimitiveExtensionTask : StartupTask
         DarkBorderThemeExtension.Instance
     ];
 
-    public LoadPrimitiveExtensionTask(PackageManager manager, ExtensionProvider provider,
+    internal LoadPrimitiveExtensionTask(PackageManager manager, IExtensionRegistry provider,
         EditorService editorService, ProjectService projectService)
     {
         _manager = manager;

--- a/src/Beutl/Services/StartupTasks/Startup.cs
+++ b/src/Beutl/Services/StartupTasks/Startup.cs
@@ -71,7 +71,7 @@ public sealed class Startup
         Register(() => new LoadInstalledExtensionTask(
             _apiApp.GetResource<PackageManager>(), this));
         Register(() => new LoadPrimitiveExtensionTask(
-            _apiApp.GetResource<PackageManager>(), _apiApp.GetResource<ExtensionProvider>(),
+            _apiApp.GetResource<PackageManager>(), _apiApp.GetResource<IExtensionRegistry>(),
             _editorService, _projectService));
         Register(() => new LoadSideloadExtensionTask(_apiApp.GetResource<PackageManager>()));
         Register(() => new AfterLoadingExtensionsTask(this));

--- a/src/Beutl/Services/Tutorials/AnimationEditTutorial.cs
+++ b/src/Beutl/Services/Tutorials/AnimationEditTutorial.cs
@@ -53,13 +53,14 @@ public static class AnimationEditTutorial
                 if (adder == null) return false;
 
                 // 楕円要素を追加
-                adder.AddElement(new ElementDescription(
+                ElementAddResult addResult = await adder.AddAsync([new ElementDescription(
                     Start: TimeSpan.Zero,
                     Length: TimeSpan.FromSeconds(5),
                     Layer: 0,
-                    EngineObjectFactory: () => new EllipseShape()));
+                    Source: new ElementSource.EngineObject(() => new EllipseShape()))],
+                    CancellationToken.None);
 
-                return true;
+                return addResult.IsSuccess;
             },
             Steps =
             [

--- a/src/Beutl/Services/UnsavedSceneStorage.cs
+++ b/src/Beutl/Services/UnsavedSceneStorage.cs
@@ -1,0 +1,282 @@
+﻿using Beutl.Editor;
+using Beutl.IO;
+using Beutl.Logging;
+using Beutl.ProjectSystem;
+using Beutl.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace Beutl.Services;
+
+internal static class UnsavedSceneStorage
+{
+    private static readonly ILogger s_logger = Log.CreateLogger(typeof(UnsavedSceneStorage));
+
+    public static string GetDirectory(Guid sceneId)
+        => Path.Combine(
+            BeutlEnvironment.GetHomeDirectoryPath(),
+            "tmp",
+            "unsaved",
+            sceneId.ToString("N"));
+
+    public static string GetElementDirectory(Guid sceneId)
+        => Path.Combine(GetDirectory(sceneId), "elements");
+
+    public static bool OwnsPath(Guid sceneId, string path)
+    {
+        string root = Path.GetFullPath(GetDirectory(sceneId));
+        string candidate = Path.GetFullPath(path);
+        string relative = Path.GetRelativePath(root, candidate);
+        return !Path.IsPathRooted(relative)
+            && !string.Equals(relative, "..", StringComparison.Ordinal)
+            && !relative.StartsWith($"..{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+            && !relative.StartsWith($"..{Path.AltDirectorySeparatorChar}", StringComparison.Ordinal);
+    }
+
+    public static void Cleanup(Guid sceneId)
+    {
+        string directory = GetDirectory(sceneId);
+        try
+        {
+            if (Directory.Exists(directory))
+                Directory.Delete(directory, recursive: true);
+        }
+        catch (Exception ex)
+        {
+            s_logger.LogWarning(
+                ex,
+                "Failed to remove temporary resources owned by scene {SceneId} from {Path}.",
+                sceneId,
+                directory);
+        }
+    }
+
+    public static SaveRelocation PrepareSave(Scene scene, Uri sceneUri)
+        => new(scene, sceneUri);
+
+    internal sealed class SaveRelocation
+    {
+        private static readonly ILogger s_logger = Log.CreateLogger<SaveRelocation>();
+        private readonly Scene _scene;
+        private readonly List<ElementRehome> _elements;
+        private readonly List<ResourceRehome> _resources;
+
+        public SaveRelocation(Scene scene, Uri sceneUri)
+        {
+            _scene = scene;
+            _elements = CreateElementRehomes(scene, sceneUri);
+            _resources = CreateResourceRehomes(scene, sceneUri);
+        }
+
+        public void Apply()
+        {
+            foreach (ResourceRehome rehome in _resources)
+            {
+                CopyFileAtomically(rehome.Original.LocalPath, rehome.Destination.LocalPath);
+            }
+            foreach (ResourceRehome rehome in _resources)
+            {
+                foreach (IFileSource source in rehome.Sources)
+                    source.ReadFrom(rehome.Destination);
+            }
+            foreach (ElementRehome rehome in _elements)
+            {
+                CoreSerializer.StoreToUri(rehome.Element, rehome.Destination);
+            }
+        }
+
+        public void Rollback()
+        {
+            foreach (ResourceRehome rehome in _resources)
+            {
+                foreach (IFileSource source in rehome.Sources)
+                {
+                    try
+                    {
+                        source.ReadFrom(rehome.Original);
+                    }
+                    catch (Exception ex)
+                    {
+                        s_logger.LogWarning(ex, "Failed to restore an AI resource URI after save failed.");
+                    }
+                }
+                TryDelete(rehome.Destination.LocalPath);
+            }
+            foreach (ElementRehome rehome in _elements)
+            {
+                rehome.Element.Uri = rehome.Original;
+                TryDelete(rehome.Destination.LocalPath);
+            }
+        }
+
+        public void Commit()
+        {
+            foreach (ElementRehome rehome in _elements)
+                TryDelete(rehome.Original.LocalPath);
+            foreach (ResourceRehome rehome in _resources)
+                TryDelete(rehome.Original.LocalPath);
+            TryPruneDirectories(GetDirectory(_scene.Id));
+        }
+
+        private static List<ElementRehome> CreateElementRehomes(Scene scene, Uri sceneUri)
+        {
+            var result = new List<ElementRehome>();
+            var destinations = new HashSet<string>(GetPathComparer());
+            foreach (Element element in scene.Children)
+            {
+                if (element.Uri is not { IsFile: true } original
+                    || !OwnsPath(scene.Id, original.LocalPath))
+                {
+                    continue;
+                }
+
+                Uri destination;
+                do
+                {
+                    destination = RandomFileNameGenerator.GenerateUri(
+                        sceneUri,
+                        EditorConstants.ElementFileExtension);
+                }
+                while (!destinations.Add(destination.LocalPath));
+
+                result.Add(new ElementRehome(element, original, destination));
+            }
+            return result;
+        }
+
+        private static List<ResourceRehome> CreateResourceRehomes(Scene scene, Uri sceneUri)
+        {
+            string destinationDirectory = Path.Combine(
+                Path.GetDirectoryName(sceneUri.LocalPath)!,
+                "resources",
+                "ai");
+            var groups = new Dictionary<string, List<IFileSource>>(GetPathComparer());
+            var seen = new HashSet<IFileSource>(ReferenceEqualityComparer.Instance);
+            foreach (IFileSource source in scene.Children
+                         .SelectMany(element => ProxySourceEnumerator.EnumerateFileSources(element)))
+            {
+                if (!seen.Add(source))
+                    continue;
+
+                Uri original;
+                try
+                {
+                    original = source.Uri;
+                }
+                catch (InvalidOperationException)
+                {
+                    continue;
+                }
+
+                if (!original.IsFile || !OwnsPath(scene.Id, original.LocalPath))
+                    continue;
+
+                if (!groups.TryGetValue(original.LocalPath, out List<IFileSource>? sources))
+                {
+                    sources = [];
+                    groups.Add(original.LocalPath, sources);
+                }
+                sources.Add(source);
+            }
+
+            var destinations = new HashSet<string>(GetPathComparer());
+            var result = new List<ResourceRehome>(groups.Count);
+            foreach ((string sourcePath, List<IFileSource> sources) in groups)
+            {
+                if (!File.Exists(sourcePath))
+                    throw new FileNotFoundException("An unsaved scene resource is missing.", sourcePath);
+
+                Directory.CreateDirectory(destinationDirectory);
+                string destination = GetUniqueDestination(
+                    destinationDirectory,
+                    Path.GetFileName(sourcePath),
+                    destinations);
+                result.Add(new ResourceRehome(
+                    UriHelper.CreateFromPath(sourcePath),
+                    UriHelper.CreateFromPath(destination),
+                    sources));
+            }
+            return result;
+        }
+
+        private static string GetUniqueDestination(
+            string directory,
+            string fileName,
+            ISet<string> reserved)
+        {
+            string stem = Path.GetFileNameWithoutExtension(fileName);
+            string extension = Path.GetExtension(fileName);
+            for (int suffix = 0; ; suffix++)
+            {
+                string candidateName = suffix == 0
+                    ? fileName
+                    : $"{stem}-{suffix}{extension}";
+                string candidate = Path.Combine(directory, candidateName);
+                if (!File.Exists(candidate) && reserved.Add(candidate))
+                    return candidate;
+            }
+        }
+
+        private static void CopyFileAtomically(string source, string destination)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+            string temporary = $"{destination}.{Guid.NewGuid():N}.tmp";
+            try
+            {
+                File.Copy(source, temporary, overwrite: false);
+                File.Move(temporary, destination, overwrite: false);
+            }
+            catch
+            {
+                TryDelete(temporary);
+                throw;
+            }
+        }
+
+        private static void TryDelete(string path)
+        {
+            try
+            {
+                File.Delete(path);
+            }
+            catch (Exception ex)
+            {
+                s_logger.LogWarning(ex, "Failed to remove obsolete unsaved-scene file {Path}.", path);
+            }
+        }
+
+        private static void TryPruneDirectories(string root)
+        {
+            try
+            {
+                if (!Directory.Exists(root))
+                    return;
+
+                foreach (string directory in Directory
+                             .EnumerateDirectories(root, "*", SearchOption.AllDirectories)
+                             .OrderByDescending(path => path.Length))
+                {
+                    if (!Directory.EnumerateFileSystemEntries(directory).Any())
+                        Directory.Delete(directory);
+                }
+                if (!Directory.EnumerateFileSystemEntries(root).Any())
+                    Directory.Delete(root);
+            }
+            catch (Exception ex)
+            {
+                s_logger.LogWarning(ex, "Failed to prune unsaved-scene storage {Path}.", root);
+            }
+        }
+
+        private static StringComparer GetPathComparer()
+            => OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal;
+
+        private sealed record ElementRehome(Element Element, Uri Original, Uri Destination);
+
+        private sealed record ResourceRehome(
+            Uri Original,
+            Uri Destination,
+            IReadOnlyList<IFileSource> Sources);
+    }
+}

--- a/src/Beutl/Services/UnsavedSceneStorage.cs
+++ b/src/Beutl/Services/UnsavedSceneStorage.cs
@@ -112,8 +112,8 @@ internal static class UnsavedSceneStorage
         {
             foreach (ElementRehome rehome in _elements)
                 TryDelete(rehome.Original.LocalPath);
-            foreach (ResourceRehome rehome in _resources)
-                TryDelete(rehome.Original.LocalPath);
+            // Distinct source instances in undo/redo may still reference the original resource.
+            // The editor's terminal cleanup removes these copies when history is retired.
             TryPruneDirectories(GetDirectory(_scene.Id));
         }
 

--- a/src/Beutl/SharedFilePickerOptions.cs
+++ b/src/Beutl/SharedFilePickerOptions.cs
@@ -52,6 +52,56 @@ public static class SharedFilePickerOptions
         };
     }
 
+    /// <summary>
+    /// The pictures an AI endpoint takes as input. Deliberately narrower than
+    /// <see cref="OpenImage"/>: the server decodes a fixed set and refuses
+    /// everything else, so a format it cannot read is better left out of the
+    /// picker than refused after the upload has gone out.
+    /// </summary>
+    public static FilePickerOpenOptions OpenAiInputImage()
+        => AiImagePicker("PNG, JPEG, WebP, GIF", ["*.png", "*.jpg", "*.jpeg", "*.webp", "*.gif"]);
+
+    /// <summary>
+    /// The pictures a video generation takes as a first or last frame. The
+    /// endpoint reads one fewer format than the image endpoints do.
+    /// </summary>
+    public static FilePickerOpenOptions OpenAiVideoFrame()
+        => AiImagePicker("PNG, JPEG, WebP", ["*.png", "*.jpg", "*.jpeg", "*.webp"]);
+
+    private static FilePickerOpenOptions AiImagePicker(string name, string[] patterns)
+    {
+        string[] mimeTypes = patterns
+            .Select(pattern => pattern switch
+            {
+                "*.png" => "image/png",
+                "*.jpg" or "*.jpeg" => "image/jpeg",
+                "*.webp" => "image/webp",
+                _ => "image/gif",
+            })
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        return new()
+        {
+            FileTypeFilter =
+            [
+                new FilePickerFileType(name)
+                {
+                    Patterns = patterns,
+                    MimeTypes = mimeTypes,
+                    AppleUniformTypeIdentifiers = mimeTypes
+                        .Select(mimeType => mimeType switch
+                        {
+                            "image/png" => "public.png",
+                            "image/jpeg" => "public.jpeg",
+                            "image/webp" => "org.webmproject.webp",
+                            _ => "com.compuserve.gif",
+                        })
+                        .ToArray(),
+                }
+            ]
+        };
+    }
+
     public static FilePickerSaveOptions SaveImage()
     {
         return new()
@@ -83,5 +133,76 @@ public static class SharedFilePickerOptions
                 }
             ]
         };
+    }
+
+    public static FilePickerSaveOptions SavePngImage()
+    {
+        return new()
+        {
+            DefaultExtension = "png",
+            FileTypeChoices =
+            [
+                new FilePickerFileType("PNG Image")
+                {
+                    Patterns = ["*.png"],
+                    AppleUniformTypeIdentifiers = ["public.png"],
+                    MimeTypes = ["image/png"]
+                }
+            ]
+        };
+    }
+
+    public static FilePickerSaveOptions SaveVideo()
+    {
+        return new()
+        {
+            FileTypeChoices =
+            [
+                new FilePickerFileType("All Videos")
+                {
+                    Patterns =
+                    [
+                        "*.mp4",
+                        "*.mov",
+                        "*.webm",
+                        "*.mkv"
+                    ],
+                    AppleUniformTypeIdentifiers = ["public.movie"],
+                    MimeTypes = ["video/*"]
+                }
+            ]
+        };
+    }
+
+    internal static IDisposable OwnStorageFiles(IReadOnlyList<IStorageFile> files)
+    {
+        ArgumentNullException.ThrowIfNull(files);
+        return new StorageFileOwnership(files.ToArray());
+    }
+
+    private sealed class StorageFileOwnership(IReadOnlyList<IStorageFile> files) : IDisposable
+    {
+        private IReadOnlyList<IStorageFile>? _files = files;
+
+        public void Dispose()
+        {
+            IReadOnlyList<IStorageFile>? owned = Interlocked.Exchange(ref _files, null);
+            if (owned is null)
+                return;
+
+            foreach (IStorageFile file in owned)
+            {
+                try
+                {
+                    file.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Trace.TraceWarning(
+                        "Failed to release a storage-picker file: {0}",
+                        ex.Message);
+                }
+            }
+        }
     }
 }

--- a/src/Beutl/ViewModels/AiModelPickerViewModel.cs
+++ b/src/Beutl/ViewModels/AiModelPickerViewModel.cs
@@ -1,0 +1,420 @@
+﻿using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using Beutl.Api.Services;
+using Beutl.Language;
+using Beutl.Logging;
+using Microsoft.Extensions.Logging;
+using Reactive.Bindings;
+using ReactiveUI.Avalonia;
+
+namespace Beutl.ViewModels;
+
+/// <summary>
+/// One entry in the model picker. It carries no price: the server publishes an
+/// ordering (<see cref="AiModelCostTier"/>) and whether the account can pay for
+/// this model, and nothing more.
+/// </summary>
+internal sealed record AiModelPickerOption(AiModelOption Model, bool IsAvailable)
+{
+    public AiModelId Id => Model.Id;
+
+    public override string ToString()
+    {
+        string cost = !IsAvailable
+            ? Strings.AiModelUnaffordable
+            : Model.CostTier switch
+            {
+                AiModelCostTier.Low => Strings.AiModelCostLow,
+                AiModelCostTier.Medium => Strings.AiModelCostMedium,
+                AiModelCostTier.High => Strings.AiModelCostHigh,
+                _ => string.Empty,
+            };
+        return cost.Length == 0 ? Model.DisplayName : $"{Model.DisplayName} — {cost}";
+    }
+}
+
+/// <summary>
+/// Which model an operation should run on.
+///
+/// The list is fetched rather than declared, because an administrator registers
+/// it on the server; until it arrives, and whenever it holds fewer than two
+/// entries, the dialog shows no picker and the request names no model, which is
+/// how it behaved before models could be chosen.
+/// </summary>
+internal sealed class AiModelPickerViewModel : IDisposable
+{
+    private readonly ILogger _logger = Log.CreateLogger<AiModelPickerViewModel>();
+    private readonly CompositeDisposable _disposables = [];
+    private readonly IAiModelCatalogService _catalog;
+    private readonly IAiEntitlementService _entitlements;
+    private readonly CancellationTokenSource _lifetimeCancellation = new();
+    // What the list currently on offer was built from. Reloading is how a model
+    // an operator changed reaches a screen that is already open, and most
+    // reloads find exactly what is already there — rebuilding then would empty
+    // the list and move the user's choice for nothing.
+    private AiModelCatalog? _loadedCatalog;
+    private AiEntitlements? _loadedEntitlements;
+    private int _disposed;
+    // Which load is the one whose answer still matters. Two can be in the air
+    // at once — switching task while a scheduled reload is fetching — and only
+    // the newest may say the list has arrived, or a request could go out while
+    // the list for the task on screen is still on its way.
+    private int _loadGeneration;
+    // How often a page that stays where it is asks again. The catalog itself is
+    // cached with a freshness window, so most of these cost nothing; without
+    // them, a page left in the foreground goes on offering a model an operator
+    // has since withdrawn for as long as it is left there. Reopening the page,
+    // or coming back to the window, is the other way this happens.
+    private static readonly TimeSpan s_reloadInterval = TimeSpan.FromMinutes(1);
+
+    public AiModelPickerViewModel(
+        IAiModelCatalogService catalog,
+        IAiEntitlementService entitlements)
+    {
+        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+        _entitlements = entitlements ?? throw new ArgumentNullException(nameof(entitlements));
+
+        Selected = new ReactivePropertySlim<AiModelPickerOption?>().DisposeWith(_disposables);
+        HasChoice = new ReactivePropertySlim<bool>(false).DisposeWith(_disposables);
+        OffersNothingUsable = new ReactivePropertySlim<bool>(false)
+            .DisposeWith(_disposables);
+        IsLoaded = new ReactivePropertySlim<bool>(false)
+            .DisposeWith(_disposables);
+        IsSelectionEnabled = new ReactivePropertySlim<bool>(true)
+            .DisposeWith(_disposables);
+        Label = Strings.AiModel;
+        Observable
+            .Interval(s_reloadInterval, AvaloniaScheduler.Instance)
+            .Subscribe(_ => ReloadOnSchedule())
+            .DisposeWith(_disposables);
+    }
+
+    /// <summary>
+    /// Whether the list for <paramref name="operation"/> may be put on offer
+    /// right now.
+    /// </summary>
+    /// <remarks>
+    /// A screen holding a name the server has not settled says no to replacing
+    /// the list that request was built against: what it carries follows the
+    /// model on offer, and moving that renames a request already paid for. It
+    /// must not say no to a list it does not have yet, though — a screen with
+    /// no list for what it is showing cannot send anything at all, which is how
+    /// coming back to an unfinished request would strand it.
+    /// </remarks>
+    public Func<AiOperationId, bool>? CanReload { get; set; }
+
+    /// <summary>
+    /// Models that must stay on the list for an operation however the catalog
+    /// changes, because a request still waiting to be collected named them.
+    /// </summary>
+    /// <remarks>
+    /// The server answers such a request before it looks at whether the model
+    /// is still offered, so the screen has to be able to say that model's name.
+    /// There may be more than one — two requests on the same operation, sent on
+    /// different models, can both be waiting.
+    /// </remarks>
+    public Func<AiOperationId, IReadOnlyList<AiModelId>>? KeepOffered { get; set; }
+
+    private void ReloadOnSchedule()
+    {
+        if (Volatile.Read(ref _disposed) != 0
+            || !IsLoaded.Value
+            || CanReload?.Invoke(Operation) == false)
+            return;
+        _ = ReloadAsync();
+    }
+
+    private async Task ReloadAsync()
+    {
+        try
+        {
+            await LoadAsync(Operation, _lifetimeCancellation.Token);
+        }
+        catch (OperationCanceledException) when (_lifetimeCancellation.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            // Offering yesterday's list is better than emptying it, so nothing
+            // is shown for a reload nobody asked for — but a list that has
+            // stopped refreshing is worth knowing about.
+            _logger.LogWarning(ex, "Failed to reload the AI model list.");
+        }
+    }
+
+    /// <summary>
+    /// What the last load was for. The image editor's five tasks are five
+    /// operations with five model lists, so this changes as the task does.
+    /// </summary>
+    public AiOperationId Operation { get; private set; }
+
+    public string Label { get; }
+
+    public ObservableCollection<AiModelPickerOption> Options { get; } = [];
+
+    /// <summary>
+    /// What all the reference pictures of one request may come to together, as
+    /// the server publishes it.
+    /// </summary>
+    public AiImageReferenceLimits ImageReferenceLimits { get; private set; }
+
+    public AiCaptionTranslationLimits CaptionTranslationLimits { get; private set; }
+
+    /// <summary>
+    /// Which models an operation is willing to offer, beyond what the server
+    /// registered. Video drops the ones that take no shape it can ask for:
+    /// offering one would only ever produce a request the server refuses.
+    /// </summary>
+    public Func<AiModelOption, bool>? Filter { get; set; }
+
+    public ReactivePropertySlim<AiModelPickerOption?> Selected { get; }
+
+    /// <summary>False while a single model is on offer, which is nothing to choose between.</summary>
+    public ReactivePropertySlim<bool> HasChoice { get; }
+
+    /// <summary>
+    /// True when the server registered models for this operation and none of
+    /// them can serve it.
+    /// </summary>
+    /// <remarks>
+    /// An empty list on its own says nothing — a server that publishes no
+    /// models at all is answered by naming none and letting it choose, which is
+    /// how this client behaved before models could be chosen. It is only when
+    /// there were models to offer and every one was ruled out that a request
+    /// would be refused however it is shaped, and the screen has nothing to
+    /// offer rather than nothing to choose between.
+    /// </remarks>
+    public ReactivePropertySlim<bool> OffersNothingUsable { get; }
+
+    /// <summary>
+    /// Whether the list has been asked for at least once.
+    /// </summary>
+    /// <remarks>
+    /// Until then nothing is known: the operation may have no model that can
+    /// serve it, and a request sent meanwhile names none and runs on whatever
+    /// the server has as its default — which may cost more than the model the
+    /// screen would have offered. A failed attempt still counts as asked: a
+    /// catalog that cannot be read must not leave the screen unable to send at
+    /// all, which is how it behaved before models could be chosen.
+    /// </remarks>
+    public ReactivePropertySlim<bool> IsLoaded { get; }
+
+    internal ReactivePropertySlim<bool> IsSelectionEnabled { get; }
+
+    /// <summary>What the request should carry. Null asks the server for its default.</summary>
+    public AiModelId? SelectedModel => Selected.Value?.Id;
+
+    /// <summary>
+    /// Drops models retained only for recovery once their durable request is
+    /// gone, and moves the selection back to a model in the current catalog.
+    /// </summary>
+    internal void ReconcileRecoveryModels()
+    {
+        if (_loadedCatalog is not { } catalog)
+            return;
+
+        ImmutableArray<AiModelOption> registered = catalog.ModelsFor(Operation);
+        HashSet<AiModelId> offeredIds = registered
+            .Where(model => Filter is not { } filter || filter(model))
+            .Select(model => model.Id)
+            .ToHashSet();
+        HashSet<AiModelId> retainedIds = (KeepOffered?.Invoke(Operation) ?? [])
+            .ToHashSet();
+        for (int index = Options.Count - 1; index >= 0; index--)
+        {
+            AiModelId id = Options[index].Id;
+            if (!offeredIds.Contains(id) && !retainedIds.Contains(id))
+                Options.RemoveAt(index);
+        }
+
+        HasChoice.Value = Options.Count > 1;
+        OffersNothingUsable.Value =
+            (!registered.IsDefaultOrEmpty && Options.Count == 0)
+            || catalog.OffersNoModel(Operation);
+        if (Selected.Value is { } selected
+            && offeredIds.Contains(selected.Id)
+            && Options.Any(option => option.Id == selected.Id))
+        {
+            return;
+        }
+
+        Selected.Value = Options.FirstOrDefault(option =>
+                offeredIds.Contains(option.Id) && option.IsAvailable)
+            ?? Options.FirstOrDefault(option => offeredIds.Contains(option.Id));
+    }
+
+    public Task LoadAsync(AiOperationId operation, CancellationToken cancellationToken)
+        => LoadAsync(operation, null, false, cancellationToken);
+
+    public Task LoadAsync(
+        AiOperationId operation,
+        AiModelId? preferred,
+        CancellationToken cancellationToken)
+        => LoadAsync(operation, preferred, preferredSpecified: preferred is not null, cancellationToken);
+
+    /// <summary>
+    /// Loads the list and lands on <paramref name="preferred"/> when it is
+    /// still offered.
+    /// </summary>
+    /// <remarks>
+    /// A run that was interrupted names its requests partly by the model it ran
+    /// on, so a resumed run has to go back to that model: landing on whichever
+    /// the account can afford today would name the unfinished pieces
+    /// differently and buy them again.
+    /// </remarks>
+    public async Task LoadAsync(
+        AiOperationId operation,
+        AiModelId? preferred,
+        bool preferredSpecified,
+        CancellationToken cancellationToken)
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+            return;
+
+        // Nothing is known about an operation this picker has not been asked
+        // for yet — least of all whether it has a model that can serve it. The
+        // image editor's five tasks are five operations, and a request sent
+        // while the list for the new one is still on its way would name no
+        // model and run on the server's default, which may cost more than the
+        // model the screen was about to offer.
+        if (Operation != operation)
+            IsLoaded.Value = false;
+
+        int generation = Interlocked.Increment(ref _loadGeneration);
+        try
+        {
+            await LoadCoreAsync(operation, preferred, preferredSpecified, generation, cancellationToken);
+        }
+        finally
+        {
+            // Report the operation as loaded only when its catalog is actually present. Marking a
+            // failed load complete would allow a task with no listed model to be sent and charged
+            // against the server default instead of the model shown by the UI.
+            if (Volatile.Read(ref _disposed) == 0
+                && generation == Volatile.Read(ref _loadGeneration))
+                IsLoaded.Value = Operation == operation;
+        }
+    }
+
+    private async Task LoadCoreAsync(
+        AiOperationId operation,
+        AiModelId? preferred,
+        bool preferredSpecified,
+        int generation,
+        CancellationToken cancellationToken)
+    {
+        AiModelCatalog catalog = await _catalog.GetAsync(cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (Volatile.Read(ref _disposed) != 0)
+            return;
+        // Overtaken while this was being fetched: the screen has moved on to
+        // another operation, and putting this list up would replace the one it
+        // is actually showing.
+        if (generation != _loadGeneration)
+            return;
+
+        // Asked again on the way back. A request may have gone out while this
+        // was being fetched, and what it carries — the model, and the shape and
+        // background that follow it — is what this list would replace.
+        if (CanReload?.Invoke(operation) == false
+            && Operation == operation
+            && IsLoaded.Value)
+            return;
+
+        AiEntitlements? entitlements = _entitlements.Entitlements.Value;
+        if (!preferredSpecified
+            && preferred is null
+            && Operation == operation
+            && ReferenceEquals(_loadedCatalog, catalog)
+            && ReferenceEquals(_loadedEntitlements, entitlements))
+        {
+            return;
+        }
+
+        // Only a reported refusal rules the operation out. Silence says nothing,
+        // so its models stay offered rather than reading as unaffordable.
+        bool operationIsAvailable =
+            entitlements is not null
+            && entitlements.Availability.GetState(operation) != AiOperationAvailabilityState.Unavailable;
+
+        // The choice already made, kept when it is still on offer: a reload is
+        // not a reason to move it.
+        AiModelId? keep = preferredSpecified ? preferred : (preferred ?? SelectedModel);
+        // Models the catalog no longer lists that an uncollected request was
+        // sent with. The server answers such a request before it looks at
+        // whether the model is still offered, so each one stays on the list,
+        // unpickable for anything new, until that request is settled. What is on
+        // offer right now may be another operation's list entirely, so a name
+        // with nothing behind it is shown as itself rather than dropped.
+        AiModelPickerOption[] mustStay = (KeepOffered?.Invoke(operation) ?? [])
+            .Select(id => Options.FirstOrDefault(option => option.Id == id)
+                ?? new AiModelPickerOption(
+                    new AiModelOption(id, id.Value, null, false),
+                    IsAvailable: false))
+            .ToArray();
+        Operation = operation;
+        ImageReferenceLimits = catalog.GetImageReferenceLimits(operation);
+        CaptionTranslationLimits = catalog.CaptionTranslationLimits;
+        _loadedCatalog = catalog;
+        _loadedEntitlements = entitlements;
+        Options.Clear();
+        ImmutableArray<AiModelOption> registered = catalog.ModelsFor(operation);
+        foreach (AiModelOption model in registered)
+        {
+            if (Filter is { } filter && !filter(model))
+                continue;
+
+            Options.Add(new AiModelPickerOption(
+                model,
+                entitlements?.ModelAvailability.CanStart(
+                    operation,
+                    model.Id,
+                    operationIsAvailable) ?? false));
+        }
+
+        foreach (AiModelPickerOption held in mustStay)
+        {
+            if (!Options.Any(option => option.Id == held.Id))
+                Options.Add(held with { IsAvailable = false });
+        }
+
+        HasChoice.Value = Options.Count > 1;
+        // Two ways an operation has nothing to run on: every model it registered
+        // was ruled out here, or the server named the operation and offered no
+        // model for it at all. A server that says nothing about the operation is
+        // neither — a request then names no model and the server picks.
+        OffersNothingUsable.Value =
+            (!registered.IsDefaultOrEmpty && Options.Count == 0)
+            || catalog.OffersNoModel(operation);
+        // Start on the first model the account can actually pay for, falling
+        // back to the server's default so the picker is never empty.
+        Selected.Value = preferredSpecified && preferred is null
+            ? null
+            : (keep is { } wanted
+                ? Options.FirstOrDefault(option => option.Id == wanted)
+                : null)
+              ?? Options.FirstOrDefault(option => option.IsAvailable && option.Model.IsDefault)
+              ?? Options.FirstOrDefault(option => option.IsAvailable)
+              ?? Options.FirstOrDefault(option => option.Model.IsDefault)
+              ?? Options.FirstOrDefault();
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+        Interlocked.Increment(ref _loadGeneration);
+        try
+        {
+            _lifetimeCancellation.Cancel();
+        }
+        finally
+        {
+            _disposables.Dispose();
+            _lifetimeCancellation.Dispose();
+        }
+    }
+}

--- a/src/Beutl/ViewModels/AiPromptLibraryViewModel.cs
+++ b/src/Beutl/ViewModels/AiPromptLibraryViewModel.cs
@@ -1,0 +1,449 @@
+﻿using System.Collections.ObjectModel;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using Avalonia.Threading;
+using Beutl.Api.Services;
+using Beutl.Language;
+using Beutl.Services.AI;
+using Reactive.Bindings;
+
+namespace Beutl.ViewModels;
+
+/// <summary>
+/// The saved prompts behind one task's prompt box. Templates and history are
+/// two lists rather than one: a template is something the account named and
+/// keeps, history is only what it happened to run, and the tab reaches them
+/// from different places.
+/// </summary>
+internal sealed class AiPromptLibraryViewModel : IDisposable
+{
+    private readonly CompositeDisposable _disposables = [];
+    private readonly object _refreshGate = new();
+    private readonly Action<Action> _dispatchToUi;
+    private readonly IPromptLibrary _library;
+    private readonly IDisposable? _libraryChangeSubscription;
+    private readonly AiRequestRecoveryContext? _recoveryContext;
+    private readonly PromptTaskKind _taskKind;
+    private readonly Func<string> _getPrompt;
+    private readonly Action<string> _applyPrompt;
+    private readonly ObservableCollection<AiPromptChoice> _templates = [];
+    private readonly ObservableCollection<AiPromptChoice> _history = [];
+    private bool _disposed;
+    private long _accountGeneration;
+
+    public AiPromptLibraryViewModel(
+        PromptTaskKind taskKind,
+        Func<string> getPrompt,
+        Action<string> applyPrompt,
+        IPromptLibrary? library = null,
+        AiRequestRecoveryContext? recoveryContext = null,
+        Action<Action>? dispatchToUi = null)
+    {
+        _taskKind = taskKind;
+        _getPrompt = getPrompt ?? throw new ArgumentNullException(nameof(getPrompt));
+        _applyPrompt = applyPrompt ?? throw new ArgumentNullException(nameof(applyPrompt));
+        _recoveryContext = recoveryContext;
+        Dispatcher dispatcher = Dispatcher.UIThread;
+        _dispatchToUi = dispatchToUi ?? (action =>
+        {
+            if (dispatcher.CheckAccess())
+                action();
+            else
+                dispatcher.Post(action);
+        });
+        _library = library ?? PromptLibraryProvider.For(
+            recoveryContext ?? throw new ArgumentNullException(nameof(recoveryContext)));
+        Templates = new ReadOnlyObservableCollection<AiPromptChoice>(_templates);
+        History = new ReadOnlyObservableCollection<AiPromptChoice>(_history);
+
+        Apply = new ReactiveCommand<AiPromptChoice>(ImmediateScheduler.Instance);
+        Apply.Subscribe(ApplyCore).DisposeWith(_disposables);
+        TogglePin = new ReactiveCommand<AiPromptChoice>(ImmediateScheduler.Instance);
+        TogglePin.Subscribe(TogglePinCore).DisposeWith(_disposables);
+        Delete = new ReactiveCommand<AiPromptChoice>(ImmediateScheduler.Instance);
+        Delete.Subscribe(DeleteCore).DisposeWith(_disposables);
+        SaveTemplate = new ReactiveCommand();
+        SaveTemplate.Subscribe(SaveTemplateCore).DisposeWith(_disposables);
+        ClearHistory = new ReactiveCommand();
+        ClearHistory.Subscribe(ClearHistoryCore).DisposeWith(_disposables);
+
+        if (_recoveryContext is not null)
+            _recoveryContext.IdentityChanged += RefreshForIdentity;
+        IDisposable? changeSubscription = null;
+        try
+        {
+            changeSubscription = (_library as IPromptLibraryChangeSource)?
+                .SubscribeChanged(RefreshFromLibraryChange);
+            _libraryChangeSubscription = changeSubscription;
+            // Subscribe before the initial snapshot. A mutation that wins this race is then
+            // either visible to the snapshot or followed by a notification; it cannot be lost
+            // between reading the shared library and attaching the observer.
+            string? account = CurrentAccount();
+            long generation = Volatile.Read(ref _accountGeneration);
+            Action initialRefresh = () =>
+                ApplyQueuedRefresh(identityChanged: false, account, generation);
+            _dispatchToUi(initialRefresh);
+        }
+        catch
+        {
+            changeSubscription?.Dispose();
+            if (_recoveryContext is not null)
+                _recoveryContext.IdentityChanged -= RefreshForIdentity;
+            throw;
+        }
+    }
+
+    /// <summary>Named prompts the account keeps, newest and pinned first.</summary>
+    public ReadOnlyObservableCollection<AiPromptChoice> Templates { get; }
+
+    /// <summary>Prompts this account has run, newest and pinned first.</summary>
+    public ReadOnlyObservableCollection<AiPromptChoice> History { get; }
+
+    /// <summary>
+    /// Drives the history popup. Applying a prompt closes it, so the tab does
+    /// not keep a panel open over the box the prompt just landed in.
+    /// </summary>
+    public ReactivePropertySlim<bool> IsHistoryOpen { get; } = new();
+
+    public ReactivePropertySlim<string> TemplateName { get; } = new();
+
+    public ReactivePropertySlim<bool> HasTemplates { get; } = new();
+
+    public ReactivePropertySlim<bool> HasHistory { get; } = new();
+
+    public ReactivePropertySlim<string?> Error { get; } = new();
+
+    public ReactiveCommand<AiPromptChoice> Apply { get; }
+
+    public ReactiveCommand<AiPromptChoice> TogglePin { get; }
+
+    public ReactiveCommand<AiPromptChoice> Delete { get; }
+
+    public ReactiveCommand SaveTemplate { get; }
+
+    public ReactiveCommand ClearHistory { get; }
+
+    public string PrivacyText => Strings.AiPromptLibraryPrivacy;
+
+    public void Record(string prompt)
+    {
+        if (string.IsNullOrWhiteSpace(prompt))
+            return;
+
+        try
+        {
+            _library.Record(_taskKind, prompt);
+        }
+        catch (AuthenticationRequiredException)
+        {
+            return;
+        }
+        catch (Exception ex) when (ex is IOException
+            or UnauthorizedAccessException
+            or InvalidDataException)
+        {
+            Error.Value = Strings.AiResultUnavailable;
+            System.Diagnostics.Trace.TraceWarning(
+                "Failed to record prompt history: {0}",
+                ex.Message);
+            return;
+        }
+        RefreshAfterLocalMutation();
+    }
+
+    public void Dispose()
+    {
+        lock (_refreshGate)
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            Interlocked.Increment(ref _accountGeneration);
+        }
+        if (_recoveryContext is not null)
+            _recoveryContext.IdentityChanged -= RefreshForIdentity;
+        _libraryChangeSubscription?.Dispose();
+        IsHistoryOpen.Dispose();
+        TemplateName.Dispose();
+        HasTemplates.Dispose();
+        HasHistory.Dispose();
+        Error.Dispose();
+        _disposables.Dispose();
+    }
+
+    private void ApplyCore(AiPromptChoice? choice)
+    {
+        if (choice is null)
+            return;
+
+        _applyPrompt(choice.Prompt);
+        Error.Value = null;
+        IsHistoryOpen.Value = false;
+    }
+
+    private void TogglePinCore(AiPromptChoice? choice)
+    {
+        if (choice is null)
+            return;
+
+        bool changed = false;
+        if (!TryMutatePromptLibrary(() =>
+            {
+                changed = choice.IsTemplate
+                    ? _library.SetTemplatePinned(choice.Id, !choice.IsPinned)
+                    : _library.SetHistoryPinned(choice.Id, !choice.IsPinned);
+            }))
+        {
+            return;
+        }
+
+        if (changed)
+        {
+            RefreshAfterLocalMutation();
+        }
+    }
+
+    private void DeleteCore(AiPromptChoice? choice)
+    {
+        if (choice is null)
+            return;
+
+        bool deleted = false;
+        if (!TryMutatePromptLibrary(() =>
+            {
+                deleted = choice.IsTemplate
+                    ? _library.DeleteTemplate(choice.Id)
+                    : _library.DeleteHistory(choice.Id);
+            }))
+        {
+            return;
+        }
+
+        if (deleted)
+        {
+            RefreshAfterLocalMutation();
+        }
+    }
+
+    private void SaveTemplateCore()
+    {
+        Error.Value = null;
+        try
+        {
+            if (!TryMutatePromptLibrary(() =>
+                    _library.SaveTemplate(TemplateName.Value, _taskKind, _getPrompt())))
+            {
+                return;
+            }
+
+            TemplateName.Value = string.Empty;
+            RefreshAfterLocalMutation();
+        }
+        catch (ArgumentException)
+        {
+            Error.Value = Strings.AiPromptTemplateInvalid;
+        }
+    }
+
+    private void ClearHistoryCore()
+    {
+        if (TryMutatePromptLibrary(_library.ClearHistory))
+        {
+            RefreshAfterLocalMutation();
+        }
+    }
+
+    private bool TryMutatePromptLibrary(Action mutation)
+    {
+        Error.Value = null;
+        try
+        {
+            mutation();
+            return true;
+        }
+        catch (AuthenticationRequiredException)
+        {
+            Error.Value = Strings.AiAuthenticationRequired;
+        }
+        catch (Exception ex) when (ex is IOException
+            or UnauthorizedAccessException
+            or InvalidDataException)
+        {
+            Error.Value = Strings.AiResultUnavailable;
+            System.Diagnostics.Trace.TraceWarning(
+                "Failed to update the prompt library: {0}",
+                ex.Message);
+        }
+
+        return false;
+    }
+
+    private void Refresh()
+    {
+        _templates.Clear();
+        foreach (PromptTemplate template in _library.Templates
+                     .Where(item => item.TaskKind == _taskKind)
+                     .OrderByDescending(item => item.IsPinned)
+                     .ThenByDescending(item => item.UpdatedAtUtc))
+        {
+            _templates.Add(new AiPromptChoice(
+                template.Id,
+                template.Name,
+                template.Prompt,
+                IsTemplate: true,
+                template.IsPinned));
+        }
+
+        _history.Clear();
+        foreach (PromptHistoryEntry history in _library.History
+                     .Where(item => item.TaskKind == _taskKind)
+                     .OrderByDescending(item => item.IsPinned)
+                     .ThenByDescending(item => item.LastUsedAtUtc))
+        {
+            _history.Add(new AiPromptChoice(
+                history.Id,
+                Summarize(history.Prompt),
+                history.Prompt,
+                IsTemplate: false,
+                history.IsPinned));
+        }
+
+        HasTemplates.Value = _templates.Count > 0;
+        HasHistory.Value = _history.Count > 0;
+    }
+
+    private void RefreshFromLibraryChange()
+    {
+        string? account = CurrentAccount();
+        long generation = Volatile.Read(ref _accountGeneration);
+        QueueRefresh(identityChanged: false, account, generation);
+    }
+
+    private void QueueRefresh(bool identityChanged, string? account, long generation)
+    {
+        _dispatchToUi(() => ApplyQueuedRefresh(identityChanged, account, generation));
+    }
+
+    private void ApplyQueuedRefresh(bool identityChanged, string? account, long generation)
+    {
+        lock (_refreshGate)
+        {
+            if (_disposed)
+                return;
+            if (generation != Volatile.Read(ref _accountGeneration))
+                return;
+            string? currentAccount = CurrentAccount();
+            if (generation != Volatile.Read(ref _accountGeneration)
+                || !StringComparer.Ordinal.Equals(account, currentAccount))
+            {
+                return;
+            }
+
+            if (identityChanged)
+            {
+                RefreshForIdentityCore();
+            }
+            else
+            {
+                try
+                {
+                    Refresh();
+                    if (Error.Value == Strings.AiResultUnavailable
+                        || Error.Value == Strings.AiAuthenticationRequired)
+                    {
+                        Error.Value = null;
+                    }
+                }
+                catch (InvalidDataException ex)
+                {
+                    ClearPromptChoices();
+                    Error.Value = Strings.AiResultUnavailable;
+                    System.Diagnostics.Trace.TraceWarning(
+                        "Failed to read the prompt library: {0}",
+                        ex.Message);
+                }
+                catch (Exception ex) when (ex is AuthenticationRequiredException
+                    or IOException
+                    or UnauthorizedAccessException)
+                {
+                    ClearPromptChoices();
+                    Error.Value = ex is AuthenticationRequiredException
+                        ? Strings.AiAuthenticationRequired
+                        : Strings.AiResultUnavailable;
+                }
+            }
+        }
+    }
+
+    private void RefreshAfterLocalMutation()
+    {
+        if (_libraryChangeSubscription is null)
+            RefreshFromLibraryChange();
+    }
+
+    private void RefreshForIdentity()
+    {
+        long generation = Interlocked.Increment(ref _accountGeneration);
+        QueueRefresh(identityChanged: true, CurrentAccount(), generation);
+    }
+
+    private string? CurrentAccount()
+        => _recoveryContext?.TryGetIdentity()?.AccountId;
+
+    private void RefreshForIdentityCore()
+    {
+        // Clear the previous account before touching the new account's store.
+        // A corrupt or unavailable destination must never leave the old
+        // account's prompt text visible in the new session.
+        ClearPromptChoices();
+        IsHistoryOpen.Value = false;
+        TemplateName.Value = string.Empty;
+        Error.Value = null;
+        try
+        {
+            Refresh();
+        }
+        catch (InvalidDataException ex)
+        {
+            // IdentityChanged is multicast and the dialog must still clear its
+            // previous account's form even when this account's library is corrupt.
+            Error.Value = Strings.AiResultUnavailable;
+            System.Diagnostics.Trace.TraceWarning(
+                "Failed to read prompt library during account switch: {0}",
+                ex.Message);
+        }
+        catch (Exception ex) when (ex is AuthenticationRequiredException
+            or IOException
+            or UnauthorizedAccessException)
+        {
+            Error.Value = ex is AuthenticationRequiredException
+                ? Strings.AiAuthenticationRequired
+                : Strings.AiResultUnavailable;
+        }
+    }
+
+    private void ClearPromptChoices()
+    {
+        _templates.Clear();
+        _history.Clear();
+        HasTemplates.Value = false;
+        HasHistory.Value = false;
+    }
+
+    // A history entry has no name, so its first line stands in for one.
+    private static string Summarize(string prompt)
+    {
+        string summary = prompt.Split('\n', 2)[0];
+        return summary.Length > 72 ? summary[..69] + "…" : summary;
+    }
+}
+
+internal sealed record AiPromptChoice(
+    Guid Id,
+    string Name,
+    string Prompt,
+    bool IsTemplate,
+    bool IsPinned)
+{
+    public override string ToString() => Name;
+}

--- a/src/Beutl/ViewModels/AiPromptLibraryViewModel.cs
+++ b/src/Beutl/ViewModels/AiPromptLibraryViewModel.cs
@@ -140,7 +140,8 @@ internal sealed class AiPromptLibraryViewModel : IDisposable
         }
         catch (Exception ex) when (ex is IOException
             or UnauthorizedAccessException
-            or InvalidDataException)
+            or InvalidDataException
+            or NotSupportedException)
         {
             Error.Value = Strings.AiResultUnavailable;
             System.Diagnostics.Trace.TraceWarning(
@@ -267,7 +268,8 @@ internal sealed class AiPromptLibraryViewModel : IDisposable
         }
         catch (Exception ex) when (ex is IOException
             or UnauthorizedAccessException
-            or InvalidDataException)
+            or InvalidDataException
+            or NotSupportedException)
         {
             Error.Value = Strings.AiResultUnavailable;
             System.Diagnostics.Trace.TraceWarning(
@@ -354,7 +356,7 @@ internal sealed class AiPromptLibraryViewModel : IDisposable
                         Error.Value = null;
                     }
                 }
-                catch (InvalidDataException ex)
+                catch (Exception ex) when (ex is InvalidDataException or NotSupportedException)
                 {
                     ClearPromptChoices();
                     Error.Value = Strings.AiResultUnavailable;
@@ -403,7 +405,7 @@ internal sealed class AiPromptLibraryViewModel : IDisposable
         {
             Refresh();
         }
-        catch (InvalidDataException ex)
+        catch (Exception ex) when (ex is InvalidDataException or NotSupportedException)
         {
             // IdentityChanged is multicast and the dialog must still clear its
             // previous account's form even when this account's library is corrupt.

--- a/src/Beutl/ViewModels/AiUsageEstimateViewModel.cs
+++ b/src/Beutl/ViewModels/AiUsageEstimateViewModel.cs
@@ -1,0 +1,106 @@
+﻿using System.Reactive.Disposables;
+using Beutl.Api.Services;
+using Beutl.Language;
+using Reactive.Bindings;
+
+namespace Beutl.ViewModels;
+
+internal sealed class AiUsageEstimateViewModel : IDisposable
+{
+    private readonly CompositeDisposable _disposables = [];
+
+    // Availability is decided by the server. The client only reflects it, so no
+    // pricing information is needed here. Until the server has answered the
+    // state is Unknown, which is neither a go-ahead nor a shortfall: the run
+    // stays offered and nothing is claimed about the balance, because the
+    // authoritative check runs again before the paid request is sent.
+    public AiUsageEstimateViewModel(
+        AiUsageViewModel usage,
+        IObservable<AiOperationAvailabilityState> availability)
+    {
+        ArgumentNullException.ThrowIfNull(usage);
+        ArgumentNullException.ThrowIfNull(availability);
+
+        State = usage.HasSnapshot
+            .CombineLatest(
+                availability,
+                (hasSnapshot, state) => hasSnapshot ? state : AiOperationAvailabilityState.Unknown)
+            .ToReadOnlyReactivePropertySlim(AiOperationAvailabilityState.Unknown)
+            .DisposeWith(_disposables);
+
+        CanAfford = usage.CanUseAi
+            .CombineLatest(
+                State,
+                (canUseAi, state) => canUseAi && state != AiOperationAvailabilityState.Unavailable)
+            .ToReadOnlyReactivePropertySlim(false)
+            .DisposeWith(_disposables);
+
+        IsInsufficient = usage.CanUseAi
+            .CombineLatest(
+                State,
+                (canUseAi, state) => canUseAi && state == AiOperationAvailabilityState.Unavailable)
+            .ToReadOnlyReactivePropertySlim(false)
+            .DisposeWith(_disposables);
+
+        Summary = usage.HasSnapshot
+            .CombineLatest(
+                usage.CanUseAi,
+                (hasSnapshot, canUseAi) =>
+                    hasSnapshot && !canUseAi ? Strings.AiPricingUnavailable : string.Empty)
+            .ToReadOnlyReactivePropertySlim(string.Empty)
+            .DisposeWith(_disposables);
+
+        HasSummary = Summary
+            .Select(summary => !string.IsNullOrEmpty(summary))
+            .ToReadOnlyReactivePropertySlim(true)
+            .DisposeWith(_disposables);
+
+        Explanation = State
+            .CombineLatest(
+                usage.IsMonthlyAllowanceExhausted,
+                usage.HasAdditionalCredits,
+                CreateExplanation)
+            .ToReadOnlyReactivePropertySlim(string.Empty)
+            .DisposeWith(_disposables);
+
+        HasExplanation = Explanation
+            .Select(explanation => !string.IsNullOrEmpty(explanation))
+            .ToReadOnlyReactivePropertySlim(false)
+            .DisposeWith(_disposables);
+    }
+
+    public ReadOnlyReactivePropertySlim<AiOperationAvailabilityState> State { get; }
+
+    /// <summary>
+    /// Whether the run may be offered. An unanswered check leaves this true so a
+    /// pending or failed lookup does not lock the account out of what it paid for.
+    /// </summary>
+    public ReadOnlyReactivePropertySlim<bool> CanAfford { get; }
+
+    /// <summary>True only where the server actually refused the operation.</summary>
+    public ReadOnlyReactivePropertySlim<bool> IsInsufficient { get; }
+
+    public ReadOnlyReactivePropertySlim<string> Summary { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> HasSummary { get; }
+
+    public ReadOnlyReactivePropertySlim<string> Explanation { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> HasExplanation { get; }
+
+    public void Dispose() => _disposables.Dispose();
+
+    private static string CreateExplanation(
+        AiOperationAvailabilityState state,
+        bool isExhausted,
+        bool hasAdditionalCredits)
+    {
+        return state switch
+        {
+            AiOperationAvailabilityState.Unavailable => Strings.AiEstimatedUsageInsufficient,
+            AiOperationAvailabilityState.Available when !isExhausted => Strings.AiEstimatedUsageMonthly,
+            AiOperationAvailabilityState.Available when hasAdditionalCredits => Strings.AiEstimatedUsageTopUp,
+            _ => string.Empty,
+        };
+    }
+}

--- a/src/Beutl/ViewModels/AiUsageViewModel.cs
+++ b/src/Beutl/ViewModels/AiUsageViewModel.cs
@@ -1,0 +1,103 @@
+﻿using System.Reactive.Disposables;
+using Beutl.Api.Services;
+using Beutl.Language;
+using Reactive.Bindings;
+
+namespace Beutl.ViewModels;
+
+internal sealed class AiUsageViewModel : IDisposable
+{
+    private readonly CompositeDisposable _disposables = [];
+
+    public AiUsageViewModel(IObservable<AiEntitlements?> entitlements)
+    {
+        CanUseAi = entitlements
+            .Select(entitlements => entitlements?.CanUseAi == true)
+            .ToReadOnlyReactivePropertySlim(false)
+            .DisposeWith(_disposables);
+
+        HasSnapshot = entitlements
+            .Select(entitlements => entitlements != null)
+            .ToReadOnlyReactivePropertySlim(false)
+            .DisposeWith(_disposables);
+
+        // The server sends monthly usage as a proportion rather than raw units.
+        UsagePercent = entitlements
+            .Select(entitlements => entitlements?.Balance.MonthlyUsage.UsedPercent ?? 0)
+            .ToReadOnlyReactivePropertySlim(0)
+            .DisposeWith(_disposables);
+
+        RemainingPercent = entitlements
+            .Select(entitlements => entitlements?.Balance.MonthlyUsage.RemainingPercent ?? 100)
+            .ToReadOnlyReactivePropertySlim(100)
+            .DisposeWith(_disposables);
+
+        IsMonthlyAllowanceExhausted = entitlements
+            .Select(entitlements => entitlements?.Balance.MonthlyUsage.IsExhausted ?? false)
+            .ToReadOnlyReactivePropertySlim(false)
+            .DisposeWith(_disposables);
+
+        HasAdditionalCreditDebt = entitlements
+            .Select(entitlements => entitlements?.Balance.HasAdditionalCreditDebt ?? false)
+            .ToReadOnlyReactivePropertySlim(false)
+            .DisposeWith(_disposables);
+
+        MonthlyUsageText = UsagePercent
+            .Select(percent => string.Format(Strings.AiMonthlyUsage, percent))
+            .ToReadOnlyReactivePropertySlim(string.Format(Strings.AiMonthlyUsage, 0))
+            .DisposeWith(_disposables);
+
+        MonthlyRemainingText = RemainingPercent
+            .Select(percent => string.Format(Strings.AiMonthlyUsageRemaining, percent))
+            .ToReadOnlyReactivePropertySlim(string.Format(Strings.AiMonthlyUsageRemaining, 100))
+            .DisposeWith(_disposables);
+
+        HasAdditionalCredits = entitlements
+            .Select(entitlements => (entitlements?.Balance.AdditionalCredits ?? 0) > 0)
+            .ToReadOnlyReactivePropertySlim(false)
+            .DisposeWith(_disposables);
+
+        AdditionalCredits = entitlements
+            .Select(entitlements => entitlements?.Balance.AdditionalCredits ?? 0)
+            .ToReadOnlyReactivePropertySlim(0)
+            .DisposeWith(_disposables);
+
+        AdditionalCreditsText = AdditionalCredits
+            .Select(credits => string.Format(Strings.AiAdditionalCredits, credits))
+            .ToReadOnlyReactivePropertySlim(string.Format(Strings.AiAdditionalCredits, 0))
+            .DisposeWith(_disposables);
+
+        AdditionalCreditDebtText = Observable.Return(Strings.AiAdditionalCreditDebt)
+            .ToReadOnlyReactivePropertySlim(Strings.AiAdditionalCreditDebt)
+            .DisposeWith(_disposables);
+    }
+
+    public ReadOnlyReactivePropertySlim<bool> CanUseAi { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> HasSnapshot { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> HasAdditionalCreditDebt { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> HasAdditionalCredits { get; }
+
+    public ReadOnlyReactivePropertySlim<int> AdditionalCredits { get; }
+
+    public ReadOnlyReactivePropertySlim<int> UsagePercent { get; }
+
+    public ReadOnlyReactivePropertySlim<int> RemainingPercent { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> IsMonthlyAllowanceExhausted { get; }
+
+    public ReadOnlyReactivePropertySlim<string> MonthlyUsageText { get; }
+
+    public ReadOnlyReactivePropertySlim<string> MonthlyRemainingText { get; }
+
+    public ReadOnlyReactivePropertySlim<string> AdditionalCreditsText { get; }
+
+    public ReadOnlyReactivePropertySlim<string> AdditionalCreditDebtText { get; }
+
+    public void Dispose()
+    {
+        _disposables.Dispose();
+    }
+}

--- a/src/Beutl/ViewModels/Dialogs/AiAspectRatioSuggestion.cs
+++ b/src/Beutl/ViewModels/Dialogs/AiAspectRatioSuggestion.cs
@@ -1,0 +1,62 @@
+﻿using System.Globalization;
+using Beutl.Media;
+
+namespace Beutl.ViewModels.Dialogs;
+
+/// <summary>
+/// Picks the offered aspect ratio closest to the scene an asset is being made
+/// for. Both the image and the video dialog ask the same question, and the
+/// image one used to answer it with fixed sizes that had no 16:9 at all — a
+/// widescreen project was offered 3:2 and the result never fitted the frame.
+/// </summary>
+internal static class AiAspectRatioSuggestion
+{
+    public static string Nearest(
+        IReadOnlyList<string> ratios,
+        PixelSize? frameSize,
+        string fallback)
+    {
+        ArgumentNullException.ThrowIfNull(ratios);
+        if (ratios.Count == 0)
+            throw new ArgumentException("At least one aspect ratio is required.", nameof(ratios));
+
+        if (frameSize is not { Width: > 0, Height: > 0 } size)
+            return ratios.Contains(fallback) ? fallback : ratios[0];
+
+        double target = (double)size.Width / size.Height;
+        string? nearest = null;
+        double nearestDistance = double.PositiveInfinity;
+        foreach (string ratio in ratios)
+        {
+            if (!TryParse(ratio, out double candidate))
+                continue;
+            // Compared in log space so 16:9 and 9:16 sit an equal distance from
+            // square; a linear difference would always favour the wider one.
+            double distance = Math.Abs(Math.Log(target) - Math.Log(candidate));
+            if (distance < nearestDistance)
+            {
+                nearestDistance = distance;
+                nearest = ratio;
+            }
+        }
+
+        return nearest ?? (ratios.Contains(fallback) ? fallback : ratios[0]);
+    }
+
+    private static bool TryParse(string value, out double ratio)
+    {
+        ratio = 0;
+        string[] parts = value.Split(':');
+        if (parts.Length != 2
+            || !double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out double width)
+            || !double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out double height)
+            || width <= 0
+            || height <= 0)
+        {
+            return false;
+        }
+
+        ratio = width / height;
+        return true;
+    }
+}

--- a/src/Beutl/ViewModels/Dialogs/AiDialogFileSeams.cs
+++ b/src/Beutl/ViewModels/Dialogs/AiDialogFileSeams.cs
@@ -1,0 +1,85 @@
+﻿namespace Beutl.ViewModels.Dialogs;
+
+/// <summary>
+/// The result of an AI dialog save picker. The picker and the file replacement
+/// are kept as separate steps so identity fencing can reject a late destination
+/// before it mutates that destination.
+/// </summary>
+internal sealed record AiSaveFileDestination(string Path);
+
+internal static class AiImageFileFormat
+{
+    public static void ValidatePngDestination(string path)
+    {
+        if (!string.Equals(
+                System.IO.Path.GetExtension(path),
+                ".png",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException(
+                "AI-generated PNG images must be saved with a .png extension.");
+        }
+    }
+}
+
+internal static class AiAtomicFileWriter
+{
+    public static void Write(
+        string destinationPath,
+        Action<Stream> write,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(destinationPath);
+        ArgumentNullException.ThrowIfNull(write);
+
+        string fullDestinationPath = System.IO.Path.GetFullPath(destinationPath);
+        string temporaryPath = fullDestinationPath + $".{Guid.NewGuid():N}.tmp";
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            UnixFileMode destinationMode = default;
+            var options = new FileStreamOptions
+            {
+                Mode = FileMode.CreateNew,
+                Access = FileAccess.Write,
+                Share = FileShare.None,
+                BufferSize = 64 * 1024,
+                Options = FileOptions.WriteThrough,
+            };
+            if (!OperatingSystem.IsWindows())
+            {
+                destinationMode = File.Exists(fullDestinationPath)
+                    ? File.GetUnixFileMode(fullDestinationPath)
+                    : UnixFileMode.UserRead | UnixFileMode.UserWrite;
+                options.UnixCreateMode = destinationMode;
+            }
+
+            using (var stream = new FileStream(
+                       temporaryPath,
+                       options))
+            {
+                write(stream);
+                cancellationToken.ThrowIfCancellationRequested();
+                stream.Flush(true);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!OperatingSystem.IsWindows())
+                File.SetUnixFileMode(temporaryPath, destinationMode);
+            File.Move(temporaryPath, fullDestinationPath, overwrite: true);
+        }
+        finally
+        {
+            try
+            {
+                File.Delete(temporaryPath);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}

--- a/src/Beutl/ViewModels/Dialogs/AiImageEditDialogViewModel.cs
+++ b/src/Beutl/ViewModels/Dialogs/AiImageEditDialogViewModel.cs
@@ -1,0 +1,1420 @@
+﻿using System.Globalization;
+using System.Reactive.Disposables;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Platform.Storage;
+using Avalonia.Threading;
+using Beutl.Api;
+using Beutl.Api.Services;
+using Beutl.Editor.Services;
+using Beutl.Graphics;
+using Beutl.Language;
+using Beutl.Logging;
+using Beutl.Media;
+using Beutl.Media.Source;
+using Beutl.ProjectSystem;
+using Beutl.Services;
+using Beutl.Services.AI;
+using Beutl.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Reactive.Bindings;
+
+namespace Beutl.ViewModels.Dialogs;
+
+internal sealed class AiImageEditDialogViewModel : IDisposable, IAsyncDisposable, IAiModelListConsumer
+{
+    private readonly CompositeDisposable _disposables = [];
+    private readonly AsyncOperationLifetime _operations = new();
+    private readonly IdentityOperationLifetime _identityOperations = new();
+    private readonly object _disposeGate = new();
+    private readonly ILogger _logger = Log.CreateLogger<AiImageEditDialogViewModel>();
+    private readonly IAiEntitlementService _entitlements;
+    private readonly IAiOperationAvailabilityService _availability;
+    private readonly IAiModelCatalogService _modelCatalog;
+    private readonly IAiPlanCoordinator _aiPlanCoordinator;
+    private readonly IAiImageEditingService _images;
+    private readonly IAuthenticatedContentService _content;
+    private readonly AiRequestKey _requestKey;
+    private readonly AiRequestRecoveryContext? _requestRecoveryContext;
+    // The model the outstanding name was built from. A refresh that withdraws
+    // that model would otherwise rebuild the name around whatever the picker
+    // fell back to, and the job the first attempt paid for would be left behind.
+    // The request details associated with every unsettled name. Remembering only one would
+    // forget an earlier request's model after another request and charge again when returning.
+    private readonly AiOutstandingRequests _outstanding = new();
+    private AiPendingAttempt? _selectedRecovery;
+    private readonly ReactivePropertySlim<int> _recoveryRevision = new();
+    // A revision used only to notify the UI when held names change. _outstanding tracks which
+    // tasks still have names.
+    private readonly ReactivePropertySlim<int> _outstandingRevision = new();
+    private readonly EditViewModel? _editViewModel;
+    private string? _sourceElementId;
+    private bool _modelsRequireResolution;
+    private string? _modelsRequiredBackground;
+    private Task? _disposeTask;
+    private IdentityOperationLifetime.Operation? _runningRequest;
+
+    internal AiImageEditDialogViewModel(
+        IAiEntitlementService entitlements,
+        IAiOperationAvailabilityService availability,
+        IAiModelCatalogService modelCatalog,
+        IAiPlanCoordinator aiPlanCoordinator,
+        IAiImageEditingService images,
+        IAuthenticatedContentService content,
+        EditViewModel? editViewModel,
+        AiRequestRecoveryContext requestRecoveryContext)
+    {
+        _entitlements = entitlements ?? throw new ArgumentNullException(nameof(entitlements));
+        _availability = availability ?? throw new ArgumentNullException(nameof(availability));
+        _modelCatalog = modelCatalog ?? throw new ArgumentNullException(nameof(modelCatalog));
+        _aiPlanCoordinator = aiPlanCoordinator
+            ?? throw new ArgumentNullException(nameof(aiPlanCoordinator));
+        _images = images ?? throw new ArgumentNullException(nameof(images));
+        _content = content ?? throw new ArgumentNullException(nameof(content));
+        _editViewModel = editViewModel;
+        _requestRecoveryContext = requestRecoveryContext;
+        _requestKey = new(
+            recoveryContext: requestRecoveryContext,
+            operation: "image.edit");
+        Usage = new AiUsageViewModel(_entitlements.Entitlements).DisposeWith(_disposables);
+        // Every edit hands the model the picture being edited, so one that takes
+        // no reference image is registered and unusable however the request is
+        // shaped. An upscale asks for a size on top of that, and removing a
+        // background asks for a transparent one — neither of which every model
+        // that takes a picture can be asked for.
+        ModelPicker = new AiModelPickerViewModel(_modelCatalog, _entitlements)
+        {
+            Filter = model =>
+                model.Image is not { } image
+                || image.CanServeAnything(
+                    requiresReferenceImages: true,
+                    requiresResolution: _modelsRequireResolution,
+                    requiredBackground: _modelsRequiredBackground),
+        }
+            .DisposeWith(_disposables);
+        PromptLibrary = new AiPromptLibraryViewModel(
+                PromptTaskKind.ImageEdit,
+                () => Prompt.Value,
+                prompt => Prompt.Value = prompt,
+                recoveryContext: requestRecoveryContext)
+            .DisposeWith(_disposables);
+
+        Tasks =
+        [
+            new AiImageEditTaskOption("remove_background", Strings.AiEditRemoveBackground),
+            new AiImageEditTaskOption("upscale", Strings.AiEditUpscale),
+            new AiImageEditTaskOption("restyle", Strings.AiEditRestyle),
+            new AiImageEditTaskOption("remove_object", Strings.AiEditRemoveObject),
+            new AiImageEditTaskOption("outpaint", Strings.AiEditOutpaint),
+        ];
+        SelectedTask = new ReactivePropertySlim<AiImageEditTaskOption>(Tasks[0])
+            .DisposeWith(_disposables);
+        EstimatedUsage = new AiUsageEstimateViewModel(
+                Usage,
+                SelectedTask.CombineLatest(
+                    _entitlements.Entitlements,
+                    (task, entitlements) => entitlements?.Availability.GetState(
+                        AiOperations.ImageEdit(new AiImageEditTaskId(task.Value)))
+                        ?? AiOperationAvailabilityState.Unknown))
+            .DisposeWith(_disposables);
+
+        ComparisonModes =
+        [
+            new AiImageComparisonMode("result", Strings.AiPreviewResult, false, true),
+            new AiImageComparisonMode("original", Strings.AiPreviewOriginal, true, false),
+            new AiImageComparisonMode("side_by_side", Strings.AiPreviewSideBySide, true, true),
+        ];
+        SelectedComparisonMode = new ReactivePropertySlim<AiImageComparisonMode>(ComparisonModes[0])
+            .DisposeWith(_disposables);
+
+        OutpaintExpansionOptions =
+        [
+            new AiOutpaintExpansionOption(10),
+            new AiOutpaintExpansionOption(25),
+            new AiOutpaintExpansionOption(50),
+        ];
+        SelectedOutpaintExpansion = new ReactivePropertySlim<AiOutpaintExpansionOption>(OutpaintExpansionOptions[1])
+            .DisposeWith(_disposables);
+        // Each task is a separate operation with its own models, so the list
+        // has to follow the task rather than be read once.
+        // Only the list this screen already has. A task whose list is not
+        // here yet has to be fetched even while its own request is waiting to be
+        // collected — without it the screen has no model to send and the paid
+        // request is stranded.
+        // Keep every model named by an uncollected request even after it leaves the catalog.
+        // A task can have more than one such request, so return all of them.
+        ModelPicker.KeepOffered = requested => ModelsOfOutstandingRequestsFor(requested);
+        ModelPicker.CanReload = requested =>
+            ModelPicker.Operation != requested
+            || !HoldsNameFor(SelectedTask.Value.Value);
+        SelectedTask
+            .Subscribe(task => _ = ReloadModelsAsync(task))
+            .DisposeWith(_disposables);
+        RequiresPrompt = SelectedTask
+            .Select(task => task.Value is "restyle" or "remove_object" or "outpaint")
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+        ShowOutpaintExpansion = SelectedTask
+            .Select(task => task.Value == "outpaint")
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+        PromptWatermark = SelectedTask
+            .Select(task => task.Value switch
+            {
+                "restyle" => Strings.AiEditRestylePrompt,
+                "remove_object" => Strings.AiEditRemoveObjectPrompt,
+                "outpaint" => Strings.AiEditOutpaintPrompt,
+                _ => Strings.AiPrompt_Placeholder,
+            })
+            .ToReadOnlyReactivePropertySlim(Strings.AiPrompt_Placeholder)
+            .DisposeWith(_disposables);
+
+        IsEditing = new ReactivePropertySlim<bool>(false)
+            .DisposeWith(_disposables);
+
+        PromptValidationError = SelectedTask
+            .CombineLatest(
+                Prompt,
+                (task, prompt) => GetPromptValidationError(task.Value, prompt))
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        VisiblePromptValidationError = AiPromptValidation
+            .WhileTyping(PromptValidationError, Prompt)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        SelectSourceFileCommand = new AsyncReactiveCommand()
+            .WithSubscribe(SelectSourceFileAsync);
+
+        SourceFilePath.Subscribe(LoadOriginalPreview).DisposeWith(_disposables);
+
+        // A name is only outstanding for the task it was built on. Switching
+        // tasks is starting a different request, which has to be paid for and
+        // has to be offered a model of its own.
+        HoldsRequestName = _outstandingRevision
+            .CombineLatest(SelectedTask, (_, selected) => HoldsNameFor(selected.Value))
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        CanEdit = SourceFilePath
+            .Select(x => !string.IsNullOrEmpty(x))
+            .CombineLatest(IsEditing, (hasSource, editing) => hasSource && !editing)
+            .CombineLatest(PromptValidationError, (canEdit, error) => canEdit && error is null)
+            .CombineLatest(
+                EstimatedUsage.CanAfford,
+                HoldsRequestName,
+                // Or a name already handed out: the server answers a repeat with the
+                // job that name made before it looks at the balance, so the request
+                // that spent the last of it is exactly the one that must stay
+                // collectable.
+                (canEdit, canAfford, outstanding) => canEdit && (canAfford || outstanding))
+            .CombineLatest(
+                ModelPicker.OffersNothingUsable,
+                HoldsRequestName,
+                // Every model the operation registered was ruled out, so a new
+                // request would be refused however it is shaped — but a name
+                // already handed out is answered from the job it made, whatever
+                // the catalog says now.
+                (can, nothingUsable, outstanding) =>
+                    can && (!nothingUsable || outstanding))
+            // Until the list has been asked for, a request would name no model
+            // and run on the server's default, which may cost more than what
+            // this task was about to offer.
+            .CombineLatest(ModelPicker.IsLoaded, (can, loaded) => can && loaded)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        Edit = new AsyncReactiveCommand(CanEdit)
+            .WithSubscribe(EditCore);
+
+        CanAddToScene = ResultImage
+            .Select(x => x != null)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        AddToScene = new AsyncReactiveCommand(CanAddToScene)
+            .WithSubscribe(AddToSceneCore);
+
+        SaveToFile = new AsyncReactiveCommand(CanAddToScene)
+            .WithSubscribe(SaveToFileCore);
+
+        StopEditing = new ReactiveCommand(IsEditing);
+        StopEditing.Subscribe(() => _runningRequest?.Cancel()).DisposeWith(_disposables);
+
+        RecoverSelectedAttempt = new ReactiveCommand();
+        RecoverSelectedAttempt.Subscribe(() =>
+        {
+            if (SelectedRecoveryAttempt!.Value is { } attempt)
+                TryRecoverPendingAttempt(attempt);
+        }).DisposeWith(_disposables);
+        AbandonSelectedAttempt = new ReactiveCommand();
+        AbandonSelectedAttempt.Subscribe(() =>
+        {
+            if (SelectedRecoveryAttempt!.Value is { } attempt)
+                AbandonPendingAttempt(attempt);
+        }).DisposeWith(_disposables);
+
+        OpenAiPlan = new ReactiveCommand();
+        OpenAiPlan.Subscribe(aiPlanCoordinator.OpenAiPlan).DisposeWith(_disposables);
+
+        ShowJoinPro = Usage.HasSnapshot
+            .CombineLatest(Usage.CanUseAi, (hasSnapshot, canUseAi) => hasSnapshot && !canUseAi)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        ShowOriginalPreview = SelectedComparisonMode
+            .CombineLatest(OriginalImage, (mode, image) => mode.Value == "original" && image is not null)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+        ShowResultPreview = SelectedComparisonMode
+            .CombineLatest(ResultImage, (mode, image) => mode.Value == "result" && image is not null)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+        ShowSideBySidePreview = SelectedComparisonMode
+            .CombineLatest(
+                OriginalImage,
+                ResultImage,
+                (mode, original, result) => mode.Value == "side_by_side" && original is not null && result is not null)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+        ShowPreviewPlaceholder = OriginalImage
+            .CombineLatest(ResultImage, (original, result) => original is null && result is null)
+            .ToReadOnlyReactivePropertySlim(true)
+            .DisposeWith(_disposables);
+
+        SelectedRecoveryAttempt = new ReactivePropertySlim<AiPendingAttempt?>()
+            .DisposeWith(_disposables);
+        RecoveryAttempts = _recoveryRevision
+            .Select(_ => (IReadOnlyList<AiPendingAttempt>)GetPendingRecoveryAttempts())
+            .ToReadOnlyReactivePropertySlim(Array.Empty<AiPendingAttempt>())
+            .DisposeWith(_disposables);
+        RecoveryAvailable = RecoveryAttempts
+            .Select(attempts => attempts.Count != 0)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+        if (_requestRecoveryContext is not null)
+            _requestRecoveryContext.IdentityChanged += OnIdentityChanged;
+
+        CoreObject? selectedObject = editViewModel?.GetService<IEditorSelection>()?.SelectedObject.Value;
+        SourceFilePath.Value = GetSelectedImageSourcePath(selectedObject);
+        _sourceElementId = selectedObject is Element selectedElement
+            ? selectedElement.Id.ToString("N")
+            : null;
+
+        _ = LoadEntitlementsAsync();
+        TryAutoRecoverSingleAttempt();
+    }
+
+    public IReadOnlyList<AiImageEditTaskOption> Tasks { get; }
+
+    public ReactivePropertySlim<AiImageEditTaskOption> SelectedTask { get; }
+
+    public IReadOnlyList<AiImageComparisonMode> ComparisonModes { get; }
+
+    public ReactivePropertySlim<AiImageComparisonMode> SelectedComparisonMode { get; }
+
+    public IReadOnlyList<AiOutpaintExpansionOption> OutpaintExpansionOptions { get; }
+
+    public ReactivePropertySlim<AiOutpaintExpansionOption> SelectedOutpaintExpansion { get; }
+
+    public ReactivePropertySlim<string> Prompt { get; } = new();
+
+    public ReadOnlyReactivePropertySlim<bool> RequiresPrompt { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> ShowOutpaintExpansion { get; }
+
+    public ReadOnlyReactivePropertySlim<string> PromptWatermark { get; }
+
+    public ReadOnlyReactivePropertySlim<string?> PromptValidationError { get; }
+
+    /// <summary>
+    /// The same message, held back until the person has typed something.
+    /// </summary>
+    public ReadOnlyReactivePropertySlim<string?> VisiblePromptValidationError { get; }
+
+    public ReactivePropertySlim<string?> SourceFilePath { get; } = new();
+
+    public AsyncReactiveCommand SelectSourceFileCommand { get; }
+
+    public ReactivePropertySlim<bool> IsEditing { get; }
+
+    /// <summary>
+    /// Whether the task on screen holds a name the server may answer from a job
+    /// it has already been paid for.
+    /// </summary>
+    public ReadOnlyReactivePropertySlim<bool> HoldsRequestName { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> CanEdit { get; }
+
+    public AsyncReactiveCommand Edit { get; }
+
+    /// <summary>
+    /// Abandons the edit in flight. An edit runs for as long as the server takes,
+    /// so a wrong task or picture must be recoverable without closing the tab.
+    /// </summary>
+    public ReactiveCommand StopEditing { get; }
+
+    /// <summary>Pending image-edit attempts that can be explicitly recovered or abandoned.</summary>
+    internal IReadOnlyList<AiPendingAttempt> PendingRecoveryAttempts
+        => GetPendingRecoveryAttempts();
+
+    internal ReactivePropertySlim<AiPendingAttempt?> SelectedRecoveryAttempt { get; }
+
+    internal ReadOnlyReactivePropertySlim<IReadOnlyList<AiPendingAttempt>> RecoveryAttempts { get; }
+
+    internal ReadOnlyReactivePropertySlim<bool> RecoveryAvailable { get; }
+
+    internal ReactiveCommand RecoverSelectedAttempt { get; }
+
+    internal ReactiveCommand AbandonSelectedAttempt { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> CanAddToScene { get; }
+
+    public AsyncReactiveCommand AddToScene { get; }
+
+    public AsyncReactiveCommand SaveToFile { get; }
+
+    public ReactiveCommand OpenAiPlan { get; }
+
+    internal IAiPlanCoordinator AiPlanCoordinator => _aiPlanCoordinator;
+
+    public ReactivePropertySlim<Ref<Bitmap>?> ResultImage { get; } = new();
+
+    public ReactivePropertySlim<Ref<Bitmap>?> OriginalImage { get; } = new();
+
+    public ReadOnlyReactivePropertySlim<bool> ShowOriginalPreview { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> ShowResultPreview { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> ShowSideBySidePreview { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> ShowPreviewPlaceholder { get; }
+
+    internal AiUsageViewModel Usage { get; }
+
+    internal AiModelPickerViewModel ModelPicker { get; }
+
+    internal AiUsageEstimateViewModel EstimatedUsage { get; }
+
+    internal AiPromptLibraryViewModel PromptLibrary { get; }
+
+    // Test seams remain unset in production; the null path below uses the
+    // current Avalonia storage provider and result importer.
+    internal Func<CancellationToken, Task<string?>>? SourceFilePicker { get; set; }
+
+    internal Func<CancellationToken, Task<AiSaveFileDestination?>>? SaveFilePicker { get; set; }
+
+    internal Func<Bitmap, AiResultImportOptions, CancellationToken, Task<ElementAddResult>>?
+        ResultImporter
+    { get; set; }
+
+    public ReadOnlyReactivePropertySlim<bool> ShowJoinPro { get; }
+
+    public ReactivePropertySlim<string?> Error { get; } = new();
+
+    public void Dispose() => _ = BeginDisposeAsync();
+
+    public ValueTask DisposeAsync() => new(BeginDisposeAsync());
+
+    private IdentityOperationLifetime.Operation? TryEnterIdentityOperation()
+        => _identityOperations.TryEnter(_operations);
+
+    private Task BeginDisposeAsync()
+    {
+        lock (_disposeGate)
+        {
+            if (_disposeTask is not null)
+                return _disposeTask;
+
+            var completion = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _disposeTask = completion.Task;
+            _ = CompleteDisposeAsync(completion);
+            return completion.Task;
+        }
+    }
+
+    private async Task CompleteDisposeAsync(TaskCompletionSource completion)
+    {
+        try
+        {
+            await DisposeCoreAsync();
+            completion.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
+        }
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        _identityOperations.Dispose();
+        await _operations.DisposeAsync(async () =>
+        {
+            ResultImage.Value?.Dispose();
+            ResultImage.Dispose();
+            OriginalImage.Value?.Dispose();
+            OriginalImage.Dispose();
+            SourceFilePath.Dispose();
+            Prompt.Dispose();
+            Error.Dispose();
+            if (_requestRecoveryContext is not null)
+                _requestRecoveryContext.IdentityChanged -= OnIdentityChanged;
+            _requestKey.Dispose();
+            _recoveryRevision.Dispose();
+            _outstandingRevision.Dispose();
+            _disposables.Dispose();
+        });
+    }
+
+    internal static string? GetSelectedImageSourcePath(CoreObject? selectedObject)
+    {
+        if (selectedObject is not Element element)
+            return null;
+
+        return element.Objects
+            .OfType<SourceImage>()
+            .Select(source => source.Source.CurrentValue)
+            .Where(source => source is { HasUri: true } && source.Uri.IsFile)
+            .Select(source => source!.Uri.LocalPath)
+            .FirstOrDefault(File.Exists);
+    }
+
+    private IReadOnlyList<AiPendingAttempt> GetPendingRecoveryAttempts()
+    {
+        try
+        {
+            return _requestKey.PendingAttempts(new AiOperationId("image.edit"));
+        }
+        catch (InvalidDataException ex)
+        {
+            _logger.LogError(ex, "Failed to read image-edit recovery attempts.");
+            return Array.Empty<AiPendingAttempt>();
+        }
+    }
+
+    private void TryAutoRecoverSingleAttempt()
+    {
+        IReadOnlyList<AiPendingAttempt> attempts = GetPendingRecoveryAttempts();
+        if (attempts.Count == 1 && attempts[0].HasCanonicalForm)
+        {
+            if (!TryRecoverPendingAttempt(attempts[0]))
+                ClearActiveRecovery();
+        }
+
+        _recoveryRevision.Value++;
+    }
+
+    private void OnIdentityChanged()
+    {
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            _identityOperations.SwitchDeferred(
+                action => Dispatcher.UIThread.Post(() => RunDeferredIdentityClear(action)),
+                ClearIdentityState,
+                TryAutoRecoverForCurrentIdentity);
+            return;
+        }
+
+        _identityOperations.Switch(ClearIdentityState);
+        TryAutoRecoverForCurrentIdentity();
+    }
+
+    private void RunDeferredIdentityClear(Action clear)
+    {
+        try
+        {
+            clear();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to clear image-edit state after an account change.");
+        }
+    }
+
+    private void TryAutoRecoverForCurrentIdentity()
+    {
+        if (_requestKey.CurrentAccountId is not null)
+            TryAutoRecoverSingleAttempt();
+    }
+
+    private void ClearIdentityState()
+    {
+        _runningRequest = null;
+        IsEditing.Value = false;
+        ClearActiveRecovery();
+        SourceFilePath.Value = null;
+        Prompt.Value = string.Empty;
+        _sourceElementId = null;
+        OriginalImage.Value?.Dispose();
+        OriginalImage.Value = null;
+        ResultImage.Value?.Dispose();
+        ResultImage.Value = null;
+        Error.Value = null;
+        ModelPicker.ReconcileRecoveryModels();
+        _recoveryRevision.Value++;
+    }
+
+    internal bool TryRecoverPendingAttempt(AiPendingAttempt attempt)
+    {
+        if (_requestKey.CurrentAccountId is not { } account
+            || !StringComparer.Ordinal.Equals(account, attempt.AccountId))
+        {
+            Error.Value = Strings.AiAuthenticationRequired;
+            return false;
+        }
+        if (!attempt.HasCanonicalForm
+            || !attempt.Operation.StartsWith("image.edit.", StringComparison.Ordinal)
+            || attempt.Form?.Task is not { } task
+            || !string.Equals(attempt.Operation, $"image.edit.{task}", StringComparison.Ordinal))
+        {
+            Error.Value = Strings.AiResultUnavailable;
+            return false;
+        }
+
+        IReadOnlyList<string> paths;
+        try
+        {
+            paths = _requestKey.ResolveSources(attempt);
+        }
+        catch (InvalidDataException ex)
+        {
+            _logger.LogWarning(ex, "Image-edit recovery source is unavailable.");
+            Error.Value = Strings.AiResultUnavailable;
+            return false;
+        }
+
+        if (paths.Count != 1 || attempt.EffectiveSources.Count != 1)
+        {
+            Error.Value = Strings.AiResultUnavailable;
+            return false;
+        }
+
+        try
+        {
+            _ = _requestKey.ReadSourceBytes(attempt.EffectiveSources[0]);
+        }
+        catch (InvalidDataException ex)
+        {
+            _logger.LogWarning(ex, "Image-edit recovery source changed.");
+            Error.Value = Strings.AiResultUnavailable;
+            return false;
+        }
+
+        AiImageEditTaskOption? taskOption = Tasks.FirstOrDefault(option => option.Value == task);
+        if (taskOption is null)
+        {
+            Error.Value = Strings.AiResultUnavailable;
+            return false;
+        }
+
+        SelectedTask.Value = taskOption;
+        Prompt.Value = attempt.Form!.Prompt ?? string.Empty;
+        if (attempt.Form.OutpaintExpansionPercent is { } percent
+            && OutpaintExpansionOptions.FirstOrDefault(option => option.Percent == percent) is { } expansion)
+            SelectedOutpaintExpansion.Value = expansion;
+        _sourceElementId = attempt.Form.SourceElementId;
+
+        SourceFilePath.Value = paths[0];
+        ActivateRecovery(attempt);
+        _recoveryRevision.Value++;
+        SelectRecoveredModel();
+        return true;
+    }
+
+    internal void AbandonPendingAttempt(AiPendingAttempt attempt)
+    {
+        try
+        {
+            _requestKey.Abandon(attempt);
+            if (_selectedRecovery is { } selected
+                && selected.AccountId == attempt.AccountId
+                && selected.Operation == attempt.Operation
+                && selected.Fingerprint == attempt.Fingerprint)
+            {
+                ClearActiveRecovery();
+                ModelPicker.ReconcileRecoveryModels();
+            }
+
+            _recoveryRevision.Value++;
+        }
+        catch (Exception ex) when (ex is InvalidDataException or AuthenticationRequiredException)
+        {
+            _logger.LogWarning(ex, "Failed to abandon image-edit recovery attempt.");
+            Error.Value = Strings.AiResultUnavailable;
+        }
+    }
+
+    private AiModelId? ModelForRequest(AiModelId? selected)
+        => _selectedRecovery is { } attempt
+            ? attempt.Model is { } model ? new AiModelId(model) : null
+            : selected;
+
+    private void ActivateRecovery(AiPendingAttempt attempt)
+    {
+        _selectedRecovery = attempt;
+        SelectedRecoveryAttempt.Value = attempt;
+        ModelPicker.IsSelectionEnabled.Value = false;
+    }
+
+    private void ClearActiveRecovery()
+    {
+        _selectedRecovery = null;
+        SelectedRecoveryAttempt.Value = null;
+        ModelPicker.IsSelectionEnabled.Value = true;
+    }
+
+    private void SelectRecoveredModel()
+    {
+        if (_selectedRecovery is not { } recovery)
+            return;
+        if (recovery.Model is not { } model)
+        {
+            ModelPicker.Selected.Value = null;
+            return;
+        }
+        AiModelId id = new(model);
+        ModelPicker.Selected.Value = ModelPicker.Options.FirstOrDefault(option => option.Id == id);
+    }
+
+    // The model a request should carry: the one the outstanding name was built
+    // from while there is one, and the picker's otherwise.
+    // Only this one request is settled. Retiring the whole run instead would
+    // throw away the name of anything else still waiting to be collected.
+    private void RetireRequestName(AiRequestName name)
+    {
+        if (!_requestKey.Retire(name))
+            return;
+        Forget(name);
+        if (_selectedRecovery is { } selected
+            && (string.Equals(selected.Key, name.Key, StringComparison.Ordinal)
+                || !_requestKey.IsCurrentPending(selected)))
+        {
+            if (!string.Equals(selected.Key, name.Key, StringComparison.Ordinal))
+                Forget(new AiRequestName(selected.Key, IsRepeat: true));
+            ClearActiveRecovery();
+            ModelPicker.ReconcileRecoveryModels();
+            _recoveryRevision.Value++;
+        }
+        // Reloads were held back while that name was outstanding, so this is
+        // where an operator's change to the model list finally lands.
+        _ = ReloadModelsAsync(SelectedTask.Value);
+    }
+
+    // A name the server never made a job under. Withdrawing it lets the picker
+    // move again and puts the balance check back in front of the next attempt.
+    private void WithdrawRequestName(AiRequestName name)
+    {
+        if (!_requestKey.WithdrawAfterNoReservation(name))
+            return;
+        Forget(name);
+        if (_selectedRecovery is { } selected
+            && (string.Equals(selected.Key, name.Key, StringComparison.Ordinal)
+                || !_requestKey.IsCurrentPending(selected)))
+        {
+            if (!string.Equals(selected.Key, name.Key, StringComparison.Ordinal))
+                Forget(new AiRequestName(selected.Key, IsRepeat: true));
+            ClearActiveRecovery();
+            ModelPicker.ReconcileRecoveryModels();
+            _recoveryRevision.Value++;
+        }
+    }
+
+    private void Forget(AiRequestName name)
+    {
+        _outstanding.Forget(name);
+        _outstandingRevision.Value++;
+    }
+
+    // Whatever the outstanding name was built from, including no model at all:
+    // a request that named none was fingerprinted without one, and letting a
+    // catalog that has since loaded name one would make it a different request.
+    // Only for the same request: an edit of another picture, or with another
+    // prompt, is a new request and is priced and run on the model on screen.
+    // Whether any request still waiting to be collected belongs to this task.
+    // Each of the five is its own operation with its own models and its own
+    // price, so a name outstanding on one says nothing about another.
+    private bool HoldsNameFor(string task)
+    {
+        AiOperationId operation = AiOperations.ImageEdit(new AiImageEditTaskId(task));
+        return _outstanding.Any(request => IsFor(request, task))
+            || _requestKey.HasPersistedFor(operation);
+    }
+
+    private AiModelId? ModelOfOutstandingRequestFor(string task)
+        => _outstanding.TryFind(request => IsFor(request, task), out string?[] held)
+            && held[ModelPartIndex] is { } model
+                ? new AiModelId(model)
+                : _requestKey.PreferredPersistedModel(
+                    AiOperations.ImageEdit(new AiImageEditTaskId(task)));
+
+    private IReadOnlyList<AiModelId> ModelsOfOutstandingRequestsFor(AiOperationId operation)
+        => _outstanding.All()
+            .Where(request => request[TaskPartIndex] is { } task
+                && AiOperations.ImageEdit(new AiImageEditTaskId(task)) == operation)
+            .Select(request => request[ModelPartIndex])
+            .OfType<string>()
+            .Concat(_requestKey.PersistedModels(operation).Select(model => model.Value))
+            .Distinct(StringComparer.Ordinal)
+            .Select(model => new AiModelId(model))
+            .ToArray();
+
+    private static bool IsFor(string?[] request, string task)
+        => string.Equals(request[TaskPartIndex], task, StringComparison.Ordinal);
+
+    private async Task LoadEntitlementsAsync()
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        if (operation is null)
+            return;
+        try
+        {
+            await _entitlements.RefreshAsync(operation.CancellationToken);
+            // Never under an outstanding name: the model the picker lands on is
+            // part of what names the request waiting to be collected.
+            if (!ModelPicker.IsLoaded.Value || !HoldsNameFor(SelectedTask.Value.Value))
+            {
+                AiOperationId requested = AiOperations.ImageEdit(
+                    new AiImageEditTaskId(SelectedTask.Value.Value));
+                await ModelPicker.LoadAsync(
+                    requested,
+                    _requestKey.PreferredPersistedModel(requested),
+                    _requestKey.HasExplicitNullPersistedModel(requested),
+                    operation.CancellationToken);
+                SelectRecoveredModel();
+            }
+        }
+        catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load AI entitlements.");
+        }
+    }
+
+    // Asking for a size is what upscaling is; the other tasks keep the one they
+    // were given.
+    private static bool RequiresResolution(string? task)
+        => string.Equals(task, "upscale", StringComparison.Ordinal);
+
+    // Cutting a background out is asking for a transparent one.
+    // Where the model sits in the request's parts. It is filled in last: which
+    // model a request carries depends on whether a name is already outstanding
+    // for the rest of it.
+    // Where the task and the model sit in the request's parts.
+    private const int TaskPartIndex = 0;
+    private const int ModelPartIndex = 2;
+
+    private static string? RequiredBackground(string? task)
+        => string.Equals(task, "remove_background", StringComparison.Ordinal)
+            ? "transparent"
+            : null;
+
+    /// <summary>
+    /// Re-reads the model list. The catalog is cached with a freshness window,
+    /// so this costs nothing while it is fresh and picks up a model an operator
+    /// added, removed or reordered once it is not — which a workspace tab left
+    /// open would otherwise never see.
+    /// </summary>
+    public void RefreshModels()
+    {
+        // A request waiting to be collected is named partly by the model it was
+        // sent with, so an operator's change waits until that name is settled.
+        // Switching tasks still reloads: that is a different request.
+        if (HoldsNameFor(SelectedTask.Value.Value))
+            return;
+        _ = ReloadModelsAsync(SelectedTask.Value);
+    }
+
+    private async Task ReloadModelsAsync(AiImageEditTaskOption task)
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        if (operation is null)
+            return;
+        // Read by the picker's filter, which runs while the list below loads.
+        _modelsRequireResolution = RequiresResolution(task.Value);
+        _modelsRequiredBackground = RequiredBackground(task.Value);
+        try
+        {
+            await _entitlements.RefreshAsync(operation.CancellationToken);
+            await ModelPicker.LoadAsync(
+                AiOperations.ImageEdit(new AiImageEditTaskId(task.Value)),
+                // Returning to a task with an uncollected request must restore the model that
+                // request named. Choosing one affordable now would create a different request
+                // and fail to reach the already-paid result.
+                ModelOfOutstandingRequestFor(task.Value),
+                _requestKey.HasExplicitNullPersistedModel(
+                    AiOperations.ImageEdit(new AiImageEditTaskId(task.Value))),
+                operation.CancellationToken);
+            SelectRecoveredModel();
+        }
+        catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load the AI models for an image edit task.");
+        }
+    }
+
+    public async Task SelectSourceFileAsync()
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        if (operation is null)
+            return;
+        if (SourceFilePicker is { } picker)
+        {
+            string? path = await picker(operation.CancellationToken);
+            if (path is not null)
+                operation.TryPublish(() =>
+                {
+                    _sourceElementId = null;
+                    SourceFilePath.Value = path;
+                });
+            return;
+        }
+        if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime
+            { MainWindow: { } window })
+            return;
+
+        if (TopLevel.GetTopLevel(window)?.StorageProvider is not { } storage)
+            return;
+
+        FilePickerOpenOptions options = SharedFilePickerOptions.OpenAiInputImage();
+        IReadOnlyList<IStorageFile> files = await storage.OpenFilePickerAsync(options);
+        using IDisposable fileOwnership = SharedFilePickerOptions.OwnStorageFiles(files);
+        if (files.Count > 0)
+        {
+            operation.TryPublish(() =>
+            {
+                _sourceElementId = null;
+                SourceFilePath.Value = files[0].Path.LocalPath;
+            });
+        }
+    }
+
+    private void LoadOriginalPreview(string? filePath)
+    {
+        OriginalImage.Value?.Dispose();
+        OriginalImage.Value = null;
+        ResultImage.Value?.Dispose();
+        ResultImage.Value = null;
+        if (string.IsNullOrEmpty(filePath) || !File.Exists(filePath))
+            return;
+
+        try
+        {
+            OriginalImage.Value = Ref<Bitmap>.Create(
+                AiImageDecodeValidator.LoadValidatedBitmap(
+                    filePath,
+                    AiRequestLimits.MaxImageUploadBytes));
+            SelectedComparisonMode.Value = ComparisonModes[1];
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load the selected image preview.");
+            Error.Value = Strings.AiEditSourcePreviewFailed;
+        }
+    }
+
+    private async Task EditCore()
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        if (operation is null)
+            return;
+        if (SourceFilePath.Value is not { } filePath)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiEditSelectSource);
+            return;
+        }
+
+        if (!operation.TryPublish(() =>
+            {
+                Error.Value = null;
+                IsEditing.Value = true;
+            }))
+        {
+            return;
+        }
+
+        _runningRequest = operation;
+        string? preparedFilePath = null;
+        AiRequestName issued = default;
+        try
+        {
+            string task = SelectedTask.Value.Value;
+            string? prompt = RequiresPrompt.Value ? Prompt.Value.Trim() : null;
+            int? outpaintExpansionPercent = task == "outpaint"
+                ? SelectedOutpaintExpansion.Value.Percent
+                : null;
+            string uploadPath = filePath;
+            // The server fingerprints an upload by the name it arrives under, so
+            // the expanded canvas is sent under a name derived from the picture
+            // it was made from — never the temporary file's own, which is named
+            // for uniqueness on disk and would differ on every attempt.
+            string uploadName = _selectedRecovery?.Form?.SourceIsPrepared == true
+                && _selectedRecovery.Form.SourceName is { } preparedName
+                ? preparedName
+                : Path.GetFileName(filePath);
+            bool recoveredPreparedSource = _selectedRecovery?.Form?.SourceIsPrepared == true;
+            if (task == "outpaint" && recoveredPreparedSource)
+            {
+                prompt = $"Extend the image naturally into the transparent canvas while preserving the original center. {prompt}";
+            }
+            if (task == "outpaint" && !recoveredPreparedSource)
+            {
+                preparedFilePath = PrepareOutpaintSource(
+                    filePath,
+                    outpaintExpansionPercent!.Value);
+                uploadPath = preparedFilePath;
+                uploadName = $"{Path.GetFileNameWithoutExtension(filePath)}-outpaint.png";
+                prompt = $"Extend the image naturally into the transparent canvas while preserving the original center. {prompt}";
+            }
+
+            // Read once, and named by that reading. What the server
+            // fingerprints is the picture that arrives — for an outpaint that
+            // is the expanded canvas, not the picture it was made from: two
+            // different sources and expansions can expand to the same canvas,
+            // and naming the source would ask for the same work twice.
+            AiRequestRecoverySource? recoveredSource = _selectedRecovery?.Form?.SourceIsPrepared == true
+                ? _selectedRecovery.EffectiveSources.FirstOrDefault(source => source.Role == "image")
+                : null;
+            if (recoveredSource?.Name is { } recoveredName)
+                uploadName = recoveredName;
+            byte[] uploadBytes = recoveredSource is not null
+                ? _requestKey.ReadSourceBytes(recoveredSource)
+                : await AiUploadBytes.ReadWithinAsync(
+                    uploadPath,
+                    AiRequestLimits.MaxImageUploadBytes,
+                    operation.CancellationToken);
+            AiOperationId editOperation = AiOperations.ImageEdit(new AiImageEditTaskId(task));
+            // Only the model the picker is currently showing for this task; a
+            // selection left over from another task belongs to another
+            // operation and would be refused.
+            // The model's place is left empty until it is known, because which
+            // model this request carries depends on whether a name is already
+            // outstanding for the rest of it.
+            string?[] requestParts =
+            [
+                task,
+                prompt,
+                null,
+                AiRequestKey.FileStamp(uploadName, uploadBytes),
+            ];
+            // Name the model shown on screen. Silently substituting one from an uncollected
+            // request would charge for something different from the UI. Requests created when
+            // the list was empty cannot be represented here and must be recovered from history.
+            AiModelId? model =
+                ModelPicker.Operation == editOperation ? ModelForRequest(ModelPicker.SelectedModel) : null;
+            requestParts[ModelPartIndex] = model?.Value;
+            AiRequestFormSnapshot form = new(
+                Prompt: Prompt.Value,
+                Task: task,
+                OutpaintExpansionPercent: outpaintExpansionPercent,
+                SourceName: uploadName,
+                SourceIsPrepared: task == "outpaint",
+                SourceElementId: _sourceElementId);
+            AiRequestRecoverySource recoverySource = task == "outpaint" && _requestKey.HasDurableRecovery
+                ? _requestKey.CreateDurableSource(
+                    "image",
+                    uploadName,
+                    uploadBytes,
+                    _sourceElementId)
+                : FileAiRequestRecoveryStore.CreateExternalSource(
+                    "image",
+                    filePath,
+                    uploadName,
+                    uploadBytes,
+                    _sourceElementId);
+            if (_selectedRecovery is { } selected
+                && !_requestKey.MatchesPending(selected, requestParts))
+            {
+                _requestKey.CleanupUncommittedSources([recoverySource]);
+                operation.TryPublish(() => Error.Value = Strings.AiRequestChanged);
+                return;
+            }
+            AiRequestName name = _requestKey.NameFor(requestParts, form, [recoverySource]);
+            issued = name;
+            _outstanding.Remember(name, requestParts);
+            _outstandingRevision.Value++;
+            using IDisposable authenticatedScope = _requestKey.EnterAuthenticatedScope(name);
+            using AiRequestRecoveryLease? claim = _requestKey.TryClaim(name);
+            if (_requestKey.HasDurableRecovery && claim is null)
+            {
+                operation.TryPublish(() => Error.Value = Strings.AiResultUnavailable);
+                return;
+            }
+
+            // Before it goes out. A name that ends here reached nothing.
+            try
+            {
+                // Not for a repeat: the server looks up the job this name
+                // already made before it looks at the balance, so refusing here
+                // would refuse to collect something already paid for.
+                if (!name.IsRepeat
+                    && !await _availability.CheckAsync(
+                        new AiOperationAvailabilityRequest.Fixed(editOperation, model),
+                        operation.CancellationToken))
+                {
+                    throw new AiUsageLimitExceededException();
+                }
+            }
+            catch
+            {
+                WithdrawRequestName(name);
+                throw;
+            }
+
+            AiImageResult response;
+            try
+            {
+                _requestKey.MarkClaimDispatched(claim);
+                response = await _images.EditAsync(
+                    new AiImageEditRequest(
+                        AiUploadSource.FromBytes(uploadName, uploadBytes),
+                        new AiImageEditTaskId(task),
+                        prompt,
+                        model,
+                        name.Key),
+                    operation.CancellationToken);
+            }
+            catch (Exception ex) when (AiRequestOutcome.CanWithdraw(name, ex))
+            {
+                WithdrawRequestName(name);
+                throw;
+            }
+
+            // Past here the picture has been paid for. Whatever goes wrong
+            // while it is fetched, the name stays: it is the way back to it.
+            using var stream = new SizeLimitedMemoryStream(
+                checked((int)AiRequestLimits.MaxImageUploadBytes));
+            await _content.CopyToAsync(response.ContentUri, stream, operation.CancellationToken);
+            operation.CancellationToken.ThrowIfCancellationRequested();
+            stream.Position = 0;
+            AiImageDecodeValidator.ValidateEncoded(stream, AiRequestLimits.MaxImageUploadBytes);
+            var resultImage = Ref<Bitmap>.Create(Bitmap.FromStream(stream));
+            RetireRequestName(name);
+            if (!operation.TryPublish(() =>
+                {
+                    ResultImage.Value?.Dispose();
+                    ResultImage.Value = resultImage;
+                    SelectedComparisonMode.Value = ComparisonModes[0];
+                    if (prompt is not null)
+                    {
+                        PromptLibrary.Record(Prompt.Value.Trim());
+                    }
+                }))
+            {
+                resultImage.Dispose();
+            }
+        }
+        // Every refusal that reserves nothing withdrew its name where it was
+        // raised, next to the request that never left. These only say what
+        // happened.
+        catch (AuthenticationRequiredException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiAuthenticationRequired);
+        }
+        catch (AiPlanRequiredException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiProRequired);
+        }
+        catch (AiUsageLimitExceededException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiUsageLimitExceeded);
+        }
+        catch (AiFileTooLargeException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiFileTooLarge);
+        }
+        // The job ran and was charged for; only fetching what it produced
+        // failed, and that is still waiting in the job history.
+        catch (AiContentUnavailableException ex)
+        {
+            _logger.LogError(ex, "Failed to download the AI result.");
+            operation.TryPublish(() => Error.Value = Strings.AiResultDownloadFailed);
+        }
+        // Settled and refunded server-side: the key that named it would keep
+        // answering with that failure, so the next attempt asks under a new one.
+        // Charged for and still the server's; asking again under the same name
+        // is what recovers it, so the key stays.
+        catch (AiResultUnavailableException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiResultUnavailable);
+        }
+        catch (AiModelUnavailableException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiModelUnavailable);
+        }
+        // Refused before the operation was reserved, so nothing was charged;
+        // what has to change is the model or the shape of the request.
+        catch (AiModelDoesNotSupportRequestException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiModelDoesNotSupportRequest);
+        }
+        // The server settled this job as failed and refunded it. Its name would
+        // keep answering with that failure, so the next attempt takes a new one.
+        catch (AiProviderErrorException)
+        {
+            RetireRequestName(issued);
+            operation.TryPublish(() => Error.Value = Strings.AiProviderError);
+        }
+        // Reachable because a request keeps its name across attempts: asking
+        // again for one the server is still working on is how its result is
+        // recovered rather than bought twice, and until it finishes the answer
+        // is this. The key stays — it is still the way back to that job.
+        catch (AiRequestInProgressException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiRequestInProgress);
+        }
+        // The job that key created is gone, so the key can only ever answer
+        // with that. The next attempt has to be a new request.
+        // The issued name belongs to a different request. Keep it so restoring the form can
+        // resend that request; discarding it could close the only route to an already-paid job.
+        catch (AiRequestChangedException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiRequestChanged);
+        }
+        catch (AiRequestWasDeletedException)
+        {
+            RetireRequestName(issued);
+            operation.TryPublish(() => Error.Value = Strings.AiRequestWasDeleted);
+        }
+        catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to edit AI image.");
+            operation.TryPublish(() => Error.Value = Strings.AiUnexpectedError);
+        }
+        finally
+        {
+            if (ReferenceEquals(_runningRequest, operation))
+                _runningRequest = null;
+            operation.TryPublish(() => IsEditing.Value = false);
+            if (preparedFilePath is not null)
+            {
+                try
+                {
+                    File.Delete(preparedFilePath);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Failed to remove temporary outpaint input {Path}", preparedFilePath);
+                }
+            }
+        }
+    }
+
+    internal static string PrepareOutpaintSource(string filePath, int expansionPercent)
+    {
+        if (expansionPercent is < 1 or > 100)
+            throw new ArgumentOutOfRangeException(nameof(expansionPercent));
+
+        using Bitmap source = AiImageDecodeValidator.LoadValidatedBitmap(
+            filePath,
+            AiRequestLimits.MaxImageUploadBytes);
+        (int expandedWidth, int expandedHeight, int horizontal, int vertical) =
+            GetOutpaintDimensions(source.Width, source.Height, expansionPercent);
+        using Bitmap expanded = source.MakeBorder(vertical, vertical, horizontal, horizontal);
+        (string result, FileStream stream) = AiTemporaryFileStore.Create("inputs", "outpaint", ".png");
+        using (stream)
+        {
+            expanded.Save(stream, EncodedImageFormat.Png);
+        }
+        return result;
+    }
+
+    internal static (int Width, int Height, int Horizontal, int Vertical) GetOutpaintDimensions(
+        int sourceWidth,
+        int sourceHeight,
+        int expansionPercent)
+    {
+        if (expansionPercent is < 1 or > 100)
+            throw new ArgumentOutOfRangeException(nameof(expansionPercent));
+        int horizontal = Math.Max(1, checked((int)Math.Round(sourceWidth * expansionPercent / 100d)));
+        int vertical = Math.Max(1, checked((int)Math.Round(sourceHeight * expansionPercent / 100d)));
+        int expandedWidth = checked(sourceWidth + horizontal * 2);
+        int expandedHeight = checked(sourceHeight + vertical * 2);
+        AiImageDecodeValidator.ValidateDimensions(expandedWidth, expandedHeight);
+        return (expandedWidth, expandedHeight, horizontal, vertical);
+    }
+
+    private static string? GetPromptValidationError(string task, string prompt)
+    {
+        if (task is not ("restyle" or "remove_object" or "outpaint"))
+            return null;
+        if (string.IsNullOrWhiteSpace(prompt))
+            return Strings.AiPromptRequired;
+
+        string finalPrompt = task == "outpaint"
+            ? $"Extend the image naturally into the transparent canvas while preserving the original center. {prompt.Trim()}"
+            : prompt.Trim();
+        return finalPrompt.Length > AiRequestLimits.MaxPromptLength
+            ? AiPromptComposer.PromptTooLongMessage
+            : null;
+    }
+
+    private async Task AddToSceneCore()
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        if (operation is null)
+            return;
+        if (_editViewModel == null || ResultImage.Value?.Value is not { } bitmap)
+            return;
+        if (!operation.IsCurrent)
+            return;
+
+        try
+        {
+            TimeSpan start = _editViewModel.Player.CurrentFrame.Value;
+            int layer = _editViewModel.Scene.Children
+                .Where(item => item.Start <= start && start < item.Range.End)
+                .Select(item => item.ZIndex)
+                .DefaultIfEmpty(-1)
+                .Max() + 1;
+            AiResultImportOptions options = new(
+                start,
+                TimeSpan.FromSeconds(5),
+                layer,
+                Strings.AiImageEdit);
+            ElementAddResult result;
+            if (ResultImporter is { } importer)
+            {
+                result = await importer(bitmap, options, operation.CancellationToken);
+            }
+            else
+            {
+                var defaultImporter = new AiResultImporter(
+                    _editViewModel.Scene,
+                    _editViewModel.GetRequiredService<IElementAdder>());
+                result = await defaultImporter.ImportImageAsync(
+                    bitmap,
+                    options,
+                    operation.CancellationToken);
+            }
+
+            if (result.Failure is LockedElementLayerFailure)
+            {
+                operation.TryPublish(() =>
+                    NotificationService.ShowWarning(Strings.Lock, Strings.LayerIsLocked));
+                return;
+            }
+            EnsureImportSucceeded(result);
+            if (result.IsSuccess)
+            {
+                operation.TryPublish(() =>
+                    NotificationService.ShowSuccess(Strings.AiImageEdit, Strings.AiImageAddedToScene));
+            }
+        }
+        catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to add the AI edited image to the scene.");
+            operation.TryPublish(() => Error.Value = Strings.AiUnexpectedError);
+        }
+
+    }
+
+    private static void EnsureImportSucceeded(ElementAddResult result)
+    {
+        if (result.IsSuccess)
+            return;
+        throw new InvalidOperationException(
+            $"Failed to add the edited image: {result.Failure?.Id}.",
+            result.Failure?.Exception);
+    }
+
+    private async Task SaveToFileCore()
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        if (operation is null)
+            return;
+        using Ref<Bitmap>? resultImage = AiResultImageLease.Acquire(ResultImage.Value);
+        if (resultImage?.Value is not { } bitmap)
+            return;
+
+        AiSaveFileDestination? destination;
+        IStorageFile? selectedStorageFile = null;
+        if (SaveFilePicker is { } picker)
+        {
+            destination = await picker(operation.CancellationToken);
+        }
+        else
+        {
+            if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime
+                { MainWindow: { } window }
+                || TopLevel.GetTopLevel(window)?.StorageProvider is not { } storage)
+                return;
+            FilePickerSaveOptions options = SharedFilePickerOptions.SavePngImage();
+            options.SuggestedFileName = $"AI Edit {DateTime.Now:yyyy-MM-dd HHmmss}";
+            options.SuggestedStartLocation = await storage.TryGetWellKnownFolderAsync(WellKnownFolder.Pictures);
+            options.DefaultExtension = "png";
+            selectedStorageFile = await storage.SaveFilePickerAsync(options);
+            destination = selectedStorageFile is null
+                ? null
+                : new AiSaveFileDestination(selectedStorageFile.Path.LocalPath);
+        }
+        using IStorageFile? storageFileOwnership = selectedStorageFile;
+
+        if (destination is null || !operation.IsCurrent)
+            return;
+
+        try
+        {
+            AiImageFileFormat.ValidatePngDestination(destination.Path);
+
+            if (!operation.TryPublish(() =>
+                {
+                    operation.CancellationToken.ThrowIfCancellationRequested();
+                    AiAtomicFileWriter.Write(
+                        destination.Path,
+                        stream =>
+                        {
+                            if (!bitmap.Save(stream, EncodedImageFormat.Png))
+                                throw new IOException("Failed to encode the edited AI image as PNG.");
+                        },
+                        operation.CancellationToken);
+                }))
+                return;
+            operation.TryPublish(() =>
+                NotificationService.ShowSuccess(Strings.AiImageEdit, Strings.AiImageSaved));
+        }
+        catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save the AI edited image.");
+            operation.TryPublish(() => Error.Value = Strings.AiUnexpectedError);
+        }
+    }
+
+}
+
+internal sealed record AiImageEditTaskOption(string Value, string DisplayName)
+{
+    public override string ToString() => DisplayName;
+}
+
+internal sealed record AiImageComparisonMode(
+    string Value,
+    string DisplayName,
+    bool ShowOriginal,
+    bool ShowResult)
+{
+    public override string ToString() => DisplayName;
+}
+
+internal sealed record AiOutpaintExpansionOption(int Percent)
+{
+    public override string ToString() => $"{Percent}%";
+}

--- a/src/Beutl/ViewModels/Dialogs/AiImageGenerationDialogViewModel.cs
+++ b/src/Beutl/ViewModels/Dialogs/AiImageGenerationDialogViewModel.cs
@@ -1,0 +1,1703 @@
+﻿using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Reactive.Disposables;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Platform.Storage;
+using Avalonia.Threading;
+using Beutl.Api;
+using Beutl.Api.Services;
+using Beutl.Editor.Services;
+using Beutl.Graphics;
+using Beutl.Language;
+using Beutl.Logging;
+using Beutl.Media;
+using Beutl.Media.Source;
+using Beutl.ProjectSystem;
+using Beutl.Services;
+using Beutl.Services.AI;
+using Beutl.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Reactive.Bindings;
+
+namespace Beutl.ViewModels.Dialogs;
+
+internal sealed class AiImageGenerationDialogViewModel : IDisposable, IAsyncDisposable, IAiModelListConsumer
+{
+    private readonly CompositeDisposable _disposables = [];
+    private readonly AsyncOperationLifetime _operations = new();
+    private readonly IdentityOperationLifetime _identityOperations = new();
+    private readonly object _disposeGate = new();
+    private readonly ILogger _logger = Log.CreateLogger<AiImageGenerationDialogViewModel>();
+    private readonly IAiEntitlementService _entitlements;
+    private readonly IAiOperationAvailabilityService _availability;
+    private IdentityOperationLifetime.Operation? _runningRequest;
+    private readonly IAiModelCatalogService _modelCatalog;
+    private readonly IAiPlanCoordinator _aiPlanCoordinator;
+    private readonly IAiImageGenerationService _images;
+    private readonly IAuthenticatedContentService _content;
+    private readonly AiRequestKey _requestKey;
+    private readonly AiRequestRecoveryContext? _requestRecoveryContext;
+    // Preserve the user's choices separately from the displayed values, which are narrowed when
+    // the model changes. Restoring the old model must also restore these values or the same intent
+    // becomes a different request and no longer reaches the result named by the outstanding key.
+    private AiImageAspectRatioOption? _chosenAspectRatio;
+    private AiImageBackgroundOption? _chosenBackground;
+    private int? _chosenSeed;
+    private readonly List<string> _chosenReferencePaths = [];
+    private AiPendingAttempt? _selectedRecovery;
+    private readonly ReactivePropertySlim<int> _recoveryRevision = new();
+    // True while model constraints update the UI. Those changes are not user choices and must
+    // not replace the preserved values.
+    private bool _applyingCapabilities;
+    private readonly EditViewModel? _editViewModel;
+    private Task? _disposeTask;
+
+    internal AiImageGenerationDialogViewModel(
+        IAiEntitlementService entitlements,
+        IAiOperationAvailabilityService availability,
+        IAiModelCatalogService modelCatalog,
+        IAiPlanCoordinator aiPlanCoordinator,
+        IAiImageGenerationService images,
+        IAuthenticatedContentService content,
+        EditViewModel? editViewModel,
+        AiRequestRecoveryContext requestRecoveryContext)
+    {
+        _entitlements = entitlements ?? throw new ArgumentNullException(nameof(entitlements));
+        _availability = availability ?? throw new ArgumentNullException(nameof(availability));
+        _modelCatalog = modelCatalog ?? throw new ArgumentNullException(nameof(modelCatalog));
+        _aiPlanCoordinator = aiPlanCoordinator
+            ?? throw new ArgumentNullException(nameof(aiPlanCoordinator));
+        _images = images ?? throw new ArgumentNullException(nameof(images));
+        _content = content ?? throw new ArgumentNullException(nameof(content));
+        _editViewModel = editViewModel;
+        _requestRecoveryContext = requestRecoveryContext;
+        _requestKey = new(
+            recoveryContext: requestRecoveryContext,
+            operation: "image.generate");
+        Usage = new AiUsageViewModel(_entitlements.Entitlements).DisposeWith(_disposables);
+        ModelPicker = new AiModelPickerViewModel(_modelCatalog, _entitlements)
+            .DisposeWith(_disposables);
+        EstimatedUsage = new AiUsageEstimateViewModel(
+                Usage,
+                _entitlements.Entitlements.Select(value =>
+                    value?.Availability.GetState(AiOperations.ImageGeneration)
+                    ?? AiOperationAvailabilityState.Unknown))
+            .DisposeWith(_disposables);
+        PromptLibrary = new AiPromptLibraryViewModel(
+                PromptTaskKind.Image,
+                ComposePrompt,
+                prompt => Prompt.Value = prompt,
+                recoveryContext: requestRecoveryContext)
+            .DisposeWith(_disposables);
+
+        Replace(
+            AspectRatioOptions,
+            DefaultAspectRatios.Select(value => new AiImageAspectRatioOption(value)));
+        SelectedAspectRatio = new ReactivePropertySlim<AiImageAspectRatioOption>(
+                GetSuggestedAspectRatio(AspectRatioOptions, editViewModel?.Scene.FrameSize))
+            .DisposeWith(_disposables);
+        Replace(
+            BackgroundOptions,
+            DefaultBackgrounds.Select(value => new AiImageBackgroundOption(value)));
+        SelectedBackground = new ReactivePropertySlim<AiImageBackgroundOption>(
+                BackgroundOptions[0])
+            .DisposeWith(_disposables);
+        HasBackgroundChoice = new ReactivePropertySlim<bool>(true)
+            .DisposeWith(_disposables);
+        SupportsSeed = new ReactivePropertySlim<bool>(true)
+            .DisposeWith(_disposables);
+        SupportsReferenceImage = new ReactivePropertySlim<bool>(true)
+            .DisposeWith(_disposables);
+        MaxReferenceImages = new ReactivePropertySlim<int>(AiRequestLimits.MaxImageReferences)
+            .DisposeWith(_disposables);
+        HasReferenceImages = new ReactivePropertySlim<bool>(false)
+            .DisposeWith(_disposables);
+        CanAddReferenceImage = new ReactivePropertySlim<bool>(true)
+            .DisposeWith(_disposables);
+        ReferenceImageCountText = new ReactivePropertySlim<string>(string.Empty)
+            .DisposeWith(_disposables);
+        Seed = new ReactivePropertySlim<int?>()
+            .DisposeWith(_disposables);
+        // A model that takes no picture cannot generate from one; offering it
+        // would only ever produce a request the server refuses.
+        ModelPicker.Filter = model =>
+            model.Image is not { } image || image.CanServeAnything(false);
+        SelectedAspectRatio.Subscribe(option =>
+            {
+                if (!_applyingCapabilities)
+                    _chosenAspectRatio = option;
+            })
+            .DisposeWith(_disposables);
+        SelectedBackground.Subscribe(option =>
+            {
+                if (!_applyingCapabilities)
+                    _chosenBackground = option;
+            })
+            .DisposeWith(_disposables);
+        Seed.Subscribe(seed =>
+            {
+                if (!_applyingCapabilities)
+                    _chosenSeed = seed;
+            })
+            .DisposeWith(_disposables);
+        ModelPicker.Selected.Subscribe(option => ApplyModelCapabilities(option?.Model))
+            .DisposeWith(_disposables);
+        // The shape and the background follow the chosen model, so replacing the
+        // list under an outstanding name would rewrite the request waiting to be
+        // collected.
+        ModelPicker.KeepOffered = operation => _requestKey.PersistedModels(operation);
+        ModelPicker.CanReload = _ => !_requestKey.HasOutstandingName.Value;
+
+        SelectReferenceImage = new AsyncReactiveCommand()
+            .WithSubscribe(SelectReferenceImageAsync);
+        ClearReferenceImages = new ReactiveCommand();
+        ClearReferenceImages.Subscribe(ClearReferenceImagesCore).DisposeWith(_disposables);
+        UpdateReferenceImageState();
+
+        IsGenerating = new ReactivePropertySlim<bool>(false)
+            .DisposeWith(_disposables);
+
+        GenerateButtonText = IsGenerating
+            .Select(x => x ? Strings.AiGenerating : Strings.AiGenerate)
+            .ToReadOnlyReactivePropertySlim(Strings.AiGenerate)
+            .DisposeWith(_disposables);
+
+        PromptValidationError = Prompt
+            .CombineLatest(
+                Style,
+                Composition,
+                Exclusions,
+                (prompt, style, composition, exclusions) =>
+                    AiPromptComposer.GetValidationError(new AiPromptParts(
+                        prompt,
+                        style,
+                        composition,
+                        Exclusions: exclusions)))
+            .ToReadOnlyReactivePropertySlim(Strings.AiPromptRequired)
+            .DisposeWith(_disposables);
+
+        VisiblePromptValidationError = AiPromptValidation
+            .WhileTyping(PromptValidationError, Prompt, Style, Composition, Exclusions)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        CanGenerate = PromptValidationError
+            .CombineLatest(IsGenerating, (error, generating) => error is null && !generating)
+            .CombineLatest(
+                EstimatedUsage.CanAfford,
+                _requestKey.HasOutstandingName,
+                // Or a name already handed out: the server answers a repeat with the
+                // job that name made before it looks at the balance, so the request
+                // that spent the last of it is exactly the one that must stay
+                // collectable.
+                (canGenerate, canAfford, outstanding) =>
+                    canGenerate && (canAfford || outstanding))
+            .CombineLatest(
+                ModelPicker.OffersNothingUsable,
+                _requestKey.HasOutstandingName,
+                // Every model the operation registered was ruled out, so a new
+                // request would be refused however it is shaped — but a name
+                // already handed out is answered from the job it made, whatever
+                // the catalog says now.
+                (can, nothingUsable, outstanding) =>
+                    can && (!nothingUsable || outstanding))
+            // Until the list has been asked for, a request would name no model
+            // and run on the server's default, which may cost more than what
+            // this screen was about to offer.
+            .CombineLatest(ModelPicker.IsLoaded, (can, loaded) => can && loaded)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        Generate = new AsyncReactiveCommand(CanGenerate)
+            .WithSubscribe(GenerateCore);
+
+        CanAddToScene = ResultImage
+            .Select(x => x != null)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        AddToScene = new AsyncReactiveCommand(CanAddToScene)
+            .WithSubscribe(AddToSceneCore);
+
+        SaveToFile = new AsyncReactiveCommand(CanAddToScene)
+            .WithSubscribe(SaveToFileCore);
+
+        StopGenerating = new ReactiveCommand(IsGenerating);
+        StopGenerating.Subscribe(() => _runningRequest?.Cancel()).DisposeWith(_disposables);
+
+        RecoverSelectedAttempt = new ReactiveCommand();
+        RecoverSelectedAttempt.Subscribe(() =>
+        {
+            if (SelectedRecoveryAttempt!.Value is { } attempt)
+                TryRecoverPendingAttempt(attempt);
+        }).DisposeWith(_disposables);
+        AbandonSelectedAttempt = new ReactiveCommand();
+        AbandonSelectedAttempt.Subscribe(() =>
+        {
+            if (SelectedRecoveryAttempt!.Value is { } attempt)
+                AbandonPendingAttempt(attempt);
+        }).DisposeWith(_disposables);
+
+        OpenAiPlan = new ReactiveCommand();
+        OpenAiPlan.Subscribe(aiPlanCoordinator.OpenAiPlan).DisposeWith(_disposables);
+
+        ShowJoinPro = Usage.HasSnapshot
+            .CombineLatest(Usage.CanUseAi, (hasSnapshot, canUseAi) => hasSnapshot && !canUseAi)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        SelectedRecoveryAttempt = new ReactivePropertySlim<AiPendingAttempt?>()
+            .DisposeWith(_disposables);
+        RecoveryAttempts = _recoveryRevision
+            .Select(_ => (IReadOnlyList<AiPendingAttempt>)GetPendingRecoveryAttempts())
+            .ToReadOnlyReactivePropertySlim(Array.Empty<AiPendingAttempt>())
+            .DisposeWith(_disposables);
+        RecoveryAvailable = RecoveryAttempts
+            .Select(attempts => attempts.Count != 0)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+        if (_requestRecoveryContext is not null)
+            _requestRecoveryContext.IdentityChanged += OnIdentityChanged;
+
+        _ = LoadEntitlementsAsync();
+        TryAutoRecoverSingleAttempt();
+    }
+
+    /// <summary>
+    /// The shapes on offer, which follow the chosen model: GPT Image-1 renders
+    /// 1:1, 3:2 and 2:3 and refuses the rest. A model the server says nothing
+    /// about keeps the list this client has always offered.
+    /// </summary>
+    public ObservableCollection<AiImageAspectRatioOption> AspectRatioOptions { get; } = [];
+
+    public ReactivePropertySlim<AiImageAspectRatioOption> SelectedAspectRatio { get; }
+
+    /// <summary>
+    /// The backgrounds on offer, which follow the chosen model the same way the
+    /// shapes do: GPT Image-1 publishes auto, opaque and transparent while GPT
+    /// Image-2 publishes auto and opaque. "auto" is always among them — it
+    /// sends no background at all, which every model takes.
+    /// </summary>
+    public ObservableCollection<AiImageBackgroundOption> BackgroundOptions { get; } = [];
+
+    public ReactivePropertySlim<AiImageBackgroundOption> SelectedBackground { get; }
+
+    /// <summary>
+    /// False for a model that publishes no background of its own, and for a
+    /// model that takes no seed or no picture to work from. The controls are
+    /// hidden rather than left to fail: the request would be refused after the
+    /// usage was reserved.
+    /// </summary>
+    public ReactivePropertySlim<bool> HasBackgroundChoice { get; }
+
+    public ReactivePropertySlim<bool> SupportsSeed { get; }
+
+    public ReactivePropertySlim<bool> SupportsReferenceImage { get; }
+
+    /// <summary>
+    /// Repeating a seed with the same prompt reproduces the same picture. Null
+    /// leaves the choice to the server, which is a different image every run.
+    /// </summary>
+    public ReactivePropertySlim<int?> Seed { get; }
+
+    public decimal SeedMinimum => AiRequestLimits.MinSeed;
+
+    public decimal SeedMaximum => AiRequestLimits.MaxSeed;
+
+    /// <summary>
+    /// The pictures the generation is guided by, in the order the model reads
+    /// them. Empty for a generation made from the prompt alone.
+    /// </summary>
+    public ObservableCollection<AiReferenceImageViewModel> ReferenceImages { get; } = [];
+
+    /// <summary>
+    /// How many pictures the chosen model takes, never more than what the
+    /// operation's price covers.
+    /// </summary>
+    public ReactivePropertySlim<int> MaxReferenceImages { get; }
+
+    public ReactivePropertySlim<bool> HasReferenceImages { get; }
+
+    public ReactivePropertySlim<bool> CanAddReferenceImage { get; }
+
+    public ReactivePropertySlim<string> ReferenceImageCountText { get; }
+
+    public AsyncReactiveCommand SelectReferenceImage { get; }
+
+    public ReactiveCommand ClearReferenceImages { get; }
+
+    public ReactivePropertySlim<string> Prompt { get; } = new();
+
+    public ReactivePropertySlim<string> Style { get; } = new();
+
+    public ReactivePropertySlim<string> Composition { get; } = new();
+
+    public ReactivePropertySlim<string> Exclusions { get; } = new();
+
+    public ReactivePropertySlim<bool> IsGenerating { get; }
+
+    public ReadOnlyReactivePropertySlim<string> GenerateButtonText { get; }
+
+    public ReadOnlyReactivePropertySlim<string?> PromptValidationError { get; }
+
+    /// <summary>
+    /// The same message, held back until the person has typed something.
+    /// </summary>
+    public ReadOnlyReactivePropertySlim<string?> VisiblePromptValidationError { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> CanGenerate { get; }
+
+    public AsyncReactiveCommand Generate { get; }
+
+    /// <summary>
+    /// Abandons the request in flight. Generation runs for as long as the server
+    /// takes, so a wrong prompt must be recoverable without closing the tab.
+    /// </summary>
+    public ReactiveCommand StopGenerating { get; }
+
+    /// <summary>Pending form attempts that can be explicitly recovered or abandoned.</summary>
+    internal IReadOnlyList<AiPendingAttempt> PendingRecoveryAttempts
+        => GetPendingRecoveryAttempts();
+
+    internal ReactivePropertySlim<AiPendingAttempt?> SelectedRecoveryAttempt { get; }
+
+    internal ReadOnlyReactivePropertySlim<IReadOnlyList<AiPendingAttempt>> RecoveryAttempts { get; }
+
+    internal ReadOnlyReactivePropertySlim<bool> RecoveryAvailable { get; }
+
+    internal ReactiveCommand RecoverSelectedAttempt { get; }
+
+    internal ReactiveCommand AbandonSelectedAttempt { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> CanAddToScene { get; }
+
+    public AsyncReactiveCommand AddToScene { get; }
+
+    public AsyncReactiveCommand SaveToFile { get; }
+
+    public ReactiveCommand OpenAiPlan { get; }
+
+    internal IAiPlanCoordinator AiPlanCoordinator => _aiPlanCoordinator;
+
+    public ReactivePropertySlim<Ref<Bitmap>?> ResultImage { get; } = new();
+
+    /// <summary>
+    /// The picture as far as the model has taken it, shown while it works.
+    /// Cleared when the run ends, whatever it ends in: what is worth keeping is
+    /// the finished picture, and a rough one left on screen would be mistaken
+    /// for it. Only models whose provider streams send any.
+    /// </summary>
+    public ReactivePropertySlim<Ref<Bitmap>?> PreviewImage { get; } = new();
+
+    internal AiUsageViewModel Usage { get; }
+
+    internal AiModelPickerViewModel ModelPicker { get; }
+
+    internal AiUsageEstimateViewModel EstimatedUsage { get; }
+
+    internal AiPromptLibraryViewModel PromptLibrary { get; }
+
+    // Unset in production: the default branches below use Avalonia storage and
+    // AiResultImporter exactly as the editor does today.
+    internal Func<CancellationToken, Task<IReadOnlyList<string>>>? ReferenceImagePicker { get; set; }
+
+    internal Func<CancellationToken, Task<AiSaveFileDestination?>>? SaveFilePicker { get; set; }
+
+    internal Func<Bitmap, AiResultImportOptions, CancellationToken, Task<ElementAddResult>>?
+        ResultImporter
+    { get; set; }
+
+    public ReadOnlyReactivePropertySlim<bool> ShowJoinPro { get; }
+
+    public ReactivePropertySlim<string?> Error { get; } = new();
+
+    /// <summary>
+    /// What this client asks for when the server says nothing about a model —
+    /// the shapes it offered before models could publish their own.
+    /// </summary>
+    // Where the model sits in the request's parts. It is filled in last: which
+    // model a request carries depends on whether a name is already outstanding
+    // for the rest of it.
+    private const int ModelPartIndex = 4;
+
+    private static readonly string[] DefaultAspectRatios =
+        ["16:9", "1:1", "9:16", "4:3", "3:4", "3:2", "2:3"];
+
+    /// <summary>
+    /// What a server that publishes no backgrounds is read as. "auto" leads
+    /// because it is the one every model takes.
+    /// </summary>
+    private static readonly string[] DefaultBackgrounds = ["auto", "opaque", "transparent"];
+
+    /// <summary>
+    /// Rebuilds the shapes around the chosen model, keeping the selection where
+    /// the model still takes it and falling back to the one nearest the scene.
+    /// </summary>
+    private void ApplyModelCapabilities(AiModelOption? model)
+    {
+        AiImageModelCapabilities image =
+            model?.Image ?? AiImageModelCapabilities.Unrestricted;
+
+        // What the user asked for is remembered apart from what the model on
+        // screen will take. Reading the choice back off the screen loses it the
+        // moment a model that takes something narrower is picked, and going
+        // back to the first model then rebuilds a different request — one the
+        // name already handed out does not belong to.
+        _applyingCapabilities = true;
+        try
+        {
+            IEnumerable<string> aspectRatios = !image.AspectRatios.IsSpecified
+                ? DefaultAspectRatios
+                : image.AspectRatios.Values;
+            var availableAspectRatios = aspectRatios.ToList();
+            if (_selectedRecovery?.Form?.AspectRatio is { } recoveredAspect
+                && !availableAspectRatios.Contains(recoveredAspect, StringComparer.Ordinal))
+                availableAspectRatios.Add(recoveredAspect);
+            Replace(
+                AspectRatioOptions,
+                availableAspectRatios.Select(value => new AiImageAspectRatioOption(value)));
+            SelectedAspectRatio.Value =
+                AspectRatioOptions.FirstOrDefault(option => option.Value == _chosenAspectRatio?.Value)
+                ?? GetSuggestedAspectRatio(AspectRatioOptions, _editViewModel?.Scene.FrameSize);
+
+            IEnumerable<string> backgrounds = !image.Backgrounds.IsSpecified
+                ? DefaultBackgrounds
+                : image.Backgrounds.Values;
+            var availableBackgrounds = backgrounds.ToList();
+            if (_selectedRecovery?.Form?.Background is { } recoveredBackground
+                && !availableBackgrounds.Contains(recoveredBackground, StringComparer.Ordinal))
+                availableBackgrounds.Add(recoveredBackground);
+            Replace(
+                BackgroundOptions,
+                availableBackgrounds.Select(value => new AiImageBackgroundOption(value)));
+            // Falling back to the first, which is always "leave it to the
+            // model": keeping a background the new model does not take would be
+            // refused after the usage was reserved.
+            SelectedBackground.Value =
+                BackgroundOptions.FirstOrDefault(option => option.Value == _chosenBackground?.Value)
+                ?? BackgroundOptions[0];
+            HasBackgroundChoice.Value = _selectedRecovery?.Form?.HasBackgroundChoice
+                ?? BackgroundOptions.Count > 1;
+            SupportsSeed.Value = _selectedRecovery?.Form?.SupportsSeed
+                ?? image.SupportsSeed;
+            Seed.Value = SupportsSeed.Value ? _chosenSeed : null;
+            // The model publishes its own count and the price covers a fixed
+            // one; whichever is smaller is what may actually be sent, and
+            // anything the new model will not take is set aside rather than
+            // refused after the usage has been reserved.
+            int maxReferences = Math.Clamp(
+                _selectedRecovery?.Form?.MaxReferenceImages
+                    ?? image.MaxReferenceImages,
+                0,
+                AiRequestLimits.MaxImageReferences);
+            SupportsReferenceImage.Value = _selectedRecovery?.Form?.SupportsReferenceImage
+                ?? maxReferences > 0;
+            if (!SupportsReferenceImage.Value)
+                maxReferences = 0;
+            MaxReferenceImages.Value = maxReferences;
+            ShowChosenReferenceImages(maxReferences);
+        }
+        finally
+        {
+            _applyingCapabilities = false;
+        }
+
+        UpdateReferenceImageState();
+    }
+
+    // The pictures the user picked, as many of them as this model takes. A
+    // model that takes fewer sets the rest aside rather than throwing them
+    // away, so going back to one that takes them all asks for the same request
+    // again rather than a smaller one.
+    private void ShowChosenReferenceImages(int maxReferences)
+    {
+        string[] wanted = WithinTotalLimit(_chosenReferencePaths.Take(maxReferences));
+        if (ReferenceImages.Select(reference => reference.Path).SequenceEqual(
+                wanted,
+                StringComparer.Ordinal))
+        {
+            return;
+        }
+
+        foreach (AiReferenceImageViewModel shown in ReferenceImages)
+            shown.Dispose();
+        ReferenceImages.Clear();
+        foreach (string path in wanted)
+        {
+            if (LoadReference(path) is { } reference)
+                ReferenceImages.Add(reference);
+        }
+    }
+
+    private void UpdateReferenceImageState()
+    {
+        HasReferenceImages.Value = ReferenceImages.Count > 0;
+        CanAddReferenceImage.Value = ReferenceImages.Count < MaxReferenceImages.Value;
+        ReferenceImageCountText.Value = string.Format(
+            CultureInfo.CurrentCulture,
+            Strings.AiReferenceImageCount,
+            ReferenceImages.Count,
+            MaxReferenceImages.Value);
+    }
+
+    private void ClearReferenceImagesCore()
+    {
+        foreach (AiReferenceImageViewModel reference in ReferenceImages)
+            reference.Dispose();
+        ReferenceImages.Clear();
+        _chosenReferencePaths.Clear();
+        UpdateReferenceImageState();
+    }
+
+    private void RemoveReferenceImage(AiReferenceImageViewModel reference)
+    {
+        if (!ReferenceImages.Remove(reference))
+            return;
+        _chosenReferencePaths.Remove(reference.Path);
+        reference.Dispose();
+        UpdateReferenceImageState();
+    }
+
+    private static void Replace<T>(ObservableCollection<T> target, IEnumerable<T> values)
+    {
+        target.Clear();
+        foreach (T value in values)
+            target.Add(value);
+    }
+
+    internal static AiImageAspectRatioOption GetSuggestedAspectRatio(
+        IReadOnlyList<AiImageAspectRatioOption> options,
+        Beutl.Media.PixelSize? frameSize)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (options.Count == 0)
+        {
+            throw new ArgumentException(
+                "At least one aspect ratio option is required.",
+                nameof(options));
+        }
+
+        string ratio = AiAspectRatioSuggestion.Nearest(
+            options.Select(option => option.Value).ToArray(),
+            frameSize,
+            "16:9");
+        return options.FirstOrDefault(option => option.Value == ratio) ?? options[0];
+    }
+
+    public void Dispose() => _ = BeginDisposeAsync();
+
+    public ValueTask DisposeAsync() => new(BeginDisposeAsync());
+
+    private IdentityOperationLifetime.Operation? TryEnterIdentityOperation()
+        => _identityOperations.TryEnter(_operations);
+
+    private Task BeginDisposeAsync()
+    {
+        lock (_disposeGate)
+        {
+            if (_disposeTask is not null)
+                return _disposeTask;
+
+            var completion = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _disposeTask = completion.Task;
+            _ = CompleteDisposeAsync(completion);
+            return completion.Task;
+        }
+    }
+
+    private async Task CompleteDisposeAsync(TaskCompletionSource completion)
+    {
+        try
+        {
+            await DisposeCoreAsync();
+            completion.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
+        }
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        _identityOperations.Dispose();
+        await _operations.DisposeAsync(async () =>
+        {
+            ResultImage.Value?.Dispose();
+            ResultImage.Dispose();
+            PreviewImage.Value?.Dispose();
+            PreviewImage.Dispose();
+            foreach (AiReferenceImageViewModel reference in ReferenceImages)
+                reference.Dispose();
+            ReferenceImages.Clear();
+            Prompt.Dispose();
+            Style.Dispose();
+            Composition.Dispose();
+            Exclusions.Dispose();
+            Error.Dispose();
+            if (_requestRecoveryContext is not null)
+                _requestRecoveryContext.IdentityChanged -= OnIdentityChanged;
+            _requestKey.Dispose();
+            _recoveryRevision.Dispose();
+            _disposables.Dispose();
+        });
+    }
+
+    /// <summary>
+    /// Re-reads the model list. The catalog is cached with a freshness window,
+    /// so this costs nothing while it is fresh and picks up a model an operator
+    /// added, removed or reordered once it is not — which a workspace tab left
+    /// open would otherwise never see.
+    /// </summary>
+    public void RefreshModels() => _ = RefreshModelsAsync();
+
+    private async Task RefreshModelsAsync()
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        if (operation is null)
+            return;
+        // A request waiting to be collected is named partly by the model it was
+        // sent with, and the rest of what names it — the shape, the background —
+        // follows whichever model the picker lands on. Moving the picker under an
+        // outstanding name would rename the request and buy it again, so an
+        // operator's change waits until the name is settled.
+        if (_requestKey.HasOutstandingName.Value)
+            return;
+
+        try
+        {
+            await _entitlements.RefreshAsync(operation.CancellationToken);
+            await ModelPicker.LoadAsync(
+                AiOperations.ImageGeneration,
+                operation.CancellationToken);
+            SelectRecoveredModel();
+            TrimReferenceImagesToLimit();
+        }
+        catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to reload the AI models for image generation.");
+        }
+    }
+
+    private IReadOnlyList<AiPendingAttempt> GetPendingRecoveryAttempts()
+    {
+        try
+        {
+            return _requestKey.PendingAttempts(AiOperations.ImageGeneration);
+        }
+        catch (InvalidDataException ex)
+        {
+            _logger.LogError(ex, "Failed to read image-generation recovery attempts.");
+            return Array.Empty<AiPendingAttempt>();
+        }
+    }
+
+    private void TryAutoRecoverSingleAttempt()
+    {
+        IReadOnlyList<AiPendingAttempt> attempts = GetPendingRecoveryAttempts();
+        if (attempts.Count == 1 && attempts[0].HasCanonicalForm)
+        {
+            if (!TryRecoverPendingAttempt(attempts[0]))
+                ClearActiveRecovery();
+        }
+
+        _recoveryRevision.Value++;
+    }
+
+    private void OnIdentityChanged()
+    {
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            _identityOperations.SwitchDeferred(
+                action => Dispatcher.UIThread.Post(() => RunDeferredIdentityClear(action)),
+                ClearIdentityState,
+                TryAutoRecoverForCurrentIdentity);
+            return;
+        }
+
+        _identityOperations.Switch(ClearIdentityState);
+        TryAutoRecoverForCurrentIdentity();
+    }
+
+    private void RunDeferredIdentityClear(Action clear)
+    {
+        try
+        {
+            clear();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to clear image-generation state after an account change.");
+        }
+    }
+
+    private void TryAutoRecoverForCurrentIdentity()
+    {
+        if (_requestKey.CurrentAccountId is not null)
+            TryAutoRecoverSingleAttempt();
+    }
+
+    private void ClearIdentityState()
+    {
+        _runningRequest = null;
+        IsGenerating.Value = false;
+        ClearActiveRecovery();
+        _chosenAspectRatio = null;
+        _chosenBackground = null;
+        _chosenSeed = null;
+        ClearReferenceImagesCore();
+        Prompt.Value = string.Empty;
+        Style.Value = string.Empty;
+        Composition.Value = string.Empty;
+        Exclusions.Value = string.Empty;
+        ResultImage.Value?.Dispose();
+        ResultImage.Value = null;
+        PreviewImage.Value?.Dispose();
+        PreviewImage.Value = null;
+        Error.Value = null;
+        ModelPicker.ReconcileRecoveryModels();
+        ApplyModelCapabilities(ModelPicker.Selected.Value?.Model);
+        UpdateReferenceImageState();
+        _recoveryRevision.Value++;
+    }
+
+    internal bool TryRecoverPendingAttempt(AiPendingAttempt attempt)
+    {
+        if (_requestKey.CurrentAccountId is not { } account
+            || !StringComparer.Ordinal.Equals(account, attempt.AccountId))
+        {
+            Error.Value = Strings.AiAuthenticationRequired;
+            return false;
+        }
+        if (!attempt.HasCanonicalForm
+            || !string.Equals(attempt.Operation, AiOperations.ImageGeneration.Value, StringComparison.Ordinal))
+        {
+            Error.Value = Strings.AiResultUnavailable;
+            return false;
+        }
+
+        IReadOnlyList<string> paths;
+        try
+        {
+            paths = _requestKey.ResolveSources(attempt);
+        }
+        catch (InvalidDataException ex)
+        {
+            // Keep the row and key. The caller must explicitly abandon it if
+            // the original source can no longer be verified.
+            _logger.LogWarning(ex, "Image-generation recovery source is unavailable.");
+            Error.Value = Strings.AiResultUnavailable;
+            return false;
+        }
+
+        AiRequestFormSnapshot form = attempt.Form!;
+        string[] referencePaths = paths.ToArray();
+        if (referencePaths.Length != attempt.EffectiveSources.Count)
+        {
+            Error.Value = Strings.AiResultUnavailable;
+            return false;
+        }
+
+        _applyingCapabilities = true;
+        try
+        {
+            Prompt.Value = form.Prompt ?? string.Empty;
+            Style.Value = form.Style ?? string.Empty;
+            Composition.Value = form.Composition ?? string.Empty;
+            Exclusions.Value = form.Exclusions ?? string.Empty;
+            if (form.AspectRatio is { } aspect)
+            {
+                _chosenAspectRatio = new AiImageAspectRatioOption(aspect);
+                if (AspectRatioOptions.FirstOrDefault(option => option.Value == aspect) is { } aspectOption)
+                    SelectedAspectRatio.Value = aspectOption;
+            }
+            if (form.Background is { } background)
+            {
+                _chosenBackground = new AiImageBackgroundOption(background);
+                if (BackgroundOptions.FirstOrDefault(option => option.Value == background) is { } backgroundOption)
+                    SelectedBackground.Value = backgroundOption;
+            }
+            Seed.Value = form.Seed;
+            _chosenSeed = form.Seed;
+        }
+        finally
+        {
+            _applyingCapabilities = false;
+        }
+
+        foreach (AiReferenceImageViewModel reference in ReferenceImages)
+            reference.Dispose();
+        ReferenceImages.Clear();
+        _chosenReferencePaths.Clear();
+        foreach (string path in referencePaths)
+        {
+            if (LoadReference(path) is not { } reference)
+            {
+                Error.Value = Strings.AiResultUnavailable;
+                return false;
+            }
+
+            ReferenceImages.Add(reference);
+            _chosenReferencePaths.Add(path);
+        }
+
+        // Re-read the durable source bytes to ensure the path verification and
+        // the preview cannot drift before the request is sent.
+        foreach (AiRequestRecoverySource source in attempt.EffectiveSources)
+        {
+            try
+            {
+                _ = _requestKey.ReadSourceBytes(source);
+            }
+            catch (InvalidDataException ex)
+            {
+                _logger.LogWarning(ex, "Image-generation recovery source changed.");
+                Error.Value = Strings.AiResultUnavailable;
+                return false;
+            }
+        }
+
+        ActivateRecovery(attempt);
+        SelectRecoveredModel();
+        ApplyModelCapabilities(ModelPicker.Selected.Value?.Model);
+        UpdateReferenceImageState();
+        _recoveryRevision.Value++;
+        return true;
+    }
+
+    internal void AbandonPendingAttempt(AiPendingAttempt attempt)
+    {
+        try
+        {
+            _requestKey.Abandon(attempt);
+            if (_selectedRecovery is { } selected
+                && selected.AccountId == attempt.AccountId
+                && selected.Operation == attempt.Operation
+                && selected.Fingerprint == attempt.Fingerprint)
+            {
+                ClearActiveRecovery();
+                ModelPicker.ReconcileRecoveryModels();
+                ApplyModelCapabilities(ModelPicker.Selected.Value?.Model);
+                UpdateReferenceImageState();
+            }
+
+            _recoveryRevision.Value++;
+        }
+        catch (Exception ex) when (ex is InvalidDataException or AuthenticationRequiredException)
+        {
+            _logger.LogWarning(ex, "Failed to abandon image-generation recovery attempt.");
+            Error.Value = Strings.AiResultUnavailable;
+        }
+    }
+
+    private AiModelId? ModelForRequest(AiModelId? selected)
+        => _selectedRecovery is { } attempt
+            ? attempt.Model is { } model ? new AiModelId(model) : null
+            : selected;
+
+    private void ActivateRecovery(AiPendingAttempt attempt)
+    {
+        _selectedRecovery = attempt;
+        SelectedRecoveryAttempt.Value = attempt;
+        ModelPicker.IsSelectionEnabled.Value = false;
+    }
+
+    private void ClearActiveRecovery()
+    {
+        _selectedRecovery = null;
+        SelectedRecoveryAttempt.Value = null;
+        ModelPicker.IsSelectionEnabled.Value = true;
+    }
+
+    private void SelectRecoveredModel()
+    {
+        if (_selectedRecovery is not { } recovery)
+            return;
+        if (recovery.Model is not { } model)
+        {
+            ModelPicker.Selected.Value = null;
+            return;
+        }
+        AiModelId id = new(model);
+        ModelPicker.Selected.Value = ModelPicker.Options.FirstOrDefault(option => option.Id == id);
+    }
+
+    // The model a request should carry: the one the outstanding name was built
+    // from while there is one, and the picker's otherwise.
+    //
+    // Only this one request is settled. Retiring the whole run instead would
+    // throw away the name of anything else still waiting to be collected.
+    private void RetireRequestName(AiRequestName name)
+    {
+        if (!_requestKey.Retire(name))
+            return;
+        if (_selectedRecovery is { } selected
+            && (string.Equals(selected.Key, name.Key, StringComparison.Ordinal)
+                || !_requestKey.IsCurrentPending(selected)))
+        {
+            ClearActiveRecovery();
+            ModelPicker.ReconcileRecoveryModels();
+            ApplyModelCapabilities(ModelPicker.Selected.Value?.Model);
+            UpdateReferenceImageState();
+            _recoveryRevision.Value++;
+        }
+        // Reloads were held back while that name was outstanding, so this is
+        // where an operator's change to the model list finally lands.
+        _ = RefreshModelsAsync();
+    }
+
+    // What the pictures of one request may come to together is published by the
+    // server and can be lowered. Anything over the new total is dropped here
+    // rather than refused once the request has been built — which is only ever
+    // reached while no name is outstanding, so this cannot rewrite a request
+    // waiting to be collected.
+    private void TrimReferenceImagesToLimit()
+    {
+        // Trim preserved references as well as visible ones. Otherwise switching back to a less
+        // restrictive model after the limit shrinks would restore an over-limit set.
+        string[] within = WithinTotalLimit(_chosenReferencePaths);
+        if (within.Length == _chosenReferencePaths.Count)
+            return;
+
+        _chosenReferencePaths.Clear();
+        _chosenReferencePaths.AddRange(within);
+        ShowChosenReferenceImages(MaxReferenceImages.Value);
+        UpdateReferenceImageState();
+    }
+
+    // What the pictures may come to together is published by the server. The
+    // ones that fit, in the order they were picked.
+    private string[] WithinTotalLimit(IEnumerable<string> paths)
+    {
+        long limit = _selectedRecovery?.Form?.MaxReferenceTotalBytes
+            ?? ModelPicker.ImageReferenceLimits.MaxTotalBytes;
+        long total = 0;
+        var within = new List<string>();
+        foreach (string path in paths)
+        {
+            long size = SizeOf(path);
+            if (total + size > limit)
+                break;
+            within.Add(path);
+            total += size;
+        }
+
+        return within.ToArray();
+    }
+
+    // A name the server never made a job under. Withdrawing it lets the picker
+    // move again and puts the balance check back in front of the next attempt.
+    private void WithdrawRequestName(AiRequestName name)
+    {
+        if (!_requestKey.WithdrawAfterNoReservation(name))
+            return;
+        if (_selectedRecovery is { } selected
+            && (string.Equals(selected.Key, name.Key, StringComparison.Ordinal)
+                || !_requestKey.IsCurrentPending(selected)))
+        {
+            ClearActiveRecovery();
+            ModelPicker.ReconcileRecoveryModels();
+            ApplyModelCapabilities(ModelPicker.Selected.Value?.Model);
+            UpdateReferenceImageState();
+            _recoveryRevision.Value++;
+        }
+    }
+
+    private async Task LoadEntitlementsAsync()
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        if (operation is null)
+            return;
+        try
+        {
+            await _entitlements.RefreshAsync(operation.CancellationToken);
+            // After the entitlements, so the picker knows which models this
+            // account can pay for rather than offering them all — but never
+            // under an outstanding name, whose request the picker names.
+            if (!ModelPicker.IsLoaded.Value || !_requestKey.HasOutstandingName.Value)
+            {
+                AiOperationId op = AiOperations.ImageGeneration;
+                await ModelPicker.LoadAsync(
+                    op,
+                    _requestKey.PreferredPersistedModel(op),
+                    _requestKey.HasExplicitNullPersistedModel(op),
+                    operation.CancellationToken);
+                SelectRecoveredModel();
+                TrimReferenceImagesToLimit();
+            }
+        }
+        catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load AI entitlements.");
+        }
+    }
+
+    private async Task GenerateCore()
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        if (operation is null
+            || !operation.TryPublish(() =>
+            {
+                Error.Value = null;
+                IsGenerating.Value = true;
+            }))
+        {
+            return;
+        }
+
+        _runningRequest = operation;
+        AiRequestName issued = default;
+        try
+        {
+            string prompt = ComposePrompt();
+            string promptField = Prompt.Value;
+            string style = Style.Value;
+            string composition = Composition.Value;
+            string exclusions = Exclusions.Value;
+            string aspectRatio = SelectedAspectRatio.Value.Value;
+            string[] referencePaths = ReferenceImages.Select(reference => reference.Path).ToArray();
+            string background = SelectedBackground.Value.Value;
+            int? seed = Seed.Value;
+            // Every picture is part of what makes this request the request it
+            // is, so each one is named in the key: the same prompt guided by
+            // different pictures is a different run and costs its own. The
+            // model's place is left empty until it is known, because which
+            // model this request carries depends on whether it is the request a
+            // name is already outstanding for.
+            AiImageReferenceLimits referenceLimits = _selectedRecovery?.Form?.MaxReferenceTotalBytes
+                is { } persistedReferenceLimit
+                ? new AiImageReferenceLimits(persistedReferenceLimit)
+                : ModelPicker.ImageReferenceLimits;
+            // Read once, and named by that reading. Reading again to send would
+            // name one set of bytes and upload another if a picture changed in
+            // between, and the answer would be recorded under a name that
+            // describes something else.
+            (AiUploadSource[] references, string[] referenceStamps, AiRequestRecoverySource[] recoverySources) =
+                await ReadReferencesAsync(
+                    referencePaths,
+                    referenceLimits.MaxTotalBytes,
+                    operation.CancellationToken,
+                    _selectedRecovery?.EffectiveSources);
+            string?[] requestParts =
+            [
+                prompt,
+                aspectRatio,
+                background,
+                seed?.ToString(CultureInfo.InvariantCulture),
+                null,
+                .. referenceStamps,
+            ];
+            AiModelId? model = ModelForRequest(ModelPicker.SelectedModel);
+            requestParts[ModelPartIndex] = model?.Value;
+            AiRequestFormSnapshot form = new(
+                Prompt: promptField,
+                Style: style,
+                Composition: composition,
+                Exclusions: exclusions,
+                AspectRatio: aspectRatio,
+                Background: background,
+                Seed: seed,
+                MaxReferenceImages: MaxReferenceImages.Value,
+                MaxReferenceTotalBytes: referenceLimits.MaxTotalBytes,
+                SupportsReferenceImage: SupportsReferenceImage.Value,
+                SupportsSeed: SupportsSeed.Value,
+                HasBackgroundChoice: HasBackgroundChoice.Value);
+            if (_selectedRecovery is { } selected
+                && !_requestKey.MatchesPending(selected, requestParts))
+            {
+                // The user changed a recovered form. Keep the old paid key
+                // reachable and require an explicit abandon before allowing a
+                // new charge; silently issuing another key would lose the path
+                // back to the original job.
+                operation.TryPublish(() => Error.Value = Strings.AiRequestChanged);
+                return;
+            }
+            AiRequestName name = _requestKey.NameFor(requestParts, form, recoverySources);
+            issued = name;
+            using IDisposable authenticatedScope = _requestKey.EnterAuthenticatedScope(name);
+            using AiRequestRecoveryLease? claim = _requestKey.TryClaim(name);
+            if (_requestKey.HasDurableRecovery && claim is null)
+            {
+                operation.TryPublish(() => Error.Value = Strings.AiResultUnavailable);
+                return;
+            }
+
+            // Before it goes out. A name that ends here reached nothing.
+            try
+            {
+                // Not for a repeat: the server looks up the job this name
+                // already made before it looks at the balance, so refusing here
+                // would refuse to collect a picture already paid for — which is
+                // exactly what the request that emptied the balance is.
+                if (!name.IsRepeat
+                    && !await _availability.CheckAsync(
+                        new AiOperationAvailabilityRequest.Fixed(
+                            AiOperations.ImageGeneration,
+                            model),
+                        operation.CancellationToken))
+                {
+                    throw new AiUsageLimitExceededException();
+                }
+            }
+            catch
+            {
+                WithdrawRequestName(name);
+                throw;
+            }
+
+            AiImageResult response;
+            try
+            {
+                _requestKey.MarkClaimDispatched(claim);
+                response = await _images.GenerateAsync(
+                    new AiImageGenerationRequest(
+                        prompt,
+                        new AiImageAspectRatioId(aspectRatio),
+                        new AiImageBackgroundId(background),
+                        seed: seed,
+                        references: references,
+                        model: model,
+                        idempotencyKey: name.Key,
+                        referenceLimits: referenceLimits),
+                    new Progress<AiImagePreview>(preview => ShowPreview(preview, operation)),
+                    operation.CancellationToken);
+            }
+            catch (Exception ex) when (AiRequestOutcome.CanWithdraw(name, ex))
+            {
+                WithdrawRequestName(name);
+                throw;
+            }
+
+            // Past here the picture has been paid for. Whatever goes wrong
+            // while it is fetched, the name stays: it is the way back to it.
+            using var stream = new SizeLimitedMemoryStream(
+                checked((int)AiRequestLimits.MaxImageUploadBytes));
+            await _content.CopyToAsync(response.ContentUri, stream, operation.CancellationToken);
+            operation.CancellationToken.ThrowIfCancellationRequested();
+            stream.Position = 0;
+            AiImageDecodeValidator.ValidateEncoded(stream, AiRequestLimits.MaxImageUploadBytes);
+            var resultImage = Ref<Bitmap>.Create(Bitmap.FromStream(stream));
+            RetireRequestName(name);
+            if (!operation.TryPublish(() =>
+                {
+                    ResultImage.Value?.Dispose();
+                    ResultImage.Value = resultImage;
+                    PromptLibrary.Record(prompt);
+                }))
+            {
+                resultImage.Dispose();
+            }
+        }
+        // Every refusal that reserves nothing withdrew its name where it was
+        // raised, next to the request that never left. These only say what
+        // happened.
+        catch (AuthenticationRequiredException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiAuthenticationRequired);
+        }
+        catch (AiPlanRequiredException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiProRequired);
+        }
+        catch (AiUsageLimitExceededException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiUsageLimitExceeded);
+        }
+        // Charged for and still the server's; asking again under the same name
+        // is what recovers it, so the key stays.
+        catch (AiResultUnavailableException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiResultUnavailable);
+        }
+        catch (AiModelUnavailableException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiModelUnavailable);
+        }
+        // Refused before the operation was reserved, so nothing was charged;
+        // what has to change is the model or the shape of the request.
+        catch (AiModelDoesNotSupportRequestException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiModelDoesNotSupportRequest);
+        }
+        // The server settled this job as failed and refunded it. Its name would
+        // keep answering with that failure, so the next attempt takes a new one.
+        catch (AiProviderErrorException)
+        {
+            RetireRequestName(issued);
+            operation.TryPublish(() => Error.Value = Strings.AiProviderError);
+        }
+        // Reachable because a request keeps its name across attempts: asking
+        // again for one the server is still working on is how its result is
+        // recovered rather than bought twice, and until it finishes the answer
+        // is this. The key stays — it is still the way back to that job.
+        catch (AiRequestInProgressException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiRequestInProgress);
+        }
+        // The job that key created is gone, so the key can only ever answer
+        // with that. The next attempt has to be a new request.
+        // The issued name belongs to a different request. Keep it so restoring the form can
+        // resend that request; discarding it could close the only route to an already-paid job.
+        catch (AiRequestChangedException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiRequestChanged);
+        }
+        catch (AiRequestWasDeletedException)
+        {
+            RetireRequestName(issued);
+            operation.TryPublish(() => Error.Value = Strings.AiRequestWasDeleted);
+        }
+        catch (AiFileTooLargeException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiFileTooLarge);
+        }
+        // The job ran and was charged for; only fetching what it produced
+        // failed, and that is still waiting in the job history.
+        catch (AiContentUnavailableException ex)
+        {
+            _logger.LogError(ex, "Failed to download the AI result.");
+            operation.TryPublish(() => Error.Value = Strings.AiResultDownloadFailed);
+        }
+        catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to generate AI image.");
+            operation.TryPublish(() => Error.Value = Strings.AiUnexpectedError);
+        }
+        finally
+        {
+            if (ReferenceEquals(_runningRequest, operation))
+                _runningRequest = null;
+            operation.TryPublish(() =>
+            {
+                IsGenerating.Value = false;
+                PreviewImage.Value?.Dispose();
+                PreviewImage.Value = null;
+            });
+        }
+    }
+
+    // Shown on the way, and only on the way: the run that is publishing it has
+    // to still be the running one, or a preview from a cancelled run would
+    // arrive after the next one started.
+    private void ShowPreview(
+        AiImagePreview preview,
+        IdentityOperationLifetime.Operation operation)
+    {
+        Ref<Bitmap> image;
+        try
+        {
+            using var stream = new MemoryStream(preview.Bytes.ToArray(), writable: false);
+            AiImageDecodeValidator.ValidateEncoded(stream, AiRequestLimits.MaxImageUploadBytes);
+            image = Ref<Bitmap>.Create(Bitmap.FromStream(stream));
+        }
+        catch (Exception ex)
+        {
+            // A rough version that cannot be decoded is not worth a failure; the
+            // finished picture is what the caller is waiting for.
+            _logger.LogWarning(ex, "Failed to decode a partial AI image.");
+            return;
+        }
+
+        if (!operation.TryPublish(() =>
+            {
+                PreviewImage.Value?.Dispose();
+                PreviewImage.Value = image;
+            }))
+        {
+            image.Dispose();
+        }
+    }
+
+    private async Task AddToSceneCore()
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        if (operation is null)
+            return;
+        if (_editViewModel == null || ResultImage.Value?.Value is not { } bitmap)
+            return;
+        if (!operation.IsCurrent)
+            return;
+
+        try
+        {
+            TimeSpan start = _editViewModel.Player.CurrentFrame.Value;
+            int layer = _editViewModel.Scene.Children
+                .Where(item => item.Start <= start && start < item.Range.End)
+                .Select(item => item.ZIndex)
+                .DefaultIfEmpty(-1)
+                .Max() + 1;
+            AiResultImportOptions options = new(
+                start,
+                TimeSpan.FromSeconds(5),
+                layer,
+                Strings.AiImageGeneration);
+            ElementAddResult result;
+            if (ResultImporter is { } importer)
+            {
+                result = await importer(bitmap, options, operation.CancellationToken);
+            }
+            else
+            {
+                var defaultImporter = new AiResultImporter(
+                    _editViewModel.Scene,
+                    _editViewModel.GetRequiredService<IElementAdder>());
+                result = await defaultImporter.ImportImageAsync(
+                    bitmap,
+                    options,
+                    operation.CancellationToken);
+            }
+
+            if (result.Failure is LockedElementLayerFailure)
+            {
+                operation.TryPublish(() =>
+                    NotificationService.ShowWarning(Strings.Lock, Strings.LayerIsLocked));
+                return;
+            }
+            EnsureImportSucceeded(result);
+            if (result.IsSuccess)
+            {
+                operation.TryPublish(() =>
+                    NotificationService.ShowSuccess(Strings.AiImageGeneration, Strings.AiImageAddedToScene));
+            }
+        }
+        catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to add the AI image to the scene.");
+            operation.TryPublish(() => Error.Value = Strings.AiUnexpectedError);
+        }
+    }
+
+    private async Task SaveToFileCore()
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        if (operation is null)
+            return;
+        using Ref<Bitmap>? resultImage = AiResultImageLease.Acquire(ResultImage.Value);
+        if (resultImage?.Value is not { } bitmap)
+            return;
+
+        AiSaveFileDestination? destination;
+        IStorageFile? selectedStorageFile = null;
+        if (SaveFilePicker is { } picker)
+        {
+            destination = await picker(operation.CancellationToken);
+        }
+        else
+        {
+            if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime
+                { MainWindow: { } window }
+                || TopLevel.GetTopLevel(window)?.StorageProvider is not { } storage)
+                return;
+            FilePickerSaveOptions options = SharedFilePickerOptions.SavePngImage();
+            options.SuggestedFileName = $"AI Image {DateTime.Now:yyyy-MM-dd HHmmss}";
+            options.SuggestedStartLocation = await storage.TryGetWellKnownFolderAsync(WellKnownFolder.Pictures);
+            options.DefaultExtension = "png";
+            selectedStorageFile = await storage.SaveFilePickerAsync(options);
+            destination = selectedStorageFile is null
+                ? null
+                : new AiSaveFileDestination(selectedStorageFile.Path.LocalPath);
+        }
+        using IStorageFile? storageFileOwnership = selectedStorageFile;
+
+        if (destination is null || !operation.IsCurrent)
+            return;
+
+        try
+        {
+            AiImageFileFormat.ValidatePngDestination(destination.Path);
+
+            if (!operation.TryPublish(() =>
+                {
+                    operation.CancellationToken.ThrowIfCancellationRequested();
+                    AiAtomicFileWriter.Write(
+                        destination.Path,
+                        stream =>
+                        {
+                            if (!bitmap.Save(stream, EncodedImageFormat.Png))
+                                throw new IOException("Failed to encode the AI image as PNG.");
+                        },
+                        operation.CancellationToken);
+                }))
+                return;
+            operation.TryPublish(() =>
+                NotificationService.ShowSuccess(Strings.AiImageGeneration, Strings.AiImageSaved));
+        }
+        catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save the AI image.");
+            operation.TryPublish(() => Error.Value = Strings.AiUnexpectedError);
+        }
+    }
+
+    private async Task SelectReferenceImageAsync()
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        if (operation is null)
+            return;
+        IReadOnlyList<string> paths;
+        IDisposable? selectedFilesOwnership = null;
+        if (ReferenceImagePicker is { } picker)
+        {
+            paths = await picker(operation.CancellationToken);
+        }
+        else
+        {
+            if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime
+                { MainWindow: { } window }
+                || TopLevel.GetTopLevel(window)?.StorageProvider is not { } storage)
+                return;
+            FilePickerOpenOptions options = SharedFilePickerOptions.OpenAiInputImage();
+            options.AllowMultiple = true;
+            IReadOnlyList<IStorageFile> files = await storage.OpenFilePickerAsync(options);
+            selectedFilesOwnership = SharedFilePickerOptions.OwnStorageFiles(files);
+            paths = files.Select(file => file.Path.LocalPath).ToArray();
+        }
+        using IDisposable? fileOwnership = selectedFilesOwnership;
+        if (paths.Count == 0)
+            return;
+
+        operation.TryPublish(() => AddReferenceImages(paths));
+    }
+
+    /// <summary>
+    /// Adds pictures in the order given, stopping at what the chosen model
+    /// takes. One that cannot be read is reported and skipped rather than
+    /// stopping the rest.
+    /// </summary>
+    internal void AddReferenceImages(IEnumerable<string> paths)
+    {
+        long total = ReferenceImages.Sum(reference => SizeOf(reference.Path));
+        foreach (string path in paths)
+        {
+            if (ReferenceImages.Count >= MaxReferenceImages.Value)
+                break;
+
+            // The server holds every picture raw, again as base64 and again
+            // through JSON, so what they come to together is bounded as well as
+            // what each one may be. Said here rather than after the whole set
+            // has been sent for the server to refuse.
+            long size = SizeOf(path);
+            if (total + size > ModelPicker.ImageReferenceLimits.MaxTotalBytes)
+            {
+                Error.Value = Strings.AiFileTooLarge;
+                break;
+            }
+
+            if (LoadReference(path) is { } reference)
+            {
+                ReferenceImages.Add(reference);
+                _chosenReferencePaths.Add(path);
+                total += size;
+            }
+        }
+
+        UpdateReferenceImageState();
+    }
+
+    // Build the upload and its name from the same read. Reading twice could make the dispatched
+    // bytes differ from the named bytes and record the result under the wrong request.
+    private async Task<(
+        AiUploadSource[] References,
+        string[] Stamps,
+        AiRequestRecoverySource[] Sources)>
+        ReadReferencesAsync(
+            string[] paths,
+            long totalLimit,
+            CancellationToken cancellationToken,
+            IReadOnlyList<AiRequestRecoverySource>? recoveredSources = null)
+    {
+        var sources = new AiUploadSource[paths.Length];
+        var stamps = new string[paths.Length];
+        var recoverySources = new AiRequestRecoverySource[paths.Length];
+        // Each image and the combined set have limits. Read only the remaining allowance so an
+        // over-limit set is rejected before every image has been copied into memory.
+        long remaining = totalLimit;
+        for (int index = 0; index < paths.Length; index++)
+        {
+            AiRequestRecoverySource? recovered = recoveredSources is { Count: > 0 }
+                ? recoveredSources.FirstOrDefault(source => source.Role == $"reference-{index.ToString(CultureInfo.InvariantCulture)}")
+                : null;
+            if (recovered is not null
+                && (recovered.DurableFile is null
+                    ? !string.Equals(
+                        Path.GetFullPath(recovered.Path ?? string.Empty),
+                        Path.GetFullPath(paths[index]),
+                        StringComparison.Ordinal)
+                    : !string.Equals(
+                        Path.GetFileName(paths[index]),
+                        recovered.DurableFile,
+                        StringComparison.Ordinal)))
+            {
+                // A user-selected locator may be replaced after recovery. Read
+                // the current file and let the fingerprint check decide whether
+                // it is still the same request.
+                recovered = null;
+            }
+            string fileName = recovered?.Name ?? Path.GetFileName(paths[index]);
+            byte[] bytes = recovered is not null
+                ? await ReadRecoveredSourceAsync(recovered, cancellationToken)
+                : await AiUploadBytes.ReadWithinAsync(
+                    paths[index],
+                    Math.Min(remaining, AiRequestLimits.MaxImageUploadBytes),
+                    cancellationToken);
+            remaining -= bytes.LongLength;
+            stamps[index] = AiRequestKey.FileStamp(fileName, bytes);
+            sources[index] = AiUploadSource.FromBytes(fileName, bytes);
+            recoverySources[index] = recovered ?? FileAiRequestRecoveryStore.CreateExternalSource(
+                $"reference-{index.ToString(CultureInfo.InvariantCulture)}",
+                paths[index],
+                fileName,
+                bytes);
+        }
+
+        return (sources, stamps, recoverySources);
+    }
+
+    private async Task<byte[]> ReadRecoveredSourceAsync(
+        AiRequestRecoverySource source,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (source.Path is null && source.DurableFile is null)
+            throw new InvalidDataException($"AI recovery source '{source.Role}' is unavailable.");
+        return _requestKey.ReadSourceBytes(source);
+    }
+
+    private static long SizeOf(string path)
+    {
+        try
+        {
+            return File.Exists(path) ? new FileInfo(path).Length : 0;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return 0;
+        }
+    }
+
+    private AiReferenceImageViewModel? LoadReference(string path)
+    {
+        if (string.IsNullOrEmpty(path) || !File.Exists(path))
+            return null;
+
+        // The upload is refused server-side once it is too big, so the file is
+        // measured here instead of after the account has waited for a round trip.
+        if (new FileInfo(path).Length > AiRequestLimits.MaxImageUploadBytes)
+        {
+            Error.Value = Strings.AiFileTooLarge;
+            return null;
+        }
+
+        try
+        {
+            return new AiReferenceImageViewModel(
+                path,
+                Ref<Bitmap>.Create(AiImageDecodeValidator.LoadValidatedBitmap(
+                    path,
+                    AiRequestLimits.MaxImageUploadBytes)),
+                RemoveReferenceImage);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load an AI reference image preview from {Path}", path);
+            Error.Value = Strings.AiEditSourcePreviewFailed;
+            return null;
+        }
+    }
+
+    private string ComposePrompt() => AiPromptComposer.Compose(new AiPromptParts(
+        Prompt.Value,
+        Style.Value,
+        Composition.Value,
+        Exclusions: Exclusions.Value));
+
+    private static void EnsureImportSucceeded(ElementAddResult result)
+    {
+        if (result.IsSuccess)
+            return;
+        throw new InvalidOperationException(
+            $"Failed to add the generated image: {result.Failure?.Id}.",
+            result.Failure?.Exception);
+    }
+
+}
+
+/// <summary>
+/// One picture guiding a generation, shown with the preview the user picked it
+/// by. Removing it is the item's own business so a list of them binds without
+/// each row having to reach back through its parent.
+/// </summary>
+internal sealed class AiReferenceImageViewModel : IDisposable
+{
+    private readonly Action<AiReferenceImageViewModel> _remove;
+    private bool _disposed;
+
+    internal AiReferenceImageViewModel(
+        string path,
+        Ref<Bitmap> preview,
+        Action<AiReferenceImageViewModel> remove)
+    {
+        Path = path;
+        Preview = preview;
+        _remove = remove;
+        Remove = new ReactiveCommand();
+        Remove.Subscribe(() => _remove(this));
+    }
+
+    public string Path { get; }
+
+    public Ref<Bitmap> Preview { get; }
+
+    public string FileName => System.IO.Path.GetFileName(Path);
+
+    public ReactiveCommand Remove { get; }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        Remove.Dispose();
+        Preview.Dispose();
+    }
+}
+
+internal sealed record AiImageAspectRatioOption(string Value)
+{
+    public override string ToString() => Value;
+}
+
+/// <summary>
+/// One background the chosen model publishes. The three this client knows are
+/// named in the user's language; anything a later server adds is shown as it
+/// came, which is still better than dropping a shape the model offers.
+/// </summary>
+internal sealed record AiImageBackgroundOption(string Value)
+{
+    public override string ToString() => Value switch
+    {
+        "auto" => Strings.AiBackgroundAuto,
+        "opaque" => Strings.AiBackgroundOpaque,
+        "transparent" => Strings.AiBackgroundTransparent,
+        _ => Value,
+    };
+}

--- a/src/Beutl/ViewModels/Dialogs/AiImageGenerationDialogViewModel.cs
+++ b/src/Beutl/ViewModels/Dialogs/AiImageGenerationDialogViewModel.cs
@@ -204,6 +204,13 @@ internal sealed class AiImageGenerationDialogViewModel : IDisposable, IAsyncDisp
                 // the catalog says now.
                 (can, nothingUsable, outstanding) =>
                     can && (!nothingUsable || outstanding))
+            .CombineLatest(
+                ModelPicker.Selected,
+                _recoveryRevision,
+                // An unavailable choice cannot start new work. An outstanding request remains
+                // collectable on its retained model because the server resolves its name before
+                // checking current affordability.
+                (can, selected, _) => can && CanUseSelectedModel(selected))
             // Until the list has been asked for, a request would name no model
             // and run on the server's default, which may cost more than what
             // this screen was about to offer.
@@ -403,6 +410,8 @@ internal sealed class AiImageGenerationDialogViewModel : IDisposable, IAsyncDisp
     // Unset in production: the default branches below use Avalonia storage and
     // AiResultImporter exactly as the editor does today.
     internal Func<CancellationToken, Task<IReadOnlyList<string>>>? ReferenceImagePicker { get; set; }
+
+    internal Action<string>? BeforeReferenceImageSizeProbe { get; set; }
 
     internal Func<CancellationToken, Task<AiSaveFileDestination?>>? SaveFilePicker { get; set; }
 
@@ -901,6 +910,20 @@ internal sealed class AiImageGenerationDialogViewModel : IDisposable, IAsyncDisp
         => _selectedRecovery is { } attempt
             ? attempt.Model is { } model ? new AiModelId(model) : null
             : selected;
+
+    private bool CanUseSelectedModel(AiModelPickerOption? selected)
+    {
+        if (selected is null || selected.IsAvailable)
+            return true;
+        if (!_requestKey.HasOutstandingName.Value
+            || _selectedRecovery is not { Model: { } model } recovery
+            || !_requestKey.IsCurrentPending(recovery))
+        {
+            return false;
+        }
+
+        return selected.Id == new AiModelId(model);
+    }
 
     private void ActivateRecovery(AiPendingAttempt attempt)
     {
@@ -1599,16 +1622,17 @@ internal sealed class AiImageGenerationDialogViewModel : IDisposable, IAsyncDisp
         if (string.IsNullOrEmpty(path) || !File.Exists(path))
             return null;
 
-        // The upload is refused server-side once it is too big, so the file is
-        // measured here instead of after the account has waited for a round trip.
-        if (new FileInfo(path).Length > AiRequestLimits.MaxImageUploadBytes)
-        {
-            Error.Value = Strings.AiFileTooLarge;
-            return null;
-        }
-
         try
         {
+            // The upload is refused server-side once it is too big, so the file is
+            // measured here instead of after the account has waited for a round trip.
+            BeforeReferenceImageSizeProbe?.Invoke(path);
+            if (new FileInfo(path).Length > AiRequestLimits.MaxImageUploadBytes)
+            {
+                Error.Value = Strings.AiFileTooLarge;
+                return null;
+            }
+
             return new AiReferenceImageViewModel(
                 path,
                 Ref<Bitmap>.Create(AiImageDecodeValidator.LoadValidatedBitmap(

--- a/src/Beutl/ViewModels/Dialogs/AiSubtitleDialogViewModel.Advanced.cs
+++ b/src/Beutl/ViewModels/Dialogs/AiSubtitleDialogViewModel.Advanced.cs
@@ -1,0 +1,4847 @@
+﻿using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Globalization;
+using System.Reactive.Disposables;
+using System.Text;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Platform.Storage;
+using Avalonia.Threading;
+using Beutl.Api.Services;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Editor.Services.Captions;
+using Beutl.Graphics.Shapes;
+using Beutl.Language;
+using Beutl.Media.Decoding;
+using Beutl.Media.Music;
+using Beutl.Media.Music.Samples;
+using Beutl.Media.Source;
+using Beutl.ProjectSystem;
+using Beutl.Services;
+using Beutl.Services.AI;
+using FluentAvalonia.UI.Controls;
+using Microsoft.Extensions.Logging;
+using Reactive.Bindings;
+
+namespace Beutl.ViewModels.Dialogs;
+
+public sealed partial class AiSubtitleDialogViewModel
+{
+    // Long enough to keep the number of paid requests down, short enough that a
+    // chunk stays inside what one upload may carry: 16 kHz mono 16-bit PCM runs
+    // at 32 kB a second, so the endpoint's 25 MiB stops a little under fourteen
+    // minutes.
+    private static readonly TimeSpan s_sceneMixChunkDuration = TimeSpan.FromMinutes(10);
+    private static readonly TimeSpan s_sceneMixComposeSlice = TimeSpan.FromSeconds(5);
+    private const int TranscribePageIndex = 0;
+    private const int EditPageIndex = 1;
+    private const int TranslatePageIndex = 2;
+    private readonly CompositeDisposable _captionDisposables = [];
+    private readonly object _templatePreviewGate = new();
+    private int _templatePreviewAttachments;
+    private CancellationTokenSource? _templatePreviewCts;
+    private readonly ObservableCollection<EditableCaptionCueViewModel> _editableCues = [];
+    private readonly ReactivePropertySlim<long> _transcriptionEstimateRevision = new();
+    private readonly ReactivePropertySlim<long> _translationEstimateRevision = new();
+    private readonly ReactivePropertySlim<bool> _canDeleteCue = new();
+    private readonly ReactivePropertySlim<bool> _canSplitCue = new();
+    private readonly ReactivePropertySlim<bool> _canMergeCue = new();
+    private string? _lastCaptionLanguage;
+    private TimeSpan _sceneMixChunkDuration = s_sceneMixChunkDuration;
+    private long _captionDocumentRevision;
+    private long _sceneAudioRevision;
+    private readonly Guid _sceneAudioSessionId = Guid.NewGuid();
+    private RecoverableCaptionResult? _partialResult;
+    private TranslationOperation? _pendingTranslation;
+    private SceneTranscriptionOperation? _pendingSceneTranscription;
+    private SourceTranscriptionOperation? _pendingSourceTranscription;
+    private readonly List<CaptionDraftEntry> _retainedCaptionRecoveries = [];
+    // Which model a restored run was named for, until the pickers have loaded
+    // and can be put back on it.
+    private AiModelId? _restoredTranscriptionModel;
+    private AiModelId? _restoredTranslationModel;
+    private AiCaptionHistoryResult? _pendingHistoryResult;
+    private ICaptionDraftSession? _captionDraftSession;
+    // Another tab owns this scene's draft, so this tab cannot write it. A paid request created
+    // without durable storage would lose its name when the session ends.
+    private bool _captionDraftScopeIsHeldElsewhere;
+    // This scene's draft was unreadable, which is not the same as absent, so do not overwrite it.
+    private bool _captionDraftIsUnreadable;
+    private CaptionDraftScope? _captionDraftBaseScope;
+    private string? _captionDraftJobId;
+    private long _captionDraftScopeRevision;
+    private bool _captionDraftScopeInitialized;
+    private AiOperationAvailabilityTracker _transcriptionAvailability = null!;
+    private AiOperationAvailabilityTracker _translationAvailability = null!;
+
+    internal void LoadHistoryResult(AiCaptionHistoryResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        // The tool tab is reusable, so a history import can arrive while the user still has
+        // unsaved captions or a paid partial result in this tab. Ask before discarding them.
+        if (HasUnsavedCaptionWork())
+        {
+            _pendingHistoryResult = result;
+            HistoryOverwriteMessage.Value = Strings.AiSubtitle_HistoryOverwritePrompt;
+            HasPendingHistoryResult.Value = true;
+            return;
+        }
+
+        ApplyHistoryResult(result);
+    }
+
+    internal void ConfirmPendingHistoryResult()
+    {
+        if (_pendingHistoryResult is not { } result)
+            return;
+
+        DiscardPendingHistoryResult();
+        ApplyHistoryResult(result);
+    }
+
+    internal void DiscardPendingHistoryResult()
+    {
+        _pendingHistoryResult = null;
+        HasPendingHistoryResult.Value = false;
+        HistoryOverwriteMessage.Value = null;
+    }
+
+    // Whether replacement requires confirmation. Visible state is insufficient: a run whose first
+    // chunk received no response looks empty but may still hold a paid request name that silent
+    // replacement would erase.
+    private bool HasUnsavedCaptionWork()
+        => HasPartialResult.Value
+            || _editableCues.Count > 0
+            || HasOutstandingTranscriptionRequest.Value
+            || HasOutstandingTranslationRequest.Value
+            || _retainedCaptionRecoveries.Any(entry => HoldsPaidWork(entry.Draft));
+
+    private void ApplyHistoryResult(AiCaptionHistoryResult result)
+    {
+        ChangeCaptionDraftJob(result.JobId.Value, deleteCurrent: true);
+        _pendingTranslation = null;
+        _pendingSceneTranscription = null;
+        _pendingSourceTranscription = null;
+        // Held names are gone now. Notify dependents so model loading resumes and balance checks
+        // stop treating the request as recovery work.
+        UpdateOutstandingCaptionRequest();
+        _partialResult = null;
+        HasPartialResult.Value = false;
+        PartialResultMessage.Value = null;
+        _lastCaptionLanguage = result.Language;
+        DetectedLanguageText.Value = CreateDetectedLanguageText(result.Language);
+        ResultSegments.Value = CloneSegments(result.Segments);
+        Error.Value = null;
+    }
+
+    internal TimeSpan SceneMixChunkDuration
+    {
+        get => _sceneMixChunkDuration;
+        set
+        {
+            if (value <= TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(value));
+
+            _sceneMixChunkDuration = value;
+        }
+    }
+
+    /// <summary>
+    /// How much of the scene one composition call asks for. An upload chunk is
+    /// minutes long, and composing that in one call materializes every sample in
+    /// it as float — hundreds of megabytes — while the compose thread, and the
+    /// editor waiting on it, can do nothing else.
+    /// </summary>
+    internal static TimeSpan SceneMixComposeSlice => s_sceneMixComposeSlice;
+
+    internal Func<TimeSpan, TimeSpan, CancellationToken, Task<AudioFrameSnapshot?>>?
+        SceneMixAudioComposer
+    { get; set; }
+
+    internal long SceneAudioRevision => Interlocked.Read(ref _sceneAudioRevision);
+
+    public ReadOnlyObservableCollection<EditableCaptionCueViewModel> Cues { get; private set; } = null!;
+
+    public ReactivePropertySlim<EditableCaptionCueViewModel?> SelectedCue { get; private set; } = null!;
+
+    /// <summary>
+    /// Whether there is anything to show in place of the cue list's empty state.
+    /// </summary>
+    public ReactivePropertySlim<bool> HasCues { get; private set; } = null!;
+
+    internal ReadOnlyReactivePropertySlim<bool> CanTranscribeInput { get; private set; } = null!;
+
+    internal ReactivePropertySlim<bool> HasValidCues { get; private set; } = null!;
+
+    private ReactivePropertySlim<bool> HasTimingValidCues { get; set; } = null!;
+
+    public ReactivePropertySlim<int> MaximumLineLength { get; private set; } = null!;
+
+    public ReactivePropertySlim<int> MaximumLineCount { get; private set; } = null!;
+
+    public ReactivePropertySlim<string?> CaptionValidationMessage { get; private set; } = null!;
+
+    public ReactivePropertySlim<string> TemplatePreviewText { get; private set; } = null!;
+
+    public ReactivePropertySlim<double> TemplatePreviewFontSize { get; private set; } = null!;
+
+    internal ReactivePropertySlim<int> SelectedSubtitlePageIndex { get; private set; } = null!;
+    internal ReadOnlyReactivePropertySlim<bool> IsTranscribePage { get; private set; } = null!;
+    internal ReadOnlyReactivePropertySlim<bool> IsEditPage { get; private set; } = null!;
+    internal ReadOnlyReactivePropertySlim<bool> IsTranslatePage { get; private set; } = null!;
+    internal ReadOnlyReactivePropertySlim<bool> IsSubtitleOperationActive { get; private set; } = null!;
+
+    /// <summary>
+    /// The rendered output of the selected caption template. Keeping this as a bitmap makes the
+    /// preview use the same Beutl renderer as the element that will be added to the scene instead
+    /// of approximating a template with an Avalonia text block.
+    /// </summary>
+    internal ReactivePropertySlim<Ref<Beutl.Media.Bitmap>?> TemplatePreviewImage { get; private set; } = null!;
+
+    internal Action? BeforeTemplatePreviewAdmission { get; set; }
+
+    internal Func<
+        IReadOnlyList<Element>,
+        Beutl.Media.PixelSize,
+        CancellationToken,
+        Task<byte[]?>> TemplatePreviewRenderer
+    { get; set; }
+        = static (elements, frameSize, cancellationToken) =>
+            CaptionTemplatePreviewRenderer.RenderPngAsync(
+                elements,
+                frameSize,
+                cancellationToken).AsTask();
+
+    public IReadOnlyList<CaptionLanguageOption> SourceLanguages { get; private set; } = null!;
+
+    public IReadOnlyList<CaptionLanguageOption> TargetLanguages { get; private set; } = null!;
+
+    public ReactivePropertySlim<CaptionLanguageOption> SelectedSourceLanguage { get; private set; } = null!;
+
+    public ReactivePropertySlim<CaptionLanguageOption> SelectedTargetLanguage { get; private set; } = null!;
+
+    public ReactivePropertySlim<string?> DetectedLanguageText { get; private set; } = null!;
+
+    public ReactivePropertySlim<bool> IsTranslating { get; private set; } = null!;
+
+    /// <summary>The line most recently translated, while a run is going on.</summary>
+    public ReactivePropertySlim<string?> TranslationPreview { get; private set; } = null!;
+
+    /// <summary>How many lines have come back so far in the run going on.</summary>
+    public ReactivePropertySlim<int> TranslatedLineCount { get; private set; } = null!;
+
+    public ReactivePropertySlim<string?> PartialResultMessage { get; } = new();
+
+    public ReactivePropertySlim<bool> HasPartialResult { get; } = new();
+
+    /// <summary>
+    /// Whether a caption run has named a piece the server has not been seen to
+    /// settle. Not the same as having a partial result: the very first piece of
+    /// a run may have been charged and lost before anything came back.
+    /// </summary>
+    /// <summary>
+    /// Whether a transcription run holds a name the server may answer from a
+    /// job it has already been paid for.
+    /// </summary>
+    /// <remarks>
+    /// Transcribing and translating are separate operations, charged
+    /// separately. A name held by one says nothing about the other, so they are
+    /// reported apart: shared, a transcription waiting to be collected would
+    /// open the translation button past a balance that cannot pay for it.
+    /// </remarks>
+    public ReactivePropertySlim<bool> HasOutstandingTranscriptionRequest { get; } = new();
+
+    /// <summary>
+    /// Whether a translation run holds a name the server may answer from a job
+    /// it has already been paid for.
+    /// </summary>
+    public ReactivePropertySlim<bool> HasOutstandingTranslationRequest { get; } = new();
+
+    public ReactivePropertySlim<bool> HasPendingHistoryResult { get; } = new();
+
+    public ReactivePropertySlim<string?> HistoryOverwriteMessage { get; } = new();
+
+    public ReadOnlyReactivePropertySlim<bool> CanTranslate { get; private set; } = null!;
+
+    public AsyncReactiveCommand Translate { get; private set; } = null!;
+
+    public ReactiveCommand ApplyPartialResult { get; private set; } = null!;
+
+    public ReactiveCommand DiscardPartialResult { get; private set; } = null!;
+
+    public AsyncReactiveCommand ImportCaptions { get; private set; } = null!;
+
+    public AsyncReactiveCommand ExportCaptions { get; private set; } = null!;
+
+    public ReactiveCommand AddCue { get; private set; } = null!;
+
+    public ReactiveCommand DeleteCue { get; private set; } = null!;
+
+    public ReactiveCommand SplitCue { get; private set; } = null!;
+
+    public ReactiveCommand MergeCue { get; private set; } = null!;
+
+    public ReactiveCommand WrapCues { get; private set; } = null!;
+
+    internal AiUsageEstimateViewModel TranscriptionEstimate { get; private set; } = null!;
+
+    internal AiUsageEstimateViewModel TranslationEstimate { get; private set; } = null!;
+
+    private void InitializeCaptionEditing()
+    {
+        Cues = new ReadOnlyObservableCollection<EditableCaptionCueViewModel>(_editableCues);
+        SelectedCue = new ReactivePropertySlim<EditableCaptionCueViewModel?>()
+            .DisposeWith(_captionDisposables);
+        MaximumLineLength = new ReactivePropertySlim<int>(42).DisposeWith(_captionDisposables);
+        MaximumLineCount = new ReactivePropertySlim<int>(2).DisposeWith(_captionDisposables);
+        CaptionValidationMessage = new ReactivePropertySlim<string?>().DisposeWith(_captionDisposables);
+        TemplatePreviewText = new ReactivePropertySlim<string>(Strings.AiSubtitle_PreviewSample)
+            .DisposeWith(_captionDisposables);
+        TemplatePreviewFontSize = new ReactivePropertySlim<double>(24).DisposeWith(_captionDisposables);
+        SelectedSubtitlePageIndex = new ReactivePropertySlim<int>(TranscribePageIndex)
+            .DisposeWith(_captionDisposables);
+        IsTranscribePage = SelectedSubtitlePageIndex.Select(value => value == TranscribePageIndex)
+            .ToReadOnlyReactivePropertySlim().DisposeWith(_captionDisposables);
+        IsEditPage = SelectedSubtitlePageIndex.Select(value => value == EditPageIndex)
+            .ToReadOnlyReactivePropertySlim().DisposeWith(_captionDisposables);
+        IsTranslatePage = SelectedSubtitlePageIndex.Select(value => value == TranslatePageIndex)
+            .ToReadOnlyReactivePropertySlim().DisposeWith(_captionDisposables);
+        TemplatePreviewImage = new ReactivePropertySlim<Ref<Beutl.Media.Bitmap>?>()
+            .DisposeWith(_captionDisposables);
+        DetectedLanguageText = new ReactivePropertySlim<string?>().DisposeWith(_captionDisposables);
+        HasCues = new ReactivePropertySlim<bool>(false).DisposeWith(_captionDisposables);
+        _editableCues.CollectionChanged += OnEditableCuesChanged;
+        HasValidCues = new ReactivePropertySlim<bool>(false).DisposeWith(_captionDisposables);
+        HasTimingValidCues = new ReactivePropertySlim<bool>(false).DisposeWith(_captionDisposables);
+        IsTranslating = new ReactivePropertySlim<bool>(false).DisposeWith(_captionDisposables);
+        IsSubtitleOperationActive = IsTranscribing.CombineLatest(
+                IsTranslating,
+                (transcribing, translating) => transcribing || translating)
+            .ToReadOnlyReactivePropertySlim().DisposeWith(_captionDisposables);
+        TranslationPreview = new ReactivePropertySlim<string?>().DisposeWith(_captionDisposables);
+        TranslatedLineCount = new ReactivePropertySlim<int>().DisposeWith(_captionDisposables);
+
+        SourceLanguages = CreateLanguageOptions(includeAuto: true);
+        TargetLanguages = CreateLanguageOptions(includeAuto: false);
+        SelectedSourceLanguage = new ReactivePropertySlim<CaptionLanguageOption>(SourceLanguages[0])
+            .DisposeWith(_captionDisposables);
+        SelectedTargetLanguage = new ReactivePropertySlim<CaptionLanguageOption>(
+                GetDefaultTargetLanguage())
+            .DisposeWith(_captionDisposables);
+
+        // The scene mix is transcribed over the scene's own range, so retiming the
+        // scene has to reach the estimate without the account re-picking anything.
+        IObservable<TimeSpan> sceneRange = CreateSceneRangeObservable();
+        CanTranscribeInput = SelectedAudioSource
+            .CombineLatest(
+                sceneRange,
+                (source, duration) => source is not null
+                    && (!source.IsSceneMix || duration > TimeSpan.Zero))
+            .ToReadOnlyReactivePropertySlim(false)
+            .DisposeWith(_captionDisposables);
+
+        _transcriptionAvailability = new AiOperationAvailabilityTracker(
+            _availability,
+            _lifetimeCts.Token);
+        _translationAvailability = new AiOperationAvailabilityTracker(
+            _availability,
+            _lifetimeCts.Token);
+        IObservable<(AudioSourceItem? Source, TimeSpan Duration, long Revision)>
+            transcriptionInputs = SelectedAudioSource.CombineLatest(
+                sceneRange,
+                _transcriptionEstimateRevision,
+                (source, duration, revision) => (source, duration, revision));
+        transcriptionInputs.Subscribe(input =>
+                _transcriptionAvailability.Check(
+                    CreateTranscriptionAvailabilityRequest(input.Source)))
+            .DisposeWith(_captionDisposables);
+        _translationEstimateRevision.Subscribe(_ => RefreshTranslationAvailability())
+            .DisposeWith(_captionDisposables);
+        TranscriptionEstimate = new AiUsageEstimateViewModel(
+                Usage,
+                _transcriptionAvailability.State)
+            .DisposeWith(_captionDisposables);
+        TranslationEstimate = new AiUsageEstimateViewModel(
+                Usage,
+                _translationAvailability.State)
+            .DisposeWith(_captionDisposables);
+
+        CanTranslate = HasTimingValidCues
+            .CombineLatest(
+                IsTranslating,
+                IsTranscribing,
+                TranslationEstimate.CanAfford,
+                HasOutstandingTranslationRequest,
+                // Or a run that has already named pieces: the server answers a
+                // repeat with the job that name made before it looks at the
+                // balance, so a run whose last piece spent the balance has to
+                // stay collectable.
+                (hasCues, translating, transcribing, canAfford, outstanding) =>
+                    hasCues && !translating && !transcribing
+                    && (canAfford || outstanding))
+            .CombineLatest(
+                TranslationModelPicker.OffersNothingUsable,
+                HasOutstandingTranslationRequest,
+                // Every model the operation registered was ruled out, so a new
+                // request would be refused however it is shaped — but a run
+                // already holding a name is answered from the job it made.
+                (can, nothingUsable, outstanding) =>
+                    can && (!nothingUsable || outstanding))
+            // Until the list has been asked for, a request would name no model
+            // and run on the server's default, which may cost more than what
+            // this screen was about to offer.
+            .CombineLatest(
+                TranslationModelPicker.IsLoaded,
+                (can, loaded) => can && loaded)
+            .ToReadOnlyReactivePropertySlim(false)
+            .DisposeWith(_captionDisposables);
+        Translate = new AsyncReactiveCommand(CanTranslate)
+            .WithSubscribe(TranslateCore)
+            .DisposeWith(_captionDisposables);
+        ApplyPartialResult = new ReactiveCommand(HasPartialResult)
+            .DisposeWith(_captionDisposables);
+        ApplyPartialResult.Subscribe(ApplyPartialResultCore).DisposeWith(_captionDisposables);
+        DiscardPartialResult = new ReactiveCommand(HasPartialResult)
+            .DisposeWith(_captionDisposables);
+        DiscardPartialResult.Subscribe(ClearPartialResult).DisposeWith(_captionDisposables);
+        ImportCaptions = new AsyncReactiveCommand()
+            .WithSubscribe(ImportCaptionsCore)
+            .DisposeWith(_captionDisposables);
+        ExportCaptions = new AsyncReactiveCommand(HasValidCues)
+            .WithSubscribe(ExportCaptionsCore)
+            .DisposeWith(_captionDisposables);
+        AddCue = new ReactiveCommand().DisposeWith(_captionDisposables);
+        AddCue.Subscribe(AddCueCore).DisposeWith(_captionDisposables);
+        DeleteCue = new ReactiveCommand(_canDeleteCue, initialValue: false)
+            .DisposeWith(_captionDisposables);
+        DeleteCue.Subscribe(DeleteCueCore).DisposeWith(_captionDisposables);
+        SplitCue = new ReactiveCommand(_canSplitCue, initialValue: false)
+            .DisposeWith(_captionDisposables);
+        SplitCue.Subscribe(SplitCueCore).DisposeWith(_captionDisposables);
+        MergeCue = new ReactiveCommand(_canMergeCue, initialValue: false)
+            .DisposeWith(_captionDisposables);
+        MergeCue.Subscribe(MergeCueCore).DisposeWith(_captionDisposables);
+        WrapCues = new ReactiveCommand().DisposeWith(_captionDisposables);
+        WrapCues.Subscribe(WrapCuesCore).DisposeWith(_captionDisposables);
+
+        ResultSegments.Subscribe(ApplyTranscriptionSegments).DisposeWith(_captionDisposables);
+        MaximumLineLength.Subscribe(_ => RefreshCaptionState()).DisposeWith(_captionDisposables);
+        MaximumLineCount.Subscribe(_ => RefreshCaptionState()).DisposeWith(_captionDisposables);
+        SelectedCaptionTemplate.Subscribe(_ => RefreshTemplatePreview()).DisposeWith(_captionDisposables);
+        SelectedSubtitlePageIndex.Subscribe(_ => RefreshTemplatePreview()).DisposeWith(_captionDisposables);
+        SelectedCue.Subscribe(_ =>
+        {
+            RefreshCueCommandStates();
+            RefreshTemplatePreview();
+        }).DisposeWith(_captionDisposables);
+        SelectedSourceLanguage.Subscribe(_ => InvalidatePartialResultResume()).DisposeWith(_captionDisposables);
+        SelectedTargetLanguage.Subscribe(_ => RefreshTranslationEstimate()).DisposeWith(_captionDisposables);
+        _captionDraftScopes
+            .DistinctUntilChanged()
+            .Subscribe(HandleCaptionDraftScopeChanged)
+            .DisposeWith(_captionDisposables);
+        if (_editViewModel is { } editViewModel)
+        {
+            editViewModel.Scene.GetObservable(Scene.FrameSizeProperty)
+                .DistinctUntilChanged()
+                .Skip(1)
+                .Subscribe(_ => RefreshTemplatePreview())
+                .DisposeWith(_captionDisposables);
+            editViewModel.Scene.Edited += OnCaptionSceneEdited;
+            Disposable.Create(() => editViewModel.Scene.Edited -= OnCaptionSceneEdited)
+                .DisposeWith(_captionDisposables);
+        }
+    }
+
+    private void OnEditableCuesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        => HasCues.Value = _editableCues.Count > 0;
+
+    private void DisposeCaptionEditing()
+    {
+        _editableCues.CollectionChanged -= OnEditableCuesChanged;
+        foreach (EditableCaptionCueViewModel cue in _editableCues)
+        {
+            cue.PropertyChanged -= OnCuePropertyChanged;
+        }
+        _editableCues.Clear();
+        _captionDraftSession?.Dispose();
+        _captionDraftSession = null;
+        StopTemplatePreviewAdmission();
+        ReplaceTemplatePreviewImage(null);
+        _captionDisposables.Dispose();
+        _transcriptionEstimateRevision.Dispose();
+        _translationEstimateRevision.Dispose();
+        _transcriptionAvailability.Dispose();
+        _translationAvailability.Dispose();
+        _canDeleteCue.Dispose();
+        _canSplitCue.Dispose();
+        _canMergeCue.Dispose();
+    }
+
+    private void OnCaptionSceneEdited(object? sender, EventArgs e)
+    {
+        Interlocked.Increment(ref _sceneAudioRevision);
+        _ = LoadAudioSourcesAsync();
+    }
+
+    private async Task TranscribeSelectedSourceAsync(
+        AudioSourceItem source,
+        AsyncOperationLifetime.Operation operationLifetime)
+    {
+        long captionRevision = Interlocked.Read(ref _captionDocumentRevision);
+        long draftScopeRevision = Interlocked.Read(ref _captionDraftScopeRevision);
+        string? language = SelectedSourceLanguage.Value.Code;
+        if (source.IsSceneMix)
+        {
+            await TranscribeSceneMixAsync(source, language, draftScopeRevision, operationLifetime);
+            return;
+        }
+
+        if (source.FilePath is not { } filePath)
+            throw new SubtitleInputException(Strings.AiSubtitle_NoAudioInRange);
+
+        await TranscribeSourceFileAsync(
+            source,
+            filePath,
+            language,
+            captionRevision,
+            draftScopeRevision,
+            operationLifetime);
+    }
+
+    private async Task TranscribeSourceFileAsync(
+        AudioSourceItem source,
+        string filePath,
+        string? language,
+        long captionRevision,
+        long draftScopeRevision,
+        AsyncOperationLifetime.Operation operationLifetime)
+    {
+        SourceAudioFingerprint fingerprint = GetSourceAudioFingerprint(filePath);
+        // Opening and decoding are the editor's own work, not the server's, and
+        // both run for as long as the audio is: off the UI thread, or the window
+        // stops answering for the length of the file.
+        using MediaReader reader = await Task.Run(
+            () => MediaReader.Open(
+                filePath,
+                new MediaOptions(MediaMode.Audio) { PreferProxy = false }),
+            RequestToken);
+        if (!reader.HasAudio)
+            throw new SubtitleInputException(Strings.AiSubtitle_NoAudioInRange);
+
+        int sampleRate = reader.AudioInfo.SampleRate;
+        if (sampleRate <= 0)
+            throw new SubtitleInputException(Strings.AiSubtitle_NoAudioInRange);
+
+        long sourceStartSamples = checked((long)Math.Max(
+            0,
+            Math.Floor(source.SourceOffset.TotalSeconds * sampleRate)));
+        double selectedDurationSeconds = source.GetSourceElapsedSeconds();
+        if (!double.IsFinite(selectedDurationSeconds) || selectedDurationSeconds <= 0)
+            throw new SubtitleInputException(Strings.AiSubtitle_NoAudioInRange);
+        long selectedSamples = GetSelectedSourceSampleCount(
+            reader.AudioInfo,
+            TimeSpan.FromSeconds(selectedDurationSeconds));
+        double sourceSampleCount = reader.AudioInfo.NumSamples.ToDouble();
+        long availableSamples = double.IsFinite(sourceSampleCount) && sourceSampleCount > 0
+            ? checked((long)Math.Floor(sourceSampleCount)) - sourceStartSamples
+            : selectedSamples;
+        if (availableSamples <= 0)
+            throw new SubtitleInputException(Strings.AiSubtitle_NoAudioInRange);
+        long totalSamples = Math.Min(selectedSamples, availableSamples);
+        int chunkSamples = checked((int)Math.Ceiling(
+            SceneMixChunkDuration.TotalSeconds * sampleRate));
+        if (totalSamples <= 0 || chunkSamples <= 0)
+            throw new SubtitleInputException(Strings.AiSubtitle_NoAudioInRange);
+
+        int chunkCount = checked((int)Math.Ceiling(totalSamples / (double)chunkSamples));
+        bool canResume = CanResumeSourceTranscription(
+            source,
+            filePath,
+            language,
+            sampleRate,
+            totalSamples,
+            chunkSamples,
+            chunkCount,
+            fingerprint,
+            draftScopeRevision);
+        SourceTranscriptionOperation operation;
+        if (canResume)
+        {
+            operation = _pendingSourceTranscription!;
+            operation.ExpectedCaptionRevision = captionRevision;
+        }
+        else
+        {
+            CaptionDraftEntry? retained = _retainedCaptionRecoveries.FirstOrDefault(entry =>
+                CanUseSourceTranscriptionDraft(
+                    entry.Draft,
+                    source,
+                    filePath,
+                    language,
+                    sampleRate,
+                    totalSamples,
+                    chunkSamples,
+                    chunkCount,
+                    fingerprint));
+            if (!TryParkCurrentCaptionRecovery())
+                throw new SubtitleInputException(Strings.AiSubtitle_RunCannotBeRecorded);
+
+            if (retained is not null)
+            {
+                _retainedCaptionRecoveries.Remove(retained);
+                operation = RestoreSourceTranscriptionOperation(
+                    retained.Draft,
+                    source,
+                    captionRevision,
+                    draftScopeRevision);
+                _captionDraftJobId = retained.JobId;
+            }
+            else
+            {
+                ChangeCaptionDraftJob(null, deleteCurrent: false);
+                operation = new SourceTranscriptionOperation(
+                    source,
+                    filePath,
+                    source.ElementId,
+                    fingerprint.FileLength,
+                    fingerprint.LastWriteTimeUtcTicks,
+                    language,
+                    sampleRate,
+                    totalSamples,
+                    chunkSamples,
+                    chunkCount,
+                    captionRevision,
+                    draftScopeRevision);
+            }
+        }
+        operation.Source = source;
+        _pendingSourceTranscription = operation;
+        _pendingSceneTranscription = null;
+        UpdateOutstandingCaptionRequest();
+        // Read once for the whole run, and taken from the run itself once it has
+        // named anything. Every piece is named partly by the model, so a picker
+        // that moved between naming a piece and sending it would put one model
+        // in the name and another in the body — which the server refuses — and
+        // one that moved between pieces, or fell back because the run's model
+        // was withdrawn, would rename the rest of the run and buy it again.
+        AiModelId? runModel = ModelOfRun(
+            operation.CompletedChunkCount > 0
+                || operation.RequestKey.HasOutstandingName.Value,
+            operation.RequestKeyModel,
+            TranscriptionModelPicker.SelectedModel);
+
+        for (int chunkIndex = operation.CompletedChunkCount;
+            chunkIndex < operation.ChunkCount;
+            chunkIndex++)
+        {
+            RequestToken.ThrowIfCancellationRequested();
+            long chunkOffset = checked((long)chunkIndex * operation.ChunkSamples);
+            int requestedSamples = checked((int)Math.Min(
+                operation.ChunkSamples,
+                operation.TotalSamples - chunkOffset));
+            (string path, FileStream stream) = AiTemporaryFileStore.Create(
+                "audio",
+                "source",
+                ".wav");
+            try
+            {
+                SpeechWaveChunkResult chunk;
+                using (stream)
+                {
+                    chunk = await Task.Run(
+                        () => WriteSpeechWave(
+                            reader,
+                            checked((int)(sourceStartSamples + chunkOffset)),
+                            requestedSamples,
+                            stream,
+                            RequestToken),
+                        RequestToken);
+                }
+                if (chunk.SourceSampleCount <= 0)
+                    throw new SubtitleInputException(Strings.AiSubtitle_NoAudioInRange);
+
+                if (chunk.SourceSampleCount < requestedSamples)
+                {
+                    operation.TotalSamples = chunkOffset + chunk.SourceSampleCount;
+                    operation.ChunkCount = chunkIndex + 1;
+                }
+
+                AiRequestName name = operation.RequestNameFor(chunkIndex, runModel);
+                UpdateOutstandingCaptionRequest();
+                // Anything that ends here ends before the request went out, so
+                // the name reached nothing — a refusal, a run stopped while the
+                // check was in the air, any of it.
+                try
+                {
+                    // Not for a repeat: the server looks up the job this name
+                    // already made before it looks at the balance, so refusing
+                    // here would refuse to collect a piece already paid for.
+                    if (!name.IsRepeat)
+                    {
+                        await EnsureAvailableAsync(
+                            new AiOperationAvailabilityRequest.Transcription(
+                                AiOperations.Transcription,
+                                chunk.UploadedDuration.TotalSeconds,
+                                runModel));
+                    }
+
+                    // Written before the chunk goes out, not after it comes
+                    // back. The first chunk is the one most likely to be charged
+                    // and lost, and without this the name that charged it would
+                    // die with the session: the next run would name the same
+                    // chunk differently and buy it again. A run that cannot be
+                    // written down is not started at all — sending it would be
+                    // paying for something no later session could ask for.
+                    switch (PublishSourceTranscriptionPartial(operation))
+                    {
+                        case CaptionDraftOutcome.Superseded:
+                            return;
+                        case CaptionDraftOutcome.NotRecorded:
+                            throw new SubtitleInputException(
+                                Strings.AiSubtitle_RunCannotBeRecorded);
+                    }
+                }
+                catch
+                {
+                    WithdrawSourceTranscriptionName(operation, name);
+                    throw;
+                }
+
+                AiTranscriptionResponse response;
+                try
+                {
+                    response = await _aiService.TranscribeAsync(
+                        new AiTranscriptionRequest(
+                            AiUploadSource.FromFile(
+                                path,
+                                FormatChunkFileName("source", chunkIndex)),
+                            language,
+                            runModel,
+                            name.Key),
+                        RequestToken);
+                }
+                catch (AiProviderErrorException)
+                {
+                    // The server settled this chunk as failed and refunded it.
+                    // Its key would keep answering with that failure, so the
+                    // rest of the run takes new ones — and the resume state is
+                    // rewritten with them, or a resumed run would ask under the
+                    // spent key again.
+                    if (operation.RequestKey.Retire())
+                    {
+                        UpdateOutstandingCaptionRequest();
+                        PublishSourceTranscriptionPartial(operation);
+                    }
+                    throw;
+                }
+                catch (Exception ex) when (AiRequestOutcome.CanWithdraw(name, ex))
+                {
+                    WithdrawSourceTranscriptionName(operation, name);
+                    throw;
+                }
+                ValidateTranscriptionSegments(
+                    response.Segments,
+                    chunk.UploadedDuration.TotalSeconds);
+                // Settle the durable key before publishing any local progress.
+                // A failed CAS means another owner replaced the recovery row;
+                // leave this operation untouched so it can still be resumed.
+                if (!operation.RequestKey.Retire(name))
+                    return;
+                operation.DetectedLanguage ??= response.Language;
+                double offsetSeconds = (sourceStartSamples + chunkOffset)
+                    / (double)operation.SampleRate;
+                foreach (AiTranscriptionSegment segment in response.Segments)
+                {
+                    operation.SourceSegments.Add(new AiTranscriptionSegment
+                    {
+                        Start = offsetSeconds + segment.Start,
+                        End = offsetSeconds + segment.End,
+                        Text = segment.Text,
+                    });
+                }
+                RecordCaptionDraftJob(response.JobId, operation.ExpectedDraftScopeRevision);
+                operation.CompletedChunkCount++;
+                // This chunk is settled; the rest of the run keeps its own
+                // names, and so does anything else still outstanding.
+                UpdateOutstandingCaptionRequest();
+                switch (PublishSourceTranscriptionPartial(operation))
+                {
+                    case CaptionDraftOutcome.Superseded:
+                        return;
+                    case CaptionDraftOutcome.NotRecorded:
+                        // The response may already have been charged.  Stop
+                        // before the final ClearPartialResult can delete the
+                        // previous durable seed; the next attempt can persist
+                        // this in-memory progress and resume by idempotency key.
+                        throw new SubtitleInputException(
+                            Strings.AiSubtitle_RunCannotBeRecorded);
+                }
+            }
+            finally
+            {
+                DeleteTemporaryAudio(path);
+            }
+        }
+
+        string? resultLanguage = operation.DetectedLanguage ?? language;
+        AiTranscriptionSegment[] mappedSegments = source.MapSegmentsToScene(
+            operation.SourceSegments);
+        if (_disposed
+            || !ReferenceEquals(SelectedAudioSource.Value, source)
+            || operation.ExpectedCaptionRevision != Interlocked.Read(ref _captionDocumentRevision)
+            || !IsCurrentCaptionDraftScope(operation.ExpectedDraftScopeRevision)
+            || !string.Equals(
+                SelectedSourceLanguage.Value.Code,
+                operation.Language,
+                StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        operationLifetime.TryPublish(() =>
+        {
+            _lastCaptionLanguage = resultLanguage;
+            DetectedLanguageText.Value = CreateDetectedLanguageText(_lastCaptionLanguage);
+            ResultSegments.Value = mappedSegments;
+            _pendingSourceTranscription = null;
+            ClearPartialResult();
+        });
+    }
+
+    private async Task TranscribeSceneMixAsync(
+        AudioSourceItem source,
+        string? language,
+        long draftScopeRevision,
+        AsyncOperationLifetime.Operation operationLifetime)
+    {
+        if (_disposed
+            || _editViewModel is null
+            || !TryGetSceneRange(out TimeSpan rangeStart, out TimeSpan duration))
+        {
+            throw new SubtitleInputException(Strings.AiSubtitle_InvalidRange);
+        }
+
+        int chunkCount = (int)Math.Ceiling(duration.TotalSeconds / SceneMixChunkDuration.TotalSeconds);
+        bool canResume = CanResumeSceneTranscription(
+            source,
+            language,
+            rangeStart,
+            duration,
+            chunkCount);
+        SceneTranscriptionOperation operation;
+        if (canResume)
+        {
+            operation = _pendingSceneTranscription!;
+            operation.ExpectedCaptionRevision = Interlocked.Read(ref _captionDocumentRevision);
+            if (operation.CompletedChunkCount == operation.ChunkCount)
+            {
+                operation.ExpectedSceneAudioRevision = Interlocked.Read(ref _sceneAudioRevision);
+            }
+        }
+        else
+        {
+            CaptionDraftEntry? retained = _retainedCaptionRecoveries.FirstOrDefault(entry =>
+                CanUseSceneTranscriptionDraft(
+                    entry.Draft,
+                    _editViewModel.Scene.Id,
+                    language,
+                    rangeStart,
+                    duration,
+                    SceneMixChunkDuration,
+                    chunkCount));
+            if (!TryParkCurrentCaptionRecovery())
+                throw new SubtitleInputException(Strings.AiSubtitle_RunCannotBeRecorded);
+
+            if (retained is not null)
+            {
+                _retainedCaptionRecoveries.Remove(retained);
+                operation = RestoreSceneTranscriptionOperation(
+                    retained.Draft,
+                    source,
+                    Interlocked.Read(ref _captionDocumentRevision),
+                    draftScopeRevision,
+                    Interlocked.Read(ref _sceneAudioRevision));
+                _captionDraftJobId = retained.JobId;
+            }
+            else
+            {
+                ChangeCaptionDraftJob(null, deleteCurrent: false);
+                operation = new SceneTranscriptionOperation(
+                    source,
+                    language,
+                    rangeStart,
+                    duration,
+                    SceneMixChunkDuration,
+                    chunkCount,
+                    Interlocked.Read(ref _captionDocumentRevision),
+                    draftScopeRevision,
+                    Interlocked.Read(ref _sceneAudioRevision),
+                    _editViewModel.Scene.Id,
+                    _sceneAudioSessionId);
+            }
+        }
+        operation.Source = source;
+        _pendingSceneTranscription = operation;
+        _pendingSourceTranscription = null;
+        UpdateOutstandingCaptionRequest();
+        // Read once for the whole run, and taken from the run itself once it has
+        // named anything. Every piece is named partly by the model, so a picker
+        // that moved between naming a piece and sending it would put one model
+        // in the name and another in the body — which the server refuses — and
+        // one that moved between pieces, or fell back because the run's model
+        // was withdrawn, would rename the rest of the run and buy it again.
+        AiModelId? runModel = ModelOfRun(
+            operation.CompletedChunkCount > 0
+                || operation.RequestKey.HasOutstandingName.Value,
+            operation.RequestKeyModel,
+            TranscriptionModelPicker.SelectedModel);
+
+        for (int index = operation.CompletedChunkCount; index < chunkCount; index++)
+        {
+            RequestToken.ThrowIfCancellationRequested();
+            TimeSpan chunkOffset = TimeSpan.FromTicks(
+                Math.Min(duration.Ticks, index * operation.ChunkDuration.Ticks));
+            TimeSpan chunkDuration = TimeSpan.FromTicks(
+                Math.Min(operation.ChunkDuration.Ticks, duration.Ticks - chunkOffset.Ticks));
+            AiRequestName name = operation.RequestNameFor(index, runModel);
+            UpdateOutstandingCaptionRequest();
+            // Before the scene is composed: mixing a chunk of audio the account
+            // cannot pay for is work thrown away. Anything that ends here ends
+            // before the request went out, so the name reached nothing — a
+            // refusal, a run stopped while the check was in the air, any of it.
+            try
+            {
+                // Not for a repeat: the server looks up the job this name
+                // already made before it looks at the balance, so refusing here
+                // would refuse to collect a piece already paid for.
+                if (!name.IsRepeat)
+                {
+                    await EnsureAvailableAsync(
+                        new AiOperationAvailabilityRequest.Transcription(
+                            AiOperations.Transcription,
+                            chunkDuration.TotalSeconds,
+                            runModel));
+                }
+
+                // Written before the chunk goes out. Scene audio is composed
+                // rather than read from a file, so nothing written down proves
+                // it is still the same audio — the server's own fingerprint
+                // does, and answers a chunk asked for again only when it
+                // matches.
+                switch (PublishSceneTranscriptionPartial(operation))
+                {
+                    case CaptionDraftOutcome.Superseded:
+                        return;
+                    case CaptionDraftOutcome.NotRecorded:
+                        throw new SubtitleInputException(
+                            Strings.AiSubtitle_RunCannotBeRecorded);
+                }
+            }
+            catch
+            {
+                WithdrawSceneTranscriptionName(operation, name);
+                throw;
+            }
+
+            (string path, FileStream stream) = AiTemporaryFileStore.Create(
+                "audio",
+                "scene-mix",
+                ".wav");
+            TimeSpan uploadedDuration;
+            try
+            {
+                try
+                {
+                    using (stream)
+                    {
+                        uploadedDuration = await WriteSceneMixWaveAsync(
+                            stream,
+                            rangeStart + chunkOffset,
+                            chunkDuration,
+                            RequestToken);
+                    }
+                }
+                catch
+                {
+                    WithdrawSceneTranscriptionName(operation, name);
+                    throw;
+                }
+                AiTranscriptionResponse response;
+                try
+                {
+                    response = await _aiService.TranscribeAsync(
+                        new AiTranscriptionRequest(
+                            AiUploadSource.FromFile(
+                                path,
+                                FormatChunkFileName("scene-mix", index)),
+                            language,
+                            runModel,
+                            name.Key),
+                        RequestToken);
+                }
+                catch (AiProviderErrorException)
+                {
+                    // The server settled this chunk as failed and refunded it.
+                    // Its key would keep answering with that failure, so the
+                    // rest of the run takes new ones — written down as well, or
+                    // a run picked up later asks under the spent key again and
+                    // gets the same failure every time.
+                    if (operation.RequestKey.Retire())
+                    {
+                        UpdateOutstandingCaptionRequest();
+                        PublishSceneTranscriptionPartial(operation);
+                    }
+                    throw;
+                }
+                catch (Exception ex) when (AiRequestOutcome.CanWithdraw(name, ex))
+                {
+                    WithdrawSceneTranscriptionName(operation, name);
+                    throw;
+                }
+                ValidateTranscriptionSegments(
+                    response.Segments,
+                    uploadedDuration.TotalSeconds);
+                if (!operation.RequestKey.Retire(name))
+                    return;
+                operation.DetectedLanguage ??= response.Language;
+                foreach (AiTranscriptionSegment segment in response.Segments)
+                {
+                    operation.Segments.Add(new AiTranscriptionSegment
+                    {
+                        Start = (rangeStart + chunkOffset).TotalSeconds + segment.Start,
+                        End = (rangeStart + chunkOffset).TotalSeconds + segment.End,
+                        Text = segment.Text,
+                    });
+                }
+                RecordCaptionDraftJob(response.JobId, operation.ExpectedDraftScopeRevision);
+                operation.CompletedChunkCount++;
+                UpdateOutstandingCaptionRequest();
+                switch (PublishSceneTranscriptionPartial(operation))
+                {
+                    case CaptionDraftOutcome.Superseded:
+                        return;
+                    case CaptionDraftOutcome.NotRecorded:
+                        // The response may already have been charged.  Stop
+                        // before the final ClearPartialResult can delete the
+                        // previous durable seed; the next attempt can persist
+                        // this in-memory progress and resume by idempotency key.
+                        throw new SubtitleInputException(
+                            Strings.AiSubtitle_RunCannotBeRecorded);
+                }
+            }
+            finally
+            {
+                DeleteTemporaryAudio(path);
+            }
+        }
+
+        if (!ReferenceEquals(SelectedAudioSource.Value, source)
+            || !TryGetSceneRange(out TimeSpan currentRangeStart, out TimeSpan currentDuration)
+            || currentRangeStart != operation.RangeStart
+            || currentDuration != operation.Duration
+            || !string.Equals(
+                SelectedSourceLanguage.Value.Code,
+                operation.Language,
+                StringComparison.Ordinal)
+            || operation.ExpectedCaptionRevision != Interlocked.Read(ref _captionDocumentRevision)
+            || operation.ExpectedSceneAudioRevision != Interlocked.Read(ref _sceneAudioRevision)
+            || !IsCurrentCaptionDraftScope(operation.ExpectedDraftScopeRevision))
+        {
+            return;
+        }
+
+        operationLifetime.TryPublish(() =>
+        {
+            _lastCaptionLanguage = operation.DetectedLanguage ?? language;
+            DetectedLanguageText.Value = CreateDetectedLanguageText(_lastCaptionLanguage);
+            ResultSegments.Value = CloneSegments(operation.Segments);
+            ClearPartialResult();
+        });
+    }
+
+    private async Task<TimeSpan> WriteSceneMixWaveAsync(
+        Stream stream,
+        TimeSpan start,
+        TimeSpan duration,
+        CancellationToken cancellationToken)
+    {
+        var writer = new SpeechWaveWriter(stream);
+        for (TimeSpan offset = TimeSpan.Zero; offset < duration; offset += SceneMixComposeSlice)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            TimeSpan sliceDuration = TimeSpan.FromTicks(
+                Math.Min(SceneMixComposeSlice.Ticks, (duration - offset).Ticks));
+            AudioFrameSnapshot? snapshot = SceneMixAudioComposer is { } composer
+                ? await composer(start + offset, sliceDuration, cancellationToken)
+                : await ((IPreviewPlayer)_editViewModel!.Player)
+                    .ComposeAudioAsync(start + offset, sliceDuration, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (snapshot is null || snapshot.SampleCount == 0)
+                throw new SubtitleInputException(Strings.AiSubtitle_NoAudioInRange);
+
+            writer.Append(snapshot, cancellationToken);
+        }
+
+        writer.Complete();
+        return writer.UploadedDuration;
+    }
+
+    private async Task TranslateCore()
+    {
+        using AsyncOperationLifetime.Operation? operationLifetime = _operations.TryEnter();
+        if (operationLifetime is null)
+            return;
+        long captionRevision = Interlocked.Read(ref _captionDocumentRevision);
+        long draftScopeRevision = Interlocked.Read(ref _captionDraftScopeRevision);
+        if (!TryBuildCaptionDocumentCore(out CaptionDocument? document, out _) || document is null)
+            return;
+        if (captionRevision != Interlocked.Read(ref _captionDocumentRevision))
+            return;
+
+        Error.Value = null;
+        IsTranslating.Value = true;
+        TranslationPreview.Value = null;
+        TranslatedLineCount.Value = 0;
+        using CancellationTokenSource requestCts =
+            CancellationTokenSource.CreateLinkedTokenSource(
+                operationLifetime.CancellationToken,
+                _lifetimeCts.Token);
+        _requestCts = requestCts;
+        try
+        {
+            string targetLanguage = SelectedTargetLanguage.Value.Code!;
+            string? selectedSourceLanguage = SelectedSourceLanguage.Value.Code;
+            string? sourceLanguage = selectedSourceLanguage ?? _lastCaptionLanguage;
+            TranslationOperation operation;
+            if (_pendingTranslation is { } current
+                && CanUseTranslationOperation(
+                    current,
+                    document,
+                    targetLanguage,
+                    selectedSourceLanguage,
+                    draftScopeRevision))
+            {
+                operation = current;
+                operation.ExpectedCaptionRevision = captionRevision;
+            }
+            else
+            {
+                CaptionDraftEntry? retained = _retainedCaptionRecoveries.FirstOrDefault(entry =>
+                    CanUseTranslationDraft(
+                        entry.Draft,
+                        document,
+                        targetLanguage,
+                        selectedSourceLanguage));
+                if (!TryParkCurrentCaptionRecovery())
+                {
+                    throw new SubtitleInputException(Strings.AiSubtitle_RunCannotBeRecorded);
+                }
+
+                if (retained is not null)
+                {
+                    _retainedCaptionRecoveries.Remove(retained);
+                    operation = RestoreTranslationOperation(
+                        retained.Draft,
+                        captionRevision,
+                        draftScopeRevision);
+                    _captionDraftJobId = retained.JobId;
+                }
+                else
+                {
+                    ChangeCaptionDraftJob(null, deleteCurrent: false);
+                    operation = CreateTranslationOperation(
+                        document,
+                        captionRevision,
+                        sourceLanguage,
+                        selectedSourceLanguage,
+                        targetLanguage,
+                        draftScopeRevision);
+                }
+            }
+            _pendingTranslation = operation;
+            UpdateOutstandingCaptionRequest();
+            // Read once for the whole run, and taken from the run itself once
+            // it has named anything — see ModelOfRun.
+            AiModelId? runModel = ModelOfRun(
+                operation.CompletedBatchCount > 0
+                    || operation.RequestKey.HasOutstandingName.Value,
+                operation.RequestKeyModel,
+                TranslationModelPicker.SelectedModel);
+            if (operation.Batches.Count == 0)
+            {
+                _pendingTranslation = null;
+                return;
+            }
+
+            for (int index = operation.CompletedBatchCount; index < operation.Batches.Count; index++)
+            {
+                TranslationBatch batch = operation.Batches[index];
+                AiRequestName name = operation.RequestNameFor(index, runModel);
+                AiCaptionTranslationLimits requestLimits = operation.Limits;
+                UpdateOutstandingCaptionRequest();
+                // Anything that ends here ends before the request went out, so
+                // the name reached nothing — a refusal, a run stopped while the
+                // check was in the air, any of it.
+                try
+                {
+                    if (!name.IsRepeat)
+                    {
+                        await EnsureAvailableAsync(
+                            CreateTranslationAvailabilityRequest(
+                                batch,
+                                runModel,
+                                requestLimits));
+                    }
+
+                    // Written before the batch goes out, not after it comes
+                    // back. The first batch is the one most likely to be charged
+                    // and lost, and without this the name that charged it would
+                    // die with the session: the next run would name the same
+                    // batch differently and buy it again. A run that cannot be
+                    // written down is not started at all — sending it would be
+                    // paying for something no later session could ask for.
+                    switch (PublishTranslationPartial(operation))
+                    {
+                        case CaptionDraftOutcome.Superseded:
+                            return;
+                        case CaptionDraftOutcome.NotRecorded:
+                            throw new SubtitleInputException(
+                                Strings.AiSubtitle_RunCannotBeRecorded);
+                    }
+                }
+                catch
+                {
+                    WithdrawTranslationName(operation, name);
+                    throw;
+                }
+
+                AiCaptionTranslationResponse response;
+                try
+                {
+                    response = await _aiService.TranslateAsync(
+                        new AiCaptionTranslationRequest(
+                            batch.Pieces.Select(piece => new AiCaptionTranslationSegment
+                            {
+                                Id = piece.Id,
+                                Text = piece.Text,
+                                Context = new AiCaptionTranslationSegmentContext(
+                                    piece.GroupId,
+                                    piece.ContextPartIndex,
+                                    piece.Start,
+                                    piece.End),
+                            }).ToArray(),
+                            operation.TargetLanguage,
+                            operation.SourceLanguage,
+                            model: runModel,
+                            idempotencyKey: name.Key,
+                            limits: requestLimits),
+                        new Progress<AiCaptionTranslationSegment>(segment =>
+                            operationLifetime.TryPublish(() => ShowTranslatedLine(segment))),
+                        RequestToken);
+                }
+                catch (AiProviderErrorException)
+                {
+                    // The server settled this batch as failed and refunded it.
+                    // Its key would keep answering with that failure, so what is
+                    // left of the run goes out under new ones — and the resume
+                    // state is rewritten with them, or a run resumed after a
+                    // restart would ask under the spent key again.
+                    if (operation.RequestKey.Retire())
+                    {
+                        UpdateOutstandingCaptionRequest();
+                        PublishTranslationPartial(operation);
+                    }
+                    throw;
+                }
+                catch (Exception ex) when (AiRequestOutcome.CanWithdraw(name, ex))
+                {
+                    WithdrawTranslationName(operation, name);
+                    throw;
+                }
+                Dictionary<string, string> translatedBatch = ValidateTranslatedBatch(
+                    batch,
+                    response);
+                if (!operation.RequestKey.Retire(name))
+                    return;
+                AddTranslatedBatch(operation, translatedBatch);
+                RecordCaptionDraftJob(response.JobId, operation.ExpectedDraftScopeRevision);
+                operation.CompletedBatchCount++;
+                UpdateOutstandingCaptionRequest();
+                switch (PublishTranslationPartial(operation))
+                {
+                    case CaptionDraftOutcome.Superseded:
+                        return;
+                    case CaptionDraftOutcome.NotRecorded:
+                        // The response may already have been charged.  Stop
+                        // before the final ClearPartialResult can delete the
+                        // previous durable seed; the next attempt can persist
+                        // this in-memory progress and resume by idempotency key.
+                        throw new SubtitleInputException(
+                            Strings.AiSubtitle_RunCannotBeRecorded);
+                }
+                RefreshTranslationEstimate();
+            }
+
+            if (_disposed
+                || operation.ExpectedCaptionRevision != Interlocked.Read(ref _captionDocumentRevision)
+                || !IsCurrentCaptionDraftScope(operation.ExpectedDraftScopeRevision)
+                || !string.Equals(
+                    SelectedTargetLanguage.Value.Code,
+                    targetLanguage,
+                    StringComparison.Ordinal)
+                || !string.Equals(
+                    SelectedSourceLanguage.Value.Code,
+                    selectedSourceLanguage,
+                    StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            operationLifetime.TryPublish(() =>
+            {
+                _lastCaptionLanguage = targetLanguage;
+                DetectedLanguageText.Value = CreateDetectedLanguageText(targetLanguage);
+                ReplaceCues(BuildTranslationDocument(operation, includeUntranslatedParts: false));
+                ClearPartialResult();
+            });
+        }
+        catch (AuthenticationRequiredException)
+        {
+            operationLifetime.TryPublish(() => SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiAuthenticationRequired));
+        }
+        catch (AiPlanRequiredException)
+        {
+            operationLifetime.TryPublish(() => SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiProRequired));
+        }
+        catch (AiUsageLimitExceededException)
+        {
+            operationLifetime.TryPublish(() => SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiUsageLimitExceeded));
+        }
+        catch (AiProviderErrorException)
+        {
+            operationLifetime.TryPublish(() => SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiProviderError));
+        }
+        // Reachable because a batch keeps its name across attempts. None of
+        // these is a settlement, so the run keeps its names and can be resumed:
+        // saying "an unexpected error" instead sent the user back to a button
+        // that looked like it would start over.
+        catch (AiResultUnavailableException)
+        {
+            operationLifetime.TryPublish(() => SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiResultUnavailable));
+        }
+        catch (AiRequestInProgressException)
+        {
+            operationLifetime.TryPublish(() => SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiRequestInProgress));
+        }
+        // This run's name belongs to another request, so name the remainder anew.
+        catch (AiRequestChangedException)
+        {
+            if (_pendingTranslation?.RequestKey.Retire() == true)
+            {
+                UpdateOutstandingCaptionRequest();
+                if (_pendingTranslation is { } changed)
+                    PublishTranslationPartial(changed);
+            }
+            operationLifetime.TryPublish(() => SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiRequestChanged));
+        }
+        catch (AiRequestWasDeletedException)
+        {
+            // The job those names made is gone, so the rest of the run needs
+            // new ones; the partial that has been paid for is still good.
+            if (_pendingTranslation?.RequestKey.Retire() == true)
+            {
+                UpdateOutstandingCaptionRequest();
+                if (_pendingTranslation is { } deleted)
+                    PublishTranslationPartial(deleted);
+            }
+            operationLifetime.TryPublish(() => SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiRequestWasDeleted));
+        }
+        catch (AiModelDoesNotSupportRequestException)
+        {
+            operationLifetime.TryPublish(() => SetCaptionErrorIfCurrent(
+                draftScopeRevision,
+                Strings.AiModelDoesNotSupportRequest));
+        }
+        catch (AiModelUnavailableException)
+        {
+            operationLifetime.TryPublish(() => SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiModelUnavailable));
+        }
+        catch (SubtitleInputException ex)
+        {
+            operationLifetime.TryPublish(() => SetCaptionErrorIfCurrent(draftScopeRevision, ex.Message));
+        }
+        catch (OperationCanceledException) when (IsRequestCanceled)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to translate subtitles.");
+            operationLifetime.TryPublish(() => SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiUnexpectedError));
+        }
+        finally
+        {
+            _requestCts = null;
+            operationLifetime.TryPublish(() =>
+            {
+                if (IsCurrentCaptionDraftScope(draftScopeRevision))
+                {
+                    IsTranslating.Value = false;
+                    TranslationPreview.Value = null;
+                }
+            });
+        }
+    }
+
+    // A run is worth picking up as soon as it has named a piece, not only once a
+    // piece has come back. The first piece is the one most likely to have been
+    // charged and lost: starting a new run instead would name it differently and
+    // buy it again.
+    private bool CanUseTranslationOperation(
+        TranslationOperation operation,
+        CaptionDocument document,
+        string targetLanguage,
+        string? selectedSourceLanguage,
+        long draftScopeRevision)
+        => (operation.CompletedBatchCount > 0
+                || operation.RequestKey.HasOutstandingName.Value)
+            && operation.CompletedBatchCount <= operation.Batches.Count
+            && operation.ExpectedDraftScopeRevision == draftScopeRevision
+            && (CaptionDocumentsEqual(operation.SourceDocument, document)
+                || CaptionDocumentsEqual(
+                    BuildTranslationDocument(operation, includeUntranslatedParts: true),
+                    document))
+            && string.Equals(operation.TargetLanguage, targetLanguage, StringComparison.Ordinal)
+            && string.Equals(
+                operation.SelectedSourceLanguage,
+                selectedSourceLanguage,
+                StringComparison.Ordinal);
+
+    private static bool CanUseTranslationDraft(
+        CaptionDraft draft,
+        CaptionDocument document,
+        string targetLanguage,
+        string? selectedSourceLanguage)
+        => draft.TranslationResume is { } resume
+            && HoldsPaidWork(draft)
+            && string.Equals(resume.TargetLanguage, targetLanguage, StringComparison.Ordinal)
+            && string.Equals(
+                resume.SelectedSourceLanguage,
+                selectedSourceLanguage,
+                StringComparison.Ordinal)
+            && (StoredCuesEqual(resume.SourceCues, document.Cues)
+                || StoredCuesEqual(draft.Cues, document.Cues));
+
+    private TranslationOperation CreateTranslationOperation(
+        CaptionDocument document,
+        long captionRevision,
+        string? sourceLanguage,
+        string? selectedSourceLanguage,
+        string targetLanguage,
+        long draftScopeRevision)
+    {
+        var sourceDocument = new CaptionDocument(document.Cues.Select(cue => cue with { }));
+        AiCaptionTranslationLimits limits = TranslationModelPicker.CaptionTranslationLimits;
+        AiModelId? model = TranslationModelPicker.SelectedModel;
+        return new TranslationOperation(
+            sourceDocument,
+            captionRevision,
+            sourceLanguage,
+            selectedSourceLanguage,
+            targetLanguage,
+            draftScopeRevision,
+            limits,
+            CreateTranslationBatches(
+                sourceDocument,
+                sourceLanguage,
+                targetLanguage,
+                model,
+                limits));
+    }
+
+    private static TranslationOperation RestoreTranslationOperation(
+        CaptionDraft draft,
+        long captionRevision,
+        long draftScopeRevision)
+    {
+        CaptionTranslationResume resume = draft.TranslationResume
+            ?? throw new InvalidDataException("The retained translation has no resume state.");
+        var sourceDocument = new CaptionDocument(RestoreCues(resume.SourceCues));
+        AiCaptionTranslationLimits limits = TranslationLimitsOf(resume);
+        AiModelId? model = string.IsNullOrEmpty(resume.RequestKeyModel)
+            ? null
+            : new AiModelId(resume.RequestKeyModel);
+        List<TranslationBatch> batches = CreateTranslationBatches(
+            sourceDocument,
+            resume.SourceLanguage,
+            resume.TargetLanguage,
+            model,
+            limits);
+        if (resume.CompletedBatchCount < 0 || resume.CompletedBatchCount > batches.Count)
+            throw new InvalidDataException("The retained translation progress is invalid.");
+
+        var operation = new TranslationOperation(
+            sourceDocument,
+            captionRevision,
+            resume.SourceLanguage,
+            resume.SelectedSourceLanguage,
+            resume.TargetLanguage,
+            draftScopeRevision,
+            limits,
+            batches,
+            string.IsNullOrEmpty(resume.RequestKeySeed) ? null : resume.RequestKeySeed,
+            resume.RequestKeyNamePending)
+        {
+            CompletedBatchCount = resume.CompletedBatchCount,
+            RequestKeyModel = resume.RequestKeyModel,
+        };
+        HashSet<string> completedIds = batches
+            .Take(operation.CompletedBatchCount)
+            .SelectMany(batch => batch.Pieces)
+            .Select(piece => piece.Id)
+            .ToHashSet(StringComparer.Ordinal);
+        if (resume.TranslatedPieces.Count != completedIds.Count
+            || resume.TranslatedPieces.Keys.Any(id => !completedIds.Contains(id)))
+        {
+            throw new InvalidDataException("The retained translated segments are invalid.");
+        }
+        foreach ((string id, string text) in resume.TranslatedPieces)
+        {
+            operation.TranslatedPieces.Add(id, text);
+        }
+        return operation;
+    }
+
+    private static AiCaptionTranslationLimits TranslationLimitsOf(
+        CaptionTranslationResume resume)
+        => resume.MaxSegments > 0
+            && resume.MaxCharacters > 0
+            && resume.MaxRequestBytes > 0
+                ? new AiCaptionTranslationLimits(
+                    resume.MaxSegments,
+                    resume.MaxCharacters,
+                    resume.MaxRequestBytes)
+                : AiCaptionTranslationLimits.Default;
+
+    private static bool CaptionDocumentsEqual(CaptionDocument left, CaptionDocument right)
+        => StoredCuesEqual(StoreCues(left.Cues), right.Cues);
+
+    private static bool StoredCuesEqual(
+        IReadOnlyList<StoredCaptionCue> stored,
+        IReadOnlyList<CaptionCue> current)
+    {
+        if (stored.Count != current.Count)
+            return false;
+
+        for (int index = 0; index < stored.Count; index++)
+        {
+            StoredCaptionCue expected = stored[index];
+            CaptionCue actual = current[index];
+            if (expected.StartTicks != actual.Start.Ticks
+                || expected.EndTicks != actual.End.Ticks
+                || expected.Text != actual.Text
+                || expected.Speaker != actual.Speaker
+                || expected.Language != actual.Language
+                || expected.Metadata.Count != actual.Metadata.Count
+                || expected.Metadata.Any(pair =>
+                    !actual.Metadata.TryGetValue(pair.Key, out string? value)
+                    || value != pair.Value))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static void AddTranslatedBatch(
+        TranslationOperation operation,
+        IReadOnlyDictionary<string, string> translatedBatch)
+    {
+        foreach ((string id, string text) in translatedBatch)
+        {
+            operation.TranslatedPieces.Add(id, text);
+        }
+    }
+
+    private static Dictionary<string, string> ValidateTranslatedBatch(
+        TranslationBatch batch,
+        AiCaptionTranslationResponse response)
+    {
+        var expectedIds = batch.Pieces
+            .Select(piece => piece.Id)
+            .ToHashSet(StringComparer.Ordinal);
+        var responseById = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (AiCaptionTranslationSegment segment in response.Segments)
+        {
+            if (!expectedIds.Contains(segment.Id)
+                || string.IsNullOrWhiteSpace(segment.Text)
+                || !responseById.TryAdd(segment.Id, segment.Text))
+            {
+                throw new AiProviderErrorException(new InvalidDataException(
+                    "The translation provider returned an invalid segment set."));
+            }
+        }
+
+        if (responseById.Count != expectedIds.Count)
+        {
+            throw new AiProviderErrorException(new InvalidDataException(
+                "The translation provider omitted one or more requested segments."));
+        }
+
+        return responseById;
+    }
+
+    internal static void ValidateTranscriptionSegments(
+        IReadOnlyList<AiTranscriptionSegment> segments,
+        double maximumEndSeconds)
+    {
+        double previousEnd = 0;
+        foreach (AiTranscriptionSegment segment in segments)
+        {
+            if (segment is null
+                || !double.IsFinite(segment.Start)
+                || !double.IsFinite(segment.End)
+                || segment.Start < previousEnd
+                || segment.End <= segment.Start
+                || segment.End > maximumEndSeconds
+                || !IsTimeSpanRepresentable(segment.Start)
+                || !IsTimeSpanRepresentable(segment.End)
+                || string.IsNullOrWhiteSpace(segment.Text))
+            {
+                throw new AiProviderErrorException(new InvalidDataException(
+                    "The transcription provider returned an invalid segment set."));
+            }
+
+            previousEnd = segment.End;
+        }
+    }
+
+    private static bool IsTimeSpanRepresentable(double seconds)
+    {
+        try
+        {
+            _ = TimeSpan.FromSeconds(seconds);
+            return true;
+        }
+        catch (OverflowException)
+        {
+            return false;
+        }
+    }
+
+    private CaptionDocument BuildTranslationDocument(
+        TranslationOperation operation,
+        bool includeUntranslatedParts)
+    {
+        TranslationPiece[] pieces = operation.Batches
+            .SelectMany(batch => batch.Pieces)
+            .ToArray();
+        var translatedCues = new List<CaptionCue>(operation.SourceDocument.Count);
+        for (int cueIndex = 0; cueIndex < operation.SourceDocument.Count; cueIndex++)
+        {
+            CaptionCue cue = operation.SourceDocument[cueIndex];
+            TranslationPiece[] cuePieces = pieces
+                .Where(piece => piece.CueIndex == cueIndex)
+                .OrderBy(piece => piece.PartIndex)
+                .ToArray();
+            if (cuePieces.Length == 0)
+            {
+                translatedCues.Add(cue);
+                continue;
+            }
+
+            bool fullyTranslated = cuePieces.All(piece =>
+                operation.TranslatedPieces.ContainsKey(piece.Id));
+            if (!fullyTranslated && !includeUntranslatedParts)
+            {
+                throw new InvalidOperationException("The translation result is incomplete.");
+            }
+
+            // Translation providers are not required to honor the editor's
+            // display limits. Normalize each completed cue here so importing
+            // a translation does not immediately surface a line warning.
+            string translatedText = string.Concat(cuePieces.Select(piece =>
+                operation.TranslatedPieces.TryGetValue(piece.Id, out string? translated)
+                    ? translated
+                    : piece.Text));
+            if (!fullyTranslated)
+            {
+                translatedCues.Add(cue with { Text = translatedText });
+                continue;
+            }
+
+            CaptionTextConstraints constraints = CreateTextConstraints();
+            string wrappedText = CaptionTextWrapper.Wrap(translatedText, constraints);
+            string[] lines = wrappedText.Split('\n');
+            if (lines.Length > constraints.MaximumLineCount
+                && (translatedText.Contains('\n') || translatedText.Contains('\r')))
+            {
+                // A provider may emit presentation line breaks of its own.
+                // Collapse those only when they would exceed the editor's
+                // line-count limit; the wrapper then lays the text out using
+                // the user's configured limits.
+                string flattened = translatedText
+                    .Replace("\r\n", "\n", StringComparison.Ordinal)
+                    .Replace('\r', '\n')
+                    .Replace('\n', ' ');
+                wrappedText = CaptionTextWrapper.Wrap(flattened, constraints);
+                lines = wrappedText.Split('\n');
+            }
+            int cueCount = (lines.Length + constraints.MaximumLineCount - 1)
+                / constraints.MaximumLineCount;
+            long durationTicks = (cue.End - cue.Start).Ticks;
+            // A valid cue normally has enough duration for every split. Keep
+            // the original cue as a last resort when the interval is shorter
+            // than the number of split cues rather than creating invalid
+            // timing or losing text.
+            if (cueCount <= 1 || durationTicks < cueCount)
+            {
+                translatedCues.Add(cue with
+                {
+                    Text = wrappedText,
+                    Language = operation.TargetLanguage,
+                });
+                continue;
+            }
+
+            long baseDuration = durationTicks / cueCount;
+            long remainder = durationTicks % cueCount;
+            long elapsed = 0;
+            for (int splitIndex = 0; splitIndex < cueCount; splitIndex++)
+            {
+                int firstLine = splitIndex * constraints.MaximumLineCount;
+                int lineCount = Math.Min(constraints.MaximumLineCount, lines.Length - firstLine);
+                long splitDuration = baseDuration + (splitIndex < remainder ? 1 : 0);
+                TimeSpan splitStart = cue.Start + TimeSpan.FromTicks(elapsed);
+                elapsed += splitDuration;
+                TimeSpan splitEnd = cue.Start + TimeSpan.FromTicks(elapsed);
+                translatedCues.Add(cue with
+                {
+                    Start = splitStart,
+                    End = splitEnd,
+                    Text = string.Join('\n', lines, firstLine, lineCount),
+                    Language = operation.TargetLanguage,
+                });
+            }
+        }
+
+        return new CaptionDocument(translatedCues);
+    }
+
+    private CaptionDraftOutcome PublishTranslationPartial(TranslationOperation operation)
+    {
+        if (_disposed || !IsCurrentCaptionDraftScope(operation.ExpectedDraftScopeRevision))
+            return CaptionDraftOutcome.Superseded;
+
+        _pendingTranslation = operation;
+        if (SetPartialResult(new RecoverableCaptionResult(
+            BuildTranslationDocument(operation, includeUntranslatedParts: true),
+            operation.TargetLanguage,
+            null,
+            PartialResultKind.Translation,
+            operation.CompletedBatchCount,
+            operation.Batches.Count,
+            operation.ExpectedDraftScopeRevision)) is var outcome
+            and not CaptionDraftOutcome.Recorded)
+        {
+            return outcome;
+        }
+        PartialResultMessage.Value = operation.CompletedBatchCount <= 0
+            ? null
+            : string.Format(
+                operation.CompletedBatchCount == operation.Batches.Count
+                    ? Strings.AiSubtitle_CompletedResultAvailable
+                    : Strings.AiSubtitle_PartialTranslationAvailable,
+                operation.CompletedBatchCount,
+                operation.Batches.Count);
+        RefreshTranslationEstimate();
+        return CaptionDraftOutcome.Recorded;
+    }
+
+    // A run is worth picking up as soon as it has named a piece, not only once a
+    // piece has come back. The first piece is the one most likely to have been
+    // charged and lost: starting a new run instead would name it differently and
+    // buy it again.
+    private bool CanResumeSceneTranscription(
+        AudioSourceItem source,
+        string? language,
+        TimeSpan rangeStart,
+        TimeSpan duration,
+        int chunkCount)
+        => _pendingSceneTranscription is { } operation
+            && (operation.CompletedChunkCount > 0
+                || operation.RequestKey.HasOutstandingName.Value)
+            && operation.CompletedChunkCount <= operation.ChunkCount
+            && source.IsSceneMix
+            && (operation.Source is null || operation.Source.IsSceneMix)
+            && operation.Language == language
+            && operation.RangeStart == rangeStart
+            && operation.Duration == duration
+            && operation.ChunkDuration == SceneMixChunkDuration
+            && operation.ChunkCount == chunkCount
+            && IsCurrentCaptionDraftScope(operation.ExpectedDraftScopeRevision)
+            && (operation.CompletedChunkCount == operation.ChunkCount
+                || operation.ExpectedSceneAudioRevision == Interlocked.Read(ref _sceneAudioRevision)
+                && (operation.CompletedChunkCount == 0
+                    || operation.AudioSessionId == _sceneAudioSessionId))
+            && operation.SceneId == _editViewModel?.Scene.Id;
+
+    private bool CanUseSceneTranscriptionDraft(
+        CaptionDraft draft,
+        Guid sceneId,
+        string? language,
+        TimeSpan rangeStart,
+        TimeSpan duration,
+        TimeSpan chunkDuration,
+        int chunkCount)
+        => draft.SceneTranscriptionResume is { } resume
+            && HoldsPaidWork(draft)
+            && resume.SceneId == sceneId
+            && resume.Language == language
+            && resume.RangeStart == rangeStart
+            && resume.Duration == duration
+            && resume.ChunkDuration == chunkDuration
+            && resume.ChunkCount == chunkCount
+            && (resume.CompletedChunkCount == 0
+                || resume.CompletedChunkCount == resume.ChunkCount
+                || resume.AudioSessionId == _sceneAudioSessionId);
+
+    private static SceneTranscriptionOperation RestoreSceneTranscriptionOperation(
+        CaptionDraft draft,
+        AudioSourceItem source,
+        long captionRevision,
+        long draftScopeRevision,
+        long sceneAudioRevision)
+    {
+        CaptionSceneTranscriptionResume resume = draft.SceneTranscriptionResume
+            ?? throw new InvalidDataException("The retained scene transcription has no resume state.");
+        var operation = new SceneTranscriptionOperation(
+            source,
+            resume.Language,
+            resume.RangeStart,
+            resume.Duration,
+            resume.ChunkDuration,
+            resume.ChunkCount,
+            captionRevision,
+            draftScopeRevision,
+            sceneAudioRevision,
+            resume.SceneId,
+            resume.AudioSessionId,
+            string.IsNullOrEmpty(resume.RequestKeySeed) ? null : resume.RequestKeySeed,
+            resume.RequestKeyNamePending)
+        {
+            CompletedChunkCount = resume.CompletedChunkCount,
+            DetectedLanguage = resume.DetectedLanguage,
+            RequestKeyModel = resume.RequestKeyModel,
+        };
+        operation.Segments.AddRange(CloneSegments(resume.Segments));
+        return operation;
+    }
+
+    private CaptionDraftOutcome PublishSceneTranscriptionPartial(SceneTranscriptionOperation operation)
+    {
+        if (_disposed || !IsCurrentCaptionDraftScope(operation.ExpectedDraftScopeRevision))
+            return CaptionDraftOutcome.Superseded;
+
+        _pendingSceneTranscription = operation;
+        string? detectedLanguage = operation.DetectedLanguage ?? operation.Language;
+        AiTranscriptionSegment[] segments = CloneSegments(operation.Segments);
+        if (SetPartialResult(new RecoverableCaptionResult(
+            CreateCaptionDocument(segments, detectedLanguage),
+            detectedLanguage,
+            segments,
+            PartialResultKind.Transcription,
+            operation.CompletedChunkCount,
+            operation.ChunkCount,
+            operation.ExpectedDraftScopeRevision)) is var outcome
+            and not CaptionDraftOutcome.Recorded)
+        {
+            return outcome;
+        }
+        PartialResultMessage.Value = operation.CompletedChunkCount <= 0
+            ? null
+            : string.Format(
+                operation.CompletedChunkCount == operation.ChunkCount
+                    ? Strings.AiSubtitle_CompletedResultAvailable
+                    : Strings.AiSubtitle_PartialTranscriptionAvailable,
+                operation.CompletedChunkCount,
+                operation.ChunkCount);
+        _transcriptionEstimateRevision.Value++;
+        return CaptionDraftOutcome.Recorded;
+    }
+
+    private bool CanResumeSourceTranscription(
+        AudioSourceItem source,
+        string filePath,
+        string? language,
+        int sampleRate,
+        long totalSamples,
+        int chunkSamples,
+        int chunkCount,
+        SourceAudioFingerprint fingerprint,
+        long draftScopeRevision)
+        => _pendingSourceTranscription is { } operation
+            && (operation.CompletedChunkCount > 0
+                || operation.RequestKey.HasOutstandingName.Value)
+            && operation.CompletedChunkCount <= operation.ChunkCount
+            && (operation.Source is null || AudioSourceItem.CanResume(source, operation.Source))
+            && AudioSourceItem.FilePathsEqual(operation.FilePath, filePath)
+            && operation.ElementId == source.ElementId
+            && operation.Language == language
+            && operation.SampleRate == sampleRate
+            && operation.TotalSamples == totalSamples
+            && operation.ChunkSamples == chunkSamples
+            && operation.ChunkCount == chunkCount
+            && operation.FileLength == fingerprint.FileLength
+            && operation.LastWriteTimeUtcTicks == fingerprint.LastWriteTimeUtcTicks
+            && operation.ExpectedDraftScopeRevision == draftScopeRevision
+            && IsCurrentCaptionDraftScope(draftScopeRevision);
+
+    private static bool CanUseSourceTranscriptionDraft(
+        CaptionDraft draft,
+        AudioSourceItem source,
+        string filePath,
+        string? language,
+        int sampleRate,
+        long totalSamples,
+        int chunkSamples,
+        int chunkCount,
+        SourceAudioFingerprint fingerprint)
+        => draft.SourceTranscriptionResume is { } resume
+            && HoldsPaidWork(draft)
+            && AudioSourceItem.FilePathsEqual(resume.FilePath, filePath)
+            && resume.ElementId == source.ElementId
+            && resume.Language == language
+            && resume.SampleRate == sampleRate
+            && resume.TotalSamples == totalSamples
+            && resume.ChunkSamples == chunkSamples
+            && resume.ChunkCount == chunkCount
+            && resume.FileLength == fingerprint.FileLength
+            && resume.LastWriteTimeUtcTicks == fingerprint.LastWriteTimeUtcTicks;
+
+    private static SourceTranscriptionOperation RestoreSourceTranscriptionOperation(
+        CaptionDraft draft,
+        AudioSourceItem source,
+        long captionRevision,
+        long draftScopeRevision)
+    {
+        CaptionSourceTranscriptionResume resume = draft.SourceTranscriptionResume
+            ?? throw new InvalidDataException("The retained source transcription has no resume state.");
+        var operation = new SourceTranscriptionOperation(
+            source,
+            resume.FilePath,
+            resume.ElementId,
+            resume.FileLength,
+            resume.LastWriteTimeUtcTicks,
+            resume.Language,
+            resume.SampleRate,
+            resume.TotalSamples,
+            resume.ChunkSamples,
+            resume.ChunkCount,
+            captionRevision,
+            draftScopeRevision,
+            string.IsNullOrEmpty(resume.RequestKeySeed) ? null : resume.RequestKeySeed,
+            resume.RequestKeyNamePending)
+        {
+            CompletedChunkCount = resume.CompletedChunkCount,
+            DetectedLanguage = resume.DetectedLanguage,
+            RequestKeyModel = resume.RequestKeyModel,
+        };
+        operation.SourceSegments.AddRange(CloneSegments(resume.Segments));
+        return operation;
+    }
+
+    private CaptionDraftOutcome PublishSourceTranscriptionPartial(SourceTranscriptionOperation operation)
+    {
+        if (_disposed || !IsCurrentCaptionDraftScope(operation.ExpectedDraftScopeRevision))
+            return CaptionDraftOutcome.Superseded;
+
+        _pendingSourceTranscription = operation;
+        if (operation.Source is not { } source)
+            return CaptionDraftOutcome.Superseded;
+
+        string? detectedLanguage = operation.DetectedLanguage ?? operation.Language;
+        AiTranscriptionSegment[] mappedSegments = source.MapSegmentsToScene(
+            operation.SourceSegments);
+        if (SetPartialResult(new RecoverableCaptionResult(
+                CreateCaptionDocument(mappedSegments, detectedLanguage),
+                detectedLanguage,
+                mappedSegments,
+                PartialResultKind.Transcription,
+                operation.CompletedChunkCount,
+                operation.ChunkCount,
+                operation.ExpectedDraftScopeRevision)) is var outcome
+            and not CaptionDraftOutcome.Recorded)
+        {
+            return outcome;
+        }
+        PartialResultMessage.Value = operation.CompletedChunkCount <= 0
+            ? null
+            : string.Format(
+                operation.CompletedChunkCount == operation.ChunkCount
+                    ? Strings.AiSubtitle_CompletedResultAvailable
+                    : Strings.AiSubtitle_PartialTranscriptionAvailable,
+                operation.CompletedChunkCount,
+                operation.ChunkCount);
+        _transcriptionEstimateRevision.Value++;
+        return CaptionDraftOutcome.Recorded;
+    }
+
+    internal static long GetSelectedSourceSampleCount(
+        AudioStreamInfo audioInfo,
+        TimeSpan selectedDuration)
+    {
+        if (audioInfo.SampleRate <= 0)
+            throw new SubtitleInputException(Strings.AiSubtitle_NoAudioInRange);
+
+        double samples = selectedDuration.TotalSeconds * audioInfo.SampleRate;
+        if (!double.IsFinite(samples) || samples <= 0 || samples > int.MaxValue)
+            throw new SubtitleInputException("The source audio duration is unsupported.");
+        return Math.Max(1, checked((long)Math.Ceiling(samples)));
+    }
+
+    private static SourceAudioFingerprint GetSourceAudioFingerprint(string filePath)
+    {
+        var info = new FileInfo(filePath);
+        if (!info.Exists || info.Length <= 0)
+            throw new SubtitleInputException(Strings.AiSubtitle_NoAudioInRange);
+
+        return new SourceAudioFingerprint(info.Length, info.LastWriteTimeUtc.Ticks);
+    }
+
+    internal static bool HasMatchingSourceAudioFingerprint(
+        string filePath,
+        SourceAudioFingerprint expected)
+        => GetSourceAudioFingerprint(filePath) == expected;
+
+    private void DeleteTemporaryAudio(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to remove temporary audio {Path}.", path);
+        }
+    }
+
+    private static CaptionDocument CreateCaptionDocument(
+        IEnumerable<AiTranscriptionSegment> segments,
+        string? language)
+        => new(segments.Select(segment => new CaptionCue(
+            TimeSpan.FromSeconds(segment.Start),
+            TimeSpan.FromSeconds(segment.End),
+            segment.Text,
+            language: language)));
+
+    private static AiTranscriptionSegment[] CloneSegments(
+        IEnumerable<AiTranscriptionSegment> segments)
+        => segments.Select(segment => new AiTranscriptionSegment
+        {
+            Start = segment.Start,
+            End = segment.End,
+            Text = segment.Text,
+        }).ToArray();
+
+    /// <summary>What became of an attempt to write a run down.</summary>
+    private enum CaptionDraftOutcome
+    {
+        /// <summary>
+        /// Written down, or there was nothing to write it to — no signed-in
+        /// user, no project, no scene. Either way the run may go ahead.
+        /// </summary>
+        Recorded,
+
+        /// <summary>
+        /// Nowhere, though it should have been. Another tab holds this scene's
+        /// draft, or the write failed. A request sent now would take its name
+        /// with it when the session ends.
+        /// </summary>
+        NotRecorded,
+
+        /// <summary>The run this belongs to is no longer the one on screen.</summary>
+        Superseded,
+    }
+
+    private CaptionDraftOutcome SetPartialResult(RecoverableCaptionResult result)
+    {
+        if (!IsCurrentCaptionDraftScope(result.DraftScopeRevision))
+            return CaptionDraftOutcome.Superseded;
+
+        // Another tab previously owned this scene's draft. Retry now in case it released the
+        // draft; giving up after one failure would permanently block paid operations in this tab.
+        if (_captionDraftSession is null && _captionDraftScopeIsHeldElsewhere)
+            TakeOverReleasedCaptionDraft();
+
+        _partialResult = result;
+        // A run that has only named its first piece has nothing to apply yet.
+        // It is still written down — the name is what makes that piece
+        // collectable — but the button that imports a partial stays closed.
+        HasPartialResult.Value = result.CompletedSteps > 0;
+        if (_captionDraftIsUnreadable && !CanWriteOverUnreadableDraft())
+            return CaptionDraftOutcome.NotRecorded;
+
+        if (_captionDraftSession is null)
+        {
+            return _captionDraftScopeIsHeldElsewhere
+                ? CaptionDraftOutcome.NotRecorded
+                : CaptionDraftOutcome.Recorded;
+        }
+
+        CaptionDraft draft = CreateCaptionDraft(result);
+        if (!HoldsPaidWork(draft) && _retainedCaptionRecoveries.Count > 0)
+        {
+            ResetCurrentCaptionRecovery();
+            PersistRetainedCaptionRecoveries();
+            return CaptionDraftOutcome.Recorded;
+        }
+
+        try
+        {
+            _captionDraftSession.Save(new CaptionDraftEntry(
+                _captionDraftJobId,
+                draft,
+                _retainedCaptionRecoveries.ToArray()));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to persist a recoverable paid caption result.");
+            // The failed write leaves the previous draft on disk. Do not delete it: it may be the
+            // only record of paid chunks and their name. Replaying that older name is safe because
+            // it identifies paid work, settled work, or nothing; deleting it can force a repurchase.
+            return CaptionDraftOutcome.NotRecorded;
+        }
+        return CaptionDraftOutcome.Recorded;
+    }
+
+    private CaptionDraft CreateCaptionDraft(RecoverableCaptionResult result)
+    {
+        CaptionTranslationResume? translationResume = null;
+        if (result.Kind == PartialResultKind.Translation
+            && _pendingTranslation is { } translation)
+        {
+            translationResume = new CaptionTranslationResume(
+                StoreCues(translation.SourceDocument.Cues),
+                translation.SourceLanguage,
+                translation.SelectedSourceLanguage,
+                translation.TargetLanguage,
+                new Dictionary<string, string>(translation.TranslatedPieces, StringComparer.Ordinal),
+                translation.CompletedBatchCount,
+                translation.RequestKeySeed,
+                translation.RequestKeyModel,
+                translation.RequestKey.HasOutstandingName.Value,
+                translation.Limits.MaxSegments,
+                translation.Limits.MaxCharacters,
+                translation.Limits.MaxRequestBytes);
+        }
+
+        CaptionSceneTranscriptionResume? sceneResume = null;
+        if (result.Kind == PartialResultKind.Transcription
+            && result.Segments is { } resultSegments
+            && _pendingSceneTranscription is { } scene
+            && scene.CompletedChunkCount == result.CompletedSteps
+            && scene.ChunkCount == result.TotalSteps
+            && SegmentsEqual(scene.Segments, resultSegments))
+        {
+            sceneResume = new CaptionSceneTranscriptionResume(
+                scene.SceneId,
+                scene.Language,
+                scene.RangeStart,
+                scene.Duration,
+                scene.ChunkDuration,
+                scene.ChunkCount,
+                CloneSegments(scene.Segments),
+                scene.DetectedLanguage,
+                scene.CompletedChunkCount,
+                scene.RequestKeySeed,
+                scene.RequestKeyModel,
+                scene.RequestKey.HasOutstandingName.Value,
+                scene.AudioSessionId);
+        }
+
+        CaptionSourceTranscriptionResume? sourceResume = null;
+        if (result.Kind == PartialResultKind.Transcription
+            && result.Segments is { } sourceResultSegments
+            && _pendingSourceTranscription is { } sourceTranscription
+            && sourceTranscription.CompletedChunkCount == result.CompletedSteps
+            && sourceTranscription.ChunkCount == result.TotalSteps
+            && (sourceTranscription.Source is null
+                || SegmentsEqual(
+                    sourceTranscription.Source.MapSegmentsToScene(
+                        sourceTranscription.SourceSegments),
+                    sourceResultSegments)))
+        {
+            sourceResume = new CaptionSourceTranscriptionResume(
+                sourceTranscription.FilePath,
+                sourceTranscription.ElementId,
+                sourceTranscription.FileLength,
+                sourceTranscription.LastWriteTimeUtcTicks,
+                sourceTranscription.Language,
+                sourceTranscription.SampleRate,
+                sourceTranscription.TotalSamples,
+                sourceTranscription.ChunkSamples,
+                sourceTranscription.ChunkCount,
+                CloneSegments(sourceTranscription.SourceSegments),
+                sourceTranscription.DetectedLanguage,
+                sourceTranscription.CompletedChunkCount,
+                sourceTranscription.RequestKeySeed,
+                sourceTranscription.RequestKeyModel,
+                sourceTranscription.RequestKey.HasOutstandingName.Value);
+        }
+
+        return new CaptionDraft(
+            FileCaptionDraftStore.CurrentVersion,
+            StoreCues(result.Document.Cues),
+            result.Language,
+            result.Segments is null ? null : CloneSegments(result.Segments),
+            result.Kind == PartialResultKind.Translation
+                ? CaptionDraftKind.Translation
+                : CaptionDraftKind.Transcription,
+            result.CompletedSteps,
+            result.TotalSteps,
+            translationResume,
+            sceneResume,
+            sourceResume);
+    }
+
+    private bool TryParkCurrentCaptionRecovery()
+    {
+        if (_partialResult is { } result)
+        {
+            var entry = new CaptionDraftEntry(_captionDraftJobId, CreateCaptionDraft(result));
+            if (HoldsPaidWork(entry.Draft))
+            {
+                string identity = GetRecoveryIdentity(entry);
+                int duplicate = _retainedCaptionRecoveries.FindIndex(candidate =>
+                    string.Equals(GetRecoveryIdentity(candidate), identity, StringComparison.Ordinal));
+                if (duplicate >= 0)
+                {
+                    _retainedCaptionRecoveries[duplicate] = entry;
+                }
+                else
+                {
+                    if (_retainedCaptionRecoveries.Count
+                        >= FileCaptionDraftStore.MaximumRetainedRecoveries)
+                        return false;
+                    _retainedCaptionRecoveries.Add(entry);
+                }
+            }
+        }
+
+        ResetCurrentCaptionRecovery();
+        return true;
+    }
+
+    private void ResetCurrentCaptionRecovery()
+    {
+        _partialResult = null;
+        _pendingTranslation = null;
+        _pendingSceneTranscription = null;
+        _pendingSourceTranscription = null;
+        _captionDraftJobId = null;
+        HasPartialResult.Value = false;
+        PartialResultMessage.Value = null;
+        ClearRestoredModelPreference();
+        UpdateOutstandingCaptionRequest();
+    }
+
+    private static string GetRecoveryIdentity(CaptionDraftEntry entry)
+    {
+        CaptionDraft draft = entry.Draft;
+        string seed = draft.TranslationResume?.RequestKeySeed
+            ?? draft.SourceTranscriptionResume?.RequestKeySeed
+            ?? draft.SceneTranscriptionResume?.RequestKeySeed
+            ?? string.Empty;
+        return $"{draft.Kind}:{seed}:{entry.JobId}";
+    }
+
+    private void PersistRetainedCaptionRecoveries()
+    {
+        if (_captionDraftSession is null || _retainedCaptionRecoveries.Count == 0)
+            return;
+
+        CaptionDraftEntry root = _retainedCaptionRecoveries[^1];
+        CaptionDraftEntry[] additional = _retainedCaptionRecoveries
+            .Take(_retainedCaptionRecoveries.Count - 1)
+            .ToArray();
+        try
+        {
+            _captionDraftSession.Save(new CaptionDraftEntry(
+                root.JobId,
+                root.Draft,
+                additional));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to persist retained paid caption recoveries.");
+        }
+    }
+
+    private void RestoreCaptionDraft()
+    {
+        if (_captionDraftSession is null)
+            return;
+
+        CaptionDraftReadResult read;
+        try
+        {
+            read = _captionDraftSession.Read();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to restore the recoverable paid caption result.");
+            read = CaptionDraftReadResult.Unreadable;
+        }
+
+        // Unreadable is not absent. The draft may contain an already-paid request name, so do not
+        // write this scene or begin paid work until it becomes readable.
+        _captionDraftIsUnreadable = read.Outcome == CaptionDraftReadOutcome.Unreadable;
+        CaptionDraftEntry? entry = read.Entry;
+        if (entry is null)
+            return;
+
+        try
+        {
+            _retainedCaptionRecoveries.Clear();
+            _retainedCaptionRecoveries.AddRange(entry.Recoveries);
+            _captionDraftJobId = entry.JobId;
+            CaptionDraft draft = entry.Draft;
+            long draftScopeRevision = Interlocked.Read(ref _captionDraftScopeRevision);
+            var document = new CaptionDocument(RestoreCues(draft.Cues));
+            PartialResultKind kind = draft.Kind == CaptionDraftKind.Translation
+                ? PartialResultKind.Translation
+                : PartialResultKind.Transcription;
+            _partialResult = new RecoverableCaptionResult(
+                document,
+                draft.Language,
+                draft.Segments is null ? null : CloneSegments(draft.Segments),
+                kind,
+                draft.CompletedSteps,
+                draft.TotalSteps,
+                draftScopeRevision);
+
+            if (draft.TranslationResume is { } translation)
+            {
+                try
+                {
+                    TranslationOperation operation = RestoreTranslationOperation(
+                        draft,
+                        Interlocked.Read(ref _captionDocumentRevision),
+                        draftScopeRevision);
+                    // The unfinished batches are named partly by the model the
+                    // run used. Landing on another one would name them
+                    // differently and buy them again.
+                    _restoredTranslationModel =
+                        string.IsNullOrEmpty(translation.RequestKeyModel)
+                            ? null
+                            : new AiModelId(translation.RequestKeyModel);
+                    PreferRestoredModel(
+                        TranslationModelPicker,
+                        _restoredTranslationModel);
+                    _pendingTranslation = operation;
+                    CaptionLanguageOption? sourceOption = SourceLanguages.FirstOrDefault(option =>
+                        string.Equals(
+                            option.Code,
+                            translation.SelectedSourceLanguage,
+                            StringComparison.Ordinal));
+                    CaptionLanguageOption? targetOption = TargetLanguages.FirstOrDefault(option =>
+                        string.Equals(
+                            option.Code,
+                            translation.TargetLanguage,
+                            StringComparison.Ordinal));
+                    if (sourceOption is not null)
+                        SelectedSourceLanguage.Value = sourceOption;
+                    if (targetOption is not null)
+                        SelectedTargetLanguage.Value = targetOption;
+                    if (draft.CompletedSteps == 0
+                        && translation.RequestKeyNamePending
+                        && _editableCues.Count == 0)
+                    {
+                        ReplaceCues(new CaptionDocument(
+                            operation.SourceDocument.Cues.Select(cue => cue with { })));
+                        operation.ExpectedCaptionRevision = Interlocked.Read(
+                            ref _captionDocumentRevision);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Restored a paid caption draft without resumable translation state.");
+                }
+            }
+
+            if (draft.SceneTranscriptionResume is { } scene
+                && scene.SceneId == _editViewModel?.Scene.Id)
+            {
+                // Scene audio is composed rather than read from a file. A pending first chunk is
+                // safe to retry because the server validates that chunk's fingerprint, and a
+                // complete result needs no new audio. A partially completed run carries its old
+                // session identifier so it cannot combine those unverifiable chunks with audio
+                // composed by this dialog lifetime.
+                _pendingSceneTranscription = new SceneTranscriptionOperation(
+                    null,
+                    scene.Language,
+                    scene.RangeStart,
+                    scene.Duration,
+                    scene.ChunkDuration,
+                    scene.ChunkCount,
+                    Interlocked.Read(ref _captionDocumentRevision),
+                    draftScopeRevision,
+                    Interlocked.Read(ref _sceneAudioRevision),
+                    scene.SceneId,
+                    scene.AudioSessionId,
+                    string.IsNullOrEmpty(scene.RequestKeySeed) ? null : scene.RequestKeySeed,
+                    scene.RequestKeyNamePending)
+                {
+                    CompletedChunkCount = scene.CompletedChunkCount,
+                    DetectedLanguage = scene.DetectedLanguage,
+                    RequestKeyModel = scene.RequestKeyModel,
+                };
+                _pendingSceneTranscription.Segments.AddRange(CloneSegments(scene.Segments));
+                _restoredTranscriptionModel =
+                    string.IsNullOrEmpty(scene.RequestKeyModel)
+                        ? null
+                        : new AiModelId(scene.RequestKeyModel);
+                PreferRestoredModel(
+                    TranscriptionModelPicker,
+                    _restoredTranscriptionModel);
+                CaptionLanguageOption? sourceOption = SourceLanguages.FirstOrDefault(option =>
+                    string.Equals(option.Code, scene.Language, StringComparison.Ordinal));
+                if (sourceOption is not null)
+                    SelectedSourceLanguage.Value = sourceOption;
+            }
+
+            if (draft.SourceTranscriptionResume is { } source)
+            {
+                _pendingSourceTranscription = new SourceTranscriptionOperation(
+                    null,
+                    source.FilePath,
+                    source.ElementId,
+                    source.FileLength,
+                    source.LastWriteTimeUtcTicks,
+                    source.Language,
+                    source.SampleRate,
+                    source.TotalSamples,
+                    source.ChunkSamples,
+                    source.ChunkCount,
+                    Interlocked.Read(ref _captionDocumentRevision),
+                    draftScopeRevision,
+                    string.IsNullOrEmpty(source.RequestKeySeed) ? null : source.RequestKeySeed,
+                    source.RequestKeyNamePending)
+                {
+                    CompletedChunkCount = source.CompletedChunkCount,
+                    DetectedLanguage = source.DetectedLanguage,
+                    RequestKeyModel = source.RequestKeyModel,
+                };
+                _restoredTranscriptionModel =
+                    string.IsNullOrEmpty(source.RequestKeyModel)
+                        ? null
+                        : new AiModelId(source.RequestKeyModel);
+                PreferRestoredModel(
+                    TranscriptionModelPicker,
+                    _restoredTranscriptionModel);
+                _pendingSourceTranscription.SourceSegments.AddRange(CloneSegments(source.Segments));
+                CaptionLanguageOption? sourceOption = SourceLanguages.FirstOrDefault(option =>
+                    string.Equals(option.Code, source.Language, StringComparison.Ordinal));
+                if (sourceOption is not null)
+                    SelectedSourceLanguage.Value = sourceOption;
+            }
+
+            // A draft written the moment its first piece was named holds the
+            // way back to that piece and nothing to apply yet.
+            HasPartialResult.Value = draft.CompletedSteps > 0;
+            PartialResultMessage.Value = draft.CompletedSteps <= 0
+                ? null
+                : draft.CompletedSteps == draft.TotalSteps
+                    ? Strings.AiSubtitle_CompletedResultAvailable
+                    : string.Format(
+                        kind == PartialResultKind.Translation
+                            ? Strings.AiSubtitle_PartialTranslationAvailable
+                            : Strings.AiSubtitle_PartialTranscriptionAvailable,
+                        draft.CompletedSteps,
+                        draft.TotalSteps);
+            // Expose the name held by a restored run to the UI. Otherwise a run that looks empty
+            // because only its first chunk was sent could be overwritten without confirmation.
+            UpdateOutstandingCaptionRequest();
+            _transcriptionEstimateRevision.Value++;
+            RefreshTranslationEstimate();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Ignored an invalid recoverable caption draft.");
+            ClearPartialResult();
+        }
+    }
+
+    private static bool SegmentsEqual(
+        IReadOnlyList<AiTranscriptionSegment> first,
+        IReadOnlyList<AiTranscriptionSegment> second)
+    {
+        if (first.Count != second.Count)
+            return false;
+
+        for (int index = 0; index < first.Count; index++)
+        {
+            if (first[index].Start != second[index].Start
+                || first[index].End != second[index].End
+                || first[index].Text != second[index].Text)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static StoredCaptionCue[] StoreCues(IEnumerable<CaptionCue> cues)
+        => cues.Select(cue => new StoredCaptionCue(
+            cue.Start.Ticks,
+            cue.End.Ticks,
+            cue.Text,
+            cue.Speaker,
+            cue.Language,
+            cue.Metadata.ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal)))
+            .ToArray();
+
+    private static CaptionCue[] RestoreCues(IEnumerable<StoredCaptionCue> cues)
+        => cues.Select(cue => new CaptionCue(
+            TimeSpan.FromTicks(cue.StartTicks),
+            TimeSpan.FromTicks(cue.EndTicks),
+            cue.Text,
+            cue.Speaker,
+            cue.Language,
+            new CaptionMetadata(cue.Metadata)))
+            .ToArray();
+
+    private void ApplyPartialResultCore()
+    {
+        if (_partialResult is not { } result
+            || !IsCurrentCaptionDraftScope(result.DraftScopeRevision))
+            return;
+
+        _lastCaptionLanguage = result.Language;
+        DetectedLanguageText.Value = CreateDetectedLanguageText(result.Language);
+        if (result.Segments is { } segments)
+        {
+            ResultSegments.Value = CloneSegments(segments);
+        }
+        else
+        {
+            ReplaceCues(new CaptionDocument(result.Document.Cues.Select(cue => cue with { })));
+        }
+
+        if (result.Kind == PartialResultKind.Translation
+            && _pendingTranslation is { } translation)
+        {
+            translation.ExpectedCaptionRevision = Interlocked.Read(ref _captionDocumentRevision);
+        }
+        else if (result.Kind == PartialResultKind.Transcription
+            && _pendingSceneTranscription is { } transcription)
+        {
+            transcription.ExpectedCaptionRevision = Interlocked.Read(ref _captionDocumentRevision);
+        }
+        else if (result.Kind == PartialResultKind.Transcription
+            && _pendingSourceTranscription is { } sourceTranscription)
+        {
+            sourceTranscription.ExpectedCaptionRevision = Interlocked.Read(
+                ref _captionDocumentRevision);
+        }
+        Error.Value = null;
+        if (result.CompletedSteps == result.TotalSteps)
+        {
+            ClearPartialResult();
+        }
+        else
+        {
+            RefreshTranslationEstimate();
+        }
+    }
+
+    private void ClearPartialResult()
+    {
+        ResetCurrentCaptionRecovery();
+        if (_retainedCaptionRecoveries.Count == 0)
+        {
+            try
+            {
+                _captionDraftSession?.Delete();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to remove the recoverable caption draft.");
+            }
+        }
+        else
+        {
+            PersistRetainedCaptionRecoveries();
+        }
+        _transcriptionEstimateRevision.Value++;
+        RefreshTranslationEstimate();
+    }
+
+    private void InvalidatePartialResultResume()
+    {
+        _transcriptionEstimateRevision.Value++;
+        RefreshTranslationEstimate();
+    }
+
+    private async Task ImportCaptionsCore()
+    {
+        using AsyncOperationLifetime.Operation? operationLifetime = _operations.TryEnter();
+        if (operationLifetime is null)
+            return;
+        IStorageProvider? storage = GetStorageProvider();
+        if (storage is null)
+            return;
+
+        IReadOnlyList<IStorageFile> files = await storage.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            AllowMultiple = false,
+            FileTypeFilter = [CreateCaptionFileType(canDecode: true)],
+        });
+        using IDisposable fileOwnership = SharedFilePickerOptions.OwnStorageFiles(files);
+        if (files.Count == 0)
+            return;
+
+        try
+        {
+            if (!_captionCodecs.TryGetByFileName(
+                    files[0].Name,
+                    out CaptionCodecInfo? codec)
+                || !codec.CanDecode)
+            {
+                throw new NotSupportedException("No caption codec is registered for this file extension.");
+            }
+            await using Stream stream = await files[0].OpenReadAsync();
+            using var memory = new SizeLimitedMemoryStream(AiCaptionHistoryResultParser.MaximumResultBytes);
+            await stream.CopyToAsync(memory, operationLifetime.CancellationToken);
+            operationLifetime.TryPublish(() => ImportCaptionBytes(memory.ToArray(), codec.Format));
+        }
+        catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to import captions.");
+            operationLifetime.TryPublish(() => Error.Value = Strings.AiSubtitle_ImportFailed);
+        }
+    }
+
+    private async Task ExportCaptionsCore()
+    {
+        using AsyncOperationLifetime.Operation? operationLifetime = _operations.TryEnter();
+        if (operationLifetime is null)
+            return;
+        if (!TryBuildCaptionDocument(out CaptionDocument? document, out _) || document is null)
+            return;
+
+        IStorageProvider? storage = GetStorageProvider();
+        if (storage is null)
+            return;
+
+        using IStorageFile? file = await storage.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            SuggestedFileName = "subtitles.srt",
+            DefaultExtension = "srt",
+            FileTypeChoices = [CreateCaptionFileType(canEncode: true)],
+        });
+        if (file is null)
+            return;
+
+        try
+        {
+            if (!_captionCodecs.TryGetByFileName(
+                    file.Name,
+                    out CaptionCodecInfo? codec)
+                || !codec.CanEncode)
+            {
+                throw new NotSupportedException("No caption codec is registered for this file extension.");
+            }
+            bool exported = await TryWriteCaptionExportAsync(
+                document,
+                codec.Format,
+                _captionSerializer,
+                ConfirmLossySrtExportAsync,
+                (bytes, cancellationToken) => WriteCaptionExportAsync(
+                    file,
+                    bytes,
+                    cancellationToken),
+                operationLifetime.CancellationToken);
+            if (!exported)
+                return;
+
+            operationLifetime.TryPublish(() => NotificationService.ShowSuccess(Strings.AiSubtitle, Strings.AiSubtitle_Exported));
+        }
+        catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to export captions.");
+            operationLifetime.TryPublish(() => Error.Value = Strings.AiSubtitle_ExportFailed);
+        }
+    }
+
+    private void AddCueCore()
+    {
+        TimeSpan start = _editableCues.LastOrDefault()?.TryCreateCue(out CaptionCue? last) == true
+            ? last!.End
+            : _editViewModel?.Player.CurrentFrame.Value ?? TimeSpan.Zero;
+        var cue = new CaptionCue(start, start + TimeSpan.FromSeconds(2), string.Empty);
+        var item = new EditableCaptionCueViewModel(_editableCues.Count + 1, cue);
+        AttachCue(item);
+        _editableCues.Add(item);
+        MarkCaptionDocumentChanged();
+        SelectedCue.Value = item;
+        RefreshCaptionState();
+    }
+
+    internal bool ImportCaptionBytes(ReadOnlySpan<byte> bytes, CaptionFormatId format)
+    {
+        CaptionImportResult result = _captionSerializer.Import(bytes, format);
+        if (result.Document is null)
+        {
+            Error.Value = result.Diagnostics.FirstOrDefault()?.Message ?? Strings.AiSubtitle_ImportFailed;
+            return false;
+        }
+
+        if (!TryParkCurrentCaptionRecovery())
+        {
+            Error.Value = Strings.AiSubtitle_RunCannotBeRecorded;
+            return false;
+        }
+        if (_retainedCaptionRecoveries.Count == 0)
+            ChangeCaptionDraftJob(null, deleteCurrent: true);
+        else
+            PersistRetainedCaptionRecoveries();
+        _lastCaptionLanguage = null;
+        DetectedLanguageText.Value = null;
+        ReplaceCues(result.Document);
+        Error.Value = result.Diagnostics.FirstOrDefault()?.Message;
+        return true;
+    }
+
+    private void ChangeCaptionDraftJob(string? jobId, bool deleteCurrent)
+    {
+        if (deleteCurrent && _captionDraftSession is not null)
+        {
+            try
+            {
+                _captionDraftSession.Delete();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to remove the previous recoverable caption draft.");
+            }
+        }
+        if (deleteCurrent)
+            _retainedCaptionRecoveries.Clear();
+        _captionDraftJobId = string.IsNullOrWhiteSpace(jobId) ? null : jobId.Trim();
+    }
+
+    private void HandleCaptionDraftScopeChanged(CaptionDraftScope? scope)
+    {
+        if (_captionDraftScopeInitialized && _captionDraftBaseScope == scope)
+            return;
+
+        bool resetCaptionState = _captionDraftScopeInitialized;
+        _captionDraftScopeInitialized = true;
+        Interlocked.Increment(ref _captionDraftScopeRevision);
+        _captionDraftBaseScope = scope;
+        _captionDraftJobId = null;
+        if (resetCaptionState)
+        {
+            ResetCaptionStateForAccountChange();
+        }
+
+        OpenCaptionDraftSession(scope);
+        RestoreCaptionDraft();
+    }
+
+    // When this run's name can no longer be used because its job vanished or belongs to another
+    // request, retain paid chunks and purchase only the remainder under a new name. Persist that
+    // name so another restoration does not retry the unusable one.
+    private void RetireTranscriptionRunNames()
+    {
+        if (_pendingSourceTranscription is { } source)
+        {
+            if (source.RequestKey.Retire())
+                PublishSourceTranscriptionPartial(source);
+        }
+
+        if (_pendingSceneTranscription is { } scene)
+        {
+            if (scene.RequestKey.Retire())
+                PublishSceneTranscriptionPartial(scene);
+        }
+
+        UpdateOutstandingCaptionRequest();
+    }
+
+    // Whether a caption run has named a piece the server has not been seen to
+    // settle. While it has, asking again may be answered by a job already paid
+    // for, so the button stays live however little is left to spend.
+    // Withdraw a name that ended before dispatch and persist that fact. Leaving it marked as held
+    // would make the next session treat unpaid work as recovery and bypass its balance check.
+    private void WithdrawSourceTranscriptionName(
+        SourceTranscriptionOperation operation,
+        AiRequestName name)
+    {
+        if (!operation.RequestKey.WithdrawAfterNoReservation(name))
+            return;
+        UpdateOutstandingCaptionRequest();
+        PublishSourceTranscriptionPartial(operation);
+    }
+
+    private void WithdrawSceneTranscriptionName(
+        SceneTranscriptionOperation operation,
+        AiRequestName name)
+    {
+        if (!operation.RequestKey.WithdrawAfterNoReservation(name))
+            return;
+        UpdateOutstandingCaptionRequest();
+        PublishSceneTranscriptionPartial(operation);
+    }
+
+    private void WithdrawTranslationName(
+        TranslationOperation operation,
+        AiRequestName name)
+    {
+        if (!operation.RequestKey.WithdrawAfterNoReservation(name))
+            return;
+        UpdateOutstandingCaptionRequest();
+        PublishTranslationPartial(operation);
+    }
+
+    private void UpdateOutstandingCaptionRequest()
+    {
+        if (_disposed)
+            return;
+
+        HasOutstandingTranscriptionRequest.Value =
+            _pendingSourceTranscription?.RequestKey.HasOutstandingName.Value == true
+            || _pendingSceneTranscription?.RequestKey.HasOutstandingName.Value == true
+            || _pendingSourceTranscription is { CompletedChunkCount: > 0 } completedSource
+            && completedSource.CompletedChunkCount == completedSource.ChunkCount
+            || _pendingSceneTranscription is { CompletedChunkCount: > 0 } completedScene
+            && completedScene.CompletedChunkCount == completedScene.ChunkCount;
+        HasOutstandingTranslationRequest.Value =
+            _pendingTranslation?.RequestKey.HasOutstandingName.Value == true
+            || _pendingTranslation is { CompletedBatchCount: > 0 } completedTranslation
+            && completedTranslation.CompletedBatchCount == completedTranslation.Batches.Count
+            || _retainedCaptionRecoveries.Any(entry =>
+                entry.Draft.Kind == CaptionDraftKind.Translation
+                && (entry.Draft.TranslationResume?.RequestKeyNamePending == true
+                    || entry.Draft.CompletedSteps > 0
+                    && entry.Draft.CompletedSteps == entry.Draft.TotalSteps));
+        HasOutstandingTranscriptionRequest.Value |= _retainedCaptionRecoveries.Any(entry =>
+            entry.Draft.Kind == CaptionDraftKind.Transcription
+            && (entry.Draft.SourceTranscriptionResume?.RequestKeyNamePending == true
+                || entry.Draft.SceneTranscriptionResume?.RequestKeyNamePending == true
+                || entry.Draft.CompletedSteps > 0
+                && entry.Draft.CompletedSteps == entry.Draft.TotalSteps));
+    }
+
+    private bool HasPendingTranslationName()
+        => _pendingTranslation?.RequestKey.HasOutstandingName.Value == true
+            || _retainedCaptionRecoveries.Any(entry =>
+                entry.Draft.TranslationResume?.RequestKeyNamePending == true);
+
+    private bool HasPendingTranscriptionName()
+        => _pendingSourceTranscription?.RequestKey.HasOutstandingName.Value == true
+            || _pendingSceneTranscription?.RequestKey.HasOutstandingName.Value == true
+            || _retainedCaptionRecoveries.Any(entry =>
+                entry.Draft.SourceTranscriptionResume?.RequestKeyNamePending == true
+                || entry.Draft.SceneTranscriptionResume?.RequestKeyNamePending == true);
+
+    private IReadOnlyList<AiModelId> OutstandingTranslationModels()
+        => EnumerateOutstandingModels(
+                _pendingTranslation is { } current
+                && (current.RequestKey.HasOutstandingName.Value
+                    || current.CompletedBatchCount > 0
+                    && current.CompletedBatchCount < current.Batches.Count)
+                        ? current.RequestKeyModel
+                        : null,
+                _retainedCaptionRecoveries
+                    .Where(entry => entry.Draft.TranslationResume is { } resume
+                        && (resume.RequestKeyNamePending
+                            || entry.Draft.CompletedSteps > 0
+                            && entry.Draft.CompletedSteps < entry.Draft.TotalSteps))
+                    .Select(entry => entry.Draft.TranslationResume!.RequestKeyModel))
+            .ToArray();
+
+    private IReadOnlyList<AiModelId> OutstandingTranscriptionModels()
+        => EnumerateOutstandingModels(
+                CurrentTranscriptionModel(),
+                _retainedCaptionRecoveries
+                    .Where(entry => entry.Draft.Kind == CaptionDraftKind.Transcription
+                        && (entry.Draft.CompletedSteps > 0
+                            && entry.Draft.CompletedSteps < entry.Draft.TotalSteps
+                            || entry.Draft.SourceTranscriptionResume?.RequestKeyNamePending == true
+                            || entry.Draft.SceneTranscriptionResume?.RequestKeyNamePending == true))
+                    .Select(entry => entry.Draft.SourceTranscriptionResume?.RequestKeyModel
+                        ?? entry.Draft.SceneTranscriptionResume?.RequestKeyModel
+                        ?? string.Empty))
+            .ToArray();
+
+    private string? CurrentTranscriptionModel()
+    {
+        if (_pendingSourceTranscription is { } source
+            && (source.RequestKey.HasOutstandingName.Value
+                || source.CompletedChunkCount > 0
+                && source.CompletedChunkCount < source.ChunkCount))
+        {
+            return source.RequestKeyModel;
+        }
+        if (_pendingSceneTranscription is { } scene
+            && (scene.RequestKey.HasOutstandingName.Value
+                || scene.CompletedChunkCount > 0
+                && scene.CompletedChunkCount < scene.ChunkCount))
+        {
+            return scene.RequestKeyModel;
+        }
+        return null;
+    }
+
+    private static IEnumerable<AiModelId> EnumerateOutstandingModels(
+        string? current,
+        IEnumerable<string> retained)
+        => retained.Prepend(current ?? string.Empty)
+            .Where(model => !string.IsNullOrWhiteSpace(model))
+            .Distinct(StringComparer.Ordinal)
+            .Select(model => new AiModelId(model));
+
+
+
+    private void ClearRestoredModelPreference()
+    {
+        _restoredTranscriptionModel = null;
+        _restoredTranslationModel = null;
+    }
+
+    // A draft can be restored before the pickers have loaded or after, so the
+    // model a run was named for is both remembered for a load still to come and
+    // applied at once to one that has already happened.
+    private static void PreferRestoredModel(
+        AiModelPickerViewModel picker,
+        AiModelId? model)
+    {
+        if (model is not { } wanted)
+            return;
+
+        AiModelPickerOption? option =
+            picker.Options.FirstOrDefault(candidate => candidate.Id == wanted);
+        if (option is not null)
+            picker.Selected.Value = option;
+    }
+
+    private bool IsCurrentCaptionDraftScope(long revision)
+        => revision == Interlocked.Read(ref _captionDraftScopeRevision);
+
+    private void SetCaptionErrorIfCurrent(long revision, string error)
+    {
+        if (!_disposed && IsCurrentCaptionDraftScope(revision))
+        {
+            Error.Value = error;
+        }
+    }
+
+    private void RecordCaptionDraftJob(AiJobId? jobId, long revision)
+    {
+        if (!_disposed
+            && jobId is { } value
+            && value.Value.Length > 0
+            && IsCurrentCaptionDraftScope(revision))
+        {
+            _captionDraftJobId = value.Value;
+        }
+    }
+
+    private void ResetCaptionStateForAccountChange()
+    {
+        _partialResult = null;
+        _pendingTranslation = null;
+        _pendingSceneTranscription = null;
+        _pendingSourceTranscription = null;
+        _retainedCaptionRecoveries.Clear();
+        _pendingHistoryResult = null;
+        _lastCaptionLanguage = null;
+        ClearRestoredModelPreference();
+        UpdateOutstandingCaptionRequest();
+        HasPartialResult.Value = false;
+        HasPendingHistoryResult.Value = false;
+        PartialResultMessage.Value = null;
+        HistoryOverwriteMessage.Value = null;
+        DetectedLanguageText.Value = null;
+        Error.Value = null;
+        IsTranscribing.Value = false;
+        IsTranslating.Value = false;
+        SelectedSubtitlePageIndex.Value = TranscribePageIndex;
+        ResultSegments.Value = null;
+        ReplaceCues(new CaptionDocument());
+        SelectedSourceLanguage.Value = SourceLanguages[0];
+        SelectedTargetLanguage.Value = GetDefaultTargetLanguage();
+        _transcriptionEstimateRevision.Value++;
+        RefreshTranslationEstimate();
+    }
+
+    private CaptionLanguageOption GetDefaultTargetLanguage()
+    {
+        string targetCode = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName == "ja" ? "en" : "ja";
+        return TargetLanguages.First(option => option.Code == targetCode);
+    }
+
+    // Recheck whether an unreadable draft is now readable. If it contains paid work, writing this
+    // run would overwrite its name and chunks. Claim the scene only after proving the draft empty.
+    private bool CanWriteOverUnreadableDraft()
+    {
+        if (_captionDraftSession is null)
+            return false;
+
+        CaptionDraftReadResult read;
+        try
+        {
+            read = _captionDraftSession.Read();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to re-read a caption draft that could not be read.");
+            return false;
+        }
+
+        if (read.Outcome == CaptionDraftReadOutcome.Unreadable)
+            return false;
+        if (read.Entry is { } entry && HoldsPaidWork(entry))
+            return false;
+
+        _captionDraftIsUnreadable = false;
+        return true;
+    }
+
+    // Take over a released draft only if it contains no paid work. Overwriting another run's name
+    // and chunks mid-execution would make them unreachable and force a repurchase; opening that
+    // scene separately can restore them safely instead.
+    private void TakeOverReleasedCaptionDraft()
+    {
+        OpenCaptionDraftSession(_captionDraftBaseScope);
+        if (_captionDraftSession is null)
+            return;
+
+        CaptionDraftReadResult left;
+        try
+        {
+            left = _captionDraftSession.Read();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to read the caption draft left by another tab.");
+            left = CaptionDraftReadResult.Unreadable;
+        }
+
+        // Take over only after proving the draft empty; unreadable is not empty.
+        if (left.Outcome == CaptionDraftReadOutcome.Absent)
+            return;
+        if (left.Entry is { } entry && !HoldsPaidWork(entry))
+            return;
+
+        _captionDraftSession.Dispose();
+        _captionDraftSession = null;
+        _captionDraftScopeIsHeldElsewhere = true;
+    }
+
+    // A draft is protected from overwrite only when it ended with a held name or contains paid
+    // chunks. An unreserved, withdrawn name may leave a seed, but no job, so it need not block takeover.
+    private static bool HoldsPaidWork(CaptionDraft draft)
+        => draft.CompletedSteps > 0
+            || draft.TranslationResume?.RequestKeyNamePending == true
+            || draft.SourceTranscriptionResume?.RequestKeyNamePending == true
+            || draft.SceneTranscriptionResume?.RequestKeyNamePending == true;
+
+    private static bool HoldsPaidWork(CaptionDraftEntry entry)
+        => HoldsPaidWork(entry.Draft)
+            || entry.Recoveries.Any(recovery => HoldsPaidWork(recovery.Draft));
+
+    private void OpenCaptionDraftSession(CaptionDraftScope? scope)
+    {
+        _captionDraftSession?.Dispose();
+        _captionDraftSession = null;
+        // Nothing to write to is not the same as failing to write. Without a
+        // signed-in user, a project and a scene there is no draft at all, and
+        // the screen works the way it did before drafts existed. A scope that
+        // exists and cannot be opened is another tab holding this scene: that
+        // run has somewhere it should be written down and cannot be.
+        _captionDraftScopeIsHeldElsewhere = false;
+        if (scope is null)
+            return;
+
+        if (_captionDraftStore.TryOpen(scope, out ICaptionDraftSession? session))
+        {
+            _captionDraftSession = session;
+        }
+        else
+        {
+            _captionDraftScopeIsHeldElsewhere = true;
+        }
+    }
+
+    internal byte[] ExportCaptionBytes(CaptionFormatId format)
+    {
+        if (!TryBuildCaptionDocument(out CaptionDocument? document, out string? error)
+            || document is null)
+        {
+            throw new CaptionExportException(null, error ?? Strings.AiSubtitle_ExportFailed);
+        }
+        return _captionSerializer.Export(document, format);
+    }
+
+    internal static async Task<bool> TryWriteCaptionExportAsync(
+        CaptionDocument document,
+        CaptionFormatId format,
+        CaptionDocumentSerializer serializer,
+        Func<CancellationToken, Task<bool>> confirmLossySrtExport,
+        Func<byte[], CancellationToken, Task> write,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(serializer);
+        ArgumentNullException.ThrowIfNull(confirmLossySrtExport);
+        ArgumentNullException.ThrowIfNull(write);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        CaptionDocument exportDocument = document;
+        if (format == CaptionFormats.Srt && HasUnsupportedSrtMetadata(document))
+        {
+            if (!await confirmLossySrtExport(cancellationToken))
+                return false;
+
+            cancellationToken.ThrowIfCancellationRequested();
+            exportDocument = new CaptionDocument(document.Cues.Select(cue => new CaptionCue(
+                cue.Start,
+                cue.End,
+                cue.Text)));
+        }
+
+        byte[] bytes = serializer.Export(exportDocument, format);
+        await write(bytes, cancellationToken);
+        return true;
+    }
+
+    private static bool HasUnsupportedSrtMetadata(CaptionDocument document)
+        => document.Cues.Any(cue =>
+            cue.Speaker is not null
+            || cue.Language is not null
+            || cue.Metadata.Count > 0);
+
+    private static async Task<bool> ConfirmLossySrtExportAsync(
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var dialog = new ContentDialog
+        {
+            Title = Strings.AiSubtitle_LossySrtExportTitle,
+            Content = Strings.AiSubtitle_LossySrtExportMessage,
+            PrimaryButtonText = Strings.AiSubtitle_Export,
+            CloseButtonText = Strings.Cancel,
+            DefaultButton = ContentDialogButton.Close,
+        };
+        var showDialog = dialog.ShowAsync();
+        using CancellationTokenRegistration cancellationRegistration =
+            cancellationToken.Register(static state =>
+            {
+                var contentDialog = (ContentDialog)state!;
+                Dispatcher.UIThread.Post(contentDialog.Hide);
+            }, dialog);
+        ContentDialogResult result = await showDialog;
+        cancellationToken.ThrowIfCancellationRequested();
+        return result == ContentDialogResult.Primary;
+    }
+
+    private void DeleteCueCore()
+    {
+        if (SelectedCue.Value is not { } selected)
+            return;
+
+        int index = _editableCues.IndexOf(selected);
+        if (index < 0)
+            return;
+
+        selected.PropertyChanged -= OnCuePropertyChanged;
+        _editableCues.RemoveAt(index);
+        RenumberCues();
+        MarkCaptionDocumentChanged();
+        SelectedCue.Value = _editableCues.Count == 0
+            ? null
+            : _editableCues[Math.Min(index, _editableCues.Count - 1)];
+        RefreshCaptionState();
+    }
+
+    private void SplitCueCore()
+    {
+        if (SelectedCue.Value is not { } selected
+            || !TryBuildCaptionDocumentCore(out CaptionDocument? document, out _)
+            || document is null)
+        {
+            return;
+        }
+
+        int index = _editableCues.IndexOf(selected);
+        if (index < 0)
+            return;
+
+        CaptionCue cue = document[index];
+        int textOffset = selected.CaretIndex;
+        if (!TryGetCueSplitTime(cue, textOffset, out TimeSpan splitTime))
+            return;
+
+        document.SplitCue(index, splitTime, textOffset);
+        ReplaceCues(document);
+        SelectedCue.Value = _editableCues[index + 1];
+    }
+
+    private void MergeCueCore()
+    {
+        if (SelectedCue.Value is not { } selected
+            || !TryBuildCaptionDocumentCore(out CaptionDocument? document, out _)
+            || document is null)
+        {
+            return;
+        }
+
+        int index = _editableCues.IndexOf(selected);
+        if (index < 0 || index >= document.Count - 1)
+            return;
+
+        document.MergeWithNext(index);
+        ReplaceCues(document);
+        SelectedCue.Value = _editableCues[index];
+    }
+
+    private void WrapCuesCore()
+    {
+        CaptionTextConstraints constraints = CreateTextConstraints();
+        foreach (EditableCaptionCueViewModel cue in _editableCues)
+        {
+            cue.Text = CaptionTextWrapper.Wrap(cue.Text, constraints);
+        }
+        RefreshCaptionState();
+    }
+
+    private void ApplyTranscriptionSegments(AiTranscriptionSegment[]? segments)
+    {
+        if (_disposed)
+            return;
+
+        if (segments is not { Length: > 0 })
+        {
+            ReplaceCues(new CaptionDocument());
+            return;
+        }
+
+        ReplaceCues(new CaptionDocument(segments.Select(segment => new CaptionCue(
+            TimeSpan.FromSeconds(segment.Start),
+            TimeSpan.FromSeconds(segment.End),
+            segment.Text,
+            language: _lastCaptionLanguage))));
+    }
+
+    private void ReplaceCues(CaptionDocument document)
+    {
+        if (_disposed)
+            return;
+
+        foreach (EditableCaptionCueViewModel cue in _editableCues)
+        {
+            cue.PropertyChanged -= OnCuePropertyChanged;
+        }
+        _editableCues.Clear();
+        for (int index = 0; index < document.Count; index++)
+        {
+            var cue = new EditableCaptionCueViewModel(index + 1, document[index]);
+            AttachCue(cue);
+            _editableCues.Add(cue);
+        }
+        MarkCaptionDocumentChanged();
+        SelectedCue.Value = _editableCues.FirstOrDefault();
+        if (document.Count > 0)
+            SelectedSubtitlePageIndex.Value = EditPageIndex;
+        RefreshCaptionState();
+    }
+
+    private void AttachCue(EditableCaptionCueViewModel cue)
+        => cue.PropertyChanged += OnCuePropertyChanged;
+
+    private void OnCuePropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(EditableCaptionCueViewModel.CaretIndex))
+        {
+            RefreshCueCommandStates();
+            return;
+        }
+
+        if (e.PropertyName != nameof(EditableCaptionCueViewModel.Number))
+        {
+            MarkCaptionDocumentChanged();
+        }
+        RefreshCueCommandStates();
+        RefreshCaptionState();
+    }
+
+    private void MarkCaptionDocumentChanged()
+        => Interlocked.Increment(ref _captionDocumentRevision);
+
+    private void RenumberCues()
+    {
+        for (int index = 0; index < _editableCues.Count; index++)
+        {
+            _editableCues[index].Number = index + 1;
+        }
+    }
+
+    private void RefreshCaptionState()
+    {
+        bool timingValid = TryBuildCaptionDocumentCore(out CaptionDocument? document, out string? parseError);
+        HasTimingValidCues.Value = timingValid && document is { Count: > 0 };
+        if (!timingValid || document is null)
+        {
+            HasValidCues.Value = false;
+            CaptionValidationMessage.Value = parseError;
+        }
+        else
+        {
+            IReadOnlyList<CaptionValidationIssue> issues = CaptionDocumentValidator.Validate(
+                document,
+                CreateTextConstraints());
+            CaptionValidationIssue[] blockingIssues = GetBlockingIssues(issues);
+            HasValidCues.Value = document.Count > 0 && blockingIssues.Length == 0;
+            CaptionValidationMessage.Value = blockingIssues.Length > 0
+                ? string.Format(Strings.AiSubtitle_ValidationIssues, blockingIssues.Length)
+                : issues.Any(issue => issue.Kind == CaptionValidationIssueKind.Overlap)
+                    ? Strings.AiSubtitle_OverlapWarning
+                    : null;
+        }
+
+        RefreshTranslationEstimate();
+        RefreshTemplatePreview();
+    }
+
+    private void RefreshCueCommandStates()
+    {
+        EditableCaptionCueViewModel? selected = SelectedCue.Value;
+        int index = selected is null ? -1 : _editableCues.IndexOf(selected);
+        _canDeleteCue.Value = index >= 0;
+        _canMergeCue.Value = index >= 0
+            && index < _editableCues.Count - 1
+            && TryBuildCaptionDocumentCore(out _, out _);
+        _canSplitCue.Value = index >= 0
+            && TryBuildCaptionDocumentCore(out CaptionDocument? document, out _)
+            && document is not null
+            && TryGetCueSplitTime(document[index], selected!.CaretIndex, out _);
+    }
+
+    private static bool TryGetCueSplitTime(
+        CaptionCue cue,
+        int textOffset,
+        out TimeSpan splitTime)
+    {
+        splitTime = default;
+        if (textOffset <= 0 || textOffset >= cue.Text.Length)
+            return false;
+
+        int[] boundaries = StringInfo.ParseCombiningCharacters(cue.Text);
+        int boundaryIndex = Array.BinarySearch(boundaries, textOffset);
+        long durationTicks = (cue.End - cue.Start).Ticks;
+        if (boundaryIndex <= 0 || durationTicks <= 1)
+            return false;
+
+        long offsetTicks = (long)Math.Round(
+            durationTicks * (boundaryIndex / (double)boundaries.Length),
+            MidpointRounding.AwayFromZero);
+        offsetTicks = Math.Clamp(offsetTicks, 1, durationTicks - 1);
+        splitTime = cue.Start + TimeSpan.FromTicks(offsetTicks);
+        return true;
+    }
+
+    private void RefreshTranslationEstimate()
+    {
+        if (_disposed)
+            return;
+
+        _translationEstimateRevision.Value++;
+    }
+
+    private void RefreshTranslationAvailability()
+    {
+        AiOperationAvailabilityRequest? request = null;
+        if (_pendingTranslation is { } operation
+            && operation.CompletedBatchCount < operation.Batches.Count
+            && operation.ExpectedCaptionRevision == Interlocked.Read(ref _captionDocumentRevision)
+            && IsCurrentCaptionDraftScope(operation.ExpectedDraftScopeRevision)
+            && string.Equals(
+                operation.TargetLanguage,
+                SelectedTargetLanguage.Value.Code,
+                StringComparison.Ordinal)
+            && string.Equals(
+                operation.SelectedSourceLanguage,
+                SelectedSourceLanguage.Value.Code,
+                StringComparison.Ordinal))
+        {
+            request = CreateTranslationAvailabilityRequest(
+                operation.Batches[operation.CompletedBatchCount],
+                limits: operation.Limits);
+        }
+        else if (TryBuildCaptionDocumentCore(out CaptionDocument? document, out _)
+                 && document is { Count: > 0 }
+                 && SelectedTargetLanguage.Value.Code is { } targetLanguage)
+        {
+            AiCaptionTranslationLimits limits =
+                TranslationModelPicker.CaptionTranslationLimits;
+            request = CreateTranslationBatches(
+                    document,
+                    SelectedSourceLanguage.Value.Code ?? _lastCaptionLanguage,
+                    targetLanguage,
+                    TranslationModelPicker.SelectedModel,
+                    limits)
+                .FirstOrDefault() is { } batch
+                ? CreateTranslationAvailabilityRequest(batch, limits: limits)
+                : null;
+        }
+
+        _translationAvailability.Check(request);
+    }
+
+    private void RefreshTemplatePreview()
+    {
+        if (_disposed)
+            return;
+
+        if (SelectedSubtitlePageIndex.Value != EditPageIndex)
+        {
+            CancellationTokenSource? previewCts;
+            lock (_templatePreviewGate)
+            {
+                previewCts = _templatePreviewCts;
+                _templatePreviewCts = null;
+            }
+            CancelTemplatePreview(previewCts);
+            ReplaceTemplatePreviewImage(null);
+            return;
+        }
+
+        string text = SelectedCue.Value?.Text
+            ?? _editableCues.FirstOrDefault()?.Text
+            ?? Strings.AiSubtitle_PreviewSample;
+        TemplatePreviewText.Value = string.IsNullOrWhiteSpace(text)
+            ? Strings.AiSubtitle_PreviewSample
+            : text;
+        TemplatePreviewFontSize.Value = 24;
+        CaptionCue cue = SelectedCue.Value?.TryCreateCue(out CaptionCue? selectedCue) == true
+            && selectedCue is not null
+            ? string.IsNullOrWhiteSpace(selectedCue.Text)
+                ? selectedCue with { Text = TemplatePreviewText.Value }
+                : selectedCue
+            : new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(2), TemplatePreviewText.Value);
+        if (Volatile.Read(ref _templatePreviewAttachments) > 0)
+            RefreshTemplatePreviewImage(cue);
+    }
+
+    internal void AttachTemplatePreview()
+    {
+        bool refresh;
+        lock (_templatePreviewGate)
+        {
+            if (_disposed)
+                return;
+
+            _templatePreviewAttachments++;
+            refresh = _templatePreviewAttachments == 1;
+        }
+        if (refresh)
+            RefreshTemplatePreview();
+    }
+
+    internal void DetachTemplatePreview()
+    {
+        CancellationTokenSource? previewCts;
+        lock (_templatePreviewGate)
+        {
+            if (_templatePreviewAttachments <= 0)
+                return;
+
+            _templatePreviewAttachments--;
+            if (_templatePreviewAttachments > 0)
+                return;
+
+            previewCts = _templatePreviewCts;
+            _templatePreviewCts = null;
+        }
+
+        CancelTemplatePreview(previewCts);
+        if (!_disposed)
+            ReplaceTemplatePreviewImage(null);
+    }
+
+    private void RefreshTemplatePreviewImage(CaptionCue cue)
+    {
+        BeforeTemplatePreviewAdmission?.Invoke();
+        CancellationTokenSource cts = new();
+        CancellationTokenSource? previous;
+        AsyncOperationLifetime.Operation? operation;
+        lock (_templatePreviewGate)
+        {
+            if (_disposed
+                || _templatePreviewAttachments <= 0
+                || SelectedSubtitlePageIndex.Value != EditPageIndex)
+            {
+                cts.Dispose();
+                return;
+            }
+
+            operation = _operations.TryEnter();
+            if (operation is null)
+            {
+                cts.Dispose();
+                return;
+            }
+
+            previous = _templatePreviewCts;
+            _templatePreviewCts = cts;
+        }
+
+        CancelTemplatePreview(previous);
+        if (!operation.TryPublish(() => ReplaceTemplatePreviewImage(null)))
+        {
+            lock (_templatePreviewGate)
+            {
+                if (ReferenceEquals(_templatePreviewCts, cts))
+                    _templatePreviewCts = null;
+            }
+            operation.Dispose();
+            cts.Dispose();
+            return;
+        }
+        CaptionTemplateId templateId = SelectedCaptionTemplate.Value.Id;
+        Beutl.Media.PixelSize frameSize = _editViewModel is { } editor
+            ? new Beutl.Media.PixelSize(editor.Scene.FrameSize.Width, editor.Scene.FrameSize.Height)
+            : new Beutl.Media.PixelSize(1920, 1080);
+        _ = RenderTemplatePreviewImageAsync(cue, templateId, frameSize, cts, operation);
+    }
+
+    private async Task RenderTemplatePreviewImageAsync(
+        CaptionCue cue,
+        CaptionTemplateId templateId,
+        Beutl.Media.PixelSize frameSize,
+        CancellationTokenSource cts,
+        AsyncOperationLifetime.Operation operation)
+    {
+        using AsyncOperationLifetime.Operation ownedOperation = operation;
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token,
+            ownedOperation.CancellationToken);
+        CancellationToken cancellationToken = linkedCts.Token;
+        try
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
+            var elements = new List<Element>();
+            using (ICaptionTemplateLease template = _captionTemplates.Acquire(
+                       templateId))
+            {
+                CaptionElementContext context = new(
+                    0,
+                    Strings.AiSubtitle,
+                    new Beutl.Graphics.Point(
+                        0,
+                        frameSize.Height * 0.35f));
+                foreach (ElementDescription description in template.CreateElements(cue, context))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    Element element;
+                    switch (description.Source)
+                    {
+                        case ElementSource.EngineObject source:
+                            element = new Element
+                            {
+                                Start = description.Start,
+                                Length = description.Length ?? TimeSpan.FromSeconds(2),
+                                ZIndex = description.Layer,
+                            };
+                            element.AddObject(source.Factory());
+                            break;
+                        case ElementSource.ElementTemplate source:
+                            element = source.Factory()
+                                ?? throw new InvalidOperationException("The element-template factory returned null.");
+                            element.Start = description.Start;
+                            if (description.Length is { } length)
+                                element.Length = length;
+                            element.ZIndex = description.Layer;
+                            break;
+                        default:
+                            return;
+                    }
+
+                    if (description.Position is { } position)
+                    {
+                        foreach (Beutl.Graphics.Drawable drawable in element.Objects.OfType<Beutl.Graphics.Drawable>())
+                        {
+                            Beutl.Graphics.Transformation.Transform? transform = drawable.Transform.CurrentValue;
+                            Beutl.Helpers.AddOrSetHelper.AddOrSet(
+                                ref transform,
+                                new Beutl.Graphics.Transformation.TranslateTransform(position));
+                            drawable.Transform.CurrentValue = transform;
+                        }
+                    }
+
+                    elements.Add(element);
+                }
+                if (elements.Count == 0)
+                    return;
+
+                byte[]? png = await TemplatePreviewRenderer(
+                        elements,
+                        frameSize,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
+                Ref<Beutl.Media.Bitmap>? image = null;
+                if (png is { Length: > 0 })
+                {
+                    using var stream = new MemoryStream(png, writable: false);
+                    image = Ref<Beutl.Media.Bitmap>.Create(Beutl.Media.Bitmap.FromStream(stream));
+                }
+
+                bool transferred = false;
+                try
+                {
+                    await Dispatcher.UIThread.InvokeAsync(() =>
+                    {
+                        if (!cancellationToken.IsCancellationRequested
+                            && SelectedSubtitlePageIndex.Value == EditPageIndex
+                            && ownedOperation.TryPublish(() => ReplaceTemplatePreviewImage(image)))
+                        {
+                            transferred = true;
+                        }
+                    });
+                }
+                finally
+                {
+                    if (!transferred)
+                        image?.Dispose();
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to render a subtitle template preview.");
+        }
+        finally
+        {
+            lock (_templatePreviewGate)
+            {
+                if (ReferenceEquals(_templatePreviewCts, cts))
+                    _templatePreviewCts = null;
+            }
+            cts.Dispose();
+        }
+    }
+
+    private void StopTemplatePreviewAdmission()
+        => CancelTemplatePreview(CloseTemplatePreviewAdmission());
+
+    private CancellationTokenSource? CloseTemplatePreviewAdmission()
+    {
+        lock (_templatePreviewGate)
+        {
+            _templatePreviewAttachments = 0;
+            CancellationTokenSource? previewCts = _templatePreviewCts;
+            _templatePreviewCts = null;
+            return previewCts;
+        }
+    }
+
+    private void ReplaceTemplatePreviewImage(Ref<Beutl.Media.Bitmap>? image)
+    {
+        Ref<Beutl.Media.Bitmap>? previous = TemplatePreviewImage.Value;
+        TemplatePreviewImage.Value = image;
+        previous?.Dispose();
+    }
+
+    private void CancelTemplatePreview(CancellationTokenSource? cancellation)
+    {
+        try
+        {
+            cancellation?.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to cancel a superseded subtitle template preview.");
+        }
+    }
+
+    internal bool TryBuildCaptionDocument(out CaptionDocument? document, out string? error)
+    {
+        if (!TryBuildCaptionDocumentCore(out document, out error) || document is null)
+            return false;
+
+        IReadOnlyList<CaptionValidationIssue> issues = CaptionDocumentValidator.Validate(
+            document,
+            CreateTextConstraints());
+        CaptionValidationIssue[] blockingIssues = GetBlockingIssues(issues);
+        if (blockingIssues.Length > 0)
+        {
+            error = string.Format(Strings.AiSubtitle_ValidationIssues, blockingIssues.Length);
+            return false;
+        }
+        return document.Count > 0;
+    }
+
+    private bool TryBuildCaptionDocumentCore(out CaptionDocument? document, out string? error)
+    {
+        var cues = new List<CaptionCue>(_editableCues.Count);
+        foreach (EditableCaptionCueViewModel item in _editableCues)
+        {
+            if (!item.TryCreateCue(out CaptionCue? cue) || cue is null)
+            {
+                document = null;
+                error = Strings.AiSubtitle_InvalidTiming;
+                return false;
+            }
+            cues.Add(cue);
+        }
+        document = new CaptionDocument(cues);
+        error = null;
+        return true;
+    }
+
+    private CaptionTextConstraints CreateTextConstraints()
+        => new(Math.Max(MaximumLineLength.Value, 1), Math.Max(MaximumLineCount.Value, 1));
+
+    private static CaptionValidationIssue[] GetBlockingIssues(
+        IReadOnlyList<CaptionValidationIssue> issues)
+        => issues.Where(issue => issue.Kind != CaptionValidationIssueKind.Overlap).ToArray();
+
+    // The line the model has just translated, shown while the rest is still
+    // being worked on. It is a preview: what ends up on the cues is the batch
+    // the server returns, checked as it always was.
+    private void ShowTranslatedLine(AiCaptionTranslationSegment segment)
+    {
+        if (_disposed || string.IsNullOrEmpty(segment.Text))
+            return;
+
+        TranslationPreview.Value = segment.Text;
+        TranslatedLineCount.Value++;
+    }
+
+    // The name the chunk is uploaded under. Part of what the server fingerprints
+    // the request by, so it has to be the same on every attempt at one chunk;
+    // the file it is read from is named for uniqueness on disk instead.
+    private static string FormatChunkFileName(string prefix, int chunkIndex)
+        => $"{prefix}-chunk-{chunkIndex:D4}.wav";
+
+    private static IReadOnlyList<CaptionLanguageOption> CreateLanguageOptions(bool includeAuto)
+    {
+        var result = new List<CaptionLanguageOption>();
+        if (includeAuto)
+        {
+            result.Add(new CaptionLanguageOption(null, Strings.AiLanguageAuto));
+        }
+        result.AddRange(
+        [
+            new CaptionLanguageOption("ja", "日本語 (ja)"),
+            new CaptionLanguageOption("en", "English (en)"),
+            new CaptionLanguageOption("zh", "中文 (zh)"),
+            new CaptionLanguageOption("ko", "한국어 (ko)"),
+            new CaptionLanguageOption("es", "Español (es)"),
+            new CaptionLanguageOption("fr", "Français (fr)"),
+            new CaptionLanguageOption("de", "Deutsch (de)"),
+            new CaptionLanguageOption("pt", "Português (pt)"),
+            new CaptionLanguageOption("it", "Italiano (it)"),
+            new CaptionLanguageOption("ru", "Русский (ru)"),
+            new CaptionLanguageOption("ar", "العربية (ar)"),
+            new CaptionLanguageOption("hi", "हिन्दी (hi)"),
+        ]);
+        return result;
+    }
+
+    private AiOperationAvailabilityRequest? CreateTranscriptionAvailabilityRequest(
+        AudioSourceItem? source)
+    {
+        if (source is null)
+            return null;
+        TimeSpan duration = source.Duration;
+        TimeSpan rangeStart = TimeSpan.Zero;
+        if (source.IsSceneMix
+            && (!TryGetSceneRange(out rangeStart, out duration) || duration <= TimeSpan.Zero))
+        {
+            return null;
+        }
+        if (source.IsSceneMix)
+        {
+            int chunkCount = (int)Math.Ceiling(
+                duration.TotalSeconds / SceneMixChunkDuration.TotalSeconds);
+            int completed = CanResumeSceneTranscription(
+                source,
+                SelectedSourceLanguage.Value.Code,
+                rangeStart,
+                duration,
+                chunkCount)
+                ? _pendingSceneTranscription!.CompletedChunkCount
+                : 0;
+            TimeSpan offset = TimeSpan.FromTicks(Math.Min(
+                duration.Ticks,
+                completed * SceneMixChunkDuration.Ticks));
+            duration = TimeSpan.FromTicks(Math.Min(
+                SceneMixChunkDuration.Ticks,
+                duration.Ticks - offset.Ticks));
+        }
+        else
+        {
+            duration = duration <= TimeSpan.Zero
+                ? duration
+                : TimeSpan.FromTicks(Math.Min(duration.Ticks, SceneMixChunkDuration.Ticks));
+        }
+        return duration > TimeSpan.Zero
+            ? new AiOperationAvailabilityRequest.Transcription(
+                AiOperations.Transcription,
+                duration.TotalSeconds,
+                TranscriptionModelPicker.SelectedModel)
+            : null;
+    }
+
+    private AiOperationAvailabilityRequest.Translation CreateTranslationAvailabilityRequest(
+        TranslationBatch batch,
+        AiModelId? model = null,
+        AiCaptionTranslationLimits? limits = null)
+        // What the batch will actually be sent to. A run in progress is priced
+        // against the model its names were built from, not against whichever the
+        // picker is showing now.
+        => new(
+            AiOperations.CaptionTranslation,
+            batch.Pieces.Sum(piece => piece.Text.Length),
+            model ?? TranslationModelPicker.SelectedModel,
+            limits ?? TranslationModelPicker.CaptionTranslationLimits);
+
+    // The model a run is named for. The picker's until the run has named
+    // anything, and from then on the run's own — including when the run named
+    // its pieces with no model at all, which is not the same as having named
+    // nothing yet.
+    private static AiModelId? ModelOfRun(
+        bool hasNamedAnything,
+        string recorded,
+        AiModelId? selected)
+        => !hasNamedAnything
+            ? selected
+            : string.IsNullOrEmpty(recorded)
+                ? null
+                : new AiModelId(recorded);
+
+    private async Task EnsureAvailableAsync(AiOperationAvailabilityRequest request)
+    {
+        AiOperationAvailabilityTracker tracker = request is AiOperationAvailabilityRequest.Translation
+            ? _translationAvailability
+            : _transcriptionAvailability;
+        if (!await tracker.CheckNowAsync(request, RequestToken))
+            throw new AiUsageLimitExceededException();
+    }
+
+    // The transcribed range is the scene's own: the tab has nothing to add to
+    // what the timeline already says about where the work starts and ends.
+    private bool TryGetSceneRange(out TimeSpan start, out TimeSpan duration)
+    {
+        start = _editViewModel?.Scene.Start ?? TimeSpan.Zero;
+        duration = _editViewModel?.Scene.Duration ?? TimeSpan.Zero;
+        return _editViewModel is not null && start >= TimeSpan.Zero && duration > TimeSpan.Zero;
+    }
+
+    private IObservable<TimeSpan> CreateSceneRangeObservable()
+        => _editViewModel is { } editor
+            ? editor.Scene.GetObservable(Scene.StartProperty)
+                .CombineLatest(
+                    editor.Scene.GetObservable(Scene.DurationProperty),
+                    (start, duration) => start < TimeSpan.Zero ? TimeSpan.Zero : duration)
+            : Observable.Return(TimeSpan.Zero);
+
+    private static string? CreateDetectedLanguageText(string? language)
+        => string.IsNullOrWhiteSpace(language)
+            ? null
+            : string.Format(Strings.AiSubtitle_DetectedLanguage, language);
+
+    private static List<TranslationBatch> CreateTranslationBatches(
+        CaptionDocument document,
+        string? sourceLanguage,
+        string targetLanguage,
+        AiModelId? model,
+        AiCaptionTranslationLimits limits)
+    {
+        var pieces = new List<TranslationPiece>();
+        for (int cueIndex = 0; cueIndex < document.Count; cueIndex++)
+        {
+            CaptionCue cue = document[cueIndex];
+            if (string.IsNullOrWhiteSpace(cue.Text))
+                continue;
+
+            int[] textElementBoundaries = CreateTranslationTextElementBoundaries(cue.Text);
+            int offset = 0;
+            int partIndex = 0;
+            while (offset < cue.Text.Length)
+            {
+                int maximumLength = Math.Min(
+                    limits.MaxCharacters,
+                    cue.Text.Length - offset);
+                int length = LargestTranslationPieceLength(
+                    cue,
+                    cueIndex,
+                    partIndex,
+                    offset,
+                    maximumLength,
+                    textElementBoundaries,
+                    sourceLanguage,
+                    targetLanguage,
+                    model,
+                    limits);
+                if (length <= 0)
+                    throw new SubtitleInputException(Strings.AiFileTooLarge);
+
+                pieces.Add(CreateTranslationPiece(
+                    cue,
+                    cueIndex,
+                    partIndex,
+                    cue.Text.Substring(offset, length),
+                    limits));
+                offset += length;
+                partIndex++;
+            }
+        }
+
+        var batches = new List<TranslationBatch>();
+        int start = 0;
+        while (start < pieces.Count)
+        {
+            int candidateCount = 0;
+            int characters = 0;
+            while (start + candidateCount < pieces.Count
+                   && candidateCount < limits.MaxSegments
+                   && characters + pieces[start + candidateCount].Text.Length
+                   <= limits.MaxCharacters)
+            {
+                characters += pieces[start + candidateCount].Text.Length;
+                candidateCount++;
+            }
+
+            int count = LargestTranslationBatchPrefix(
+                pieces,
+                start,
+                candidateCount,
+                sourceLanguage,
+                targetLanguage,
+                model,
+                limits);
+            if (count <= 0)
+                throw new SubtitleInputException(Strings.AiFileTooLarge);
+
+            batches.Add(new TranslationBatch(pieces.GetRange(start, count).ToArray()));
+            start += count;
+        }
+        return batches;
+    }
+
+    private static int LargestTranslationPieceLength(
+        CaptionCue cue,
+        int cueIndex,
+        int partIndex,
+        int offset,
+        int maximumLength,
+        int[] textElementBoundaries,
+        string? sourceLanguage,
+        string targetLanguage,
+        AiModelId? model,
+        AiCaptionTranslationLimits limits)
+    {
+        int low = 1;
+        int high = maximumLength;
+        int best = 0;
+        while (low <= high)
+        {
+            int midpoint = low + ((high - low) / 2);
+            int length = KeepTranslationBoundaryTogether(
+                cue.Text,
+                textElementBoundaries,
+                offset,
+                midpoint);
+            if (length <= 0)
+            {
+                low = midpoint + 1;
+                continue;
+            }
+
+            TranslationPiece piece = CreateTranslationPiece(
+                cue,
+                cueIndex,
+                partIndex,
+                cue.Text.Substring(offset, length),
+                limits);
+            if (TranslationBatchFits(
+                    [piece],
+                    sourceLanguage,
+                    targetLanguage,
+                    model,
+                    limits))
+            {
+                best = Math.Max(best, length);
+                low = midpoint + 1;
+            }
+            else
+            {
+                high = midpoint - 1;
+            }
+        }
+        return best;
+    }
+
+    private static int LargestTranslationBatchPrefix(
+        List<TranslationPiece> pieces,
+        int start,
+        int maximumCount,
+        string? sourceLanguage,
+        string targetLanguage,
+        AiModelId? model,
+        AiCaptionTranslationLimits limits)
+    {
+        int low = 1;
+        int high = maximumCount;
+        int best = 0;
+        while (low <= high)
+        {
+            int count = low + ((high - low) / 2);
+            if (TranslationBatchFits(
+                    pieces.GetRange(start, count),
+                    sourceLanguage,
+                    targetLanguage,
+                    model,
+                    limits))
+            {
+                best = count;
+                low = count + 1;
+            }
+            else
+            {
+                high = count - 1;
+            }
+        }
+        return best;
+    }
+
+    private static bool TranslationBatchFits(
+        IReadOnlyList<TranslationPiece> pieces,
+        string? sourceLanguage,
+        string targetLanguage,
+        AiModelId? model,
+        AiCaptionTranslationLimits limits)
+    {
+        try
+        {
+            _ = new AiCaptionTranslationRequest(
+                pieces.Select(piece => new AiCaptionTranslationSegment
+                {
+                    Id = piece.Id,
+                    Text = piece.Text,
+                    Context = new AiCaptionTranslationSegmentContext(
+                        piece.GroupId,
+                        piece.ContextPartIndex,
+                        piece.Start,
+                        piece.End),
+                }).ToArray(),
+                targetLanguage,
+                sourceLanguage,
+                model: model,
+                limits: limits);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    private static TranslationPiece CreateTranslationPiece(
+        CaptionCue cue,
+        int cueIndex,
+        int partIndex,
+        string text,
+        AiCaptionTranslationLimits limits)
+    {
+        int contextGroup = partIndex / limits.MaxSegments;
+        return new TranslationPiece(
+            cueIndex,
+            partIndex,
+            partIndex % limits.MaxSegments,
+            $"c{cueIndex}-p{partIndex}",
+            contextGroup == 0 ? $"c{cueIndex}" : $"c{cueIndex}-g{contextGroup}",
+            cue.Start,
+            cue.End,
+            text);
+    }
+
+    internal static int[] CreateTranslationTextElementBoundaries(string text)
+        => StringInfo.ParseCombiningCharacters(text);
+
+    internal static int KeepTranslationBoundaryTogether(
+        string text,
+        int[] textElementBoundaries,
+        int offset,
+        int length)
+    {
+        int end = offset + length;
+        if (end >= text.Length || length <= 0)
+            return length;
+
+        int boundaryIndex = Array.BinarySearch(textElementBoundaries, end);
+        if (boundaryIndex < 0)
+            boundaryIndex = ~boundaryIndex - 1;
+        if (boundaryIndex < 0 || textElementBoundaries[boundaryIndex] <= offset)
+            return 0;
+        int textElementBoundary = textElementBoundaries[boundaryIndex];
+        int offsetBoundaryIndex = Array.BinarySearch(textElementBoundaries, offset);
+        if (offsetBoundaryIndex < 0)
+            throw new ArgumentException("The offset must be a text-element boundary.", nameof(offset));
+
+        for (int candidateIndex = boundaryIndex;
+             candidateIndex > offsetBoundaryIndex;
+             candidateIndex--)
+        {
+            int boundary = textElementBoundaries[candidateIndex];
+            int previousTextElement = textElementBoundaries[candidateIndex - 1];
+            if (!char.IsWhiteSpace(text[previousTextElement])
+                || (boundary < text.Length && char.IsWhiteSpace(text[boundary])))
+            {
+                continue;
+            }
+
+            int separatorIndex = candidateIndex - 1;
+            while (separatorIndex > offsetBoundaryIndex
+                   && char.IsWhiteSpace(text[textElementBoundaries[separatorIndex - 1]]))
+            {
+                separatorIndex--;
+            }
+            int separatorStart = textElementBoundaries[separatorIndex];
+            if (separatorStart > offset)
+            {
+                // Keep the complete separator with the preceding word. A
+                // leading separator is part of the next word for this purpose.
+                return boundary - offset;
+            }
+        }
+
+        int trailingTextElement = textElementBoundaries[boundaryIndex - 1];
+        if (char.IsWhiteSpace(text[trailingTextElement])
+            && char.IsWhiteSpace(text[textElementBoundary]))
+        {
+            int separatorIndex = boundaryIndex - 1;
+            while (separatorIndex > offsetBoundaryIndex
+                   && char.IsWhiteSpace(text[textElementBoundaries[separatorIndex - 1]]))
+            {
+                separatorIndex--;
+            }
+            int separatorStart = textElementBoundaries[separatorIndex];
+            if (separatorStart > offset)
+                return separatorStart - offset;
+        }
+
+        // A single word longer than the provider limit still has to make
+        // progress, but it may only be split between complete text elements.
+        return textElementBoundary - offset;
+    }
+
+    internal static SpeechWaveChunkResult WriteSpeechWave(
+        MediaReader reader,
+        int startSample,
+        int requestedSamples,
+        Stream stream,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        ArgumentNullException.ThrowIfNull(stream);
+        if (startSample < 0)
+            throw new ArgumentOutOfRangeException(nameof(startSample));
+        if (requestedSamples <= 0)
+            throw new ArgumentOutOfRangeException(nameof(requestedSamples));
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!stream.CanWrite || !stream.CanSeek)
+        {
+            throw new ArgumentException(
+                "The destination stream must be writable and seekable.",
+                nameof(stream));
+        }
+
+        int sourceRate = reader.AudioInfo.SampleRate;
+        if (sourceRate <= 0)
+            throw new SubtitleInputException(Strings.AiSubtitle_NoAudioInRange);
+
+        const int outputRate = 16_000;
+        const int waveHeaderLength = 44;
+        using var writer = new BinaryWriter(stream, Encoding.ASCII, leaveOpen: true);
+        writer.Write(Encoding.ASCII.GetBytes("RIFF"));
+        writer.Write(0);
+        writer.Write(Encoding.ASCII.GetBytes("WAVEfmt "));
+        writer.Write(16);
+        writer.Write((short)1);
+        writer.Write((short)1);
+        writer.Write(outputRate);
+        writer.Write(outputRate * sizeof(short));
+        writer.Write((short)sizeof(short));
+        writer.Write((short)16);
+        writer.Write(Encoding.ASCII.GetBytes("data"));
+        writer.Write(0);
+
+        int sourceSamplesWritten = 0;
+        int outputSamplesWritten = 0;
+        int decodeBlockSize = Math.Max(1, Math.Min(sourceRate, requestedSamples));
+        double nextOutputSourcePosition = 0;
+        while (sourceSamplesWritten < requestedSamples)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            int length = Math.Min(decodeBlockSize, requestedSamples - sourceSamplesWritten);
+            if (!reader.ReadAudio(
+                    checked(startSample + sourceSamplesWritten),
+                    length,
+                    out Ref<IPcm>? audioRef))
+            {
+                throw new SubtitleInputException(Strings.AiSubtitle_NoAudioInRange);
+            }
+
+            using (audioRef)
+            {
+                if (audioRef.Value is not Pcm<Stereo32BitFloat> pcm)
+                    throw new SubtitleInputException(Strings.AiSubtitle_NoAudioInRange);
+
+                int decodedSamples = Math.Min(pcm.NumSamples, length);
+                if (decodedSamples == 0)
+                    break;
+
+                Span<Stereo32BitFloat> source = pcm.DataSpan[..decodedSamples];
+                double blockEnd = sourceSamplesWritten + decodedSamples;
+                while (nextOutputSourcePosition < blockEnd)
+                {
+                    int sourceIndex = Math.Clamp(
+                        (int)Math.Floor(nextOutputSourcePosition - sourceSamplesWritten),
+                        0,
+                        decodedSamples - 1);
+                    Stereo32BitFloat sample = source[sourceIndex];
+                    double mono = (sample.Left + sample.Right) / 2d;
+                    mono = double.IsFinite(mono) ? Math.Clamp(mono, -1, 1) : 0;
+                    writer.Write((short)Math.Round(mono * short.MaxValue));
+                    outputSamplesWritten++;
+                    nextOutputSourcePosition = outputSamplesWritten * (double)sourceRate / outputRate;
+                }
+                sourceSamplesWritten += decodedSamples;
+                if (decodedSamples < length)
+                    break;
+            }
+        }
+
+        if (sourceSamplesWritten == 0 || outputSamplesWritten == 0)
+            throw new SubtitleInputException(Strings.AiSubtitle_NoAudioInRange);
+
+        int dataLength = checked(outputSamplesWritten * sizeof(short));
+        stream.Position = 4;
+        writer.Write(checked(waveHeaderLength - 8 + dataLength));
+        stream.Position = 40;
+        writer.Write(dataLength);
+        stream.Position = waveHeaderLength + dataLength;
+        return new SpeechWaveChunkResult(
+            sourceSamplesWritten,
+            outputSamplesWritten,
+            TimeSpan.FromSeconds(outputSamplesWritten / (double)outputRate));
+    }
+
+    /// <summary>
+    /// Writes one 16-bit mono PCM wave from as many composed slices as it is
+    /// handed. The slices are separate calls because a whole upload chunk cannot
+    /// be composed at once (see <see cref="SceneMixComposeSlice"/>), and the
+    /// resampling position carries across them so a slice boundary neither drops
+    /// a sample nor shifts the ones after it.
+    /// </summary>
+    internal sealed class SpeechWaveWriter(Stream stream)
+    {
+        private const int WaveHeaderLength = 44;
+        private const int MaximumOutputRate = 16_000;
+        private readonly Stream _stream = stream;
+        private int _sourceRate;
+        private int _outputRate;
+        private long _sourceFramesWritten;
+        private double _nextOutputSourcePosition;
+        private int _outputSampleCount;
+
+        public TimeSpan UploadedDuration => _outputRate == 0
+            ? TimeSpan.Zero
+            : TimeSpan.FromSeconds(_outputSampleCount / (double)_outputRate);
+
+        public void Append(AudioFrameSnapshot snapshot, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(snapshot);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (snapshot.SampleRate <= 0 || snapshot.ChannelCount <= 0 || snapshot.SampleCount <= 0)
+                throw new SubtitleInputException(Strings.AiSubtitle_NoAudioInRange);
+
+            if (_sourceRate == 0)
+            {
+                _sourceRate = snapshot.SampleRate;
+                _outputRate = Math.Min(_sourceRate, MaximumOutputRate);
+                WriteHeader();
+            }
+            else if (snapshot.SampleRate != _sourceRate)
+            {
+                // Resampling assumes one rate for the whole wave; a slice at another
+                // rate would land its samples at the wrong time.
+                throw new SubtitleInputException(Strings.AiSubtitle_NoAudioInRange);
+            }
+
+            using var writer = new BinaryWriter(_stream, Encoding.ASCII, leaveOpen: true);
+            long sliceStart = _sourceFramesWritten;
+            long sliceEnd = sliceStart + snapshot.SampleCount;
+            while (_nextOutputSourcePosition < sliceEnd)
+            {
+                if ((_outputSampleCount & 4095) == 0)
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                int frame = (int)Math.Clamp(
+                    (long)Math.Floor(_nextOutputSourcePosition) - sliceStart,
+                    0,
+                    snapshot.SampleCount - 1);
+                double mono = 0;
+                for (int channel = 0; channel < snapshot.ChannelCount; channel++)
+                {
+                    float sample = snapshot.Interleaved[(frame * snapshot.ChannelCount) + channel];
+                    mono += float.IsFinite(sample) ? sample : 0;
+                }
+
+                mono = Math.Clamp(mono / snapshot.ChannelCount, -1, 1);
+                writer.Write((short)Math.Round(mono * short.MaxValue));
+                _outputSampleCount++;
+                _nextOutputSourcePosition = _outputSampleCount * (double)_sourceRate / _outputRate;
+            }
+
+            _sourceFramesWritten = sliceEnd;
+        }
+
+        public void Complete()
+        {
+            if (_outputSampleCount == 0)
+                throw new SubtitleInputException(Strings.AiSubtitle_NoAudioInRange);
+
+            int dataLength = checked(_outputSampleCount * sizeof(short));
+            using var writer = new BinaryWriter(_stream, Encoding.ASCII, leaveOpen: true);
+            _stream.Position = 4;
+            writer.Write(checked(WaveHeaderLength - 8 + dataLength));
+            _stream.Position = 40;
+            writer.Write(dataLength);
+            _stream.Position = WaveHeaderLength + dataLength;
+        }
+
+        private void WriteHeader()
+        {
+            using var writer = new BinaryWriter(_stream, Encoding.ASCII, leaveOpen: true);
+            writer.Write(Encoding.ASCII.GetBytes("RIFF"));
+            writer.Write(0);
+            writer.Write(Encoding.ASCII.GetBytes("WAVEfmt "));
+            writer.Write(16);
+            writer.Write((short)1);
+            writer.Write((short)1);
+            writer.Write(_outputRate);
+            writer.Write(_outputRate * sizeof(short));
+            writer.Write((short)sizeof(short));
+            writer.Write((short)16);
+            writer.Write(Encoding.ASCII.GetBytes("data"));
+            writer.Write(0);
+        }
+    }
+
+    internal static async Task WriteCaptionExportAsync(
+        IStorageFile file,
+        byte[] bytes,
+        CancellationToken cancellationToken)
+    {
+        Uri path = file.Path;
+        if (path.IsFile && !string.IsNullOrWhiteSpace(path.LocalPath))
+        {
+            string destinationPath = path.LocalPath;
+            string temporaryPath = destinationPath + $".{Guid.NewGuid():N}.tmp";
+            try
+            {
+                UnixFileMode destinationMode = default;
+                var options = new FileStreamOptions
+                {
+                    Mode = FileMode.CreateNew,
+                    Access = FileAccess.Write,
+                    Share = FileShare.None,
+                    Options = FileOptions.WriteThrough,
+                };
+                if (!OperatingSystem.IsWindows())
+                {
+                    destinationMode = File.Exists(destinationPath)
+                        ? File.GetUnixFileMode(destinationPath)
+                        : UnixFileMode.UserRead | UnixFileMode.UserWrite;
+                    options.UnixCreateMode = destinationMode;
+                }
+
+                await using (var stream = new FileStream(temporaryPath, options))
+                {
+                    await stream.WriteAsync(bytes, cancellationToken);
+                    await stream.FlushAsync(cancellationToken);
+                    stream.Flush(flushToDisk: true);
+                }
+
+                if (!OperatingSystem.IsWindows())
+                    File.SetUnixFileMode(temporaryPath, destinationMode);
+                File.Move(temporaryPath, destinationPath, overwrite: true);
+            }
+            finally
+            {
+                try { File.Delete(temporaryPath); }
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { }
+            }
+        }
+        else
+        {
+            await WriteNonLocalCaptionExportAsync(file, bytes, cancellationToken);
+        }
+    }
+
+    private static async Task WriteNonLocalCaptionExportAsync(
+        IStorageFile destination,
+        byte[] bytes,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        IStorageFolder parent = await destination.GetParentAsync()
+            ?? throw new NotSupportedException(
+                "The storage provider cannot stage a safe replacement for this caption file.");
+        IStorageFolder? stagingFolder = null;
+        IStorageFolder? backupFolder = null;
+        IStorageFile? stagedFile = null;
+        IStorageFile? backupFile = null;
+        bool originalIsInBackup = false;
+        bool preserveRecoveryArtifacts = false;
+        try
+        {
+            string transaction = Guid.NewGuid().ToString("N");
+            stagingFolder = await parent.CreateFolderAsync($"beutl-caption-{transaction}-stage")
+                ?? throw new NotSupportedException(
+                    "The storage provider cannot create a caption staging folder.");
+            stagedFile = await stagingFolder.CreateFileAsync(destination.Name)
+                ?? throw new NotSupportedException(
+                    "The storage provider cannot create a staged caption file.");
+
+            await using (Stream stream = await stagedFile.OpenWriteAsync())
+            {
+                await stream.WriteAsync(bytes, cancellationToken);
+                await stream.FlushAsync(cancellationToken);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+
+            backupFolder = await parent.CreateFolderAsync($"beutl-caption-{transaction}-backup")
+                ?? throw new NotSupportedException(
+                    "The storage provider cannot create a caption backup folder.");
+            IStorageItem? movedOriginal;
+            try
+            {
+                movedOriginal = await destination.MoveAsync(backupFolder);
+            }
+            catch
+            {
+                preserveRecoveryArtifacts = true;
+                throw;
+            }
+            if (movedOriginal is not IStorageFile movedOriginalFile)
+            {
+                movedOriginal?.Dispose();
+                preserveRecoveryArtifacts = true;
+                throw new IOException("The storage provider could not move the previous caption file to safety.");
+            }
+            backupFile = movedOriginalFile;
+            originalIsInBackup = true;
+
+            try
+            {
+                IStorageItem? movedStaged = await stagedFile.MoveAsync(parent);
+                if (movedStaged is not IStorageFile committed)
+                {
+                    movedStaged?.Dispose();
+                    throw new IOException("The storage provider could not publish the staged caption file.");
+                }
+                TryDisposeStorageItem(committed);
+                originalIsInBackup = false;
+            }
+            catch (Exception commitException)
+            {
+                Exception? rollbackException = await TryRestoreNonLocalCaptionAsync(
+                    parent,
+                    backupFile,
+                    destination.Name);
+                if (rollbackException is not null)
+                {
+                    preserveRecoveryArtifacts = true;
+                    throw new AggregateException(
+                        "Caption export failed and the previous file could not be restored; its backup was preserved.",
+                        commitException,
+                        rollbackException);
+                }
+
+                originalIsInBackup = false;
+                throw;
+            }
+
+            await TryDeleteStorageItemAsync(backupFile);
+        }
+        finally
+        {
+            if (!preserveRecoveryArtifacts)
+            {
+                await TryDeleteStorageItemAsync(stagedFile);
+                if (!originalIsInBackup)
+                {
+                    await TryDeleteStorageItemAsync(stagingFolder);
+                    await TryDeleteStorageItemAsync(backupFolder);
+                }
+            }
+
+            TryDisposeStorageItem(backupFile);
+            TryDisposeStorageItem(stagedFile);
+            TryDisposeStorageItem(backupFolder);
+            TryDisposeStorageItem(stagingFolder);
+            TryDisposeStorageItem(parent);
+        }
+    }
+
+    private static async Task<Exception?> TryRestoreNonLocalCaptionAsync(
+        IStorageFolder parent,
+        IStorageFile backupFile,
+        string destinationName)
+    {
+        try
+        {
+            IStorageFile? failedReplacement = await parent.GetFileAsync(destinationName);
+            try
+            {
+                if (failedReplacement is not null)
+                {
+                    await failedReplacement.DeleteAsync();
+                }
+            }
+            finally
+            {
+                TryDisposeStorageItem(failedReplacement);
+            }
+
+            IStorageItem restored = await backupFile.MoveAsync(parent)
+                ?? throw new IOException("The storage provider returned no restored caption file.");
+            TryDisposeStorageItem(restored);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return ex;
+        }
+    }
+
+    private static async Task TryDeleteStorageItemAsync(IStorageItem? item)
+    {
+        if (item is null)
+            return;
+
+        try
+        {
+            await item.DeleteAsync();
+        }
+        catch
+        {
+            // A completed replacement must not be reported as failed only because a provider could
+            // not remove its empty staging folder. If rollback failed, recovery artifacts are kept.
+        }
+    }
+
+    private static void TryDisposeStorageItem(IDisposable? item)
+    {
+        try
+        {
+            item?.Dispose();
+        }
+        catch
+        {
+            // Storage handles are cleanup-only here; the write or rollback outcome is authoritative.
+        }
+    }
+
+    private FilePickerFileType CreateCaptionFileType(
+        bool canDecode = false,
+        bool canEncode = false)
+        => new(Strings.AiSubtitle_CaptionFiles)
+        {
+            Patterns = _captionCodecs.Codecs
+                .Where(codec => (!canDecode || codec.CanDecode)
+                    && (!canEncode || codec.CanEncode))
+                .SelectMany(codec => codec.FileExtensions)
+                .Select(extension => $"*{extension}")
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(pattern => pattern, StringComparer.OrdinalIgnoreCase)
+                .ToArray(),
+            MimeTypes = ["text/plain", "application/octet-stream"],
+        };
+
+    private static IStorageProvider? GetStorageProvider()
+    {
+        if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime
+            { MainWindow: { } window })
+        {
+            return null;
+        }
+        return TopLevel.GetTopLevel(window)?.StorageProvider;
+    }
+
+    private sealed record TranslationPiece(
+        int CueIndex,
+        int PartIndex,
+        int ContextPartIndex,
+        string Id,
+        string GroupId,
+        TimeSpan Start,
+        TimeSpan End,
+        string Text);
+
+    private sealed record TranslationBatch(IReadOnlyList<TranslationPiece> Pieces);
+
+    private sealed class TranslationOperation(
+        CaptionDocument sourceDocument,
+        long expectedCaptionRevision,
+        string? sourceLanguage,
+        string? selectedSourceLanguage,
+        string targetLanguage,
+        long expectedDraftScopeRevision,
+        AiCaptionTranslationLimits limits,
+        IReadOnlyList<TranslationBatch> batches,
+        string? requestKeySeed = null,
+        bool requestKeyNamePending = false)
+    {
+        public CaptionDocument SourceDocument { get; } = sourceDocument;
+
+        public long ExpectedCaptionRevision { get; set; } = expectedCaptionRevision;
+
+        public string? SourceLanguage { get; } = sourceLanguage;
+
+        public string? SelectedSourceLanguage { get; } = selectedSourceLanguage;
+
+        public string TargetLanguage { get; } = targetLanguage;
+
+        public long ExpectedDraftScopeRevision { get; } = expectedDraftScopeRevision;
+
+        public AiCaptionTranslationLimits Limits { get; } = limits;
+
+        public IReadOnlyList<TranslationBatch> Batches { get; } = batches;
+
+        /// <summary>
+        /// Names this run's requests, one key per batch. Restored with the rest
+        /// of the resume state so a batch resumed after a restart asks for the
+        /// translation it already paid for instead of buying a second one.
+        /// </summary>
+        public AiRequestKey RequestKey { get; } = new(requestKeySeed, requestKeyNamePending);
+
+        public string RequestKeySeed => RequestKey.Seed;
+
+
+        /// <summary>The model the names handed out so far were built from.</summary>
+        public string RequestKeyModel { get; set; } = string.Empty;
+
+        public AiRequestName RequestNameFor(int batchIndex, AiModelId? model)
+        {
+            RequestKeyModel = model?.Value ?? string.Empty;
+            return RequestKey.NameFor(batchIndex, model?.Value, TargetLanguage, SourceLanguage);
+        }
+
+        public Dictionary<string, string> TranslatedPieces { get; } = new(StringComparer.Ordinal);
+
+        public int CompletedBatchCount { get; set; }
+    }
+
+    private sealed class SceneTranscriptionOperation(
+        AudioSourceItem? source,
+        string? language,
+        TimeSpan rangeStart,
+        TimeSpan duration,
+        TimeSpan chunkDuration,
+        int chunkCount,
+        long expectedCaptionRevision,
+        long expectedDraftScopeRevision,
+        long expectedSceneAudioRevision,
+        Guid sceneId,
+        Guid audioSessionId,
+        string? requestKeySeed = null,
+        bool requestKeyNamePending = false)
+    {
+        public AudioSourceItem? Source { get; set; } = source;
+
+        /// <summary>
+        /// Names this run's requests, one key per chunk. Held with the rest of
+        /// the resume state so a retried chunk asks for the transcription it
+        /// already paid for instead of buying a second one.
+        /// </summary>
+        public AiRequestKey RequestKey { get; } = new(requestKeySeed, requestKeyNamePending);
+
+        public string RequestKeySeed => RequestKey.Seed;
+
+
+        /// <summary>The model the names handed out so far were built from.</summary>
+        public string RequestKeyModel { get; set; } = string.Empty;
+
+        // The model belongs in the key because the server refuses a key that
+        // comes back with a different request behind it, and it fingerprints
+        // the model. A chunk sent to another model is another request and takes
+        // another key, which is also what it costs.
+        public AiRequestName RequestNameFor(int chunkIndex, AiModelId? model)
+        {
+            RequestKeyModel = model?.Value ?? string.Empty;
+            return RequestKey.NameFor(chunkIndex, model?.Value);
+        }
+
+        public string? Language { get; } = language;
+
+        public TimeSpan RangeStart { get; } = rangeStart;
+
+        public TimeSpan Duration { get; } = duration;
+
+        public TimeSpan ChunkDuration { get; } = chunkDuration;
+
+        public int ChunkCount { get; } = chunkCount;
+
+        public long ExpectedCaptionRevision { get; set; } = expectedCaptionRevision;
+
+        public long ExpectedDraftScopeRevision { get; } = expectedDraftScopeRevision;
+
+        public long ExpectedSceneAudioRevision { get; set; } = expectedSceneAudioRevision;
+
+        public Guid SceneId { get; } = sceneId;
+
+        public Guid AudioSessionId { get; } = audioSessionId;
+
+        public List<AiTranscriptionSegment> Segments { get; } = [];
+
+        public string? DetectedLanguage { get; set; }
+
+        public int CompletedChunkCount { get; set; }
+    }
+
+    private sealed class SourceTranscriptionOperation(
+        AudioSourceItem? source,
+        string filePath,
+        Guid elementId,
+        long fileLength,
+        long lastWriteTimeUtcTicks,
+        string? language,
+        int sampleRate,
+        long totalSamples,
+        int chunkSamples,
+        int chunkCount,
+        long expectedCaptionRevision,
+        long expectedDraftScopeRevision,
+        string? requestKeySeed = null,
+        bool requestKeyNamePending = false)
+    {
+        public AudioSourceItem? Source { get; set; } = source;
+
+        /// <summary>
+        /// Names this run's requests, one key per chunk. Restored with the rest
+        /// of the resume state so a chunk resumed after a restart asks for the
+        /// transcription it already paid for instead of buying a second one.
+        /// </summary>
+        public AiRequestKey RequestKey { get; } = new(requestKeySeed, requestKeyNamePending);
+
+        public string RequestKeySeed => RequestKey.Seed;
+
+
+        /// <summary>The model the names handed out so far were built from.</summary>
+        public string RequestKeyModel { get; set; } = string.Empty;
+
+        public AiRequestName RequestNameFor(int chunkIndex, AiModelId? model)
+        {
+            RequestKeyModel = model?.Value ?? string.Empty;
+            return RequestKey.NameFor(chunkIndex, model?.Value);
+        }
+
+        public string FilePath { get; } = filePath;
+
+        public Guid ElementId { get; } = elementId;
+
+        public long FileLength { get; } = fileLength;
+
+        public long LastWriteTimeUtcTicks { get; } = lastWriteTimeUtcTicks;
+
+        public string? Language { get; } = language;
+
+        public int SampleRate { get; } = sampleRate;
+
+        public long TotalSamples { get; set; } = totalSamples;
+
+        public int ChunkSamples { get; } = chunkSamples;
+
+        public int ChunkCount { get; set; } = chunkCount;
+
+        public long ExpectedCaptionRevision { get; set; } = expectedCaptionRevision;
+
+        public long ExpectedDraftScopeRevision { get; } = expectedDraftScopeRevision;
+
+        public List<AiTranscriptionSegment> SourceSegments { get; } = [];
+
+        public string? DetectedLanguage { get; set; }
+
+        public int CompletedChunkCount { get; set; }
+    }
+
+    private sealed record RecoverableCaptionResult(
+        CaptionDocument Document,
+        string? Language,
+        AiTranscriptionSegment[]? Segments,
+        PartialResultKind Kind,
+        int CompletedSteps,
+        int TotalSteps,
+        long DraftScopeRevision);
+
+    private enum PartialResultKind
+    {
+        Translation,
+        Transcription,
+    }
+}
+
+internal readonly record struct SpeechWaveChunkResult(
+    int SourceSampleCount,
+    int OutputSampleCount,
+    TimeSpan UploadedDuration);
+
+internal readonly record struct SourceAudioFingerprint(
+    long FileLength,
+    long LastWriteTimeUtcTicks);
+
+internal sealed class SubtitleInputException : Exception
+{
+    public SubtitleInputException()
+    {
+    }
+
+    public SubtitleInputException(string message)
+        : base(message)
+    {
+    }
+
+    public SubtitleInputException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Beutl/ViewModels/Dialogs/AiSubtitleDialogViewModel.Advanced.cs
+++ b/src/Beutl/ViewModels/Dialogs/AiSubtitleDialogViewModel.Advanced.cs
@@ -3389,8 +3389,14 @@ public sealed partial class AiSubtitleDialogViewModel
                 SelectedSourceLanguage.Value.Code,
                 StringComparison.Ordinal))
         {
+            AiModelId? runModel = ModelOfRun(
+                operation.CompletedBatchCount > 0
+                    || operation.RequestKey.HasOutstandingName.Value,
+                operation.RequestKeyModel,
+                TranslationModelPicker.SelectedModel);
             request = CreateTranslationAvailabilityRequest(
                 operation.Batches[operation.CompletedBatchCount],
+                runModel,
                 limits: operation.Limits);
         }
         else if (TryBuildCaptionDocumentCore(out CaptionDocument? document, out _)
@@ -3818,16 +3824,24 @@ public sealed partial class AiSubtitleDialogViewModel
 
     private AiOperationAvailabilityRequest.Translation CreateTranslationAvailabilityRequest(
         TranslationBatch batch,
-        AiModelId? model = null,
-        AiCaptionTranslationLimits? limits = null)
+        AiCaptionTranslationLimits limits)
+        => CreateTranslationAvailabilityRequest(
+            batch,
+            TranslationModelPicker.SelectedModel,
+            limits);
+
+    private static AiOperationAvailabilityRequest.Translation CreateTranslationAvailabilityRequest(
+        TranslationBatch batch,
+        AiModelId? model,
+        AiCaptionTranslationLimits limits)
         // What the batch will actually be sent to. A run in progress is priced
         // against the model its names were built from, not against whichever the
         // picker is showing now.
         => new(
             AiOperations.CaptionTranslation,
             batch.Pieces.Sum(piece => piece.Text.Length),
-            model ?? TranslationModelPicker.SelectedModel,
-            limits ?? TranslationModelPicker.CaptionTranslationLimits);
+            model,
+            limits);
 
     // The model a run is named for. The picker's until the run has named
     // anything, and from then on the run's own — including when the run named

--- a/src/Beutl/ViewModels/Dialogs/AiSubtitleDialogViewModel.Advanced.cs
+++ b/src/Beutl/ViewModels/Dialogs/AiSubtitleDialogViewModel.Advanced.cs
@@ -642,6 +642,8 @@ public sealed partial class AiSubtitleDialogViewModel
             chunkIndex++)
         {
             RequestToken.ThrowIfCancellationRequested();
+            if (!ReferenceEquals(SelectedAudioSource.Value, source))
+                return;
             long chunkOffset = checked((long)chunkIndex * operation.ChunkSamples);
             int requestedSamples = checked((int)Math.Min(
                 operation.ChunkSamples,
@@ -726,10 +728,11 @@ public sealed partial class AiSubtitleDialogViewModel
                             runModel,
                             name.Key),
                         RequestToken);
+                    ValidateTranscriptionSegments(response.Segments, chunk.UploadedDuration.TotalSeconds);
                 }
                 catch (AiProviderErrorException)
                 {
-                    // The server settled this chunk as failed and refunded it.
+                    // Failed or invalid settled responses need a fresh key on retry.
                     // Its key would keep answering with that failure, so the
                     // rest of the run takes new ones — and the resume state is
                     // rewritten with them, or a resumed run would ask under the
@@ -746,9 +749,6 @@ public sealed partial class AiSubtitleDialogViewModel
                     WithdrawSourceTranscriptionName(operation, name);
                     throw;
                 }
-                ValidateTranscriptionSegments(
-                    response.Segments,
-                    chunk.UploadedDuration.TotalSeconds);
                 // Settle the durable key before publishing any local progress.
                 // A failed CAS means another owner replaced the recovery row;
                 // leave this operation untouched so it can still be resumed.
@@ -906,6 +906,11 @@ public sealed partial class AiSubtitleDialogViewModel
         for (int index = operation.CompletedChunkCount; index < chunkCount; index++)
         {
             RequestToken.ThrowIfCancellationRequested();
+            if (operation.ExpectedSceneAudioRevision != Interlocked.Read(ref _sceneAudioRevision)
+                || !ReferenceEquals(SelectedAudioSource.Value, source)
+                || !TryGetSceneRange(out TimeSpan liveStart, out TimeSpan liveDuration)
+                || liveStart != operation.RangeStart || liveDuration != operation.Duration)
+                return;
             TimeSpan chunkOffset = TimeSpan.FromTicks(
                 Math.Min(duration.Ticks, index * operation.ChunkDuration.Ticks));
             TimeSpan chunkDuration = TimeSpan.FromTicks(
@@ -983,12 +988,13 @@ public sealed partial class AiSubtitleDialogViewModel
                                 FormatChunkFileName("scene-mix", index)),
                             language,
                             runModel,
-                            name.Key),
+                                name.Key),
                         RequestToken);
+                    ValidateTranscriptionSegments(response.Segments, uploadedDuration.TotalSeconds);
                 }
                 catch (AiProviderErrorException)
                 {
-                    // The server settled this chunk as failed and refunded it.
+                    // Failed or invalid settled responses need a fresh key on retry.
                     // Its key would keep answering with that failure, so the
                     // rest of the run takes new ones — written down as well, or
                     // a run picked up later asks under the spent key again and
@@ -1005,9 +1011,6 @@ public sealed partial class AiSubtitleDialogViewModel
                     WithdrawSceneTranscriptionName(operation, name);
                     throw;
                 }
-                ValidateTranscriptionSegments(
-                    response.Segments,
-                    uploadedDuration.TotalSeconds);
                 if (!operation.RequestKey.Retire(name))
                     return;
                 operation.DetectedLanguage ??= response.Language;
@@ -1223,6 +1226,7 @@ public sealed partial class AiSubtitleDialogViewModel
                 }
 
                 AiCaptionTranslationResponse response;
+                Dictionary<string, string> translatedBatch;
                 try
                 {
                     response = await _aiService.TranslateAsync(
@@ -1245,10 +1249,11 @@ public sealed partial class AiSubtitleDialogViewModel
                         new Progress<AiCaptionTranslationSegment>(segment =>
                             operationLifetime.TryPublish(() => ShowTranslatedLine(segment))),
                         RequestToken);
+                    translatedBatch = ValidateTranslatedBatch(batch, response);
                 }
                 catch (AiProviderErrorException)
                 {
-                    // The server settled this batch as failed and refunded it.
+                    // Failed or invalid settled responses need a fresh key on retry.
                     // Its key would keep answering with that failure, so what is
                     // left of the run goes out under new ones — and the resume
                     // state is rewritten with them, or a run resumed after a
@@ -1265,9 +1270,6 @@ public sealed partial class AiSubtitleDialogViewModel
                     WithdrawTranslationName(operation, name);
                     throw;
                 }
-                Dictionary<string, string> translatedBatch = ValidateTranslatedBatch(
-                    batch,
-                    response);
                 if (!operation.RequestKey.Retire(name))
                     return;
                 AddTranslatedBatch(operation, translatedBatch);

--- a/src/Beutl/ViewModels/Dialogs/AiSubtitleDialogViewModel.Advanced.cs
+++ b/src/Beutl/ViewModels/Dialogs/AiSubtitleDialogViewModel.Advanced.cs
@@ -563,6 +563,7 @@ public sealed partial class AiSubtitleDialogViewModel
             filePath,
             language,
             sampleRate,
+            sourceStartSamples,
             totalSamples,
             chunkSamples,
             chunkCount,
@@ -583,6 +584,7 @@ public sealed partial class AiSubtitleDialogViewModel
                     filePath,
                     language,
                     sampleRate,
+                    sourceStartSamples,
                     totalSamples,
                     chunkSamples,
                     chunkCount,
@@ -611,6 +613,7 @@ public sealed partial class AiSubtitleDialogViewModel
                     fingerprint.LastWriteTimeUtcTicks,
                     language,
                     sampleRate,
+                    sourceStartSamples,
                     totalSamples,
                     chunkSamples,
                     chunkCount,
@@ -655,7 +658,7 @@ public sealed partial class AiSubtitleDialogViewModel
                     chunk = await Task.Run(
                         () => WriteSpeechWave(
                             reader,
-                            checked((int)(sourceStartSamples + chunkOffset)),
+                            checked((int)(operation.SourceStartSamples + chunkOffset)),
                             requestedSamples,
                             stream,
                             RequestToken),
@@ -1878,6 +1881,7 @@ public sealed partial class AiSubtitleDialogViewModel
         string filePath,
         string? language,
         int sampleRate,
+        long sourceStartSamples,
         long totalSamples,
         int chunkSamples,
         int chunkCount,
@@ -1892,6 +1896,7 @@ public sealed partial class AiSubtitleDialogViewModel
             && operation.ElementId == source.ElementId
             && operation.Language == language
             && operation.SampleRate == sampleRate
+            && operation.SourceStartSamples == sourceStartSamples
             && operation.TotalSamples == totalSamples
             && operation.ChunkSamples == chunkSamples
             && operation.ChunkCount == chunkCount
@@ -1906,6 +1911,7 @@ public sealed partial class AiSubtitleDialogViewModel
         string filePath,
         string? language,
         int sampleRate,
+        long sourceStartSamples,
         long totalSamples,
         int chunkSamples,
         int chunkCount,
@@ -1916,6 +1922,7 @@ public sealed partial class AiSubtitleDialogViewModel
             && resume.ElementId == source.ElementId
             && resume.Language == language
             && resume.SampleRate == sampleRate
+            && resume.SourceStartSamples == sourceStartSamples
             && resume.TotalSamples == totalSamples
             && resume.ChunkSamples == chunkSamples
             && resume.ChunkCount == chunkCount
@@ -1938,6 +1945,7 @@ public sealed partial class AiSubtitleDialogViewModel
             resume.LastWriteTimeUtcTicks,
             resume.Language,
             resume.SampleRate,
+            resume.SourceStartSamples ?? -1,
             resume.TotalSamples,
             resume.ChunkSamples,
             resume.ChunkCount,
@@ -2190,7 +2198,8 @@ public sealed partial class AiSubtitleDialogViewModel
                 sourceTranscription.CompletedChunkCount,
                 sourceTranscription.RequestKeySeed,
                 sourceTranscription.RequestKeyModel,
-                sourceTranscription.RequestKey.HasOutstandingName.Value);
+                sourceTranscription.RequestKey.HasOutstandingName.Value,
+                sourceTranscription.SourceStartSamples);
         }
 
         return new CaptionDraft(
@@ -2426,6 +2435,7 @@ public sealed partial class AiSubtitleDialogViewModel
                     source.LastWriteTimeUtcTicks,
                     source.Language,
                     source.SampleRate,
+                    source.SourceStartSamples ?? -1,
                     source.TotalSamples,
                     source.ChunkSamples,
                     source.ChunkCount,
@@ -4760,6 +4770,7 @@ public sealed partial class AiSubtitleDialogViewModel
         long lastWriteTimeUtcTicks,
         string? language,
         int sampleRate,
+        long sourceStartSamples,
         long totalSamples,
         int chunkSamples,
         int chunkCount,
@@ -4800,6 +4811,8 @@ public sealed partial class AiSubtitleDialogViewModel
         public string? Language { get; } = language;
 
         public int SampleRate { get; } = sampleRate;
+
+        public long SourceStartSamples { get; } = sourceStartSamples;
 
         public long TotalSamples { get; set; } = totalSamples;
 

--- a/src/Beutl/ViewModels/Dialogs/AiSubtitleDialogViewModel.cs
+++ b/src/Beutl/ViewModels/Dialogs/AiSubtitleDialogViewModel.cs
@@ -1,0 +1,842 @@
+﻿using Beutl.Animation;
+using Beutl.Api;
+using Beutl.Api.Services;
+using Beutl.Audio;
+using Beutl.Collections;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Editor.Services.Captions;
+using Beutl.Engine;
+using Beutl.Graphics.Shapes;
+using Beutl.Language;
+using Beutl.Logging;
+using Beutl.Media;
+using Beutl.Media.Source;
+using Beutl.ProjectSystem;
+using Beutl.Services;
+using Beutl.Services.AI;
+using Beutl.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Reactive.Bindings;
+
+namespace Beutl.ViewModels.Dialogs;
+
+public sealed partial class AiSubtitleDialogViewModel : IDisposable, IAsyncDisposable, IAiModelListConsumer
+{
+    private readonly CompositeDisposable _disposables = [];
+    private readonly AsyncOperationLifetime _operations = new();
+    private readonly object _disposeGate = new();
+    private readonly LifetimeCancellationSource _lifetimeCts = new();
+    private CancellationTokenSource? _requestCts;
+    private readonly ILogger _logger = Log.CreateLogger<AiSubtitleDialogViewModel>();
+    private readonly SubtitleAiCapabilities _aiService;
+    private readonly IAiEntitlementService _entitlements;
+    private readonly IAiOperationAvailabilityService _availability;
+    private readonly IAiModelCatalogService _modelCatalog;
+    private readonly IAiPlanCoordinator _aiPlanCoordinator;
+    private readonly EditViewModel? _editViewModel;
+    private readonly ICaptionCodecProvider _captionCodecs;
+    private readonly ICaptionTemplateProvider _captionTemplates;
+    private readonly CaptionDocumentSerializer _captionSerializer;
+    private readonly ICaptionDraftStore _captionDraftStore;
+    private readonly IObservable<CaptionDraftScope?> _captionDraftScopes;
+    private bool _disposed;
+    private bool _updatingAudioSources;
+    private Task? _disposeTask;
+
+    internal AiSubtitleDialogViewModel(
+        IAiEntitlementService entitlements,
+        IAiOperationAvailabilityService availability,
+        IAiModelCatalogService modelCatalog,
+        IAiPlanCoordinator aiPlanCoordinator,
+        IAiTranscriptionService transcription,
+        IAiCaptionTranslationService translation,
+        CaptionCatalog captionCatalog,
+        ICaptionDraftStore captionDraftStore,
+        IObservable<CaptionDraftScope?> captionDraftScopes,
+        EditViewModel? editViewModel = null)
+    {
+        _entitlements = entitlements ?? throw new ArgumentNullException(nameof(entitlements));
+        _availability = availability ?? throw new ArgumentNullException(nameof(availability));
+        _modelCatalog = modelCatalog ?? throw new ArgumentNullException(nameof(modelCatalog));
+        _aiPlanCoordinator = aiPlanCoordinator
+            ?? throw new ArgumentNullException(nameof(aiPlanCoordinator));
+        _aiService = new SubtitleAiCapabilities(
+            transcription ?? throw new ArgumentNullException(nameof(transcription)),
+            translation ?? throw new ArgumentNullException(nameof(translation)));
+        ArgumentNullException.ThrowIfNull(captionCatalog);
+        _editViewModel = editViewModel;
+        _captionDraftStore = captionDraftStore
+            ?? throw new ArgumentNullException(nameof(captionDraftStore));
+        _captionDraftScopes = captionDraftScopes
+            ?? throw new ArgumentNullException(nameof(captionDraftScopes));
+        _captionCodecs = captionCatalog.Codecs;
+        _captionTemplates = captionCatalog.Templates;
+        _captionSerializer = captionCatalog.Serializer;
+        Usage = new AiUsageViewModel(_entitlements.Entitlements).DisposeWith(_disposables);
+        // Two operations on one screen, so two pickers: transcription and
+        // translation have their own models and their own prices.
+        TranscriptionModelPicker = new AiModelPickerViewModel(_modelCatalog, _entitlements)
+            .DisposeWith(_disposables);
+        TranslationModelPicker = new AiModelPickerViewModel(_modelCatalog, _entitlements)
+            .DisposeWith(_disposables);
+        // A run holds the model it started on, so replacing the list under it
+        // could not rename its pieces — but it would say the wrong thing about
+        // what the next one will cost.
+        TranscriptionModelPicker.CanReload =
+            _ => !HasPendingTranscriptionName();
+        TranslationModelPicker.CanReload =
+            _ => !HasPendingTranslationName();
+        TranscriptionModelPicker.KeepOffered = operation =>
+            operation == AiOperations.Transcription
+                ? OutstandingTranscriptionModels()
+                : [];
+        TranslationModelPicker.KeepOffered = operation =>
+            operation == AiOperations.CaptionTranslation
+                ? OutstandingTranslationModels()
+                : [];
+
+        AudioSources = new ReactivePropertySlim<IReadOnlyList<AudioSourceItem>>([])
+            .DisposeWith(_disposables);
+        SelectedAudioSource = new ReactivePropertySlim<AudioSourceItem?>()
+            .DisposeWith(_disposables);
+        SelectedAudioSource.Subscribe(_ =>
+        {
+            if (_updatingAudioSources)
+                return;
+
+            ResultSegments.Value = null;
+            Error.Value = null;
+            InvalidatePartialResultResume();
+        }).DisposeWith(_disposables);
+
+        CaptionTemplates = captionCatalog.Templates.Templates;
+        SelectedCaptionTemplate = new ReactivePropertySlim<CaptionTemplateDescriptor>(CaptionTemplates[0])
+            .DisposeWith(_disposables);
+        CaptionTemplates.CollectionChanged += OnCaptionTemplatesChanged;
+
+        IsTranscribing = new ReactivePropertySlim<bool>(false)
+            .DisposeWith(_disposables);
+        TranscriptionStatusText = IsTranscribing
+            .Select(value => value ? Strings.AiSubtitle_Transcribing : string.Empty)
+            .ToReadOnlyReactivePropertySlim(string.Empty)
+            .DisposeWith(_disposables);
+
+        InitializeCaptionEditing();
+
+        CanTranscribe = CanTranscribeInput
+            .CombineLatest(
+                IsTranscribing,
+                IsTranslating,
+                (hasInput, transcribing, translating) => hasInput && !transcribing && !translating)
+            .CombineLatest(
+                TranscriptionEstimate.CanAfford,
+                HasOutstandingTranscriptionRequest,
+                // Or a run that has already named pieces: the server answers a
+                // repeat with the job that name made before it looks at the
+                // balance, so a run whose last piece spent the balance has to
+                // stay collectable.
+                (canTranscribe, canAfford, outstanding) =>
+                    canTranscribe && (canAfford || outstanding))
+            .CombineLatest(
+                TranscriptionModelPicker.OffersNothingUsable,
+                HasOutstandingTranscriptionRequest,
+                // Every model the operation registered was ruled out, so a new
+                // request would be refused however it is shaped — but a run
+                // already holding a name is answered from the job it made.
+                (can, nothingUsable, outstanding) =>
+                    can && (!nothingUsable || outstanding))
+            // Until the list has been asked for, a request would name no model
+            // and run on the server's default, which may cost more than what
+            // this screen was about to offer.
+            .CombineLatest(
+                TranscriptionModelPicker.IsLoaded,
+                (can, loaded) => can && loaded)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        Transcribe = new AsyncReactiveCommand(CanTranscribe)
+            .WithSubscribe(TranscribeCore);
+
+        StopRequest = new ReactiveCommand(
+            IsTranscribing.CombineLatest(IsTranslating, (a, b) => a || b));
+        StopRequest.Subscribe(() => _requestCts?.Cancel()).DisposeWith(_disposables);
+
+        CanAddToScene = HasValidCues
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        AddToScene = new AsyncReactiveCommand(CanAddToScene)
+            .WithSubscribe(AddToSceneCore);
+
+        OpenAiPlan = new ReactiveCommand();
+        OpenAiPlan.Subscribe(aiPlanCoordinator.OpenAiPlan).DisposeWith(_disposables);
+
+        ShowJoinPro = Usage.HasSnapshot
+            .CombineLatest(Usage.CanUseAi, (hasSnapshot, canUseAi) => hasSnapshot && !canUseAi)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        _ = LoadEntitlementsAsync();
+        _ = LoadAudioSourcesAsync();
+    }
+
+    public ReactivePropertySlim<IReadOnlyList<AudioSourceItem>> AudioSources { get; }
+
+    public ReactivePropertySlim<AudioSourceItem?> SelectedAudioSource { get; }
+
+    public ICoreReadOnlyList<CaptionTemplateDescriptor> CaptionTemplates { get; }
+
+    public ReactivePropertySlim<CaptionTemplateDescriptor> SelectedCaptionTemplate { get; }
+
+    public ReactivePropertySlim<bool> IsTranscribing { get; }
+
+    public ReadOnlyReactivePropertySlim<string> TranscriptionStatusText { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> CanTranscribe { get; }
+
+    public AsyncReactiveCommand Transcribe { get; }
+
+    /// <summary>
+    /// Abandons the transcription or translation in flight. A long scene takes
+    /// minutes, so a wrong audio source must not mean closing the tab.
+    /// </summary>
+    public ReactiveCommand StopRequest { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> CanAddToScene { get; }
+
+    public AsyncReactiveCommand AddToScene { get; }
+
+    public ReactiveCommand OpenAiPlan { get; }
+
+    internal IAiPlanCoordinator AiPlanCoordinator => _aiPlanCoordinator;
+
+    internal void RefreshAvailability()
+    {
+        _transcriptionEstimateRevision.Value++;
+        RefreshTranslationEstimate();
+    }
+
+    public ReactivePropertySlim<AiTranscriptionSegment[]?> ResultSegments { get; } = new();
+
+    internal AiUsageViewModel Usage { get; }
+
+    internal AiModelPickerViewModel TranscriptionModelPicker { get; }
+
+    internal AiModelPickerViewModel TranslationModelPicker { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> ShowJoinPro { get; }
+
+    public ReactivePropertySlim<string?> Error { get; } = new();
+
+    public void Dispose() => _ = BeginDisposeAsync();
+
+    public ValueTask DisposeAsync() => new(BeginDisposeAsync());
+
+    private Task BeginDisposeAsync()
+    {
+        TaskCompletionSource completion;
+        CancellationTokenSource? previewCts;
+        Task disposeTask;
+        lock (_disposeGate)
+        {
+            if (_disposeTask is not null)
+                return _disposeTask;
+
+            _disposed = true;
+            previewCts = CloseTemplatePreviewAdmission();
+            completion = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _disposeTask = completion.Task;
+            disposeTask = completion.Task;
+        }
+
+        CancelTemplatePreview(previewCts);
+        _ = CompleteDisposeAsync(completion);
+        return disposeTask;
+    }
+
+    private async Task CompleteDisposeAsync(TaskCompletionSource completion)
+    {
+        try
+        {
+            await _operations.DisposeAsync(
+                _lifetimeCts.Cancel,
+                () =>
+                {
+                    CaptionTemplates.CollectionChanged -= OnCaptionTemplatesChanged;
+                    DisposeCaptionEditing();
+                    AudioSources.Dispose();
+                    SelectedAudioSource.Dispose();
+                    SelectedCaptionTemplate.Dispose();
+                    IsTranscribing.Dispose();
+                    ResultSegments.Dispose();
+                    PartialResultMessage.Dispose();
+                    HasPartialResult.Dispose();
+                    HasPendingHistoryResult.Dispose();
+                    HistoryOverwriteMessage.Dispose();
+                    Error.Dispose();
+                    _disposables.Dispose();
+                    _lifetimeCts.Dispose();
+                    return ValueTask.CompletedTask;
+                });
+            completion.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
+        }
+    }
+
+    /// <summary>
+    /// Re-reads the model list. The catalog is cached with a freshness window,
+    /// so this costs nothing while it is fresh and picks up a model an operator
+    /// added, removed or reordered once it is not — which a workspace tab left
+    /// open would otherwise never see.
+    /// </summary>
+    public void RefreshModels() => _ = RefreshModelsAsync();
+
+    private async Task RefreshModelsAsync()
+    {
+        using AsyncOperationLifetime.Operation? operation = _operations.TryEnter();
+        if (operation is null)
+            return;
+        // A run waiting to be collected names its unfinished pieces partly by
+        // the model it started on. The run itself holds that model, so a reload
+        // could not rename them — but moving the picker under a run that is
+        // still going says the wrong thing about what the next piece will cost.
+        if (HasOutstandingTranscriptionRequest.Value
+            || HasOutstandingTranslationRequest.Value)
+        {
+            return;
+        }
+
+        try
+        {
+            await TranscriptionModelPicker.LoadAsync(
+                AiOperations.Transcription,
+                _restoredTranscriptionModel,
+                operation.CancellationToken);
+            await TranslationModelPicker.LoadAsync(
+                AiOperations.CaptionTranslation,
+                _restoredTranslationModel,
+                operation.CancellationToken);
+        }
+        catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to reload the AI models for subtitles.");
+        }
+    }
+
+    private async Task LoadEntitlementsAsync()
+    {
+        using AsyncOperationLifetime.Operation? operation = _operations.TryEnter();
+        if (operation is null)
+            return;
+        try
+        {
+            await _entitlements.RefreshAsync(operation.CancellationToken);
+            // A restored run is put back on the model it was named for; without
+            // that, its unfinished pieces would be named differently and bought
+            // a second time.
+            await TranscriptionModelPicker.LoadAsync(
+                AiOperations.Transcription,
+                _restoredTranscriptionModel,
+                operation.CancellationToken);
+            await TranslationModelPicker.LoadAsync(
+                AiOperations.CaptionTranslation,
+                _restoredTranslationModel,
+                operation.CancellationToken);
+        }
+        catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load AI entitlements.");
+        }
+    }
+
+    private Task LoadAudioSourcesAsync()
+    {
+        if (_disposed)
+            return Task.CompletedTask;
+
+        if (_editViewModel == null)
+        {
+            AudioSources.Value = [];
+            return Task.CompletedTask;
+        }
+
+        var items = new List<AudioSourceItem>();
+        Scene scene = _editViewModel.Scene;
+        items.Add(AudioSourceItem.CreateSceneMix(
+            Strings.AiSubtitle_SceneMix,
+            scene.Start,
+            scene.Duration));
+        foreach (Element element in scene.Children)
+        {
+            foreach (EngineObject obj in element.Objects)
+            {
+                if (obj is SourceSound sound
+                    && sound.Source.CurrentValue is { } source
+                    && source.HasUri
+                    && source.Uri.IsFile)
+                {
+                    // Use the original audio duration. Element length is user-editable and cannot
+                    // be trusted for usage calculation.
+                    TimeSpan duration = sound.TryGetOriginalDuration(out TimeSpan original)
+                        ? original
+                        : element.Length;
+                    items.Add(new AudioSourceItem(
+                        element.Name,
+                        source.Uri.LocalPath,
+                        duration,
+                        element.Start,
+                        element.Length,
+                        sound.OffsetPosition.CurrentValue,
+                        sound.Speed.CurrentValue,
+                        sound.Speed.Animation as KeyFrameAnimation<float>,
+                        elementId: element.Id));
+                }
+            }
+        }
+
+        AudioSourceItem? previous = SelectedAudioSource.Value;
+        AudioSourceItem? selected = previous is null
+            ? items.FirstOrDefault()
+            : items.FirstOrDefault(item =>
+                AudioSourceItem.HasSameSelectionIdentity(item, previous))
+              ?? items.FirstOrDefault();
+        if (selected is not null
+            && previous is not null
+            && AudioSourceItem.CanReuseSelectionSnapshot(selected, previous))
+        {
+            int selectedIndex = items.IndexOf(selected);
+            items[selectedIndex] = previous;
+            selected = previous;
+        }
+
+        AudioSources.Value = items;
+        if (!ReferenceEquals(SelectedAudioSource.Value, selected))
+        {
+            _updatingAudioSources = true;
+            try
+            {
+                SelectedAudioSource.Value = selected;
+            }
+            finally
+            {
+                _updatingAudioSources = false;
+            }
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// The token the request in flight runs under: the tab's lifetime, plus the
+    /// person's own request to stop.
+    /// </summary>
+    private CancellationToken RequestToken => _requestCts?.Token ?? _lifetimeCts.Token;
+
+    private bool IsRequestCanceled
+        => _lifetimeCts.IsCancellationRequested || _requestCts?.IsCancellationRequested == true;
+
+    private async Task TranscribeCore()
+    {
+        using AsyncOperationLifetime.Operation? operation = _operations.TryEnter();
+        if (operation is null)
+            return;
+        if (SelectedAudioSource.Value is not { } source)
+        {
+            return;
+        }
+
+        long draftScopeRevision = Interlocked.Read(ref _captionDraftScopeRevision);
+        Error.Value = null;
+        IsTranscribing.Value = true;
+        using CancellationTokenSource requestCts =
+            CancellationTokenSource.CreateLinkedTokenSource(
+                operation.CancellationToken,
+                _lifetimeCts.Token);
+        _requestCts = requestCts;
+        try
+        {
+            await TranscribeSelectedSourceAsync(source, operation);
+        }
+        catch (AuthenticationRequiredException)
+        {
+            SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiAuthenticationRequired);
+        }
+        catch (AiPlanRequiredException)
+        {
+            SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiProRequired);
+        }
+        catch (AiUsageLimitExceededException)
+        {
+            SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiUsageLimitExceeded);
+        }
+        catch (AiFileTooLargeException)
+        {
+            SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiFileTooLarge);
+        }
+        catch (AiResultUnavailableException)
+        {
+            SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiResultUnavailable);
+        }
+        catch (AiModelUnavailableException)
+        {
+            SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiModelUnavailable);
+        }
+        catch (AiModelDoesNotSupportRequestException)
+        {
+            SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiModelDoesNotSupportRequest);
+        }
+        catch (AiProviderErrorException)
+        {
+            SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiProviderError);
+        }
+        // Reachable because a chunk keeps its name across attempts: asking again
+        // for one the server is still working on is how its result is recovered
+        // rather than bought twice, and until it finishes the answer is this.
+        catch (AiRequestInProgressException)
+        {
+            SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiRequestInProgress);
+        }
+        // This execution's name belongs to another request. Scene-mixed audio can change whenever
+        // it is recomposed, so a restored execution can arrive here. Keep paid chunks as-is and
+        // purchase the remainder under new names.
+        catch (AiRequestChangedException)
+        {
+            RetireTranscriptionRunNames();
+            SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiRequestChanged);
+        }
+        catch (AiRequestWasDeletedException)
+        {
+            // The job those names made is gone, so the rest of the run needs new
+            // ones — written to the draft as well, or a run resumed after a
+            // restart would ask under the same deleted name and stop there for
+            // good. The pieces already paid for stay paid.
+            RetireTranscriptionRunNames();
+            SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiRequestWasDeleted);
+        }
+        catch (SubtitleInputException ex)
+        {
+            SetCaptionErrorIfCurrent(draftScopeRevision, ex.Message);
+        }
+        catch (OperationCanceledException) when (IsRequestCanceled)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to transcribe audio.");
+            SetCaptionErrorIfCurrent(draftScopeRevision, Strings.AiUnexpectedError);
+        }
+        finally
+        {
+            _requestCts = null;
+            operation.TryPublish(() =>
+            {
+                if (IsCurrentCaptionDraftScope(draftScopeRevision))
+                    IsTranscribing.Value = false;
+            });
+        }
+    }
+
+    private async Task AddToSceneCore()
+    {
+        using AsyncOperationLifetime.Operation? operation = _operations.TryEnter();
+        if (operation is null)
+            return;
+        if (_editViewModel == null
+            || !TryBuildCaptionDocument(out CaptionDocument? document, out _)
+            || document is null)
+        {
+            return;
+        }
+
+        try
+        {
+            CaptionSceneImportResult result = await AiCaptionSceneImporter.AddAsync(
+                _editViewModel.Scene,
+                _editViewModel.GetRequiredService<IElementAdder>(),
+                document,
+                _captionTemplates,
+                SelectedCaptionTemplate.Value.Id,
+                operation.CancellationToken);
+
+            if (result.IsSuccess)
+            {
+                operation.TryPublish(() => NotificationService.ShowSuccess(Strings.AiSubtitle, Strings.AiSubtitleAddedToScene));
+            }
+            else if (result.FailureId == ElementAddFailureIds.LockedLayer)
+            {
+                operation.TryPublish(() => NotificationService.ShowWarning(Strings.Lock, Strings.LayerIsLocked));
+            }
+            else
+            {
+                throw new InvalidOperationException(
+                    $"Failed to add caption elements: {result.FailureId}.");
+            }
+        }
+        catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to add subtitles to the scene.");
+            operation.TryPublish(() => Error.Value = Strings.AiUnexpectedError);
+        }
+    }
+
+    private void OnCaptionTemplatesChanged(
+        object? sender,
+        System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+    {
+        if (_disposed)
+            return;
+
+        CaptionTemplateDescriptor? selected = CaptionTemplates
+            .FirstOrDefault(template => template.Id == SelectedCaptionTemplate.Value.Id);
+        SelectedCaptionTemplate.Value = selected
+            ?? CaptionTemplates.FirstOrDefault(template => template.Id == CaptionTemplateIds.DefaultText)
+            ?? CaptionTemplates[0];
+    }
+
+    // This private adapter keeps the partial implementation cohesive while the public API exposes
+    // transcription and translation as independent capabilities.
+    private sealed class SubtitleAiCapabilities(
+        IAiTranscriptionService transcription,
+        IAiCaptionTranslationService translation)
+    {
+        public Task<AiTranscriptionResponse> TranscribeAsync(
+            AiTranscriptionRequest request,
+            CancellationToken cancellationToken)
+            => transcription.TranscribeAsync(request, cancellationToken);
+
+        public Task<AiCaptionTranslationResponse> TranslateAsync(
+            AiCaptionTranslationRequest request,
+            IProgress<AiCaptionTranslationSegment>? progress,
+            CancellationToken cancellationToken)
+            => translation.TranslateAsync(request, progress, cancellationToken);
+    }
+
+}
+
+public sealed class AudioSourceItem
+{
+    private const int AnimationSampleRate = 1000;
+    private readonly TimeSpan _elementStart;
+    private readonly TimeSpan _elementLength;
+    private readonly TimeSpan _sourceOffset;
+    private readonly float _speed;
+    private readonly KeyFrameAnimation<float>? _speedAnimation;
+    private readonly Guid _elementId;
+
+    public AudioSourceItem(
+        string name,
+        string filePath,
+        TimeSpan duration,
+        TimeSpan elementStart = default,
+        TimeSpan? elementLength = null,
+        TimeSpan sourceOffset = default,
+        float speed = 100,
+        KeyFrameAnimation<float>? speedAnimation = null,
+        Guid elementId = default)
+    {
+        Name = name;
+        FilePath = filePath;
+        Duration = duration;
+        _elementId = elementId;
+        _elementStart = elementStart;
+        _elementLength = elementLength ?? duration;
+        _sourceOffset = sourceOffset;
+        _speed = Math.Max(speed, 0);
+        _speedAnimation = speedAnimation;
+    }
+
+    private AudioSourceItem(string name, TimeSpan sceneStart, TimeSpan duration)
+    {
+        Name = name;
+        FilePath = null;
+        Duration = duration;
+        IsSceneMix = true;
+        SceneStart = sceneStart;
+        _elementStart = sceneStart;
+        _elementLength = duration;
+        _speed = 100;
+    }
+
+    public string Name { get; }
+
+    public string? FilePath { get; }
+
+    public TimeSpan Duration { get; }
+
+    public bool IsSceneMix { get; }
+
+    public TimeSpan SceneStart { get; }
+
+    internal Guid ElementId => _elementId;
+
+    internal TimeSpan ElementLength => _elementLength;
+
+    internal TimeSpan SourceOffset => _sourceOffset;
+
+    internal float Speed => _speed;
+
+    internal double GetSourceElapsedSeconds()
+    {
+        if (_speedAnimation is null)
+            return Math.Max(_elementLength.TotalSeconds * (_speed / 100d), 0);
+
+        using var integrator = new SpeedIntegrator(AnimationSampleRate);
+        integrator.EnsureCache(_speedAnimation);
+        TimeSpan elapsed = _speedAnimation.UseGlobalClock
+            ? integrator.Integrate(_elementStart + _elementLength, _speedAnimation)
+              - integrator.Integrate(_elementStart, _speedAnimation)
+            : integrator.Integrate(_elementLength, _speedAnimation);
+        return Math.Max(elapsed.TotalSeconds, 0);
+    }
+
+    internal static AudioSourceItem CreateSceneMix(string name, TimeSpan sceneStart, TimeSpan duration)
+        => new(name, sceneStart, duration);
+
+    internal static bool CanResume(AudioSourceItem? candidate, AudioSourceItem? previous)
+    {
+        if (candidate is null || previous is null)
+            return false;
+        if (ReferenceEquals(candidate, previous))
+            return true;
+        if (candidate.IsSceneMix || previous.IsSceneMix)
+            return false;
+
+        return FilePathsEqual(candidate.FilePath!, previous.FilePath!)
+            && candidate.Duration == previous.Duration
+            && candidate._elementId == previous._elementId
+            && candidate._elementStart == previous._elementStart
+            && candidate._elementLength == previous._elementLength
+            && candidate._sourceOffset == previous._sourceOffset
+            && candidate._speed == previous._speed
+            && ReferenceEquals(candidate._speedAnimation, previous._speedAnimation);
+    }
+
+    internal static bool HasSameSelectionIdentity(
+        AudioSourceItem candidate,
+        AudioSourceItem previous)
+    {
+        if (candidate.IsSceneMix || previous.IsSceneMix)
+            return candidate.IsSceneMix && previous.IsSceneMix;
+        if (candidate._elementId != Guid.Empty && previous._elementId != Guid.Empty)
+            return candidate._elementId == previous._elementId;
+        return FilePathsEqual(candidate.FilePath!, previous.FilePath!);
+    }
+
+    internal static bool CanReuseSelectionSnapshot(
+        AudioSourceItem candidate,
+        AudioSourceItem previous)
+        => candidate.IsSceneMix && previous.IsSceneMix
+            ? candidate.SceneStart == previous.SceneStart
+              && candidate.Duration == previous.Duration
+            : string.Equals(candidate.Name, previous.Name, StringComparison.Ordinal)
+              && CanResume(candidate, previous);
+
+    internal static bool FilePathsEqual(string first, string second)
+        => GetFilePathComparer().Equals(Path.GetFullPath(first), Path.GetFullPath(second));
+
+    private static StringComparer GetFilePathComparer()
+        => OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+
+    internal AiTranscriptionSegment[] MapSegmentsToScene(IEnumerable<AiTranscriptionSegment> segments)
+    {
+        ArgumentNullException.ThrowIfNull(segments);
+
+        double elementLength = Math.Max(_elementLength.TotalSeconds, 0);
+        if (elementLength <= 0)
+            return [];
+
+        using var integrator = new SpeedIntegrator(AnimationSampleRate);
+        if (_speedAnimation != null)
+        {
+            integrator.EnsureCache(_speedAnimation);
+        }
+
+        double SourceElapsedAt(double localSeconds)
+        {
+            TimeSpan localTime = TimeSpan.FromSeconds(Math.Clamp(localSeconds, 0, elementLength));
+            if (_speedAnimation == null)
+                return localTime.TotalSeconds * (_speed / 100d);
+
+            TimeSpan elapsed = _speedAnimation.UseGlobalClock
+                ? integrator.Integrate(_elementStart + localTime, _speedAnimation)
+                  - integrator.Integrate(_elementStart, _speedAnimation)
+                : integrator.Integrate(localTime, _speedAnimation);
+            return Math.Max(elapsed.TotalSeconds, 0);
+        }
+
+        double totalSourceElapsed = SourceElapsedAt(elementLength);
+        if (totalSourceElapsed <= 0)
+            return [];
+
+        double sourceWindowStart = _sourceOffset.TotalSeconds;
+        double sourceWindowEnd = sourceWindowStart + totalSourceElapsed;
+
+        double ToLocalTime(double sourceSeconds)
+        {
+            double target = Math.Clamp(sourceSeconds - sourceWindowStart, 0, totalSourceElapsed);
+            double low = 0;
+            double high = elementLength;
+            for (int iteration = 0; iteration < 50; iteration++)
+            {
+                double middle = (low + high) / 2;
+                if (SourceElapsedAt(middle) < target)
+                {
+                    low = middle;
+                }
+                else
+                {
+                    high = middle;
+                }
+            }
+            return (low + high) / 2;
+        }
+
+        var result = new List<AiTranscriptionSegment>();
+        foreach (AiTranscriptionSegment segment in segments)
+        {
+            if (!double.IsFinite(segment.Start)
+                || !double.IsFinite(segment.End)
+                || segment.End <= segment.Start)
+            {
+                continue;
+            }
+
+            double clippedStart = Math.Max(segment.Start, sourceWindowStart);
+            double clippedEnd = Math.Min(segment.End, sourceWindowEnd);
+            if (clippedEnd <= clippedStart)
+                continue;
+
+            double sceneStart = _elementStart.TotalSeconds + ToLocalTime(clippedStart);
+            double sceneEnd = _elementStart.TotalSeconds + ToLocalTime(clippedEnd);
+            if (sceneEnd <= sceneStart)
+                continue;
+
+            result.Add(new AiTranscriptionSegment
+            {
+                Start = sceneStart,
+                End = sceneEnd,
+                Text = segment.Text,
+            });
+        }
+
+        return result.ToArray();
+    }
+
+    public override string ToString() => $"{Name} ({Duration.TotalSeconds:F1}s)";
+}

--- a/src/Beutl/ViewModels/Dialogs/AiVideoGenerationDialogViewModel.cs
+++ b/src/Beutl/ViewModels/Dialogs/AiVideoGenerationDialogViewModel.cs
@@ -1688,7 +1688,7 @@ internal sealed class AiVideoGenerationDialogViewModel : IDisposable, IAsyncDisp
                     job = await _videos.GetAsync(jobId, token);
                     transientFailures = 0;
                 }
-                catch (Exception ex) when (IsTransientPollingFailure(ex))
+                catch (Exception ex) when (IsTransientPollingFailure(ex, token))
                 {
                     transientFailures++;
                     operation.TryPublish(() => StatusText.Value = Strings.AiVideoProcessing);
@@ -1891,9 +1891,20 @@ internal sealed class AiVideoGenerationDialogViewModel : IDisposable, IAsyncDisp
         }
     }
 
-    private static bool IsTransientPollingFailure(Exception exception)
-        => exception is HttpRequestException
-            || exception is AiException { IsTransient: true };
+    private static bool IsTransientPollingFailure(
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            return false;
+
+        return exception is OperationCanceledException
+            or TimeoutException
+            or HttpRequestException
+            or AiException { IsTransient: true }
+            || exception.InnerException is { } inner
+            && IsTransientPollingFailure(inner, cancellationToken);
+    }
 
     private TimeSpan GetTransientPollDelay(int failureCount)
     {

--- a/src/Beutl/ViewModels/Dialogs/AiVideoGenerationDialogViewModel.cs
+++ b/src/Beutl/ViewModels/Dialogs/AiVideoGenerationDialogViewModel.cs
@@ -1,0 +1,2290 @@
+﻿using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.Reactive.Disposables;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Platform.Storage;
+using Avalonia.Threading;
+using Beutl.Api;
+using Beutl.Api.Services;
+using Beutl.Editor.Services;
+using Beutl.Graphics;
+using Beutl.Language;
+using Beutl.Logging;
+using Beutl.Media;
+using Beutl.Media.Source;
+using Beutl.ProjectSystem;
+using Beutl.Services;
+using Beutl.Services.AI;
+using Beutl.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Reactive.Bindings;
+
+namespace Beutl.ViewModels.Dialogs;
+
+internal sealed class AiVideoGenerationDialogViewModel : IDisposable, IAsyncDisposable, IAiModelListConsumer
+{
+    private readonly CompositeDisposable _disposables = [];
+    private readonly AsyncOperationLifetime _operations = new();
+    private readonly IdentityOperationLifetime _identityOperations = new();
+    private readonly object _disposeGate = new();
+    private readonly ILogger _logger = Log.CreateLogger<AiVideoGenerationDialogViewModel>();
+    private readonly IAiEntitlementService _entitlements;
+    private readonly IAiOperationAvailabilityService _availability;
+    private readonly IAiModelCatalogService _modelCatalog;
+    private readonly IAiPlanCoordinator _aiPlanCoordinator;
+    private readonly IAiVideoService _videos;
+    private readonly IAuthenticatedContentService _content;
+    private readonly IAiJobKindRegistry _jobKinds;
+    private readonly IAiJobMonitor _jobMonitor;
+    private readonly AiOperationAvailabilityTracker _availabilityTracker;
+    private readonly AiRequestKey _requestKey;
+    private readonly AiRequestRecoveryContext? _requestRecoveryContext;
+    // The model the outstanding name was built from. A refresh that withdraws
+    // that model would otherwise rebuild the name around whatever the picker
+    // fell back to, and the job the first attempt paid for would be left behind.
+    private readonly CancellationTokenSource _availabilityLifetimeCts = new();
+    private readonly EditViewModel? _editViewModel;
+    private readonly HashSet<string> _temporaryFiles = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, int> _temporaryFileLeases = new(StringComparer.Ordinal);
+    // Temporary frame files retained for each unsettled request name.
+    private readonly Dictionary<string, IDisposable> _framesHeldByName =
+        new(StringComparer.Ordinal);
+    // Preserve the user's choices separately from the displayed values, which are narrowed when
+    // the model changes. Restoring the old model must also restore these values or the same intent
+    // becomes a different request and no longer reaches the result named by the outstanding key.
+    private AiVideoDurationOption? _chosenDuration;
+    private AiVideoResolutionOption? _chosenResolution;
+    private AiVideoAspectRatioOption? _chosenAspectRatio;
+    private bool _chosenAudio = true;
+    private int? _chosenSeed;
+    private (string? Path, string? ElementId) _chosenFirstFrame;
+    private (string? Path, string? ElementId) _chosenLastFrame;
+    // True while model constraints update the UI. Those changes are not user choices and must
+    // not replace the preserved values.
+    private bool _applyingCapabilities;
+    private readonly HashSet<string> _temporaryFilesPendingDeletion = new(StringComparer.Ordinal);
+    private readonly object _lifetimeGate = new();
+    private CancellationTokenSource? _pollingCts;
+    private IdentityOperationLifetime.Operation? _runningRequest;
+    private string? _firstFrameElementId;
+    private string? _lastFrameElementId;
+    private AiVideoResultSnapshot? _resultSnapshot;
+    private AiPendingAttempt? _selectedRecovery;
+    private readonly ReactivePropertySlim<int> _recoveryRevision = new();
+    private Task? _disposeTask;
+
+    internal AiVideoGenerationDialogViewModel(
+        IAiEntitlementService entitlements,
+        IAiOperationAvailabilityService availability,
+        IAiModelCatalogService modelCatalog,
+        IAiPlanCoordinator aiPlanCoordinator,
+        IAiVideoService videos,
+        IAuthenticatedContentService content,
+        IAiJobKindRegistry jobKinds,
+        IAiJobMonitor jobMonitor,
+        EditViewModel? editViewModel,
+        AiRequestRecoveryContext requestRecoveryContext)
+    {
+        _entitlements = entitlements ?? throw new ArgumentNullException(nameof(entitlements));
+        _availability = availability ?? throw new ArgumentNullException(nameof(availability));
+        _modelCatalog = modelCatalog ?? throw new ArgumentNullException(nameof(modelCatalog));
+        _aiPlanCoordinator = aiPlanCoordinator
+            ?? throw new ArgumentNullException(nameof(aiPlanCoordinator));
+        _videos = videos ?? throw new ArgumentNullException(nameof(videos));
+        _content = content ?? throw new ArgumentNullException(nameof(content));
+        _jobKinds = jobKinds ?? throw new ArgumentNullException(nameof(jobKinds));
+        _jobMonitor = jobMonitor ?? throw new ArgumentNullException(nameof(jobMonitor));
+        _editViewModel = editViewModel;
+        _requestRecoveryContext = requestRecoveryContext;
+        _requestKey = new(
+            recoveryContext: requestRecoveryContext,
+            operation: "video.generate");
+        Usage = new AiUsageViewModel(_entitlements.Entitlements).DisposeWith(_disposables);
+        ModelPicker = new AiModelPickerViewModel(_modelCatalog, _entitlements)
+            .DisposeWith(_disposables);
+        PromptLibrary = new AiPromptLibraryViewModel(
+                PromptTaskKind.Video,
+                ComposePrompt,
+                prompt => Prompt.Value = prompt,
+                recoveryContext: requestRecoveryContext)
+            .DisposeWith(_disposables);
+
+        Replace(
+            DurationOptions,
+            DefaultDurations.Select(seconds => new AiVideoDurationOption(seconds)));
+        SelectedDuration = new ReactivePropertySlim<AiVideoDurationOption>(DurationOptions[1])
+            .DisposeWith(_disposables);
+        // The lengths a model takes are a short, unevenly spaced list, so the
+        // slider walks that list by index instead of pretending every second in
+        // between can be asked for.
+        DurationIndex = new ReactivePropertySlim<int>(DurationOptions.IndexOf(SelectedDuration.Value))
+            .DisposeWith(_disposables);
+        MaxDurationIndex = new ReactivePropertySlim<int>(DurationOptions.Count - 1)
+            .DisposeWith(_disposables);
+        SelectedDuration.Subscribe(option => DurationIndex.Value = IndexOfDuration(option))
+            .DisposeWith(_disposables);
+        DurationIndex.Subscribe(index =>
+        {
+            if (index >= 0 && index < DurationOptions.Count)
+                SelectedDuration.Value = DurationOptions[index];
+        }).DisposeWith(_disposables);
+        _availabilityTracker = new AiOperationAvailabilityTracker(
+            _availability,
+            _availabilityLifetimeCts.Token);
+        SelectedDuration.Subscribe(option =>
+                _availabilityTracker.Check(new AiOperationAvailabilityRequest.Video(
+                    AiOperations.VideoGeneration,
+                    option.Seconds,
+                    ModelPicker.SelectedModel)))
+            .DisposeWith(_disposables);
+        // A dearer model can put the same clip out of reach, so the estimate
+        // has to be re-asked when the choice changes.
+        ModelPicker.Selected.Subscribe(_ =>
+                _availabilityTracker.Check(new AiOperationAvailabilityRequest.Video(
+                    AiOperations.VideoGeneration,
+                    SelectedDuration.Value.Seconds,
+                    ModelPicker.SelectedModel)))
+            .DisposeWith(_disposables);
+        EstimatedUsage = new AiUsageEstimateViewModel(
+                Usage,
+                _availabilityTracker.State)
+            .DisposeWith(_disposables);
+
+        Replace(
+            ResolutionOptions,
+            DefaultResolutions.Select(value => new AiVideoResolutionOption(value)));
+        SelectedResolution = new ReactivePropertySlim<AiVideoResolutionOption>(ResolutionOptions[0])
+            .DisposeWith(_disposables);
+
+        // Resolution says how many pixels; this says what shape they are in.
+        // Without it a vertical clip could not be asked for at all.
+        Replace(
+            AspectRatioOptions,
+            DefaultAspectRatios.Select(value => new AiVideoAspectRatioOption(value)));
+        SelectedAspectRatio = new ReactivePropertySlim<AiVideoAspectRatioOption>(
+                GetSuggestedAspectRatio(AspectRatioOptions, editViewModel?.Scene.FrameSize))
+            .DisposeWith(_disposables);
+        // On by default: the model produces sound and the plan is priced for it.
+        GenerateAudio = new ReactivePropertySlim<bool>(true)
+            .DisposeWith(_disposables);
+        SupportsAudio = new ReactivePropertySlim<bool>(true)
+            .DisposeWith(_disposables);
+        SupportsSeed = new ReactivePropertySlim<bool>(true)
+            .DisposeWith(_disposables);
+        Seed = new ReactivePropertySlim<int?>()
+            .DisposeWith(_disposables);
+        // A model that cannot be given a shape must not be offered one, so the
+        // lists are rebuilt from whichever model is chosen.
+        ModelPicker.Filter = model =>
+            model.Video is not { } video || video.CanServeAnything();
+        SelectedDuration.Subscribe(option =>
+            {
+                if (!_applyingCapabilities)
+                    _chosenDuration = option;
+            })
+            .DisposeWith(_disposables);
+        SelectedResolution.Subscribe(option =>
+            {
+                if (!_applyingCapabilities)
+                    _chosenResolution = option;
+            })
+            .DisposeWith(_disposables);
+        SelectedAspectRatio.Subscribe(option =>
+            {
+                if (!_applyingCapabilities)
+                    _chosenAspectRatio = option;
+            })
+            .DisposeWith(_disposables);
+        GenerateAudio.Subscribe(value =>
+            {
+                if (!_applyingCapabilities)
+                    _chosenAudio = value;
+            })
+            .DisposeWith(_disposables);
+        Seed.Subscribe(seed =>
+            {
+                if (!_applyingCapabilities)
+                    _chosenSeed = seed;
+            })
+            .DisposeWith(_disposables);
+        ModelPicker.Selected.Subscribe(option => ApplyModelCapabilities(option?.Model))
+            .DisposeWith(_disposables);
+        // The shape, and whether frames may guide the clip at all, follow the
+        // chosen model; replacing the list under an outstanding name would
+        // rewrite the request waiting to be collected.
+        ModelPicker.KeepOffered = operation => _requestKey.PersistedModels(operation);
+        ModelPicker.CanReload = _ => !_requestKey.HasOutstandingName.Value;
+
+        IsGenerating = new ReactivePropertySlim<bool>(false)
+            .DisposeWith(_disposables);
+        IsWaitingForJob = new ReactivePropertySlim<bool>(false)
+            .DisposeWith(_disposables);
+
+        PromptValidationError = Prompt
+            .CombineLatest(
+                Style,
+                Composition,
+                Motion,
+                Exclusions,
+                (prompt, style, composition, motion, exclusions) =>
+                    AiPromptComposer.GetValidationError(new AiPromptParts(
+                        prompt,
+                        style,
+                        composition,
+                        motion,
+                        exclusions)))
+            .ToReadOnlyReactivePropertySlim(Strings.AiPromptRequired)
+            .DisposeWith(_disposables);
+
+        VisiblePromptValidationError = AiPromptValidation
+            .WhileTyping(PromptValidationError, Prompt, Style, Composition, Motion, Exclusions)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        SelectFirstFrame = new AsyncReactiveCommand()
+            .WithSubscribe(() => SelectFrameAsync(isFirstFrame: true));
+        SelectLastFrame = new AsyncReactiveCommand()
+            .WithSubscribe(() => SelectFrameAsync(isFirstFrame: false));
+        CaptureCurrentFrame = new AsyncReactiveCommand()
+            .WithSubscribe(CaptureCurrentFrameAsync);
+        ClearFirstFrame = new ReactiveCommand();
+        ClearFirstFrame.Subscribe(() => SetFrame(isFirstFrame: true, null)).DisposeWith(_disposables);
+        ClearLastFrame = new ReactiveCommand();
+        ClearLastFrame.Subscribe(() => SetFrame(isFirstFrame: false, null)).DisposeWith(_disposables);
+
+        CanGenerate = PromptValidationError
+            .CombineLatest(IsGenerating, (error, generating) => error is null && !generating)
+            .CombineLatest(
+                FirstFramePath,
+                LastFramePath,
+                (canGenerate, firstFrame, lastFrame) =>
+                    canGenerate && (string.IsNullOrEmpty(lastFrame) || !string.IsNullOrEmpty(firstFrame)))
+            .CombineLatest(
+                EstimatedUsage.CanAfford,
+                _requestKey.HasOutstandingName,
+                // Or a name already handed out: the server answers a repeat with the
+                // job that name made before it looks at the balance, so the request
+                // that spent the last of it is exactly the one that must stay
+                // collectable.
+                (canGenerate, canAfford, outstanding) =>
+                    canGenerate && (canAfford || outstanding))
+            .CombineLatest(
+                ModelPicker.OffersNothingUsable,
+                _requestKey.HasOutstandingName,
+                // Every model the operation registered was ruled out, so a new
+                // request would be refused however it is shaped — but a name
+                // already handed out is answered from the job it made, whatever
+                // the catalog says now.
+                (can, nothingUsable, outstanding) =>
+                    can && (!nothingUsable || outstanding))
+            // Until the list has been asked for, a request would name no model
+            // and run on the server's default, which may cost more than what
+            // this screen was about to offer.
+            .CombineLatest(ModelPicker.IsLoaded, (can, loaded) => can && loaded)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        Generate = new AsyncReactiveCommand(CanGenerate)
+            .WithSubscribe(GenerateCore);
+        StopGenerating = new ReactiveCommand(IsGenerating);
+        StopGenerating.Subscribe(StopGeneratingCore).DisposeWith(_disposables);
+
+        RecoverSelectedAttempt = new ReactiveCommand();
+        RecoverSelectedAttempt.Subscribe(() =>
+        {
+            if (SelectedRecoveryAttempt!.Value is { } attempt)
+                TryRecoverPendingAttempt(attempt);
+        }).DisposeWith(_disposables);
+        AbandonSelectedAttempt = new ReactiveCommand();
+        AbandonSelectedAttempt.Subscribe(() =>
+        {
+            if (SelectedRecoveryAttempt!.Value is { } attempt)
+                AbandonPendingAttempt(attempt);
+        }).DisposeWith(_disposables);
+
+        CanAddToScene = ResultVideoPath
+            .Select(x => x != null)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        AddToScene = new AsyncReactiveCommand(CanAddToScene)
+            .WithSubscribe(AddToSceneCore);
+
+        SaveToFile = new AsyncReactiveCommand(CanAddToScene)
+            .WithSubscribe(SaveToFileCore);
+
+        OpenResult = new ReactiveCommand(CanAddToScene);
+        OpenResult.Subscribe(OpenResultCore).DisposeWith(_disposables);
+
+        OpenAiPlan = new ReactiveCommand();
+        OpenAiPlan.Subscribe(aiPlanCoordinator.OpenAiPlan).DisposeWith(_disposables);
+
+        ShowJoinPro = Usage.HasSnapshot
+            .CombineLatest(Usage.CanUseAi, (hasSnapshot, canUseAi) => hasSnapshot && !canUseAi)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        SelectedRecoveryAttempt = new ReactivePropertySlim<AiPendingAttempt?>()
+            .DisposeWith(_disposables);
+        RecoveryAttempts = _recoveryRevision
+            .Select(_ => (IReadOnlyList<AiPendingAttempt>)GetPendingRecoveryAttempts())
+            .ToReadOnlyReactivePropertySlim(Array.Empty<AiPendingAttempt>())
+            .DisposeWith(_disposables);
+        RecoveryAvailable = RecoveryAttempts
+            .Select(attempts => attempts.Count != 0)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+        if (_requestRecoveryContext is not null)
+            _requestRecoveryContext.IdentityChanged += OnIdentityChanged;
+
+        CoreObject? selectedObject = editViewModel?.GetService<IEditorSelection>()?.SelectedObject.Value;
+        SetFrame(
+            isFirstFrame: true,
+            AiImageEditDialogViewModel.GetSelectedImageSourcePath(selectedObject),
+            selectedObject is Element selectedElement ? selectedElement.Id.ToString("N") : null);
+
+        _ = LoadEntitlementsAsync();
+        TryAutoRecoverSingleAttempt();
+    }
+
+    /// <summary>
+    /// The lengths on offer, which follow the chosen model: Veo 3.1 takes 4, 6
+    /// or 8 seconds and nothing between, MiniMax H3 nothing under five. A model
+    /// that publishes none leaves the list this client has always offered.
+    /// </summary>
+    public ObservableCollection<AiVideoDurationOption> DurationOptions { get; } = [];
+
+    public ReactivePropertySlim<AiVideoDurationOption> SelectedDuration { get; }
+
+    /// <summary>Where the duration slider sits in <see cref="DurationOptions"/>.</summary>
+    public ReactivePropertySlim<int> DurationIndex { get; }
+
+    /// <summary>The last index <see cref="DurationOptions"/> currently holds.</summary>
+    public ReactivePropertySlim<int> MaxDurationIndex { get; }
+
+    public ObservableCollection<AiVideoResolutionOption> ResolutionOptions { get; } = [];
+
+    public ReactivePropertySlim<AiVideoResolutionOption> SelectedResolution { get; }
+
+    public ObservableCollection<AiVideoAspectRatioOption> AspectRatioOptions { get; } = [];
+
+    public ReactivePropertySlim<AiVideoAspectRatioOption> SelectedAspectRatio { get; }
+
+    public ReactivePropertySlim<bool> GenerateAudio { get; }
+
+    /// <summary>
+    /// False for a model that produces no sound, or takes no seed. The controls
+    /// are hidden rather than left to fail: a request carrying either would be
+    /// refused, and a switch that does nothing is worse than none.
+    /// </summary>
+    public ReactivePropertySlim<bool> SupportsAudio { get; }
+
+    public ReactivePropertySlim<bool> SupportsSeed { get; }
+
+    /// <summary>
+    /// Repeating a seed with the same prompt reproduces the same clip. Null
+    /// leaves the choice to the server, which is a different clip every run.
+    /// </summary>
+    public ReactivePropertySlim<int?> Seed { get; }
+
+    public decimal SeedMinimum => AiRequestLimits.MinSeed;
+
+    public decimal SeedMaximum => AiRequestLimits.MaxSeed;
+
+    /// <summary>
+    /// What this client asks for when the server says nothing about a model —
+    /// the lists it offered before models could publish their own. The server
+    /// accepts more than these; a shape it would take but this dialog has no
+    /// control for is simply not offered.
+    /// </summary>
+    private static readonly int[] DefaultDurations = [4, 6, 8];
+
+    private static readonly string[] DefaultResolutions = ["720p", "1080p"];
+
+    // Where the model sits in the request's parts. It is filled in last: which
+    // model a request carries depends on whether a name is already outstanding
+    // for the rest of it.
+    private const int ModelPartIndex = 6;
+
+    private static readonly string[] DefaultAspectRatios = ["16:9", "9:16"];
+
+    /// <summary>
+    /// Rebuilds the lists around the chosen model, keeping each selection where
+    /// the model still takes it. A length is snapped to the nearest on offer
+    /// rather than reset: a model that takes 6 but not 5 should land on 6, and
+    /// leaving 5 in place would be charged for and then refused.
+    /// </summary>
+    private void ApplyModelCapabilities(AiModelOption? model)
+    {
+        AiVideoModelCapabilities video = model?.Video ?? AiVideoModelCapabilities.Unrestricted;
+
+        // What the user asked for is remembered apart from what the model on
+        // screen will take. Reading the choice back off the screen loses it the
+        // moment a model that takes something narrower is picked, and going
+        // back to the first model then rebuilds a different request — one the
+        // name already handed out does not belong to.
+        _applyingCapabilities = true;
+        try
+        {
+            ApplyModelCapabilitiesCore(video);
+        }
+        finally
+        {
+            _applyingCapabilities = false;
+        }
+    }
+
+    private void ApplyModelCapabilitiesCore(AiVideoModelCapabilities video)
+    {
+        // The model's own lists, already narrowed to what the server accepts.
+        // The client's own are a fallback for a server that publishes none.
+        IEnumerable<int> durations = video.DurationsSeconds.IsSpecified
+            ? video.DurationsSeconds.Values
+            : DefaultDurations;
+        var availableDurations = durations.ToList();
+        if (_selectedRecovery?.Form?.DurationSeconds is { } recoveredDuration
+            && !availableDurations.Contains(recoveredDuration))
+            availableDurations.Add(recoveredDuration);
+        Replace(DurationOptions, availableDurations.Select(seconds => new AiVideoDurationOption(seconds)));
+        SelectedDuration.Value = NearestDuration(
+            _chosenDuration ?? SelectedDuration.Value,
+            DurationOptions);
+        MaxDurationIndex.Value = DurationOptions.Count - 1;
+        DurationIndex.Value = IndexOfDuration(SelectedDuration.Value);
+
+        IEnumerable<string> resolutions = video.Resolutions.IsSpecified
+            ? video.Resolutions.Values
+            : DefaultResolutions;
+        var availableResolutions = resolutions.ToList();
+        if (_selectedRecovery?.Form?.Resolution is { } recoveredResolution
+            && !availableResolutions.Contains(recoveredResolution, StringComparer.Ordinal))
+            availableResolutions.Add(recoveredResolution);
+        Replace(ResolutionOptions, availableResolutions.Select(value => new AiVideoResolutionOption(value)));
+        SelectedResolution.Value =
+            ResolutionOptions.FirstOrDefault(option => option.Value == _chosenResolution?.Value)
+            ?? ResolutionOptions[0];
+
+        IEnumerable<string> aspectRatios = video.AspectRatios.IsSpecified
+            ? video.AspectRatios.Values
+            : DefaultAspectRatios;
+        var availableAspectRatios = aspectRatios.ToList();
+        if (_selectedRecovery?.Form?.AspectRatio is { } recoveredAspect
+            && !availableAspectRatios.Contains(recoveredAspect, StringComparer.Ordinal))
+            availableAspectRatios.Add(recoveredAspect);
+        Replace(
+            AspectRatioOptions,
+            availableAspectRatios.Select(value => new AiVideoAspectRatioOption(value)));
+        SelectedAspectRatio.Value =
+            AspectRatioOptions.FirstOrDefault(option => option.Value == _chosenAspectRatio?.Value)
+            // The shape it would have started on, which is the one nearest the
+            // scene rather than whichever the model happens to list first.
+            ?? GetSuggestedAspectRatio(AspectRatioOptions, _editViewModel?.Scene.FrameSize);
+
+        SupportsAudio.Value = _selectedRecovery?.Form?.SupportsAudio
+            ?? video.SupportsAudio;
+        GenerateAudio.Value = SupportsAudio.Value && _chosenAudio;
+        SupportsSeed.Value = _selectedRecovery?.Form?.SupportsSeed
+            ?? video.SupportsSeed;
+        Seed.Value = SupportsSeed.Value ? _chosenSeed : null;
+        // A model conditions on the frames it publishes, and one of the two is
+        // not the other. A picker left up for a frame the model does not take
+        // only produces a request refused after the shape has been checked.
+        //
+        // A last frame is only ever sent alongside a first one — the endpoint
+        // takes no request without one — so a model that publishes a last frame
+        // and no first frame can be given neither.
+        SupportsFirstFrame.Value = _selectedRecovery?.Form?.SupportsFirstFrame
+            ?? video.SupportsFirstFrame;
+        SupportsLastFrame.Value = SupportsFirstFrame.Value
+            && (_selectedRecovery?.Form?.SupportsLastFrame ?? video.SupportsLastFrame);
+        SupportsFrameGuidance.Value = SupportsFirstFrame.Value;
+        // Set aside rather than thrown away: a model that takes no frame is
+        // shown none, and going back to one that does puts the same frames back.
+        // The temporary file they were captured into is held for as long as a
+        // name that points at it is outstanding, so it is still there to go back
+        // to.
+        SetFrameCore(
+            isFirstFrame: true,
+            SupportsFirstFrame.Value ? _chosenFirstFrame.Path : null,
+            SupportsFirstFrame.Value ? _chosenFirstFrame.ElementId : null);
+        SetFrameCore(
+            isFirstFrame: false,
+            SupportsLastFrame.Value ? _chosenLastFrame.Path : null,
+            SupportsLastFrame.Value ? _chosenLastFrame.ElementId : null);
+    }
+
+    private static void Replace<T>(ObservableCollection<T> target, IEnumerable<T> values)
+    {
+        target.Clear();
+        foreach (T value in values)
+            target.Add(value);
+    }
+
+    private int IndexOfDuration(AiVideoDurationOption option)
+        => Math.Max(0, DurationOptions.IndexOf(option));
+
+    private static AiVideoDurationOption NearestDuration(
+        AiVideoDurationOption current,
+        IReadOnlyList<AiVideoDurationOption> options)
+    {
+        AiVideoDurationOption nearest = options[0];
+        foreach (AiVideoDurationOption option in options)
+        {
+            if (Math.Abs(option.Seconds - current.Seconds)
+                < Math.Abs(nearest.Seconds - current.Seconds))
+            {
+                nearest = option;
+            }
+        }
+
+        return nearest;
+    }
+
+    internal static AiVideoAspectRatioOption GetSuggestedAspectRatio(
+        IReadOnlyList<AiVideoAspectRatioOption> options,
+        Beutl.Media.PixelSize? frameSize)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (options.Count == 0)
+        {
+            throw new ArgumentException(
+                "At least one aspect ratio option is required.",
+                nameof(options));
+        }
+
+        string ratio = AiAspectRatioSuggestion.Nearest(
+            options.Select(option => option.Value).ToArray(),
+            frameSize,
+            "16:9");
+        return options.FirstOrDefault(option => option.Value == ratio) ?? options[0];
+    }
+
+    public ReactivePropertySlim<string> Prompt { get; } = new();
+
+    public ReactivePropertySlim<string> Style { get; } = new();
+
+    public ReactivePropertySlim<string> Composition { get; } = new();
+
+    public ReactivePropertySlim<string> Motion { get; } = new();
+
+    public ReactivePropertySlim<string> Exclusions { get; } = new();
+
+    /// <summary>Whether the chosen model conditions on a starting frame.</summary>
+    public ReactivePropertySlim<bool> SupportsFirstFrame { get; } = new(true);
+
+    /// <summary>Whether it conditions on an ending one, which is not the same.</summary>
+    public ReactivePropertySlim<bool> SupportsLastFrame { get; } = new(true);
+
+    /// <summary>Whether it takes either, and the section is worth showing.</summary>
+    public ReactivePropertySlim<bool> SupportsFrameGuidance { get; } = new(true);
+
+    public ReactivePropertySlim<string?> FirstFramePath { get; } = new();
+
+    public ReactivePropertySlim<string?> LastFramePath { get; } = new();
+
+    public ReactivePropertySlim<Ref<Bitmap>?> FirstFramePreview { get; } = new();
+
+    public ReactivePropertySlim<Ref<Bitmap>?> LastFramePreview { get; } = new();
+
+    public AsyncReactiveCommand SelectFirstFrame { get; }
+
+    public AsyncReactiveCommand SelectLastFrame { get; }
+
+    public AsyncReactiveCommand CaptureCurrentFrame { get; }
+
+    public ReactiveCommand ClearFirstFrame { get; }
+
+    public ReactiveCommand ClearLastFrame { get; }
+
+    public ReactivePropertySlim<bool> IsGenerating { get; }
+
+    public ReactivePropertySlim<bool> IsWaitingForJob { get; }
+
+    public ReadOnlyReactivePropertySlim<string?> PromptValidationError { get; }
+
+    /// <summary>
+    /// The same message, held back until the person has typed something.
+    /// </summary>
+    public ReadOnlyReactivePropertySlim<string?> VisiblePromptValidationError { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> CanGenerate { get; }
+
+    public AsyncReactiveCommand Generate { get; }
+
+    /// <summary>
+    /// Abandons the run in flight, from the moment it is submitted until the
+    /// result lands, so a wrong prompt does not mean closing the tab.
+    /// </summary>
+    public ReactiveCommand StopGenerating { get; }
+
+    /// <summary>Pending video attempts that can be explicitly recovered or abandoned.</summary>
+    internal IReadOnlyList<AiPendingAttempt> PendingRecoveryAttempts
+        => GetPendingRecoveryAttempts();
+
+    internal ReactivePropertySlim<AiPendingAttempt?> SelectedRecoveryAttempt { get; }
+
+    internal ReadOnlyReactivePropertySlim<IReadOnlyList<AiPendingAttempt>> RecoveryAttempts { get; }
+
+    internal ReadOnlyReactivePropertySlim<bool> RecoveryAvailable { get; }
+
+    internal ReactiveCommand RecoverSelectedAttempt { get; }
+
+    internal ReactiveCommand AbandonSelectedAttempt { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> CanAddToScene { get; }
+
+    public AsyncReactiveCommand AddToScene { get; }
+
+    public AsyncReactiveCommand SaveToFile { get; }
+
+    public ReactiveCommand OpenResult { get; }
+
+    public ReactiveCommand OpenAiPlan { get; }
+
+    internal IAiPlanCoordinator AiPlanCoordinator => _aiPlanCoordinator;
+
+    internal void RefreshAvailability()
+        => _availabilityTracker.Refresh(new AiOperationAvailabilityRequest.Video(
+            AiOperations.VideoGeneration,
+            SelectedDuration.Value.Seconds,
+            ModelPicker.SelectedModel));
+
+    public ReactivePropertySlim<string?> ResultVideoPath { get; } = new();
+
+    public ReactivePropertySlim<string> StatusText { get; } = new(Strings.AiVideoIdle);
+
+    internal AiUsageViewModel Usage { get; }
+
+    internal AiModelPickerViewModel ModelPicker { get; }
+
+    internal AiUsageEstimateViewModel EstimatedUsage { get; }
+
+    internal AiPromptLibraryViewModel PromptLibrary { get; }
+
+    internal Func<CancellationToken, Task<Bitmap>>? CurrentFrameRenderer { get; set; }
+
+    // Null in production. Tests can suspend the picker/importer at a precise
+    // point while changing the authenticated identity.
+    internal Func<CancellationToken, Task<string?>>? FramePicker { get; set; }
+
+    internal Func<CancellationToken, Task<AiSaveFileDestination?>>? SaveFilePicker { get; set; }
+
+    internal Func<string, AiResultImportOptions, CancellationToken, Task<ElementAddResult>>?
+        ResultImporter
+    { get; set; }
+
+    internal Func<TimeSpan, CancellationToken, Task> PollDelayAsync { get; set; } = Task.Delay;
+
+    internal TimeSpan PollInterval { get; set; } = TimeSpan.FromSeconds(5);
+
+    internal TimeSpan MaximumTransientPollDelay { get; set; } = TimeSpan.FromSeconds(30);
+
+    public ReadOnlyReactivePropertySlim<bool> ShowJoinPro { get; }
+
+    public ReactivePropertySlim<string?> Error { get; } = new();
+
+    public void Dispose() => _ = BeginDisposeAsync();
+
+    public ValueTask DisposeAsync() => new(BeginDisposeAsync());
+
+    private IdentityOperationLifetime.Operation? TryEnterIdentityOperation()
+        => _identityOperations.TryEnter(_operations);
+
+    private Task BeginDisposeAsync()
+    {
+        lock (_disposeGate)
+        {
+            if (_disposeTask is not null)
+                return _disposeTask;
+
+            var completion = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _disposeTask = completion.Task;
+            _ = CompleteDisposeAsync(completion);
+            return completion.Task;
+        }
+    }
+
+    private async Task CompleteDisposeAsync(TaskCompletionSource completion)
+    {
+        try
+        {
+            await DisposeCoreAsync();
+            completion.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
+        }
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        _identityOperations.Dispose();
+        await _operations.DisposeAsync(
+            _availabilityLifetimeCts.Cancel,
+            async () =>
+        {
+
+            string[] temporaryFiles;
+            CancellationTokenSource? pollingCts;
+            lock (_lifetimeGate)
+            {
+                temporaryFiles = _temporaryFiles.ToArray();
+                _temporaryFiles.Clear();
+                _temporaryFileLeases.Clear();
+                _temporaryFilesPendingDeletion.Clear();
+                _framesHeldByName.Clear();
+                pollingCts = _pollingCts;
+                _pollingCts = null;
+            }
+
+            pollingCts?.Dispose();
+            Prompt.Dispose();
+            Style.Dispose();
+            Composition.Dispose();
+            Motion.Dispose();
+            Exclusions.Dispose();
+            FirstFramePreview.Value?.Dispose();
+            FirstFramePreview.Value = null;
+            LastFramePreview.Value?.Dispose();
+            LastFramePreview.Value = null;
+            FirstFramePath.Value = null;
+            LastFramePath.Value = null;
+            FirstFramePreview.Dispose();
+            LastFramePreview.Dispose();
+            SupportsFirstFrame.Dispose();
+            SupportsLastFrame.Dispose();
+            SupportsFrameGuidance.Dispose();
+            FirstFramePath.Dispose();
+            LastFramePath.Dispose();
+            Error.Dispose();
+            if (_requestRecoveryContext is not null)
+                _requestRecoveryContext.IdentityChanged -= OnIdentityChanged;
+            _requestKey.Dispose();
+            _recoveryRevision.Dispose();
+            _disposables.Dispose();
+            _availabilityTracker.Dispose();
+            _availabilityLifetimeCts.Dispose();
+            foreach (string path in temporaryFiles)
+            {
+                DeleteTemporaryFile(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Re-reads the model list. The catalog is cached with a freshness window,
+    /// so this costs nothing while it is fresh and picks up a model an operator
+    /// added, removed or reordered once it is not — which a workspace tab left
+    /// open would otherwise never see.
+    /// </summary>
+    public void RefreshModels() => _ = RefreshModelsAsync();
+
+    private async Task RefreshModelsAsync()
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        if (operation is null)
+            return;
+        // A clip waiting to be collected is named partly by the model it was
+        // sent with, and what the picker allows — the shape, and whether frames
+        // may guide it at all — follows that model. Moving the picker under an
+        // outstanding name would rename the request and buy it again, so an
+        // operator's change waits until the name is settled.
+        if (_requestKey.HasOutstandingName.Value)
+            return;
+
+        try
+        {
+            await _entitlements.RefreshAsync(operation.CancellationToken);
+            await ModelPicker.LoadAsync(
+                AiOperations.VideoGeneration,
+                operation.CancellationToken);
+            SelectRecoveredModel();
+        }
+        catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to reload the AI models for video generation.");
+        }
+    }
+
+    private IReadOnlyList<AiPendingAttempt> GetPendingRecoveryAttempts()
+    {
+        try
+        {
+            return _requestKey.PendingAttempts(AiOperations.VideoGeneration);
+        }
+        catch (InvalidDataException ex)
+        {
+            _logger.LogError(ex, "Failed to read video-generation recovery attempts.");
+            return Array.Empty<AiPendingAttempt>();
+        }
+    }
+
+    private void TryAutoRecoverSingleAttempt()
+    {
+        IReadOnlyList<AiPendingAttempt> attempts = GetPendingRecoveryAttempts();
+        if (attempts.Count == 1 && attempts[0].HasCanonicalForm)
+        {
+            if (!TryRecoverPendingAttempt(attempts[0]))
+                ClearActiveRecovery();
+        }
+
+        _recoveryRevision.Value++;
+    }
+
+    private void OnIdentityChanged()
+    {
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            _identityOperations.SwitchDeferred(
+                action => Dispatcher.UIThread.Post(() => RunDeferredIdentityClear(action)),
+                ClearIdentityState,
+                TryAutoRecoverForCurrentIdentity);
+            return;
+        }
+
+        _identityOperations.Switch(ClearIdentityState);
+        TryAutoRecoverForCurrentIdentity();
+    }
+
+    private void RunDeferredIdentityClear(Action clear)
+    {
+        try
+        {
+            clear();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to clear video-generation state after an account change.");
+        }
+    }
+
+    private void TryAutoRecoverForCurrentIdentity()
+    {
+        if (_requestKey.CurrentAccountId is not null)
+            TryAutoRecoverSingleAttempt();
+    }
+
+    private void ClearIdentityState()
+    {
+        _runningRequest = null;
+        IsGenerating.Value = false;
+        IsWaitingForJob.Value = false;
+        ClearActiveRecovery();
+        _chosenDuration = null;
+        _chosenResolution = null;
+        _chosenAspectRatio = null;
+        _chosenAudio = true;
+        _chosenSeed = null;
+        SetFrameCore(isFirstFrame: true, null, null);
+        SetFrameCore(isFirstFrame: false, null, null);
+        Prompt.Value = string.Empty;
+        Style.Value = string.Empty;
+        Composition.Value = string.Empty;
+        Motion.Value = string.Empty;
+        Exclusions.Value = string.Empty;
+        if (ResultVideoPath.Value is { } resultPath)
+            RequestTemporaryFileDeletion(resultPath);
+        ResultVideoPath.Value = null;
+        _resultSnapshot = null;
+        StatusText.Value = Strings.AiVideoIdle;
+        Error.Value = null;
+        ModelPicker.ReconcileRecoveryModels();
+        ApplyModelCapabilities(ModelPicker.Selected.Value?.Model);
+        _recoveryRevision.Value++;
+    }
+
+    internal bool TryRecoverPendingAttempt(AiPendingAttempt attempt)
+    {
+        if (_requestKey.CurrentAccountId is not { } account
+            || !StringComparer.Ordinal.Equals(account, attempt.AccountId))
+        {
+            Error.Value = Strings.AiAuthenticationRequired;
+            return false;
+        }
+        if (!attempt.HasCanonicalForm
+            || !string.Equals(attempt.Operation, AiOperations.VideoGeneration.Value, StringComparison.Ordinal))
+        {
+            Error.Value = Strings.AiResultUnavailable;
+            return false;
+        }
+
+        IReadOnlyList<string> paths;
+        try
+        {
+            paths = _requestKey.ResolveSources(attempt);
+            foreach (AiRequestRecoverySource source in attempt.EffectiveSources)
+                _ = _requestKey.ReadSourceBytes(source);
+        }
+        catch (InvalidDataException ex)
+        {
+            // Keep the row and key until the user explicitly abandons it.
+            _logger.LogWarning(ex, "Video-generation recovery source is unavailable.");
+            Error.Value = Strings.AiResultUnavailable;
+            return false;
+        }
+
+        AiRequestFormSnapshot form = attempt.Form!;
+        if (paths.Count != attempt.EffectiveSources.Count)
+        {
+            Error.Value = Strings.AiResultUnavailable;
+            return false;
+        }
+
+        _applyingCapabilities = true;
+        try
+        {
+            Prompt.Value = form.Prompt ?? string.Empty;
+            Style.Value = form.Style ?? string.Empty;
+            Composition.Value = form.Composition ?? string.Empty;
+            Motion.Value = form.Motion ?? string.Empty;
+            Exclusions.Value = form.Exclusions ?? string.Empty;
+            _chosenDuration = form.DurationSeconds is { } seconds
+                ? new AiVideoDurationOption(seconds)
+                : SelectedDuration.Value;
+            _chosenResolution = form.Resolution is { } resolution
+                ? new AiVideoResolutionOption(resolution)
+                : SelectedResolution.Value;
+            _chosenAspectRatio = form.AspectRatio is { } aspect
+                ? new AiVideoAspectRatioOption(aspect)
+                : SelectedAspectRatio.Value;
+            _chosenAudio = form.GenerateAudio ?? true;
+            _chosenSeed = form.Seed;
+            ApplyRecoveredScalarSelections(form);
+        }
+        finally
+        {
+            _applyingCapabilities = false;
+        }
+
+        string? firstPath = null;
+        string? lastPath = null;
+        string? firstElement = form.FirstFrameElementId;
+        string? lastElement = form.LastFrameElementId;
+        for (int index = 0; index < attempt.EffectiveSources.Count; index++)
+        {
+            AiRequestRecoverySource source = attempt.EffectiveSources[index];
+            string path = paths[index];
+            if (source.Role == "first-frame")
+            {
+                firstPath = path;
+                firstElement ??= source.ElementId;
+            }
+            else if (source.Role == "last-frame")
+            {
+                lastPath = path;
+                lastElement ??= source.ElementId;
+            }
+        }
+
+        SetFrameCore(isFirstFrame: true, firstPath, firstElement);
+        SetFrameCore(isFirstFrame: false, lastPath, lastElement);
+        ActivateRecovery(attempt);
+        ApplyModelCapabilities(ModelPicker.Selected.Value?.Model);
+        _recoveryRevision.Value++;
+        SelectRecoveredModel();
+        return true;
+    }
+
+    private void ApplyRecoveredScalarSelections(AiRequestFormSnapshot form)
+    {
+        if (form.DurationSeconds is { } duration
+            && DurationOptions.FirstOrDefault(option => option.Seconds == duration) is { } durationOption)
+            SelectedDuration.Value = durationOption;
+        if (form.Resolution is { } resolution
+            && ResolutionOptions.FirstOrDefault(option => option.Value == resolution) is { } resolutionOption)
+            SelectedResolution.Value = resolutionOption;
+        if (form.AspectRatio is { } aspect
+            && AspectRatioOptions.FirstOrDefault(option => option.Value == aspect) is { } aspectOption)
+            SelectedAspectRatio.Value = aspectOption;
+        GenerateAudio.Value = form.GenerateAudio ?? true;
+        Seed.Value = form.Seed;
+    }
+
+    internal void AbandonPendingAttempt(AiPendingAttempt attempt)
+    {
+        try
+        {
+            _requestKey.Abandon(attempt);
+            if (_selectedRecovery is { } selected
+                && selected.AccountId == attempt.AccountId
+                && selected.Operation == attempt.Operation
+                && selected.Fingerprint == attempt.Fingerprint)
+            {
+                ClearActiveRecovery();
+                ModelPicker.ReconcileRecoveryModels();
+                ApplyModelCapabilities(ModelPicker.Selected.Value?.Model);
+            }
+
+            _recoveryRevision.Value++;
+        }
+        catch (Exception ex) when (ex is InvalidDataException or AuthenticationRequiredException)
+        {
+            _logger.LogWarning(ex, "Failed to abandon video-generation recovery attempt.");
+            Error.Value = Strings.AiResultUnavailable;
+        }
+    }
+
+    private AiModelId? ModelForRequest(AiModelId? selected)
+        => _selectedRecovery is { } attempt
+            ? attempt.Model is { } model ? new AiModelId(model) : null
+            : selected;
+
+    private void ActivateRecovery(AiPendingAttempt attempt)
+    {
+        _selectedRecovery = attempt;
+        SelectedRecoveryAttempt.Value = attempt;
+        ModelPicker.IsSelectionEnabled.Value = false;
+    }
+
+    private void ClearActiveRecovery()
+    {
+        _selectedRecovery = null;
+        SelectedRecoveryAttempt.Value = null;
+        ModelPicker.IsSelectionEnabled.Value = true;
+    }
+
+    private void SelectRecoveredModel()
+    {
+        if (_selectedRecovery is not { } recovery)
+            return;
+        if (recovery.Model is not { } model)
+        {
+            ModelPicker.Selected.Value = null;
+            return;
+        }
+        AiModelId id = new(model);
+        ModelPicker.Selected.Value = ModelPicker.Options.FirstOrDefault(option => option.Id == id);
+    }
+
+    // The model a request should carry: the one the outstanding name was built
+    // from while there is one, and the picker's otherwise.
+    // Only this one request is settled. Retiring the whole run instead would
+    // throw away the name of anything else still waiting to be collected.
+    private void RetireRequestName(AiRequestName name)
+    {
+        if (!_requestKey.Retire(name))
+            return;
+        ReleaseFramesOf(name);
+        if (_selectedRecovery is { } selected
+            && (string.Equals(selected.Key, name.Key, StringComparison.Ordinal)
+                || !_requestKey.IsCurrentPending(selected)))
+        {
+            ReleaseFramesOf(new AiRequestName(selected.Key, IsRepeat: true));
+            ClearActiveRecovery();
+            ModelPicker.ReconcileRecoveryModels();
+            ApplyModelCapabilities(ModelPicker.Selected.Value?.Model);
+            _recoveryRevision.Value++;
+        }
+        // Reloads were held back while that name was outstanding, so this is
+        // where an operator's change to the model list finally lands.
+        _ = RefreshModelsAsync();
+    }
+
+    // A name the server never made a job under. Withdrawing it lets the picker
+    // move again and puts the balance check back in front of the next attempt.
+    private void WithdrawRequestName(AiRequestName name)
+    {
+        if (!_requestKey.WithdrawAfterNoReservation(name))
+            return;
+        ReleaseFramesOf(name);
+        if (_selectedRecovery is { } selected
+            && (string.Equals(selected.Key, name.Key, StringComparison.Ordinal)
+                || !_requestKey.IsCurrentPending(selected)))
+        {
+            ReleaseFramesOf(new AiRequestName(selected.Key, IsRepeat: true));
+            ClearActiveRecovery();
+            ModelPicker.ReconcileRecoveryModels();
+            ApplyModelCapabilities(ModelPicker.Selected.Value?.Model);
+            _recoveryRevision.Value++;
+        }
+    }
+
+
+
+    private async Task LoadEntitlementsAsync()
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        if (operation is null)
+            return;
+        try
+        {
+            await _entitlements.RefreshAsync(operation.CancellationToken);
+            // Never under an outstanding name: the model the picker lands on is
+            // part of what names the clip waiting to be collected.
+            if (!ModelPicker.IsLoaded.Value || !_requestKey.HasOutstandingName.Value)
+            {
+                await ModelPicker.LoadAsync(
+                    AiOperations.VideoGeneration,
+                    _requestKey.PreferredPersistedModel(AiOperations.VideoGeneration),
+                    _requestKey.HasExplicitNullPersistedModel(AiOperations.VideoGeneration),
+                    operation.CancellationToken);
+                SelectRecoveredModel();
+            }
+        }
+        catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load AI entitlements.");
+        }
+    }
+
+    private async Task SelectFrameAsync(bool isFirstFrame)
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        if (operation is null)
+            return;
+        string? path;
+        IDisposable? selectedFilesOwnership = null;
+        if (FramePicker is { } picker)
+        {
+            path = await picker(operation.CancellationToken);
+        }
+        else
+        {
+            if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime
+                { MainWindow: { } window }
+                || TopLevel.GetTopLevel(window)?.StorageProvider is not { } storage)
+                return;
+            IReadOnlyList<IStorageFile> files = await storage.OpenFilePickerAsync(
+                SharedFilePickerOptions.OpenAiVideoFrame());
+            selectedFilesOwnership = SharedFilePickerOptions.OwnStorageFiles(files);
+            path = files.Count > 0 ? files[0].Path.LocalPath : null;
+        }
+        using IDisposable? fileOwnership = selectedFilesOwnership;
+        if (path is not null)
+        {
+            operation.TryPublish(() =>
+                SetFrameCore(isFirstFrame, path, sourceElementId: null));
+        }
+    }
+
+    private async Task CaptureCurrentFrameAsync()
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        if (operation is null)
+            return;
+        if (_editViewModel is null)
+            return;
+
+        CancellationToken lifetimeToken = operation.CancellationToken;
+        if (!operation.TryPublish(() => Error.Value = null))
+            return;
+
+        string? unpublishedPath = null;
+        try
+        {
+            using Bitmap bitmap = CurrentFrameRenderer is { } renderer
+                ? await renderer(lifetimeToken)
+                : await _editViewModel.Player.DrawFrameAtFullScale();
+            lifetimeToken.ThrowIfCancellationRequested();
+
+            lifetimeToken.ThrowIfCancellationRequested();
+            (unpublishedPath, FileStream stream) = AiTemporaryFileStore.Create(
+                "inputs",
+                "frame",
+                ".png");
+            using (stream)
+            {
+                bitmap.Save(stream, EncodedImageFormat.Png);
+            }
+            if (new FileInfo(unpublishedPath).Length > AiRequestLimits.MaxFrameUploadBytes)
+                throw new AiFileTooLargeException();
+            lifetimeToken.ThrowIfCancellationRequested();
+
+            bool published = operation.TryPublish(() =>
+            {
+                lock (_lifetimeGate)
+                {
+                    _temporaryFiles.Add(unpublishedPath);
+                    try
+                    {
+                        SetFrameCore(isFirstFrame: true, unpublishedPath, sourceElementId: null);
+                    }
+                    catch
+                    {
+                        _temporaryFiles.Remove(unpublishedPath);
+                        throw;
+                    }
+                }
+            });
+            if (!published)
+                return;
+
+            unpublishedPath = null;
+        }
+        catch (OperationCanceledException) when (lifetimeToken.IsCancellationRequested)
+        {
+        }
+        catch (AiFileTooLargeException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiFileTooLarge);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to capture the current frame for AI video generation.");
+            operation.TryPublish(() => Error.Value = Strings.AiVideoFrameCaptureFailed);
+        }
+        finally
+        {
+            if (unpublishedPath is not null)
+            {
+                DeleteTemporaryFile(unpublishedPath);
+            }
+        }
+    }
+
+    private void SetFrame(bool isFirstFrame, string? path, string? sourceElementId = null)
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        operation?.TryPublish(() => SetFrameCore(isFirstFrame, path, sourceElementId));
+    }
+
+    private void SetFrameCore(bool isFirstFrame, string? path, string? sourceElementId)
+    {
+        if (!string.IsNullOrEmpty(path)
+            && File.Exists(path)
+            && new FileInfo(path).Length > AiRequestLimits.MaxFrameUploadBytes)
+        {
+            Error.Value = Strings.AiFileTooLarge;
+            return;
+        }
+
+        // Preserve a user-selected frame when model constraints merely hide it, so restoring the
+        // old model also restores the same request with the same frame.
+        if (!_applyingCapabilities)
+        {
+            if (isFirstFrame)
+            {
+                _chosenFirstFrame = (path, sourceElementId);
+            }
+            else
+            {
+                _chosenLastFrame = (path, sourceElementId);
+            }
+        }
+
+        ReactivePropertySlim<string?> pathProperty = isFirstFrame ? FirstFramePath : LastFramePath;
+        ReactivePropertySlim<Ref<Bitmap>?> previewProperty = isFirstFrame ? FirstFramePreview : LastFramePreview;
+        string? previousPath = pathProperty.Value;
+        previewProperty.Value?.Dispose();
+        previewProperty.Value = null;
+        pathProperty.Value = path;
+        if (isFirstFrame)
+        {
+            _firstFrameElementId = sourceElementId;
+        }
+        else
+        {
+            _lastFrameElementId = sourceElementId;
+        }
+
+        // Do not delete a temporary frame that model constraints only hid; it is required to
+        // reconstruct the same request after restoring the old model.
+        if (!_applyingCapabilities
+            && !string.Equals(previousPath, path, StringComparison.Ordinal))
+        {
+            RequestTemporaryFileDeletion(previousPath);
+        }
+
+        if (string.IsNullOrEmpty(path) || !File.Exists(path))
+            return;
+
+        try
+        {
+            previewProperty.Value = Ref<Bitmap>.Create(
+                AiImageDecodeValidator.LoadValidatedBitmap(
+                    path,
+                    AiRequestLimits.MaxFrameUploadBytes));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load an AI video frame preview from {Path}", path);
+            Error.Value = Strings.AiEditSourcePreviewFailed;
+        }
+    }
+
+    private void OpenResultCore()
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        if (operation is null)
+            return;
+        if (ResultVideoPath.Value is not { } path || !File.Exists(path))
+            return;
+
+        try
+        {
+            operation.TryPublish(() =>
+                Process.Start(new ProcessStartInfo(path) { UseShellExecute = true, Verb = "open" }));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to open the generated AI video preview.");
+            operation.TryPublish(() => Error.Value = Strings.AiVideoPreviewOpenFailed);
+        }
+    }
+
+    private async Task GenerateCore()
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        if (operation is null)
+            return;
+        if (!operation.TryPublish(() =>
+            {
+                Error.Value = null;
+                IsGenerating.Value = true;
+                StatusText.Value = Strings.AiVideoSubmitting;
+            }))
+        {
+            return;
+        }
+
+        _runningRequest = operation;
+        bool persistedServerJob = false;
+        AiRequestName issued = default;
+        AiRequestRecoveryLease? claim = null;
+        try
+        {
+            string prompt = ComposePrompt();
+            string promptField = Prompt.Value;
+            string style = Style.Value;
+            string composition = Composition.Value;
+            string motion = Motion.Value;
+            string exclusions = Exclusions.Value;
+            int durationSeconds = SelectedDuration.Value.Seconds;
+            string resolution = SelectedResolution.Value.Value;
+            string aspectRatio = SelectedAspectRatio.Value.Value;
+            bool generateAudio = GenerateAudio.Value;
+            int? seed = Seed.Value;
+            string? firstFramePath = FirstFramePath.Value;
+            string? lastFramePath = LastFramePath.Value;
+            string? firstFrameElementId = _firstFrameElementId;
+            string? lastFrameElementId = _lastFrameElementId;
+
+            // The model's place is left empty until it is known, because which
+            // model this request carries depends on whether a name is already
+            // outstanding for the rest of it.
+            // Read once, and named by that reading. Reading again to send would
+            // name one set of bytes and upload another if a frame changed in
+            // between, and the answer would be recorded under a name that
+            // describes something else.
+            AiRequestRecoverySource? existingFirstSource = _selectedRecovery?.EffectiveSources
+                .FirstOrDefault(source => source.Role == "first-frame");
+            AiRequestRecoverySource? existingLastSource = _selectedRecovery?.EffectiveSources
+                .FirstOrDefault(source => source.Role == "last-frame");
+            if (existingFirstSource is not null
+                && !RecoverySourceMatchesPath(existingFirstSource, firstFramePath))
+                existingFirstSource = null;
+            if (existingLastSource is not null
+                && !RecoverySourceMatchesPath(existingLastSource, lastFramePath))
+                existingLastSource = null;
+            (AiUploadSource? firstFrame, string firstFrameStamp, byte[]? firstFrameBytes, string? firstFrameName) = await ReadFrameAsync(
+                firstFramePath,
+                operation.CancellationToken,
+                existingFirstSource);
+            (AiUploadSource? lastFrame, string lastFrameStamp, byte[]? lastFrameBytes, string? lastFrameName) = await ReadFrameAsync(
+                lastFramePath,
+                operation.CancellationToken,
+                existingLastSource);
+            string?[] requestParts =
+            [
+                prompt,
+                durationSeconds.ToString(CultureInfo.InvariantCulture),
+                resolution,
+                aspectRatio,
+                generateAudio ? "audio" : "silent",
+                seed?.ToString(CultureInfo.InvariantCulture),
+                null,
+                firstFrameStamp,
+                lastFrameStamp,
+            ];
+            AiModelId? model = ModelForRequest(ModelPicker.SelectedModel);
+            requestParts[ModelPartIndex] = model?.Value;
+            AiRequestFormSnapshot form = new(
+                Prompt: promptField,
+                Style: style,
+                Composition: composition,
+                Motion: motion,
+                Exclusions: exclusions,
+                AspectRatio: aspectRatio,
+                Resolution: resolution,
+                DurationSeconds: durationSeconds,
+                GenerateAudio: generateAudio,
+                Seed: seed,
+                SupportsAudio: SupportsAudio.Value,
+                SupportsSeed: SupportsSeed.Value,
+                SupportsFirstFrame: SupportsFirstFrame.Value,
+                SupportsLastFrame: SupportsLastFrame.Value,
+                FirstFrameElementId: firstFrameElementId,
+                LastFrameElementId: lastFrameElementId);
+            var recoverySources = new List<AiRequestRecoverySource>(2);
+            try
+            {
+                if (firstFramePath is { } firstPath && firstFrame is not null && firstFrameBytes is not null)
+                {
+                    recoverySources.Add(
+                        IsTemporaryFile(firstPath) && _requestKey.HasDurableRecovery
+                            ? _requestKey.CreateDurableSource(
+                                "first-frame",
+                                firstFrameName ?? Path.GetFileName(firstPath),
+                                firstFrameBytes,
+                                firstFrameElementId)
+                            : FileAiRequestRecoveryStore.CreateExternalSource(
+                                "first-frame",
+                                firstPath,
+                                firstFrameName ?? Path.GetFileName(firstPath),
+                                firstFrameBytes,
+                                firstFrameElementId));
+                }
+                if (lastFramePath is { } lastPath && lastFrame is not null && lastFrameBytes is not null)
+                {
+                    recoverySources.Add(
+                        IsTemporaryFile(lastPath) && _requestKey.HasDurableRecovery
+                            ? _requestKey.CreateDurableSource(
+                                "last-frame",
+                                lastFrameName ?? Path.GetFileName(lastPath),
+                                lastFrameBytes,
+                                lastFrameElementId)
+                            : FileAiRequestRecoveryStore.CreateExternalSource(
+                                "last-frame",
+                                lastPath,
+                                lastFrameName ?? Path.GetFileName(lastPath),
+                                lastFrameBytes,
+                                lastFrameElementId));
+                }
+            }
+            catch
+            {
+                _requestKey.CleanupUncommittedSources(recoverySources);
+                throw;
+            }
+            if (_selectedRecovery is { } selected
+                && !_requestKey.MatchesPending(selected, requestParts))
+            {
+                _requestKey.CleanupUncommittedSources(recoverySources);
+                operation.TryPublish(() => Error.Value = Strings.AiRequestChanged);
+                return;
+            }
+            AiRequestName name = _requestKey.NameFor(requestParts, form, recoverySources);
+            issued = name;
+            using IDisposable authenticatedScope = _requestKey.EnterAuthenticatedScope(name);
+            claim = _requestKey.TryClaim(name);
+            if (_requestKey.HasDurableRecovery && claim is null)
+            {
+                operation.TryPublish(() => Error.Value = Strings.AiResultUnavailable);
+                return;
+            }
+            // Held for as long as the name is, not just for as long as the
+            // request is in the air. A frame captured from the scene lives in a
+            // temporary file, and the request is named partly by that file as it
+            // stands — deleted, the request can never be asked for again, and
+            // choosing another model is enough to delete it.
+            HoldFramesFor(name, firstFramePath, lastFramePath);
+
+            // Before it goes out. A name that ends here reached nothing.
+            try
+            {
+                // Not for a repeat: the server looks up the job this name
+                // already made before it looks at the balance, so refusing here
+                // would refuse to collect something already paid for.
+                if (!name.IsRepeat
+                    && !await _availabilityTracker.CheckNowAsync(
+                        new AiOperationAvailabilityRequest.Video(
+                            AiOperations.VideoGeneration,
+                            durationSeconds,
+                            model),
+                        operation.CancellationToken))
+                {
+                    throw new AiUsageLimitExceededException();
+                }
+            }
+            catch
+            {
+                WithdrawRequestName(name);
+                throw;
+            }
+
+            AiVideoGenerationResult response;
+            try
+            {
+                _requestKey.MarkClaimDispatched(claim);
+                response = await _videos.CreateAsync(
+                    new AiVideoGenerationRequest(
+                        prompt,
+                        durationSeconds,
+                        new AiVideoResolutionId(resolution),
+                        new AiVideoAspectRatioId(aspectRatio),
+                        generateAudio,
+                        seed: seed,
+                        firstFrame: firstFrame,
+                        lastFrame: lastFrame,
+                        model: model,
+                        idempotencyKey: name.Key),
+                    operation.CancellationToken);
+            }
+            catch (Exception ex) when (AiRequestOutcome.CanWithdraw(name, ex))
+            {
+                WithdrawRequestName(name);
+                throw;
+            }
+
+            // Past here the clip has been reserved and paid for. Whatever goes
+            // wrong while it is waited on, the name stays: it is the way back.
+            persistedServerJob = true;
+
+            var pendingSnapshot = new AiVideoResultSnapshot(durationSeconds);
+            if (!operation.TryPublish(() =>
+                {
+                    PromptLibrary.Record(prompt);
+                }))
+            {
+                return;
+            }
+
+            // Retired only once the server has settled the job. A clip whose
+            // result never reached the client is still recoverable under the key
+            // that created it, and asking again under a new one would pay twice.
+            if (await PollJobAsync(response.JobId, operation, pendingSnapshot))
+            {
+                RetireRequestName(name);
+            }
+        }
+        // Every refusal that reserves nothing withdrew its name where it was
+        // raised, next to the request that never left. These only say what
+        // happened.
+        catch (AuthenticationRequiredException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiAuthenticationRequired);
+        }
+        catch (AiPlanRequiredException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiProRequired);
+        }
+        catch (AiUsageLimitExceededException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiUsageLimitExceeded);
+        }
+        // Charged for and still the server's; asking again under the same name
+        // is what recovers it, so the key stays.
+        catch (AiResultUnavailableException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiResultUnavailable);
+        }
+        catch (AiModelUnavailableException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiModelUnavailable);
+        }
+        // Refused before the operation was reserved, so nothing was charged;
+        // what has to change is the model or the shape of the request.
+        catch (AiModelDoesNotSupportRequestException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiModelDoesNotSupportRequest);
+        }
+        // The server settled this job as failed and refunded it. Its name would
+        // keep answering with that failure, so the next attempt takes a new one.
+        catch (AiProviderErrorException)
+        {
+            RetireRequestName(issued);
+            operation.TryPublish(() => Error.Value = Strings.AiProviderError);
+        }
+        // Reachable because a request keeps its name across attempts: asking
+        // again for one the server is still working on is how its result is
+        // recovered rather than bought twice, and until it finishes the answer
+        // is this. The key stays — it is still the way back to that job.
+        catch (AiRequestInProgressException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiRequestInProgress);
+        }
+        // The job that key created is gone, so the key can only ever answer
+        // with that. The next attempt has to be a new request.
+        // The issued name belongs to a different request. Keep it so restoring the form can
+        // resend that request; discarding it could close the only route to an already-paid job.
+        catch (AiRequestChangedException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiRequestChanged);
+        }
+        catch (AiRequestWasDeletedException)
+        {
+            RetireRequestName(issued);
+            operation.TryPublish(() => Error.Value = Strings.AiRequestWasDeleted);
+        }
+        catch (AiJobNotFoundException)
+        {
+            // The create key points at a job the server no longer retains. Keeping the
+            // key would make every poll/retry return the same terminal absence.
+            RetireRequestName(issued);
+            operation.TryPublish(() => Error.Value = Strings.AiRequestWasDeleted);
+        }
+        catch (AiJobLimitReachedException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiVideoJobLimitReached);
+        }
+        catch (AiFileTooLargeException)
+        {
+            operation.TryPublish(() => Error.Value = Strings.AiFileTooLarge);
+        }
+        catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
+        {
+            if (persistedServerJob)
+                await RefreshJobHistoryAfterLocalStopAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to generate AI video.");
+            operation.TryPublish(() => Error.Value = Strings.AiUnexpectedError);
+        }
+        finally
+        {
+            // A dispatched request's fence remains durable after disposal, and
+            // AiRequestKey can reacquire that exact owner on an immediate
+            // same-key refresh. Pre-dispatch claims are released normally.
+            claim?.Dispose();
+            if (ReferenceEquals(_runningRequest, operation))
+                _runningRequest = null;
+            operation.TryPublish(() => IsGenerating.Value = false);
+        }
+    }
+
+    /// <summary>Waits for the job to finish, showing what it is doing.</summary>
+    /// <returns>
+    /// True once the server has settled the job — the clip is in hand, or the
+    /// job failed and was refunded. False while its outcome is still unknown to
+    /// this client, which is what makes the request worth repeating as itself.
+    /// </returns>
+    private async Task<bool> PollJobAsync(
+        AiJobId jobId,
+        IdentityOperationLifetime.Operation operation,
+        AiVideoResultSnapshot pendingSnapshot)
+    {
+        CancellationTokenSource pollingCts;
+        lock (_lifetimeGate)
+        {
+            _pollingCts?.Cancel();
+            _pollingCts?.Dispose();
+            pollingCts = CancellationTokenSource.CreateLinkedTokenSource(operation.CancellationToken);
+            _pollingCts = pollingCts;
+        }
+        CancellationToken token = pollingCts.Token;
+        operation.TryPublish(() => IsWaitingForJob.Value = true);
+
+        int transientFailures = 0;
+        try
+        {
+            while (!token.IsCancellationRequested)
+            {
+                AiVideoJob job;
+                try
+                {
+                    job = await _videos.GetAsync(jobId, token);
+                    transientFailures = 0;
+                }
+                catch (Exception ex) when (IsTransientPollingFailure(ex))
+                {
+                    transientFailures++;
+                    operation.TryPublish(() => StatusText.Value = Strings.AiVideoProcessing);
+                    await PollDelayAsync(GetTransientPollDelay(transientFailures), token);
+                    continue;
+                }
+                AiJobStatusSemantics status = _jobKinds.GetStatus(AiJobKinds.Video, job.Status);
+                if (status.Outcome == AiJobOutcomes.Succeeded)
+                {
+                    if (job.ContentUri is not { } contentUri)
+                    {
+                        throw new InvalidOperationException("A successful video job did not provide content.");
+                    }
+
+                    string? localPath = await DownloadVideoAsync(
+                        contentUri,
+                        job.ContentMetadata,
+                        operation,
+                        token);
+                    if (localPath is null)
+                        return false;
+
+                    operation.TryPublish(() =>
+                    {
+                        string? previousPath = ResultVideoPath.Value;
+                        StatusText.Value = Strings.AiVideoCompleted;
+                        ResultVideoPath.Value = localPath;
+                        _resultSnapshot = pendingSnapshot;
+                        if (!string.Equals(previousPath, localPath, StringComparison.Ordinal))
+                        {
+                            RequestTemporaryFileDeletion(previousPath);
+                        }
+                    });
+                    return true;
+                }
+                if (status.IsTerminal)
+                {
+                    operation.TryPublish(() =>
+                    {
+                        StatusText.Value = Strings.AiVideoFailed;
+                        Error.Value = AiErrorMessage.Localize(job.Error) ?? Strings.AiProviderError;
+                    });
+                    return true;
+                }
+
+                if (!status.ShouldPoll)
+                {
+                    // An unknown status is not a terminal outcome. The server may
+                    // have introduced it during a rolling upgrade, so keep the
+                    // request recoverable and require a later history refresh.
+                    operation.TryPublish(() =>
+                    {
+                        StatusText.Value = Strings.AiResultUnavailable;
+                        Error.Value = Strings.AiResultUnavailable;
+                    });
+                    return false;
+                }
+
+                operation.TryPublish(() => StatusText.Value = Strings.AiVideoProcessing);
+                await PollDelayAsync(PollInterval, token);
+            }
+        }
+        catch (OperationCanceledException) when (
+            pollingCts.IsCancellationRequested
+            && !operation.CancellationToken.IsCancellationRequested)
+        {
+            await RefreshJobHistoryAfterLocalStopAsync();
+            operation.TryPublish(() => StatusText.Value = Strings.AiVideoWaitStopped);
+        }
+        finally
+        {
+            operation.TryPublish(() => IsWaitingForJob.Value = false);
+            lock (_lifetimeGate)
+            {
+                if (ReferenceEquals(_pollingCts, pollingCts))
+                    _pollingCts = null;
+            }
+
+            pollingCts.Dispose();
+        }
+
+        // Stopped waiting rather than heard an answer: the job is still the
+        // server's, and the key that created it is still the way back to it.
+        return false;
+    }
+
+    private async Task<string?> DownloadVideoAsync(
+        Uri contentUri,
+        AiContentMetadata? declaredMetadata,
+        IdentityOperationLifetime.Operation operation,
+        CancellationToken cancellationToken)
+    {
+        string? filePath = null;
+        try
+        {
+            (string stagingPath, FileStream destination) = AiTemporaryFileStore.Create(
+                "results",
+                "ai-video",
+                ".download");
+            filePath = stagingPath;
+            AiContentDownload download;
+            await using (destination)
+            {
+                using Stream boundedDestination =
+                    AiVideoResultDownload.CreateBoundedStream(destination);
+                download = await _content.CopyToAsync(
+                    contentUri,
+                    boundedDestination,
+                    cancellationToken);
+            }
+            AiContentMetadata? metadata = AiContentMetadata.Combine(
+                declaredMetadata,
+                download.Metadata);
+            string extension = metadata?.GetFileExtension(".mp4", "video") ?? ".mp4";
+            string completedPath = Path.ChangeExtension(stagingPath, extension);
+            File.Move(stagingPath, completedPath);
+            AiTemporaryFileStore.EnsurePrivateFile(completedPath);
+            filePath = completedPath;
+
+            if (!operation.TryPublish(() =>
+                {
+                    lock (_lifetimeGate)
+                    {
+                        _temporaryFiles.Add(filePath);
+                    }
+                }))
+            {
+                DeleteTemporaryFile(filePath);
+                return null;
+            }
+
+            return filePath;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            if (filePath is not null)
+            {
+                DeleteTemporaryFile(filePath);
+            }
+
+            throw;
+        }
+        // The clip was rendered and charged for; only fetching it failed, and it
+        // is still waiting in the job history.
+        catch (AiContentUnavailableException ex)
+        {
+            if (filePath is not null)
+            {
+                DeleteTemporaryFile(filePath);
+            }
+            _logger.LogError(ex, "Failed to download the AI video.");
+            operation.TryPublish(() => Error.Value = Strings.AiResultDownloadFailed);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            if (filePath is not null)
+            {
+                DeleteTemporaryFile(filePath);
+            }
+            _logger.LogError(ex, "Failed to download the AI video.");
+            operation.TryPublish(() => Error.Value = Strings.AiUnexpectedError);
+            return null;
+        }
+    }
+
+    // A job the server already accepted keeps running and lands in the job centre,
+    // so stopping means stopping the wait. Before that there is nothing to keep and
+    // the request itself goes.
+    private void StopGeneratingCore()
+    {
+        CancellationTokenSource? polling;
+        lock (_lifetimeGate)
+        {
+            polling = _pollingCts;
+        }
+
+        if (polling is { IsCancellationRequested: false })
+        {
+            polling.Cancel();
+            return;
+        }
+
+        _runningRequest?.Cancel();
+    }
+
+    private async Task RefreshJobHistoryAfterLocalStopAsync()
+    {
+        try
+        {
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await _jobMonitor.RefreshAsync(timeout.Token);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogDebug(ex, "Failed to refresh AI job history after stopping a local wait.");
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
+    private static bool IsTransientPollingFailure(Exception exception)
+        => exception is HttpRequestException
+            || exception is AiException { IsTransient: true };
+
+    private TimeSpan GetTransientPollDelay(int failureCount)
+    {
+        double multiplier = Math.Pow(2, Math.Min(failureCount - 1, 10));
+        double milliseconds = Math.Min(
+            PollInterval.TotalMilliseconds * multiplier,
+            MaximumTransientPollDelay.TotalMilliseconds);
+        return TimeSpan.FromMilliseconds(Math.Max(0, milliseconds));
+    }
+
+    // Retain each temporary frame until the unsettled name that includes its exact contents is
+    // settled. Deleting it on a model change would make the same request impossible to resend.
+    private void HoldFramesFor(AiRequestName name, string? firstFrame, string? lastFrame)
+    {
+        if (string.IsNullOrEmpty(name.Key))
+            return;
+
+        var held = new CompositeDisposable(
+            AcquireTemporaryFileLease(firstFrame),
+            AcquireTemporaryFileLease(lastFrame));
+        lock (_lifetimeGate)
+        {
+            if (_framesHeldByName.Remove(name.Key, out IDisposable? previous))
+                previous.Dispose();
+            _framesHeldByName.Add(name.Key, held);
+        }
+    }
+
+    private void ReleaseFramesOf(AiRequestName name)
+    {
+        if (string.IsNullOrEmpty(name.Key))
+            return;
+
+        IDisposable? held;
+        lock (_lifetimeGate)
+        {
+            if (!_framesHeldByName.Remove(name.Key, out held))
+                return;
+        }
+
+        held.Dispose();
+    }
+
+    // Build the upload and its name from the same read. Reading twice could make the dispatched
+    // bytes differ from the named bytes and record the result under the wrong request.
+    private async Task<(
+        AiUploadSource? Frame,
+        string Stamp,
+        byte[]? Bytes,
+        string? Name)> ReadFrameAsync(
+        string? path,
+        CancellationToken cancellationToken,
+        AiRequestRecoverySource? recoveredSource = null)
+    {
+        if (string.IsNullOrEmpty(path))
+            return (null, string.Empty, null, null);
+
+        string fileName = recoveredSource?.Name ?? Path.GetFileName(path);
+        byte[] bytes = recoveredSource is not null
+            ? _requestKey.ReadSourceBytes(recoveredSource)
+            : await AiUploadBytes.ReadWithinAsync(
+                path,
+                AiRequestLimits.MaxFrameUploadBytes,
+                cancellationToken);
+        // Exclude the filename: the server identifies a frame by its content and type. Scene
+        // captures get a new temporary filename each time, which must not turn a resend of the
+        // same frame into a newly charged request.
+        return (
+            AiUploadSource.FromBytes(fileName, bytes),
+            AiRequestKey.ContentStamp(bytes),
+            bytes,
+            fileName);
+    }
+
+    private bool IsTemporaryFile(string path)
+    {
+        lock (_lifetimeGate)
+            return _temporaryFiles.Contains(path);
+    }
+
+    private static bool RecoverySourceMatchesPath(
+        AiRequestRecoverySource source,
+        string? path)
+    {
+        if (path is null)
+            return false;
+        return source.DurableFile is { } durable
+            ? string.Equals(Path.GetFileName(path), durable, StringComparison.Ordinal)
+            : string.Equals(
+                Path.GetFullPath(source.Path ?? string.Empty),
+                Path.GetFullPath(path),
+                StringComparison.Ordinal);
+    }
+
+    private IDisposable AcquireTemporaryFileLease(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return Disposable.Empty;
+
+        lock (_lifetimeGate)
+        {
+            if (!_temporaryFiles.Contains(path))
+                return Disposable.Empty;
+
+            _temporaryFileLeases[path] = _temporaryFileLeases.GetValueOrDefault(path) + 1;
+        }
+
+        return Disposable.Create(() => ReleaseTemporaryFileLease(path));
+    }
+
+    private void ReleaseTemporaryFileLease(string path)
+    {
+        lock (_lifetimeGate)
+        {
+            if (!_temporaryFileLeases.TryGetValue(path, out int count))
+                return;
+
+            if (count > 1)
+            {
+                _temporaryFileLeases[path] = count - 1;
+                return;
+            }
+
+            _temporaryFileLeases.Remove(path);
+            if (_temporaryFilesPendingDeletion.Contains(path))
+            {
+                DeleteTrackedTemporaryFile(path);
+            }
+        }
+    }
+
+    private void RequestTemporaryFileDeletion(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return;
+
+        lock (_lifetimeGate)
+        {
+            if (!_temporaryFiles.Contains(path))
+                return;
+
+            _temporaryFilesPendingDeletion.Add(path);
+            if (!_temporaryFileLeases.ContainsKey(path))
+            {
+                DeleteTrackedTemporaryFile(path);
+            }
+        }
+    }
+
+    // Called with _lifetimeGate held so a new lease cannot race with deletion.
+    private void DeleteTrackedTemporaryFile(string path)
+    {
+        if (DeleteTemporaryFile(path))
+        {
+            _temporaryFiles.Remove(path);
+            _temporaryFilesPendingDeletion.Remove(path);
+        }
+    }
+
+    private bool DeleteTemporaryFile(string path)
+    {
+        try
+        {
+            File.Delete(path);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to remove temporary AI file {Path}", path);
+            return false;
+        }
+    }
+
+    private async Task AddToSceneCore()
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        if (operation is null)
+            return;
+        if (_editViewModel == null || ResultVideoPath.Value is not { } filePath)
+            return;
+        if (!operation.IsCurrent)
+            return;
+        using IDisposable fileLease = AcquireTemporaryFileLease(filePath);
+
+        try
+        {
+            TimeSpan start = _editViewModel.Player.CurrentFrame.Value;
+            int layer = _editViewModel.Scene.Children
+                .Where(item => item.Start <= start && start < item.Range.End)
+                .Select(item => item.ZIndex)
+                .DefaultIfEmpty(-1)
+                .Max() + 1;
+            int durationSeconds = _resultSnapshot?.DurationSeconds ?? SelectedDuration.Value.Seconds;
+            AiResultImportOptions options = new(
+                start,
+                TimeSpan.FromSeconds(durationSeconds),
+                layer,
+                Strings.AiVideoGeneration);
+            ElementAddResult result;
+            if (ResultImporter is { } importer)
+            {
+                result = await importer(filePath, options, operation.CancellationToken);
+            }
+            else
+            {
+                var defaultImporter = new AiResultImporter(
+                    _editViewModel.Scene,
+                    _editViewModel.GetRequiredService<IElementAdder>());
+                result = await defaultImporter.ImportVideoAsync(
+                    filePath,
+                    options,
+                    operation.CancellationToken);
+            }
+
+            if (result.Failure is LockedElementLayerFailure)
+            {
+                operation.TryPublish(() =>
+                    NotificationService.ShowWarning(Strings.Lock, Strings.LayerIsLocked));
+                return;
+            }
+            EnsureImportSucceeded(result);
+            if (result.IsSuccess)
+            {
+                operation.TryPublish(() =>
+                    NotificationService.ShowSuccess(Strings.AiVideoGeneration, Strings.AiVideoAddedToScene));
+            }
+        }
+        catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to add the AI video to the scene.");
+            operation.TryPublish(() => Error.Value = Strings.AiUnexpectedError);
+        }
+
+    }
+
+    private static void EnsureImportSucceeded(ElementAddResult result)
+    {
+        if (result.IsSuccess)
+            return;
+        throw new InvalidOperationException(
+            $"Failed to add the generated video: {result.Failure?.Id}.",
+            result.Failure?.Exception);
+    }
+
+    private async Task SaveToFileCore()
+    {
+        using IdentityOperationLifetime.Operation? operation = TryEnterIdentityOperation();
+        if (operation is null)
+            return;
+        if (ResultVideoPath.Value is not { } filePath)
+            return;
+        using IDisposable fileLease = AcquireTemporaryFileLease(filePath);
+
+        AiSaveFileDestination? destination;
+        IStorageFile? selectedStorageFile = null;
+        if (SaveFilePicker is { } picker)
+        {
+            destination = await picker(operation.CancellationToken);
+        }
+        else
+        {
+            if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime
+                { MainWindow: { } window }
+                || TopLevel.GetTopLevel(window)?.StorageProvider is not { } storage)
+                return;
+            FilePickerSaveOptions options = SharedFilePickerOptions.SaveVideo();
+            options.SuggestedFileName = $"AI Video {DateTime.Now:yyyy-MM-dd HHmmss}";
+            options.SuggestedStartLocation = await storage.TryGetWellKnownFolderAsync(WellKnownFolder.Videos);
+            options.DefaultExtension = Path.GetExtension(filePath).TrimStart('.');
+            selectedStorageFile = await storage.SaveFilePickerAsync(options);
+            destination = selectedStorageFile is null
+                ? null
+                : new AiSaveFileDestination(selectedStorageFile.Path.LocalPath);
+        }
+        using IStorageFile? storageFileOwnership = selectedStorageFile;
+
+        if (destination is null || !operation.IsCurrent)
+            return;
+
+        try
+        {
+            string sourceExtension = Path.GetExtension(filePath);
+            string destinationExtension = Path.GetExtension(destination.Path);
+            if (!IsSupportedVideoExtension(destinationExtension)
+                || !string.Equals(sourceExtension, destinationExtension, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    "The destination must use the generated video's format.");
+            }
+
+            string temporaryPath = destination.Path + $".{Guid.NewGuid():N}.tmp";
+            try
+            {
+                UnixFileMode? existingMode = !OperatingSystem.IsWindows() && File.Exists(destination.Path)
+                    ? File.GetUnixFileMode(destination.Path)
+                    : null;
+                await CopyVideoFileAsync(filePath, temporaryPath, operation.CancellationToken);
+                if (!OperatingSystem.IsWindows() && existingMode is { } mode)
+                    File.SetUnixFileMode(temporaryPath, mode);
+                if (!operation.IsCurrent)
+                    return;
+
+                // The only UI publication is the same-volume rename. The old destination
+                // remains untouched if the copy or cancellation fails beforehand.
+                if (!operation.TryPublish(() => File.Move(temporaryPath, destination.Path, true)))
+                    return;
+            }
+            finally
+            {
+                try
+                {
+                    File.Delete(temporaryPath);
+                }
+                catch (IOException)
+                {
+                }
+                catch (UnauthorizedAccessException)
+                {
+                }
+            }
+            operation.TryPublish(() =>
+                NotificationService.ShowSuccess(Strings.AiVideoGeneration, Strings.AiVideoSaved));
+        }
+        catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save the AI video.");
+            operation.TryPublish(() => Error.Value = Strings.AiUnexpectedError);
+        }
+    }
+
+    private static async Task CopyVideoFileAsync(
+        string sourcePath,
+        string destinationPath,
+        CancellationToken cancellationToken)
+    {
+        await using var source = new FileStream(
+            sourcePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 128 * 1024,
+            options: FileOptions.Asynchronous | FileOptions.SequentialScan);
+        await using var destination = new FileStream(
+            destinationPath,
+            new FileStreamOptions
+            {
+                Mode = FileMode.CreateNew,
+                Access = FileAccess.Write,
+                Share = FileShare.None,
+                BufferSize = 128 * 1024,
+                Options = FileOptions.Asynchronous | FileOptions.SequentialScan | FileOptions.WriteThrough,
+            });
+        await source.CopyToAsync(destination, 128 * 1024, cancellationToken);
+        await destination.FlushAsync(cancellationToken);
+        destination.Flush(true);
+    }
+
+    private static bool IsSupportedVideoExtension(string extension)
+        => extension.Equals(".mp4", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".webm", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".mov", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".mkv", StringComparison.OrdinalIgnoreCase);
+
+    private string ComposePrompt() => AiPromptComposer.Compose(new AiPromptParts(
+        Prompt.Value,
+        Style.Value,
+        Composition.Value,
+        Motion.Value,
+        Exclusions.Value));
+
+    private sealed record AiVideoResultSnapshot(int DurationSeconds);
+
+}
+
+internal sealed record AiVideoDurationOption(int Seconds)
+{
+    public override string ToString() => $"{Seconds} {Strings.AiVideoSeconds}";
+}
+
+internal sealed record AiVideoAspectRatioOption(string Value)
+{
+    public override string ToString() => Value;
+}
+
+internal sealed record AiVideoResolutionOption(string Value)
+{
+    public override string ToString() => Value;
+}

--- a/src/Beutl/ViewModels/Dialogs/EditableCaptionCueViewModel.cs
+++ b/src/Beutl/ViewModels/Dialogs/EditableCaptionCueViewModel.cs
@@ -1,0 +1,202 @@
+﻿using System.ComponentModel;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Beutl.Editor.Services.Captions;
+
+namespace Beutl.ViewModels.Dialogs;
+
+public sealed class EditableCaptionCueViewModel : INotifyPropertyChanged
+{
+    private int _number;
+    private string _startText;
+    private string _endText;
+    private string _text;
+    private int _caretIndex;
+    private string _speaker;
+    private string _language;
+    private readonly CaptionMetadata _metadata;
+
+    public EditableCaptionCueViewModel(int number, CaptionCue cue)
+    {
+        ArgumentNullException.ThrowIfNull(cue);
+
+        _number = number;
+        _startText = FormatTime(cue.Start);
+        _endText = FormatTime(cue.End);
+        _text = cue.Text;
+        _caretIndex = cue.Text.Length;
+        _speaker = cue.Speaker ?? string.Empty;
+        _language = cue.Language ?? string.Empty;
+        _metadata = cue.Metadata;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public int Number
+    {
+        get => _number;
+        internal set => SetField(ref _number, value);
+    }
+
+    public string StartText
+    {
+        get => _startText;
+        set => SetField(ref _startText, value);
+    }
+
+    public string EndText
+    {
+        get => _endText;
+        set => SetField(ref _endText, value);
+    }
+
+    public string Text
+    {
+        get => _text;
+        set
+        {
+            string normalized = value ?? string.Empty;
+            if (!SetField(ref _text, normalized))
+                return;
+
+            if (_caretIndex > normalized.Length)
+            {
+                CaretIndex = normalized.Length;
+            }
+        }
+    }
+
+    public int CaretIndex
+    {
+        get => _caretIndex;
+        set => SetField(ref _caretIndex, Math.Clamp(value, 0, Text.Length));
+    }
+
+    public string Speaker
+    {
+        get => _speaker;
+        set => SetField(ref _speaker, value ?? string.Empty);
+    }
+
+    public string Language
+    {
+        get => _language;
+        set => SetField(ref _language, value ?? string.Empty);
+    }
+
+    public bool TryCreateCue(out CaptionCue? cue)
+    {
+        cue = null;
+        if (!TryParseTime(StartText, out TimeSpan start)
+            || !TryParseTime(EndText, out TimeSpan end)
+            || start < TimeSpan.Zero
+            || end <= start)
+        {
+            return false;
+        }
+
+        cue = new CaptionCue(
+            start,
+            end,
+            Text,
+            NormalizeOptional(Speaker),
+            NormalizeOptional(Language),
+            _metadata);
+        return true;
+    }
+
+    internal static string FormatTime(TimeSpan value)
+    {
+        long totalHours = (long)value.TotalHours;
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{totalHours:00}:{value.Minutes:00}:{value.Seconds:00}.{value.Milliseconds:000}");
+    }
+
+    internal static bool TryParseTime(string? value, out TimeSpan result)
+    {
+        result = default;
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        string input = value.Trim();
+        string[] formats =
+        [
+            @"h\:mm\:ss\.fff",
+            @"hh\:mm\:ss\.fff",
+            @"h\:mm\:ss",
+            @"hh\:mm\:ss",
+            @"m\:ss\.fff",
+            @"mm\:ss\.fff",
+            @"m\:ss",
+            @"mm\:ss",
+        ];
+
+        return TryParseTotalHours(input, out result)
+            || TimeSpan.TryParseExact(input, formats, CultureInfo.InvariantCulture, out result)
+            || TimeSpan.TryParse(input, CultureInfo.InvariantCulture, out result);
+    }
+
+    private static bool TryParseTotalHours(string input, out TimeSpan result)
+    {
+        result = default;
+        int firstColon = input.IndexOf(':');
+        int secondColon = firstColon < 0 ? -1 : input.IndexOf(':', firstColon + 1);
+        if (firstColon <= 0 || secondColon <= firstColon + 1)
+            return false;
+        if (input.IndexOf(':', secondColon + 1) >= 0)
+            return false;
+
+        if (!long.TryParse(input.AsSpan(0, firstColon), NumberStyles.None, CultureInfo.InvariantCulture, out long hours)
+            || !int.TryParse(
+                input.AsSpan(firstColon + 1, secondColon - firstColon - 1),
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out int minutes)
+            || !decimal.TryParse(
+                input.AsSpan(secondColon + 1),
+                NumberStyles.AllowDecimalPoint,
+                CultureInfo.InvariantCulture,
+                out decimal seconds)
+            || minutes is < 0 or > 59
+            || seconds is < 0 or >= 60)
+        {
+            return false;
+        }
+
+        try
+        {
+            decimal ticks = checked(
+                hours * (decimal)TimeSpan.TicksPerHour
+                + minutes * (decimal)TimeSpan.TicksPerMinute
+                + seconds * TimeSpan.TicksPerSecond);
+            if (ticks > TimeSpan.MaxValue.Ticks)
+                return false;
+
+            result = TimeSpan.FromTicks(decimal.ToInt64(decimal.Round(ticks)));
+            return true;
+        }
+        catch (OverflowException)
+        {
+            return false;
+        }
+    }
+
+    private static string? NormalizeOptional(string value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+            return false;
+
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        return true;
+    }
+}
+
+public sealed record CaptionLanguageOption(string? Code, string DisplayName)
+{
+    public override string ToString() => DisplayName;
+}

--- a/src/Beutl/ViewModels/Dialogs/IAiModelListConsumer.cs
+++ b/src/Beutl/ViewModels/Dialogs/IAiModelListConsumer.cs
@@ -1,0 +1,15 @@
+﻿namespace Beutl.ViewModels.Dialogs;
+
+/// <summary>
+/// A screen that offers a list of AI models and can be told to read it again.
+/// </summary>
+/// <remarks>
+/// The list is cached with a freshness window, so asking again costs nothing
+/// while it is fresh. A screen built once and kept — a workspace page returned
+/// to, a window brought back to the front — would otherwise go on offering
+/// models an operator has since withdrawn.
+/// </remarks>
+internal interface IAiModelListConsumer
+{
+    void RefreshModels();
+}

--- a/src/Beutl/ViewModels/EditContext/ElementAdderImpl.cs
+++ b/src/Beutl/ViewModels/EditContext/ElementAdderImpl.cs
@@ -1,15 +1,15 @@
-﻿using Beutl.Audio;
+﻿using System.Collections.Immutable;
+using Beutl.Audio;
 using Beutl.Composition;
 using Beutl.Editor;
 using Beutl.Editor.Components.Helpers;
-using Beutl.Editor.Components.TimelineTab.ViewModels;
 using Beutl.Editor.Models;
+using Beutl.Editor.Services;
 using Beutl.Engine;
 using Beutl.Graphics;
 using Beutl.Graphics.Rendering;
 using Beutl.Graphics.Transformation;
 using Beutl.Helpers;
-using Beutl.Language;
 using Beutl.Logging;
 using Beutl.Media;
 using Beutl.Media.Decoding;
@@ -22,344 +22,629 @@ using Microsoft.Extensions.Logging;
 
 namespace Beutl.ViewModels;
 
-internal sealed class ElementAdderImpl(EditViewModel context) : IElementAdder
+internal sealed class ElementAdderImpl : IElementAdder, IAsyncDisposable
 {
     private readonly ILogger _logger = Log.CreateLogger<ElementAdderImpl>();
-    private readonly EditViewModel _context = context;
+    private readonly EditViewModel _context;
+    private readonly ElementSourceHandlerRegistry _sourceHandlers;
+    private readonly AsyncOperationLifetime _operations = new();
 
-    public void AddElement(ElementDescription desc)
+    internal Action? BeforeCompanionAudioMaterialization { get; set; }
+
+    public ElementAdderImpl(EditViewModel context)
     {
-        _logger.LogInformation("Adding new element with description: {Description}", desc);
+        ArgumentNullException.ThrowIfNull(context);
+        _context = context;
+        _sourceHandlers = new ElementSourceHandlerRegistry(
+        [
+            new ElementSourceHandlerRegistration(
+                new EngineObjectSourceHandler(this),
+                order: 0),
+            new ElementSourceHandlerRegistration(
+                new ElementTemplateSourceHandler(this),
+                order: 10),
+            new ElementSourceHandlerRegistration(
+                new FileSourceHandler(this),
+                order: 20),
+        ],
+        context.ExtensionProvider,
+        failure => _logger.LogWarning(
+            failure.Exception,
+            "Ignoring invalid element source-handler contribution from {ExtensionType}.",
+            failure.ExtensionType));
+    }
 
-        Scene scene = _context.Scene;
-        if (!EnsureSceneIsSaved(scene))
+    public IElementSourceHandlerRegistry SourceHandlers => _sourceHandlers;
+
+    public async ValueTask DisposeAsync()
+    {
+        await _operations.DisposeAsync();
+        await _sourceHandlers.DisposeAsync();
+    }
+
+    public async ValueTask<ElementAddResult> AddAsync(
+        IReadOnlyList<ElementDescription> descriptions,
+        CancellationToken cancellationToken)
+    {
+        using AsyncOperationLifetime.Operation operation = _operations.TryEnter()
+            ?? throw new ObjectDisposedException(nameof(ElementAdderImpl));
+        using CancellationTokenSource linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            operation.CancellationToken);
+        CancellationToken operationToken = linkedCancellation.Token;
+        var handlerLeases = new List<IElementSourceHandlerLease>();
+        var preflightLeases = new List<IElementSourcePreflight>();
+        var materializationResources = new List<ElementMaterializationResource>();
+        ElementAddResult? result = null;
+        try
         {
-            return;
+            result = await AddCoreAsync(
+                descriptions,
+                handlerLeases,
+                preflightLeases,
+                materializationResources,
+                operationToken);
+            return result;
         }
-
-        if (scene.IsLayerLocked(desc.Layer))
-        {
-            NotificationService.ShowWarning(Strings.Lock, Strings.LayerIsLocked);
-            return;
-        }
-
-        Element CreateElement()
-        {
-            _logger.LogDebug("Creating new element with start: {Start}, length: {Length}, layer: {Layer}", desc.Start,
-                desc.Length, desc.Layer);
-            var element = new Element
-            {
-                Start = desc.Start,
-                Length = desc.Length,
-                ZIndex = desc.Layer,
-            };
-            element.Uri = ElementFileNaming.GetUri(scene.Uri!, element.Id);
-            return element;
-        }
-
-        void SetAccentColor(Element element, string str)
-        {
-            _logger.LogDebug("Setting accent color for element: {Element}, color string: {ColorString}", element, str);
-            element.AccentColor = ColorGenerator.GenerateColor(str);
-        }
-
-        void SetTransform(Drawable drawable)
-        {
-            if (!desc.Position.IsDefault)
-            {
-                _logger.LogDebug(
-                    "Setting transform for drawable: {Drawable}, position: {Position}",
-                    drawable, desc.Position);
-                Transform? transform = drawable.Transform.CurrentValue;
-                AddOrSetHelper.AddOrSet(
-                    ref transform,
-                    new TranslateTransform(desc.Position));
-                drawable.Transform.CurrentValue = transform;
-            }
-        }
-
-        T? TrySetDuration<T>(Element element, Func<T> init, Func<T, TimeSpan> getDuration)
+        finally
         {
             try
             {
-                var state = init();
-                element.Length = getDuration(state);
-                return state;
+                await ReleasePipelineResourcesAsync(preflightLeases, materializationResources);
             }
-            catch
+            finally
             {
-                return default;
+                ReleaseHandlerLeases(handlerLeases);
             }
         }
-
-        TimelineTabViewModel? timeline = _context.FindToolTab<TimelineTabViewModel>();
-        using var compositeDisposable = new CompositeDisposable();
-
-        if (desc.FileName != null)
-        {
-            _logger.LogInformation("Adding element from file: {FileName}", desc.FileName);
-            (TimeRange Range, int ZIndex)? scrollPos = null;
-
-            Element CreateElementFor<TValue>(out TValue value)
-                where TValue : EngineObject, new()
-            {
-                Element element = CreateElement();
-                element.Name = Path.GetFileName(desc.FileName);
-                SetAccentColor(element, typeof(TValue).FullName!);
-
-                value = new TValue();
-                element.AddObject(value);
-                if (value is Drawable drawable)
-                {
-                    SetTransform(drawable);
-                }
-
-                return element;
-            }
-
-            if (MatchFileImage(desc.FileName))
-            {
-                _logger.LogDebug("File is an image.");
-                Element element = CreateElementFor<SourceImage>(out var t);
-                t.Source.CurrentValue = ImageSource.Open(desc.FileName);
-
-                CoreSerializer.StoreToUri(element, element.Uri!);
-                scene.AddChild(element);
-                scrollPos = (element.Range, element.ZIndex);
-            }
-            else if (MatchFileVideoOnly(desc.FileName))
-            {
-                _logger.LogDebug("File is a video.");
-                // Probe the audio track so a video-only file (e.g. an .mkv without sound) does not
-                // get a SourceSound element that would crash on AudioInfo access (#2183).
-                bool hasAudio = HasAudioTrack(desc.FileName);
-                // The audio companion goes to desc.Layer + 1; refuse the whole import when that
-                // layer is locked and an audio companion is actually going to be created.
-                if (hasAudio && scene.IsLayerLocked(desc.Layer + 1))
-                {
-                    NotificationService.ShowWarning(Strings.Lock, Strings.LayerIsLocked);
-                    return;
-                }
-
-                Element element1 = CreateElementFor<SourceVideo>(out var t1);
-                var video = VideoSource.Open(desc.FileName);
-                t1.Source.CurrentValue = video;
-                var videoResource = TrySetDuration(
-                    element1,
-                    () => video.ToResource(CompositionContext.Default),
-                    v => v.Duration);
-
-                Element? element2 = null;
-                SoundSource.Resource? soundResource = null;
-                if (hasAudio)
-                {
-                    element2 = CreateElementFor<SourceSound>(out var t2);
-                    element2.ZIndex++;
-                    var sound = SoundSource.Open(desc.FileName);
-                    t2.Source.CurrentValue = sound;
-                    soundResource = TrySetDuration(
-                        element2,
-                        () => sound.ToResource(CompositionContext.Default),
-                        v => v.Duration);
-                }
-                // VideoSource.Resource, SoundSource.ResourceのMediaReaderは参照カウンターで管理され、Resource間で共有される
-                // すぐに解放してしまうとこのDuration設定時とレンダリング時の2回MediaReaderが生成されてしまう
-                // 作成 -> 参照カウントを引く -> 解放 -> レンダラ側で作成 のようになってしまう
-                // これを以下のようにさせる
-                // 作成 -> レンダラ側で参照カウントを追加 -> 以下のDisposeで参照カウントを引く -> 実体は解放されない
-                compositeDisposable.Add(Disposable.Create(() => RenderThread.Dispatcher.Dispatch(() =>
-                {
-                    videoResource?.Dispose();
-                    soundResource?.Dispose();
-                }, DispatchPriority.Low)));
-
-                CoreSerializer.StoreToUri(element1, element1.Uri!);
-                scene.AddChild(element1);
-                if (element2 != null)
-                {
-                    CoreSerializer.StoreToUri(element2, element2.Uri!);
-                    scene.AddChild(element2);
-                    // グループ化
-                    scene.Groups.Add([element1.Id, element2.Id]);
-                }
-                scrollPos = (element1.Range, element1.ZIndex);
-            }
-            else if (MatchFileAudioOnly(desc.FileName))
-            {
-                _logger.LogDebug("File is an audio.");
-                Element element = CreateElementFor<SourceSound>(out var t);
-                var sound = SoundSource.Open(desc.FileName);
-                t.Source.CurrentValue = sound;
-                var soundResource = TrySetDuration(
-                    element,
-                    () => sound.ToResource(CompositionContext.Default),
-                    v => v.Duration);
-                compositeDisposable.Add(Disposable.Create(() =>
-                    RenderThread.Dispatcher.Dispatch(() => soundResource?.Dispose(), DispatchPriority.Low)));
-
-                CoreSerializer.StoreToUri(element, element.Uri!);
-                scene.AddChild(element);
-                scrollPos = (element.Range, element.ZIndex);
-            }
-
-            _context.HistoryManager.Commit(CommandNames.AddElement);
-
-            if (scrollPos.HasValue && timeline != null)
-            {
-                _logger.LogDebug("Scrolling to position: {ScrollPosition}", scrollPos.Value);
-                timeline?.ScrollTo.Execute(scrollPos.Value);
-            }
-        }
-        else
-        {
-            _logger.LogInformation("Adding new element without file.");
-            Element element = CreateElement();
-            if (desc.EngineObjectFactory != null)
-            {
-                EngineObject? engineObject;
-                try
-                {
-                    engineObject = desc.EngineObjectFactory();
-                }
-                catch (Exception ex)
-                {
-                    // Aborting before any scene mutation keeps the add transactional: nothing is
-                    // persisted or committed to history when the factory fails.
-                    _logger.LogError(ex, "Failed to create the engine object for the new element; aborting add.");
-                    return;
-                }
-
-                if (engineObject == null)
-                {
-                    // A factory that returns null (rather than throwing) would otherwise NRE below,
-                    // bypassing the guard above. Abort here too, before mutating the scene.
-                    _logger.LogError("EngineObjectFactory returned null for the new element; aborting add.");
-                    return;
-                }
-
-                Type objectType = engineObject.GetType();
-                element.Name = desc.ResolveName(objectType);
-                element.AccentColor = ColorGenerator.GenerateColor(objectType.FullName ?? objectType.Name);
-                element.AddObject(engineObject);
-                if (engineObject is Drawable drawable)
-                {
-                    SetTransform(drawable);
-                }
-            }
-
-            CoreSerializer.StoreToUri(element, element.Uri!);
-            scene.AddChild(element);
-            _context.HistoryManager.Commit(CommandNames.AddElement);
-
-            timeline?.ScrollTo.Execute((element.Range, element.ZIndex));
-        }
-
-        _logger.LogInformation("Element added successfully.");
     }
 
-    public void AddElementFromTemplate(ObjectTemplateItem template, TimeSpan start, int layer)
+    private async ValueTask<ElementAddResult> AddCoreAsync(
+        IReadOnlyList<ElementDescription> descriptions,
+        ICollection<IElementSourceHandlerLease> handlerLeases,
+        ICollection<IElementSourcePreflight> preflightLeases,
+        ICollection<ElementMaterializationResource> materializationResources,
+        CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Adding element from template: {TemplateName}", template.Name.Value);
+        ArgumentNullException.ThrowIfNull(descriptions);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (descriptions.Count == 0)
+            return ElementAddResult.Failed(new EmptyElementAddRequestFailure());
 
+        _logger.LogInformation("Adding {Count} new element descriptions.", descriptions.Count);
         Scene scene = _context.Scene;
-        if (!EnsureSceneIsSaved(scene))
+        Guid sceneId = scene.Id;
+        var plans = new List<ElementCreationPlan>(descriptions.Count);
+        foreach (ElementDescription description in descriptions)
         {
-            return;
-        }
-
-        if (scene.IsLayerLocked(layer))
-        {
-            NotificationService.ShowWarning(Strings.Lock, Strings.LayerIsLocked);
-            return;
-        }
-
-        ICoreSerializable? instance = template.CreateInstance();
-        Element newElement;
-        if (instance is Element templateElement)
-        {
-            // ObjectRegenerator で ID を再生成
-            ObjectRegenerator.Regenerate(templateElement, out newElement);
-
-            newElement.Start = start;
-            newElement.ZIndex = layer;
-        }
-        else if (instance is EngineObject templateEngineObject)
-        {
-            ObjectRegenerator.Regenerate(
-                templateEngineObject, templateEngineObject.GetType(), out ICoreSerializable regenerated);
-            var newEngineObject = (EngineObject)regenerated;
-
-            newElement = new Element
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!_sourceHandlers.TryAcquire(
+                    description.Source.GetType(),
+                    out IElementSourceHandlerLease? handlerLease))
             {
-                Start = start,
-                Length = TimeSpan.FromSeconds(5),
-                ZIndex = layer,
-                Name = template.Name.Value,
-                AccentColor = ColorGenerator.GenerateColor(
-                    template.ActualType.FullName ?? template.ActualType.Name),
-            };
-            newElement.AddObject(newEngineObject);
+                return ElementAddResult.Failed(
+                    new UnsupportedElementSourceFailure(description.Source.GetType()),
+                    description);
+            }
+            handlerLeases.Add(handlerLease);
+            IElementSourceHandler handler = handlerLease.Handler;
+
+            ElementSourcePreflightResult preflight;
+            try
+            {
+                preflight = await handler.PreflightAsync(
+                    new ElementSourcePreflightContext(scene, description),
+                    cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                return ElementAddResult.Failed(
+                    new ElementSourcePreflightFailure(
+                        $"Preflight failed for element source '{description.Source.GetType().FullName}'.",
+                        ex),
+                    description);
+            }
+
+            if (preflight is null)
+            {
+                return ElementAddResult.Failed(
+                    new ElementSourcePreflightFailure("The element source handler returned no preflight result."),
+                    description);
+            }
+            if (!preflight.IsSuccess)
+                return ElementAddResult.Failed(preflight.Failure!, description);
+            if (preflight.Preflight is null || preflight.TargetLayers.Count == 0)
+            {
+                return ElementAddResult.Failed(
+                    new ElementSourcePreflightFailure("The element source handler returned an incomplete preflight result."),
+                    description);
+            }
+            preflightLeases.Add(preflight.Preflight);
+
+            foreach (int layer in preflight.TargetLayers)
+            {
+                if (scene.IsLayerLocked(layer))
+                {
+                    _logger.LogInformation(
+                        "Refusing element batch because target layer {Layer} is locked.",
+                        layer);
+                    return ElementAddResult.Failed(new LockedElementLayerFailure(layer), description);
+                }
+            }
+
+            plans.Add(new ElementCreationPlan(
+                description,
+                handlerLease,
+                preflight.Preflight,
+                preflight.TargetLayers.ToImmutableHashSet()));
         }
-        else
+
+        var preparedElements = new List<Element>(descriptions.Count);
+        var itemResults = new List<ElementAddItemResult>(descriptions.Count);
+        var groups = new List<ImmutableHashSet<Guid>>();
+        var elementReferences = new HashSet<Element>(ReferenceEqualityComparer.Instance);
+        var elementIds = _context.Scene.Children
+            .Select(element => element.Id)
+            .ToHashSet();
+
+        foreach (ElementCreationPlan plan in plans)
         {
-            _logger.LogWarning("Failed to create element from template.");
-            return;
+            cancellationToken.ThrowIfCancellationRequested();
+            ElementSourceMaterializationResult result;
+            try
+            {
+                result = await plan.HandlerLease.Handler.MaterializeAsync(
+                    new ElementSourceMaterializationContext(scene, plan.Description),
+                    plan.Preflight,
+                    cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                CleanupStagedFiles(
+                    preparedElements.Select(element => element.Uri?.LocalPath),
+                    new OperationCanceledException(cancellationToken));
+                throw;
+            }
+            catch (Exception ex)
+            {
+                CleanupStagedFiles(preparedElements.Select(element => element.Uri?.LocalPath), ex);
+                return ElementAddResult.Failed(
+                    new ElementMaterializationFailure(
+                        $"Materialization failed for element source '{plan.Description.Source.GetType().FullName}'.",
+                        ex),
+                    plan.Description);
+            }
+
+            if (result is null)
+            {
+                return FailMaterialization(
+                    preparedElements,
+                    plan.Description,
+                    new InvalidElementMaterializationFailure(
+                        "The element source handler returned no materialization result."));
+            }
+            if (!result.IsSuccess)
+                return FailMaterialization(preparedElements, plan.Description, result.Failure!);
+            if (result.Materialization is not { } materialization)
+            {
+                return FailMaterialization(
+                    preparedElements,
+                    plan.Description,
+                    new InvalidElementMaterializationFailure(
+                        "The element source handler returned an incomplete materialization result."));
+            }
+            foreach (ElementMaterializationResource resource in materialization.Resources)
+            {
+                materializationResources.Add(resource);
+            }
+
+            ElementAddFailure? validationFailure = ValidateMaterialization(
+                materialization,
+                plan.TargetLayers,
+                elementReferences,
+                elementIds);
+            if (validationFailure is not null)
+            {
+                return FailMaterialization(preparedElements, plan.Description, validationFailure);
+            }
+
+            try
+            {
+                Uri? sceneUri = scene.Uri;
+                string elementDirectory = sceneUri is not null
+                    ? Path.GetDirectoryName(sceneUri.LocalPath)!
+                    : UnsavedSceneStorage.GetElementDirectory(scene.Id);
+                Directory.CreateDirectory(elementDirectory);
+                foreach (Element element in materialization.Elements)
+                {
+                    element.Uri = sceneUri is not null
+                        ? ElementFileNaming.GetUri(sceneUri, element.Id)
+                        : RandomFileNameGenerator.GenerateUri(
+                            elementDirectory,
+                            EditorConstants.ElementFileExtension);
+                    preparedElements.Add(element);
+                }
+            }
+            catch (Exception ex)
+            {
+                CleanupStagedFiles(preparedElements.Select(element => element.Uri?.LocalPath), ex);
+                return ElementAddResult.Failed(
+                    new InvalidElementMaterializationFailure(
+                        $"The materialized elements could not apply their request metadata: {ex.Message}"),
+                    plan.Description);
+            }
+
+            groups.AddRange(materialization.Groups.Select(group => group.ToImmutableHashSet()));
+            itemResults.Add(new ElementAddItemResult(
+                plan.Description,
+                materialization.PrimaryElement,
+                materialization.CompanionElements));
         }
 
-        newElement.Uri = ElementFileNaming.GetUri(scene.Uri!, newElement.Id);
+        string[] stagedFiles = preparedElements
+            .Select(element => element.Uri!.LocalPath)
+            .ToArray();
 
-        CoreSerializer.StoreToUri(newElement, newElement.Uri!);
-        scene.AddChild(newElement);
-        _context.HistoryManager.Commit(CommandNames.AddElementFromTemplate);
+        try
+        {
+            foreach (Element element in preparedElements)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                CoreSerializer.StoreToUri(element, element.Uri!);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            CleanupStagedFiles(stagedFiles, new OperationCanceledException(cancellationToken));
+            throw;
+        }
+        catch (Exception ex)
+        {
+            CleanupStagedFiles(stagedFiles, ex);
+            return ElementAddResult.Failed(new ElementPersistenceFailure(ex));
+        }
 
-        TimelineTabViewModel? timeline = _context.FindToolTab<TimelineTabViewModel>();
-        timeline?.ScrollTo.Execute((newElement.Range, newElement.ZIndex));
+        CommitValidationFailure? commitValidation = RevalidateBeforeCommit(
+            scene,
+            sceneId,
+            plans,
+            itemResults);
+        if (commitValidation is not null)
+        {
+            CleanupStagedFiles(
+                stagedFiles,
+                commitValidation.Failure.Exception
+                ?? new InvalidOperationException(commitValidation.Failure.Message));
+            return ElementAddResult.Failed(
+                commitValidation.Failure,
+                commitValidation.Description);
+        }
 
-        _logger.LogInformation("Element from template added successfully.");
+        try
+        {
+            foreach (Element element in preparedElements)
+            {
+                scene.AddChild(element);
+            }
+
+            if (groups.Count > 0)
+            {
+                scene.Groups.AddRange(groups);
+            }
+
+            _context.HistoryManager.Commit(CommandNames.AddElement);
+        }
+        catch (Exception ex)
+        {
+            try
+            {
+                _context.HistoryManager.Rollback();
+            }
+            catch (Exception rollbackException)
+            {
+                _logger.LogError(
+                    rollbackException,
+                    "Failed to roll back an unsuccessful element batch mutation caused by {OriginalError}.",
+                    ex.Message);
+            }
+
+            CleanupStagedFiles(stagedFiles, ex);
+            return ElementAddResult.Failed(new ElementSceneMutationFailure(ex));
+        }
+
+        _logger.LogInformation("Added {Count} elements successfully.", preparedElements.Count);
+        return ElementAddResult.Succeeded(itemResults);
     }
 
-    private bool EnsureSceneIsSaved(Scene scene)
+    private CommitValidationFailure? RevalidateBeforeCommit(
+        Scene scene,
+        Guid expectedSceneId,
+        IReadOnlyList<ElementCreationPlan> plans,
+        IReadOnlyList<ElementAddItemResult> itemResults)
     {
-        if (scene.Uri is not null)
+        Scene currentScene = _context.Scene;
+        if (!ReferenceEquals(scene, currentScene)
+            || scene.Id != expectedSceneId
+            || currentScene.Id != expectedSceneId)
         {
-            return true;
+            return new CommitValidationFailure(
+                new ElementSceneChangedFailure(expectedSceneId, currentScene.Id),
+                null);
         }
 
-        _logger.LogWarning("Cannot add an element before the scene is saved.");
-        NotificationService.ShowWarning(
-            Strings.File,
-            Strings.ElementAdder_ProjectNotSaved);
-        return false;
+        for (int index = 0; index < plans.Count; index++)
+        {
+            ElementCreationPlan plan = plans[index];
+            foreach (int layer in plan.TargetLayers)
+            {
+                if (scene.IsLayerLocked(layer))
+                {
+                    return new CommitValidationFailure(
+                        new LockedElementLayerFailure(layer),
+                        plan.Description);
+                }
+            }
+
+            if (itemResults[index].Elements.Any(element => !plan.TargetLayers.Contains(element.ZIndex)))
+            {
+                return new CommitValidationFailure(
+                    new InvalidElementMaterializationFailure(
+                        "A materialized element changed to a layer that was not reserved during preflight."),
+                    plan.Description);
+            }
+        }
+
+        var ids = scene.Children.Select(element => element.Id).ToHashSet();
+        foreach (ElementAddItemResult item in itemResults)
+        {
+            foreach (Element element in item.Elements)
+            {
+                if (!ids.Add(element.Id))
+                {
+                    return new CommitValidationFailure(
+                        new InvalidElementMaterializationFailure(
+                            "Materialized element identifiers must still be unique immediately before commit."),
+                        item.Description);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private ElementAddResult FailMaterialization(
+        IReadOnlyCollection<Element> preparedElements,
+        ElementDescription description,
+        ElementAddFailure failure)
+    {
+        CleanupStagedFiles(
+            preparedElements.Select(element => element.Uri?.LocalPath),
+            failure.Exception ?? new InvalidOperationException(failure.Message));
+        return ElementAddResult.Failed(failure, description);
+    }
+
+    private static ElementAddFailure? ValidateMaterialization(
+        ElementMaterialization materialization,
+        IReadOnlySet<int> targetLayers,
+        ISet<Element> knownElements,
+        ISet<Guid> knownElementIds)
+    {
+        if (materialization.Elements.Count == 0
+            || !materialization.Elements.Contains(materialization.PrimaryElement))
+        {
+            return new InvalidElementMaterializationFailure(
+                "A materialization must contain its primary element.");
+        }
+
+        var localIds = new HashSet<Guid>();
+        foreach (Element element in materialization.Elements)
+        {
+            if (!knownElements.Add(element))
+            {
+                return new InvalidElementMaterializationFailure(
+                    "A materialized element instance cannot appear more than once in a batch.");
+            }
+            if (!localIds.Add(element.Id) || !knownElementIds.Add(element.Id))
+            {
+                return new InvalidElementMaterializationFailure(
+                    "Materialized element identifiers must be unique within the scene and batch.");
+            }
+            if (!targetLayers.Contains(element.ZIndex))
+            {
+                return new InvalidElementMaterializationFailure(
+                    $"Materialized layer {element.ZIndex} was not reserved during preflight.");
+            }
+        }
+
+        foreach (IReadOnlySet<Guid> group in materialization.Groups)
+        {
+            if (group.Count < 2 || group.Any(id => !localIds.Contains(id)))
+            {
+                return new InvalidElementMaterializationFailure(
+                    "Materialized groups must contain at least two elements from the same result.");
+            }
+        }
+
+        return null;
+    }
+
+    private async ValueTask ReleasePipelineResourcesAsync(
+        IReadOnlyList<IElementSourcePreflight> preflightLeases,
+        IReadOnlyList<ElementMaterializationResource> materializationResources)
+    {
+        List<Exception>? errors = null;
+        for (int index = materializationResources.Count - 1; index >= 0; index--)
+        {
+            ElementMaterializationResource resource = materializationResources[index];
+            try
+            {
+                await resource.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                (errors ??= []).Add(ex);
+            }
+        }
+
+        for (int index = preflightLeases.Count - 1; index >= 0; index--)
+        {
+            try
+            {
+                await preflightLeases[index].DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                (errors ??= []).Add(ex);
+            }
+        }
+
+        if (errors is not null)
+        {
+            foreach (Exception error in errors)
+            {
+                _logger.LogWarning(error, "An element pipeline resource failed to release.");
+            }
+        }
+    }
+
+    private static void ReleaseHandlerLeases(IReadOnlyList<IElementSourceHandlerLease> handlerLeases)
+    {
+        for (int index = handlerLeases.Count - 1; index >= 0; index--)
+        {
+            handlerLeases[index].Dispose();
+        }
+    }
+
+    private Element CreateElement(Scene scene, ElementDescription description)
+    {
+        _logger.LogDebug(
+            "Creating an element with start {Start}, length {Length}, and layer {Layer}.",
+            description.Start,
+            description.Length,
+            description.Layer);
+        return new Element
+        {
+            Start = description.Start,
+            Length = description.Length
+                     ?? throw new InvalidOperationException("A non-template element source requires a length."),
+            ZIndex = description.Layer,
+        };
+    }
+
+    private Element CreateElementFor<TValue>(
+        Scene scene,
+        ElementDescription description,
+        string fileName,
+        out TValue value)
+        where TValue : EngineObject, new()
+    {
+        Element element = CreateElement(scene, description);
+        element.Name = string.IsNullOrWhiteSpace(description.Name)
+            ? Path.GetFileName(fileName)
+            : description.Name;
+        string typeName = typeof(TValue).FullName!;
+        element.AccentColor = ColorGenerator.GenerateColor(typeName);
+
+        value = new TValue();
+        element.AddObject(value);
+        if (value is Drawable drawable)
+        {
+            SetTransform(drawable, description);
+        }
+
+        return element;
+    }
+
+    private void SetTransform(Drawable drawable, ElementDescription description)
+    {
+        if (description.Position is not { } position)
+            return;
+
+        Transform? transform = drawable.Transform.CurrentValue;
+        AddOrSetHelper.AddOrSet(ref transform, new TranslateTransform(position));
+        drawable.Transform.CurrentValue = transform;
+    }
+
+    private static T? TrySetDuration<T>(Element element, Func<T> initialize, Func<T, TimeSpan> getDuration)
+    {
+        T? state = default;
+        try
+        {
+            state = initialize();
+            element.Length = getDuration(state);
+            return state;
+        }
+        catch
+        {
+            if (state is IDisposable disposable)
+                RenderThread.Dispatcher.Dispatch(disposable.Dispose, DispatchPriority.Low);
+            return default;
+        }
+    }
+
+    private static IDisposable? DisposeResourceOnRenderThread(IDisposable? resource)
+    {
+        return resource is null
+            ? null
+            : Disposable.Create(() =>
+                RenderThread.Dispatcher.Dispatch(resource.Dispose, DispatchPriority.Low));
+    }
+
+    private void CleanupStagedFiles(IEnumerable<string?> paths, Exception originalException)
+    {
+        foreach (string path in paths
+                     .Where(path => !string.IsNullOrWhiteSpace(path))
+                     .Select(path => path!)
+                     .Distinct(StringComparer.Ordinal))
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            catch (Exception cleanupException)
+            {
+                _logger.LogWarning(
+                    cleanupException,
+                    "Failed to delete staged element file {Path} while handling {OriginalError}.",
+                    path,
+                    originalException.Message);
+            }
+        }
     }
 
     private static bool MatchFileExtensions(string filePath, IEnumerable<string> extensions)
     {
         string ext = Path.GetExtension(filePath);
         return extensions
-            .Select(x =>
+            .Select(value =>
             {
-                int idx = x.LastIndexOf('.');
-                if (0 <= idx)
-                    return x.Substring(idx);
-                else
-                    return x;
+                int index = value.LastIndexOf('.');
+                return index >= 0 ? value[index..] : value;
             })
             .Contains(ext, StringComparer.OrdinalIgnoreCase);
     }
 
     private static bool MatchFileAudioOnly(string filePath)
-    {
-        return MatchFileExtensions(filePath, DecoderRegistry.EnumerateDecoder()
-            .SelectMany(x => x.AudioExtensions())
-            .Distinct());
-    }
+        => MatchFileExtensions(
+            filePath,
+            DecoderRegistry.EnumerateDecoder()
+                .SelectMany(decoder => decoder.AudioExtensions())
+                .Distinct());
 
     private static bool MatchFileVideoOnly(string filePath)
-    {
-        return MatchFileExtensions(filePath, DecoderRegistry.EnumerateDecoder()
-            .SelectMany(x => x.VideoExtensions())
-            .Distinct());
-    }
+        => MatchFileExtensions(
+            filePath,
+            DecoderRegistry.EnumerateDecoder()
+                .SelectMany(decoder => decoder.VideoExtensions())
+                .Distinct());
 
     private bool HasAudioTrack(string filePath)
     {
@@ -370,11 +655,10 @@ internal sealed class ElementAdderImpl(EditViewModel context) : IElementAdder
         }
         catch (Exception ex)
         {
-            // A failed audio open means either the file genuinely has no audio track, or the audio
-            // decoder is unavailable (e.g. missing FFmpeg natives, unsupported codec). Treat both as
-            // audio-less so the video import proceeds, but log the reason so a silently dropped
-            // audio companion stays diagnosable.
-            _logger.LogWarning(ex, "Failed to open the audio stream of '{File}' for track detection; importing as video-only.", filePath);
+            _logger.LogWarning(
+                ex,
+                "Failed to open the audio stream of '{File}' for track detection; importing as video-only.",
+                filePath);
             return false;
         }
     }
@@ -400,4 +684,310 @@ internal sealed class ElementAdderImpl(EditViewModel context) : IElementAdder
         ];
         return MatchFileExtensions(filePath, extensions);
     }
+
+    private sealed class EngineObjectSourceHandler(ElementAdderImpl owner) : IElementSourceHandler
+    {
+        public Type SourceType => typeof(ElementSource.EngineObject);
+
+        public ValueTask<ElementSourcePreflightResult> PreflightAsync(
+            ElementSourcePreflightContext context,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (context.Description.Length is null)
+            {
+                return ValueTask.FromResult(ElementSourcePreflightResult.Rejected(
+                    new ElementSourcePreflightFailure(
+                        "An engine-object element source requires a requested length.")));
+            }
+
+            return ValueTask.FromResult(ElementSourcePreflightResult.Ready(
+                StatelessPreflight.Instance,
+                [context.Description.Layer]));
+        }
+
+        public ValueTask<ElementSourceMaterializationResult> MaterializeAsync(
+            ElementSourceMaterializationContext context,
+            IElementSourcePreflight preflight,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var source = (ElementSource.EngineObject)context.Description.Source;
+            EngineObject engineObject;
+            try
+            {
+                engineObject = source.Factory()
+                    ?? throw new InvalidOperationException("The engine-object factory returned null.");
+            }
+            catch (Exception ex)
+            {
+                return ValueTask.FromResult(ElementSourceMaterializationResult.Rejected(
+                    new ElementMaterializationFailure("The engine-object factory failed.", ex)));
+            }
+
+            Element element = owner.CreateElement(context.Scene, context.Description);
+            Type objectType = engineObject.GetType();
+            element.Name = context.Description.ResolveName(objectType);
+            element.AccentColor = ColorGenerator.GenerateColor(objectType.FullName ?? objectType.Name);
+            element.AddObject(engineObject);
+            if (engineObject is Drawable drawable)
+            {
+                owner.SetTransform(drawable, context.Description);
+            }
+
+            return ValueTask.FromResult(ElementSourceMaterializationResult.Materialized(
+                new ElementMaterialization(element)));
+        }
+    }
+
+    private sealed class ElementTemplateSourceHandler(ElementAdderImpl owner) : IElementSourceHandler
+    {
+        public Type SourceType => typeof(ElementSource.ElementTemplate);
+
+        public ValueTask<ElementSourcePreflightResult> PreflightAsync(
+            ElementSourcePreflightContext context,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(ElementSourcePreflightResult.Ready(
+                StatelessPreflight.Instance,
+                [context.Description.Layer]));
+        }
+
+        public ValueTask<ElementSourceMaterializationResult> MaterializeAsync(
+            ElementSourceMaterializationContext context,
+            IElementSourcePreflight preflight,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var source = (ElementSource.ElementTemplate)context.Description.Source;
+            Element element;
+            try
+            {
+                element = source.Factory()
+                    ?? throw new InvalidOperationException("The element-template factory returned null.");
+            }
+            catch (Exception ex)
+            {
+                return ValueTask.FromResult(ElementSourceMaterializationResult.Rejected(
+                    new ElementMaterializationFailure("The element-template factory failed.", ex)));
+            }
+
+            element.Start = context.Description.Start;
+            if (context.Description.Length is { } length)
+            {
+                element.Length = length;
+            }
+            element.ZIndex = context.Description.Layer;
+            if (!string.IsNullOrWhiteSpace(context.Description.Name))
+            {
+                element.Name = context.Description.Name;
+            }
+            if (context.Description.Position is not null)
+            {
+                foreach (Drawable drawable in element.Objects.OfType<Drawable>())
+                {
+                    owner.SetTransform(drawable, context.Description);
+                }
+            }
+
+            return ValueTask.FromResult(ElementSourceMaterializationResult.Materialized(
+                new ElementMaterialization(element)));
+        }
+    }
+
+    private sealed class FileSourceHandler(ElementAdderImpl owner) : IElementSourceHandler
+    {
+        public Type SourceType => typeof(ElementSource.File);
+
+        public async ValueTask<ElementSourcePreflightResult> PreflightAsync(
+            ElementSourcePreflightContext context,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (context.Description.Length is null)
+            {
+                return ElementSourcePreflightResult.Rejected(
+                    new ElementSourcePreflightFailure(
+                        "A file element source requires a requested length."));
+            }
+
+            string fileName = ((ElementSource.File)context.Description.Source).FileName;
+            FileSourceKind kind = MatchFileImage(fileName)
+                ? FileSourceKind.Image
+                : MatchFileVideoOnly(fileName)
+                    ? FileSourceKind.Video
+                    : MatchFileAudioOnly(fileName)
+                        ? FileSourceKind.Audio
+                        : FileSourceKind.Unsupported;
+            if (kind == FileSourceKind.Unsupported)
+            {
+                return ElementSourcePreflightResult.Rejected(
+                    new UnsupportedElementSourceFailure(
+                        typeof(ElementSource.File),
+                        $"The file '{fileName}' is not supported by a registered media decoder."));
+            }
+
+            bool hasAudio = kind == FileSourceKind.Video
+                && await Task.Run(() => owner.HasAudioTrack(fileName), cancellationToken);
+            int[] layers = hasAudio
+                ? [context.Description.Layer, context.Description.Layer + 1]
+                : [context.Description.Layer];
+            return ElementSourcePreflightResult.Ready(new FilePreflight(kind, hasAudio), layers);
+        }
+
+        public async ValueTask<ElementSourceMaterializationResult> MaterializeAsync(
+            ElementSourceMaterializationContext context,
+            IElementSourcePreflight preflight,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (preflight is not FilePreflight filePreflight)
+            {
+                return ElementSourceMaterializationResult.Rejected(
+                    new InvalidElementMaterializationFailure(
+                        "The file source handler received preflight state from another handler."));
+            }
+
+            string fileName = ((ElementSource.File)context.Description.Source).FileName;
+            var resources = new List<ElementMaterializationResource>();
+            try
+            {
+                switch (filePreflight.Kind)
+                {
+                    case FileSourceKind.Image:
+                        Element imageElement = owner.CreateElementFor<SourceImage>(
+                            context.Scene,
+                            context.Description,
+                            fileName,
+                            out SourceImage sourceImage);
+                        sourceImage.Source.CurrentValue = ImageSource.Open(fileName);
+                        return ElementSourceMaterializationResult.Materialized(
+                            new ElementMaterialization(imageElement));
+
+                    case FileSourceKind.Video:
+                        Element videoElement = owner.CreateElementFor<SourceVideo>(
+                            context.Scene,
+                            context.Description,
+                            fileName,
+                            out SourceVideo sourceVideo);
+                        VideoSource video = VideoSource.Open(fileName);
+                        sourceVideo.Source.CurrentValue = video;
+                        VideoSource.Resource? videoResource = TrySetDuration(
+                            videoElement,
+                            () => video.ToResource(CompositionContext.Default),
+                            resource => resource.Duration);
+                        if (DisposeResourceOnRenderThread(videoResource) is { } videoDisposal)
+                        {
+                            resources.Add(ElementMaterializationResource.Temporary(videoDisposal));
+                        }
+
+                        if (!filePreflight.HasAudio)
+                        {
+                            return ElementSourceMaterializationResult.Materialized(
+                                new ElementMaterialization(videoElement, resources: resources));
+                        }
+
+                        Element soundElement = owner.CreateElementFor<SourceSound>(
+                            context.Scene,
+                            context.Description,
+                            fileName,
+                            out SourceSound sourceSound);
+                        soundElement.ZIndex++;
+                        owner.BeforeCompanionAudioMaterialization?.Invoke();
+                        SoundSource sound = SoundSource.Open(fileName);
+                        sourceSound.Source.CurrentValue = sound;
+                        SoundSource.Resource? soundResource = TrySetDuration(
+                            soundElement,
+                            () => sound.ToResource(CompositionContext.Default),
+                            resource => resource.Duration);
+                        if (DisposeResourceOnRenderThread(soundResource) is { } soundDisposal)
+                        {
+                            resources.Add(ElementMaterializationResource.Temporary(soundDisposal));
+                        }
+
+                        return ElementSourceMaterializationResult.Materialized(
+                            new ElementMaterialization(
+                                videoElement,
+                                [soundElement],
+                                [ImmutableHashSet.Create(videoElement.Id, soundElement.Id)],
+                                resources));
+
+                    case FileSourceKind.Audio:
+                        Element audioElement = owner.CreateElementFor<SourceSound>(
+                            context.Scene,
+                            context.Description,
+                            fileName,
+                            out SourceSound sourceAudio);
+                        SoundSource audio = SoundSource.Open(fileName);
+                        sourceAudio.Source.CurrentValue = audio;
+                        SoundSource.Resource? audioResource = TrySetDuration(
+                            audioElement,
+                            () => audio.ToResource(CompositionContext.Default),
+                            resource => resource.Duration);
+                        if (DisposeResourceOnRenderThread(audioResource) is { } audioDisposal)
+                        {
+                            resources.Add(ElementMaterializationResource.Temporary(audioDisposal));
+                        }
+                        return ElementSourceMaterializationResult.Materialized(
+                            new ElementMaterialization(audioElement, resources: resources));
+
+                    default:
+                        return ElementSourceMaterializationResult.Rejected(
+                            new UnsupportedElementSourceFailure(typeof(ElementSource.File)));
+                }
+            }
+            catch (Exception materializationFailure)
+            {
+                List<Exception>? cleanupFailures = null;
+                for (int i = resources.Count - 1; i >= 0; i--)
+                {
+                    try
+                    {
+                        await resources[i].DisposeAsync();
+                    }
+                    catch (Exception cleanupFailure)
+                    {
+                        (cleanupFailures ??= []).Add(cleanupFailure);
+                    }
+                }
+
+                if (cleanupFailures is null)
+                    throw;
+                throw new AggregateException([materializationFailure, .. cleanupFailures]);
+            }
+        }
+    }
+
+    private enum FileSourceKind
+    {
+        Unsupported,
+        Image,
+        Video,
+        Audio,
+    }
+
+    private sealed record StatelessPreflight : IElementSourcePreflight
+    {
+        public static StatelessPreflight Instance { get; } = new();
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed record FilePreflight(
+        FileSourceKind Kind,
+        bool HasAudio) : IElementSourcePreflight
+    {
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed record ElementCreationPlan(
+        ElementDescription Description,
+        IElementSourceHandlerLease HandlerLease,
+        IElementSourcePreflight Preflight,
+        IReadOnlySet<int> TargetLayers);
+
+    private sealed record CommitValidationFailure(
+        ElementAddFailure Failure,
+        ElementDescription? Description);
 }

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -9,6 +9,7 @@ using Beutl.Configuration;
 using Beutl.Editor;
 using Beutl.Editor.Observers;
 using Beutl.Editor.Operations;
+using Beutl.Editor.Services.AI;
 using Beutl.Editor.VersionControl;
 using Beutl.Graphics.Rendering;
 using Beutl.Graphics.Rendering.Cache;
@@ -21,7 +22,9 @@ using Beutl.Models;
 using Beutl.ProjectSystem;
 using Beutl.Serialization;
 using Beutl.Services;
+using Beutl.Services.AI;
 using Beutl.Services.PrimitiveImpls;
+using Beutl.ViewModels.Tools;
 using Microsoft.Extensions.Logging;
 using Reactive.Bindings;
 using Reactive.Bindings.Extensions;
@@ -29,7 +32,7 @@ using Dispatcher = Avalonia.Threading.Dispatcher;
 
 namespace Beutl.ViewModels;
 
-public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEditorContext, IPreviewRenderQuality
+public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorContext, ISupportAutoSaveEditorContext, IPreviewRenderQuality
 {
     private readonly ILogger _logger = Log.CreateLogger<EditViewModel>();
     private readonly AutoSaveService _autoSaveService = new();
@@ -173,8 +176,7 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
         BufferStatus = new BufferStatusViewModel(this)
             .DisposeWith(_disposables);
 
-        DockHost = new DockHostViewModel(SceneId, this)
-            .DisposeWith(_disposables);
+        DockHost = new DockHostViewModel(SceneId, this);
 
         _elementAdder = new ElementAdderImpl(this);
         _clipboardGateway = new Beutl.Editor.Components.Services.AvaloniaClipboardGateway();
@@ -559,6 +561,21 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
 
     public Scene Scene { get; private set; }
 
+    Scene IAiJobResultEditorContext.Scene => Scene;
+
+    TimeSpan IAiJobResultEditorContext.CurrentTime => Player.CurrentFrame.Value;
+
+    IElementAdder IAiJobResultEditorContext.ElementAdder => _elementAdder;
+
+    int IAiJobResultEditorContext.GetNextLayer(TimeSpan start)
+    {
+        return Scene.Children
+            .Where(item => item.Start <= start && start < item.Range.End)
+            .Select(item => item.ZIndex)
+            .DefaultIfEmpty(-1)
+            .Max() + 1;
+    }
+
     // Host services injected from the composition root via EditorExtension.TryCreateContext;
     // exposed so editor-scoped view models (DockHost, output, property editors) can reach them.
     public Beutl.Api.Services.ExtensionProvider ExtensionProvider { get; }
@@ -605,19 +622,20 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
     public async ValueTask DisposeAsync()
     {
         _logger.LogInformation("Disposing EditViewModel ({SceneId}).", SceneId);
+        Scene scene = Scene;
 
         // Block any proxy-invalidation flush already posted to the UI thread from running after this
         // nulls Scene / disposes FrameCacheManager below.
         _disposed = true;
         _autoSaveCancellation.Cancel();
         GlobalConfiguration.Instance.EditorConfig.PropertyChanged -= OnEditorConfigPropertyChanged;
-        if (!EditorService.IsWorktreeMutationActive)
+        if (scene.Uri is not null && !EditorService.IsWorktreeMutationActive)
         {
             using IDisposable fileWrite = await EditorService.BeginProjectFileWriteAsync(
                 CancellationToken.None);
             SaveState();
         }
-        else
+        else if (scene.Uri is not null)
         {
             _logger.LogDebug(
                 "Skipping the final view-state save during a worktree mutation ({SceneId}).",
@@ -626,6 +644,17 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
         _editorSelection.SelectedObject.Value = null;
         // Player を破棄する前にイベント購読を外し、Subject 破棄後の OnNext を抑止する。
         DisposeCommandStateNotifier();
+        // Tool contexts can own paid-AI operations that still publish through the editor.
+        // Cancel and drain them before retiring element handlers and the player.
+        AiWorkspaceViewModel[] aiWorkspaces = DockHost.Factory.EnumerateTools()
+            .Select(static tool => tool.ToolContext)
+            .OfType<AiWorkspaceViewModel>()
+            .ToArray();
+        DockHost.Dispose();
+        await Task.WhenAll(aiWorkspaces.Select(static workspace => workspace.DisposeAsync().AsTask()));
+        // Retire and cancel UI-initiated element operations before waiting for handler leases.
+        // Awaiting yields the UI thread so cancellation continuations can release those leases.
+        await _elementAdder.DisposeAsync();
         await Player.DisposeAsync();
         _elementNudgeService?.Dispose();
         _historyMutationPlaybackGuard.Dispose();
@@ -634,6 +663,9 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
         Player = null!;
         BufferStatus = null!;
 
+        // Closing the editor discards every live and redoable owner of unsaved sidecars and AI
+        // resources, so its scene-scoped temporary directory must not survive the tab.
+        UnsavedSceneStorage.Cleanup(scene.Id);
         Scene = null!;
         Commands = null!;
         HistoryManager.Clear();
@@ -1165,8 +1197,25 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
         public ValueTask<bool> OnSave()
         {
             viewModel._logger.LogInformation("Saving scene ({SceneId}).", scene.Id);
-            CoreSerializer.StoreToUri(scene, scene.Uri!);
-            Parallel.ForEach(scene.Children, item => CoreSerializer.StoreToUri(item, item.Uri!));
+            Uri sceneUri = scene.Uri
+                ?? throw new InvalidOperationException("An unsaved scene needs a destination before it can be saved.");
+            UnsavedSceneStorage.SaveRelocation relocation =
+                UnsavedSceneStorage.PrepareSave(scene, sceneUri);
+            try
+            {
+                relocation.Apply();
+                Parallel.ForEach(scene.Children, item => CoreSerializer.StoreToUri(item, item.Uri!));
+                // The scene is the commit record for every child/resource URI. Persist it only
+                // after every referenced file is durable at its new location.
+                CoreSerializer.StoreToUri(scene, sceneUri, CoreSerializationMode.Write);
+            }
+            catch
+            {
+                relocation.Rollback();
+                throw;
+            }
+
+            relocation.Commit();
             viewModel.SaveState(isExplicitUserSave: true);
             viewModel._logger.LogInformation("Scene ({SceneId}) saved successfully.", scene.Id);
 

--- a/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
@@ -42,7 +42,7 @@ internal class PackageOperationHandler
         PackageIdentity packageId,
         CancellationToken cancellationToken)
     {
-        await _packageInstaller.TrackInstallOperationAsync(async () =>
+        await _packageInstaller.TrackInstallOperationWithShutdownFallbackAsync(async () =>
         {
             PackageInstallContext context = await _packageInstaller.PrepareForInstall(
                 release,
@@ -60,14 +60,14 @@ internal class PackageOperationHandler
                 _installedPackageRepository.UpgradePackages(packageId);
                 ActivateInstalledPackage(packageId);
             });
-        }).ConfigureAwait(false);
+        }, () => _queue.InstallQueue(packageId)).ConfigureAwait(false);
     }
 
     public async Task DownloadAndLoadPackage(
         PackageIdentity packageId,
         CancellationToken cancellationToken)
     {
-        await _packageInstaller.TrackInstallOperationAsync(async () =>
+        await _packageInstaller.TrackInstallOperationWithShutdownFallbackAsync(async () =>
         {
             PackageInstallContext context = _packageInstaller.PrepareForInstall(
                 packageId.Id,
@@ -86,7 +86,7 @@ internal class PackageOperationHandler
                 _installedPackageRepository.UpgradePackages(packageId);
                 ActivateInstalledPackage(packageId);
             });
-        }).ConfigureAwait(false);
+        }, () => _queue.InstallQueue(packageId)).ConfigureAwait(false);
     }
 
     private void ActivateInstalledPackage(PackageIdentity packageId)

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -442,9 +442,11 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
     internal async void OpenAiVideoGeneration()
         => await OpenAiWorkspaceAsync(AiWorkspaceSection.VideoGeneration);
 
-    private async Task<object?> OpenAiWorkspaceAsync(AiWorkspaceSection section)
+    private async Task<object?> OpenAiWorkspaceAsync(AiWorkspaceSection section, EditViewModel? target = null)
     {
-        if (_editorService.SelectedTabItem.Value?.Context.Value is not EditViewModel editorContext)
+        EditViewModel? editorContext = target ?? _editorService.SelectedTabItem.Value?.Context.Value as EditViewModel;
+        if (editorContext is null
+            || !_editorService.TabItems.Any(item => ReferenceEquals(item.Context.Value, editorContext)))
         {
             return null;
         }
@@ -474,7 +476,18 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
             }
         }
 
-        return workspace.Show(section);
+        return _editorService.TabItems.Any(item => ReferenceEquals(item.Context.Value, editorContext))
+            ? workspace.Show(section)
+            : null;
+    }
+
+    internal async Task<bool> PresentCaptionResultAsync(EditViewModel editor, AiCaptionHistoryResult result)
+    {
+        if (await OpenAiWorkspaceAsync(AiWorkspaceSection.Subtitles, editor)
+            is not AiSubtitleDialogViewModel viewModel)
+            return false;
+        viewModel.LoadHistoryResult(result);
+        return true;
     }
 
     internal static async Task<bool> TryOpenNewAiWorkspaceAsync(
@@ -541,7 +554,7 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
             _beutlClients.GetResource<IAiJobMonitor>(),
             _beutlClients.GetResource<IAiJobKindRegistry>(),
             _aiJobResultHandlers,
-            OpenAiSubtitle);
+            result => PresentCaptionResultAsync(editViewModel, result));
 
     private void OnExit(object? sender, ControlledApplicationLifetimeExitEventArgs e)
     {

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -459,7 +459,9 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
         if (workspace is null)
         {
             workspace = CreateAiWorkspaceViewModel(editorContext);
-            if (!editorContext.OpenToolTab(workspace))
+            if (!await TryOpenNewAiWorkspaceAsync(
+                    workspace,
+                    () => editorContext.OpenToolTab(workspace)))
             {
                 return null;
             }
@@ -473,6 +475,19 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
         }
 
         return workspace.Show(section);
+    }
+
+    internal static async Task<bool> TryOpenNewAiWorkspaceAsync(
+        AiWorkspaceViewModel workspace,
+        Func<bool> tryOpen)
+    {
+        ArgumentNullException.ThrowIfNull(workspace);
+        ArgumentNullException.ThrowIfNull(tryOpen);
+        if (tryOpen())
+            return true;
+
+        await workspace.DisposeAsync();
+        return false;
     }
 
     internal AiWorkspaceViewModel CreateAiWorkspaceViewModel(EditViewModel editViewModel)

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -1,15 +1,23 @@
 ﻿using System.Collections.ObjectModel;
+using System.Reactive.Linq;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Beutl.AgentHost;
 using Beutl.Api;
+using Beutl.Api.Objects;
 using Beutl.Api.Services;
 using Beutl.Editor.Components.VersionControl.ViewModels;
+using Beutl.Editor.Services.AI;
+using Beutl.Editor.Services.Captions;
 using Beutl.Helpers;
 using Beutl.Logging;
 using Beutl.Services;
+using Beutl.Services.AI;
+using Beutl.Services.PrimitiveImpls;
 using Beutl.Services.StartupTasks;
+using Beutl.ViewModels.Dialogs;
 using Beutl.ViewModels.ExtensionsPages;
+using Beutl.ViewModels.Tools;
 using DynamicData;
 using DynamicData.Binding;
 using Microsoft.Extensions.Logging;
@@ -26,11 +34,32 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
     private readonly EditorService _editorService;
     private readonly VersionControlCoordinator _versionControlCoordinator;
     private readonly ExtensionProvider _extensionProvider;
+    private readonly CaptionCatalog _captionCatalog;
+    private readonly AiJobResultRegistry _aiJobResultHandlers;
     private readonly AgentHostEndpoint _agentHostEndpoint;
+    private readonly IAiPlanCoordinator _aiPlanCoordinator;
+    private readonly AiRequestRecoveryContext _aiRequestRecoveryContext;
     private readonly ILogger _logger = Log.CreateLogger<MainViewModel>();
+    private readonly AiJobCompletionNotifier _aiJobCompletionNotifier;
+    private readonly Action<BeutlApiApplication> _shutdownHandoff;
+    private readonly Func<TimeSpan, Task>? _waitForPackageInstallerIdle;
+    private PackageInstaller? _packageInstallerForShutdown;
+    private readonly object _disposeGate = new();
+    private readonly object _apiClientDisposeGate = new();
+    private int _shutdownCompleted;
+    private Task? _disposeTask;
+    private Task? _apiClientDisposeTask;
 
     public MainViewModel()
+        : this(null)
     {
+    }
+
+    internal MainViewModel(
+        Action<BeutlApiApplication>? shutdownHandoff,
+        Func<TimeSpan, Task>? waitForPackageInstallerIdle = null)
+    {
+        _shutdownHandoff = shutdownHandoff ?? PerformShutdownHandoff;
         _authHttpClient = new HttpClient();
         // Composition root: own the editor-session services here and thread the instances
         // down to child view models and services.
@@ -38,9 +67,46 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
         _projectService = new ProjectService();
         _editorService = new EditorService(_extensionProvider);
         _versionControlCoordinator = new VersionControlCoordinator(_projectService, _editorService);
+        _captionCatalog = CaptionCatalog.ComposeWithDefaultElementFactory(
+            Beutl.Language.Strings.AiSubtitle_DefaultTemplate,
+            Beutl.Editor.Services.ObjectTemplateService.Instance.FindByBaseType(
+                typeof(Beutl.Graphics.Drawable)),
+            _extensionProvider,
+            CaptionPresentationDefaults.ElementFactory,
+            failure => _logger.LogWarning(
+                failure.Exception,
+                "Ignoring invalid caption {ContributionKind} contribution from {ExtensionName}.",
+                failure.Kind,
+                failure.ExtensionName));
+        _aiJobResultHandlers = BuiltInAiJobResultCapabilities.CreateRegistry(
+            _extensionProvider,
+            failure => _logger.LogWarning(
+                failure.Exception,
+                "Ignoring invalid AI job result {Capability} contribution from {ExtensionType}.",
+                failure.Capability,
+                failure.ExtensionType));
         _agentHostEndpoint = new AgentHostEndpoint(_projectService, _editorService);
         _beutlClients = new BeutlApiApplication(_authHttpClient, _extensionProvider);
+        _waitForPackageInstallerIdle = waitForPackageInstallerIdle;
+        _aiRequestRecoveryContext = new AiRequestRecoveryContext(
+            new FileAiRequestRecoveryStore(Path.Combine(
+                BeutlEnvironment.GetHomeDirectoryPath(),
+                "ai")),
+            () => _beutlClients.AuthenticatedUser.Value is { } user
+                ? new AiAuthenticatedRequestIdentity(user.Profile.Id, user)
+                : null,
+            _beutlClients.AuthenticatedUser.Select<AuthenticatedUser?, AiAuthenticatedRequestIdentity?>
+                (user => user is { } authenticated
+                    ? new AiAuthenticatedRequestIdentity(authenticated.Profile.Id, authenticated)
+                    : null));
+        _aiPlanCoordinator = new AiPlanCoordinator(
+            _beutlClients.GetResource<IAiEntitlementService>());
         ContextCommandManager = _beutlClients.GetResource<ContextCommandManager>();
+        _aiJobCompletionNotifier = new AiJobCompletionNotifier(
+            _beutlClients.GetResource<IAiJobMonitor>().Snapshot,
+            _beutlClients.GetResource<IAiJobKindRegistry>(),
+            _aiJobResultHandlers,
+            OpenAiJobCenter);
 
         MenuBar = new MenuBarViewModel(_projectService, _editorService, _versionControlCoordinator);
 
@@ -135,8 +201,74 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
 
     public SettingsDialogViewModel CreateSettingsDialog()
     {
-        return new SettingsDialogViewModel(_beutlClients, _extensionProvider, _agentHostEndpoint);
+        return new SettingsDialogViewModel(
+            _beutlClients,
+            _extensionProvider,
+            _agentHostEndpoint,
+            _aiPlanCoordinator);
     }
+
+    internal AiImageGenerationDialogViewModel CreateAiImageGenerationToolViewModel(EditViewModel editViewModel)
+        => new(
+            _beutlClients.GetResource<IAiEntitlementService>(),
+            _beutlClients.GetResource<IAiOperationAvailabilityService>(),
+            _beutlClients.GetResource<IAiModelCatalogService>(),
+            _aiPlanCoordinator,
+            _beutlClients.GetResource<IAiImageGenerationService>(),
+            _beutlClients.GetResource<IAuthenticatedContentService>(),
+            editViewModel,
+            _aiRequestRecoveryContext);
+
+    internal AiImageEditDialogViewModel CreateAiImageEditToolViewModel(EditViewModel editViewModel)
+        => new(
+            _beutlClients.GetResource<IAiEntitlementService>(),
+            _beutlClients.GetResource<IAiOperationAvailabilityService>(),
+            _beutlClients.GetResource<IAiModelCatalogService>(),
+            _aiPlanCoordinator,
+            _beutlClients.GetResource<IAiImageEditingService>(),
+            _beutlClients.GetResource<IAuthenticatedContentService>(),
+            editViewModel,
+            _aiRequestRecoveryContext);
+
+    internal AiSubtitleDialogViewModel CreateAiSubtitleToolViewModel(EditViewModel? editViewModel)
+    {
+        _captionCatalog.RefreshObjectTemplates(
+            Beutl.Editor.Services.ObjectTemplateService.Instance.FindByBaseType(
+                typeof(Beutl.Graphics.Drawable)));
+        return new AiSubtitleDialogViewModel(
+            _beutlClients.GetResource<IAiEntitlementService>(),
+            _beutlClients.GetResource<IAiOperationAvailabilityService>(),
+            _beutlClients.GetResource<IAiModelCatalogService>(),
+            _aiPlanCoordinator,
+            _beutlClients.GetResource<IAiTranscriptionService>(),
+            _beutlClients.GetResource<IAiCaptionTranslationService>(),
+            _captionCatalog,
+            CaptionDraftStoreProvider.Current,
+            CreateCaptionDraftScopes(editViewModel),
+            editViewModel);
+    }
+
+    private IObservable<CaptionDraftScope?> CreateCaptionDraftScopes(EditViewModel? editViewModel)
+        => _beutlClients.AuthenticatedUser.Select(user =>
+        {
+            Project? project = BeutlApplication.Current.Project;
+            return user is null || project is null || editViewModel is null
+                ? null
+                : new CaptionDraftScope(user.Profile.Id, project.Id, editViewModel.Scene.Id);
+        });
+
+    internal AiVideoGenerationDialogViewModel CreateAiVideoGenerationToolViewModel(EditViewModel editViewModel)
+        => new(
+            _beutlClients.GetResource<IAiEntitlementService>(),
+            _beutlClients.GetResource<IAiOperationAvailabilityService>(),
+            _beutlClients.GetResource<IAiModelCatalogService>(),
+            _aiPlanCoordinator,
+            _beutlClients.GetResource<IAiVideoService>(),
+            _beutlClients.GetResource<IAuthenticatedContentService>(),
+            _beutlClients.GetResource<IAiJobKindRegistry>(),
+            _beutlClients.GetResource<IAiJobMonitor>(),
+            editViewModel,
+            _aiRequestRecoveryContext);
 
     public Startup RunStartupTask()
     {
@@ -151,7 +283,7 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
     {
         if (Application.Current is { ApplicationLifetime: IControlledApplicationLifetime lifetime })
         {
-            lifetime.Exit += OnExit;
+            RegisterExitHandler(lifetime);
         }
 
         _agentHostEndpoint.StartInBackground();
@@ -161,28 +293,27 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
     {
         try
         {
-            DisposeOrThrow();
+            BeginDisposeOrThrow();
         }
         catch (ProjectCloseAbortedException)
         {
         }
     }
 
-    private void DisposeOrThrow()
+    private void BeginDisposeOrThrow()
     {
         _projectService.CloseProjectOrThrow();
-        CommandPalette.Dispose();
-        TitleBarBranch.Dispose();
-        _agentHostEndpoint.RequestStop();
-        _versionControlCoordinator.Dispose();
-        BeutlApplication.Current.Items.Clear();
+        lock (_disposeGate)
+        {
+            _disposeTask ??= DisposeCoreAsync();
+        }
     }
 
     internal bool TryDisposeForWindowClose()
     {
         try
         {
-            DisposeOrThrow();
+            BeginDisposeOrThrow();
             return true;
         }
         catch (ProjectCloseAbortedException)
@@ -191,107 +322,353 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
         }
     }
 
-    private void OnExit(object? sender, ControlledApplicationLifetimeExitEventArgs e)
+    internal Task WaitForDisposalAsync()
     {
-        _agentHostEndpoint.RequestStop();
+        lock (_disposeGate)
+        {
+            return _disposeTask ?? Task.CompletedTask;
+        }
+    }
+
+    private async Task DisposeCoreAsync()
+    {
         try
         {
-            ProxyMediaServices.Current?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            PackageInstaller packageInstaller = _beutlClients.GetResource<PackageInstaller>();
+            _packageInstallerForShutdown = packageInstaller;
+            packageInstaller.BeginShutdown();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to begin package installer shutdown.");
+        }
+        try
+        {
+            // The host uses project/editor services, so join its complete lifecycle before
+            // closing either service.
+            await _agentHostEndpoint.StopAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to stop the agent host during shutdown.");
+        }
+        try
+        {
+            _aiJobCompletionNotifier.Dispose();
+            CommandPalette.Dispose();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to dispose shell notification services during shutdown.");
+        }
+
+        try
+        {
+            TitleBarBranch.Dispose();
+            _versionControlCoordinator.Dispose();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to dispose version-control shell services during shutdown.");
+        }
+
+        await CloseEditorSessionAsync();
+
+        // Recovery source publication markers belong to the editor operations
+        // above. Release their cross-process locks only after every tab has
+        // canceled and drained its paid-AI work.
+        _aiRequestRecoveryContext.Dispose();
+
+        try
+        {
+            await _aiJobResultHandlers.DisposeAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to drain AI job result handlers during shutdown.");
+        }
+
+        try
+        {
+            await _captionCatalog.DisposeAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to drain caption registrations during shutdown.");
+        }
+
+        try
+        {
+            if (ProxyMediaServices.Current is { } proxyMediaServices)
+            {
+                await proxyMediaServices.DisposeAsync();
+            }
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Proxy media services failed to dispose during shutdown.");
         }
 
-        // Drain installs first so fallback queueing is reflected in the snapshot below.
         try
         {
-            if (_beutlClients.TryGetCreatedResource<PackageInstaller>() is { } installer)
-            {
-                Task drain = installer.DisposeAsync().AsTask();
-                // Pump UI jobs while draining so the queued activation can complete.
-                long deadline = Environment.TickCount64 + 30_000;
-                while (!drain.IsCompleted && Environment.TickCount64 < deadline)
-                {
-                    Avalonia.Threading.Dispatcher.UIThread.RunJobs();
-                    Thread.Sleep(10);
-                }
-
-                if (drain.IsCompleted)
-                {
-                    drain.GetAwaiter().GetResult();
-                }
-                else
-                {
-                    _logger.LogWarning("Package installer did not drain within the shutdown deadline.");
-                    // Disposal keeps installer resources alive until the tracked work
-                    // stops, so fallback queueing for a still-running install/update can
-                    // still happen after the deadline. Wait for actual idleness so the
-                    // snapshot below reflects every queued recovery, while continuing to
-                    // pump UI jobs so queued activations keep progressing. The extra wait
-                    // is bounded so shutdown never hangs behind a non-cooperative install.
-                    Task idle = installer.WaitUntilIdleAsync(TimeSpan.FromSeconds(30));
-                    long idleDeadline = Environment.TickCount64 + 30_000;
-                    while (!idle.IsCompleted && Environment.TickCount64 < idleDeadline)
-                    {
-                        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
-                        Thread.Sleep(10);
-                    }
-
-                    if (!idle.IsCompleted)
-                    {
-                        _logger.LogWarning("Package installer did not become idle within the shutdown deadline.");
-                    }
-                }
-            }
+            BeutlApplication.Current.Items.Clear();
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Package installer failed to drain during shutdown.");
+            _logger.LogError(ex, "Failed to clear application services during shutdown.");
         }
 
-        PackageChangesQueue queue = _beutlClients.GetResource<PackageChangesQueue>();
+        await CompleteShutdownAsync();
+    }
+
+    internal async void OpenAiJobCenter()
+        => await OpenAiWorkspaceAsync(AiWorkspaceSection.Jobs);
+
+    internal async void OpenAiImageGeneration()
+        => await OpenAiWorkspaceAsync(AiWorkspaceSection.ImageGeneration);
+
+    internal async void OpenAiImageEdit()
+        => await OpenAiWorkspaceAsync(AiWorkspaceSection.ImageEdit);
+
+    internal async void OpenAiSubtitle(AiCaptionHistoryResult? historyResult = null)
+    {
+        if (await OpenAiWorkspaceAsync(AiWorkspaceSection.Subtitles) is AiSubtitleDialogViewModel viewModel
+            && historyResult is not null)
+        {
+            viewModel.LoadHistoryResult(historyResult);
+        }
+    }
+
+    internal async void OpenAiVideoGeneration()
+        => await OpenAiWorkspaceAsync(AiWorkspaceSection.VideoGeneration);
+
+    private async Task<object?> OpenAiWorkspaceAsync(AiWorkspaceSection section)
+    {
+        if (_editorService.SelectedTabItem.Value?.Context.Value is not EditViewModel editorContext)
+        {
+            return null;
+        }
+
+        // A tab already on that page is the one the person means. Otherwise an open
+        // AI tab is turned to it, because the menu is a request to see something,
+        // not a request for another tab; the tab strip's own button adds those.
+        AiWorkspaceViewModel? workspace =
+            editorContext.FindToolTab<AiWorkspaceViewModel>(tab => tab.SelectedSection.Value?.Id == section)
+            ?? editorContext.FindToolTab<AiWorkspaceViewModel>();
+
+        if (workspace is null)
+        {
+            workspace = CreateAiWorkspaceViewModel(editorContext);
+            if (!editorContext.OpenToolTab(workspace))
+            {
+                return null;
+            }
+        }
+        else
+        {
+            if (!editorContext.OpenToolTab(workspace))
+            {
+                return null;
+            }
+        }
+
+        return workspace.Show(section);
+    }
+
+    internal AiWorkspaceViewModel CreateAiWorkspaceViewModel(EditViewModel editViewModel)
+    {
+        var workspace = new AiWorkspaceViewModel(
+            editViewModel,
+            section => CreateAiPage(section, editViewModel));
+
+        // A tab added while another is open is added to see something else, so it
+        // starts on the first page no open tab is showing.
+        if (FindUnshownSection(editViewModel) is { } section)
+        {
+            workspace.Show(section);
+        }
+
+        return workspace;
+    }
+
+    private static AiWorkspaceSection? FindUnshownSection(EditViewModel editViewModel)
+    {
+        AiWorkspaceSection[] shown = editViewModel.DockHost.Factory.EnumerateTools()
+            .Select(tool => tool.ToolContext)
+            .OfType<AiWorkspaceViewModel>()
+            .Select(tab => tab.SelectedSection.Value?.Id)
+            .OfType<AiWorkspaceSection>()
+            .ToArray();
+
+        return shown.Length == 0
+            ? null
+            : Enum.GetValues<AiWorkspaceSection>().Cast<AiWorkspaceSection?>()
+                .FirstOrDefault(section => !shown.Contains(section!.Value));
+    }
+
+    private IAsyncDisposable CreateAiPage(AiWorkspaceSection section, EditViewModel editViewModel)
+        => section switch
+        {
+            AiWorkspaceSection.ImageGeneration => CreateAiImageGenerationToolViewModel(editViewModel),
+            AiWorkspaceSection.ImageEdit => CreateAiImageEditToolViewModel(editViewModel),
+            AiWorkspaceSection.VideoGeneration => CreateAiVideoGenerationToolViewModel(editViewModel),
+            AiWorkspaceSection.Subtitles => CreateAiSubtitleToolViewModel(editViewModel),
+            AiWorkspaceSection.Jobs => CreateAiJobCenterViewModel(editViewModel),
+            _ => throw new ArgumentOutOfRangeException(nameof(section)),
+        };
+
+    internal AiJobCenterViewModel CreateAiJobCenterViewModel(EditViewModel editViewModel)
+        => new(
+            editViewModel,
+            _beutlClients.GetResource<IAiEntitlementService>(),
+            _beutlClients.GetResource<IAuthenticatedContentService>(),
+            _beutlClients.GetResource<IAiJobClient>(),
+            _beutlClients.GetResource<IAiJobMonitor>(),
+            _beutlClients.GetResource<IAiJobKindRegistry>(),
+            _aiJobResultHandlers,
+            OpenAiSubtitle);
+
+    private void OnExit(object? sender, ControlledApplicationLifetimeExitEventArgs e)
+    {
+        if (sender is IControlledApplicationLifetime lifetime)
+        {
+            lifetime.Exit -= OnExit;
+        }
+
+        CompleteShutdown();
+    }
+
+    internal void RegisterExitHandler(IControlledApplicationLifetime lifetime)
+    {
+        ArgumentNullException.ThrowIfNull(lifetime);
+        lifetime.Exit -= OnExit;
+        lifetime.Exit += OnExit;
+    }
+
+    internal void CompleteShutdown()
+        => Dispose();
+
+    private async Task CompleteShutdownAsync()
+    {
+        if (Interlocked.Exchange(ref _shutdownCompleted, 1) != 0)
+            return;
+
+        try
+        {
+            if (_waitForPackageInstallerIdle is not null)
+                await _waitForPackageInstallerIdle(TimeSpan.FromSeconds(5));
+            else if (_packageInstallerForShutdown is not null)
+                await _packageInstallerForShutdown.WaitUntilIdleAsync(TimeSpan.FromSeconds(5));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to wait for package operations during shutdown.");
+        }
+
+        try
+        {
+            _shutdownHandoff(_beutlClients);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to hand package changes to the shutdown helper.");
+        }
+        finally
+        {
+            await DisposeApiClientsAsync();
+        }
+    }
+
+    private async Task CloseEditorSessionAsync()
+    {
+        EditorTabItem[] tabs = _editorService.TabItems.ToArray();
+        try
+        {
+            _editorService.SelectedTabItem.Value = null;
+            _editorService.TabItems.Clear();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to unpublish editor tabs during shutdown.");
+        }
+
+        foreach (EditorTabItem tab in tabs)
+        {
+            try
+            {
+                await tab.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to dispose an editor tab during shutdown.");
+            }
+        }
+
+        try
+        {
+            _projectService.CloseProject();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to close the active project during shutdown.");
+        }
+    }
+
+    private void PerformShutdownHandoff(BeutlApiApplication clients)
+    {
+        PackageChangesQueue queue = clients.GetResource<PackageChangesQueue>();
         PackageIdentity[] installs = queue.GetInstalls().ToArray();
         PackageIdentity[] uninstalls = queue.GetUninstalls().ToArray();
 
-        if (installs.Length > 0 || uninstalls.Length > 0)
+        if (installs.Length == 0 && uninstalls.Length == 0)
+            return;
+
+        var startInfo = new ProcessStartInfo() { UseShellExecute = true, };
+        DotNetProcess.Configure(startInfo, Path.Combine(AppContext.BaseDirectory, "Beutl.PackageTools.UI"));
+
+        if (installs.Length > 0)
         {
-            var startInfo = new ProcessStartInfo() { UseShellExecute = true, };
-            DotNetProcess.Configure(startInfo, Path.Combine(AppContext.BaseDirectory, "Beutl.PackageTools.UI"));
-
-            if (installs.Length > 0)
+            startInfo.ArgumentList.Add("--installs");
+            foreach (PackageIdentity? item in installs)
             {
-                startInfo.ArgumentList.Add("--installs");
-                foreach (PackageIdentity? item in installs)
-                {
-                    startInfo.ArgumentList.Add(item.HasVersion ? $"{item.Id}/{item.Version}" : item.Id);
-                }
+                startInfo.ArgumentList.Add(item.HasVersion ? $"{item.Id}/{item.Version}" : item.Id);
             }
-
-            if (uninstalls.Length > 0)
-            {
-                startInfo.ArgumentList.Add("--uninstalls");
-                foreach (PackageIdentity? item in uninstalls)
-                {
-                    startInfo.ArgumentList.Add(item.HasVersion ? $"{item.Id}/{item.Version}" : item.Id);
-                }
-            }
-
-            startInfo.ArgumentList.AddRange(["--session-id", Telemetry.Instance._sessionId]);
-
-            if (Debugger.IsAttached)
-                startInfo.ArgumentList.Add("--launch-debugger");
-
-            Process.Start(startInfo);
         }
 
+        if (uninstalls.Length > 0)
+        {
+            startInfo.ArgumentList.Add("--uninstalls");
+            foreach (PackageIdentity? item in uninstalls)
+            {
+                startInfo.ArgumentList.Add(item.HasVersion ? $"{item.Id}/{item.Version}" : item.Id);
+            }
+        }
+
+        startInfo.ArgumentList.AddRange(["--session-id", Telemetry.Instance._sessionId]);
+
+        if (Debugger.IsAttached)
+            startInfo.ArgumentList.Add("--launch-debugger");
+
+        Process.Start(startInfo);
+    }
+
+    private Task DisposeApiClientsAsync()
+    {
+        lock (_apiClientDisposeGate)
+        {
+            return _apiClientDisposeTask ??= DisposeApiClientsCoreAsync();
+        }
+    }
+
+    private async Task DisposeApiClientsCoreAsync()
+    {
         try
         {
-            _beutlClients.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            await _beutlClients.DisposeAsync();
         }
-        catch (Exception ex)
+        finally
         {
-            _logger.LogWarning(ex, "Beutl API application failed to dispose during shutdown.");
+            _authHttpClient.Dispose();
         }
     }
 

--- a/src/Beutl/ViewModels/MenuBarViewModel.Ai.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.Ai.cs
@@ -1,0 +1,37 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Reactive.Bindings;
+
+namespace Beutl.ViewModels;
+
+public partial class MenuBarViewModel
+{
+    [MemberNotNull(
+        nameof(ShowAiJobs),
+        nameof(GenerateImage),
+        nameof(GenerateSubtitles),
+        nameof(EditImage),
+        nameof(GenerateVideo))]
+    private void InitializeAiCommands(IObservable<bool> isSceneOpened)
+    {
+        ShowAiJobs = new ReactiveCommandSlim(isSceneOpened);
+        GenerateImage = new ReactiveCommandSlim(isSceneOpened);
+        GenerateSubtitles = new ReactiveCommandSlim(isSceneOpened);
+        EditImage = new ReactiveCommandSlim(isSceneOpened);
+        GenerateVideo = new ReactiveCommandSlim(isSceneOpened);
+    }
+
+    // AI
+    //    Generate image
+    //    Generate subtitles
+    //    Edit image
+    //    Generate video
+    public ReactiveCommandSlim ShowAiJobs { get; private set; } = null!;
+
+    public ReactiveCommandSlim GenerateImage { get; private set; } = null!;
+
+    public ReactiveCommandSlim GenerateSubtitles { get; private set; } = null!;
+
+    public ReactiveCommandSlim EditImage { get; private set; } = null!;
+
+    public ReactiveCommandSlim GenerateVideo { get; private set; } = null!;
+}

--- a/src/Beutl/ViewModels/MenuBarViewModel.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.cs
@@ -33,12 +33,15 @@ public sealed partial class MenuBarViewModel
         IsProjectOpened = _projectService.IsOpened;
 
         IObservable<bool> isSceneOpened = _editorService.SelectedTabItem
-            .SelectMany(i => i?.Context ?? Observable.Empty<IEditorContext?>())
-            .Select(v => v is EditViewModel);
+            .Select(item => item?.Context.Select(context => context is EditViewModel)
+                ?? Observable.Return(false))
+            .Switch()
+            .DistinctUntilChanged();
 
         InitializeFilesCommands();
         InitializeSceneCommands(isSceneOpened);
         InitializeViewCommands(isSceneOpened);
+        InitializeAiCommands(isSceneOpened);
 
         Undo = new AsyncReactiveCommand(IsProjectOpened)
             .WithSubscribe(OnUndo);

--- a/src/Beutl/ViewModels/SettingsDialogViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsDialogViewModel.cs
@@ -2,6 +2,7 @@
 using Beutl.AgentHost;
 using Beutl.Api;
 using Beutl.Api.Services;
+using Beutl.Services;
 using Beutl.ViewModels.SettingsPages;
 
 namespace Beutl.ViewModels;
@@ -21,9 +22,11 @@ public sealed class SettingsDialogViewModel : IDisposable
     public SettingsDialogViewModel(
         BeutlApiApplication clients,
         ExtensionProvider extensionProvider,
-        AgentHostEndpoint agentHostEndpoint)
+        AgentHostEndpoint agentHostEndpoint,
+        IAiPlanCoordinator aiPlanCoordinator)
     {
-        _account = new(() => new AccountSettingsPageViewModel(clients));
+        ArgumentNullException.ThrowIfNull(aiPlanCoordinator);
+        _account = new(() => new AccountSettingsPageViewModel(clients, aiPlanCoordinator));
         _editor = new(() => new EditorSettingsPageViewModel());
         _view = new(() => new ViewSettingsPageViewModel(_editor));
         _font = new(() => new FontSettingsPageViewModel());

--- a/src/Beutl/ViewModels/SettingsPages/AccountSettingsPageViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsPages/AccountSettingsPageViewModel.cs
@@ -1,5 +1,7 @@
 ﻿using Beutl.Api;
+using Beutl.Api.Clients;
 using Beutl.Api.Objects;
+using Beutl.Api.Services;
 using Beutl.Logging;
 using Beutl.Services;
 using Beutl.ViewModels.ExtensionsPages;
@@ -14,12 +16,28 @@ public sealed class AccountSettingsPageViewModel : BasePageViewModel
 {
     private readonly ILogger _logger = Log.CreateLogger<AccountSettingsPageViewModel>();
     private readonly CompositeDisposable _disposables = [];
+    private readonly LifetimeCancellationSource _lifetimeCts = new();
     private readonly BeutlApiApplication _clients;
     private readonly ReactivePropertySlim<CancellationTokenSource?> _cts = new();
+    private readonly IAiEntitlementService _entitlements;
+    private readonly IAiPlanCoordinator _aiPlanCoordinator;
+    private readonly object _entitlementsLoadGate = new();
+    private CancellationTokenSource? _entitlementsLoadCts;
+    private long _entitlementsLoadVersion;
+    private bool _disposed;
 
-    public AccountSettingsPageViewModel(BeutlApiApplication clients)
+    public AccountSettingsPageViewModel(
+        BeutlApiApplication clients,
+        IAiPlanCoordinator aiPlanCoordinator)
     {
-        _clients = clients;
+        _clients = clients ?? throw new ArgumentNullException(nameof(clients));
+        _aiPlanCoordinator = aiPlanCoordinator
+            ?? throw new ArgumentNullException(nameof(aiPlanCoordinator));
+        _entitlements = clients.GetResource<IAiEntitlementService>();
+        Usage = new AiUsageViewModel(_entitlements.Entitlements).DisposeWith(_disposables);
+        _clients.AuthenticatedUser
+            .Subscribe(HandleAuthenticatedUserChanged)
+            .DisposeWith(_disposables);
 
         SigningIn = _cts.Select(x => x != null)
             .ToReadOnlyReactivePropertySlim()
@@ -63,7 +81,55 @@ public sealed class AccountSettingsPageViewModel : BasePageViewModel
         SignOut.Subscribe(() => _clients.SignOut()).DisposeWith(_disposables);
 
         OpenAccountSettings = new();
-        OpenAccountSettings.Subscribe(BeutlApiApplication.OpenAccountSettings);
+        OpenAccountSettings.Subscribe(_aiPlanCoordinator.OpenAccountSettings).DisposeWith(_disposables);
+
+        OpenAiPlan = new();
+        OpenAiPlan.Subscribe(_aiPlanCoordinator.OpenAiPlan).DisposeWith(_disposables);
+
+        IObservable<AiEntitlements?> currentEntitlements = _entitlements.Entitlements;
+
+        PlanName = currentEntitlements
+            .Select(x => string.Equals(x?.Plan, "pro", StringComparison.Ordinal)
+                ? SettingsStrings.AiPlan_Pro
+                : SettingsStrings.AiPlan_Free)
+            .ToReadOnlyReactivePropertySlim(SettingsStrings.AiPlan_Free)
+            .DisposeWith(_disposables);
+
+        SubscriptionStatus = currentEntitlements
+            // A portal cancellation keeps the status on "active" until the period
+            // ends, so the scheduled flag is what the user needs to see.
+            .Select(x => x is { CancelAtPeriodEnd: true }
+                ? SettingsStrings.AiPlan_SubscriptionStatus_CancelScheduled
+                : x?.SubscriptionStatus switch
+                {
+                    "active" => SettingsStrings.AiPlan_SubscriptionStatus_Active,
+                    "canceled" => SettingsStrings.AiPlan_SubscriptionStatus_Canceled,
+                    "incomplete_expired" or null => null,
+                    _ => SettingsStrings.AiPlan_SubscriptionStatus_ActionRequired,
+                })
+            .ToReadOnlyReactivePropertySlim<string?>()
+            .DisposeWith(_disposables);
+
+        CancelScheduledNotice = currentEntitlements
+            .Select(x => x is { CancelAtPeriodEnd: true, CurrentPeriodEnd: { } periodEnd }
+                ? string.Format(
+                    SettingsStrings.AiPlan_CancelScheduledNotice,
+                    periodEnd.ToLocalTime().ToString("d"))
+                : null)
+            .ToReadOnlyReactivePropertySlim<string?>()
+            .DisposeWith(_disposables);
+
+        HasCancelScheduledNotice = CancelScheduledNotice
+            .Select(notice => notice is not null)
+            .ToReadOnlyReactivePropertySlim(false)
+            .DisposeWith(_disposables);
+
+        AiPlanActionText = currentEntitlements
+            .Select(entitlements => IsManageableSubscription(entitlements?.SubscriptionStatus)
+                ? SettingsStrings.AiPlan_ManageAndTopUp
+                : SettingsStrings.AiPlan_JoinPro)
+            .ToReadOnlyReactivePropertySlim(SettingsStrings.AiPlan_JoinPro)
+            .DisposeWith(_disposables);
 
         Refresh = new AsyncReactiveCommand(IsLoading.Select(x => !x));
         Refresh.Subscribe(async () =>
@@ -75,14 +141,16 @@ public sealed class AccountSettingsPageViewModel : BasePageViewModel
                     IsLoading.Value = true;
                     if (_clients.AuthenticatedUser.Value is { } user)
                     {
-                        using (await user.Lock.LockAsync())
+                        using (await user.Lock.LockAsync(_lifetimeCts.Token))
                         {
                             activity?.AddEvent(new("Entered_AsyncLock"));
 
-                            await user.RefreshAsync(CancellationToken.None);
-                            await user.Profile.RefreshAsync(CancellationToken.None);
+                            await user.RefreshAsync(_lifetimeCts.Token);
+                            await user.Profile.RefreshAsync(_lifetimeCts.Token);
                         }
                     }
+
+                    await LoadEntitlementsAsync();
                 }
                 catch (Exception ex)
                 {
@@ -122,13 +190,76 @@ public sealed class AccountSettingsPageViewModel : BasePageViewModel
 
     public ReactiveCommand OpenAccountSettings { get; }
 
+    public ReactiveCommand OpenAiPlan { get; }
+
+    public ReadOnlyReactivePropertySlim<string> PlanName { get; }
+
+    public ReadOnlyReactivePropertySlim<string?> SubscriptionStatus { get; }
+
+    public ReadOnlyReactivePropertySlim<string?> CancelScheduledNotice { get; }
+
+    public ReadOnlyReactivePropertySlim<bool> HasCancelScheduledNotice { get; }
+
+    internal AiUsageViewModel Usage { get; }
+
+    public ReadOnlyReactivePropertySlim<string> AiPlanActionText { get; }
+
     public ReactivePropertySlim<bool> IsLoading { get; } = new();
 
     public AsyncReactiveCommand Refresh { get; }
 
+    // Called when the app regains focus. The UI coordinator only reports a pending
+    // reload after the plan page was opened, so returning from an unrelated
+    // window costs no request.
+    public void NotifyReturnedToApplication()
+    {
+        lock (_entitlementsLoadGate)
+        {
+            if (_disposed)
+                return;
+        }
+
+        _ = RefreshAfterExternalPlanChangeAsync();
+    }
+
+    private async Task RefreshAfterExternalPlanChangeAsync()
+    {
+        try
+        {
+            await _aiPlanCoordinator.RefreshIfPendingAsync(_lifetimeCts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to reload AI plan information.");
+        }
+    }
+
+    public ReactivePropertySlim<bool> IsAiPlanLoading { get; } = new(false);
+
+    public ReactivePropertySlim<string?> AiPlanError { get; } = new();
+
     public override void Dispose()
     {
+        CancellationTokenSource? entitlementLoad;
+        lock (_entitlementsLoadGate)
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            _entitlementsLoadVersion++;
+            entitlementLoad = _entitlementsLoadCts;
+            _entitlementsLoadCts = null;
+        }
+        CancelEntitlementLoad(entitlementLoad);
+        _lifetimeCts.Cancel();
         _disposables.Dispose();
+        IsAiPlanLoading.Dispose();
+        AiPlanError.Dispose();
+        _lifetimeCts.Dispose();
     }
 
     private async Task SignInCore(string? provider = null)
@@ -138,7 +269,7 @@ public sealed class AccountSettingsPageViewModel : BasePageViewModel
             try
             {
                 _cts.Value = new CancellationTokenSource();
-                AuthenticatedUser? user = provider switch
+                _ = provider switch
                 {
                     "Google" => await _clients.SignInWithGoogleAsync(_cts.Value.Token),
                     "GitHub" => await _clients.SignInWithGitHubAsync(_cts.Value.Token),
@@ -149,22 +280,138 @@ public sealed class AccountSettingsPageViewModel : BasePageViewModel
             {
                 activity?.SetStatus(ActivityStatusCode.Error);
                 _logger.LogError(apiex, "An unexpected error has occurred.");
-                // Todo: エラー説明
+                // Present API failures as a localized generic sign-in error.
                 Error.Value = MessageStrings.ApiErrorOccurred;
             }
-            catch (OperationCanceledException)
-            {
-            }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 activity?.SetStatus(ActivityStatusCode.Error);
                 _logger.LogError(ex, "An unexpected error has occurred.");
                 Error.Value = MessageStrings.UnexpectedError;
+            }
+            catch (OperationCanceledException)
+            {
             }
             finally
             {
                 _cts.Value = null;
             }
         }
+    }
+
+    private async Task LoadEntitlementsAsync()
+    {
+        var authenticatedUser = _clients.AuthenticatedUser.Value;
+        if (authenticatedUser == null)
+            return;
+
+        CancellationTokenSource operationCts;
+        CancellationTokenSource? previousOperation;
+        long operationVersion;
+        lock (_entitlementsLoadGate)
+        {
+            if (_disposed)
+                return;
+
+            operationCts = CancellationTokenSource.CreateLinkedTokenSource(_lifetimeCts.Token);
+            previousOperation = _entitlementsLoadCts;
+            _entitlementsLoadCts = operationCts;
+            operationVersion = ++_entitlementsLoadVersion;
+            IsAiPlanLoading.Value = true;
+            AiPlanError.Value = null;
+        }
+        CancelEntitlementLoad(previousOperation);
+        try
+        {
+            await _entitlements.RefreshAsync(operationCts.Token);
+        }
+        catch (OperationCanceledException) when (operationCts.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load AI plan information.");
+            SetEntitlementLoadError(
+                authenticatedUser,
+                operationCts,
+                operationVersion);
+        }
+        finally
+        {
+            lock (_entitlementsLoadGate)
+            {
+                if (IsCurrentEntitlementLoad(
+                        authenticatedUser,
+                        operationCts,
+                        operationVersion))
+                {
+                    IsAiPlanLoading.Value = false;
+                    _entitlementsLoadCts = null;
+                }
+            }
+            operationCts.Dispose();
+        }
+    }
+
+    private void HandleAuthenticatedUserChanged(AuthenticatedUser? user)
+    {
+        CancellationTokenSource? previousOperation;
+        lock (_entitlementsLoadGate)
+        {
+            if (_disposed)
+                return;
+
+            _entitlementsLoadVersion++;
+            previousOperation = _entitlementsLoadCts;
+            _entitlementsLoadCts = null;
+            IsAiPlanLoading.Value = false;
+            AiPlanError.Value = null;
+        }
+        CancelEntitlementLoad(previousOperation);
+        if (user != null)
+        {
+            _ = LoadEntitlementsAsync();
+        }
+    }
+
+    private bool IsCurrentEntitlementLoad(
+        AuthenticatedUser authenticatedUser,
+        CancellationTokenSource operationCts,
+        long operationVersion)
+    {
+        return !_disposed
+            && operationVersion == _entitlementsLoadVersion
+            && ReferenceEquals(_entitlementsLoadCts, operationCts)
+            && ReferenceEquals(_clients.AuthenticatedUser.Value, authenticatedUser);
+    }
+
+    private void SetEntitlementLoadError(
+        AuthenticatedUser authenticatedUser,
+        CancellationTokenSource operationCts,
+        long operationVersion)
+    {
+        lock (_entitlementsLoadGate)
+        {
+            if (IsCurrentEntitlementLoad(authenticatedUser, operationCts, operationVersion))
+            {
+                AiPlanError.Value = SettingsStrings.AiPlan_LoadFailed;
+            }
+        }
+    }
+
+    private static void CancelEntitlementLoad(CancellationTokenSource? cancellationTokenSource)
+    {
+        try
+        {
+            cancellationTokenSource?.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+    }
+
+    internal static bool IsManageableSubscription(string? status)
+    {
+        return status is not null and not "canceled" and not "incomplete_expired";
     }
 }

--- a/src/Beutl/ViewModels/Tools/AiJobCenterViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/AiJobCenterViewModel.cs
@@ -1,0 +1,1599 @@
+﻿using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Avalonia.Threading;
+using Beutl.Api;
+using Beutl.Api.Services;
+using Beutl.Editor.Services.AI;
+using Beutl.Editor.Services.Captions;
+using Beutl.Graphics;
+using Beutl.Language;
+using Beutl.Logging;
+using Beutl.Media;
+using Beutl.Media.Source;
+using Beutl.ProjectSystem;
+using Beutl.Services;
+using Beutl.Services.AI;
+using Microsoft.Extensions.Logging;
+using Reactive.Bindings;
+using SkiaSharp;
+
+namespace Beutl.ViewModels.Tools;
+
+public sealed class AiJobCenterViewModel : IDisposable, IAsyncDisposable
+{
+    private readonly CompositeDisposable _disposables = [];
+    private readonly LifetimeCancellationSource _lifetimeCts = new();
+    private readonly AsyncOperationLifetime _operations = new();
+    private readonly object _lifetimeGate = new();
+    private readonly ILogger _logger = Log.CreateLogger<AiJobCenterViewModel>();
+    private readonly EditViewModel _editViewModel;
+    private readonly IAiEntitlementService _entitlements;
+    private readonly IAuthenticatedContentService _content;
+    private readonly IAiJobClient _jobClient;
+    private readonly IAiJobMonitor _jobMonitor;
+    private readonly IAiJobKindRegistry _jobKinds;
+    private readonly AiJobResultRegistry _resultHandlers;
+    private readonly AiJobResultContext _resultContext;
+    private readonly ObservableCollection<AiJobItemViewModel> _jobs = [];
+    private string? _operationError;
+    private string? _snapshotError;
+    private AiJobConfirmationAction _confirmationAction;
+    private AiJobItemViewModel? _confirmationItem;
+    private IAiJobRetryHandlerLease? _confirmationLease;
+    private IAiJobRetryHandler? _confirmationHandler;
+    private Task<AiJobRetryPreflight>? _confirmationPreflightTask;
+    private CancellationTokenSource? _confirmationPreflightCts;
+    private long _confirmationRevision;
+    private bool _isDisposed;
+    private Task? _disposeTask;
+    private readonly SemaphoreSlim _previewLoadGate = new(4, 4);
+    private readonly HashSet<AiJobItemViewModel> _visiblePreviewItems = [];
+    private long _snapshotSequence;
+    private long _appliedSnapshotSequence;
+
+    internal AiJobCenterViewModel(
+        EditViewModel editViewModel,
+        IAiEntitlementService entitlements,
+        IAuthenticatedContentService content,
+        IAiJobClient jobClient,
+        IAiJobMonitor jobMonitor,
+        IAiJobKindRegistry jobKinds,
+        AiJobResultRegistry resultHandlers,
+        Action<AiCaptionHistoryResult>? openCaptionResult)
+    {
+        _editViewModel = editViewModel ?? throw new ArgumentNullException(nameof(editViewModel));
+        _entitlements = entitlements ?? throw new ArgumentNullException(nameof(entitlements));
+        _content = content ?? throw new ArgumentNullException(nameof(content));
+        _jobClient = jobClient ?? throw new ArgumentNullException(nameof(jobClient));
+        _jobMonitor = jobMonitor ?? throw new ArgumentNullException(nameof(jobMonitor));
+        _jobKinds = jobKinds ?? throw new ArgumentNullException(nameof(jobKinds));
+        _resultHandlers = resultHandlers ?? throw new ArgumentNullException(nameof(resultHandlers));
+        _resultContext = new AiJobResultContext(_editViewModel, _content, openCaptionResult);
+        Jobs = new ReadOnlyObservableCollection<AiJobItemViewModel>(_jobs);
+        Usage = new AiUsageViewModel(_entitlements.Entitlements).DisposeWith(_disposables);
+
+        Refresh = new AsyncReactiveCommand(
+                IsLoading.CombineLatest(
+                    IsAuthenticationRequired,
+                    (isLoading, authenticationRequired) => !isLoading && !authenticationRequired))
+            .WithSubscribe(() => RefreshJobsAsync(append: false))
+            .DisposeWith(_disposables);
+        LoadMore = new AsyncReactiveCommand(
+                HasMore.CombineLatest(
+                    IsLoading,
+                    IsAuthenticationRequired,
+                    (hasMore, isLoading, authenticationRequired) =>
+                        hasMore && !isLoading && !authenticationRequired))
+            .WithSubscribe(() => RefreshJobsAsync(append: true))
+            .DisposeWith(_disposables);
+
+        _jobMonitor.Snapshot
+            .Subscribe(QueueSnapshot)
+            .DisposeWith(_disposables);
+        _jobMonitor.AcquirePolling().DisposeWith(_disposables);
+        _ = RefreshEntitlementsAsync();
+    }
+
+    public ReadOnlyObservableCollection<AiJobItemViewModel> Jobs { get; }
+
+    internal AiUsageViewModel Usage { get; }
+
+    internal EditViewModel Editor => _editViewModel;
+
+    public ReactivePropertySlim<bool> IsLoading { get; } = new();
+
+    public ReactivePropertySlim<bool> IsInitialLoading { get; } = new();
+
+    public ReactivePropertySlim<bool> IsListLoading { get; } = new();
+
+    public ReactivePropertySlim<bool> IsAuthenticationRequired { get; } = new();
+
+    public ReactivePropertySlim<bool> HasJobs { get; } = new();
+
+    public ReactivePropertySlim<bool> HasMore { get; } = new();
+
+    public ReactivePropertySlim<bool> ShowEmptyState { get; } = new();
+
+    public ReactivePropertySlim<bool> ShowListFooter { get; } = new();
+
+    public ReactivePropertySlim<string?> Error { get; } = new();
+
+    public ReactivePropertySlim<bool> IsConfirmationOpen { get; } = new();
+
+    public ReactivePropertySlim<bool> IsConfirmationLoading { get; } = new();
+
+    public ReactivePropertySlim<bool> CanConfirm { get; } = new();
+
+    public ReactivePropertySlim<string> ConfirmationTitle { get; } = new(string.Empty);
+
+    public ReactivePropertySlim<string> ConfirmationMessage { get; } = new(string.Empty);
+
+    public ReactivePropertySlim<string> ConfirmationActionText { get; } = new(string.Empty);
+
+    public AsyncReactiveCommand Refresh { get; }
+
+    public AsyncReactiveCommand LoadMore { get; }
+
+    internal async Task RequestRetryConfirmationAsync(AiJobItemViewModel item)
+    {
+        using AsyncOperationLifetime.Operation? lifetimeOperation = _operations.TryEnter();
+        if (lifetimeOperation is null)
+            return;
+        ArgumentNullException.ThrowIfNull(item);
+        if (!item.CanRetry || IsDisposed)
+            return;
+
+        ReleaseConfirmationResources();
+        long revision = Interlocked.Increment(ref _confirmationRevision);
+        _confirmationAction = AiJobConfirmationAction.Retry;
+        _confirmationItem = item;
+        _confirmationLease = null;
+        _confirmationHandler = null;
+        ConfirmationTitle.Value = Strings.AiJobCenter_RetryTitle;
+        ConfirmationMessage.Value = Strings.AiJobCenter_CheckingRetryCost;
+        ConfirmationActionText.Value = Strings.AiJobCenter_Retry;
+        CanConfirm.Value = false;
+        IsConfirmationLoading.Value = true;
+        IsConfirmationOpen.Value = true;
+
+        IAiJobRetryHandlerLease? lease = null;
+        Task<AiJobRetryPreflight>? preflightTask = null;
+        CancellationTokenSource? preflightCts = null;
+        try
+        {
+            if (!_jobKinds.TryAcquireRetryHandler(item.Job.Kind, out lease))
+            {
+                SetOperationError(Strings.AiPricingUnavailable);
+                return;
+            }
+
+            _confirmationLease = lease;
+
+            AiJobStatusSemantics status = _jobKinds.GetStatus(item.Job);
+            IAiJobRetryHandler retryHandler = lease.Handler;
+            if (!retryHandler.CanRetry(item.Job, status))
+            {
+                SetOperationError(Strings.AiPricingUnavailable);
+                ReleaseConfirmationResources();
+                return;
+            }
+
+            _confirmationHandler = retryHandler;
+            preflightCts = CancellationTokenSource.CreateLinkedTokenSource(
+                lifetimeOperation.CancellationToken);
+            _confirmationPreflightCts = preflightCts;
+            preflightTask = retryHandler.GetPreflightAsync(
+                item.Job,
+                preflightCts.Token).AsTask();
+            _confirmationPreflightTask = preflightTask;
+            AiJobRetryPreflight estimate = await preflightTask;
+            if (ReferenceEquals(_confirmationPreflightTask, preflightTask))
+            {
+                _confirmationPreflightTask = null;
+                if (ReferenceEquals(_confirmationPreflightCts, preflightCts))
+                {
+                    _confirmationPreflightCts = null;
+                    preflightCts.Dispose();
+                }
+            }
+            if (!TryPublishConfirmationPreflight(revision, lease, estimate))
+                return;
+            if (!estimate.CanSubmit)
+            {
+                ReleaseConfirmationResources();
+                lease = null;
+            }
+        }
+        catch (AuthenticationRequiredException)
+        {
+            if (IsCurrentConfirmation(revision, lease))
+            {
+                SetOperationError(Strings.AiAuthenticationRequired);
+                ReleaseConfirmationResources();
+            }
+        }
+        catch (AiJobRetryPreparationRejectedException)
+        {
+            if (IsCurrentConfirmation(revision, lease))
+            {
+                SetOperationError(Strings.AiResultUnavailable);
+                ReleaseConfirmationResources();
+            }
+        }
+        catch (AiJobRetryPreparationUnavailableException)
+        {
+            if (IsCurrentConfirmation(revision, lease))
+            {
+                SetOperationError(Strings.AiPricingUnavailable);
+                ReleaseConfirmationResources();
+            }
+        }
+        catch (OperationCanceledException) when (preflightCts?.IsCancellationRequested == true)
+        {
+            if (IsCurrentConfirmation(revision, lease))
+                ReleaseConfirmationResources();
+        }
+        catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+        {
+            if (IsCurrentConfirmation(revision, lease))
+                ReleaseConfirmationResources();
+        }
+        catch (Exception ex)
+        {
+            if (IsCurrentConfirmation(revision, lease))
+            {
+                _logger.LogDebug(ex, "Failed to refresh authoritative pricing before retrying AI job {JobId}", item.Id);
+                SetOperationError(Strings.AiPricingUnavailable);
+                ReleaseConfirmationResources();
+            }
+        }
+        finally
+        {
+            CompleteConfirmationLoading(revision);
+        }
+    }
+
+    private bool TryPublishConfirmationPreflight(
+        long revision,
+        IAiJobRetryHandlerLease lease,
+        AiJobRetryPreflight estimate)
+    {
+        lock (_lifetimeGate)
+        {
+            if (revision != _confirmationRevision
+                || _isDisposed
+                || !ReferenceEquals(_confirmationLease, lease))
+                return false;
+
+            ConfirmationMessage.Value = estimate.IsAvailable
+                ? string.Join(
+                    Environment.NewLine,
+                    Strings.AiJobCenter_RetryConfirmation,
+                    estimate.Explanation)
+                : estimate.Explanation;
+            CanConfirm.Value = estimate.CanSubmit;
+            return true;
+        }
+    }
+
+    private void CompleteConfirmationLoading(long revision)
+    {
+        lock (_lifetimeGate)
+        {
+            if (revision == _confirmationRevision && !_isDisposed)
+                IsConfirmationLoading.Value = false;
+        }
+    }
+
+    private bool IsCurrentConfirmation(long revision, IAiJobRetryHandlerLease? lease)
+        => revision == Volatile.Read(ref _confirmationRevision)
+            && !IsDisposed
+            && (lease is null || ReferenceEquals(_confirmationLease, lease));
+
+    internal void RequestDeleteConfirmation(AiJobItemViewModel item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        if (!item.CanDelete || IsDisposed)
+            return;
+
+        ReleaseConfirmationResources();
+        Interlocked.Increment(ref _confirmationRevision);
+        _confirmationAction = AiJobConfirmationAction.Delete;
+        _confirmationItem = item;
+        ConfirmationTitle.Value = string.IsNullOrWhiteSpace(item.Summary)
+            ? Strings.AiJobCenter_DeleteTitle
+            : string.Format(Strings.AiJobCenter_DeleteTitleFormat, Shorten(item.Summary));
+        ConfirmationMessage.Value = Strings.AiJobCenter_DeleteConfirmation;
+        ConfirmationActionText.Value = Strings.Delete;
+        CanConfirm.Value = true;
+        IsConfirmationLoading.Value = false;
+        IsConfirmationOpen.Value = true;
+    }
+
+    private static string Shorten(string text, int maximumLength = 48)
+    {
+        string normalized = text.ReplaceLineEndings(" ").Trim();
+        return normalized.Length <= maximumLength
+            ? normalized
+            : normalized[..maximumLength].TrimEnd() + "…";
+    }
+
+    private void ReleaseConfirmationResources()
+    {
+        IAiJobRetryHandlerLease? lease = Interlocked.Exchange(ref _confirmationLease, null);
+        Task<AiJobRetryPreflight>? preflight = Interlocked.Exchange(ref _confirmationPreflightTask, null);
+        CancellationTokenSource? preflightCts = Interlocked.Exchange(
+            ref _confirmationPreflightCts,
+            null);
+        _confirmationHandler = null;
+        CancelPreflight(preflightCts);
+        if (lease is not null)
+        {
+            if (preflight is { IsCompleted: false })
+            {
+                _ = DisposeLeaseAfterPreflightAsync(preflight, lease, preflightCts);
+            }
+            else
+            {
+                DisposeConfirmationLease(lease);
+                preflightCts?.Dispose();
+            }
+        }
+        else
+        {
+            preflightCts?.Dispose();
+        }
+    }
+
+    private async Task DisposeLeaseAfterPreflightAsync(
+        Task<AiJobRetryPreflight> preflight,
+        IAiJobRetryHandlerLease lease,
+        CancellationTokenSource? preflightCts)
+    {
+        using AsyncOperationLifetime.Operation? lifetimeOperation = _operations.TryEnter();
+        try
+        {
+            await preflight;
+        }
+        catch
+        {
+        }
+        DisposeConfirmationLease(lease);
+        preflightCts?.Dispose();
+    }
+
+    private void DisposeConfirmationLease(IAiJobRetryHandlerLease lease)
+    {
+        try
+        {
+            lease.Dispose();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to release an AI retry confirmation lease");
+        }
+    }
+
+    private void CancelPreflight(CancellationTokenSource? preflightCts)
+    {
+        if (preflightCts is null)
+            return;
+
+        try
+        {
+            preflightCts.Cancel();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "AI retry preflight cancellation callback failed");
+        }
+    }
+
+    private void ClearConfirmationState()
+    {
+        Interlocked.Increment(ref _confirmationRevision);
+        _confirmationAction = AiJobConfirmationAction.None;
+        _confirmationItem = null;
+        IsConfirmationOpen.Value = false;
+        IsConfirmationLoading.Value = false;
+        CanConfirm.Value = false;
+    }
+
+    internal void CancelConfirmation()
+    {
+        ClearConfirmationState();
+        ReleaseConfirmationResources();
+    }
+
+    internal async Task ConfirmPendingActionAsync()
+    {
+        using AsyncOperationLifetime.Operation? lifetimeOperation = _operations.TryEnter();
+        if (lifetimeOperation is null)
+            return;
+        if (!CanConfirm.Value || _confirmationItem is not { } item)
+            return;
+
+        AiJobConfirmationAction action = _confirmationAction;
+        IAiJobRetryHandlerLease? lease = Interlocked.Exchange(ref _confirmationLease, null);
+        IAiJobRetryHandler? handler = _confirmationHandler;
+        _confirmationHandler = null;
+        ClearConfirmationState();
+        switch (action)
+        {
+            case AiJobConfirmationAction.Retry:
+                await RetryJobAsync(item, lease, handler);
+                break;
+            case AiJobConfirmationAction.Delete:
+                lease?.Dispose();
+                await DeleteJobAsync(item);
+                break;
+            default:
+                lease?.Dispose();
+                break;
+        }
+    }
+
+    public async Task DeleteJobAsync(AiJobItemViewModel item)
+    {
+        using AsyncOperationLifetime.Operation? lifetimeOperation = _operations.TryEnter();
+        if (lifetimeOperation is null)
+            return;
+        ArgumentNullException.ThrowIfNull(item);
+        if (!item.IsTerminal)
+            return;
+
+        using IDisposable? operation = TryBeginOperation(item);
+        if (operation is null)
+            return;
+
+        try
+        {
+            await _jobClient.DeleteAsync(new AiJobId(item.Id), lifetimeOperation.CancellationToken);
+            if (!IsDisposed)
+            {
+                await _jobMonitor.RefreshAsync(lifetimeOperation.CancellationToken);
+            }
+        }
+        catch (AiJobNotFoundException)
+        {
+            // A different tab or a concurrent refresh already removed it. Re-read the
+            // authoritative list instead of presenting an idempotent delete as a failure.
+            if (!IsDisposed)
+            {
+                await _jobMonitor.RefreshAsync(lifetimeOperation.CancellationToken);
+            }
+        }
+        catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete AI job {JobId}", item.Id);
+            SetOperationError(Strings.AiJobCenter_DeleteFailed);
+        }
+    }
+
+    public async Task RetryJobAsync(AiJobItemViewModel item)
+        => await RetryJobAsync(item, confirmedLease: null, confirmedHandler: null);
+
+    private async Task RetryJobAsync(
+        AiJobItemViewModel item,
+        IAiJobRetryHandlerLease? confirmedLease,
+        IAiJobRetryHandler? confirmedHandler)
+    {
+        using AsyncOperationLifetime.Operation? lifetimeOperation = _operations.TryEnter();
+        if (lifetimeOperation is null)
+        {
+            confirmedLease?.Dispose();
+            return;
+        }
+        ArgumentNullException.ThrowIfNull(item);
+        if (!item.CanRetry)
+        {
+            confirmedLease?.Dispose();
+            return;
+        }
+
+        using IDisposable? operation = TryBeginOperation(item);
+        if (operation is null)
+        {
+            confirmedLease?.Dispose();
+            return;
+        }
+
+        IAiJobRetryHandlerLease? lease = confirmedLease;
+
+        try
+        {
+            if (lease is null && !_jobKinds.TryAcquireRetryHandler(item.Job.Kind, out lease))
+            {
+                SetOperationError(Strings.AiPricingUnavailable);
+                return;
+            }
+
+            using (lease)
+            {
+                AiJobStatusSemantics status = _jobKinds.GetStatus(item.Job);
+                IAiJobRetryHandler retryHandler = confirmedHandler ?? lease.Handler;
+                if (!retryHandler.CanRetry(item.Job, status))
+                {
+                    SetOperationError(Strings.AiPricingUnavailable);
+                    return;
+                }
+
+                if (confirmedLease is null)
+                {
+                    AiJobRetryPreflight estimate = await retryHandler.GetPreflightAsync(
+                        item.Job,
+                        lifetimeOperation.CancellationToken);
+                    if (!estimate.CanSubmit)
+                    {
+                        SetOperationError(estimate.Explanation);
+                        return;
+                    }
+                }
+
+                AiJobRetryPreparationResult prepared = await retryHandler.PrepareAsync(
+                    item.Job,
+                    lifetimeOperation.CancellationToken);
+                await using (prepared)
+                {
+                    if (!prepared.IsReady)
+                    {
+                        SetOperationError(prepared.Explanation);
+                        return;
+                    }
+
+                    IAiJobRetryPreparation preparation = prepared.TakePreparation();
+                    await using (preparation)
+                    {
+                        await preparation.ExecuteAsync(lifetimeOperation.CancellationToken);
+                    }
+                }
+            }
+
+            item.MarkRetrySubmitted();
+
+            if (!IsDisposed)
+            {
+                try
+                {
+                    await _jobMonitor.RefreshAsync(lifetimeOperation.CancellationToken);
+                }
+                catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "AI job {JobId} was retried, but refreshing the job list failed",
+                        item.Id);
+                    SetOperationError(Strings.AiJobCenter_LoadFailed);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+        {
+        }
+        catch (AiUsageLimitExceededException)
+        {
+            SetOperationError(Strings.AiUsageLimitExceeded);
+        }
+        catch (AiJobRetryPreparationRejectedException)
+        {
+            // The durable key or authenticated account changed after the
+            // dialog preflight. Require the user to start a fresh confirmation
+            // instead of silently creating a new paid request.
+            SetOperationError(Strings.AiResultUnavailable);
+        }
+        catch (AuthenticationRequiredException)
+        {
+            SetOperationError(Strings.AiAuthenticationRequired);
+        }
+        catch (AiJobRetryPreparationUnavailableException)
+        {
+            SetOperationError(Strings.AiPricingUnavailable);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retry AI job {JobId}", item.Id);
+            SetOperationError(Strings.AiJobCenter_RetryFailed);
+        }
+    }
+
+    internal async Task<AiJobRetryPreflight> GetRetryEstimateAsync(AiJobItemViewModel item)
+    {
+        using AsyncOperationLifetime.Operation? lifetimeOperation = _operations.TryEnter();
+        if (lifetimeOperation is null)
+            return RetryUnavailable();
+        ArgumentNullException.ThrowIfNull(item);
+        if (!item.CanRetry)
+            return RetryUnavailable();
+
+        try
+        {
+            if (!_jobKinds.TryAcquireRetryHandler(
+                    item.Job.Kind,
+                    out IAiJobRetryHandlerLease? lease))
+                return RetryUnavailable();
+
+            using (lease)
+            {
+                AiJobStatusSemantics status = _jobKinds.GetStatus(item.Job);
+                IAiJobRetryHandler retryHandler = lease.Handler;
+                if (!retryHandler.CanRetry(item.Job, status))
+                {
+                    return RetryUnavailable();
+                }
+
+                AiJobRetryPreflight estimate = await retryHandler.GetPreflightAsync(
+                    item.Job,
+                    lifetimeOperation.CancellationToken);
+                SetOperationError(estimate.CanSubmit ? null : estimate.Explanation);
+                return estimate;
+            }
+        }
+        catch (AuthenticationRequiredException)
+        {
+            SetOperationError(Strings.AiAuthenticationRequired);
+            return new AiJobRetryPreflight(false, false, Strings.AiAuthenticationRequired);
+        }
+        catch (AiJobRetryPreparationRejectedException)
+        {
+            SetOperationError(Strings.AiResultUnavailable);
+            return new AiJobRetryPreflight(false, false, Strings.AiResultUnavailable);
+        }
+        catch (AiJobRetryPreparationUnavailableException)
+        {
+            SetOperationError(Strings.AiPricingUnavailable);
+            return RetryUnavailable();
+        }
+        catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+        {
+            return RetryUnavailable();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to refresh authoritative pricing before retrying AI job {JobId}", item.Id);
+            SetOperationError(Strings.AiPricingUnavailable);
+            return RetryUnavailable();
+        }
+    }
+
+    public async Task AddToSceneAsync(AiJobItemViewModel item)
+    {
+        using AsyncOperationLifetime.Operation? lifetimeOperation = _operations.TryEnter();
+        if (lifetimeOperation is null)
+            return;
+        ArgumentNullException.ThrowIfNull(item);
+        if (!item.CanAddToScene)
+            return;
+
+        using IDisposable? operation = TryBeginOperation(item);
+        if (operation is null)
+            return;
+
+        try
+        {
+            AiJobStatusSemantics status = _jobKinds.GetStatus(item.Job);
+            if (!_resultHandlers.TryAcquireApplicator(
+                    item.Job.Kind,
+                    out IAiJobResultApplicatorLease? applicatorLease))
+            {
+                return;
+            }
+
+            using (applicatorLease)
+            {
+                IAiJobResultApplicator applicator = applicatorLease.Applicator;
+                if (!applicator.CanApply(item.Job, status))
+                    return;
+
+                await applicator.ApplyAsync(
+                    item.Job,
+                    _resultContext,
+                    lifetimeOperation.CancellationToken);
+            }
+        }
+        catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to add AI job {JobId} result to the scene", item.Id);
+            SetOperationError(Strings.AiJobCenter_AddFailed);
+        }
+    }
+
+    public void Dispose()
+    {
+        _ = DisposeAsync().AsTask().ContinueWith(
+            static task => _ = task.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        lock (_lifetimeGate)
+        {
+            if (_disposeTask is not null)
+                return new ValueTask(_disposeTask);
+
+            _isDisposed = true;
+            var completion = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _disposeTask = completion.Task;
+            _ = CompleteDisposeAsync(completion);
+            return new ValueTask(completion.Task);
+        }
+    }
+
+    private async Task CompleteDisposeAsync(TaskCompletionSource completion)
+    {
+        CancelConfirmation();
+        try
+        {
+            await _operations.DisposeAsync(
+            cancelAdditionalWork: () =>
+            {
+                try { _lifetimeCts.Cancel(); }
+                catch (Exception ex) { _logger.LogDebug(ex, "AI job center lifetime cancellation callback failed"); }
+            },
+            disposeResources: () =>
+            {
+                _disposables.Dispose();
+                foreach (AiJobItemViewModel job in _jobs) job.Dispose();
+                _jobs.Clear();
+                _visiblePreviewItems.Clear();
+                IsLoading.Dispose();
+                IsInitialLoading.Dispose();
+                IsListLoading.Dispose();
+                IsAuthenticationRequired.Dispose();
+                HasJobs.Dispose();
+                HasMore.Dispose();
+                ShowEmptyState.Dispose();
+                ShowListFooter.Dispose();
+                Error.Dispose();
+                IsConfirmationOpen.Dispose();
+                IsConfirmationLoading.Dispose();
+                CanConfirm.Dispose();
+                ConfirmationTitle.Dispose();
+                ConfirmationMessage.Dispose();
+                ConfirmationActionText.Dispose();
+                _previewLoadGate.Dispose();
+                _lifetimeCts.Dispose();
+                return ValueTask.CompletedTask;
+            });
+            completion.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
+        }
+    }
+
+    private bool IsDisposed => Volatile.Read(ref _isDisposed);
+
+    private async Task RefreshJobsAsync(bool append)
+    {
+        using AsyncOperationLifetime.Operation? lifetimeOperation = _operations.TryEnter();
+        if (lifetimeOperation is null)
+            return;
+        SetOperationError(null);
+        if (append)
+        {
+            await _jobMonitor.LoadNextPageAsync(lifetimeOperation.CancellationToken);
+        }
+        else
+        {
+            await _jobMonitor.RefreshAsync(lifetimeOperation.CancellationToken);
+        }
+    }
+
+    private async Task RefreshEntitlementsAsync()
+    {
+        using AsyncOperationLifetime.Operation? lifetimeOperation = _operations.TryEnter();
+        if (lifetimeOperation is null)
+            return;
+        try
+        {
+            await _entitlements.RefreshAsync(lifetimeOperation.CancellationToken);
+        }
+        catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "AI entitlement refresh failed while opening the job center");
+        }
+    }
+
+    private void QueueSnapshot(AiJobMonitorSnapshot snapshot)
+    {
+        if (IsDisposed)
+            return;
+
+        long sequence = Interlocked.Increment(ref _snapshotSequence);
+
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            ApplySnapshot(snapshot, sequence);
+        }
+        else
+        {
+            Dispatcher.UIThread.Post(() => ApplySnapshot(snapshot, sequence));
+        }
+    }
+
+    internal void ApplySnapshot(AiJobMonitorSnapshot snapshot)
+        => ApplySnapshot(snapshot, Interlocked.Increment(ref _snapshotSequence));
+
+    internal void ApplySnapshot(AiJobMonitorSnapshot snapshot, long sequence)
+    {
+        lock (_lifetimeGate)
+        {
+            if (_isDisposed || sequence < _appliedSnapshotSequence)
+                return;
+            _appliedSnapshotSequence = sequence;
+
+            var existing = _jobs.ToDictionary(item => item.Id, StringComparer.Ordinal);
+            var desired = new List<AiJobItemViewModel>(snapshot.Jobs.Length);
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (AiJob response in snapshot.Jobs)
+            {
+                string id = response.Id.Value;
+                if (!seen.Add(id))
+                    continue;
+
+                if (existing.TryGetValue(id, out AiJobItemViewModel? item))
+                {
+                    item.Update(response);
+                }
+                else
+                {
+                    item = new AiJobItemViewModel(response, _jobKinds, _resultHandlers);
+                }
+
+                desired.Add(item);
+            }
+
+            SynchronizeJobs(desired);
+            _visiblePreviewItems.RemoveWhere(item => !_jobs.Contains(item));
+            if (_confirmationItem is not null && !_jobs.Contains(_confirmationItem))
+            {
+                CancelConfirmation();
+            }
+
+            bool hasJobs = _jobs.Count > 0;
+            bool authenticationRequired = snapshot.Error is AuthenticationRequiredException;
+            if (authenticationRequired != IsAuthenticationRequired.Value)
+            {
+                _operationError = null;
+            }
+
+            IsAuthenticationRequired.Value = authenticationRequired;
+            IsLoading.Value = snapshot.IsLoading;
+            IsInitialLoading.Value = snapshot.IsLoading && !hasJobs;
+            IsListLoading.Value = snapshot.IsLoading && hasJobs;
+            HasJobs.Value = hasJobs;
+            HasMore.Value = snapshot.NextCursor is not null;
+            ShowEmptyState.Value = !snapshot.IsLoading && !hasJobs && snapshot.Error is null;
+            ShowListFooter.Value = hasJobs && (snapshot.IsLoading || snapshot.NextCursor is not null);
+            _snapshotError = snapshot.Error switch
+            {
+                null => null,
+                AuthenticationRequiredException => Strings.AiAuthenticationRequired,
+                _ => Strings.AiJobCenter_LoadFailed,
+            };
+            UpdateVisibleError();
+            LoadVisiblePreviews_NoLock();
+        }
+    }
+
+    internal void SetPreviewVisibility(AiJobItemViewModel item, bool isVisible)
+    {
+        lock (_lifetimeGate)
+        {
+            if (_isDisposed)
+                return;
+            if (!isVisible || !_jobs.Contains(item))
+            {
+                _visiblePreviewItems.Remove(item);
+                item.ReleasePreviewForReload();
+                return;
+            }
+
+            _visiblePreviewItems.Add(item);
+            TryLoadPreview_NoLock(item);
+        }
+    }
+
+    private void LoadVisiblePreviews_NoLock()
+    {
+        foreach (AiJobItemViewModel item in _visiblePreviewItems)
+            TryLoadPreview_NoLock(item);
+    }
+
+    private void TryLoadPreview_NoLock(AiJobItemViewModel item)
+    {
+        if (item.TryClaimPreviewLoad(out long loadGeneration))
+            _ = LoadPreviewAsync(item, loadGeneration);
+    }
+
+    private async Task LoadPreviewAsync(AiJobItemViewModel item, long loadGeneration)
+    {
+        using AsyncOperationLifetime.Operation? lifetimeOperation = _operations.TryEnter();
+        if (lifetimeOperation is null)
+            return;
+
+        bool enteredGate = false;
+        try
+        {
+            await _previewLoadGate.WaitAsync(lifetimeOperation.CancellationToken);
+            enteredGate = true;
+            lock (_lifetimeGate)
+            {
+                if (_isDisposed || !_visiblePreviewItems.Contains(item))
+                {
+                    item.ResetPreviewLoadClaim(loadGeneration);
+                    return;
+                }
+            }
+            if (item.ContentUri is not { } contentUri)
+            {
+                item.ResetPreviewLoadClaim(loadGeneration);
+                return;
+            }
+
+            using var buffer = new SizeLimitedMemoryStream(
+                checked((int)AiRequestLimits.MaxImageUploadBytes));
+            await _content.CopyToAsync(contentUri, buffer, lifetimeOperation.CancellationToken);
+            buffer.Position = 0;
+            Bitmap preview = await Task.Run(
+                () => DecodePreview(buffer),
+                lifetimeOperation.CancellationToken);
+            item.SetPreview(Ref<Bitmap>.Create(preview), loadGeneration);
+        }
+        catch (OperationCanceledException) when (lifetimeOperation.CancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            // The card still names the job; only the picture beside it is missing.
+            _logger.LogDebug(ex, "Failed to load a preview for AI job {JobId}", item.Id);
+            item.ResetPreviewLoadClaim(loadGeneration);
+        }
+        finally
+        {
+            if (enteredGate)
+                _previewLoadGate.Release();
+        }
+    }
+
+    internal static Bitmap DecodePreview(Stream encodedContent)
+    {
+        ArgumentNullException.ThrowIfNull(encodedContent);
+        using SKCodec codec = SKCodec.Create(encodedContent)
+            ?? throw new InvalidDataException("Failed to inspect the AI preview image.");
+        SKImageInfo sourceInfo = codec.Info;
+        AiImageDecodeValidator.Validate(sourceInfo);
+
+        const int maxDimension = 512;
+        double scale = Math.Min(1d, Math.Min(
+            maxDimension / (double)sourceInfo.Width,
+            maxDimension / (double)sourceInfo.Height));
+        int width = Math.Max(1, (int)Math.Round(sourceInfo.Width * scale));
+        int height = Math.Max(1, (int)Math.Round(sourceInfo.Height * scale));
+        var decodeInfo = new SKImageInfo(
+            sourceInfo.Width,
+            sourceInfo.Height,
+            SKColorType.Rgba8888,
+            SKAlphaType.Premul);
+        if (codec.StartScanlineDecode(decodeInfo) != SKCodecResult.Success)
+        {
+            // Some codecs, notably interlaced PNG, cannot expose scanlines. Keep
+            // their fallback surface far below the validated server maximum so
+            // four concurrent previews still have a deterministic memory bound.
+            if ((long)sourceInfo.Width * sourceInfo.Height > 4_194_304)
+            {
+                throw new InvalidDataException(
+                    "The AI preview image is too large for its decoder.");
+            }
+
+            using SKBitmap source = SKBitmap.Decode(codec)
+                ?? throw new InvalidDataException("Failed to decode the AI preview image.");
+            using SKBitmap resized = source.Resize(
+                new SKImageInfo(width, height),
+                new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.Linear))
+                ?? throw new InvalidDataException("Failed to resize the AI preview image.");
+            return EncodePreview(resized);
+        }
+
+        int sourceRowBytes = checked(sourceInfo.Width * 4);
+        byte[] sourceRow = new byte[sourceRowBytes];
+        byte[] thumbnailPixels = new byte[checked(width * height * 4)];
+        GCHandle rowHandle = GCHandle.Alloc(sourceRow, GCHandleType.Pinned);
+        try
+        {
+            int nextSourceRow = 0;
+            for (int y = 0; y < height; y++)
+            {
+                int sourceY = Math.Min(
+                    sourceInfo.Height - 1,
+                    (int)(((long)(2 * y + 1) * sourceInfo.Height) / (2L * height)));
+                int rowsToSkip = sourceY - nextSourceRow;
+                if (rowsToSkip > 0 && !codec.SkipScanlines(rowsToSkip))
+                    throw new InvalidDataException("Failed to seek within the AI preview image.");
+                if (codec.GetScanlines(rowHandle.AddrOfPinnedObject(), 1, sourceRowBytes) != 1)
+                    throw new InvalidDataException("Failed to decode the AI preview image.");
+                nextSourceRow = sourceY + 1;
+
+                int targetRow = y * width * 4;
+                for (int x = 0; x < width; x++)
+                {
+                    int sourceX = Math.Min(
+                        sourceInfo.Width - 1,
+                        (int)(((long)(2 * x + 1) * sourceInfo.Width) / (2L * width)));
+                    Buffer.BlockCopy(sourceRow, sourceX * 4, thumbnailPixels, targetRow + x * 4, 4);
+                }
+            }
+        }
+        finally
+        {
+            rowHandle.Free();
+        }
+
+        using var thumbnail = new SKBitmap(new SKImageInfo(
+            width,
+            height,
+            SKColorType.Rgba8888,
+            SKAlphaType.Premul));
+        Marshal.Copy(thumbnailPixels, 0, thumbnail.GetPixels(), thumbnailPixels.Length);
+        return EncodePreview(thumbnail);
+    }
+
+    private static Bitmap EncodePreview(SKBitmap thumbnail)
+    {
+        using SKImage image = SKImage.FromBitmap(thumbnail);
+        using SKData png = image.Encode(SKEncodedImageFormat.Png, 90);
+        using var stream = new MemoryStream();
+        png.SaveTo(stream);
+        stream.Position = 0;
+        return Bitmap.FromStream(stream);
+    }
+
+    private void SynchronizeJobs(IReadOnlyList<AiJobItemViewModel> desired)
+    {
+        for (int index = 0; index < desired.Count; index++)
+        {
+            AiJobItemViewModel item = desired[index];
+            if (index < _jobs.Count && ReferenceEquals(_jobs[index], item))
+                continue;
+
+            int oldIndex = _jobs.IndexOf(item);
+            if (oldIndex >= 0)
+            {
+                _jobs.Move(oldIndex, index);
+            }
+            else
+            {
+                _jobs.Insert(index, item);
+            }
+        }
+
+        while (_jobs.Count > desired.Count)
+        {
+            AiJobItemViewModel stale = _jobs[^1];
+            _jobs.RemoveAt(_jobs.Count - 1);
+            stale.Dispose();
+        }
+    }
+
+    private IDisposable? TryBeginOperation(AiJobItemViewModel item)
+    {
+        lock (_lifetimeGate)
+        {
+            if (_isDisposed)
+                return null;
+
+            IDisposable? operation = item.TryBeginOperation();
+            if (operation is not null)
+            {
+                _operationError = null;
+                UpdateVisibleError();
+            }
+            return operation;
+        }
+    }
+
+    private void SetOperationError(string? error)
+    {
+        lock (_lifetimeGate)
+        {
+            if (_isDisposed)
+                return;
+
+            _operationError = error;
+            UpdateVisibleError();
+        }
+    }
+
+    private void UpdateVisibleError()
+    {
+        Error.Value = IsAuthenticationRequired.Value
+            ? Strings.AiAuthenticationRequired
+            : _operationError ?? _snapshotError;
+    }
+
+    private static AiJobRetryPreflight RetryUnavailable()
+        => new(false, false, Strings.AiPricingUnavailable);
+
+}
+
+internal enum AiJobConfirmationAction
+{
+    None,
+    Retry,
+    Delete,
+}
+
+public sealed class AiJobItemViewModel : INotifyPropertyChanged, IDisposable
+{
+    private readonly ILogger _logger = Log.CreateLogger<AiJobItemViewModel>();
+    private readonly object _stateGate = new();
+    private readonly IAiJobKindRegistry _jobKinds;
+    private readonly AiJobResultRegistry _resultHandlers;
+    private AiJob _response;
+    private Ref<Bitmap>? _preview;
+    private bool _disposeRequested;
+    private bool _isOperationActive;
+    private bool _retrySubmitted;
+    private bool _isBusyDisposed;
+    private bool _previewRequested;
+    private long _previewLoadGeneration;
+
+    public AiJobItemViewModel(
+        AiJob response,
+        IAiJobKindRegistry jobKinds,
+        AiJobResultRegistry resultHandlers)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+        _jobKinds = jobKinds ?? throw new ArgumentNullException(nameof(jobKinds));
+        _resultHandlers = resultHandlers ?? throw new ArgumentNullException(nameof(resultHandlers));
+        Id = response.Id.Value;
+        _response = response;
+        ApplyResponse();
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public string Id { get; }
+
+    public string Kind { get; private set; } = string.Empty;
+
+    public string Status { get; private set; } = string.Empty;
+
+    public Uri? ContentUri { get; private set; }
+
+    public string? FileId { get; private set; }
+
+    public string? Error { get; private set; }
+
+    public bool CanRetry { get; private set; }
+
+    public string? Prompt { get; private set; }
+
+    public string? ImageSize { get; private set; }
+
+    public string? Resolution { get; private set; }
+
+    public string? Task { get; private set; }
+
+    public string? Language { get; private set; }
+
+    public int? DurationSeconds { get; private set; }
+
+    public DateTimeOffset GeneratedAt { get; private set; }
+
+    public string Summary { get; private set; } = string.Empty;
+
+    public string Details { get; private set; } = string.Empty;
+
+    public bool HasDetails { get; private set; }
+
+    public string CreatedAtText { get; private set; } = string.Empty;
+
+    public string CreatedAtTooltip { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Whether this job's result is a picture worth showing beside its prompt.
+    /// </summary>
+    public bool HasImagePreview { get; private set; }
+
+    public Ref<Bitmap>? Preview
+    {
+        get
+        {
+            lock (_stateGate)
+                return _preview;
+        }
+    }
+
+    public bool IsTerminal { get; private set; }
+
+    public bool ShouldPoll { get; private set; }
+
+    public bool IsFailed { get; private set; }
+
+    public bool CanDelete { get; private set; }
+
+    public bool CanAddToScene { get; private set; }
+
+    public ReactivePropertySlim<bool> IsBusy { get; } = new();
+
+    public string KindDisplayName { get; private set; } = string.Empty;
+
+    public string StatusDisplayName { get; private set; } = string.Empty;
+
+    internal AiJob Job => _response;
+
+    /// <summary>
+    /// Claims the one download this item's preview is allowed, so a list that
+    /// refreshes while polling does not fetch the same picture again.
+    /// </summary>
+    internal bool TryClaimPreviewLoad()
+        => TryClaimPreviewLoad(out _);
+
+    internal bool TryClaimPreviewLoad(out long loadGeneration)
+    {
+        lock (_stateGate)
+        {
+            if (_previewRequested || !HasImagePreview || _disposeRequested)
+            {
+                loadGeneration = 0;
+                return false;
+            }
+
+            _previewRequested = true;
+            loadGeneration = _previewLoadGeneration;
+            return true;
+        }
+    }
+
+    internal bool IsPreviewLoadRequested
+    {
+        get
+        {
+            lock (_stateGate)
+                return _previewRequested;
+        }
+    }
+
+    internal void ResetPreviewLoadClaim(long? loadGeneration = null)
+    {
+        lock (_stateGate)
+        {
+            if (!_disposeRequested
+                && (!loadGeneration.HasValue || loadGeneration.Value == _previewLoadGeneration))
+            {
+                _previewRequested = false;
+            }
+        }
+    }
+
+    internal void SetPreview(Ref<Bitmap>? preview, long? loadGeneration = null)
+    {
+        Ref<Bitmap>? previous;
+        lock (_stateGate)
+        {
+            if (_disposeRequested
+                || (loadGeneration.HasValue
+                    && (!_previewRequested || loadGeneration.Value != _previewLoadGeneration)))
+            {
+                preview?.Dispose();
+                return;
+            }
+
+            if (ReferenceEquals(_preview, preview))
+                return;
+
+            previous = _preview;
+            _preview = preview;
+            previous?.Dispose();
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Preview)));
+        }
+    }
+
+    internal void ReleasePreviewForReload()
+    {
+        Ref<Bitmap>? previous;
+        lock (_stateGate)
+        {
+            if (_disposeRequested)
+                return;
+
+            _previewLoadGeneration++;
+            _previewRequested = false;
+            previous = _preview;
+            _preview = null;
+            previous?.Dispose();
+            if (previous is not null)
+            {
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Preview)));
+            }
+        }
+    }
+
+    internal void Update(AiJob response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+        if (!string.Equals(Id, response.Id.Value, StringComparison.Ordinal))
+            throw new ArgumentException("The updated AI job must have the same id.", nameof(response));
+
+        lock (_stateGate)
+        {
+            if (_disposeRequested)
+                return;
+
+            _response = response;
+            ApplyResponse();
+        }
+
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(null));
+    }
+
+    internal void MarkRetrySubmitted()
+    {
+        lock (_stateGate)
+        {
+            if (_disposeRequested || _retrySubmitted)
+                return;
+
+            _retrySubmitted = true;
+            CanRetry = false;
+        }
+
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CanRetry)));
+    }
+
+    internal IDisposable? TryBeginOperation()
+    {
+        lock (_stateGate)
+        {
+            if (_disposeRequested || _isOperationActive)
+                return null;
+
+            _isOperationActive = true;
+            IsBusy.Value = true;
+            return Disposable.Create(EndOperation);
+        }
+    }
+
+    public void Dispose()
+    {
+        Ref<Bitmap>? previous;
+        lock (_stateGate)
+        {
+            if (_disposeRequested)
+                return;
+
+            _disposeRequested = true;
+            if (!_isOperationActive)
+            {
+                DisposeBusyProperty();
+            }
+
+            previous = _preview;
+            _preview = null;
+            previous?.Dispose();
+        }
+
+    }
+
+    private void EndOperation()
+    {
+        lock (_stateGate)
+        {
+            if (!_isOperationActive)
+                return;
+
+            _isOperationActive = false;
+            IsBusy.Value = false;
+            if (_disposeRequested)
+            {
+                DisposeBusyProperty();
+            }
+        }
+    }
+
+    private void DisposeBusyProperty()
+    {
+        if (_isBusyDisposed)
+            return;
+
+        _isBusyDisposed = true;
+        IsBusy.Dispose();
+    }
+
+    private void ApplyResponse()
+    {
+        Kind = NormalizeToken(_response.Kind.Value);
+        Status = NormalizeToken(_response.Status.Value);
+        ContentUri = _response.ContentUri;
+        FileId = _response.FileId?.Value;
+        Error = AiErrorMessage.Localize(_response.Error);
+        Prompt = GetString("prompt");
+        ImageSize = GetString("size");
+        Resolution = GetString("resolution");
+        Task = GetString("task");
+        Language = GetString("targetLanguage") ?? GetString("language");
+        DurationSeconds = GetInt32("durationSeconds");
+        GeneratedAt = _response.CreatedAt.ToUniversalTime();
+        var presentation = new AiJobPresentation(
+            Kind.Length > 0 ? Kind : Strings.AiJobCenter_NoDescription,
+            Status.Length > 0 ? Status : Strings.AiJobCenter_NoDescription,
+            Prompt
+            ?? GetString("filename")
+            ?? Strings.AiJobCenter_NoDescription,
+            CreateDetails(),
+            false);
+        AiJobStatusSemantics status = AiJobStatusSemantics.Unknown;
+        bool canRetry = false;
+        bool canHandleResult = false;
+        try
+        {
+            status = _jobKinds.GetStatus(_response);
+        }
+        catch
+        {
+            status = AiJobStatusSemantics.Unknown;
+        }
+
+        if (_jobKinds.TryAcquireRetryHandler(
+                _response.Kind,
+                out IAiJobRetryHandlerLease? retryLease))
+        {
+            using (retryLease)
+            {
+                try
+                {
+                    canRetry = retryLease.Handler.CanRetry(_response, status);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(
+                        ex,
+                        "AI job retry handler for '{Kind}' failed while checking eligibility.",
+                        _response.Kind);
+                    canRetry = false;
+                }
+            }
+        }
+
+        if (_resultHandlers.TryAcquirePresenter(
+                _response.Kind,
+                out IAiJobPresenterLease? presenterLease))
+        {
+            using (presenterLease)
+            {
+                try
+                {
+                    AiJobPresentation candidate = presenterLease.Presenter.Present(_response, status)
+                        ?? throw new InvalidOperationException(
+                            $"AI job presenter for '{_response.Kind}' returned no presentation.");
+                    ValidatePresentation(candidate);
+                    presentation = candidate;
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        if (_resultHandlers.TryAcquireApplicator(
+                _response.Kind,
+                out IAiJobResultApplicatorLease? applicatorLease))
+        {
+            using (applicatorLease)
+            {
+                try
+                {
+                    canHandleResult = applicatorLease.Applicator.CanApply(_response, status);
+                }
+                catch
+                {
+                    canHandleResult = false;
+                }
+            }
+        }
+
+        Summary = presentation.Summary;
+        Details = presentation.Details;
+        HasDetails = Details.Length > 0;
+        CreatedAtText = RelativeTimeText.Format(_response.CreatedAt, DateTimeOffset.Now);
+        CreatedAtTooltip = _response.CreatedAt.ToLocalTime().ToString("g");
+        IsTerminal = status.IsTerminal;
+        ShouldPoll = status.ShouldPoll;
+        IsFailed = presentation.IsFailure;
+        CanDelete = status.IsTerminal;
+        CanRetry = canRetry && !_retrySubmitted;
+        CanAddToScene = canHandleResult;
+        KindDisplayName = presentation.KindDisplayName;
+        StatusDisplayName = presentation.StatusDisplayName;
+        HasImagePreview = presentation.HasImagePreview && ContentUri is not null && canHandleResult;
+    }
+
+    private static void ValidatePresentation(AiJobPresentation presentation)
+    {
+        if (presentation.KindDisplayName is null
+            || presentation.StatusDisplayName is null
+            || presentation.Summary is null
+            || presentation.Details is null)
+        {
+            throw new InvalidOperationException(
+                "An AI job result handler returned a presentation with a null text field.");
+        }
+    }
+
+    private string CreateDetails()
+    {
+        var details = new List<string>();
+        if (ImageSize is not null)
+        {
+            details.Add(ImageSize);
+        }
+        if (DurationSeconds is not null)
+        {
+            details.Add($"{DurationSeconds} {Strings.AiVideoSeconds}");
+        }
+        if (Resolution is not null)
+        {
+            details.Add(Resolution);
+        }
+        if (Language is not null)
+        {
+            details.Add(Language);
+        }
+        return string.Join(" · ", details);
+    }
+
+    private string? GetString(string propertyName)
+    {
+        if (_response.InputParameters is not { ValueKind: JsonValueKind.Object } input
+            || !input.TryGetProperty(propertyName, out JsonElement value)
+            || value.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        return NormalizeText(value.GetString());
+    }
+
+    private int? GetInt32(string propertyName)
+    {
+        if (_response.InputParameters is not { ValueKind: JsonValueKind.Object } input
+            || !input.TryGetProperty(propertyName, out JsonElement value)
+            || value.ValueKind != JsonValueKind.Number
+            || !value.TryGetInt32(out int result))
+        {
+            return null;
+        }
+
+        return result;
+    }
+
+    private static string NormalizeToken(string? value)
+        => NormalizeText(value)?.ToLowerInvariant() ?? string.Empty;
+
+    private static string? NormalizeText(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/Beutl/ViewModels/Tools/AiJobCenterViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/AiJobCenterViewModel.cs
@@ -1541,7 +1541,7 @@ public sealed class AiJobItemViewModel : INotifyPropertyChanged, IDisposable
         CanAddToScene = canHandleResult;
         KindDisplayName = presentation.KindDisplayName;
         StatusDisplayName = presentation.StatusDisplayName;
-        HasImagePreview = presentation.HasImagePreview && ContentUri is not null && canHandleResult;
+        HasImagePreview = presentation.HasImagePreview && ContentUri is not null;
     }
 
     private static void ValidatePresentation(AiJobPresentation presentation)

--- a/src/Beutl/ViewModels/Tools/AiJobCenterViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/AiJobCenterViewModel.cs
@@ -942,7 +942,9 @@ public sealed class AiJobCenterViewModel : IDisposable, IAsyncDisposable
             enteredGate = true;
             lock (_lifetimeGate)
             {
-                if (_isDisposed || !_visiblePreviewItems.Contains(item))
+                if (_isDisposed
+                    || !_visiblePreviewItems.Contains(item)
+                    || !item.IsPreviewLoadCurrent(loadGeneration))
                 {
                     item.ResetPreviewLoadClaim(loadGeneration);
                     return;
@@ -1275,6 +1277,16 @@ public sealed class AiJobItemViewModel : INotifyPropertyChanged, IDisposable
         {
             lock (_stateGate)
                 return _previewRequested;
+        }
+    }
+
+    internal bool IsPreviewLoadCurrent(long loadGeneration)
+    {
+        lock (_stateGate)
+        {
+            return !_disposeRequested
+                && _previewRequested
+                && loadGeneration == _previewLoadGeneration;
         }
     }
 

--- a/src/Beutl/ViewModels/Tools/AiJobCenterViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/AiJobCenterViewModel.cs
@@ -64,7 +64,7 @@ public sealed class AiJobCenterViewModel : IDisposable, IAsyncDisposable
         IAiJobMonitor jobMonitor,
         IAiJobKindRegistry jobKinds,
         AiJobResultRegistry resultHandlers,
-        Action<AiCaptionHistoryResult>? openCaptionResult)
+        Func<AiCaptionHistoryResult, Task<bool>>? openCaptionResult)
     {
         _editViewModel = editViewModel ?? throw new ArgumentNullException(nameof(editViewModel));
         _entitlements = entitlements ?? throw new ArgumentNullException(nameof(entitlements));

--- a/src/Beutl/ViewModels/Tools/AiWorkspaceViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/AiWorkspaceViewModel.cs
@@ -1,0 +1,271 @@
+﻿using System.Text.Json.Nodes;
+using Beutl.Services.PrimitiveImpls;
+using Beutl.ViewModels.Dialogs;
+using Reactive.Bindings;
+using Reactive.Bindings.Extensions;
+using Icon = FluentIcons.Common.Icon;
+
+namespace Beutl.ViewModels.Tools;
+
+/// <summary>Identifies one page of the AI tool tab, and is what a saved dock layout remembers.</summary>
+internal enum AiWorkspaceSection
+{
+    ImageGeneration,
+    ImageEdit,
+    VideoGeneration,
+    Subtitles,
+    Jobs,
+}
+
+/// <summary>
+/// One page of an AI tool tab. Its view model is built the first time the page
+/// is shown and kept afterwards, so a half-written prompt survives a look at
+/// something else while a page nobody opens never talks to the server. Pages
+/// belong to their own tab: a second tab is a second workbench, not a mirror.
+/// </summary>
+internal sealed class AiWorkspaceSectionViewModel : IAsyncDisposable
+{
+    private readonly Func<IAsyncDisposable> _create;
+    private readonly object _disposeGate = new();
+    private IAsyncDisposable? _content;
+    private Task? _disposeTask;
+    private bool _disposed;
+
+    internal AiWorkspaceSectionViewModel(
+        AiWorkspaceSection id,
+        string displayName,
+        Icon icon,
+        Func<IAsyncDisposable> create)
+    {
+        Id = id;
+        DisplayName = displayName;
+        Icon = icon;
+        _create = create;
+    }
+
+    public AiWorkspaceSection Id { get; }
+
+    public string DisplayName { get; }
+
+    public Icon Icon { get; }
+
+    internal object? Content => _content;
+
+    internal object EnsureContent()
+    {
+        lock (_disposeGate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return _content ??= _create();
+        }
+    }
+
+    public ValueTask DisposeAsync() => new(BeginDisposeAsync());
+
+    private Task BeginDisposeAsync()
+    {
+        lock (_disposeGate)
+        {
+            if (_disposeTask is not null)
+                return _disposeTask;
+
+            _disposed = true;
+            var completion = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _disposeTask = completion.Task;
+            _ = CompleteDisposeAsync(completion);
+            return completion.Task;
+        }
+    }
+
+    private async Task CompleteDisposeAsync(TaskCompletionSource completion)
+    {
+        try
+        {
+            await DisposeCoreAsync();
+            completion.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
+        }
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        IAsyncDisposable? content;
+        lock (_disposeGate)
+        {
+            content = _content;
+            _content = null;
+        }
+
+        if (content is not null)
+            await content.DisposeAsync();
+    }
+}
+
+/// <summary>
+/// An AI tool tab. The five AI workflows used to be five dock tabs, which pushed
+/// everything else off the tab strip; they are pages of this one tab now, and a
+/// second tab can be opened when two of them are needed at once.
+/// </summary>
+internal sealed class AiWorkspaceViewModel : IToolContext, IAsyncDisposable
+{
+    private readonly CompositeDisposable _disposables = [];
+    private readonly EditViewModel _editViewModel;
+    private readonly AiWorkspaceSectionViewModel[] _sections;
+    private readonly object _disposeGate = new();
+    private Task? _disposeTask;
+    private bool _disposed;
+
+    internal AiWorkspaceViewModel(
+        EditViewModel editViewModel,
+        Func<AiWorkspaceSection, IAsyncDisposable> createPage)
+    {
+        ArgumentNullException.ThrowIfNull(editViewModel);
+        ArgumentNullException.ThrowIfNull(createPage);
+
+        _editViewModel = editViewModel;
+
+        // Making comes first and the history reads back over it, so the pages run
+        // in that order rather than in the order the menu lists them.
+        _sections =
+        [
+            Section(AiWorkspaceSection.ImageGeneration, Strings.AiImageGeneration, Icon.SparkleCircle),
+            Section(AiWorkspaceSection.ImageEdit, Strings.AiImageEdit, Icon.ImageEdit),
+            Section(AiWorkspaceSection.VideoGeneration, Strings.AiVideoGeneration, Icon.Video),
+            Section(AiWorkspaceSection.Subtitles, Strings.AiSubtitle, Icon.Subtitles),
+            Section(AiWorkspaceSection.Jobs, Strings.AiJobCenter, Icon.History),
+        ];
+
+        SelectedSection = new ReactivePropertySlim<AiWorkspaceSectionViewModel?>(_sections[0])
+            .DisposeWith(_disposables);
+
+        // The selector can report null for an instant while its items are handed
+        // over; keeping the last page on screen through that avoids a blank flash.
+        IObservable<AiWorkspaceSectionViewModel> shown =
+            SelectedSection.Where(section => section is not null).Select(section => section!);
+
+        ActiveContent = shown
+            .Select(section => section.EnsureContent())
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        // A page is built once and kept, so coming back to it does not reload
+        // the model list the way opening it the first time did. Without this, a
+        // tab left in the foreground goes on offering models an operator has
+        // since withdrawn for as long as the tab lives.
+        ActiveContent
+            .Subscribe(content => (content as IAiModelListConsumer)?.RefreshModels())
+            .DisposeWith(_disposables);
+
+        // Two AI tabs side by side are told apart by the page each one is on,
+        // which is why the dock tab is named after the page rather than "AI".
+        Header = shown
+            .Select(section => section.DisplayName)
+            .ToReadOnlyReactivePropertySlim(Strings.Ai)
+            .DisposeWith(_disposables);
+
+        AiWorkspaceSectionViewModel Section(AiWorkspaceSection id, string displayName, Icon icon)
+            => new(id, displayName, icon, () => createPage(id));
+    }
+
+    public ToolTabExtension Extension => AiWorkspaceTabExtension.Instance;
+
+    public IReactiveProperty<bool> IsSelected { get; } = new ReactivePropertySlim<bool>();
+
+    public IReadOnlyReactiveProperty<string> Header { get; }
+
+    internal IReadOnlyList<AiWorkspaceSectionViewModel> Sections => _sections;
+
+    internal ReactivePropertySlim<AiWorkspaceSectionViewModel?> SelectedSection { get; }
+
+    public ReadOnlyReactivePropertySlim<object?> ActiveContent { get; }
+
+    /// <summary>
+    /// Brings a page to the front of this tab and hands back its view model,
+    /// building it if this is the first look at that page.
+    /// </summary>
+    internal object Show(AiWorkspaceSection section)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        AiWorkspaceSectionViewModel target = _sections.First(item => item.Id == section);
+        SelectedSection.Value = target;
+        return target.EnsureContent();
+    }
+
+    public object? GetService(Type serviceType)
+    {
+        ArgumentNullException.ThrowIfNull(serviceType);
+        return serviceType.IsInstanceOfType(this)
+            ? this
+            : _editViewModel.GetService(serviceType);
+    }
+
+    public void ReadFromJson(JsonObject json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+
+        // Which page, and nothing from inside it: prompts and generated content
+        // are deliberately kept out of the persisted dock layout.
+        if (json["section"] is JsonValue value
+            && value.TryGetValue(out string? name)
+            && Enum.TryParse(name, out AiWorkspaceSection section))
+        {
+            Show(section);
+        }
+    }
+
+    public void WriteToJson(JsonObject json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+        if (SelectedSection.Value is { } section)
+        {
+            json["section"] = section.Id.ToString();
+        }
+    }
+
+    public ValueTask DisposeAsync() => new(BeginDisposeAsync());
+
+    public void Dispose() => _ = BeginDisposeAsync();
+
+    private Task BeginDisposeAsync()
+    {
+        lock (_disposeGate)
+        {
+            if (_disposeTask is not null)
+                return _disposeTask;
+
+            _disposed = true;
+            var completion = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _disposeTask = completion.Task;
+            _ = CompleteDisposeAsync(completion);
+            return completion.Task;
+        }
+    }
+
+    private async Task CompleteDisposeAsync(TaskCompletionSource completion)
+    {
+        try
+        {
+            await DisposeCoreAsync();
+            completion.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
+        }
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        _disposables.Dispose();
+        IsSelected.Dispose();
+        Task[] disposals = _sections
+            .Select(section => section.DisposeAsync().AsTask())
+            .ToArray();
+        await Task.WhenAll(disposals);
+    }
+}

--- a/src/Beutl/Views/MacWindow.axaml.cs
+++ b/src/Beutl/Views/MacWindow.axaml.cs
@@ -422,6 +422,8 @@ public sealed partial class MacWindow : Window
 
     private bool _captureStopped;
     private Task? _captureStopTask;
+    private bool _viewModelDisposed;
+    private Task? _viewModelDisposeTask;
 
     protected override void OnClosing(WindowClosingEventArgs e)
     {
@@ -443,13 +445,14 @@ public sealed partial class MacWindow : Window
             }
         }
 
-        if (DataContext is MainViewModel viewModel)
+        if (!_viewModelDisposed && DataContext is MainViewModel viewModel)
         {
-            if (!viewModel.TryDisposeForWindowClose())
+            e.Cancel = true;
+            if (_viewModelDisposeTask is null && viewModel.TryDisposeForWindowClose())
             {
-                e.Cancel = true;
-                return;
+                _viewModelDisposeTask = DisposeViewModelAndCloseAsync(viewModel);
             }
+            return;
         }
 
         base.OnClosing(e);
@@ -459,11 +462,34 @@ public sealed partial class MacWindow : Window
         viewConfig.IsWindowMaximized = WindowState == WindowState.Maximized;
     }
 
+    private async Task DisposeViewModelAndCloseAsync(MainViewModel viewModel)
+    {
+        try
+        {
+            await viewModel.WaitForDisposalAsync();
+        }
+        finally
+        {
+            _viewModelDisposed = true;
+            Close();
+        }
+    }
+
     private async Task StopCaptureAndCloseAsync(MainView mv)
     {
-        await mv.EnsureCaptureStoppedAsync();
-        _captureStopped = true;
-        Close();
+        try
+        {
+            await mv.EnsureCaptureStoppedAsync();
+        }
+        catch (Exception ex)
+        {
+            await ex.Handle();
+        }
+        finally
+        {
+            _captureStopped = true;
+            Close();
+        }
     }
 
     private async void OpenTutorialsDialog(object? sender, EventArgs e) => await mainView.ShowTutorialsDialogAsync();

--- a/src/Beutl/Views/MainView.axaml
+++ b/src/Beutl/Views/MainView.axaml
@@ -35,7 +35,7 @@
     <Grid RowDefinitions="Auto,1,*">
         <Grid x:Name="Titlebar"
               Background="Transparent"
-              ColumnDefinitions="Auto,Auto,Auto,*">
+              ColumnDefinitions="Auto,Auto,*,Auto">
             <Image Name="WindowIcon"
                    MaxWidth="24"
                    MaxHeight="24"
@@ -195,8 +195,40 @@
                         <MenuItem Command="{CompiledBinding MenuBar.PasteLayer}" Header="{x:Static lang:Strings.Paste}" />
                     </MenuItem>
                 </MenuItem>
-                <!--  オブジェクト  -->
-                <MenuItem Header="{x:Static lang:Strings.Object}" />
+                <!--  AI  -->
+                <MenuItem Header="{x:Static lang:Strings.Ai}">
+                    <MenuItem Command="{CompiledBinding MenuBar.ShowAiJobs}"
+                              Header="{x:Static lang:Strings.AiJobCenter}">
+                        <MenuItem.Icon>
+                            <icons:FluentIcon Icon="History" />
+                        </MenuItem.Icon>
+                    </MenuItem>
+                    <Separator />
+                    <MenuItem Command="{CompiledBinding MenuBar.GenerateImage}"
+                              Header="{x:Static lang:Strings.AiGenerateImage}">
+                        <MenuItem.Icon>
+                            <icons:FluentIcon Icon="SparkleCircle" />
+                        </MenuItem.Icon>
+                    </MenuItem>
+                    <MenuItem Command="{CompiledBinding MenuBar.GenerateSubtitles}"
+                              Header="{x:Static lang:Strings.AiGenerateSubtitles}">
+                        <MenuItem.Icon>
+                            <icons:FluentIcon Icon="Subtitles" />
+                        </MenuItem.Icon>
+                    </MenuItem>
+                    <MenuItem Command="{CompiledBinding MenuBar.EditImage}"
+                              Header="{x:Static lang:Strings.AiEditImage}">
+                        <MenuItem.Icon>
+                            <icons:FluentIcon Icon="ImageEdit" />
+                        </MenuItem.Icon>
+                    </MenuItem>
+                    <MenuItem Command="{CompiledBinding MenuBar.GenerateVideo}"
+                              Header="{x:Static lang:Strings.AiGenerateVideo}">
+                        <MenuItem.Icon>
+                            <icons:FluentIcon Icon="Video" />
+                        </MenuItem.Icon>
+                    </MenuItem>
+                </MenuItem>
                 <!--  ヘルプ  -->
                 <MenuItem Header="{x:Static lang:Strings.Help}">
                     <MenuItem Click="OpenTutorialsDialog" Header="{x:Static lang:Strings.Tutorials}" />
@@ -225,6 +257,7 @@
                         Spacing="8">
                 <views:TitleBreadcrumbBar Name="TitleBreadcrumbBar"
                                           Margin="8,0,0,0"
+                                          MinWidth="0"
                                           wnd:AppWindow.AllowInteractionInTitleBar="True"
                                           DataContext="{Binding TitleBreadcrumbBar}" />
                 <views:TitleBarBranchView x:Name="TitleBarBranchWidget"
@@ -233,7 +266,8 @@
                                           DataContext="{Binding TitleBarBranch}" />
             </StackPanel>
 
-            <StackPanel Grid.Column="3"
+            <StackPanel x:Name="TitlebarActions"
+                        Grid.Column="3"
                         Margin="0,0,4,0"
                         HorizontalAlignment="Right"
                         Orientation="Horizontal"

--- a/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
+++ b/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
@@ -16,6 +16,7 @@ using Beutl.Editor.VersionControl;
 using Beutl.Models;
 using Beutl.ProjectSystem;
 using Beutl.Services;
+using Beutl.Services.PrimitiveImpls;
 using Beutl.ViewModels;
 using Beutl.ViewModels.Dialogs;
 using Beutl.Views.Dialogs;
@@ -77,6 +78,11 @@ public partial class MainView
         viewModel.MenuBar.ImportProject.Subscribe(OnImportProject).AddTo(_disposables);
 
         InitializeDockLayoutPresetMenu(viewModel);
+        viewModel.MenuBar.ShowAiJobs.Subscribe(viewModel.OpenAiJobCenter).AddTo(_disposables);
+        viewModel.MenuBar.GenerateImage.Subscribe(viewModel.OpenAiImageGeneration).AddTo(_disposables);
+        viewModel.MenuBar.GenerateSubtitles.Subscribe(() => viewModel.OpenAiSubtitle()).AddTo(_disposables);
+        viewModel.MenuBar.EditImage.Subscribe(viewModel.OpenAiImageEdit).AddTo(_disposables);
+        viewModel.MenuBar.GenerateVideo.Subscribe(viewModel.OpenAiVideoGeneration).AddTo(_disposables);
     }
 
     private void InitializeDockLayoutPresetMenu(MainViewModel viewModel)

--- a/src/Beutl/Views/MainWindow.axaml.cs
+++ b/src/Beutl/Views/MainWindow.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Platform;
 
 using Beutl.Configuration;
+using Beutl.Services;
 using Beutl.ViewModels;
 
 using FluentAvalonia.UI.Windowing;
@@ -64,6 +65,8 @@ public sealed partial class MainWindow : AppWindow
 
     private bool _captureStopped;
     private Task? _captureStopTask;
+    private bool _viewModelDisposed;
+    private Task? _viewModelDisposeTask;
 
     protected override void OnClosing(WindowClosingEventArgs e)
     {
@@ -85,13 +88,14 @@ public sealed partial class MainWindow : AppWindow
             }
         }
 
-        if (DataContext is MainViewModel viewModel)
+        if (!_viewModelDisposed && DataContext is MainViewModel viewModel)
         {
-            if (!viewModel.TryDisposeForWindowClose())
+            e.Cancel = true;
+            if (_viewModelDisposeTask is null && viewModel.TryDisposeForWindowClose())
             {
-                e.Cancel = true;
-                return;
+                _viewModelDisposeTask = DisposeViewModelAndCloseAsync(viewModel);
             }
+            return;
         }
 
         base.OnClosing(e);
@@ -101,10 +105,33 @@ public sealed partial class MainWindow : AppWindow
         viewConfig.IsWindowMaximized = WindowState == WindowState.Maximized;
     }
 
+    private async Task DisposeViewModelAndCloseAsync(MainViewModel viewModel)
+    {
+        try
+        {
+            await viewModel.WaitForDisposalAsync();
+        }
+        finally
+        {
+            _viewModelDisposed = true;
+            Close();
+        }
+    }
+
     private async Task StopCaptureAndCloseAsync(MainView mv)
     {
-        await mv.EnsureCaptureStoppedAsync();
-        _captureStopped = true;
-        Close();
+        try
+        {
+            await mv.EnsureCaptureStoppedAsync();
+        }
+        catch (Exception ex)
+        {
+            await ex.Handle();
+        }
+        finally
+        {
+            _captureStopped = true;
+            Close();
+        }
     }
 }

--- a/src/Beutl/Views/PlayerView.axaml.DragDrop.cs
+++ b/src/Beutl/Views/PlayerView.axaml.DragDrop.cs
@@ -1,6 +1,8 @@
 ﻿using Avalonia.Input;
 using Avalonia.Platform.Storage;
+using Beutl.Editor.Components.TimelineTab.ViewModels;
 using Beutl.Editor.Models;
+using Beutl.Editor.Services;
 using Beutl.Engine;
 using Beutl.Graphics;
 using Beutl.Graphics.Effects;
@@ -8,8 +10,10 @@ using Beutl.Graphics.Rendering;
 using Beutl.Graphics.Transformation;
 using Beutl.Helpers;
 using Beutl.ProjectSystem;
+using Beutl.Services;
 using Beutl.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using AvaPoint = Avalonia.Point;
 
 namespace Beutl.Views;
@@ -87,7 +91,6 @@ public partial class PlayerView
                 return elements.Length == 0 ? 0 : elements.Max(v => v.ZIndex) + 1;
             }
 
-            var adder = editViewModel.GetRequiredService<IElementAdder>();
             if (e.DataTransfer.TryGetValue(BeutlDataFormats.EngineObject) is { } typeName
                 && TypeFormat.ToType(typeName) is { } type)
             {
@@ -95,20 +98,80 @@ public partial class PlayerView
 
                 int zindex = CalculateZIndex(scene);
 
-                adder.AddElement(new ElementDescription(
+                await AddElement(editViewModel, new ElementDescription(
                     frame, TimeSpan.FromSeconds(5), zindex,
-                    EngineObjectFactory: () => (EngineObject)Activator.CreateInstance(type)!,
+                    new ElementSource.EngineObject(() => (EngineObject)Activator.CreateInstance(type)!),
                     Position: centeredPosition));
             }
             else if (e.DataTransfer.TryGetFile()?.TryGetLocalPath() is { } fileName)
             {
                 int zindex = CalculateZIndex(scene);
 
-                adder.AddElement(new ElementDescription(
-                    frame, TimeSpan.FromSeconds(5), zindex, FileName: fileName, Position: centeredPosition));
+                await AddElement(editViewModel, new ElementDescription(
+                    frame,
+                    TimeSpan.FromSeconds(5),
+                    zindex,
+                    new ElementSource.File(fileName),
+                    Position: centeredPosition));
 
                 e.Handled = true;
             }
+        }
+    }
+
+    internal async Task AddElement(EditViewModel editViewModel, ElementDescription description)
+    {
+        if (editViewModel.FindToolTab<TimelineTabViewModel>() is { } timeline)
+        {
+            try
+            {
+                await timeline.AddElement.ExecuteAsync(description);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+            return;
+        }
+
+        ElementAddResult? result = await AddPlayerDropAsync(
+            editViewModel.GetRequiredService<IElementAdder>(),
+            description);
+        if (result is null)
+            return;
+        if (result.IsSuccess)
+            return;
+
+        if (result.Failure is LockedElementLayerFailure)
+        {
+            NotificationService.ShowWarning(Strings.Lock, Strings.LayerIsLocked);
+            return;
+        }
+
+        _logger.LogError(
+            result.Failure?.Exception,
+            "Failed to add a player drop: {FailureId}",
+            result.Failure?.Id);
+        NotificationService.ShowError(Strings.AddElement, MessageStrings.UnexpectedError);
+    }
+
+    internal static async Task<ElementAddResult?> AddPlayerDropAsync(
+        IElementAdder elementAdder,
+        ElementDescription description)
+    {
+        try
+        {
+            return await elementAdder.AddAsync([description], CancellationToken.None);
+        }
+        catch (OperationCanceledException)
+        {
+            return null;
+        }
+        catch (ObjectDisposedException)
+        {
+            return null;
         }
     }
 

--- a/src/Beutl/Views/Tools/AiImageEditView.axaml
+++ b/src/Beutl/Views/Tools/AiImageEditView.axaml
@@ -1,0 +1,214 @@
+﻿<UserControl x:Class="Beutl.Views.Tools.AiImageEditView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:btl="using:Beutl.Controls"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
+             xmlns:ai="using:Beutl.Services.AI"
+             xmlns:lang="using:Beutl.Language"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:tools="using:Beutl.Views.Tools"
+             xmlns:vm="using:Beutl.ViewModels.Dialogs"
+             d:DesignHeight="640"
+             d:DesignWidth="480"
+             x:CompileBindings="True"
+             x:DataType="vm:AiImageEditDialogViewModel"
+             mc:Ignorable="d">
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled">
+        <StackPanel Margin="12,10" Spacing="8">
+            <Border Padding="8"
+                    Background="{DynamicResource ControlFillColorDefaultBrush}"
+                    CornerRadius="4"
+                    IsVisible="{CompiledBinding RecoveryAvailable.Value}">
+                <StackPanel Spacing="6">
+                    <TextBlock Text="{x:Static lang:Strings.AiPendingRequest}" TextWrapping="Wrap" />
+                    <ComboBox AutomationProperties.Name="{x:Static lang:Strings.AiPendingRequest}"
+                              ItemsSource="{CompiledBinding RecoveryAttempts.Value}"
+                              SelectedItem="{CompiledBinding SelectedRecoveryAttempt.Value}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate x:DataType="ai:AiPendingAttempt">
+                                <TextBlock Text="{CompiledBinding DisplayName}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                    <WrapPanel Orientation="Horizontal">
+                        <Button Margin="0,0,6,0"
+                                Command="{CompiledBinding RecoverSelectedAttempt}"
+                                Content="{x:Static lang:Strings.AiRecoverRequest}" />
+                        <Button Command="{CompiledBinding AbandonSelectedAttempt}"
+                                Content="{x:Static lang:Strings.AiAbandonRequest}" />
+                    </WrapPanel>
+                </StackPanel>
+            </Border>
+            <StackPanel Spacing="4">
+                <TextBlock Text="{x:Static lang:Strings.AiEditSourceImage}" />
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBox AutomationProperties.Name="{x:Static lang:Strings.AiEditSourceImage}"
+                             IsReadOnly="True"
+                             Text="{CompiledBinding SourceFilePath.Value}"
+                             Watermark="{x:Static lang:Strings.AiEditNoSourceSelected}" />
+                    <Button Grid.Column="1"
+                            Margin="8,0,0,0"
+                            AutomationProperties.Name="{x:Static lang:Strings.AiEditBrowse}"
+                            Command="{CompiledBinding SelectSourceFileCommand}"
+                            Content="{x:Static lang:Strings.AiEditBrowse}"
+                            ToolTip.Tip="{x:Static lang:Strings.AiEditBrowse}" />
+                </Grid>
+            </StackPanel>
+
+            <StackPanel Spacing="4">
+                <TextBlock Text="{x:Static lang:Strings.AiEditTask}" />
+                <ComboBox x:Name="TaskPicker"
+                          HorizontalAlignment="Stretch"
+                          AutomationProperties.Name="{x:Static lang:Strings.AiEditTask}"
+                          ItemsSource="{CompiledBinding Tasks}"
+                          SelectedItem="{CompiledBinding SelectedTask.Value}" />
+            </StackPanel>
+
+            <!--  The models follow the selected task, which is its own operation.  -->
+            <StackPanel IsVisible="{CompiledBinding ModelPicker.HasChoice.Value}" Spacing="4">
+                <TextBlock Text="{x:Static lang:Strings.AiModel}" />
+                <ComboBox HorizontalAlignment="Stretch"
+                          AutomationProperties.Name="{x:Static lang:Strings.AiModel}"
+                          ItemsSource="{CompiledBinding ModelPicker.Options}"
+                          SelectedItem="{CompiledBinding ModelPicker.Selected.Value}"
+                          IsEnabled="{CompiledBinding ModelPicker.IsSelectionEnabled.Value}" />
+            </StackPanel>
+
+            <StackPanel IsVisible="{CompiledBinding RequiresPrompt.Value}" Spacing="4">
+                <Expander Header="{x:Static lang:Strings.AiPromptTemplates}">
+                    <tools:AiPromptTemplatesView Margin="0,8,0,0"
+                                                 DataContext="{CompiledBinding PromptLibrary}" />
+                </Expander>
+                <!--  The history button sits over the box it fills in, so reaching for an
+                      earlier prompt does not mean opening the templates panel below.  -->
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBlock VerticalAlignment="Center" Text="{x:Static lang:Strings.AiPrompt}" />
+                    <tools:AiPromptHistoryButton Grid.Column="1"
+                                                 DataContext="{CompiledBinding PromptLibrary}" />
+                </Grid>
+                <TextBox AcceptsReturn="True"
+                         AutomationProperties.Name="{x:Static lang:Strings.AiPrompt}"
+                         Height="72"
+                         MaxLength="4000"
+                         Text="{CompiledBinding Prompt.Value}"
+                         TextWrapping="Wrap"
+                         Watermark="{CompiledBinding PromptWatermark.Value}" />
+                <TextBlock AutomationProperties.LiveSetting="Assertive"
+                           Foreground="{DynamicResource SystemFillColorCautionBrush}"
+                           IsVisible="{CompiledBinding VisiblePromptValidationError.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
+                           Text="{CompiledBinding VisiblePromptValidationError.Value}"
+                           TextWrapping="Wrap" />
+                <StackPanel IsVisible="{CompiledBinding ShowOutpaintExpansion.Value}" Spacing="4">
+                    <TextBlock Text="{x:Static lang:Strings.AiEditOutpaintExpansion}" />
+                    <ComboBox AutomationProperties.Name="{x:Static lang:Strings.AiEditOutpaintExpansion}"
+                              ItemsSource="{CompiledBinding OutpaintExpansionOptions}"
+                              SelectedItem="{CompiledBinding SelectedOutpaintExpansion.Value}" />
+                </StackPanel>
+            </StackPanel>
+
+            <StackPanel IsVisible="{CompiledBinding ResultImage.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
+                        Spacing="4">
+                <TextBlock Text="{x:Static lang:Strings.AiPreviewMode}" />
+                <ComboBox HorizontalAlignment="Stretch"
+                          AutomationProperties.Name="{x:Static lang:Strings.AiPreviewMode}"
+                          ItemsSource="{CompiledBinding ComparisonModes}"
+                          SelectedItem="{CompiledBinding SelectedComparisonMode.Value}" />
+            </StackPanel>
+
+            <StackPanel Spacing="8">
+                <StackPanel IsVisible="{CompiledBinding Usage.HasSnapshot.Value}" Spacing="4">
+                    <tools:AiUsageSummaryView DataContext="{CompiledBinding Usage}" />
+                    <tools:AiUsageEstimateView DataContext="{CompiledBinding EstimatedUsage}" />
+                </StackPanel>
+                <Grid ColumnDefinitions="*,Auto">
+                    <Button HorizontalAlignment="Stretch"
+                            AutomationProperties.Name="{x:Static lang:Strings.AiEditRun}"
+                            Classes="accent"
+                            Command="{CompiledBinding Edit}"
+                            Content="{x:Static lang:Strings.AiEditRun}"
+                            IsEnabled="{CompiledBinding CanEdit.Value}"
+                            ToolTip.Tip="{x:Static lang:Strings.AiEditRun}" />
+                    <Button Grid.Column="1"
+                            Margin="8,0,0,0"
+                            AutomationProperties.Name="{x:Static lang:Strings.Cancel}"
+                            Command="{CompiledBinding StopEditing}"
+                            Content="{x:Static lang:Strings.Cancel}"
+                            IsVisible="{CompiledBinding IsEditing.Value}" />
+                </Grid>
+            </StackPanel>
+
+            <Border Height="320"
+                    Background="{DynamicResource ControlFillColorDefaultBrush}"
+                    CornerRadius="8"
+                    IsVisible="{CompiledBinding !ShowPreviewPlaceholder.Value}">
+                <Grid>
+                    <btl:BitmapView Stretch="Uniform"
+                                    IsVisible="{CompiledBinding ShowOriginalPreview.Value}"
+                                    Source="{CompiledBinding OriginalImage.Value}" />
+                    <btl:BitmapView Stretch="Uniform"
+                                    IsVisible="{CompiledBinding ShowResultPreview.Value}"
+                                    Source="{CompiledBinding ResultImage.Value}" />
+                    <Grid ColumnDefinitions="*,8,*"
+                          IsVisible="{CompiledBinding ShowSideBySidePreview.Value}">
+                        <Border Grid.Column="0"
+                                BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
+                                BorderThickness="1"
+                                CornerRadius="4">
+                            <btl:BitmapView Stretch="Uniform"
+                                            Source="{CompiledBinding OriginalImage.Value}" />
+                        </Border>
+                        <Border Grid.Column="2"
+                                BorderBrush="{DynamicResource AccentFillColorDefaultBrush}"
+                                BorderThickness="1"
+                                CornerRadius="4">
+                            <btl:BitmapView Stretch="Uniform"
+                                            Source="{CompiledBinding ResultImage.Value}" />
+                        </Border>
+                    </Grid>
+                </Grid>
+            </Border>
+
+            <Border Padding="16"
+                    Background="{DynamicResource ControlFillColorDefaultBrush}"
+                    CornerRadius="8"
+                    IsVisible="{CompiledBinding ShowPreviewPlaceholder.Value}">
+                <StackPanel HorizontalAlignment="Center" Spacing="8">
+                    <icons:FluentIcon HorizontalAlignment="Center"
+                                      FontSize="24"
+                                      Icon="ImageEdit"
+                                      Opacity="0.6" />
+                    <TextBlock HorizontalAlignment="Center"
+                               Opacity="0.6"
+                               Text="{x:Static lang:Strings.AiImageEditIdle}"
+                               TextAlignment="Center"
+                               TextWrapping="Wrap" />
+                </StackPanel>
+            </Border>
+
+            <TextBlock AutomationProperties.LiveSetting="Assertive"
+                       AutomationProperties.Name="{CompiledBinding Error.Value}"
+                       Foreground="{DynamicResource SystemFillColorCautionBrush}"
+                       IsVisible="{CompiledBinding Error.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
+                       Text="{CompiledBinding Error.Value}"
+                       TextWrapping="Wrap" />
+
+            <StackPanel IsVisible="{CompiledBinding ShowJoinPro.Value}" Spacing="8">
+                <TextBlock Text="{x:Static lang:Strings.AiProRequired}"
+                           TextWrapping="Wrap" />
+                <Button HorizontalAlignment="Left"
+                        Command="{CompiledBinding OpenAiPlan}"
+                        Content="{x:Static lang:Strings.AiJoinPro}" />
+            </StackPanel>
+
+            <WrapPanel IsVisible="{CompiledBinding CanAddToScene.Value}" Orientation="Horizontal">
+                <Button Margin="0,0,8,8"
+                        Command="{CompiledBinding AddToScene}"
+                        Content="{x:Static lang:Strings.AiAddToScene}" />
+                <Button Margin="0,0,0,8"
+                        Command="{CompiledBinding SaveToFile}"
+                        Content="{x:Static lang:Strings.AiSaveToFile}" />
+            </WrapPanel>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/Beutl/Views/Tools/AiImageEditView.axaml.cs
+++ b/src/Beutl/Views/Tools/AiImageEditView.axaml.cs
@@ -1,0 +1,26 @@
+﻿using Avalonia.Controls;
+using Beutl.ViewModels.Dialogs;
+
+namespace Beutl.Views.Tools;
+
+public partial class AiImageEditView : UserControl
+{
+    private IDisposable? _planReturnRefresh;
+
+    public AiImageEditView()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        _planReturnRefresh?.Dispose();
+        _planReturnRefresh = DataContext is AiImageEditDialogViewModel viewModel
+            ? AiPlanReturnRefresh.Attach(
+                this,
+                viewModel.AiPlanCoordinator,
+                viewModel.RefreshModels)
+            : null;
+    }
+}

--- a/src/Beutl/Views/Tools/AiImageGenerationView.axaml
+++ b/src/Beutl/Views/Tools/AiImageGenerationView.axaml
@@ -1,0 +1,265 @@
+﻿<UserControl x:Class="Beutl.Views.Tools.AiImageGenerationView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:btl="using:Beutl.Controls"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
+             xmlns:ai="using:Beutl.Services.AI"
+             xmlns:lang="using:Beutl.Language"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:tools="using:Beutl.Views.Tools"
+             xmlns:vm="using:Beutl.ViewModels.Dialogs"
+             d:DesignHeight="640"
+             d:DesignWidth="480"
+             x:CompileBindings="True"
+             x:DataType="vm:AiImageGenerationDialogViewModel"
+             mc:Ignorable="d">
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled">
+        <StackPanel Margin="12,10" Spacing="8">
+            <Border Padding="8"
+                    Background="{DynamicResource ControlFillColorDefaultBrush}"
+                    CornerRadius="4"
+                    IsVisible="{CompiledBinding RecoveryAvailable.Value}">
+                <StackPanel Spacing="6">
+                    <TextBlock Text="{x:Static lang:Strings.AiPendingRequest}" TextWrapping="Wrap" />
+                    <ComboBox AutomationProperties.Name="{x:Static lang:Strings.AiPendingRequest}"
+                              ItemsSource="{CompiledBinding RecoveryAttempts.Value}"
+                              SelectedItem="{CompiledBinding SelectedRecoveryAttempt.Value}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate x:DataType="ai:AiPendingAttempt">
+                                <TextBlock Text="{CompiledBinding DisplayName}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                    <WrapPanel Orientation="Horizontal">
+                        <Button Margin="0,0,6,0"
+                                Command="{CompiledBinding RecoverSelectedAttempt}"
+                                Content="{x:Static lang:Strings.AiRecoverRequest}" />
+                        <Button Command="{CompiledBinding AbandonSelectedAttempt}"
+                                Content="{x:Static lang:Strings.AiAbandonRequest}" />
+                    </WrapPanel>
+                </StackPanel>
+            </Border>
+            <Expander Header="{x:Static lang:Strings.AiPromptTemplates}">
+                <tools:AiPromptTemplatesView Margin="0,8,0,0"
+                                             DataContext="{CompiledBinding PromptLibrary}" />
+            </Expander>
+
+            <StackPanel Spacing="4">
+                <!--  The history button sits over the box it fills in, so reaching for an
+                      earlier prompt does not mean opening the templates panel below.  -->
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBlock VerticalAlignment="Center" Text="{x:Static lang:Strings.AiPrompt}" />
+                    <tools:AiPromptHistoryButton Grid.Column="1"
+                                                 DataContext="{CompiledBinding PromptLibrary}" />
+                </Grid>
+                <TextBox AcceptsReturn="True"
+                         AutomationProperties.Name="{x:Static lang:Strings.AiPrompt}"
+                         Height="80"
+                         MaxLength="4000"
+                         Text="{CompiledBinding Prompt.Value}"
+                         TextWrapping="Wrap"
+                         Watermark="{x:Static lang:Strings.AiPrompt_Placeholder}" />
+                <TextBlock AutomationProperties.LiveSetting="Assertive"
+                           Foreground="{DynamicResource SystemFillColorCautionBrush}"
+                           IsVisible="{CompiledBinding VisiblePromptValidationError.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
+                           Text="{CompiledBinding VisiblePromptValidationError.Value}"
+                           TextWrapping="Wrap" />
+            </StackPanel>
+
+            <!--  One field per row: the tab is docked at whatever width there is, and a
+                  half-width box trims a model name away to nothing.  -->
+            <StackPanel x:Name="AspectRatioField" Spacing="4">
+                <TextBlock Text="{x:Static lang:Strings.AiAspectRatio}" />
+                <ComboBox HorizontalAlignment="Stretch"
+                          AutomationProperties.Name="{x:Static lang:Strings.AiAspectRatio}"
+                          ItemsSource="{CompiledBinding AspectRatioOptions}"
+                          SelectedItem="{CompiledBinding SelectedAspectRatio.Value}" />
+            </StackPanel>
+
+            <!--  Hidden when the operation offers a single model: there is nothing to choose.  -->
+            <StackPanel x:Name="ModelField"
+                        IsVisible="{CompiledBinding ModelPicker.HasChoice.Value}"
+                        Spacing="4">
+                <TextBlock Text="{x:Static lang:Strings.AiModel}" />
+                <ComboBox HorizontalAlignment="Stretch"
+                          AutomationProperties.Name="{x:Static lang:Strings.AiModel}"
+                          ItemsSource="{CompiledBinding ModelPicker.Options}"
+                          SelectedItem="{CompiledBinding ModelPicker.Selected.Value}"
+                          IsEnabled="{CompiledBinding ModelPicker.IsSelectionEnabled.Value}" />
+            </StackPanel>
+
+            <!--  Hidden for a model that publishes no background of its own: there is
+                  nothing to choose, and asking for one would be refused.  -->
+            <StackPanel IsVisible="{CompiledBinding HasBackgroundChoice.Value}" Spacing="4">
+                <TextBlock Text="{x:Static lang:Strings.AiBackground}" />
+                <ComboBox HorizontalAlignment="Stretch"
+                          AutomationProperties.Name="{x:Static lang:Strings.AiBackground}"
+                          ItemsSource="{CompiledBinding BackgroundOptions}"
+                          SelectedItem="{CompiledBinding SelectedBackground.Value}" />
+            </StackPanel>
+
+            <Expander Header="{x:Static lang:Strings.AiPromptDetails}">
+                <StackPanel Margin="0,8,0,0" Spacing="8">
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="{x:Static lang:Strings.AiPromptStyle}" />
+                        <TextBox AutomationProperties.Name="{x:Static lang:Strings.AiPromptStyle}"
+                                 MaxLength="4000"
+                                 Text="{CompiledBinding Style.Value}"
+                                 Watermark="{x:Static lang:Strings.AiPromptStylePlaceholder}" />
+                    </StackPanel>
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="{x:Static lang:Strings.AiPromptComposition}" />
+                        <TextBox AutomationProperties.Name="{x:Static lang:Strings.AiPromptComposition}"
+                                 MaxLength="4000"
+                                 Text="{CompiledBinding Composition.Value}"
+                                 Watermark="{x:Static lang:Strings.AiPromptCompositionPlaceholder}" />
+                    </StackPanel>
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="{x:Static lang:Strings.AiPromptAvoid}" />
+                        <TextBox AutomationProperties.Name="{x:Static lang:Strings.AiPromptAvoid}"
+                                 MaxLength="4000"
+                                 Text="{CompiledBinding Exclusions.Value}"
+                                 Watermark="{x:Static lang:Strings.AiPromptAvoidPlaceholder}" />
+                    </StackPanel>
+                    <StackPanel IsVisible="{CompiledBinding SupportsSeed.Value}" Spacing="4">
+                        <TextBlock Text="{x:Static lang:Strings.AiPromptSeed}" />
+                        <NumericUpDown AutomationProperties.Name="{x:Static lang:Strings.AiPromptSeed}"
+                                       FormatString="0"
+                                       Maximum="{CompiledBinding SeedMaximum}"
+                                       Minimum="{CompiledBinding SeedMinimum}"
+                                       Value="{CompiledBinding Seed.Value}"
+                                       Watermark="{x:Static lang:Strings.AiPromptSeedPlaceholder}" />
+                    </StackPanel>
+                </StackPanel>
+            </Expander>
+
+            <Expander Header="{x:Static lang:Strings.AiReferenceImageHeader}"
+                      IsVisible="{CompiledBinding SupportsReferenceImage.Value}">
+                <StackPanel Margin="0,8,0,0" Spacing="8">
+                    <TextBlock Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                               Text="{x:Static lang:Strings.AiReferenceImageDescription}"
+                               TextWrapping="Wrap" />
+                    <TextBlock Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                               Text="{CompiledBinding ReferenceImageCountText.Value}" />
+                    <!--  The order the rows are in is the order the model reads them in.  -->
+                    <ItemsControl IsVisible="{CompiledBinding HasReferenceImages.Value}"
+                                  ItemsSource="{CompiledBinding ReferenceImages}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="vm:AiReferenceImageViewModel">
+                                <Grid Margin="0,0,0,4" ColumnDefinitions="Auto,*,Auto">
+                                    <Border Width="96"
+                                            Height="96"
+                                            Background="{DynamicResource ControlFillColorDefaultBrush}"
+                                            CornerRadius="4">
+                                        <btl:BitmapView Source="{CompiledBinding Preview}" Stretch="Uniform" />
+                                    </Border>
+                                    <TextBlock Grid.Column="1"
+                                               Margin="8,0"
+                                               VerticalAlignment="Center"
+                                               MaxLines="2"
+                                               Text="{CompiledBinding FileName}"
+                                               TextTrimming="CharacterEllipsis"
+                                               TextWrapping="Wrap"
+                                               ToolTip.Tip="{CompiledBinding Path}" />
+                                    <Button Grid.Column="2"
+                                            VerticalAlignment="Center"
+                                            AutomationProperties.Name="{x:Static lang:Strings.AiRemoveReferenceImage}"
+                                            Command="{CompiledBinding Remove}"
+                                            Content="{x:Static lang:Strings.AiRemoveReferenceImage}" />
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                    <WrapPanel Orientation="Horizontal">
+                        <Button Margin="0,0,4,4"
+                                AutomationProperties.Name="{x:Static lang:Strings.AiReferenceImage}"
+                                Command="{CompiledBinding SelectReferenceImage}"
+                                Content="{x:Static lang:Strings.AiEditBrowse}"
+                                IsEnabled="{CompiledBinding CanAddReferenceImage.Value}" />
+                        <Button Margin="0,0,0,4"
+                                Command="{CompiledBinding ClearReferenceImages}"
+                                Content="{x:Static lang:Strings.AiClearReferenceImage}"
+                                IsVisible="{CompiledBinding HasReferenceImages.Value}" />
+                    </WrapPanel>
+                </StackPanel>
+            </Expander>
+
+            <StackPanel Spacing="8">
+                <StackPanel IsVisible="{CompiledBinding Usage.HasSnapshot.Value}" Spacing="4">
+                    <tools:AiUsageSummaryView DataContext="{CompiledBinding Usage}" />
+                    <tools:AiUsageEstimateView DataContext="{CompiledBinding EstimatedUsage}" />
+                </StackPanel>
+                <Grid ColumnDefinitions="*,Auto">
+                    <Button HorizontalAlignment="Stretch"
+                            Classes="accent"
+                            Command="{CompiledBinding Generate}"
+                            Content="{CompiledBinding GenerateButtonText.Value}"
+                            IsEnabled="{CompiledBinding CanGenerate.Value}" />
+                    <Button Grid.Column="1"
+                            Margin="8,0,0,0"
+                            AutomationProperties.Name="{x:Static lang:Strings.Cancel}"
+                            Command="{CompiledBinding StopGenerating}"
+                            Content="{x:Static lang:Strings.Cancel}"
+                            IsVisible="{CompiledBinding IsGenerating.Value}" />
+                </Grid>
+            </StackPanel>
+
+            <!--  The picture as far as the model has taken it, while it works.  -->
+            <Border Height="320"
+                    Background="{DynamicResource ControlFillColorDefaultBrush}"
+                    CornerRadius="8"
+                    IsVisible="{CompiledBinding PreviewImage.Value, Converter={x:Static ObjectConverters.IsNotNull}}">
+                <btl:BitmapView Stretch="Uniform" Source="{CompiledBinding PreviewImage.Value}" />
+            </Border>
+
+            <Border Height="320"
+                    Background="{DynamicResource ControlFillColorDefaultBrush}"
+                    CornerRadius="8"
+                    IsVisible="{CompiledBinding ResultImage.Value, Converter={x:Static ObjectConverters.IsNotNull}}">
+                <btl:BitmapView Stretch="Uniform" Source="{CompiledBinding ResultImage.Value}" />
+            </Border>
+
+            <Border Padding="16"
+                    Background="{DynamicResource ControlFillColorDefaultBrush}"
+                    CornerRadius="8"
+                    IsVisible="{CompiledBinding ResultImage.Value, Converter={x:Static ObjectConverters.IsNull}}">
+                <StackPanel HorizontalAlignment="Center" Spacing="8">
+                    <icons:FluentIcon HorizontalAlignment="Center"
+                                      FontSize="24"
+                                      Icon="ImageMultiple"
+                                      Opacity="0.6" />
+                    <TextBlock HorizontalAlignment="Center"
+                               Opacity="0.6"
+                               Text="{x:Static lang:Strings.AiImageGenerationIdle}"
+                               TextAlignment="Center"
+                               TextWrapping="Wrap" />
+                </StackPanel>
+            </Border>
+
+            <TextBlock AutomationProperties.LiveSetting="Assertive"
+                       AutomationProperties.Name="{CompiledBinding Error.Value}"
+                       Foreground="{DynamicResource SystemFillColorCautionBrush}"
+                       IsVisible="{CompiledBinding Error.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
+                       Text="{CompiledBinding Error.Value}"
+                       TextWrapping="Wrap" />
+
+            <StackPanel IsVisible="{CompiledBinding ShowJoinPro.Value}" Spacing="8">
+                <TextBlock Text="{x:Static lang:Strings.AiProRequired}"
+                           TextWrapping="Wrap" />
+                <Button HorizontalAlignment="Left"
+                        Command="{CompiledBinding OpenAiPlan}"
+                        Content="{x:Static lang:Strings.AiJoinPro}" />
+            </StackPanel>
+
+            <WrapPanel IsVisible="{CompiledBinding CanAddToScene.Value}" Orientation="Horizontal">
+                <Button Margin="0,0,8,8"
+                        Command="{CompiledBinding AddToScene}"
+                        Content="{x:Static lang:Strings.AiAddToScene}" />
+                <Button Margin="0,0,0,8"
+                        Command="{CompiledBinding SaveToFile}"
+                        Content="{x:Static lang:Strings.AiSaveToFile}" />
+            </WrapPanel>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/Beutl/Views/Tools/AiImageGenerationView.axaml.cs
+++ b/src/Beutl/Views/Tools/AiImageGenerationView.axaml.cs
@@ -1,0 +1,26 @@
+﻿using Avalonia.Controls;
+using Beutl.ViewModels.Dialogs;
+
+namespace Beutl.Views.Tools;
+
+public partial class AiImageGenerationView : UserControl
+{
+    private IDisposable? _planReturnRefresh;
+
+    public AiImageGenerationView()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        _planReturnRefresh?.Dispose();
+        _planReturnRefresh = DataContext is AiImageGenerationDialogViewModel viewModel
+            ? AiPlanReturnRefresh.Attach(
+                this,
+                viewModel.AiPlanCoordinator,
+                viewModel.RefreshModels)
+            : null;
+    }
+}

--- a/src/Beutl/Views/Tools/AiJobCenterView.axaml
+++ b/src/Beutl/Views/Tools/AiJobCenterView.axaml
@@ -1,0 +1,246 @@
+﻿<UserControl x:Class="Beutl.Views.Tools.AiJobCenterView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:btl="using:Beutl.Controls"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
+             xmlns:lang="using:Beutl.Language"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:tools="using:Beutl.Views.Tools"
+             xmlns:ui="using:FluentAvalonia.UI.Controls"
+             xmlns:viewModels="using:Beutl.ViewModels.Tools"
+             d:DesignHeight="640"
+             d:DesignWidth="340"
+             x:CompileBindings="True"
+             x:DataType="viewModels:AiJobCenterViewModel"
+             mc:Ignorable="d">
+    <Grid RowDefinitions="Auto,Auto,Auto,Auto,*">
+        <Grid Grid.Row="0"
+              Margin="8"
+              ColumnDefinitions="*,Auto">
+            <!--  The page selector above already names this page, so only the
+                  sentence that says what it is for is repeated here.  -->
+            <TextBlock VerticalAlignment="Center"
+                       FontSize="11"
+                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                       Text="{x:Static lang:Strings.AiJobCenter_Description}"
+                       TextWrapping="Wrap" />
+            <Button x:Name="RefreshButton"
+                    Grid.Column="1"
+                    Padding="7"
+                    AutomationProperties.Name="{x:Static lang:Strings.Refresh}"
+                    Command="{CompiledBinding Refresh}"
+                    Theme="{StaticResource TransparentButton}"
+                    ToolTip.Tip="{x:Static lang:Strings.Refresh}">
+                <icons:FluentIcon Icon="ArrowSync" />
+            </Button>
+        </Grid>
+
+        <tools:AiUsageSummaryView Grid.Row="1"
+                                  Margin="8,0"
+                                  DataContext="{CompiledBinding Usage}" />
+
+        <TextBlock Grid.Row="2"
+                   Margin="8"
+                   AutomationProperties.LiveSetting="Assertive"
+                   AutomationProperties.Name="{CompiledBinding Error.Value}"
+                   Foreground="{DynamicResource SystemFillColorCautionBrush}"
+                   IsVisible="{CompiledBinding Error.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
+                   Text="{CompiledBinding Error.Value}"
+                   TextWrapping="Wrap" />
+
+        <Border Grid.Row="3"
+                Margin="8,0,8,8"
+                Padding="10"
+                BorderBrush="{DynamicResource AccentFillColorDefaultBrush}"
+                BorderThickness="1"
+                CornerRadius="7"
+                IsVisible="{CompiledBinding IsConfirmationOpen.Value}">
+            <StackPanel Spacing="8">
+                <TextBlock FontWeight="SemiBold"
+                           Text="{CompiledBinding ConfirmationTitle.Value}" />
+                <TextBlock AutomationProperties.LiveSetting="Polite"
+                           AutomationProperties.Name="{CompiledBinding ConfirmationMessage.Value}"
+                           Text="{CompiledBinding ConfirmationMessage.Value}"
+                           TextWrapping="Wrap" />
+                <WrapPanel HorizontalAlignment="Right" Orientation="Horizontal">
+                    <ui:ProgressRing Width="18"
+                                     Height="18"
+                                     Margin="0,0,8,8"
+                                     AutomationProperties.Name="{x:Static lang:Strings.AiJobCenter_CheckingRetryCost}"
+                                     IsIndeterminate="True"
+                                     IsVisible="{CompiledBinding IsConfirmationLoading.Value}" />
+                    <Button x:Name="ConfirmationCancelButton"
+                            Margin="0,0,8,8"
+                            AutomationProperties.Name="{x:Static lang:Strings.Cancel}"
+                            Click="OnCancelConfirmationClick"
+                            Content="{x:Static lang:Strings.Cancel}" />
+                    <Button x:Name="ConfirmationConfirmButton"
+                            Margin="0,0,0,8"
+                            AutomationProperties.Name="{CompiledBinding ConfirmationActionText.Value}"
+                            Click="OnConfirmClick"
+                            Content="{CompiledBinding ConfirmationActionText.Value}"
+                            IsEnabled="{CompiledBinding CanConfirm.Value}" />
+                </WrapPanel>
+            </StackPanel>
+        </Border>
+
+        <Grid Grid.Row="4">
+            <TextBlock Margin="16"
+                       AutomationProperties.LiveSetting="Polite"
+                       AutomationProperties.Name="{x:Static lang:Strings.AiJobCenter_Empty}"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center"
+                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                       IsVisible="{CompiledBinding ShowEmptyState.Value}"
+                       Text="{x:Static lang:Strings.AiJobCenter_Empty}"
+                       TextAlignment="Center"
+                       TextWrapping="Wrap" />
+
+            <Grid RowDefinitions="*,Auto"
+                  IsVisible="{CompiledBinding HasJobs.Value}">
+                <ScrollViewer Grid.Row="0"
+                              Margin="4"
+                              HorizontalScrollBarVisibility="Disabled"
+                              VerticalScrollBarVisibility="Auto">
+                    <ItemsControl x:Name="JobList"
+                                  AutomationProperties.Name="{x:Static lang:Strings.AiJobCenter}"
+                                  ItemsSource="{CompiledBinding Jobs}">
+                        <ItemsControl.ItemContainerTheme>
+                            <ControlTheme TargetType="ContentPresenter">
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                            </ControlTheme>
+                        </ItemsControl.ItemContainerTheme>
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <VirtualizingStackPanel />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="viewModels:AiJobItemViewModel">
+                                <tools:AiJobCard Margin="4,0,4,8"
+                                                 Padding="10"
+                                                 AutomationProperties.Name="{CompiledBinding Summary}"
+                                                 BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
+                                                 BorderThickness="1"
+                                                 CornerRadius="7"
+                                                 Loaded="OnJobCardLoaded"
+                                                 Unloaded="OnJobCardUnloaded">
+                                    <StackPanel Spacing="7">
+                                        <Border Height="96"
+                                                Background="{DynamicResource ControlFillColorDefaultBrush}"
+                                                CornerRadius="4"
+                                                IsVisible="{CompiledBinding Preview, Converter={x:Static ObjectConverters.IsNotNull}}">
+                                            <btl:BitmapView Source="{CompiledBinding Preview}" Stretch="Uniform" />
+                                        </Border>
+                                        <Grid ColumnDefinitions="*,Auto">
+                                            <TextBlock FontWeight="SemiBold"
+                                                       Text="{CompiledBinding KindDisplayName}" />
+                                            <Border Grid.Column="1"
+                                                    Padding="6,2"
+                                                    Background="{DynamicResource ControlFillColorSecondaryBrush}"
+                                                    CornerRadius="8">
+                                                <TextBlock AutomationProperties.LiveSetting="Polite"
+                                                           AutomationProperties.Name="{CompiledBinding StatusDisplayName}"
+                                                           FontSize="10"
+                                                           Text="{CompiledBinding StatusDisplayName}" />
+                                            </Border>
+                                        </Grid>
+                                        <TextBlock MaxLines="3"
+                                                   Text="{CompiledBinding Summary}"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   TextWrapping="Wrap" />
+                                        <TextBlock FontSize="11"
+                                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                                   IsVisible="{CompiledBinding HasDetails}"
+                                                   Text="{CompiledBinding Details}"
+                                                   TextWrapping="Wrap" />
+                                        <TextBlock FontSize="10"
+                                                   Foreground="{DynamicResource TextFillColorTertiaryBrush}"
+                                                   Text="{CompiledBinding CreatedAtText}"
+                                                   ToolTip.Tip="{CompiledBinding CreatedAtTooltip}" />
+                                        <TextBlock AutomationProperties.LiveSetting="Assertive"
+                                                   AutomationProperties.Name="{CompiledBinding Error}"
+                                                   Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+                                                   IsVisible="{CompiledBinding IsFailed}"
+                                                   Text="{CompiledBinding Error}"
+                                                   TextWrapping="Wrap" />
+                                        <WrapPanel Orientation="Horizontal">
+                                            <Button Margin="0,0,6,6"
+                                                    AutomationProperties.Name="{x:Static lang:Strings.AiAddToScene}"
+                                                    Click="OnAddToSceneClick"
+                                                    Content="{x:Static lang:Strings.AiAddToScene}"
+                                                    IsEnabled="{CompiledBinding !IsBusy.Value}"
+                                                    IsVisible="{CompiledBinding CanAddToScene}"
+                                                    Tag="{Binding}"
+                                                    ToolTip.Tip="{x:Static lang:Strings.AiAddToScene}" />
+                                            <Button Margin="0,0,6,6"
+                                                    AutomationProperties.Name="{x:Static lang:Strings.AiJobCenter_Retry}"
+                                                    Click="OnRetryClick"
+                                                    Content="{x:Static lang:Strings.AiJobCenter_Retry}"
+                                                    IsEnabled="{CompiledBinding !IsBusy.Value}"
+                                                    IsVisible="{CompiledBinding CanRetry}"
+                                                    Tag="{Binding}"
+                                                    ToolTip.Tip="{x:Static lang:Strings.AiJobCenter_Retry}" />
+                                            <Button Margin="0,0,6,6"
+                                                    Padding="6"
+                                                    AutomationProperties.Name="{x:Static lang:Strings.Delete}"
+                                                    Click="OnDeleteClick"
+                                                    IsEnabled="{CompiledBinding !IsBusy.Value}"
+                                                    IsVisible="{CompiledBinding CanDelete}"
+                                                    Tag="{Binding}"
+                                                    Theme="{StaticResource TransparentButton}"
+                                                    ToolTip.Tip="{x:Static lang:Strings.Delete}">
+                                                <icons:FluentIcon FontSize="16" Icon="Delete" />
+                                            </Button>
+                                            <ui:ProgressRing Width="18"
+                                                             Height="18"
+                                                             Margin="0,0,6,6"
+                                                             AutomationProperties.Name="{CompiledBinding StatusDisplayName}"
+                                                             IsIndeterminate="True"
+                                                             IsVisible="{CompiledBinding ShouldPoll}" />
+                                            <ui:ProgressRing Width="18"
+                                                             Height="18"
+                                                             Margin="0,0,0,6"
+                                                             AutomationProperties.Name="{x:Static lang:Strings.AiJobCenter_StatusRunning}"
+                                                             IsIndeterminate="True"
+                                                             IsVisible="{CompiledBinding IsBusy.Value}" />
+                                        </WrapPanel>
+                                    </StackPanel>
+                                </tools:AiJobCard>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+
+                <WrapPanel Grid.Row="1"
+                           Margin="8,0,8,8"
+                           HorizontalAlignment="Center"
+                           IsVisible="{CompiledBinding ShowListFooter.Value}"
+                           Orientation="Horizontal">
+                    <Button x:Name="LoadMoreButton"
+                            Margin="0,0,8,8"
+                            AutomationProperties.Name="{x:Static lang:Strings.AiJobCenter_LoadMore}"
+                            Command="{CompiledBinding LoadMore}"
+                            Content="{x:Static lang:Strings.AiJobCenter_LoadMore}"
+                            IsVisible="{CompiledBinding HasMore.Value}"
+                            ToolTip.Tip="{x:Static lang:Strings.AiJobCenter_LoadMore}" />
+                    <ui:ProgressRing Width="18"
+                                     Height="18"
+                                     Margin="0,0,0,8"
+                                     AutomationProperties.Name="{x:Static lang:Strings.Refresh}"
+                                     IsIndeterminate="True"
+                                     IsVisible="{CompiledBinding IsListLoading.Value}" />
+                </WrapPanel>
+            </Grid>
+
+            <ui:ProgressRing Width="28"
+                             Height="28"
+                             HorizontalAlignment="Center"
+                             VerticalAlignment="Center"
+                             AutomationProperties.Name="{x:Static lang:Strings.Refresh}"
+                             IsIndeterminate="True"
+                             IsVisible="{CompiledBinding IsInitialLoading.Value}" />
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/Beutl/Views/Tools/AiJobCenterView.axaml.cs
+++ b/src/Beutl/Views/Tools/AiJobCenterView.axaml.cs
@@ -1,0 +1,92 @@
+﻿using Avalonia.Automation;
+using Avalonia.Automation.Peers;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Beutl.ViewModels.Tools;
+
+namespace Beutl.Views.Tools;
+
+public partial class AiJobCenterView : UserControl
+{
+    public AiJobCenterView()
+    {
+        InitializeComponent();
+    }
+
+    private void OnJobCardLoaded(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is AiJobCenterViewModel viewModel
+            && sender is AiJobCard { DataContext: AiJobItemViewModel item })
+        {
+            viewModel.SetPreviewVisibility(item, true);
+        }
+    }
+
+    private void OnJobCardUnloaded(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is AiJobCenterViewModel viewModel
+            && sender is AiJobCard { DataContext: AiJobItemViewModel item })
+        {
+            viewModel.SetPreviewVisibility(item, false);
+        }
+    }
+
+    private async void OnAddToSceneClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is AiJobCenterViewModel viewModel
+            && sender is Button { Tag: AiJobItemViewModel { CanAddToScene: true } item })
+        {
+            await viewModel.AddToSceneAsync(item);
+        }
+    }
+
+    private async void OnRetryClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not AiJobCenterViewModel viewModel
+            || sender is not Button { Tag: AiJobItemViewModel { CanRetry: true } item })
+        {
+            return;
+        }
+
+        await viewModel.RequestRetryConfirmationAsync(item);
+    }
+
+    private void OnDeleteClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not AiJobCenterViewModel viewModel
+            || sender is not Button { Tag: AiJobItemViewModel { CanDelete: true } item })
+        {
+            return;
+        }
+
+        viewModel.RequestDeleteConfirmation(item);
+    }
+
+    private async void OnConfirmClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is AiJobCenterViewModel viewModel)
+        {
+            await viewModel.ConfirmPendingActionAsync();
+        }
+    }
+
+    private void OnCancelConfirmationClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is AiJobCenterViewModel viewModel)
+        {
+            viewModel.CancelConfirmation();
+        }
+    }
+}
+
+internal sealed class AiJobCard : Border
+{
+    protected override AutomationPeer OnCreateAutomationPeer()
+        => new AiJobCardAutomationPeer(this);
+
+    private sealed class AiJobCardAutomationPeer(AiJobCard owner) : ControlAutomationPeer(owner)
+    {
+        protected override AutomationControlType GetAutomationControlTypeCore()
+            => AutomationControlType.ListItem;
+    }
+}

--- a/src/Beutl/Views/Tools/AiPlanReturnRefresh.cs
+++ b/src/Beutl/Views/Tools/AiPlanReturnRefresh.cs
@@ -1,0 +1,116 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Beutl.Logging;
+using Beutl.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Beutl.Views.Tools;
+
+// The AI plan is managed on the website. Any control that can send the user
+// there attaches this so the entitlements are re-read when the app is focused
+// again; otherwise a change made in the browser — a customer portal
+// cancellation in particular — stays invisible until the next manual reload.
+internal static class AiPlanReturnRefresh
+{
+    private static readonly ILogger s_logger = Log.CreateLogger(typeof(AiPlanReturnRefresh));
+
+    public static IDisposable Attach(
+        Control control,
+        IAiPlanCoordinator coordinator,
+        Action? refreshed = null)
+    {
+        ArgumentNullException.ThrowIfNull(control);
+        ArgumentNullException.ThrowIfNull(coordinator);
+        return new Subscription(control, coordinator, refreshed);
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private readonly Control _control;
+        private readonly IAiPlanCoordinator _coordinator;
+        private readonly Action? _refreshed;
+        private readonly CancellationTokenSource _cts = new();
+        private WindowBase? _window;
+        private bool _disposed;
+        private bool _refreshInProgress;
+
+        public Subscription(
+            Control control,
+            IAiPlanCoordinator coordinator,
+            Action? refreshed)
+        {
+            _control = control;
+            _coordinator = coordinator;
+            _refreshed = refreshed;
+            _control.Loaded += OnLoaded;
+            _control.Unloaded += OnUnloaded;
+            if (_control.IsLoaded)
+            {
+                Subscribe();
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            _control.Loaded -= OnLoaded;
+            _control.Unloaded -= OnUnloaded;
+            Unsubscribe();
+            _cts.Cancel();
+            _cts.Dispose();
+        }
+
+        private void OnLoaded(object? sender, EventArgs e) => Subscribe();
+
+        private void OnUnloaded(object? sender, EventArgs e) => Unsubscribe();
+
+        private void Subscribe()
+        {
+            if (_disposed || _window is not null)
+                return;
+
+            if (TopLevel.GetTopLevel(_control) is WindowBase window)
+            {
+                _window = window;
+                window.Activated += OnActivated;
+            }
+        }
+
+        private void Unsubscribe()
+        {
+            if (_window is null)
+                return;
+
+            _window.Activated -= OnActivated;
+            _window = null;
+        }
+
+        private async void OnActivated(object? sender, EventArgs e)
+        {
+            if (_disposed || _refreshInProgress)
+                return;
+
+            _refreshInProgress = true;
+            try
+            {
+                await _coordinator.RefreshIfPendingAsync(_cts.Token);
+                if (!_disposed)
+                    _refreshed?.Invoke();
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception ex)
+            {
+                s_logger.LogError(ex, "Failed to reload AI entitlements after returning to the app.");
+            }
+            finally
+            {
+                _refreshInProgress = false;
+            }
+        }
+    }
+}

--- a/src/Beutl/Views/Tools/AiPlanReturnRefresh.cs
+++ b/src/Beutl/Views/Tools/AiPlanReturnRefresh.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Threading;
 using Beutl.Logging;
 using Beutl.Services;
 using Microsoft.Extensions.Logging;
@@ -76,6 +77,7 @@ internal static class AiPlanReturnRefresh
             {
                 _window = window;
                 window.Activated += OnActivated;
+                _coordinator.Refreshed += OnRefreshed;
             }
         }
 
@@ -85,6 +87,7 @@ internal static class AiPlanReturnRefresh
                 return;
 
             _window.Activated -= OnActivated;
+            _coordinator.Refreshed -= OnRefreshed;
             _window = null;
         }
 
@@ -97,8 +100,6 @@ internal static class AiPlanReturnRefresh
             try
             {
                 await _coordinator.RefreshIfPendingAsync(_cts.Token);
-                if (!_disposed)
-                    _refreshed?.Invoke();
             }
             catch (OperationCanceledException)
             {
@@ -110,6 +111,32 @@ internal static class AiPlanReturnRefresh
             finally
             {
                 _refreshInProgress = false;
+            }
+        }
+
+        private void OnRefreshed(object? sender, EventArgs e)
+        {
+            if (!Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.Post(InvokeRefreshed);
+                return;
+            }
+
+            InvokeRefreshed();
+        }
+
+        private void InvokeRefreshed()
+        {
+            if (_disposed || _window is null)
+                return;
+
+            try
+            {
+                _refreshed?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                s_logger.LogError(ex, "Failed to update an AI view after refreshing entitlements.");
             }
         }
     }

--- a/src/Beutl/Views/Tools/AiPromptChoiceListView.axaml
+++ b/src/Beutl/Views/Tools/AiPromptChoiceListView.axaml
@@ -1,0 +1,86 @@
+<UserControl x:Class="Beutl.Views.Tools.AiPromptChoiceListView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
+             xmlns:lang="using:Beutl.Language"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:Beutl.ViewModels"
+             x:Name="Root"
+             d:DesignWidth="320"
+             x:CompileBindings="True"
+             x:DataType="vm:AiPromptLibraryViewModel"
+             mc:Ignorable="d">
+    <UserControl.Styles>
+        <!--  Opacity rather than IsVisible: the row must not change height when actions appear.  -->
+        <Style Selector="ListBoxItem :is(Button).row-action">
+            <Setter Property="Opacity" Value="0" />
+            <Setter Property="IsHitTestVisible" Value="False" />
+        </Style>
+        <Style Selector="ListBoxItem:pointerover :is(Button).row-action">
+            <Setter Property="Opacity" Value="1" />
+            <Setter Property="IsHitTestVisible" Value="True" />
+        </Style>
+        <Style Selector="ListBoxItem:selected :is(Button).row-action">
+            <Setter Property="Opacity" Value="1" />
+            <Setter Property="IsHitTestVisible" Value="True" />
+        </Style>
+        <!--  A pin is state as well as an action, so a pinned row says so unasked.  -->
+        <Style Selector="ListBoxItem ToggleButton.row-action:checked">
+            <Setter Property="Opacity" Value="1" />
+            <Setter Property="IsHitTestVisible" Value="True" />
+        </Style>
+    </UserControl.Styles>
+
+    <!--  Applying is a button rather than the row's selection: it is an action,
+          and re-picking the same prompt has to work a second time.  -->
+    <ListBox x:Name="ChoiceList"
+             Background="Transparent"
+             ItemsSource="{Binding #Root.Choices}"
+             SelectionMode="Single">
+        <ListBox.ItemTemplate>
+            <DataTemplate x:DataType="vm:AiPromptChoice">
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBlock VerticalAlignment="Center"
+                               Text="{CompiledBinding Name}"
+                               TextTrimming="CharacterEllipsis"
+                               ToolTip.Tip="{CompiledBinding Prompt}" />
+
+                    <StackPanel Grid.Column="1"
+                                VerticalAlignment="Center"
+                                Orientation="Horizontal"
+                                Spacing="2">
+                        <Button Padding="6"
+                                AutomationProperties.Name="{x:Static lang:Strings.AiPromptApply}"
+                                Classes="row-action"
+                                Command="{Binding #Root.((vm:AiPromptLibraryViewModel)DataContext).Apply}"
+                                CommandParameter="{CompiledBinding}"
+                                Theme="{StaticResource TransparentButton}"
+                                ToolTip.Tip="{x:Static lang:Strings.AiPromptApply}">
+                            <icons:FluentIcon FontSize="16" Icon="Checkmark" />
+                        </Button>
+                        <ToggleButton Padding="6"
+                                      AutomationProperties.Name="{x:Static lang:Strings.AiPromptPin}"
+                                      Classes="row-action"
+                                      Command="{Binding #Root.((vm:AiPromptLibraryViewModel)DataContext).TogglePin}"
+                                      CommandParameter="{CompiledBinding}"
+                                      IsChecked="{CompiledBinding IsPinned, Mode=OneWay}"
+                                      Theme="{StaticResource TransparentToggleButton}"
+                                      ToolTip.Tip="{x:Static lang:Strings.AiPromptPin}">
+                            <icons:FluentIcon FontSize="16" Icon="Pin" />
+                        </ToggleButton>
+                        <Button Padding="6"
+                                AutomationProperties.Name="{x:Static lang:Strings.Delete}"
+                                Classes="row-action"
+                                Command="{Binding #Root.((vm:AiPromptLibraryViewModel)DataContext).Delete}"
+                                CommandParameter="{CompiledBinding}"
+                                Theme="{StaticResource TransparentButton}"
+                                ToolTip.Tip="{x:Static lang:Strings.Delete}">
+                            <icons:FluentIcon FontSize="16" Icon="Delete" />
+                        </Button>
+                    </StackPanel>
+                </Grid>
+            </DataTemplate>
+        </ListBox.ItemTemplate>
+    </ListBox>
+</UserControl>

--- a/src/Beutl/Views/Tools/AiPromptChoiceListView.axaml.cs
+++ b/src/Beutl/Views/Tools/AiPromptChoiceListView.axaml.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections;
+using Avalonia;
+using Avalonia.Controls;
+
+namespace Beutl.Views.Tools;
+
+public partial class AiPromptChoiceListView : UserControl
+{
+    /// <summary>
+    /// Which of the library's two lists this instance shows. The commands come
+    /// from the shared view model either way, so only the items differ.
+    /// </summary>
+    public static readonly StyledProperty<IEnumerable?> ChoicesProperty =
+        AvaloniaProperty.Register<AiPromptChoiceListView, IEnumerable?>(nameof(Choices));
+
+    public AiPromptChoiceListView()
+    {
+        InitializeComponent();
+    }
+
+    public IEnumerable? Choices
+    {
+        get => GetValue(ChoicesProperty);
+        set => SetValue(ChoicesProperty, value);
+    }
+}

--- a/src/Beutl/Views/Tools/AiPromptHistoryButton.axaml
+++ b/src/Beutl/Views/Tools/AiPromptHistoryButton.axaml
@@ -1,0 +1,57 @@
+<UserControl x:Class="Beutl.Views.Tools.AiPromptHistoryButton"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
+             xmlns:lang="using:Beutl.Language"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:tools="using:Beutl.Views.Tools"
+             xmlns:vm="using:Beutl.ViewModels"
+             d:DesignWidth="32"
+             x:CompileBindings="True"
+             x:DataType="vm:AiPromptLibraryViewModel"
+             mc:Ignorable="d">
+    <Panel>
+        <ToggleButton x:Name="HistoryToggle"
+                      Padding="6,2"
+                      MinWidth="0"
+                      MinHeight="0"
+                      AutomationProperties.Name="{x:Static lang:Strings.AiPromptHistory}"
+                      IsChecked="{CompiledBinding IsHistoryOpen.Value, Mode=TwoWay}"
+                      Theme="{StaticResource TransparentButton}"
+                      ToolTip.Tip="{x:Static lang:Strings.AiPromptHistory}">
+            <icons:FluentIcon FontSize="12" Icon="History" />
+        </ToggleButton>
+        <Popup x:Name="HistoryPopup"
+               IsLightDismissEnabled="True"
+               IsOpen="{CompiledBinding IsHistoryOpen.Value, Mode=TwoWay}"
+               Placement="BottomEdgeAlignedRight"
+               PlacementTarget="{Binding #HistoryToggle}">
+            <Border MinWidth="280"
+                    MaxWidth="360"
+                    Padding="8"
+                    Background="{DynamicResource FlyoutPresenterBackground}"
+                    BorderBrush="{DynamicResource FlyoutBorderThemeBrush}"
+                    BorderThickness="1"
+                    CornerRadius="8">
+                <StackPanel Spacing="6">
+                    <TextBlock FontWeight="SemiBold"
+                               Text="{x:Static lang:Strings.AiPromptHistory}" />
+                    <TextBlock FontSize="11"
+                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                               IsVisible="{CompiledBinding !HasHistory.Value}"
+                               Text="{x:Static lang:Strings.AiPromptHistoryEmpty}"
+                               TextWrapping="Wrap" />
+                    <tools:AiPromptChoiceListView x:Name="HistoryList"
+                                                  MaxHeight="280"
+                                                  Choices="{CompiledBinding History}"
+                                                  IsVisible="{CompiledBinding HasHistory.Value}" />
+                    <Button HorizontalAlignment="Right"
+                            Command="{CompiledBinding ClearHistory}"
+                            Content="{x:Static lang:Strings.AiPromptClearRecent}"
+                            IsVisible="{CompiledBinding HasHistory.Value}" />
+                </StackPanel>
+            </Border>
+        </Popup>
+    </Panel>
+</UserControl>

--- a/src/Beutl/Views/Tools/AiPromptHistoryButton.axaml.cs
+++ b/src/Beutl/Views/Tools/AiPromptHistoryButton.axaml.cs
@@ -1,0 +1,11 @@
+﻿using Avalonia.Controls;
+
+namespace Beutl.Views.Tools;
+
+public partial class AiPromptHistoryButton : UserControl
+{
+    public AiPromptHistoryButton()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Beutl/Views/Tools/AiPromptTemplatesView.axaml
+++ b/src/Beutl/Views/Tools/AiPromptTemplatesView.axaml
@@ -1,0 +1,47 @@
+<UserControl x:Class="Beutl.Views.Tools.AiPromptTemplatesView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:lang="using:Beutl.Language"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:tools="using:Beutl.Views.Tools"
+             xmlns:vm="using:Beutl.ViewModels"
+             d:DesignWidth="340"
+             x:CompileBindings="True"
+             x:DataType="vm:AiPromptLibraryViewModel"
+             mc:Ignorable="d">
+    <StackPanel Spacing="8">
+        <tools:AiPromptChoiceListView x:Name="TemplateList"
+                                      MaxHeight="240"
+                                      Choices="{CompiledBinding Templates}"
+                                      IsVisible="{CompiledBinding HasTemplates.Value}" />
+        <TextBlock FontSize="11"
+                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                   IsVisible="{CompiledBinding !HasTemplates.Value}"
+                   Text="{x:Static lang:Strings.AiPromptTemplatesEmpty}"
+                   TextWrapping="Wrap" />
+        <Grid ColumnDefinitions="*,Auto">
+            <TextBox AutomationProperties.Name="{x:Static lang:Strings.AiPromptTemplateName}"
+                     Text="{CompiledBinding TemplateName.Value}"
+                     Watermark="{x:Static lang:Strings.AiPromptTemplateName}" />
+            <Button Grid.Column="1"
+                    Margin="8,0,0,0"
+                    AutomationProperties.Name="{x:Static lang:Strings.AiPromptSaveTemplate}"
+                    Command="{CompiledBinding SaveTemplate}"
+                    Content="{x:Static lang:Strings.AiPromptSaveTemplate}" />
+        </Grid>
+        <TextBlock AutomationProperties.LiveSetting="Assertive"
+                   AutomationProperties.Name="{CompiledBinding Error.Value}"
+                   Foreground="{DynamicResource SystemFillColorCautionBrush}"
+                   IsVisible="{CompiledBinding Error.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
+                   Text="{CompiledBinding Error.Value}"
+                   TextWrapping="Wrap" />
+        <!--  Where prompts are kept matters the first time and never again, so it
+              is said while the list is still empty.  -->
+        <TextBlock FontSize="11"
+                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                   IsVisible="{CompiledBinding !HasTemplates.Value}"
+                   Text="{CompiledBinding PrivacyText}"
+                   TextWrapping="Wrap" />
+    </StackPanel>
+</UserControl>

--- a/src/Beutl/Views/Tools/AiPromptTemplatesView.axaml.cs
+++ b/src/Beutl/Views/Tools/AiPromptTemplatesView.axaml.cs
@@ -1,0 +1,11 @@
+﻿using Avalonia.Controls;
+
+namespace Beutl.Views.Tools;
+
+public partial class AiPromptTemplatesView : UserControl
+{
+    public AiPromptTemplatesView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Beutl/Views/Tools/AiSubtitleView.axaml
+++ b/src/Beutl/Views/Tools/AiSubtitleView.axaml
@@ -1,0 +1,463 @@
+﻿<UserControl x:Class="Beutl.Views.Tools.AiSubtitleView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:captions="using:Beutl.Editor.Services.Captions"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
+             xmlns:lang="using:Beutl.Language"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:tools="using:Beutl.Views.Tools"
+             xmlns:ui="using:FluentAvalonia.UI.Controls"
+             xmlns:vm="using:Beutl.ViewModels.Dialogs"
+             d:DesignHeight="640"
+             d:DesignWidth="520"
+             x:CompileBindings="True"
+             x:DataType="vm:AiSubtitleDialogViewModel"
+             mc:Ignorable="d">
+    <UserControl.Resources>
+        <!--  A caption set runs to hundreds of cues, so a row is the two things
+              needed to find one; the row that is selected turns into the editor.  -->
+        <DataTemplate x:Key="CueSummaryTemplate" x:DataType="vm:EditableCaptionCueViewModel">
+            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
+                <StackPanel VerticalAlignment="Center" Spacing="1">
+                    <TextBlock FontSize="10"
+                               Foreground="{DynamicResource TextFillColorTertiaryBrush}"
+                               Text="{CompiledBinding Number}" />
+                    <TextBlock FontSize="11"
+                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                               Text="{CompiledBinding StartText}" />
+                </StackPanel>
+                <TextBlock Grid.Column="1"
+                           VerticalAlignment="Center"
+                           MaxLines="2"
+                           Text="{CompiledBinding Text}"
+                           TextTrimming="CharacterEllipsis"
+                           TextWrapping="Wrap" />
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate x:Key="CueEditorTemplate" x:DataType="vm:EditableCaptionCueViewModel">
+            <StackPanel Spacing="5">
+                <TextBlock FontSize="10"
+                           Foreground="{DynamicResource TextFillColorTertiaryBrush}"
+                           Text="{CompiledBinding Number}" />
+                <WrapPanel Orientation="Horizontal">
+                    <TextBox MinWidth="116"
+                             Margin="0,0,6,6"
+                             AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_CueStart}"
+                             Text="{CompiledBinding StartText}" />
+                    <TextBox MinWidth="116"
+                             Margin="0,0,0,6"
+                             AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_CueEnd}"
+                             Text="{CompiledBinding EndText}" />
+                </WrapPanel>
+                <WrapPanel Orientation="Horizontal">
+                    <TextBox MinWidth="116"
+                             Margin="0,0,6,6"
+                             AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_Speaker}"
+                             Text="{CompiledBinding Speaker}"
+                             Watermark="{x:Static lang:Strings.AiSubtitle_Speaker}" />
+                    <TextBox MinWidth="116"
+                             Margin="0,0,0,6"
+                             AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_Language}"
+                             Text="{CompiledBinding Language}"
+                             Watermark="{x:Static lang:Strings.AiSubtitle_Language}" />
+                </WrapPanel>
+                <TextBox AcceptsReturn="True"
+                         AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_Text}"
+                         CaretIndex="{CompiledBinding CaretIndex, Mode=TwoWay}"
+                         MinHeight="48"
+                         Text="{CompiledBinding Text}"
+                         TextWrapping="Wrap"
+                         Watermark="{x:Static lang:Strings.AiSubtitle_Text}" />
+            </StackPanel>
+        </DataTemplate>
+    </UserControl.Resources>
+
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled">
+        <StackPanel Margin="12,10" Spacing="8">
+            <TabStrip x:Name="SubtitleWorkflowTabs"
+                      AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle}"
+                      IsEnabled="{CompiledBinding !IsSubtitleOperationActive.Value}"
+                      SelectedIndex="{CompiledBinding SelectedSubtitlePageIndex.Value, Mode=TwoWay}"
+                      Theme="{StaticResource LiteNavTabStrip}">
+                <TabStrip.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel />
+                    </ItemsPanelTemplate>
+                </TabStrip.ItemsPanel>
+                <TabStripItem AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_Transcribe}">
+                    <TextBlock Text="{x:Static lang:Strings.AiSubtitle_Transcribe}" />
+                </TabStripItem>
+                <TabStripItem AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_Edit}">
+                    <TextBlock Text="{x:Static lang:Strings.AiSubtitle_Edit}" />
+                </TabStripItem>
+                <TabStripItem AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_Translate}">
+                    <TextBlock Text="{x:Static lang:Strings.AiSubtitle_Translate}" />
+                </TabStripItem>
+            </TabStrip>
+            <!--  One field per row: a source names the range it covers, and half a
+                  docked tab is not enough width to read that.  -->
+            <StackPanel IsVisible="{CompiledBinding IsTranscribePage.Value}" Spacing="8">
+                <TextBlock Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                           Text="{x:Static lang:Strings.AiSubtitle_TranscribeDescription}"
+                           TextWrapping="Wrap" />
+                <StackPanel Spacing="4">
+                    <TextBlock Text="{x:Static lang:Strings.AiSubtitle_AudioSource}" />
+                    <ComboBox HorizontalAlignment="Stretch"
+                              AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_AudioSource}"
+                              ItemsSource="{CompiledBinding AudioSources.Value}"
+                              SelectedItem="{CompiledBinding SelectedAudioSource.Value}" />
+                </StackPanel>
+                <StackPanel Spacing="4">
+                    <TextBlock Text="{x:Static lang:Strings.AiSubtitle_SourceLanguage}" />
+                    <ComboBox HorizontalAlignment="Stretch"
+                              AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_SourceLanguage}"
+                              ItemsSource="{CompiledBinding SourceLanguages}"
+                              SelectedItem="{CompiledBinding SelectedSourceLanguage.Value}" />
+                </StackPanel>
+                <StackPanel IsVisible="{CompiledBinding TranscriptionModelPicker.HasChoice.Value}" Spacing="4">
+                    <TextBlock Text="{x:Static lang:Strings.AiModel}" />
+                    <ComboBox HorizontalAlignment="Stretch"
+                              AutomationProperties.Name="{x:Static lang:Strings.AiModel}"
+                              ItemsSource="{CompiledBinding TranscriptionModelPicker.Options}"
+                              SelectedItem="{CompiledBinding TranscriptionModelPicker.Selected.Value}" />
+                </StackPanel>
+                <TextBlock AutomationProperties.LiveSetting="Polite"
+                           AutomationProperties.Name="{CompiledBinding DetectedLanguageText.Value}"
+                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                           IsVisible="{CompiledBinding DetectedLanguageText.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
+                           Text="{CompiledBinding DetectedLanguageText.Value}" />
+            </StackPanel>
+
+            <StackPanel IsVisible="{CompiledBinding IsEditPage.Value}" Spacing="4">
+                <TextBlock Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                           Text="{x:Static lang:Strings.AiSubtitle_EditDescription}"
+                           TextWrapping="Wrap" />
+                <TextBlock Text="{x:Static lang:Strings.AiSubtitle_Template}"
+                           ToolTip.Tip="{x:Static lang:Strings.AiSubtitle_TemplateDescription}" />
+                <ComboBox x:Name="CaptionTemplateComboBox"
+                          HorizontalAlignment="Stretch"
+                          AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_Template}"
+                          ItemsSource="{CompiledBinding CaptionTemplates}"
+                          SelectedItem="{CompiledBinding SelectedCaptionTemplate.Value}"
+                          ToolTip.Tip="{x:Static lang:Strings.AiSubtitle_TemplateDescription}">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate x:DataType="captions:CaptionTemplateDescriptor">
+                            <StackPanel>
+                                <TextBlock Text="{CompiledBinding Name}" />
+                                <TextBlock FontSize="11"
+                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                           Text="{CompiledBinding ProviderId.Value}" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+                <TextBlock FontSize="11"
+                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                           Text="{x:Static lang:Strings.AiSubtitle_TemplatePreview}" />
+                <Border MinHeight="56"
+                        Padding="8"
+                        Background="{DynamicResource ControlFillColorDefaultBrush}"
+                        CornerRadius="6">
+                    <Grid>
+                        <tools:CaptionTemplatePreviewBitmapView x:Name="CaptionTemplatePreviewBitmap"
+                                                                HorizontalAlignment="Center"
+                                                                VerticalAlignment="Center"
+                                                                AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_TemplatePreview}"
+                                                                IsVisible="{CompiledBinding TemplatePreviewImage.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
+                                                                Source="{CompiledBinding TemplatePreviewImage.Value}"
+                                                                Stretch="Uniform" />
+                        <TextBlock x:Name="CaptionTemplatePreviewFallback"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_TemplatePreview}"
+                                   FontSize="{CompiledBinding TemplatePreviewFontSize.Value}"
+                                   IsVisible="{CompiledBinding TemplatePreviewImage.Value, Converter={x:Static ObjectConverters.IsNull}}"
+                                   Text="{CompiledBinding TemplatePreviewText.Value}"
+                                   TextAlignment="Center"
+                                   TextWrapping="Wrap" />
+                    </Grid>
+                </Border>
+            </StackPanel>
+
+            <StackPanel IsVisible="{CompiledBinding IsTranscribePage.Value}" Spacing="8">
+                <StackPanel IsVisible="{CompiledBinding Usage.HasSnapshot.Value}" Spacing="4">
+                    <tools:AiUsageSummaryView DataContext="{CompiledBinding Usage}" />
+                    <tools:AiUsageEstimateView DataContext="{CompiledBinding TranscriptionEstimate}" />
+                </StackPanel>
+                <!--  A long scene takes minutes to transcribe, so the shared stop
+                      action remains available below every workflow page.  -->
+                <Button HorizontalAlignment="Stretch"
+                        Classes="accent"
+                        Command="{CompiledBinding Transcribe}"
+                        Content="{x:Static lang:Strings.AiSubtitle_Transcribe}"
+                        IsEnabled="{CompiledBinding CanTranscribe.Value}" />
+                <StackPanel Orientation="Horizontal" Spacing="6">
+                    <ui:ProgressRing x:Name="TranscriptionProgressRing"
+                                     Width="16"
+                                     Height="16"
+                                     AutomationProperties.Name="{CompiledBinding TranscriptionStatusText.Value}"
+                                     IsIndeterminate="True"
+                                     IsVisible="{CompiledBinding IsTranscribing.Value}" />
+                    <TextBlock x:Name="TranscriptionStatusText"
+                               VerticalAlignment="Center"
+                               AutomationProperties.Name="{CompiledBinding TranscriptionStatusText.Value}"
+                               AutomationProperties.LiveSetting="Polite"
+                               Text="{CompiledBinding TranscriptionStatusText.Value}" />
+                </StackPanel>
+            </StackPanel>
+
+            <Border Padding="10"
+                    Background="{DynamicResource SystemFillColorCautionBackgroundBrush}"
+                    CornerRadius="6"
+                    IsVisible="{CompiledBinding HasPendingHistoryResult.Value}">
+                <StackPanel Spacing="8">
+                    <TextBlock AutomationProperties.LiveSetting="Polite"
+                               AutomationProperties.Name="{CompiledBinding HistoryOverwriteMessage.Value}"
+                               Text="{CompiledBinding HistoryOverwriteMessage.Value}"
+                               TextWrapping="Wrap" />
+                    <WrapPanel Orientation="Horizontal">
+                        <Button x:Name="ConfirmHistoryOverwriteButton"
+                                Margin="0,0,8,0"
+                                AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_HistoryOverwriteApply}"
+                                Click="OnConfirmHistoryOverwriteClick"
+                                Content="{x:Static lang:Strings.AiSubtitle_HistoryOverwriteApply}" />
+                        <Button x:Name="CancelHistoryOverwriteButton"
+                                AutomationProperties.Name="{x:Static lang:Strings.Cancel}"
+                                Click="OnCancelHistoryOverwriteClick"
+                                Content="{x:Static lang:Strings.Cancel}" />
+                    </WrapPanel>
+                </StackPanel>
+            </Border>
+
+            <Border Padding="10"
+                    Background="{DynamicResource SystemFillColorCautionBackgroundBrush}"
+                    CornerRadius="6"
+                    IsVisible="{CompiledBinding HasPartialResult.Value}">
+                <StackPanel Spacing="8">
+                    <TextBlock AutomationProperties.LiveSetting="Polite"
+                               Text="{CompiledBinding PartialResultMessage.Value}"
+                               TextWrapping="Wrap" />
+                    <WrapPanel Orientation="Horizontal">
+                        <Button Margin="0,0,8,0"
+                                AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_UsePartialResult}"
+                                Command="{CompiledBinding ApplyPartialResult}"
+                                Content="{x:Static lang:Strings.AiSubtitle_UsePartialResult}" />
+                        <Button AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_DiscardPartialResult}"
+                                Command="{CompiledBinding DiscardPartialResult}"
+                                Content="{x:Static lang:Strings.AiSubtitle_DiscardPartialResult}" />
+                    </WrapPanel>
+                </StackPanel>
+            </Border>
+
+            <StackPanel IsEnabled="{CompiledBinding !IsTranslating.Value}"
+                        IsVisible="{CompiledBinding IsEditPage.Value}"
+                        Spacing="8">
+                <!--  Reading a file in or out is about the whole set; the icons below
+                      act on the one cue that is selected. Keeping them apart is what
+                      says which is which.  -->
+                <StackPanel Spacing="4">
+                    <TextBlock Text="{x:Static lang:Strings.AiSubtitle_CaptionsFile}" />
+                    <WrapPanel Orientation="Horizontal">
+                        <Button Margin="0,0,6,0"
+                                AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_Import}"
+                                Command="{CompiledBinding ImportCaptions}"
+                                Content="{x:Static lang:Strings.AiSubtitle_Import}" />
+                        <Button AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_Export}"
+                                Command="{CompiledBinding ExportCaptions}"
+                                Content="{x:Static lang:Strings.AiSubtitle_Export}" />
+                    </WrapPanel>
+                </StackPanel>
+
+                <StackPanel Spacing="4">
+                    <Grid ColumnDefinitions="*,Auto">
+                        <TextBlock VerticalAlignment="Center"
+                                   Text="{x:Static lang:Strings.AiSubtitle_CueEditing}" />
+                        <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="2">
+                            <Button Padding="6"
+                                    AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_AddCue}"
+                                    Command="{CompiledBinding AddCue}"
+                                    Theme="{StaticResource TransparentButton}"
+                                    ToolTip.Tip="{x:Static lang:Strings.AiSubtitle_AddCue}">
+                                <icons:FluentIcon FontSize="16" Icon="Add" />
+                            </Button>
+                            <Button Padding="6"
+                                    AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_SplitCue}"
+                                    Command="{CompiledBinding SplitCue}"
+                                    Theme="{StaticResource TransparentButton}"
+                                    ToolTip.Tip="{x:Static lang:Strings.AiSubtitle_SplitCue}">
+                                <icons:FluentIcon FontSize="16" Icon="ArrowSplit" />
+                            </Button>
+                            <Button Padding="6"
+                                    AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_MergeCue}"
+                                    Command="{CompiledBinding MergeCue}"
+                                    Theme="{StaticResource TransparentButton}"
+                                    ToolTip.Tip="{x:Static lang:Strings.AiSubtitle_MergeCue}">
+                                <icons:FluentIcon FontSize="16" Icon="ArrowJoin" />
+                            </Button>
+                            <Button Padding="6"
+                                    AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_DeleteCue}"
+                                    Command="{CompiledBinding DeleteCue}"
+                                    Theme="{StaticResource TransparentButton}"
+                                    ToolTip.Tip="{x:Static lang:Strings.AiSubtitle_DeleteCue}">
+                                <icons:FluentIcon FontSize="16" Icon="Delete" />
+                            </Button>
+                        </StackPanel>
+                    </Grid>
+
+                    <!--  The list grows into the panel's own scroll rather than carrying
+                          a second one, so the wheel does the same thing everywhere.  -->
+                    <ListBox x:Name="CaptionCueList"
+                             AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle}"
+                             IsVisible="{CompiledBinding HasCues.Value}"
+                             ItemsSource="{CompiledBinding Cues}"
+                             ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                             SelectedItem="{CompiledBinding SelectedCue.Value}">
+                        <ListBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel />
+                            </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
+                        <ListBox.Styles>
+                            <Style Selector="ListBoxItem">
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                            </Style>
+                            <!--  Both templates come from styles: a locally set one would
+                                  outrank the selected state and never swap.  -->
+                            <Style Selector="ListBoxItem ContentControl.cue">
+                                <Setter Property="ContentTemplate" Value="{StaticResource CueSummaryTemplate}" />
+                            </Style>
+                            <Style Selector="ListBoxItem:selected ContentControl.cue">
+                                <Setter Property="ContentTemplate" Value="{StaticResource CueEditorTemplate}" />
+                            </Style>
+                        </ListBox.Styles>
+                        <ListBox.ItemTemplate>
+                            <DataTemplate x:DataType="vm:EditableCaptionCueViewModel">
+                                <ContentControl Classes="cue" Content="{CompiledBinding}" />
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+
+                    <Border Padding="12"
+                            Background="{DynamicResource ControlFillColorDefaultBrush}"
+                            CornerRadius="6"
+                            IsVisible="{CompiledBinding !HasCues.Value}">
+                        <TextBlock HorizontalAlignment="Center"
+                                   Opacity="0.6"
+                                   Text="{x:Static lang:Strings.AiSubtitle_CueListEmpty}"
+                                   TextAlignment="Center"
+                                   TextWrapping="Wrap" />
+                    </Border>
+                </StackPanel>
+
+                <TextBlock AutomationProperties.LiveSetting="Polite"
+                           Foreground="{DynamicResource SystemFillColorCautionBrush}"
+                           IsVisible="{CompiledBinding CaptionValidationMessage.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
+                           Text="{CompiledBinding CaptionValidationMessage.Value}"
+                           TextWrapping="Wrap" />
+                <!--  Wrapping is one action driven by the two numbers beside it, so it
+                      lives with them rather than among the cue actions.  -->
+                <StackPanel Spacing="4">
+                    <TextBlock Text="{x:Static lang:Strings.AiSubtitle_LineWrapping}" />
+                    <WrapPanel Orientation="Horizontal">
+                        <StackPanel MinWidth="120"
+                                    Margin="0,0,8,8"
+                                    Spacing="2">
+                            <TextBlock FontSize="11"
+                                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                       Text="{x:Static lang:Strings.AiSubtitle_MaxLineLength}" />
+                            <NumericUpDown AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_MaxLineLength}"
+                                           Maximum="200"
+                                           Minimum="1"
+                                           Value="{CompiledBinding MaximumLineLength.Value}" />
+                        </StackPanel>
+                        <StackPanel MinWidth="120"
+                                    Margin="0,0,8,8"
+                                    Spacing="2">
+                            <TextBlock FontSize="11"
+                                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                       Text="{x:Static lang:Strings.AiSubtitle_MaxLineCount}" />
+                            <NumericUpDown AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_MaxLineCount}"
+                                           Maximum="10"
+                                           Minimum="1"
+                                           Value="{CompiledBinding MaximumLineCount.Value}" />
+                        </StackPanel>
+                        <Button VerticalAlignment="Bottom"
+                                Margin="0,0,0,8"
+                                AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_WrapCues}"
+                                Command="{CompiledBinding WrapCues}"
+                                Content="{x:Static lang:Strings.AiSubtitle_WrapCues}" />
+                    </WrapPanel>
+                </StackPanel>
+            </StackPanel>
+
+            <StackPanel IsEnabled="{CompiledBinding !IsTranslating.Value}"
+                        IsVisible="{CompiledBinding IsTranslatePage.Value}"
+                        Spacing="8">
+                <TextBlock Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                           Text="{x:Static lang:Strings.AiSubtitle_TranslateDescription}"
+                           TextWrapping="Wrap" />
+                <StackPanel Spacing="4">
+                    <TextBlock Text="{x:Static lang:Strings.AiSubtitle_TargetLanguage}" />
+                    <ComboBox HorizontalAlignment="Stretch"
+                              AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_TargetLanguage}"
+                              ItemsSource="{CompiledBinding TargetLanguages}"
+                              SelectedItem="{CompiledBinding SelectedTargetLanguage.Value}" />
+                </StackPanel>
+                <StackPanel IsVisible="{CompiledBinding TranslationModelPicker.HasChoice.Value}" Spacing="4">
+                    <TextBlock Text="{x:Static lang:Strings.AiModel}" />
+                    <ComboBox HorizontalAlignment="Stretch"
+                              AutomationProperties.Name="{x:Static lang:Strings.AiModel}"
+                              ItemsSource="{CompiledBinding TranslationModelPicker.Options}"
+                              SelectedItem="{CompiledBinding TranslationModelPicker.Selected.Value}" />
+                </StackPanel>
+                <tools:AiUsageEstimateView DataContext="{CompiledBinding TranslationEstimate}" />
+                <Button HorizontalAlignment="Left"
+                        AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_Translate}"
+                        Command="{CompiledBinding Translate}"
+                        Content="{x:Static lang:Strings.AiSubtitle_Translate}"
+                        IsEnabled="{CompiledBinding CanTranslate.Value}" />
+            </StackPanel>
+
+            <StackPanel IsVisible="{CompiledBinding IsTranslatePage.Value}" Spacing="6">
+                <!--  The line the model has just translated, while the rest is still
+                      being worked on.  -->
+                <TextBlock AutomationProperties.LiveSetting="Polite"
+                           Opacity="0.7"
+                           IsVisible="{CompiledBinding TranslationPreview.Value, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                           Text="{CompiledBinding TranslationPreview.Value}"
+                           TextTrimming="CharacterEllipsis"
+                           TextWrapping="NoWrap" />
+            </StackPanel>
+
+            <!--  A result can move the workflow to Edit while the operation is settling,
+                  so its stop action remains reachable independently of the selected page.  -->
+            <Button x:Name="SubtitleStopButton"
+                    HorizontalAlignment="Left"
+                    AutomationProperties.Name="{x:Static lang:Strings.Cancel}"
+                    Command="{CompiledBinding StopRequest}"
+                    Content="{x:Static lang:Strings.Cancel}"
+                    IsVisible="{CompiledBinding IsSubtitleOperationActive.Value}" />
+
+            <TextBlock AutomationProperties.LiveSetting="Assertive"
+                       AutomationProperties.Name="{CompiledBinding Error.Value}"
+                       Foreground="{DynamicResource SystemFillColorCautionBrush}"
+                       IsVisible="{CompiledBinding Error.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
+                       Text="{CompiledBinding Error.Value}"
+                       TextWrapping="Wrap" />
+
+            <StackPanel IsVisible="{CompiledBinding ShowJoinPro.Value}" Spacing="8">
+                <TextBlock Text="{x:Static lang:Strings.AiProRequired}" TextWrapping="Wrap" />
+                <Button HorizontalAlignment="Left"
+                        Command="{CompiledBinding OpenAiPlan}"
+                        Content="{x:Static lang:Strings.AiJoinPro}" />
+            </StackPanel>
+
+            <Button Command="{CompiledBinding AddToScene}"
+                    Content="{x:Static lang:Strings.AiSubtitle_AddToScene}"
+                    IsEnabled="{CompiledBinding CanAddToScene.Value}"
+                    IsVisible="{CompiledBinding IsEditPage.Value}" />
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/Beutl/Views/Tools/AiSubtitleView.axaml.cs
+++ b/src/Beutl/Views/Tools/AiSubtitleView.axaml.cs
@@ -1,0 +1,92 @@
+﻿using Avalonia.Automation;
+using Avalonia.Automation.Peers;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Beutl.Controls;
+using Beutl.ViewModels.Dialogs;
+
+namespace Beutl.Views.Tools;
+
+public partial class AiSubtitleView : UserControl
+{
+    private IDisposable? _planReturnRefresh;
+    private AiSubtitleDialogViewModel? _templatePreviewOwner;
+
+    public AiSubtitleView()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        _planReturnRefresh?.Dispose();
+        _planReturnRefresh = DataContext is AiSubtitleDialogViewModel viewModel
+            ? AiPlanReturnRefresh.Attach(
+                this,
+                viewModel.AiPlanCoordinator,
+                () =>
+                {
+                    viewModel.RefreshAvailability();
+                    viewModel.RefreshModels();
+                })
+            : null;
+        UpdateTemplatePreviewOwner();
+    }
+
+    protected override void OnLoaded(RoutedEventArgs e)
+    {
+        base.OnLoaded(e);
+        UpdateTemplatePreviewOwner();
+        (DataContext as AiSubtitleDialogViewModel)?.RefreshAvailability();
+    }
+
+    protected override void OnUnloaded(RoutedEventArgs e)
+    {
+        _templatePreviewOwner?.DetachTemplatePreview();
+        _templatePreviewOwner = null;
+        base.OnUnloaded(e);
+    }
+
+    private void UpdateTemplatePreviewOwner()
+    {
+        AiSubtitleDialogViewModel? next = IsLoaded
+            ? DataContext as AiSubtitleDialogViewModel
+            : null;
+        if (ReferenceEquals(_templatePreviewOwner, next))
+            return;
+
+        _templatePreviewOwner?.DetachTemplatePreview();
+        _templatePreviewOwner = next;
+        _templatePreviewOwner?.AttachTemplatePreview();
+    }
+
+    private void OnConfirmHistoryOverwriteClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is AiSubtitleDialogViewModel viewModel)
+        {
+            viewModel.ConfirmPendingHistoryResult();
+        }
+    }
+
+    private void OnCancelHistoryOverwriteClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is AiSubtitleDialogViewModel viewModel)
+        {
+            viewModel.DiscardPendingHistoryResult();
+        }
+    }
+}
+
+internal sealed class CaptionTemplatePreviewBitmapView : BitmapView
+{
+    protected override AutomationPeer OnCreateAutomationPeer()
+        => new CaptionTemplatePreviewAutomationPeer(this);
+
+    private sealed class CaptionTemplatePreviewAutomationPeer(
+        CaptionTemplatePreviewBitmapView owner) : ControlAutomationPeer(owner)
+    {
+        protected override AutomationControlType GetAutomationControlTypeCore()
+            => AutomationControlType.Image;
+    }
+}

--- a/src/Beutl/Views/Tools/AiUsageEstimateView.axaml
+++ b/src/Beutl/Views/Tools/AiUsageEstimateView.axaml
@@ -1,0 +1,23 @@
+<UserControl x:Class="Beutl.Views.Tools.AiUsageEstimateView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:Beutl.ViewModels"
+             d:DesignWidth="340"
+             x:CompileBindings="True"
+             x:DataType="vm:AiUsageEstimateViewModel"
+             mc:Ignorable="d">
+    <StackPanel Spacing="2">
+        <TextBlock FontSize="11"
+                   FontWeight="SemiBold"
+                   IsVisible="{CompiledBinding HasSummary.Value}"
+                   Text="{CompiledBinding Summary.Value}"
+                   TextWrapping="Wrap" />
+        <TextBlock FontSize="11"
+                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                   IsVisible="{CompiledBinding HasExplanation.Value}"
+                   Text="{CompiledBinding Explanation.Value}"
+                   TextWrapping="Wrap" />
+    </StackPanel>
+</UserControl>

--- a/src/Beutl/Views/Tools/AiUsageEstimateView.axaml.cs
+++ b/src/Beutl/Views/Tools/AiUsageEstimateView.axaml.cs
@@ -1,0 +1,11 @@
+﻿using Avalonia.Controls;
+
+namespace Beutl.Views.Tools;
+
+public partial class AiUsageEstimateView : UserControl
+{
+    public AiUsageEstimateView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Beutl/Views/Tools/AiUsageSummaryView.axaml
+++ b/src/Beutl/Views/Tools/AiUsageSummaryView.axaml
@@ -1,0 +1,34 @@
+<UserControl x:Class="Beutl.Views.Tools.AiUsageSummaryView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:Beutl.ViewModels"
+             d:DesignWidth="340"
+             x:CompileBindings="True"
+             x:DataType="vm:AiUsageViewModel"
+             mc:Ignorable="d">
+    <!--  The remaining share is the complement of the used share, so it lives in
+          the tooltip instead of costing a second line in a narrow dock pane.  -->
+    <StackPanel IsVisible="{CompiledBinding HasSnapshot.Value}"
+                Spacing="2"
+                ToolTip.Tip="{CompiledBinding MonthlyRemainingText.Value}">
+        <Grid ColumnDefinitions="*,Auto">
+            <TextBlock FontSize="11"
+                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                       Text="{CompiledBinding MonthlyUsageText.Value}"
+                       TextTrimming="CharacterEllipsis" />
+            <TextBlock Grid.Column="1"
+                       Margin="8,0,0,0"
+                       FontSize="11"
+                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                       IsVisible="{CompiledBinding HasAdditionalCredits.Value}"
+                       Text="{CompiledBinding AdditionalCreditsText.Value}" />
+        </Grid>
+        <TextBlock FontSize="11"
+                   Foreground="{DynamicResource SystemFillColorCautionBrush}"
+                   IsVisible="{CompiledBinding HasAdditionalCreditDebt.Value}"
+                   Text="{CompiledBinding AdditionalCreditDebtText.Value}"
+                   TextWrapping="Wrap" />
+    </StackPanel>
+</UserControl>

--- a/src/Beutl/Views/Tools/AiUsageSummaryView.axaml.cs
+++ b/src/Beutl/Views/Tools/AiUsageSummaryView.axaml.cs
@@ -1,0 +1,11 @@
+﻿using Avalonia.Controls;
+
+namespace Beutl.Views.Tools;
+
+public partial class AiUsageSummaryView : UserControl
+{
+    public AiUsageSummaryView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Beutl/Views/Tools/AiVideoGenerationView.axaml
+++ b/src/Beutl/Views/Tools/AiVideoGenerationView.axaml
@@ -1,0 +1,326 @@
+﻿<UserControl x:Class="Beutl.Views.Tools.AiVideoGenerationView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:btl="using:Beutl.Controls"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
+             xmlns:ai="using:Beutl.Services.AI"
+             xmlns:lang="using:Beutl.Language"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:tools="using:Beutl.Views.Tools"
+             xmlns:vm="using:Beutl.ViewModels.Dialogs"
+             d:DesignHeight="640"
+             d:DesignWidth="520"
+             x:CompileBindings="True"
+             x:DataType="vm:AiVideoGenerationDialogViewModel"
+             mc:Ignorable="d">
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled">
+        <StackPanel Margin="12,10" Spacing="8">
+            <Border Padding="8"
+                    Background="{DynamicResource ControlFillColorDefaultBrush}"
+                    CornerRadius="4"
+                    IsVisible="{CompiledBinding RecoveryAvailable.Value}">
+                <StackPanel Spacing="6">
+                    <TextBlock Text="{x:Static lang:Strings.AiPendingRequest}" TextWrapping="Wrap" />
+                    <ComboBox AutomationProperties.Name="{x:Static lang:Strings.AiPendingRequest}"
+                              ItemsSource="{CompiledBinding RecoveryAttempts.Value}"
+                              SelectedItem="{CompiledBinding SelectedRecoveryAttempt.Value}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate x:DataType="ai:AiPendingAttempt">
+                                <TextBlock Text="{CompiledBinding DisplayName}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                    <WrapPanel Orientation="Horizontal">
+                        <Button Margin="0,0,6,0"
+                                Command="{CompiledBinding RecoverSelectedAttempt}"
+                                Content="{x:Static lang:Strings.AiRecoverRequest}" />
+                        <Button Command="{CompiledBinding AbandonSelectedAttempt}"
+                                Content="{x:Static lang:Strings.AiAbandonRequest}" />
+                    </WrapPanel>
+                </StackPanel>
+            </Border>
+            <Expander Header="{x:Static lang:Strings.AiPromptTemplates}">
+                <tools:AiPromptTemplatesView Margin="0,8,0,0"
+                                             DataContext="{CompiledBinding PromptLibrary}" />
+            </Expander>
+
+            <StackPanel Spacing="4">
+                <!--  The history button sits over the box it fills in, so reaching for an
+                      earlier prompt does not mean opening the templates panel below.  -->
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBlock VerticalAlignment="Center" Text="{x:Static lang:Strings.AiPrompt}" />
+                    <tools:AiPromptHistoryButton Grid.Column="1"
+                                                 DataContext="{CompiledBinding PromptLibrary}" />
+                </Grid>
+                <TextBox AcceptsReturn="True"
+                         AutomationProperties.Name="{x:Static lang:Strings.AiPrompt}"
+                         Height="80"
+                         MaxLength="4000"
+                         Text="{CompiledBinding Prompt.Value}"
+                         TextWrapping="Wrap"
+                         Watermark="{x:Static lang:Strings.AiVideoPrompt_Placeholder}" />
+                <TextBlock AutomationProperties.LiveSetting="Assertive"
+                           Foreground="{DynamicResource SystemFillColorCautionBrush}"
+                           IsVisible="{CompiledBinding VisiblePromptValidationError.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
+                           Text="{CompiledBinding VisiblePromptValidationError.Value}"
+                           TextWrapping="Wrap" />
+            </StackPanel>
+
+            <!--  One row per decision, coarsest first: which model runs it, how long it
+                  runs for, and only then the two that describe the frame itself.  -->
+            <StackPanel x:Name="ModelField"
+                        IsVisible="{CompiledBinding ModelPicker.HasChoice.Value}"
+                        Spacing="4">
+                <TextBlock Text="{x:Static lang:Strings.AiModel}" />
+                <ComboBox HorizontalAlignment="Stretch"
+                          AutomationProperties.Name="{x:Static lang:Strings.AiModel}"
+                          ItemsSource="{CompiledBinding ModelPicker.Options}"
+                          SelectedItem="{CompiledBinding ModelPicker.Selected.Value}"
+                          IsEnabled="{CompiledBinding ModelPicker.IsSelectionEnabled.Value}" />
+            </StackPanel>
+
+            <!--  A length is one number on a short scale, so it is dragged rather
+                  than picked out of a list: the slider stops on the lengths the
+                  model takes and shows which one it landed on.  -->
+            <StackPanel x:Name="DurationField" Spacing="4">
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBlock VerticalAlignment="Center"
+                               Text="{x:Static lang:Strings.AiVideoDuration}" />
+                    <TextBlock x:Name="DurationValue"
+                               Grid.Column="1"
+                               VerticalAlignment="Center"
+                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                               Text="{CompiledBinding SelectedDuration.Value}" />
+                </Grid>
+                <Slider x:Name="DurationSlider"
+                        AutomationProperties.Name="{x:Static lang:Strings.AiVideoDuration}"
+                        IsSnapToTickEnabled="True"
+                        Maximum="{CompiledBinding MaxDurationIndex.Value}"
+                        Minimum="0"
+                        TickFrequency="1"
+                        TickPlacement="BottomRight"
+                        Value="{CompiledBinding DurationIndex.Value}" />
+                <ItemsControl x:Name="DurationScale" ItemsSource="{CompiledBinding DurationOptions}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <UniformGrid Rows="1" />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="vm:AiVideoDurationOption">
+                            <TextBlock HorizontalAlignment="Center"
+                                       FontSize="11"
+                                       Foreground="{DynamicResource TextFillColorTertiaryBrush}"
+                                       Text="{CompiledBinding Seconds}" />
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+
+            <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                <StackPanel x:Name="ResolutionField" Spacing="4">
+                    <TextBlock Text="{x:Static lang:Strings.AiVideoResolution}" />
+                    <ComboBox HorizontalAlignment="Stretch"
+                              AutomationProperties.Name="{x:Static lang:Strings.AiVideoResolution}"
+                              ItemsSource="{CompiledBinding ResolutionOptions}"
+                              SelectedItem="{CompiledBinding SelectedResolution.Value}" />
+                </StackPanel>
+                <StackPanel x:Name="AspectRatioField"
+                            Grid.Column="1"
+                            Spacing="4">
+                    <TextBlock Text="{x:Static lang:Strings.AiAspectRatio}" />
+                    <ComboBox HorizontalAlignment="Stretch"
+                              AutomationProperties.Name="{x:Static lang:Strings.AiAspectRatio}"
+                              ItemsSource="{CompiledBinding AspectRatioOptions}"
+                              SelectedItem="{CompiledBinding SelectedAspectRatio.Value}" />
+                </StackPanel>
+            </Grid>
+
+            <!--  Hidden for a model that produces no sound: the request would be refused.  -->
+            <CheckBox Content="{x:Static lang:Strings.AiGenerateAudio}"
+                      IsChecked="{CompiledBinding GenerateAudio.Value}"
+                      IsVisible="{CompiledBinding SupportsAudio.Value}" />
+
+            <Expander Header="{x:Static lang:Strings.AiPromptDetails}">
+                <StackPanel Margin="0,8,0,0" Spacing="8">
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="{x:Static lang:Strings.AiPromptStyle}" />
+                        <TextBox AutomationProperties.Name="{x:Static lang:Strings.AiPromptStyle}"
+                                 MaxLength="4000"
+                                 Text="{CompiledBinding Style.Value}"
+                                 Watermark="{x:Static lang:Strings.AiPromptStylePlaceholder}" />
+                    </StackPanel>
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="{x:Static lang:Strings.AiPromptComposition}" />
+                        <TextBox AutomationProperties.Name="{x:Static lang:Strings.AiPromptComposition}"
+                                 MaxLength="4000"
+                                 Text="{CompiledBinding Composition.Value}"
+                                 Watermark="{x:Static lang:Strings.AiPromptCompositionPlaceholder}" />
+                    </StackPanel>
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="{x:Static lang:Strings.AiPromptMotion}" />
+                        <TextBox AutomationProperties.Name="{x:Static lang:Strings.AiPromptMotion}"
+                                 MaxLength="4000"
+                                 Text="{CompiledBinding Motion.Value}"
+                                 Watermark="{x:Static lang:Strings.AiPromptMotionPlaceholder}" />
+                    </StackPanel>
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="{x:Static lang:Strings.AiPromptAvoid}" />
+                        <TextBox AutomationProperties.Name="{x:Static lang:Strings.AiPromptAvoid}"
+                                 MaxLength="4000"
+                                 Text="{CompiledBinding Exclusions.Value}"
+                                 Watermark="{x:Static lang:Strings.AiPromptAvoidPlaceholder}" />
+                    </StackPanel>
+                    <StackPanel IsVisible="{CompiledBinding SupportsSeed.Value}" Spacing="4">
+                        <TextBlock Text="{x:Static lang:Strings.AiPromptSeed}" />
+                        <NumericUpDown AutomationProperties.Name="{x:Static lang:Strings.AiPromptSeed}"
+                                       FormatString="0"
+                                       Maximum="{CompiledBinding SeedMaximum}"
+                                       Minimum="{CompiledBinding SeedMinimum}"
+                                       Value="{CompiledBinding Seed.Value}"
+                                       Watermark="{x:Static lang:Strings.AiPromptSeedPlaceholder}" />
+                    </StackPanel>
+                </StackPanel>
+            </Expander>
+
+            <Expander Header="{x:Static lang:Strings.AiVideoFrameGuidanceHeader}"
+                      IsVisible="{CompiledBinding SupportsFrameGuidance.Value}">
+                <StackPanel Margin="0,8,0,0" Spacing="8">
+                    <TextBlock Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                               Text="{x:Static lang:Strings.AiVideoFrameGuidanceDescription}"
+                               TextWrapping="Wrap" />
+                    <Button HorizontalAlignment="Left"
+                            AutomationProperties.Name="{x:Static lang:Strings.AiVideoUseCurrentFrame}"
+                            Command="{CompiledBinding CaptureCurrentFrame}"
+                            Content="{x:Static lang:Strings.AiVideoUseCurrentFrame}"
+                            ToolTip.Tip="{x:Static lang:Strings.AiVideoUseCurrentFrame}" />
+                    <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                        <StackPanel IsVisible="{CompiledBinding SupportsFirstFrame.Value}" Spacing="4">
+                            <TextBlock Text="{x:Static lang:Strings.AiVideoFirstFrame}" />
+                            <Border Height="96"
+                                    Background="{DynamicResource ControlFillColorDefaultBrush}"
+                                    CornerRadius="4"
+                                    IsVisible="{CompiledBinding FirstFramePreview.Value, Converter={x:Static ObjectConverters.IsNotNull}}">
+                                <btl:BitmapView Source="{CompiledBinding FirstFramePreview.Value}"
+                                                Stretch="Uniform" />
+                            </Border>
+                            <TextBlock IsVisible="{CompiledBinding FirstFramePath.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
+                                       MaxLines="1"
+                                       Text="{CompiledBinding FirstFramePath.Value}"
+                                       TextTrimming="CharacterEllipsis" />
+                            <WrapPanel Orientation="Horizontal">
+                                <Button Margin="0,0,4,4"
+                                        AutomationProperties.Name="{x:Static lang:Strings.AiVideoBrowseFirstFrame}"
+                                        Command="{CompiledBinding SelectFirstFrame}"
+                                        Content="{x:Static lang:Strings.AiEditBrowse}" />
+                                <Button Margin="0,0,0,4"
+                                        AutomationProperties.Name="{x:Static lang:Strings.AiVideoClearFirstFrame}"
+                                        Command="{CompiledBinding ClearFirstFrame}"
+                                        Content="{x:Static lang:Strings.AiClearFrame}"
+                                        IsVisible="{CompiledBinding FirstFramePath.Value, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                            </WrapPanel>
+                        </StackPanel>
+                        <StackPanel Grid.Column="1"
+                                    IsVisible="{CompiledBinding SupportsLastFrame.Value}"
+                                    Spacing="4">
+                            <TextBlock Text="{x:Static lang:Strings.AiVideoLastFrame}" />
+                            <Border Height="96"
+                                    Background="{DynamicResource ControlFillColorDefaultBrush}"
+                                    CornerRadius="4"
+                                    IsVisible="{CompiledBinding LastFramePreview.Value, Converter={x:Static ObjectConverters.IsNotNull}}">
+                                <btl:BitmapView Source="{CompiledBinding LastFramePreview.Value}"
+                                                Stretch="Uniform" />
+                            </Border>
+                            <TextBlock IsVisible="{CompiledBinding LastFramePath.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
+                                       MaxLines="1"
+                                       Text="{CompiledBinding LastFramePath.Value}"
+                                       TextTrimming="CharacterEllipsis" />
+                            <WrapPanel Orientation="Horizontal">
+                                <Button Margin="0,0,4,4"
+                                        AutomationProperties.Name="{x:Static lang:Strings.AiVideoBrowseLastFrame}"
+                                        Command="{CompiledBinding SelectLastFrame}"
+                                        Content="{x:Static lang:Strings.AiEditBrowse}" />
+                                <Button Margin="0,0,0,4"
+                                        AutomationProperties.Name="{x:Static lang:Strings.AiVideoClearLastFrame}"
+                                        Command="{CompiledBinding ClearLastFrame}"
+                                        Content="{x:Static lang:Strings.AiClearFrame}"
+                                        IsVisible="{CompiledBinding LastFramePath.Value, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                            </WrapPanel>
+                        </StackPanel>
+                    </Grid>
+                </StackPanel>
+            </Expander>
+
+            <StackPanel Spacing="8">
+                <StackPanel IsVisible="{CompiledBinding Usage.HasSnapshot.Value}" Spacing="4">
+                    <tools:AiUsageSummaryView DataContext="{CompiledBinding Usage}" />
+                    <tools:AiUsageEstimateView DataContext="{CompiledBinding EstimatedUsage}" />
+                </StackPanel>
+                <Grid ColumnDefinitions="*,Auto">
+                    <Button HorizontalAlignment="Stretch"
+                            Classes="accent"
+                            Command="{CompiledBinding Generate}"
+                            Content="{x:Static lang:Strings.AiGenerate}"
+                            IsEnabled="{CompiledBinding CanGenerate.Value}" />
+                    <Button Grid.Column="1"
+                            Margin="8,0,0,0"
+                            AutomationProperties.Name="{x:Static lang:Strings.Cancel}"
+                            Command="{CompiledBinding StopGenerating}"
+                            Content="{x:Static lang:Strings.Cancel}"
+                            IsVisible="{CompiledBinding IsGenerating.Value}" />
+                </Grid>
+            </StackPanel>
+
+            <Border Padding="16"
+                    Background="{DynamicResource ControlFillColorDefaultBrush}"
+                    CornerRadius="8">
+                <Grid>
+                    <StackPanel HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Spacing="8">
+                        <icons:FluentIcon FontSize="32"
+                                           Icon="Video"
+                                           Opacity="0.6" />
+                        <TextBlock HorizontalAlignment="Center"
+                                   AutomationProperties.LiveSetting="Polite"
+                                   AutomationProperties.Name="{CompiledBinding StatusText.Value}"
+                                   Opacity="0.6"
+                                   Text="{CompiledBinding StatusText.Value}"
+                                   TextAlignment="Center"
+                                   TextWrapping="Wrap" />
+                        <Button AutomationProperties.Name="{x:Static lang:Strings.AiVideoOpenPreview}"
+                                Command="{CompiledBinding OpenResult}"
+                                Content="{x:Static lang:Strings.AiVideoOpenPreview}"
+                                IsVisible="{CompiledBinding ResultVideoPath.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
+                                ToolTip.Tip="{x:Static lang:Strings.AiVideoOpenPreview}" />
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <TextBlock AutomationProperties.LiveSetting="Assertive"
+                       AutomationProperties.Name="{CompiledBinding Error.Value}"
+                       Foreground="{DynamicResource SystemFillColorCautionBrush}"
+                       IsVisible="{CompiledBinding Error.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
+                       Text="{CompiledBinding Error.Value}"
+                       TextWrapping="Wrap" />
+
+            <StackPanel IsVisible="{CompiledBinding ShowJoinPro.Value}" Spacing="8">
+                <TextBlock Text="{x:Static lang:Strings.AiProRequired}"
+                           TextWrapping="Wrap" />
+                <Button HorizontalAlignment="Left"
+                        Command="{CompiledBinding OpenAiPlan}"
+                        Content="{x:Static lang:Strings.AiJoinPro}" />
+            </StackPanel>
+
+            <WrapPanel IsVisible="{CompiledBinding CanAddToScene.Value}" Orientation="Horizontal">
+                <Button Margin="0,0,8,8"
+                        Command="{CompiledBinding AddToScene}"
+                        Content="{x:Static lang:Strings.AiAddToScene}" />
+                <Button Margin="0,0,0,8"
+                        Command="{CompiledBinding SaveToFile}"
+                        Content="{x:Static lang:Strings.AiSaveToFile}" />
+            </WrapPanel>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/Beutl/Views/Tools/AiVideoGenerationView.axaml.cs
+++ b/src/Beutl/Views/Tools/AiVideoGenerationView.axaml.cs
@@ -1,0 +1,36 @@
+﻿using Avalonia.Controls;
+using Beutl.ViewModels.Dialogs;
+
+namespace Beutl.Views.Tools;
+
+public partial class AiVideoGenerationView : UserControl
+{
+    private IDisposable? _planReturnRefresh;
+
+    public AiVideoGenerationView()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        _planReturnRefresh?.Dispose();
+        _planReturnRefresh = DataContext is AiVideoGenerationDialogViewModel viewModel
+            ? AiPlanReturnRefresh.Attach(
+                this,
+                viewModel.AiPlanCoordinator,
+                () =>
+                {
+                    viewModel.RefreshAvailability();
+                    viewModel.RefreshModels();
+                })
+            : null;
+    }
+
+    protected override void OnLoaded(Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        base.OnLoaded(e);
+        (DataContext as AiVideoGenerationDialogViewModel)?.RefreshAvailability();
+    }
+}

--- a/src/Beutl/Views/Tools/AiWorkspaceView.axaml
+++ b/src/Beutl/Views/Tools/AiWorkspaceView.axaml
@@ -1,0 +1,70 @@
+﻿<UserControl x:Class="Beutl.Views.Tools.AiWorkspaceView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:dialogs="using:Beutl.ViewModels.Dialogs"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:tools="using:Beutl.Views.Tools"
+             xmlns:viewModels="using:Beutl.ViewModels.Tools"
+             d:DesignHeight="640"
+             d:DesignWidth="380"
+             x:CompileBindings="True"
+             x:DataType="viewModels:AiWorkspaceViewModel"
+             mc:Ignorable="d">
+    <UserControl.DataTemplates>
+        <DataTemplate DataType="dialogs:AiImageGenerationDialogViewModel">
+            <tools:AiImageGenerationView />
+        </DataTemplate>
+        <DataTemplate DataType="dialogs:AiImageEditDialogViewModel">
+            <tools:AiImageEditView />
+        </DataTemplate>
+        <DataTemplate DataType="dialogs:AiVideoGenerationDialogViewModel">
+            <tools:AiVideoGenerationView />
+        </DataTemplate>
+        <DataTemplate DataType="dialogs:AiSubtitleDialogViewModel">
+            <tools:AiSubtitleView />
+        </DataTemplate>
+        <DataTemplate DataType="viewModels:AiJobCenterViewModel">
+            <tools:AiJobCenterView />
+        </DataTemplate>
+    </UserControl.DataTemplates>
+    <Grid RowDefinitions="Auto,*">
+        <TabStrip x:Name="SectionStrip"
+                  Padding="4,2,4,0"
+                  ItemsSource="{CompiledBinding Sections}"
+                  SelectedItem="{CompiledBinding SelectedSection.Value}"
+                  Theme="{StaticResource LiteNavTabStrip}">
+            <!--  A narrow dock would push the last pages off the edge of a single
+                  row, and a page you cannot reach is a page you have lost.  -->
+            <TabStrip.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <WrapPanel />
+                </ItemsPanelTemplate>
+            </TabStrip.ItemsPanel>
+            <TabStrip.Styles>
+                <Style x:DataType="viewModels:AiWorkspaceSectionViewModel" Selector="TabStripItem">
+                    <Setter Property="Padding" Value="10,5,10,3" />
+                    <Setter Property="AutomationProperties.Name" Value="{Binding DisplayName}" />
+                    <Setter Property="ToolTip.Tip" Value="{Binding DisplayName}" />
+
+                    <!--  Five names never fit a docked panel, so only the page you
+                          are on spells itself out; the rest stay as icons.  -->
+                    <Style Selector="^ > StackPanel > TextBlock">
+                        <Setter Property="IsVisible" Value="{Binding $parent[TabStripItem].IsSelected}" />
+                    </Style>
+                </Style>
+            </TabStrip.Styles>
+            <TabStrip.ItemTemplate>
+                <DataTemplate x:DataType="viewModels:AiWorkspaceSectionViewModel">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <icons:FluentIcon FontSize="20" Icon="{CompiledBinding Icon}" />
+                        <TextBlock VerticalAlignment="Center" Text="{CompiledBinding DisplayName}" />
+                    </StackPanel>
+                </DataTemplate>
+            </TabStrip.ItemTemplate>
+        </TabStrip>
+
+        <ContentControl Grid.Row="1" Content="{CompiledBinding ActiveContent.Value}" />
+    </Grid>
+</UserControl>

--- a/src/Beutl/Views/Tools/AiWorkspaceView.axaml.cs
+++ b/src/Beutl/Views/Tools/AiWorkspaceView.axaml.cs
@@ -1,0 +1,11 @@
+﻿using Avalonia.Controls;
+
+namespace Beutl.Views.Tools;
+
+public partial class AiWorkspaceView : UserControl
+{
+    public AiWorkspaceView()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AccountSettingsPageViewModelTests.cs
+++ b/tests/Beutl.HeadlessUITests/AccountSettingsPageViewModelTests.cs
@@ -1,0 +1,394 @@
+﻿using System.Net;
+using System.Reflection;
+using System.Text;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Beutl.Api;
+using Beutl.Api.Clients;
+using Beutl.Api.Objects;
+using Beutl.Api.Services;
+using Beutl.Language;
+using Beutl.Pages.SettingsPages;
+using Beutl.Services;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels.SettingsPages;
+using Reactive.Bindings;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture, NonParallelizable]
+public sealed class AccountSettingsPageViewModelTests
+{
+    [AvaloniaTest]
+    public async Task DelayedEntitlements_SignOutCancelsAndClearsLoadingState()
+    {
+        using var handler = new ControlledHandler(honorCancellation: true);
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, "user-a");
+        using var viewModel = new AccountSettingsPageViewModel(clients, CreateCoordinator(clients));
+        await handler.WaitForRequestCountAsync(1);
+
+        SetAuthenticatedUser(clients, null);
+
+        await WaitUntilAsync(() => handler.Requests[0].CancellationToken.IsCancellationRequested);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.IsAiPlanLoading.Value, Is.False);
+            Assert.That(viewModel.AiPlanError.Value, Is.Null);
+            Assert.That(handler.Requests, Has.Count.EqualTo(1));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task PortalCancellation_ReportsTheScheduledEndWhileStillActive()
+    {
+        // Stripe keeps the status on "active" until the period ends, so the
+        // scheduled flag is the only signal that the plan will stop.
+        using var handler = new ControlledHandler(honorCancellation: false);
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, "user-a");
+        using var viewModel = new AccountSettingsPageViewModel(clients, CreateCoordinator(clients));
+        await handler.WaitForRequestCountAsync(1);
+
+        handler.Complete(
+            0,
+            JsonResponse(HttpStatusCode.OK, EntitlementsJson(cancelAtPeriodEnd: true)));
+        await WaitUntilAsync(() => !viewModel.IsAiPlanLoading.Value);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                viewModel.SubscriptionStatus.Value,
+                Is.EqualTo(SettingsStrings.AiPlan_SubscriptionStatus_CancelScheduled));
+            Assert.That(viewModel.HasCancelScheduledNotice.Value, Is.True);
+            Assert.That(viewModel.CancelScheduledNotice.Value, Is.Not.Null);
+            Assert.That(
+                viewModel.AiPlanActionText.Value,
+                Is.EqualTo(SettingsStrings.AiPlan_ManageAndTopUp),
+                "The user must still be able to resume the subscription.");
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ActiveSubscription_DoesNotClaimAScheduledCancellation()
+    {
+        using var handler = new ControlledHandler(honorCancellation: false);
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, "user-a");
+        using var viewModel = new AccountSettingsPageViewModel(clients, CreateCoordinator(clients));
+        await handler.WaitForRequestCountAsync(1);
+
+        handler.Complete(0, JsonResponse(HttpStatusCode.OK, EntitlementsJson()));
+        await WaitUntilAsync(() => !viewModel.IsAiPlanLoading.Value);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                viewModel.SubscriptionStatus.Value,
+                Is.EqualTo(SettingsStrings.AiPlan_SubscriptionStatus_Active));
+            Assert.That(viewModel.HasCancelScheduledNotice.Value, Is.False);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ReturningFromThePlanPage_RereadsTheEntitlements()
+    {
+        // A cancellation made in the Stripe customer portal happens in a browser,
+        // so the app only learns about it by asking the server again.
+        using var handler = new ControlledHandler(honorCancellation: false);
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, "user-a");
+        var coordinator = CreateCoordinator(clients);
+        using var viewModel = new AccountSettingsPageViewModel(clients, coordinator);
+        await handler.WaitForRequestCountAsync(1);
+        handler.Complete(0, JsonResponse(HttpStatusCode.OK, EntitlementsJson()));
+        await WaitUntilAsync(() => !viewModel.IsAiPlanLoading.Value);
+
+        // Returning without having opened the plan must not cost a request.
+        viewModel.NotifyReturnedToApplication();
+        await Task.Delay(25);
+        HeadlessTestHelpers.Settle();
+        Assert.That(handler.Requests, Has.Count.EqualTo(1));
+
+        coordinator.OpenAiPlan();
+        viewModel.NotifyReturnedToApplication();
+        await handler.WaitForRequestCountAsync(2);
+        handler.Complete(1, JsonResponse(HttpStatusCode.OK, EntitlementsJson(cancelAtPeriodEnd: true)));
+        await WaitUntilAsync(() =>
+            viewModel.SubscriptionStatus.Value
+                == SettingsStrings.AiPlan_SubscriptionStatus_CancelScheduled);
+
+        // The pending flag is consumed, so focusing the app again is free.
+        viewModel.NotifyReturnedToApplication();
+        await Task.Delay(25);
+        HeadlessTestHelpers.Settle();
+        Assert.That(handler.Requests, Has.Count.EqualTo(2));
+    }
+
+    [AvaloniaTest]
+    public async Task LoadedPage_WindowActivationRefreshesAfterBrowserReturn()
+    {
+        using var handler = new ControlledHandler(honorCancellation: false);
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(
+            httpClient,
+            new ExtensionProvider());
+        SetAuthenticatedUser(clients, "user-a");
+        var coordinator = CreateCoordinator(clients);
+        using var viewModel = new AccountSettingsPageViewModel(clients, coordinator);
+        await handler.WaitForRequestCountAsync(1);
+        handler.Complete(0, JsonResponse(HttpStatusCode.OK, EntitlementsJson()));
+        await WaitUntilAsync(() => !viewModel.IsAiPlanLoading.Value);
+
+        var page = new AccountSettingsPage { DataContext = viewModel };
+        var accountWindow = new Window { Content = page };
+        var browserWindow = new Window();
+        try
+        {
+            accountWindow.Show();
+            browserWindow.Show();
+            HeadlessTestHelpers.Settle();
+
+            coordinator.OpenAiPlan();
+            accountWindow.Activate();
+            HeadlessTestHelpers.Settle();
+            await handler.WaitForRequestCountAsync(2);
+            handler.Complete(
+                1,
+                JsonResponse(HttpStatusCode.OK, EntitlementsJson(cancelAtPeriodEnd: true)));
+            await WaitUntilAsync(() =>
+                viewModel.SubscriptionStatus.Value
+                    == SettingsStrings.AiPlan_SubscriptionStatus_CancelScheduled);
+
+            Assert.That(handler.Requests, Has.Count.EqualTo(2));
+        }
+        finally
+        {
+            browserWindow.Close();
+            accountWindow.Close();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task DelayedEntitlements_AccountSwitchIgnoresStaleFailure()
+    {
+        using var handler = new ControlledHandler(honorCancellation: false);
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, "user-a");
+        using var viewModel = new AccountSettingsPageViewModel(clients, CreateCoordinator(clients));
+        await handler.WaitForRequestCountAsync(1);
+
+        SetAuthenticatedUser(clients, "user-b");
+        handler.Complete(0, JsonResponse(HttpStatusCode.InternalServerError, "{}"));
+        await handler.WaitForRequestCountAsync(2);
+        handler.Complete(1, JsonResponse(HttpStatusCode.OK, EntitlementsJson()));
+        await WaitUntilAsync(() => !viewModel.IsAiPlanLoading.Value);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.AiPlanError.Value, Is.Null);
+            Assert.That(viewModel.PlanName.Value, Is.EqualTo(SettingsStrings.AiPlan_Pro));
+            Assert.That(clients.AuthenticatedUser.Value?.Profile.Id, Is.EqualTo("user-b"));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task DelayedEntitlements_CurrentFailurePublishesLocalizedError()
+    {
+        using var handler = new ControlledHandler(honorCancellation: false);
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, "user-a");
+        using var viewModel = new AccountSettingsPageViewModel(clients, CreateCoordinator(clients));
+        await handler.WaitForRequestCountAsync(1);
+
+        handler.Complete(0, JsonResponse(HttpStatusCode.InternalServerError, "{}"));
+        await WaitUntilAsync(() => !viewModel.IsAiPlanLoading.Value);
+
+        Assert.That(viewModel.AiPlanError.Value, Is.Not.Null.And.Not.Empty);
+    }
+
+    [AvaloniaTest]
+    public async Task Dispose_CancelsDelayedEntitlementsAndStopsAccountObservation()
+    {
+        using var handler = new ControlledHandler(honorCancellation: true);
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, "user-a");
+        var viewModel = new AccountSettingsPageViewModel(clients, CreateCoordinator(clients));
+        await handler.WaitForRequestCountAsync(1);
+
+        viewModel.Dispose();
+        await WaitUntilAsync(() => handler.Requests[0].CancellationToken.IsCancellationRequested);
+        SetAuthenticatedUser(clients, "user-b");
+        await Task.Delay(25);
+        HeadlessTestHelpers.Settle();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(handler.Requests, Has.Count.EqualTo(1));
+            Assert.DoesNotThrow(viewModel.Dispose);
+        }
+    }
+
+    private static void SetAuthenticatedUser(BeutlApiApplication clients, string? userId)
+    {
+        FieldInfo field = typeof(BeutlApiApplication).GetField(
+            "_authenticatedUser",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var state = (ReactivePropertySlim<AuthenticatedUser?>)field.GetValue(clients)!;
+        if (userId is null)
+        {
+            state.Value = null;
+            return;
+        }
+
+        var profile = new Profile(new ProfileResponse
+        {
+            Id = userId,
+            Name = userId,
+            DisplayName = userId,
+            Bio = null,
+            IconId = null,
+            IconUrl = null,
+        }, clients);
+        state.Value = new AuthenticatedUser(profile, new AuthResponse
+        {
+            Token = $"token-{userId}",
+            RefreshToken = $"refresh-{userId}",
+            Expiration = DateTime.UtcNow.AddHours(1),
+        }, clients, DateTime.UtcNow);
+    }
+
+    private static AiPlanCoordinator CreateCoordinator(BeutlApiApplication clients)
+        => new(
+            clients.GetResource<IAiEntitlementService>(),
+            _ => { },
+            () => "en");
+
+    private static HttpResponseMessage JsonResponse(HttpStatusCode statusCode, string json)
+        => new(statusCode)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+
+    private static string EntitlementsJson(bool cancelAtPeriodEnd = false) => $$"""
+        {
+          "plan": "pro",
+          "subscriptionStatus": "active",
+          "currentPeriodStart": "2026-08-01T00:00:00Z",
+          "currentPeriodEnd": "2026-09-01T00:00:00Z",
+          "cancelAtPeriodEnd": {{(cancelAtPeriodEnd ? "true" : "false")}},
+          "canUseAi": true,
+          "balance": {
+            "monthlyUsage": {
+              "usedPercent": 2,
+              "remainingPercent": 98,
+              "isExhausted": false
+            },
+            "additionalCredits": 5,
+            "hasAdditionalCreditDebt": false
+          },
+          "availability": { "image.generate": true }
+        }
+        """;
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (!condition())
+        {
+            HeadlessTestHelpers.Settle();
+            await Task.Delay(10, timeout.Token);
+        }
+    }
+
+    private sealed class ControlledHandler(bool honorCancellation) : HttpMessageHandler
+    {
+        private readonly Lock _gate = new();
+        private readonly SemaphoreSlim _requestSignal = new(0);
+        private readonly List<PendingRequest> _requests = [];
+
+        public IReadOnlyList<PendingRequest> Requests
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _requests.ToArray();
+                }
+            }
+        }
+
+        public void Complete(int index, HttpResponseMessage response)
+        {
+            PendingRequest request;
+            lock (_gate)
+            {
+                request = _requests[index];
+            }
+            response.RequestMessage = request.Request;
+            request.Completion.TrySetResult(response);
+        }
+
+        public async Task WaitForRequestCountAsync(int count)
+        {
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            while (Requests.Count < count)
+            {
+                await _requestSignal.WaitAsync(timeout.Token);
+            }
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var pending = new PendingRequest(request, cancellationToken);
+            if (honorCancellation)
+            {
+                pending.CancellationRegistration = cancellationToken.Register(
+                    () => pending.Completion.TrySetCanceled(cancellationToken));
+            }
+            lock (_gate)
+            {
+                _requests.Add(pending);
+            }
+            _requestSignal.Release();
+            return pending.Completion.Task;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                foreach (PendingRequest request in Requests)
+                {
+                    request.CancellationRegistration.Dispose();
+                    request.Completion.TrySetCanceled();
+                }
+                _requestSignal.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class PendingRequest(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        public HttpRequestMessage Request { get; } = request;
+
+        public CancellationToken CancellationToken { get; } = cancellationToken;
+
+        public TaskCompletionSource<HttpResponseMessage> Completion { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public CancellationTokenRegistration CancellationRegistration { get; set; }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiAspectRatioSuggestionTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiAspectRatioSuggestionTests.cs
@@ -1,0 +1,59 @@
+﻿using Beutl.Media;
+using Beutl.ViewModels.Dialogs;
+using NUnit.Framework;
+
+namespace Beutl.HeadlessUITests;
+
+/// <summary>
+/// The dialog offers the shape the scene is in. Before ratios existed the
+/// choices were three fixed sizes with no 16:9 at all, so a widescreen project
+/// was handed 3:2 and the generated asset never fitted the frame.
+/// </summary>
+public class AiAspectRatioSuggestionTests
+{
+    private static readonly string[] s_imageRatios = ["16:9", "1:1", "9:16", "4:3", "3:4"];
+
+    [TestCase(1920, 1080, "16:9")]
+    [TestCase(3840, 2160, "16:9")]
+    [TestCase(1080, 1920, "9:16")]
+    [TestCase(1080, 1080, "1:1")]
+    [TestCase(1440, 1080, "4:3")]
+    [TestCase(1080, 1440, "3:4")]
+    public void Nearest_MatchesTheSceneTheAssetIsMadeFor(int width, int height, string expected)
+    {
+        Assert.That(
+            AiAspectRatioSuggestion.Nearest(s_imageRatios, new PixelSize(width, height), "16:9"),
+            Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void Nearest_TreatsAPortraitSceneAsFarFromWideAsALandscapeOne()
+    {
+        // Measured in log space: a linear difference would put 9:16 closer to
+        // 16:9 than 1:1 is, and every vertical project would be offered a
+        // widescreen image.
+        Assert.That(
+            AiAspectRatioSuggestion.Nearest(["16:9", "1:1", "9:16"], new PixelSize(1080, 1920), "16:9"),
+            Is.EqualTo("9:16"));
+    }
+
+    [Test]
+    public void Nearest_FallsBackWhenThereIsNoSceneToMatch()
+    {
+        Assert.That(
+            AiAspectRatioSuggestion.Nearest(s_imageRatios, null, "16:9"),
+            Is.EqualTo("16:9"));
+        Assert.That(
+            AiAspectRatioSuggestion.Nearest(s_imageRatios, new PixelSize(0, 0), "16:9"),
+            Is.EqualTo("16:9"));
+    }
+
+    [Test]
+    public void Nearest_ChoosesFromOnlyWhatIsOffered()
+    {
+        // The video dialog offers two; a 4:3 scene still has to land on one.
+        Assert.That(
+            AiAspectRatioSuggestion.Nearest(["16:9", "9:16"], new PixelSize(1440, 1080), "16:9"),
+            Is.EqualTo("16:9"));
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiCaptionExtensionCompositionTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiCaptionExtensionCompositionTests.cs
@@ -1,0 +1,235 @@
+﻿using System.Runtime.CompilerServices;
+using System.Text;
+using Avalonia.Headless.NUnit;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services.Captions;
+using Beutl.Extensibility;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture, NonParallelizable]
+public sealed class AiCaptionExtensionCompositionTests
+{
+    private const int TestPackageId = -42_001;
+    private static readonly CaptionFormatId s_testFormat = new("test.caption");
+
+    [AvaloniaTest]
+    public async Task OpenTool_UsesDynamicContributionsAndDropsThemAfterUnload()
+    {
+        await TestReset.ResetShellAsync();
+        (WeakReference codecReference, WeakReference factoryReference) =
+            RegisterTestExtensions();
+        using var openTool =
+            TestShell.MainViewModel.CreateAiSubtitleToolViewModel(editViewModel: null);
+        try
+        {
+            bool imported = openTool.ImportCaptionBytes(
+                Encoding.UTF8.GetBytes("from plugin codec"),
+                s_testFormat);
+            CaptionTemplateDescriptor pluginTemplate = openTool.CaptionTemplates
+                .Single(template => template.Name == "Plugin caption template");
+            openTool.SelectedCaptionTemplate.Value = pluginTemplate;
+            Assert.Multiple(() =>
+            {
+                Assert.That(imported, Is.True);
+                Assert.That(openTool.Cues.Single().Text, Is.EqualTo("from plugin codec"));
+                Assert.That(
+                    openTool.CaptionTemplates.Select(template => template.Name),
+                    Does.Contain("Plugin caption template"));
+            });
+        }
+        finally
+        {
+            RemoveTestExtensions();
+        }
+
+        // Move collection to a later continuation so the JIT cannot keep the
+        // removed extension array alive as a temporary in the removal frame.
+        await Task.Yield();
+
+        using var newlyOpenedTool =
+            TestShell.MainViewModel.CreateAiSubtitleToolViewModel(editViewModel: null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                openTool.CaptionTemplates.Select(template => template.Name),
+                Does.Not.Contain("Plugin caption template"));
+            Assert.That(
+                openTool.SelectedCaptionTemplate.Value.Id,
+                Is.EqualTo(CaptionTemplateIds.DefaultText));
+            Assert.Throws<NotSupportedException>(() =>
+                openTool.ImportCaptionBytes(
+                    Encoding.UTF8.GetBytes("no longer registered"),
+                    s_testFormat));
+            Assert.That(
+                newlyOpenedTool.CaptionTemplates.Select(template => template.Name),
+                Does.Not.Contain("Plugin caption template"));
+            Assert.That(Collect(codecReference), Is.False);
+            Assert.That(Collect(factoryReference), Is.False);
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task InvalidCodecContribution_DoesNotSuppressTemplateContribution()
+    {
+        await TestReset.ResetShellAsync();
+        TestShell.Extensions.AddExtensions(
+            TestPackageId,
+            [
+                new InvalidCaptionDecoderExtension(),
+                .. CreateTemplateExtensions(new TestCaptionElementFactory()),
+            ]);
+        try
+        {
+            using var viewModel =
+                TestShell.MainViewModel.CreateAiSubtitleToolViewModel(editViewModel: null);
+
+            Assert.That(
+                viewModel.CaptionTemplates.Select(template => template.Name),
+                Does.Contain("Plugin caption template"));
+        }
+        finally
+        {
+            TestShell.Extensions.RemoveExtensions(TestPackageId);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (WeakReference Codec, WeakReference Factory) RegisterTestExtensions()
+    {
+        var codec = new TestCaptionCodec();
+        var factory = new TestCaptionElementFactory();
+        TestShell.Extensions.AddExtensions(
+            TestPackageId,
+            [.. CreateCodecExtensions(codec), .. CreateTemplateExtensions(factory)]);
+        return (new WeakReference(codec), new WeakReference(factory));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void RemoveTestExtensions()
+    {
+        _ = TestShell.Extensions.RemoveExtensions(TestPackageId);
+    }
+
+    private static bool Collect(WeakReference reference)
+    {
+        for (int i = 0; reference.IsAlive && i < 10; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
+        return reference.IsAlive;
+    }
+
+    private static Extension[] CreateCodecExtensions(TestCaptionCodec codec)
+        =>
+        [
+            new TestCaptionCodecDescriptorExtension([
+                new CaptionCodecDescriptorRegistration(
+                    new CaptionCodecDescriptor(s_testFormat, [".plugcap"])),
+            ]),
+            new TestCaptionDecoderExtension([
+                new CaptionDecoderRegistration(s_testFormat, codec),
+            ]),
+            new TestCaptionEncoderExtension([
+                new CaptionEncoderRegistration(s_testFormat, codec),
+            ]),
+        ];
+
+    private sealed class TestCaptionCodecDescriptorExtension(
+        IReadOnlyCollection<CaptionCodecDescriptorRegistration> registrations)
+        : CaptionCodecDescriptorExtension
+    {
+        public override IReadOnlyCollection<CaptionCodecDescriptorRegistration> Registrations
+            => registrations;
+    }
+
+    private sealed class TestCaptionDecoderExtension(
+        IReadOnlyCollection<CaptionDecoderRegistration> registrations)
+        : CaptionDecoderExtension
+    {
+        public override IReadOnlyCollection<CaptionDecoderRegistration> Registrations
+            => registrations;
+    }
+
+    private sealed class TestCaptionEncoderExtension(
+        IReadOnlyCollection<CaptionEncoderRegistration> registrations)
+        : CaptionEncoderExtension
+    {
+        public override IReadOnlyCollection<CaptionEncoderRegistration> Registrations
+            => registrations;
+    }
+
+    private sealed class InvalidCaptionDecoderExtension : CaptionDecoderExtension
+    {
+        public override IReadOnlyCollection<CaptionDecoderRegistration> Registrations => [null!];
+    }
+
+    private static Extension[] CreateTemplateExtensions(ICaptionElementFactory factory)
+    {
+        var id = new CaptionTemplateId("beutl.tests.plugin-caption");
+        return
+        [
+            new TestCaptionTemplateDescriptorExtension([
+                new CaptionTemplateDescriptorRegistration(new CaptionTemplateDescriptor(
+                    id,
+                    new CaptionTemplateProviderId("beutl.tests"),
+                    "Plugin caption template")),
+            ]),
+            new TestCaptionElementFactoryExtension([
+                new CaptionElementFactoryRegistration(id, factory),
+            ]),
+            new TestCaptionPlacementExtension([
+                new CaptionPlacementPolicyRegistration(
+                    id,
+                    DefaultCaptionPlacementPolicy.Instance),
+            ]),
+        ];
+    }
+
+    private sealed class TestCaptionTemplateDescriptorExtension(
+        IReadOnlyCollection<CaptionTemplateDescriptorRegistration> registrations)
+        : CaptionTemplateDescriptorExtension
+    {
+        public override IReadOnlyCollection<CaptionTemplateDescriptorRegistration> Registrations
+            => registrations;
+    }
+
+    private sealed class TestCaptionElementFactoryExtension(
+        IReadOnlyCollection<CaptionElementFactoryRegistration> registrations)
+        : CaptionElementFactoryExtension
+    {
+        public override IReadOnlyCollection<CaptionElementFactoryRegistration> Registrations
+            => registrations;
+    }
+
+    private sealed class TestCaptionPlacementExtension(
+        IReadOnlyCollection<CaptionPlacementPolicyRegistration> registrations)
+        : CaptionPlacementPolicyExtension
+    {
+        public override IReadOnlyCollection<CaptionPlacementPolicyRegistration> Registrations
+            => registrations;
+    }
+
+    private sealed class TestCaptionCodec : ICaptionDecoder, ICaptionEncoder
+    {
+        public CaptionImportResult Decode(string content)
+            => CaptionImportResult.Imported(new CaptionDocument(
+            [
+                new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), content),
+            ]));
+
+        public string Encode(CaptionDocument document)
+            => string.Join("\n", document.Cues.Select(cue => cue.Text));
+    }
+
+    private sealed class TestCaptionElementFactory : ICaptionElementFactory
+    {
+        public IReadOnlyList<ElementDescription> CreateElements(
+            CaptionCue cue,
+            CaptionElementContext context)
+            => throw new NotSupportedException();
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiCaptionHistoryResultParserTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiCaptionHistoryResultParserTests.cs
@@ -1,0 +1,237 @@
+﻿using System.Text;
+using Beutl.Api.Services;
+using Beutl.Services.AI;
+using Beutl.ViewModels.Dialogs;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public sealed class AiCaptionHistoryResultParserTests
+{
+    [Test]
+    public void TryParse_TranscriptionRestoresTimedSegments()
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes("""
+            {
+              "version": 1,
+              "kind": "stt",
+              "language": "JA",
+              "segments": [
+                { "start": 0.5, "end": 1.25, "text": "First" },
+                { "start": 2, "end": 3.5, "text": "Second" }
+              ]
+            }
+            """);
+
+        bool parsed = AiCaptionHistoryResultParser.TryParse(
+            bytes,
+            "stt",
+            new AiJobId("job-stt"),
+            out AiCaptionHistoryResult? result);
+
+        Assert.That(parsed, Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result!.JobId, Is.EqualTo(new AiJobId("job-stt")));
+            Assert.That(result.Language, Is.EqualTo("ja"));
+            Assert.That(result.Segments.Select(segment => segment.Text),
+                Is.EqualTo(new[] { "First", "Second" }));
+            Assert.That(result.Segments[0].Start, Is.EqualTo(0.5));
+            Assert.That(result.Segments[1].End, Is.EqualTo(3.5));
+        }
+    }
+
+    [TestCase("1e20", "1e20")]
+    [TestCase("1", "1e20")]
+    public void TryParse_RejectsTimestampsOutsideTimeSpanRange(string start, string end)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes($$"""
+            {
+              "version": 1,
+              "kind": "stt",
+              "segments": [
+                { "start": {{start}}, "end": {{end}}, "text": "Invalid" }
+              ]
+            }
+            """);
+
+        Assert.That(AiCaptionHistoryResultParser.TryParse(
+            bytes,
+            "stt",
+            new AiJobId("job-overflow"),
+            out _), Is.False);
+    }
+
+    [Test]
+    public void TryParse_TranslationWithoutTimingsKeepsItsOrderAndIsCollectable()
+    {
+        // Untimed translations must remain collectable in input order.
+        byte[] bytes = Encoding.UTF8.GetBytes("""
+            {
+              "version": 1,
+              "kind": "translation",
+              "targetLanguage": "ja",
+              "segments": [
+                { "id": "1", "text": "First" },
+                { "id": "2", "text": "Second" }
+              ]
+            }
+            """);
+
+        bool parsed = AiCaptionHistoryResultParser.TryParse(
+            bytes,
+            "translation",
+            new AiJobId("job-translation"),
+            out AiCaptionHistoryResult? result);
+
+        Assert.That(parsed, Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result!.Segments.Select(segment => segment.Text),
+                Is.EqualTo(new[] { "First", "Second" }));
+            Assert.That(result.Segments[0].Start, Is.EqualTo(0));
+            Assert.That(
+                result.Segments[1].Start,
+                Is.GreaterThan(result.Segments[0].End - 0.001),
+                "Synthetic ranges must preserve input order.");
+            Assert.That(result.Language, Is.EqualTo("ja"));
+        }
+    }
+
+    [Test]
+    public void TryParse_TranslationWithMixedContextPreservesKnownTimingsAndPlacesUntimedCuesSafely()
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes("""
+            {
+              "version": 1,
+              "kind": "translation",
+              "targetLanguage": "ja",
+              "segments": [
+                {
+                  "id": "1",
+                  "text": "First",
+                  "context": { "groupId": "g1", "partIndex": 0, "start": 4, "end": 6 }
+                },
+                { "id": "2", "text": "Second" },
+                {
+                  "id": "3",
+                  "text": "Earlier timed",
+                  "context": { "groupId": "g0", "partIndex": 0, "start": 1, "end": 2 }
+                },
+                { "id": "4", "text": "Fourth" }
+              ]
+            }
+            """);
+
+        bool parsed = AiCaptionHistoryResultParser.TryParse(
+            bytes,
+            "translation",
+            new AiJobId("job-translation"),
+            out AiCaptionHistoryResult? result);
+
+        Assert.That(parsed, Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result!.Segments.Select(segment => segment.Text),
+                Is.EqualTo(new[] { "Earlier timed", "First", "Second", "Fourth" }));
+            Assert.That(result.Segments.Select(segment => segment.Start),
+                Is.EqualTo(new[] { 1d, 4d, 6d, 7d }));
+            Assert.That(result.Segments.Select(segment => segment.End),
+                Is.EqualTo(new[] { 2d, 6d, 7d, 8d }));
+        }
+    }
+
+    [Test]
+    public void TryParse_TranslationReassemblesTimedPartsByGroup()
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes("""
+            {
+              "version": 1,
+              "kind": "translation",
+              "sourceLanguage": "en",
+              "targetLanguage": "ja",
+              "segments": [
+                {
+                  "id": "c1-p5",
+                  "text": "Second",
+                  "context": { "groupId": "c1", "partIndex": 5, "start": 4, "end": 5 }
+                },
+                {
+                  "id": "c0-p1",
+                  "text": " world",
+                  "context": { "groupId": "c0", "partIndex": 1, "start": 1, "end": 3 }
+                },
+                {
+                  "id": "c0-p0",
+                  "text": "Hello",
+                  "context": { "groupId": "c0", "partIndex": 0, "start": 1, "end": 3 }
+                }
+              ]
+            }
+            """);
+
+        bool parsed = AiCaptionHistoryResultParser.TryParse(
+            bytes,
+            "translation",
+            new AiJobId("job-translation"),
+            out AiCaptionHistoryResult? result);
+
+        Assert.That(parsed, Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result!.Language, Is.EqualTo("ja"));
+            Assert.That(result.Segments.Select(segment => segment.Text),
+                Is.EqualTo(new[] { "Hello world", "Second" }));
+            Assert.That(result.Segments.Select(segment => segment.Start),
+                Is.EqualTo(new[] { 1d, 4d }));
+        }
+    }
+
+    [TestCase("stt", "{ \"version\": 1, \"kind\": \"stt\", \"segments\": [{ \"start\": 1, \"end\": 1, \"text\": \"bad\" }] }")]
+    [TestCase("translation", "{ \"version\": 1, \"kind\": \"translation\", \"targetLanguage\": \"ja\", \"segments\": [{ \"id\": \"c0-p1\", \"text\": \"first available part\", \"context\": { \"groupId\": \"c0\", \"partIndex\": 1, \"start\": 0, \"end\": 1 } }, { \"id\": \"c0-p3\", \"text\": \"gap\", \"context\": { \"groupId\": \"c0\", \"partIndex\": 3, \"start\": 0, \"end\": 1 } }] }")]
+    public void TryParse_RejectsResultsThatCannotBeSafelyImported(string kind, string json)
+    {
+        Assert.That(AiCaptionHistoryResultParser.TryParse(
+            Encoding.UTF8.GetBytes(json),
+            kind,
+            new AiJobId("job-invalid"),
+            out _), Is.False);
+    }
+
+    [Test]
+    public void SizeLimitedMemoryStream_RejectsTheFirstWritePastTheLimit()
+    {
+        using var stream = new SizeLimitedMemoryStream(4);
+
+        stream.Write([1, 2, 3, 4]);
+
+        Assert.Throws<InvalidDataException>(() => stream.WriteByte(5));
+        Assert.That(stream.ToArray(), Is.EqualTo(new byte[] { 1, 2, 3, 4 }));
+    }
+
+    [Test]
+    public void AudioSourceItem_MapsOnlyTheSelectedSourceWindow()
+    {
+        var source = new AudioSourceItem(
+            "source",
+            "source.wav",
+            TimeSpan.FromSeconds(60),
+            elementStart: TimeSpan.FromSeconds(2),
+            elementLength: TimeSpan.FromSeconds(5),
+            sourceOffset: TimeSpan.FromSeconds(10));
+
+        AiTranscriptionSegment[] mapped = source.MapSegmentsToScene(
+        [
+            new AiTranscriptionSegment { Start = 10, End = 12, Text = "inside" },
+            new AiTranscriptionSegment { Start = 5, End = 9, Text = "outside" },
+        ]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(mapped, Has.Length.EqualTo(1));
+            Assert.That(mapped[0].Start, Is.EqualTo(2).Within(1e-9));
+            Assert.That(mapped[0].End, Is.EqualTo(4).Within(1e-9));
+            Assert.That(mapped[0].Text, Is.EqualTo("inside"));
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiCompactPresentationTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiCompactPresentationTests.cs
@@ -1,0 +1,1070 @@
+﻿using System.Globalization;
+using System.Reactive.Linq;
+using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Automation.Peers;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless.NUnit;
+using Avalonia.Layout;
+using Avalonia.LogicalTree;
+using Avalonia.VisualTree;
+using Beutl.Api;
+using Beutl.Api.Services;
+using Beutl.Editor.Services.Captions;
+using Beutl.Language;
+using Beutl.Services;
+using Beutl.Services.AI;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.ViewModels.Dialogs;
+using Beutl.Views.Tools;
+using FluentAvalonia.UI.Controls;
+using Reactive.Bindings;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture, NonParallelizable]
+public sealed class AiCompactPresentationTests
+{
+    [AvaloniaTest]
+    public void UsageSummary_CollapsesWithoutASnapshotAndReportsTheShareAsTextAlone()
+    {
+        using var entitlements = new ReactivePropertySlim<AiEntitlements?>();
+        using var usage = new AiUsageViewModel(entitlements);
+        var view = new AiUsageSummaryView
+        {
+            DataContext = usage,
+            VerticalAlignment = VerticalAlignment.Top,
+        };
+        var window = new Window { Content = view, Width = 340, Height = 400 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            Assert.That(view.Bounds.Height, Is.Zero,
+                "Without an entitlement snapshot there is no usage to report.");
+
+            entitlements.Value = CreateEntitlements(used: 125, limit: 500, additionalCredits: 40);
+            HeadlessTestHelpers.Render();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(view.Bounds.Height, Is.GreaterThan(0));
+                Assert.That(view.Bounds.Height, Is.LessThanOrEqualTo(24),
+                    "The usage readout must stay one caption row.");
+                Assert.That(
+                    view.GetLogicalDescendants().OfType<ProgressBar>(),
+                    Is.Empty,
+                    "The share is already in the text; a meter only repeats it.");
+                Assert.That(
+                    view.GetLogicalDescendants().OfType<TextBlock>().Select(text => text.FontSize),
+                    Is.All.LessThanOrEqualTo(11),
+                    "Usage is secondary information and stays at the compact size.");
+                Assert.That(
+                    ToolTip.GetTip(view.GetLogicalDescendants().OfType<StackPanel>().First()),
+                    Is.EqualTo(usage.MonthlyRemainingText.Value),
+                    "The remaining share moved into the tooltip rather than costing a line.");
+            }
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_GivesTheAspectRatioAndModelARowEach()
+    {
+        await TestReset.ResetShellAsync();
+        BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        await using AiImageGenerationDialogViewModel viewModel = CreateImageGenerationDialog(clients);
+        var view = new AiImageGenerationView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 480, Height = 640 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            Control aspectRatio = view.FindControl<Control>("AspectRatioField")!;
+            Control model = view.FindControl<Control>("ModelField")!;
+
+            viewModel.ModelPicker.HasChoice.Value = true;
+            HeadlessTestHelpers.Render();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(model.IsVisible, Is.True);
+                Assert.That(aspectRatio.Bounds.Bottom, Is.LessThanOrEqualTo(model.Bounds.Top + 1),
+                    "One selector per row, so neither is trimmed to half a docked tab.");
+                Assert.That(
+                    new[] { aspectRatio, model }.Select(field => field.Bounds.Width),
+                    Is.All.EqualTo(aspectRatio.Bounds.Width),
+                    "Each selector gets the full width.");
+            }
+
+            viewModel.ModelPicker.HasChoice.Value = false;
+            HeadlessTestHelpers.Render();
+
+            Assert.That(model.IsVisible, Is.False,
+                "A single model on offer is not a choice, so its row goes away.");
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageEdit_SwitchesTasksThroughADropDown()
+    {
+        await TestReset.ResetShellAsync();
+        BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        await using AiImageEditDialogViewModel viewModel = CreateImageEditDialog(clients);
+        var view = new AiImageEditView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 480, Height = 640 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            ComboBox picker = view.FindControl<ComboBox>("TaskPicker")!;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(picker.ItemCount, Is.EqualTo(viewModel.Tasks.Count));
+                Assert.That(picker.SelectedItem, Is.SameAs(viewModel.SelectedTask.Value));
+                Assert.That(picker.Bounds.Height, Is.LessThanOrEqualTo(40),
+                    "A collapsed drop-down keeps the task list to one row in a narrow dock pane.");
+            }
+
+            picker.SelectedItem = viewModel.Tasks[2];
+            HeadlessTestHelpers.Render();
+
+            Assert.That(viewModel.SelectedTask.Value, Is.SameAs(viewModel.Tasks[2]));
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task VideoGeneration_StacksTheSelectorsFromCoarsestToFinest()
+    {
+        await TestReset.ResetShellAsync();
+        BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        await using AiVideoGenerationDialogViewModel viewModel = CreateVideoGenerationDialog(clients);
+        var view = new AiVideoGenerationView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 460, Height = 900 };
+
+        try
+        {
+            window.Show();
+            viewModel.ModelPicker.HasChoice.Value = true;
+            HeadlessTestHelpers.Render();
+
+            Control model = view.FindControl<Control>("ModelField")!;
+            Control duration = view.FindControl<Control>("DurationField")!;
+            Control resolution = view.FindControl<Control>("ResolutionField")!;
+            Control aspectRatio = view.FindControl<Control>("AspectRatioField")!;
+            double modelTop = TopIn(view, model);
+            double durationTop = TopIn(view, duration);
+            double resolutionTop = TopIn(view, resolution);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(durationTop, Is.GreaterThanOrEqualTo(modelTop + model.Bounds.Height),
+                    "The model comes first: it decides what the rest of the run costs.");
+                Assert.That(resolutionTop, Is.GreaterThanOrEqualTo(durationTop + duration.Bounds.Height));
+                Assert.That(TopIn(view, aspectRatio), Is.EqualTo(resolutionTop).Within(1),
+                    "Resolution and aspect ratio describe the same frame, so they share a row.");
+                Assert.That(model.Bounds.Width, Is.EqualTo(duration.Bounds.Width).Within(1));
+                Assert.That(resolution.Bounds.Width, Is.LessThan(duration.Bounds.Width));
+            }
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Subtitle_EmptyCueListDoesNotReserveAScreenful()
+    {
+        await TestReset.ResetShellAsync();
+        BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        using AiSubtitleDialogViewModel viewModel = CreateSubtitleDialog(clients);
+        viewModel.SelectedSubtitlePageIndex.Value = 1;
+        var view = new AiSubtitleView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 460, Height = 900 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            ListBox cues = view.FindControl<ListBox>("CaptionCueList")!;
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.Cues, Is.Empty);
+                Assert.That(cues.IsEffectivelyVisible, Is.False,
+                    "An empty cue list is a sentence, not an empty box.");
+                Assert.That(
+                    view.GetLogicalDescendants().OfType<TextBlock>()
+                        .Any(text => text.Text == Strings.AiSubtitle_CueListEmpty
+                            && text.IsEffectivelyVisible),
+                    Is.True,
+                    "It says what would put cues there.");
+            }
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_LeadsWithTheTemplatesAndKeepsTheDetailsBelowTheOptions()
+    {
+        await TestReset.ResetShellAsync();
+        BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        await using AiImageGenerationDialogViewModel viewModel = CreateImageGenerationDialog(clients);
+        var view = new AiImageGenerationView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 420, Height = 1200 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            Expander templates = FindExpander(view, Strings.AiPromptTemplates);
+            Expander details = FindExpander(view, Strings.AiPromptDetails);
+            Expander reference = FindExpander(view, Strings.AiReferenceImageHeader);
+            TextBox prompt = view.GetLogicalDescendants().OfType<TextBox>().First(box => box.AcceptsReturn);
+            ComboBox background = view.GetLogicalDescendants()
+                .OfType<ComboBox>()
+                .Single(box => AutomationProperties.GetName(box) == Strings.AiBackground);
+            Button generate = view.GetLogicalDescendants()
+                .OfType<Button>()
+                .Single(button => ReferenceEquals(button.Command, viewModel.Generate));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(TopIn(view, templates), Is.LessThan(TopIn(view, prompt)),
+                    "A saved prompt is picked before one is written.");
+                Assert.That(
+                    TopIn(view, details),
+                    Is.GreaterThan(TopIn(view, background) + background.Bounds.Height),
+                    "The details are a refinement, so they sit under the choices they refine.");
+                Assert.That(
+                    TopIn(view, reference),
+                    Is.GreaterThan(TopIn(view, details)),
+                    "A picture to work from is the last thing added, under everything written by hand.");
+                Assert.That(generate.Classes, Does.Contain("accent"));
+                Assert.That(
+                    generate.Bounds.Width,
+                    Is.GreaterThan(view.Bounds.Width - 40),
+                    "The run button takes the row: it is what the tab is for.");
+            }
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task VideoGeneration_KeepsTheDetailsAndFrameGuidanceBelowTheOptions()
+    {
+        await TestReset.ResetShellAsync();
+        BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        await using AiVideoGenerationDialogViewModel viewModel = CreateVideoGenerationDialog(clients);
+        var view = new AiVideoGenerationView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 460, Height = 1400 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            Expander templates = FindExpander(view, Strings.AiPromptTemplates);
+            Expander details = FindExpander(view, Strings.AiPromptDetails);
+            Expander frames = FindExpander(view, Strings.AiVideoFrameGuidanceHeader);
+            TextBox prompt = view.GetLogicalDescendants().OfType<TextBox>().First(box => box.AcceptsReturn);
+            CheckBox generateAudio = view.GetLogicalDescendants().OfType<CheckBox>().Single();
+            Button generate = view.GetLogicalDescendants()
+                .OfType<Button>()
+                .Single(button => ReferenceEquals(button.Command, viewModel.Generate));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(TopIn(view, templates), Is.LessThan(TopIn(view, prompt)));
+                Assert.That(
+                    TopIn(view, details),
+                    Is.GreaterThan(TopIn(view, generateAudio) + generateAudio.Bounds.Height));
+                Assert.That(TopIn(view, frames), Is.GreaterThan(TopIn(view, details)));
+                Assert.That(generate.Classes, Does.Contain("accent"));
+                Assert.That(generate.Bounds.Width, Is.GreaterThan(view.Bounds.Width - 40));
+            }
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task PromptDetails_LabelEveryFieldItAsksFor()
+    {
+        await TestReset.ResetShellAsync();
+        BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        await using AiImageGenerationDialogViewModel viewModel = CreateImageGenerationDialog(clients);
+        var view = new AiImageGenerationView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 420, Height = 900 };
+
+        try
+        {
+            window.Show();
+            Expander details = view.GetLogicalDescendants()
+                .OfType<Expander>()
+                .Single(expander => Equals(expander.Header, Strings.AiPromptDetails));
+            details.IsExpanded = true;
+            HeadlessTestHelpers.Render();
+
+            List<string> labels = details.GetLogicalDescendants()
+                .OfType<TextBlock>()
+                .Select(text => text.Text ?? string.Empty)
+                .ToList();
+            int fieldCount = details.GetLogicalDescendants().OfType<TextBox>().Count()
+                + details.GetLogicalDescendants().OfType<NumericUpDown>().Count();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(labels, Does.Contain(Strings.AiPromptStyle));
+                Assert.That(labels, Does.Contain(Strings.AiPromptComposition));
+                Assert.That(labels, Does.Contain(Strings.AiPromptAvoid));
+                Assert.That(labels, Does.Contain(Strings.AiPromptSeed),
+                    "The seed is what makes a result reproducible, so it is offered here.");
+                Assert.That(fieldCount, Is.EqualTo(4),
+                    "A watermark disappears as soon as there is text, so every field carries a label.");
+            }
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task AiTabs_OfferThePlanOnlyWhereThereIsNoPlanYet()
+    {
+        await TestReset.ResetShellAsync();
+        BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        await using AiImageGenerationDialogViewModel viewModel = CreateImageGenerationDialog(clients);
+        var view = new AiImageGenerationView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 420, Height = 900 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            List<Button> planButtons = view.GetLogicalDescendants()
+                .OfType<Button>()
+                .Where(button => ReferenceEquals(button.Command, viewModel.OpenAiPlan))
+                .ToList();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(planButtons, Has.Count.EqualTo(1),
+                    "Buying more is a settings errand, not a button beside every run.");
+                Assert.That(planButtons[0].Content, Is.EqualTo(Strings.AiJoinPro));
+            }
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task VideoGeneration_SetsTheLengthWithASliderThatStopsOnWhatTheModelTakes()
+    {
+        await TestReset.ResetShellAsync();
+        BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        await using AiVideoGenerationDialogViewModel viewModel = CreateVideoGenerationDialog(clients);
+        var view = new AiVideoGenerationView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 460, Height = 900 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            Slider slider = view.FindControl<Slider>("DurationSlider")!;
+            TextBlock value = view.FindControl<TextBlock>("DurationValue")!;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(slider.Minimum, Is.Zero);
+                Assert.That(slider.Maximum, Is.EqualTo(viewModel.DurationOptions.Count - 1),
+                    "The scale is the list of lengths, so it cannot land between them.");
+                Assert.That(slider.IsSnapToTickEnabled, Is.True);
+                Assert.That(slider.Value, Is.EqualTo(1));
+                Assert.That(value.Text, Is.EqualTo(viewModel.SelectedDuration.Value.ToString()));
+            }
+
+            slider.Value = 2;
+            HeadlessTestHelpers.Render();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.SelectedDuration.Value.Seconds, Is.EqualTo(8));
+                Assert.That(value.Text, Is.EqualTo(viewModel.SelectedDuration.Value.ToString()),
+                    "The chosen length is spelled out: a slider position is not a number of seconds.");
+            }
+
+            viewModel.SelectedDuration.Value = viewModel.DurationOptions.Single(option => option.Seconds == 4);
+            HeadlessTestHelpers.Render();
+
+            Assert.That(slider.Value, Is.Zero, "The slider follows a length chosen anywhere else.");
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_SeedFieldCarriesTheValueBothWays()
+    {
+        await TestReset.ResetShellAsync();
+        BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        await using AiImageGenerationDialogViewModel viewModel = CreateImageGenerationDialog(clients);
+        var view = new AiImageGenerationView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 420, Height = 1200 };
+
+        try
+        {
+            window.Show();
+            FindExpander(view, Strings.AiPromptDetails).IsExpanded = true;
+            HeadlessTestHelpers.Render();
+
+            AssertSeedFieldCarriesTheValueBothWays(view, viewModel.Seed);
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task VideoGeneration_SeedFieldCarriesTheValueBothWays()
+    {
+        await TestReset.ResetShellAsync();
+        BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        await using AiVideoGenerationDialogViewModel viewModel = CreateVideoGenerationDialog(clients);
+        var view = new AiVideoGenerationView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 460, Height = 1400 };
+
+        try
+        {
+            window.Show();
+            FindExpander(view, Strings.AiPromptDetails).IsExpanded = true;
+            HeadlessTestHelpers.Render();
+
+            AssertSeedFieldCarriesTheValueBothWays(view, viewModel.Seed);
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    // A seed is only worth offering if the number typed in is the number sent,
+    // which is a decimal in the field and an integer in the request.
+    private static void AssertSeedFieldCarriesTheValueBothWays(Visual view, ReactivePropertySlim<int?> seed)
+    {
+        NumericUpDown field = view.GetLogicalDescendants().OfType<NumericUpDown>().Single();
+
+        field.Value = 4242m;
+        HeadlessTestHelpers.Render();
+        Assert.That(seed.Value, Is.EqualTo(4242));
+
+        seed.Value = 7;
+        HeadlessTestHelpers.Render();
+        Assert.That(field.Value, Is.EqualTo(7m));
+
+        seed.Value = null;
+        HeadlessTestHelpers.Render();
+        Assert.That(field.Value, Is.Null, "Nothing typed in means the server picks the seed.");
+    }
+
+    private static Expander FindExpander(Visual view, string header)
+        => view.GetLogicalDescendants().OfType<Expander>().Single(expander => Equals(expander.Header, header));
+
+    private static double TopIn(Visual root, Visual control)
+        => control.TranslatePoint(default, root)?.Y ?? double.NaN;
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_SaysNothingIsWrongUntilSomethingHasBeenTyped()
+    {
+        await TestReset.ResetShellAsync();
+        BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        await using AiImageGenerationDialogViewModel viewModel = CreateImageGenerationDialog(clients);
+        var view = new AiImageGenerationView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 420, Height = 900 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.PromptValidationError.Value, Is.EqualTo(Strings.AiPromptRequired),
+                    "The request still cannot be sent.");
+                Assert.That(viewModel.VisiblePromptValidationError.Value, Is.Null,
+                    "But a tab nobody has typed in yet has not made a mistake.");
+                Assert.That(FindValidationText(view)?.IsVisible ?? false, Is.False);
+            }
+
+            viewModel.Prompt.Value = "a calm sunset";
+            HeadlessTestHelpers.Render();
+            Assert.That(viewModel.VisiblePromptValidationError.Value, Is.Null);
+
+            viewModel.Prompt.Value = string.Empty;
+            HeadlessTestHelpers.Render();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.VisiblePromptValidationError.Value,
+                    Is.EqualTo(Strings.AiPromptRequired),
+                    "Once the box has been used, emptying it is worth pointing out.");
+                Assert.That(FindValidationText(view)?.IsVisible ?? false, Is.True);
+            }
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task VideoGeneration_HoldsTheValidationBackTheSameWay()
+    {
+        await TestReset.ResetShellAsync();
+        BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        await using AiVideoGenerationDialogViewModel viewModel = CreateVideoGenerationDialog(clients);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.PromptValidationError.Value, Is.EqualTo(Strings.AiPromptRequired));
+            Assert.That(viewModel.VisiblePromptValidationError.Value, Is.Null,
+                "An untouched tab has not made a mistake.");
+        }
+
+        // A detail alone still composes into a prompt, so the complaint waits for
+        // the box to be emptied again rather than for the main prompt specifically.
+        viewModel.Motion.Value = "slow push-in";
+        Assert.That(viewModel.VisiblePromptValidationError.Value, Is.Null);
+
+        viewModel.Motion.Value = string.Empty;
+        Assert.That(viewModel.VisiblePromptValidationError.Value, Is.EqualTo(Strings.AiPromptRequired));
+    }
+
+    [AvaloniaTest]
+    public async Task ImageEdit_HoldsTheValidationBackUntilThePromptIsUsed()
+    {
+        await TestReset.ResetShellAsync();
+        BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        await using AiImageEditDialogViewModel viewModel = CreateImageEditDialog(clients);
+        viewModel.SelectedTask.Value = viewModel.Tasks.First(task => task.Value == "restyle");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.PromptValidationError.Value, Is.EqualTo(Strings.AiPromptRequired));
+            Assert.That(viewModel.VisiblePromptValidationError.Value, Is.Null);
+        }
+
+        viewModel.Prompt.Value = "watercolour";
+        viewModel.Prompt.Value = string.Empty;
+
+        Assert.That(viewModel.VisiblePromptValidationError.Value, Is.EqualTo(Strings.AiPromptRequired));
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_KeepsTheResultBoxAndItsActionsAwayUntilThereIsAResult()
+    {
+        await TestReset.ResetShellAsync();
+        BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        await using AiImageGenerationDialogViewModel viewModel = CreateImageGenerationDialog(clients);
+        var view = new AiImageGenerationView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 300, Height = 560 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(
+                    view.GetLogicalDescendants().OfType<Border>()
+                        .Any(border => border.IsVisible && border.Height == 320),
+                    Is.False,
+                    "An empty 320px box would be most of a docked tab.");
+                Assert.That(
+                    view.GetLogicalDescendants().OfType<TextBlock>()
+                        .Any(text => text.IsVisible && text.Text == Strings.AiImageGenerationIdle),
+                    Is.True,
+                    "What stands there instead says what to do next.");
+                Assert.That(
+                    view.GetLogicalDescendants().OfType<Button>()
+                        .Any(button => button.IsEffectivelyVisible
+                            && Equals(button.Content, Strings.AiAddToScene)),
+                    Is.False,
+                    "There is nothing to add to the scene yet.");
+            }
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_OffersAWayOutWhileTheRequestRuns()
+    {
+        await TestReset.ResetShellAsync();
+        BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        await using AiImageGenerationDialogViewModel viewModel = CreateImageGenerationDialog(clients);
+        var view = new AiImageGenerationView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 420, Height = 900 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            Button cancel = view.GetLogicalDescendants().OfType<Button>()
+                .Single(button => Equals(button.Content, Strings.Cancel));
+            Assert.That(cancel.IsVisible, Is.False, "Nothing is running yet.");
+
+            viewModel.IsGenerating.Value = true;
+            HeadlessTestHelpers.Render();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(cancel.IsVisible, Is.True,
+                    "Generation runs for as long as the server takes; leaving must not mean closing the tab.");
+                Assert.That(viewModel.StopGenerating.CanExecute(), Is.True);
+            }
+
+            viewModel.IsGenerating.Value = false;
+            HeadlessTestHelpers.Render();
+            Assert.That(viewModel.StopGenerating.CanExecute(), Is.False);
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Subtitle_ShowsProgressAndOffersOneStopForTranscriptionAndTranslation()
+    {
+        await TestReset.ResetShellAsync();
+        BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        using AiSubtitleDialogViewModel viewModel = CreateSubtitleDialog(clients);
+        var view = new AiSubtitleView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 340, Height = 900 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+            ProgressRing progress = view.FindControl<ProgressRing>("TranscriptionProgressRing")!;
+            TextBlock status = view.FindControl<TextBlock>("TranscriptionStatusText")!;
+            AutomationPeer statusPeer = ControlAutomationPeer.CreatePeerForElement(status);
+            var automationChanges = new List<AutomationPropertyChangedEventArgs>();
+            statusPeer.PropertyChanged += (_, args) => automationChanges.Add(args);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.StopRequest.CanExecute(), Is.False);
+                Assert.That(progress.IsEffectivelyVisible, Is.False);
+                Assert.That(status.IsEffectivelyVisible, Is.True);
+                Assert.That(status.Text, Is.Empty);
+                Assert.That(viewModel.TranscriptionStatusText.Value, Is.Empty);
+            }
+
+            viewModel.IsTranscribing.Value = true;
+            HeadlessTestHelpers.Render();
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.StopRequest.CanExecute(), Is.True);
+                Assert.That(progress.IsEffectivelyVisible, Is.True);
+                Assert.That(progress.IsIndeterminate, Is.True);
+                Assert.That(status.IsEffectivelyVisible, Is.True);
+                Assert.That(status.Text, Is.EqualTo(Strings.AiSubtitle_Transcribing));
+                Assert.That(
+                    viewModel.TranscriptionStatusText.Value,
+                    Is.EqualTo(Strings.AiSubtitle_Transcribing));
+                Assert.That(
+                    AutomationProperties.GetName(progress),
+                    Is.EqualTo(Strings.AiSubtitle_Transcribing));
+                Assert.That(
+                    AutomationProperties.GetLiveSetting(status),
+                    Is.EqualTo(AutomationLiveSetting.Polite));
+                Assert.That(
+                    automationChanges.Any(change =>
+                        ReferenceEquals(
+                            change.Property,
+                            AutomationElementIdentifiers.NameProperty)
+                        && Equals(change.NewValue, Strings.AiSubtitle_Transcribing)),
+                    Is.True);
+            }
+
+            viewModel.IsTranscribing.Value = false;
+            HeadlessTestHelpers.Render();
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.StopRequest.CanExecute(), Is.False);
+                Assert.That(progress.IsEffectivelyVisible, Is.False);
+                Assert.That(status.IsEffectivelyVisible, Is.True);
+                Assert.That(status.Text, Is.Empty);
+                Assert.That(viewModel.TranscriptionStatusText.Value, Is.Empty);
+            }
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Subtitle_SeparatesTranscribeEditAndTranslateWorkflows()
+    {
+        await TestReset.ResetShellAsync();
+        BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        await using AiSubtitleDialogViewModel viewModel = CreateSubtitleDialog(clients);
+        var view = new AiSubtitleView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 180, Height = 900 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+            TabStrip workflow = view.FindControl<TabStrip>("SubtitleWorkflowTabs")!;
+            Button stop = view.FindControl<Button>("SubtitleStopButton")!;
+            ScrollViewer scroll = (ScrollViewer)view.Content!;
+            TabStripItem[] workflowItems = workflow.GetVisualDescendants()
+                .OfType<TabStripItem>()
+                .ToArray();
+            ComboBox source = FindByAutomationName<ComboBox>(view, Strings.AiSubtitle_AudioSource);
+            ComboBox template = view.FindControl<ComboBox>("CaptionTemplateComboBox")!;
+            ComboBox target = FindByAutomationName<ComboBox>(view, Strings.AiSubtitle_TargetLanguage);
+            ListBox cues = view.FindControl<ListBox>("CaptionCueList")!;
+            TextBlock transcribeDescription = view.GetLogicalDescendants()
+                .OfType<TextBlock>()
+                .Single(text => text.Text == Strings.AiSubtitle_TranscribeDescription);
+            TextBlock editDescription = view.GetLogicalDescendants()
+                .OfType<TextBlock>()
+                .Single(text => text.Text == Strings.AiSubtitle_EditDescription);
+            TextBlock translateDescription = view.GetLogicalDescendants()
+                .OfType<TextBlock>()
+                .Single(text => text.Text == Strings.AiSubtitle_TranslateDescription);
+            double[] workflowItemTops = workflowItems
+                .Select(item => item.TranslatePoint(default, workflow)?.Y ?? double.PositiveInfinity)
+                .ToArray();
+            double rightmostWorkflowItem = workflowItems.Max(item =>
+                item.TranslatePoint(new Point(item.Bounds.Width, 0), workflow)?.X
+                ?? double.PositiveInfinity);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(workflowItems.Select(AutomationProperties.GetName),
+                    Is.EqualTo(new[]
+                    {
+                        Strings.AiSubtitle_Transcribe,
+                        Strings.AiSubtitle_Edit,
+                        Strings.AiSubtitle_Translate,
+                    }));
+                Assert.That(workflowItemTops.Select(value => Math.Round(value)).Distinct().Count(),
+                    Is.GreaterThan(1),
+                    "The workflow choices wrap instead of clipping in a 180px dock.");
+                Assert.That(rightmostWorkflowItem, Is.LessThanOrEqualTo(workflow.Bounds.Width + 1));
+                Assert.That(scroll.Extent.Width, Is.LessThanOrEqualTo(scroll.Viewport.Width + 1));
+                Assert.That(viewModel.SelectedSubtitlePageIndex.Value, Is.Zero);
+                Assert.That(source.IsEffectivelyVisible, Is.True);
+                Assert.That(template.IsEffectivelyVisible, Is.False);
+                Assert.That(target.IsEffectivelyVisible, Is.False);
+                Assert.That(transcribeDescription.IsEffectivelyVisible, Is.True);
+                Assert.That(editDescription.IsEffectivelyVisible, Is.False);
+                Assert.That(translateDescription.IsEffectivelyVisible, Is.False);
+                Assert.That(stop.IsEffectivelyVisible, Is.False);
+            }
+
+            viewModel.HistoryOverwriteMessage.Value = "History notice";
+            viewModel.HasPendingHistoryResult.Value = true;
+            viewModel.PartialResultMessage.Value = "Partial notice";
+            viewModel.HasPartialResult.Value = true;
+            viewModel.Error.Value = "Global error";
+            HeadlessTestHelpers.Render();
+            TextBlock historyNotice = view.GetLogicalDescendants().OfType<TextBlock>()
+                .Single(text => text.Text == "History notice");
+            TextBlock partialNotice = view.GetLogicalDescendants().OfType<TextBlock>()
+                .Single(text => text.Text == "Partial notice");
+            TextBlock errorNotice = view.GetLogicalDescendants().OfType<TextBlock>()
+                .Single(text => text.Text == "Global error");
+            for (int page = 0; page < 3; page++)
+            {
+                workflow.SelectedIndex = page;
+                HeadlessTestHelpers.Render();
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(historyNotice.IsEffectivelyVisible, Is.True);
+                    Assert.That(partialNotice.IsEffectivelyVisible, Is.True);
+                    Assert.That(errorNotice.IsEffectivelyVisible, Is.True);
+                }
+            }
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.SelectedSubtitlePageIndex.Value, Is.EqualTo(2));
+                Assert.That(source.IsEffectivelyVisible, Is.False);
+                Assert.That(template.IsEffectivelyVisible, Is.False);
+                Assert.That(target.IsEffectivelyVisible, Is.True);
+                Assert.That(translateDescription.IsEffectivelyVisible, Is.True);
+            }
+
+            viewModel.IsTranslating.Value = true;
+            viewModel.ResultSegments.Value =
+            [
+                new AiTranscriptionSegment { Start = 0, End = 2, Text = "Ready to edit" },
+            ];
+            HeadlessTestHelpers.Render();
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.SelectedSubtitlePageIndex.Value, Is.EqualTo(1));
+                Assert.That(workflow.SelectedIndex, Is.EqualTo(1));
+                Assert.That(workflow.IsEffectivelyEnabled, Is.False,
+                    "Navigation stays on the page that owns the operation context.");
+                Assert.That(stop.IsEffectivelyVisible, Is.True,
+                    "The shared cancel action remains reachable independently of page content.");
+                Assert.That(template.IsEffectivelyVisible, Is.True);
+                Assert.That(target.IsEffectivelyVisible, Is.False);
+            }
+            viewModel.IsTranslating.Value = false;
+            HeadlessTestHelpers.Render();
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.SelectedSubtitlePageIndex.Value, Is.EqualTo(1));
+                Assert.That(workflow.SelectedIndex, Is.EqualTo(1));
+                Assert.That(source.IsEffectivelyVisible, Is.False);
+                Assert.That(template.IsEffectivelyVisible, Is.True);
+                Assert.That(cues.IsEffectivelyVisible, Is.True);
+                Assert.That(target.IsEffectivelyVisible, Is.False);
+                Assert.That(editDescription.IsEffectivelyVisible, Is.True);
+                Assert.That(stop.IsEffectivelyVisible, Is.False);
+            }
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Subtitle_ReadsTheSourceAndLanguageAtADockedWidth()
+    {
+        await TestReset.ResetShellAsync();
+        BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        using AiSubtitleDialogViewModel viewModel = CreateSubtitleDialog(clients);
+        var view = new AiSubtitleView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 300, Height = 900 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            ComboBox source = FindByAutomationName<ComboBox>(view, Strings.AiSubtitle_AudioSource);
+            ComboBox language = FindByAutomationName<ComboBox>(view, Strings.AiSubtitle_SourceLanguage);
+
+            Point sourceOrigin = source.TranslatePoint(default, view) ?? default;
+            Point languageOrigin = language.TranslatePoint(default, view) ?? default;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(
+                    sourceOrigin.Y + source.Bounds.Height,
+                    Is.LessThanOrEqualTo(languageOrigin.Y + 1),
+                    "Side by side, neither reads at a docked width.");
+                Assert.That(source.Bounds.Width, Is.EqualTo(language.Bounds.Width));
+                Assert.That(source.Bounds.Width, Is.GreaterThan(200),
+                    "The source names the range it covers, so it needs the room to say so.");
+            }
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Subtitle_ShowsACueAsOneRowAndOpensTheOneThatIsSelected()
+    {
+        await TestReset.ResetShellAsync();
+        using AiSubtitleDialogViewModel viewModel =
+            TestShell.MainViewModel.CreateAiSubtitleToolViewModel(null);
+        viewModel.ResultSegments.Value =
+        [
+            new AiTranscriptionSegment { Start = 0, End = 2, Text = "first line" },
+            new AiTranscriptionSegment { Start = 2, End = 4, Text = "second line" },
+            new AiTranscriptionSegment { Start = 4, End = 6, Text = "third line" },
+        ];
+        var view = new AiSubtitleView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 380, Height = 900 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            ListBox list = view.FindControl<ListBox>("CaptionCueList")!;
+            ListBoxItem[] rows = list.GetRealizedContainers().OfType<ListBoxItem>().ToArray();
+            Assert.That(rows, Has.Length.EqualTo(3));
+
+            ListBoxItem opened = rows.Single(row => row.IsSelected);
+            ListBoxItem[] closed = rows.Where(row => !row.IsSelected).ToArray();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(closed.Select(row => row.Bounds.Height), Is.All.LessThan(72),
+                    "A cue nobody is editing is one row, so a whole caption set can be read.");
+                Assert.That(opened.Bounds.Height, Is.GreaterThan(closed[0].Bounds.Height),
+                    "The one being worked on is the editor.");
+                Assert.That(
+                    closed.SelectMany(row => row.GetVisualDescendants().OfType<TextBox>()),
+                    Is.Empty,
+                    "The fields exist only where they are being used.");
+                Assert.That(
+                    opened.GetVisualDescendants().OfType<TextBox>().Count(),
+                    Is.EqualTo(5));
+            }
+
+            list.SelectedItem = closed[0].DataContext;
+            HeadlessTestHelpers.Render();
+
+            Assert.That(
+                closed[0].GetVisualDescendants().OfType<TextBox>().Count(),
+                Is.EqualTo(5),
+                "Selecting another cue moves the editor to it.");
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    private static TextBlock? FindValidationText(Visual view)
+        => view.GetLogicalDescendants()
+            .OfType<TextBlock>()
+            .FirstOrDefault(text => text.Text == Strings.AiPromptRequired);
+
+    private static T FindByAutomationName<T>(Visual view, string name)
+        where T : Control
+        => view.GetLogicalDescendants()
+            .OfType<T>()
+            .Single(control => AutomationProperties.GetName(control) == name);
+
+    private static AiImageGenerationDialogViewModel CreateImageGenerationDialog(BeutlApiApplication clients)
+        => new(
+            clients.GetResource<IAiEntitlementService>(),
+            clients.GetResource<IAiOperationAvailabilityService>(),
+            clients.GetResource<IAiModelCatalogService>(),
+            new AiPlanCoordinator(clients.GetResource<IAiEntitlementService>()),
+            clients.GetResource<IAiImageGenerationService>(),
+            clients.GetResource<IAuthenticatedContentService>(),
+            editViewModel: null,
+            requestRecoveryContext: AiRetryTestContext.CreateForm());
+
+    private static AiImageEditDialogViewModel CreateImageEditDialog(BeutlApiApplication clients)
+        => new(
+            clients.GetResource<IAiEntitlementService>(),
+            clients.GetResource<IAiOperationAvailabilityService>(),
+            clients.GetResource<IAiModelCatalogService>(),
+            new AiPlanCoordinator(clients.GetResource<IAiEntitlementService>()),
+            clients.GetResource<IAiImageEditingService>(),
+            clients.GetResource<IAuthenticatedContentService>(),
+            editViewModel: null,
+            requestRecoveryContext: AiRetryTestContext.CreateForm());
+
+    private static AiVideoGenerationDialogViewModel CreateVideoGenerationDialog(BeutlApiApplication clients)
+        => new(
+            clients.GetResource<IAiEntitlementService>(),
+            clients.GetResource<IAiOperationAvailabilityService>(),
+            clients.GetResource<IAiModelCatalogService>(),
+            new AiPlanCoordinator(clients.GetResource<IAiEntitlementService>()),
+            clients.GetResource<IAiVideoService>(),
+            clients.GetResource<IAuthenticatedContentService>(),
+            clients.GetResource<IAiJobKindRegistry>(),
+            clients.GetResource<IAiJobMonitor>(),
+            editViewModel: null,
+            requestRecoveryContext: AiRetryTestContext.CreateForm());
+
+    private static AiSubtitleDialogViewModel CreateSubtitleDialog(BeutlApiApplication clients)
+        => new(
+            clients.GetResource<IAiEntitlementService>(),
+            clients.GetResource<IAiOperationAvailabilityService>(),
+            clients.GetResource<IAiModelCatalogService>(),
+            new AiPlanCoordinator(clients.GetResource<IAiEntitlementService>()),
+            clients.GetResource<IAiTranscriptionService>(),
+            clients.GetResource<IAiCaptionTranslationService>(),
+            CaptionCatalog.CreateDefault("Default"),
+            CaptionDraftStoreProvider.Current,
+            Observable.Return<CaptionDraftScope?>(null));
+
+    private static AiEntitlements CreateEntitlements(int used, int limit, int additionalCredits)
+    {
+        int usedPercent = limit <= 0 ? 0 : Math.Clamp((int)Math.Round(used * 100.0 / limit), 0, 100);
+        return new AiEntitlements(
+            "pro",
+            "active",
+            null,
+            null,
+            false,
+            true,
+            new AiBalance(
+                new AiMonthlyUsage(usedPercent, 100 - usedPercent, limit > 0 && used >= limit),
+                additionalCredits,
+                false),
+            new AiOperationAvailability([]));
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiDialogWorkflowTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiDialogWorkflowTests.cs
@@ -4092,6 +4092,96 @@ public sealed class AiDialogWorkflowTests
     }
 
     [AvaloniaTest]
+    public async Task SourceFileTranscription_RestartWithDifferentSourceWindowStartsANewRun()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-source-window-draft-identity");
+        var draftStore = new FileCaptionDraftStore(Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "source-window-draft-identity"));
+        CaptionDraftScope scope = new("user-a", Guid.NewGuid(), editor.Scene.Id);
+        IObservable<CaptionDraftScope?> scopes = Observable.Return<CaptionDraftScope?>(scope);
+        string sourcePath = Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "source-window-draft-identity.wav");
+        const int sampleRate = 16_000;
+        WritePcmWave(sourcePath, sampleRate, sampleCount: sampleRate * 2);
+        var keys = new List<string?>();
+        int requestCount = 0;
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/transcriptions")
+            {
+                keys.Add(IdempotencyKeyOf(request));
+                if (++requestCount == 1)
+                {
+                    return JsonResponse(HttpStatusCode.ServiceUnavailable, """
+                        {
+                          "error_code": "aiResultUnavailable",
+                          "message": "The paid result is temporarily unavailable.",
+                          "documentation_url": null
+                        }
+                        """);
+                }
+                return CreateTranscriptionResponse("replacement-source-window");
+            }
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        Guid elementId = Guid.NewGuid();
+        var originalWindow = new AudioSourceItem(
+            "Source",
+            sourcePath,
+            TimeSpan.FromSeconds(2),
+            elementLength: TimeSpan.FromSeconds(1),
+            sourceOffset: TimeSpan.Zero,
+            elementId: elementId);
+        var shiftedWindow = new AudioSourceItem(
+            "Source",
+            sourcePath,
+            TimeSpan.FromSeconds(2),
+            elementLength: TimeSpan.FromSeconds(1),
+            sourceOffset: TimeSpan.FromSeconds(1),
+            elementId: elementId);
+
+        try
+        {
+            await using (var first = CreateSubtitleDialog(clients, editor, draftStore, scopes))
+            {
+                first.SelectedAudioSource.Value = originalWindow;
+                await WaitUntilAsync(() => first.Usage.HasSnapshot.Value && first.CanTranscribe.Value);
+                await first.Transcribe.ExecuteAsync();
+                Assert.That(first.HasOutstandingTranscriptionRequest.Value, Is.True);
+            }
+
+            await using var restored = CreateSubtitleDialog(clients, editor, draftStore, scopes);
+            restored.SelectedAudioSource.Value = shiftedWindow;
+            await WaitUntilAsync(() => restored.Usage.HasSnapshot.Value
+                && restored.TranscriptionModelPicker.IsLoaded.Value);
+            restored.RefreshAvailability();
+            await WaitUntilAsync(() => restored.CanTranscribe.Value);
+            await restored.Transcribe.ExecuteAsync();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(requestCount, Is.EqualTo(2));
+                Assert.That(keys, Has.Count.EqualTo(2));
+                Assert.That(keys[1], Is.Not.EqualTo(keys[0]));
+                Assert.That(restored.HasOutstandingTranscriptionRequest.Value, Is.True,
+                    "The original paid recovery remains available after the replacement window completes.");
+            }
+        }
+        finally
+        {
+            File.Delete(sourcePath);
+        }
+    }
+
+    [AvaloniaTest]
     public async Task SourceFileTranscription_SaveFailureAfterFinalResponsePreservesSeedForRestart()
     {
         await TestReset.ResetShellAsync();

--- a/tests/Beutl.HeadlessUITests/AiDialogWorkflowTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiDialogWorkflowTests.cs
@@ -3355,6 +3355,7 @@ public sealed class AiDialogWorkflowTests
         await TestReset.ResetShellAsync();
         bool firstModelRemoved = false;
         var sentModels = new List<string?>();
+        var availability = new RecordingAvailabilityService();
         int translationRequests = 0;
         using var handler = new StubHandler(request =>
         {
@@ -3385,7 +3386,9 @@ public sealed class AiDialogWorkflowTests
         using var httpClient = new HttpClient(handler);
         await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
         SetAuthenticatedUser(clients, httpClient);
-        using var viewModel = CreateSubtitleDialog(clients);
+        using var viewModel = CreateSubtitleDialog(
+            clients,
+            availabilityService: availability);
         await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
             && viewModel.TranslationModelPicker.Options.Count == 2);
         viewModel.ResultSegments.Value = CreateTranslationBatchSegments();
@@ -3410,11 +3413,13 @@ public sealed class AiDialogWorkflowTests
                 Is.False,
                 "The removed model stays visible only because the partial run still owns it.");
         }
+        availability.Clear();
         viewModel.TranslationModelPicker.Selected.Value =
             viewModel.TranslationModelPicker.Options.First(option =>
                 option.Id == new AiModelId("translation-b"));
 
         viewModel.RefreshAvailability();
+        await WaitUntilAsync(() => availability.GetRequestsSnapshot().Count > 0);
         await WaitUntilAsync(() => viewModel.CanTranslate.Value);
         await viewModel.Translate.ExecuteAsync();
 
@@ -3427,8 +3432,82 @@ public sealed class AiDialogWorkflowTests
                 "translation-a",
                 "translation-a",
             }));
+            Assert.That(
+                availability.GetRequestsSnapshot()
+                    .OfType<AiOperationAvailabilityRequest.Translation>()
+                    .Select(request => request.Model?.Value),
+                Is.All.EqualTo("translation-a"));
             Assert.That(viewModel.HasPartialResult.Value, Is.False);
         }
+    }
+
+    [AvaloniaTest]
+    public async Task SubtitleTranslation_PendingNoModelRunRemainsUnmodeledForAvailability()
+    {
+        await TestReset.ResetShellAsync();
+        bool publishModels = false;
+        int translationRequests = 0;
+        var availability = new RecordingAvailabilityService();
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/capabilities")
+            {
+                return JsonResponse(
+                    HttpStatusCode.OK,
+                    CaptionCapabilitiesJson(
+                        removeFirst: true,
+                        omitTranslationModels: !publishModels));
+            }
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/translations")
+            {
+                int requestNumber = ++translationRequests;
+                return requestNumber == 1
+                    ? CreateTranslationResponse(request, "translation-unmodeled")
+                    : JsonResponse(HttpStatusCode.InternalServerError, """
+                        {
+                          "error_code": "aiProviderError",
+                          "message": "Provider failed.",
+                          "documentation_url": null
+                        }
+                        """);
+            }
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(
+            clients,
+            availabilityService: availability);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.ResultSegments.Value = CreateTranslationBatchSegments();
+        await WaitUntilAsync(() => viewModel.CanTranslate.Value);
+
+        await viewModel.Translate.ExecuteAsync();
+        viewModel.ApplyPartialResult.Execute();
+        Assert.That(viewModel.HasPartialResult.Value, Is.True);
+
+        publishModels = true;
+        IAiModelCatalogService catalog = clients.GetResource<IAiModelCatalogService>();
+        catalog.Invalidate();
+        await viewModel.TranslationModelPicker.LoadAsync(
+            AiOperations.CaptionTranslation,
+            CancellationToken.None);
+        Assert.That(
+            viewModel.TranslationModelPicker.SelectedModel,
+            Is.EqualTo(new AiModelId("translation-b")));
+
+        availability.Clear();
+        viewModel.RefreshAvailability();
+        await WaitUntilAsync(() => availability.GetRequestsSnapshot().Count > 0);
+
+        Assert.That(
+            availability.GetRequestsSnapshot()
+                .OfType<AiOperationAvailabilityRequest.Translation>()
+                .Select(request => request.Model),
+            Is.All.Null);
     }
 
     [AvaloniaTest]
@@ -5182,10 +5261,11 @@ public sealed class AiDialogWorkflowTests
         BeutlApiApplication clients,
         EditViewModel? editor = null,
         ICaptionDraftStore? draftStore = null,
-        IObservable<CaptionDraftScope?>? draftScopes = null)
+        IObservable<CaptionDraftScope?>? draftScopes = null,
+        IAiOperationAvailabilityService? availabilityService = null)
         => new(
             clients.GetResource<IAiEntitlementService>(),
-            clients.GetResource<IAiOperationAvailabilityService>(),
+            availabilityService ?? clients.GetResource<IAiOperationAvailabilityService>(),
             clients.GetResource<IAiModelCatalogService>(),
             CreatePlanCoordinator(clients),
             clients.GetResource<IAiTranscriptionService>(),
@@ -5194,6 +5274,34 @@ public sealed class AiDialogWorkflowTests
             draftStore ?? CaptionDraftStoreProvider.Current,
             draftScopes ?? Observable.Return<CaptionDraftScope?>(null),
             editor);
+
+    private sealed class RecordingAvailabilityService : IAiOperationAvailabilityService
+    {
+        private readonly object _gate = new();
+        private readonly List<AiOperationAvailabilityRequest> _requests = [];
+
+        public Task<bool> CheckAsync(
+            AiOperationAvailabilityRequest request,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_gate)
+                _requests.Add(request);
+            return Task.FromResult(true);
+        }
+
+        public IReadOnlyList<AiOperationAvailabilityRequest> GetRequestsSnapshot()
+        {
+            lock (_gate)
+                return _requests.ToArray();
+        }
+
+        public void Clear()
+        {
+            lock (_gate)
+                _requests.Clear();
+        }
+    }
 
     private static IAiPlanCoordinator CreatePlanCoordinator(BeutlApiApplication clients)
         => new AiPlanCoordinator(clients.GetResource<IAiEntitlementService>());
@@ -5303,7 +5411,8 @@ public sealed class AiDialogWorkflowTests
         bool removeFirst,
         int? maxSegments = null,
         int? maxCharacters = null,
-        int? maxRequestBytes = null)
+        int? maxRequestBytes = null,
+        bool omitTranslationModels = false)
     {
         static object Model(string id, bool isDefault) => new
         {
@@ -5313,9 +5422,11 @@ public sealed class AiDialogWorkflowTests
             isDefault,
         };
 
-        object[] translationModels = removeFirst
-            ? [Model("translation-b", true)]
-            : [Model("translation-a", true), Model("translation-b", false)];
+        object[]? translationModels = omitTranslationModels
+            ? null
+            : removeFirst
+                ? [Model("translation-b", true)]
+                : [Model("translation-a", true), Model("translation-b", false)];
         object[] transcriptionModels = removeFirst
             ? [Model("transcription-b", true)]
             : [Model("transcription-a", true), Model("transcription-b", false)];

--- a/tests/Beutl.HeadlessUITests/AiDialogWorkflowTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiDialogWorkflowTests.cs
@@ -1,0 +1,5650 @@
+﻿using System.IO.Pipelines;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Reactive.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Platform.Storage;
+using Beutl.Api;
+using Beutl.Api.Clients;
+using Beutl.Api.Objects;
+using Beutl.Api.Services;
+using Beutl.Audio;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services.Captions;
+using Beutl.Graphics;
+using Beutl.Language;
+using Beutl.Media;
+using Beutl.Media.Source;
+using Beutl.ProjectSystem;
+using Beutl.Serialization;
+using Beutl.Services;
+using Beutl.Services.AI;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.ViewModels.Dialogs;
+using Beutl.Views.Tools;
+using FluentAvalonia.UI.Controls;
+using Reactive.Bindings;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture, NonParallelizable]
+public sealed class AiDialogWorkflowTests
+{
+    private static readonly byte[] s_png = Convert.FromBase64String(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==");
+
+    [AvaloniaTest]
+    public async Task DisposedDialogsIgnoreIdentityClearsAlreadyQueuedToTheUiThread()
+    {
+        await TestReset.ResetShellAsync();
+        string account = "account-a";
+        using var context = CreateIdentityContext(() => account);
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        var generation = CreateImageGenerationDialog(clients, context: context);
+        var edit = CreateImageEditDialog(clients, context: context);
+        var video = CreateVideoGenerationDialog(clients, context: context);
+
+        account = "account-b";
+        Task.Run(context.RefreshIdentity).GetAwaiter().GetResult();
+        await generation.DisposeAsync();
+        await edit.DisposeAsync();
+        await video.DisposeAsync();
+
+        Assert.DoesNotThrow(() => HeadlessTestHelpers.Settle());
+    }
+
+    [AvaloniaTest]
+    public async Task ImageEdit_SourcePickerResultFromPreviousIdentityIsIgnored()
+    {
+        await TestReset.ResetShellAsync();
+        string account = "account-a";
+        using var context = CreateIdentityContext(() => account);
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateImageEditDialog(clients, context: context);
+        var picker = new TaskCompletionSource<string?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        viewModel.SourceFilePicker = _ => picker.Task;
+
+        Task command = viewModel.SelectSourceFileCommand.ExecuteAsync();
+        await Task.Yield();
+        account = "account-b";
+        await Task.Run(context.RefreshIdentity);
+        HeadlessTestHelpers.Settle();
+        picker.SetResult(Path.Combine(Path.GetTempPath(), "stale-edit-source.png"));
+        await command;
+
+        Assert.That(viewModel.SourceFilePath.Value, Is.Null);
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_ReferencePickerResultFromPreviousIdentityIsIgnored()
+    {
+        await TestReset.ResetShellAsync();
+        string account = "account-a";
+        using var context = CreateIdentityContext(() => account);
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateImageGenerationDialog(clients, context: context);
+        var picker = new TaskCompletionSource<IReadOnlyList<string>>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        viewModel.ReferenceImagePicker = _ => picker.Task;
+
+        Task command = viewModel.SelectReferenceImage.ExecuteAsync();
+        await Task.Yield();
+        account = "account-b";
+        await Task.Run(context.RefreshIdentity);
+        HeadlessTestHelpers.Settle();
+        picker.SetResult([Path.Combine(Path.GetTempPath(), "stale-reference.png")]);
+        await command;
+
+        Assert.That(viewModel.ReferenceImages, Is.Empty);
+    }
+
+    [AvaloniaTest]
+    public async Task VideoGeneration_FramePickerResultFromPreviousIdentityIsIgnored()
+    {
+        await TestReset.ResetShellAsync();
+        string account = "account-a";
+        using var context = CreateIdentityContext(() => account);
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        await using var viewModel = CreateVideoGenerationDialog(clients, context: context);
+        var picker = new TaskCompletionSource<string?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        viewModel.FramePicker = _ => picker.Task;
+
+        Task command = viewModel.SelectFirstFrame.ExecuteAsync();
+        await Task.Yield();
+        account = "account-b";
+        await Task.Run(context.RefreshIdentity);
+        HeadlessTestHelpers.Settle();
+        picker.SetResult(Path.Combine(Path.GetTempPath(), "stale-frame.png"));
+        await command;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.FirstFramePath.Value, Is.Null);
+            Assert.That(viewModel.FirstFramePreview.Value, Is.Null);
+        });
+    }
+
+    [AvaloniaTest]
+    public void ImageSaveLease_SurvivesResultReplacement()
+    {
+        var owner = Ref<Bitmap>.Create(new Bitmap(2, 2));
+        using Ref<Bitmap>? saveLease = AiResultImageLease.Acquire(owner);
+
+        owner.Dispose();
+
+        using var output = new MemoryStream();
+        Assert.DoesNotThrow(() => saveLease!.Value.Save(output, EncodedImageFormat.Png));
+        Assert.That(output.Length, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void AiImageSavePicker_OffersOnlyPng()
+    {
+        FilePickerSaveOptions options = SharedFilePickerOptions.SavePngImage();
+        FilePickerFileType type = options.FileTypeChoices!.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(options.DefaultExtension, Is.EqualTo("png"));
+            Assert.That(type.Patterns, Is.EqualTo(new[] { "*.png" }));
+            Assert.That(type.MimeTypes, Is.EqualTo(new[] { "image/png" }));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_ModelRefreshRetriesInitialEntitlementFailure()
+    {
+        await TestReset.ResetShellAsync();
+        int entitlementRequests = 0;
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => ++entitlementRequests == 1
+                ? JsonResponse(HttpStatusCode.ServiceUnavailable, "{}")
+                : JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/capabilities" => JsonResponse(
+                HttpStatusCode.OK,
+                ImageCapabilitiesJson()),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => Volatile.Read(ref entitlementRequests) == 1);
+
+        Assert.That(viewModel.Usage.HasSnapshot.Value, Is.False);
+
+        viewModel.RefreshModels();
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.ModelPicker.Options.Count > 0);
+
+        Assert.That(entitlementRequests, Is.EqualTo(2));
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_GeneratesAndImportsResult()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-image-dialog");
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/images" => JsonResponse(HttpStatusCode.OK, ImageResponseJson("image-job", "image-file")),
+            "/api/contents/image-file" => ByteResponse(s_png, "image/png"),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateImageGenerationDialog(clients, editor);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.Prompt.Value = "A calm blue sky";
+
+        await viewModel.Generate.ExecuteAsync();
+        await viewModel.AddToScene.ExecuteAsync();
+        HeadlessTestHelpers.Settle();
+
+        string persistedElement = CoreSerializer.SerializeToJsonObject(editor.Scene.Children.Single()).ToJsonString();
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.ResultImage.Value, Is.Not.Null);
+            Assert.That(persistedElement, Does.Not.Contain("image-job"));
+            Assert.That(persistedElement, Does.Not.Contain("image-file"));
+            Assert.That(persistedElement, Does.Not.Contain("A calm blue sky"));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_SaveRejectsNonPngDestinationWithoutReplacingFile()
+    {
+        await TestReset.ResetShellAsync();
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/images" => JsonResponse(
+                HttpStatusCode.OK,
+                ImageResponseJson("image-save-job", "image-save-file")),
+            "/api/contents/image-save-file" => ByteResponse(s_png, "image/png"),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.Prompt.Value = "Save as PNG";
+        await viewModel.Generate.ExecuteAsync();
+        string destinationPath = Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "existing.jpg");
+        byte[] original = [9, 8, 7];
+        await File.WriteAllBytesAsync(destinationPath, original);
+        viewModel.SaveFilePicker = _ => Task.FromResult<AiSaveFileDestination?>(
+            new(destinationPath));
+
+        await viewModel.SaveToFile.ExecuteAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(File.ReadAllBytes(destinationPath), Is.EqualTo(original));
+            Assert.That(viewModel.Error.Value, Is.Not.Null);
+            Assert.That(
+                Directory.EnumerateFiles(
+                    Path.GetDirectoryName(destinationPath)!,
+                    "existing.jpg.*.tmp"),
+                Is.Empty);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_PreDispatchFailuresFreeTheModelAgain()
+    {
+        // A name is issued before dispatch. If a request rejected by preflight retains it,
+        // changing the model still sends the first named model, so the UI and charge disagree.
+        await TestReset.ResetShellAsync();
+        bool affordable = false;
+        bool failAvailability = false;
+        var sentModels = new List<string?>();
+        using var handler = new StubHandler(async (request, token) =>
+        {
+            switch (request.RequestUri?.AbsolutePath)
+            {
+                case "/api/v3/user/ai-availability":
+                    if (failAvailability)
+                        throw new HttpRequestException("Availability is temporarily unavailable.");
+                    return JsonResponse(
+                        HttpStatusCode.OK,
+                        affordable ? "{ \"available\": true }" : "{ \"available\": false }");
+                case "/api/v3/user/entitlements":
+                    return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                case "/api/v3/ai/capabilities":
+                    return JsonResponse(HttpStatusCode.OK, ImageCapabilitiesJson());
+                case "/api/v3/ai/images":
+                    string body = await request.Content!.ReadAsStringAsync(token);
+                    using (JsonDocument sent = JsonDocument.Parse(body))
+                    {
+                        sentModels.Add(
+                            sent.RootElement.TryGetProperty("model", out JsonElement model)
+                                ? model.GetString()
+                                : null);
+                    }
+                    return JsonResponse(
+                        HttpStatusCode.OK,
+                        ImageResponseJson("image-job", "image-file"));
+                case "/api/contents/image-file":
+                    return ByteResponse(s_png, "image/png");
+                default:
+                    return JsonResponse(HttpStatusCode.NotFound, "{}");
+            }
+        }, handleAvailability: false);
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using AiImageGenerationDialogViewModel viewModel = CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.ModelPicker.Options.Count == 3);
+        viewModel.Prompt.Value = "A calm blue sky";
+        viewModel.ModelPicker.Selected.Value = viewModel.ModelPicker.Options
+            .First(option => option.Id.Value == "openai/gpt-image-1");
+
+        await viewModel.Generate.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                viewModel.Error.Value,
+                Is.EqualTo(Beutl.Language.Strings.AiUsageLimitExceeded));
+            Assert.That(sentModels, Is.Empty, "Nothing was sent, so nothing was reserved.");
+        });
+
+        affordable = true;
+        failAvailability = true;
+        viewModel.ModelPicker.Selected.Value = viewModel.ModelPicker.Options
+            .First(option => option.Id.Value == "openai/gpt-image-2");
+        await viewModel.Generate.ExecuteAsync();
+
+        Assert.That(sentModels, Is.Empty, "A transient preflight failure dispatches nothing.");
+
+        failAvailability = false;
+        viewModel.ModelPicker.Selected.Value = viewModel.ModelPicker.Options
+            .First(option => option.Id.Value == "qwen/qwen-image-3-pro");
+        await viewModel.Generate.ExecuteAsync();
+
+        Assert.That(
+            sentModels,
+            Is.EqualTo(new[] { "qwen/qwen-image-3-pro" }),
+            "The model on screen is the model that is charged for.");
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_FirstAuthenticationRefusalWithdrawsUnreservedName()
+    {
+        await TestReset.ResetShellAsync();
+        int availabilityRequests = 0;
+        var sentKeys = new List<string?>();
+        using var handler = new StubHandler(
+            (request, _) => Task.FromResult(request.RequestUri?.AbsolutePath switch
+            {
+                "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+                "/api/v3/ai/capabilities" => JsonResponse(HttpStatusCode.OK, "{\"operations\":{}}"),
+                "/api/v3/user/ai-availability" => RecordAvailability(),
+                "/api/v3/ai/images" => RejectAuthentication(request),
+                _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+            }),
+            handleAvailability: false);
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using AiImageGenerationDialogViewModel viewModel = CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.ModelPicker.IsLoaded.Value);
+        viewModel.Prompt.Value = "Authentication expires before dispatch";
+        await WaitUntilAsync(() => viewModel.CanGenerate.Value);
+
+        await viewModel.Generate.ExecuteAsync();
+        await WaitUntilAsync(() => viewModel.CanGenerate.Value);
+        await viewModel.Generate.ExecuteAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.Error.Value, Is.EqualTo(Strings.AiAuthenticationRequired));
+            Assert.That(availabilityRequests, Is.EqualTo(2),
+                "Each authoritative first-attempt refusal must restore the availability gate.");
+            Assert.That(sentKeys, Has.Count.EqualTo(2));
+            Assert.That(sentKeys[1], Is.EqualTo(sentKeys[0]),
+                "Withdrawing an unreserved request keeps its unused idempotency name reusable.");
+            Assert.That(viewModel.ResultImage.Value, Is.Null);
+        }
+
+        HttpResponseMessage RecordAvailability()
+        {
+            availabilityRequests++;
+            return JsonResponse(HttpStatusCode.OK, "{\"available\":true}");
+        }
+
+        HttpResponseMessage RejectAuthentication(HttpRequestMessage request)
+        {
+            sentKeys.Add(IdempotencyKeyOf(request));
+            return JsonResponse(HttpStatusCode.Unauthorized, """
+                {
+                  "error_code": "authenticationIsRequired",
+                  "message": "Sign in again.",
+                  "documentation_url": null
+                }
+                """);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_AFailureAfterTheChargeKeepsTheName()
+    {
+        // Authentication can fail while fetching an already-paid result. Treating that as an
+        // unreserved request and discarding the name would lose the route back to the image.
+        await TestReset.ResetShellAsync();
+        var sentKeys = new List<string?>();
+        int availabilityRequests = 0;
+        int imageRequests = 0;
+        bool contentIsReachable = false;
+        using var handler = new StubHandler(
+            (request, _) => Task.FromResult(request.RequestUri?.AbsolutePath switch
+            {
+                "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+                "/api/v3/user/ai-availability" => RecordAvailability(),
+                "/api/v3/ai/images" => RecordImageRequest(request),
+                "/api/contents/image-file" => contentIsReachable
+                    ? ByteResponse(s_png, "image/png")
+                    : JsonResponse(HttpStatusCode.Unauthorized, """
+                        {
+                          "error_code": "authenticationIsRequired",
+                          "message": "Sign in again.",
+                          "documentation_url": null
+                        }
+                        """),
+                _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+            }),
+            handleAvailability: false);
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using AiImageGenerationDialogViewModel viewModel = CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.Prompt.Value = "A calm blue sky";
+
+        await viewModel.Generate.ExecuteAsync();
+        await WaitUntilAsync(() => viewModel.CanGenerate.Value);
+        await viewModel.Generate.ExecuteAsync();
+        await WaitUntilAsync(() => viewModel.CanGenerate.Value);
+        await viewModel.Generate.ExecuteAsync();
+        contentIsReachable = true;
+        await WaitUntilAsync(() => viewModel.CanGenerate.Value);
+        await viewModel.Generate.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sentKeys, Has.Count.EqualTo(4));
+            Assert.That(
+                sentKeys[1],
+                Is.EqualTo(sentKeys[0]),
+                "A repeat authentication refusal must retain the paid request name.");
+            Assert.That(sentKeys[2], Is.EqualTo(sentKeys[0]));
+            Assert.That(sentKeys[3], Is.EqualTo(sentKeys[0]));
+            Assert.That(availabilityRequests, Is.EqualTo(1),
+                "Repeat authentication and raw-size refusals must retain the paid request name.");
+            Assert.That(viewModel.ResultImage.Value, Is.Not.Null);
+        });
+
+        HttpResponseMessage RecordAvailability()
+        {
+            availabilityRequests++;
+            return JsonResponse(HttpStatusCode.OK, "{\"available\":true}");
+        }
+
+        HttpResponseMessage RecordImageRequest(HttpRequestMessage request)
+        {
+            sentKeys.Add(IdempotencyKeyOf(request));
+            if (++imageRequests == 2)
+            {
+                return JsonResponse(HttpStatusCode.Unauthorized, """
+                    {
+                      "error_code": "authenticationIsRequired",
+                      "message": "Sign in again.",
+                      "documentation_url": null
+                    }
+                    """);
+            }
+            if (imageRequests == 3)
+            {
+                return JsonResponse(
+                    HttpStatusCode.RequestEntityTooLarge,
+                    string.Empty);
+            }
+
+            return JsonResponse(
+                HttpStatusCode.OK,
+                ImageResponseJson("image-job", "image-file"));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_FinishingAnotherRequestLeavesTheFirstNameAlone()
+    {
+        // A loses its response after being charged, then B succeeds with changed input. Settling
+        // B must not discard every name or returning to A would purchase it again under a new key.
+        await TestReset.ResetShellAsync();
+        var sentKeys = new List<(string prompt, string? key)>();
+        using var handler = new StubHandler(async (request, token) =>
+        {
+            switch (request.RequestUri?.AbsolutePath)
+            {
+                case "/api/v3/user/entitlements":
+                    return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                case "/api/v3/ai/images":
+                    string body = await request.Content!.ReadAsStringAsync(token);
+                    using (JsonDocument sent = JsonDocument.Parse(body))
+                    {
+                        string prompt = sent.RootElement.GetProperty("prompt").GetString()!;
+                        sentKeys.Add((prompt, IdempotencyKeyOf(request)));
+                        return prompt.Contains("second", StringComparison.Ordinal)
+                            ? JsonResponse(
+                                HttpStatusCode.OK,
+                                ImageResponseJson("image-job", "image-file"))
+                            : JsonResponse(HttpStatusCode.Conflict, """
+                                {
+                                  "error_code": "aiRequestInProgress",
+                                  "message": "The first attempt is still running.",
+                                  "documentation_url": null
+                                }
+                                """);
+                    }
+                case "/api/contents/image-file":
+                    return ByteResponse(s_png, "image/png");
+                default:
+                    return JsonResponse(HttpStatusCode.NotFound, "{}");
+            }
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using AiImageGenerationDialogViewModel viewModel = CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+
+        viewModel.Prompt.Value = "the first picture";
+        await viewModel.Generate.ExecuteAsync();
+        viewModel.Prompt.Value = "the second picture";
+        await viewModel.Generate.ExecuteAsync();
+        viewModel.Prompt.Value = "the first picture";
+        await viewModel.Generate.ExecuteAsync();
+
+        Assert.That(sentKeys, Has.Count.EqualTo(3));
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                sentKeys[2].key,
+                Is.EqualTo(sentKeys[0].key),
+                "Coming back to the unfinished request asks for it under its own name.");
+            Assert.That(sentKeys[1].key, Is.Not.EqualTo(sentKeys[0].key));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_NamesARequestByTheModelOnScreen()
+    {
+        // The model is part of the request. Recovering A made with X requires restoring both its
+        // prompt and X; leaving Y selected correctly creates a newly charged request for Y.
+        await TestReset.ResetShellAsync();
+        var sent = new List<(string Prompt, string? Model, string? Key)>();
+        using var handler = new StubHandler(async (request, token) =>
+        {
+            switch (request.RequestUri?.AbsolutePath)
+            {
+                case "/api/v3/user/entitlements":
+                    return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                case "/api/v3/ai/capabilities":
+                    return JsonResponse(HttpStatusCode.OK, ImageCapabilitiesJson());
+                case "/api/v3/ai/images":
+                    string body = await request.Content!.ReadAsStringAsync(token);
+                    using (JsonDocument document = JsonDocument.Parse(body))
+                    {
+                        string prompt = document.RootElement.GetProperty("prompt").GetString()!;
+                        sent.Add((
+                            prompt,
+                            document.RootElement.TryGetProperty("model", out JsonElement model)
+                                ? model.GetString()
+                                : null,
+                            IdempotencyKeyOf(request)));
+                        return prompt.Contains("second", StringComparison.Ordinal)
+                            ? JsonResponse(
+                                HttpStatusCode.OK,
+                                ImageResponseJson("image-job", "image-file"))
+                            : JsonResponse(HttpStatusCode.Conflict, """
+                                {
+                                  "error_code": "aiRequestInProgress",
+                                  "message": "The first attempt is still running.",
+                                  "documentation_url": null
+                                }
+                                """);
+                    }
+                case "/api/contents/image-file":
+                    return ByteResponse(s_png, "image/png");
+                default:
+                    return JsonResponse(HttpStatusCode.NotFound, "{}");
+            }
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using AiImageGenerationDialogViewModel viewModel = CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.ModelPicker.Options.Count == 3);
+
+        viewModel.ModelPicker.Selected.Value = viewModel.ModelPicker.Options
+            .First(option => option.Id.Value == "openai/gpt-image-1");
+        viewModel.Prompt.Value = "the first picture";
+        await viewModel.Generate.ExecuteAsync();
+
+        viewModel.ModelPicker.Selected.Value = viewModel.ModelPicker.Options
+            .First(option => option.Id.Value == "openai/gpt-image-2");
+        viewModel.Prompt.Value = "the second picture";
+        await viewModel.Generate.ExecuteAsync();
+
+        // Restoring only the prompt while leaving Y selected is a new request for Y.
+        viewModel.Prompt.Value = "the first picture";
+        await viewModel.Generate.ExecuteAsync();
+
+        // Restoring X as well finally reconstructs request A.
+        viewModel.ModelPicker.Selected.Value = viewModel.ModelPicker.Options
+            .First(option => option.Id.Value == "openai/gpt-image-1");
+        await viewModel.Generate.ExecuteAsync();
+
+        Assert.That(sent, Has.Count.EqualTo(4));
+        Assert.Multiple(() =>
+        {
+            Assert.That(sent[0].Model, Is.EqualTo("openai/gpt-image-1"));
+            Assert.That(sent[1].Model, Is.EqualTo("openai/gpt-image-2"));
+            Assert.That(
+                sent[2].Model,
+                Is.EqualTo("openai/gpt-image-2"),
+                "The screen said this model, so this is what is asked for and charged.");
+            Assert.That(sent[2].Key, Is.Not.EqualTo(sent[0].Key));
+            Assert.That(
+                sent[3].Key,
+                Is.EqualTo(sent[0].Key),
+                "Put back as it was, it asks for what that name already paid for.");
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_LookingAtAnotherModelDoesNotRewriteTheRequest()
+    {
+        // Comparing models narrows displayed values to each model's limits. Those automatic
+        // values must not replace the user's choices or restoring the old model changes the request.
+        await TestReset.ResetShellAsync();
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/capabilities" => JsonResponse(
+                HttpStatusCode.OK,
+                ImageCapabilitiesJson()),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using AiImageGenerationDialogViewModel viewModel = CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.ModelPicker.Options.Count == 3);
+
+        // GPT Image-1 takes 3:2 and a transparent background; GPT Image-2 takes
+        // neither.
+        viewModel.ModelPicker.Selected.Value = viewModel.ModelPicker.Options
+            .First(option => option.Id.Value == "openai/gpt-image-1");
+        viewModel.SelectedAspectRatio.Value = viewModel.AspectRatioOptions
+            .First(option => option.Value == "3:2");
+        viewModel.SelectedBackground.Value = viewModel.BackgroundOptions
+            .First(option => option.Value == "transparent");
+
+        viewModel.ModelPicker.Selected.Value = viewModel.ModelPicker.Options
+            .First(option => option.Id.Value == "openai/gpt-image-2");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.SelectedAspectRatio.Value.Value, Is.Not.EqualTo("3:2"),
+                "This model does not take it, so it is not on offer.");
+            Assert.That(
+                viewModel.BackgroundOptions.Select(option => option.Value),
+                Does.Not.Contain("transparent"));
+        }
+
+        viewModel.ModelPicker.Selected.Value = viewModel.ModelPicker.Options
+            .First(option => option.Id.Value == "openai/gpt-image-1");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                viewModel.SelectedAspectRatio.Value.Value,
+                Is.EqualTo("3:2"),
+                "Back on a model that takes it, the request is the one it was.");
+            Assert.That(
+                viewModel.SelectedBackground.Value.Value,
+                Is.EqualTo("transparent"));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageEdit_NamesARequestByTheModelOnScreen()
+    {
+        // The model is part of the request. When the UI shows X, dispatch and billing must also
+        // use X rather than silently substituting a model from an uncollected request.
+        await TestReset.ResetShellAsync();
+        string sourcePath = Path.Combine(Path.GetTempPath(), $"source-{Guid.NewGuid():N}.png");
+        await File.WriteAllBytesAsync(sourcePath, s_png);
+        var sent = new List<(string? Model, string? Key)>();
+        try
+        {
+            using var handler = new StubHandler(async (request, cancellationToken) =>
+            {
+                switch (request.RequestUri?.AbsolutePath)
+                {
+                    case "/api/v3/user/entitlements":
+                        return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                    case "/api/v3/ai/capabilities":
+                        return JsonResponse(HttpStatusCode.OK, ImageEditCapabilitiesJson());
+                    case "/api/v3/ai/images/edit":
+                        string body = await request.Content!.ReadAsStringAsync(cancellationToken);
+                        sent.Add((ModelOfMultipart(body), IdempotencyKeyOf(request)));
+                        // The first response is lost, leaving its name uncollected for the next send.
+                        return sent.Count == 1
+                            ? throw new HttpRequestException("The connection was reset.")
+                            : JsonResponse(
+                                HttpStatusCode.OK,
+                                ImageResponseJson("edit-job", "edit-file"));
+                    case "/api/contents/edit-file":
+                        return ByteResponse(s_png, "image/png");
+                    default:
+                        return JsonResponse(HttpStatusCode.NotFound, "{}");
+                }
+            });
+            using var httpClient = new HttpClient(handler);
+            await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+            SetAuthenticatedUser(clients, httpClient);
+            using var viewModel = CreateImageEditDialog(clients);
+            viewModel.SelectedTask.Value = viewModel.Tasks
+                .First(option => option.Value == "upscale");
+            await WaitUntilAsync(() => viewModel.ModelPicker.Options.Count == 2);
+            viewModel.ModelPicker.Selected.Value = viewModel.ModelPicker.Options
+                .First(option => option.Id.Value == "topaz/gigapixel-2");
+            viewModel.SourceFilePath.Value = sourcePath;
+
+            await viewModel.Edit.ExecuteAsync();
+            await viewModel.Edit.ExecuteAsync();
+
+            Assert.That(sent, Has.Count.EqualTo(2));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(
+                    sent[0].Model,
+                    Is.EqualTo("topaz/gigapixel-2"),
+                    "The screen said this model, so this is what is asked for and charged.");
+                Assert.That(
+                    sent[1].Model,
+                    Is.EqualTo("topaz/gigapixel-2"),
+                    "Asking again does not quietly move to another model.");
+                Assert.That(
+                    sent[1].Key,
+                    Is.EqualTo(sent[0].Key),
+                    "The same request under the same name reaches what it paid for.");
+            }
+        }
+        finally
+        {
+            File.Delete(sourcePath);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageEdit_ComingBackToAnUncollectedTaskCanStillSendIt()
+    {
+        // Return to a task while another request remains uncollected. Failing to reload that
+        // task's models would leave no selectable model and strand the already-paid request.
+        await TestReset.ResetShellAsync();
+        string sourcePath = Path.Combine(Path.GetTempPath(), $"source-{Guid.NewGuid():N}.png");
+        await File.WriteAllBytesAsync(sourcePath, s_png);
+        try
+        {
+            using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+            {
+                "/api/v3/user/entitlements" => JsonResponse(
+                    HttpStatusCode.OK,
+                    EntitlementsJson()),
+                "/api/v3/ai/images/edit" => JsonResponse(HttpStatusCode.Conflict, """
+                    {
+                      "error_code": "aiRequestInProgress",
+                      "message": "The first attempt is still running.",
+                      "documentation_url": null
+                    }
+                    """),
+                _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+            });
+            using var httpClient = new HttpClient(handler);
+            await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+            SetAuthenticatedUser(clients, httpClient);
+            using var viewModel = CreateImageEditDialog(clients);
+            viewModel.SelectedTask.Value = viewModel.Tasks
+                .Single(task => task.Value == "upscale");
+            viewModel.SourceFilePath.Value = sourcePath;
+            await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+                && viewModel.CanEdit.Value);
+
+            await viewModel.Edit.ExecuteAsync();
+            Assert.That(
+                viewModel.Error.Value,
+                Is.EqualTo(Beutl.Language.Strings.AiRequestInProgress));
+
+            viewModel.SelectedTask.Value = viewModel.Tasks
+                .Single(task => task.Value == "remove_background");
+            await WaitUntilAsync(() => viewModel.ModelPicker.IsLoaded.Value);
+            viewModel.SelectedTask.Value = viewModel.Tasks
+                .Single(task => task.Value == "upscale");
+
+            await WaitUntilAsync(() => viewModel.CanEdit.Value);
+            Assert.That(
+                viewModel.ModelPicker.IsLoaded.Value,
+                Is.True,
+                "The task holding an uncollected request has its own list again.");
+        }
+        finally
+        {
+            File.Delete(sourcePath);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Transcription_AnUncollectedRunIsNotOverwrittenWithoutAsking()
+    {
+        // A run whose first chunk received no response has no visible partial result or cue, but
+        // its name may still represent paid work and history import must not discard it silently.
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-subtitle-history-guard");
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/transcriptions" => JsonResponse(HttpStatusCode.Conflict, """
+                {
+                  "error_code": "aiRequestInProgress",
+                  "message": "The first attempt is still running.",
+                  "documentation_url": null
+                }
+                """),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(clients, editor);
+        viewModel.SceneMixChunkDuration = TimeSpan.FromMilliseconds(50);
+        viewModel.SceneMixAudioComposer = (start, duration, cancellationToken) =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            int sampleCount = Math.Max(1, (int)Math.Ceiling(duration.TotalSeconds * 16_000));
+            return Task.FromResult<AudioFrameSnapshot?>(new AudioFrameSnapshot(
+                new float[sampleCount],
+                16_000,
+                1,
+                start));
+        };
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.SelectedAudioSource.Value?.IsSceneMix == true);
+        editor.Scene.Start = TimeSpan.Zero;
+        editor.Scene.Duration = TimeSpan.FromMilliseconds(100);
+        await WaitUntilAsync(() => viewModel.CanTranscribe.Value);
+
+        await viewModel.Transcribe.ExecuteAsync();
+        HeadlessTestHelpers.Settle();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.HasPartialResult.Value, Is.False,
+                "Nothing has come back, so there is nothing to apply.");
+            Assert.That(viewModel.HasOutstandingTranscriptionRequest.Value, Is.True);
+        }
+
+        viewModel.LoadHistoryResult(new AiCaptionHistoryResult(
+            new AiJobId("history-job"),
+            [new AiTranscriptionSegment { Start = 0, End = 1, Text = "from history" }],
+            "en"));
+        HeadlessTestHelpers.Settle();
+
+        Assert.That(
+            viewModel.HasPendingHistoryResult.Value,
+            Is.True,
+            "A run that may already have been charged for is worth asking about.");
+
+        viewModel.ConfirmPendingHistoryResult();
+        HeadlessTestHelpers.Settle();
+
+        Assert.That(
+            viewModel.HasOutstandingTranscriptionRequest.Value,
+            Is.False,
+            "Once it is overwritten the run is gone, and so is what it was holding.");
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_ShowsTheRoughPictureWhileTheModelWorks()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-image-streaming");
+        // A reply that is still arriving, which is the whole point: the rough
+        // version has to be on screen while the run is still going on.
+        var pipe = new Pipe();
+        await pipe.Writer.WriteAsync(Encoding.UTF8.GetBytes(
+            "event: partial\ndata: {\"index\":0,\"image\":\""
+            + Convert.ToBase64String(s_png)
+            + "\"}\n\n"));
+        await pipe.Writer.FlushAsync();
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/contents/image-file" => ByteResponse(s_png, "image/png"),
+            "/api/v3/ai/images" => EventStreamResponse(pipe.Reader.AsStream()),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateImageGenerationDialog(clients, editor);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.Prompt.Value = "A calm blue sky";
+
+        Task generating = viewModel.Generate.ExecuteAsync();
+        await WaitUntilAsync(() => viewModel.PreviewImage.Value is not null);
+        Assert.That(viewModel.ResultImage.Value, Is.Null,
+            "A rough version is not the picture the run produced.");
+
+        await pipe.Writer.WriteAsync(Encoding.UTF8.GetBytes(
+            "event: result\ndata: "
+            + ImageResponseJson("image-job", "image-file").ReplaceLineEndings(string.Empty)
+            + "\n\n"));
+        await pipe.Writer.CompleteAsync();
+        await generating;
+        HeadlessTestHelpers.Settle();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.ResultImage.Value, Is.Not.Null);
+            // Cleared when the run ends: what stays on screen is the result.
+            Assert.That(viewModel.PreviewImage.Value, Is.Null);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task SceneMixTranscription_TakesItsRangeFromTheSceneItself()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-subtitle-scene-range");
+        editor.Scene.Start = TimeSpan.Zero;
+        editor.Scene.Duration = TimeSpan.Zero;
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(clients, editor);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.SelectedAudioSource.Value?.IsSceneMix == true);
+
+        Assert.That(viewModel.CanTranscribeInput.Value, Is.False,
+            "A scene with no duration has nothing to transcribe.");
+
+        editor.Scene.Duration = TimeSpan.FromSeconds(3);
+        HeadlessTestHelpers.Settle();
+
+        Assert.That(viewModel.CanTranscribeInput.Value, Is.True,
+            "Retiming the scene reaches the tab without it asking for a range of its own.");
+    }
+
+    [AvaloniaTest]
+    public async Task SceneMixTranscription_ComposesTheSceneInSlicesRatherThanOneLongCall()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-subtitle-scene-mix-slices");
+        var requestedDurations = new List<TimeSpan>();
+        byte[]? uploaded = null;
+        int transcriptionRequests = 0;
+        using var handler = new StubHandler(async (request, cancellationToken) =>
+        {
+            switch (request.RequestUri?.AbsolutePath)
+            {
+                case "/api/v3/user/entitlements":
+                    return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                case "/api/v3/ai/transcriptions":
+                    Interlocked.Increment(ref transcriptionRequests);
+                    uploaded = await request.Content!.ReadAsByteArrayAsync(cancellationToken);
+                    return CreateTranscriptionResponse("transcription-slices");
+                default:
+                    return JsonResponse(HttpStatusCode.NotFound, "{}");
+            }
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(clients, editor);
+        viewModel.SceneMixChunkDuration = TimeSpan.FromSeconds(12);
+        viewModel.SceneMixAudioComposer = (start, duration, cancellationToken) =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            requestedDurations.Add(duration);
+            int sampleCount = Math.Max(1, (int)Math.Round(duration.TotalSeconds * 16_000));
+            return Task.FromResult<AudioFrameSnapshot?>(new AudioFrameSnapshot(
+                new float[sampleCount],
+                16_000,
+                1,
+                start));
+        };
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.SelectedAudioSource.Value?.IsSceneMix == true);
+        editor.Scene.Start = TimeSpan.Zero;
+        editor.Scene.Duration = TimeSpan.FromSeconds(12);
+        await WaitUntilAsync(() => viewModel.CanTranscribe.Value);
+
+        await viewModel.Transcribe.ExecuteAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(transcriptionRequests, Is.EqualTo(1),
+                "Slicing is about how the scene is composed, not how much is uploaded at a time.");
+            Assert.That(requestedDurations, Has.Count.GreaterThan(1));
+            Assert.That(
+                requestedDurations,
+                Is.All.LessThanOrEqualTo(AiSubtitleDialogViewModel.SceneMixComposeSlice),
+                "Asking for a whole chunk in one call is what left the editor unresponsive.");
+            Assert.That(
+                requestedDurations.Aggregate(TimeSpan.Zero, (total, slice) => total + slice),
+                Is.EqualTo(TimeSpan.FromSeconds(12)));
+            Assert.That(ReadWaveDataLength(uploaded), Is.EqualTo(12 * 16_000 * sizeof(short)),
+                "Every slice reaches the wave, so no audio is lost at a boundary.");
+            Assert.That(viewModel.Error.Value, Is.Null);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_SendsTheSeedAsJsonAndTheReferenceAsAnUpload()
+    {
+        await TestReset.ResetShellAsync();
+        string referencePath = Path.Combine(
+            Path.GetTempPath(),
+            $"beutl-ai-reference-{Guid.NewGuid():N}.png");
+        await File.WriteAllBytesAsync(referencePath, s_png);
+        string? jsonBody = null;
+        string? uploadBody = null;
+        using var handler = new StubHandler(async (request, cancellationToken) =>
+        {
+            switch (request.RequestUri?.AbsolutePath)
+            {
+                case "/api/v3/user/entitlements":
+                    return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                case "/api/v3/ai/images":
+                    string body = await request.Content!.ReadAsStringAsync(cancellationToken);
+                    if (request.Content is MultipartFormDataContent)
+                    {
+                        uploadBody = body;
+                    }
+                    else
+                    {
+                        jsonBody = body;
+                    }
+
+                    return JsonResponse(HttpStatusCode.OK, ImageResponseJson("image-job", "image-file"));
+                case "/api/contents/image-file":
+                    return ByteResponse(s_png, "image/png");
+                default:
+                    return JsonResponse(HttpStatusCode.NotFound, "{}");
+            }
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        try
+        {
+            using var viewModel = CreateImageGenerationDialog(clients);
+            await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+            viewModel.Prompt.Value = "A calm blue sky";
+            viewModel.Seed.Value = 4242;
+
+            await viewModel.Generate.ExecuteAsync();
+
+            viewModel.AddReferenceImages([referencePath]);
+            await viewModel.Generate.ExecuteAsync();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(jsonBody, Does.Contain("\"seed\":4242"),
+                    "A seed is what makes a result reproducible, so it has to reach the server.");
+                Assert.That(viewModel.ReferenceImages, Has.Count.EqualTo(1),
+                    "The chosen picture is shown back before it is paid for.");
+                Assert.That(uploadBody, Is.Not.Null,
+                    "A reference turns the request into an upload.");
+                Assert.That(uploadBody, Does.Contain("reference[]"));
+                Assert.That(uploadBody, Does.Contain(Path.GetFileName(referencePath)));
+                Assert.That(uploadBody, Does.Contain("4242"));
+                Assert.That(viewModel.Error.Value, Is.Null);
+            }
+        }
+        finally
+        {
+            File.Delete(referencePath);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_UsesTheSeedSnapshottedBeforeAvailability()
+    {
+        await TestReset.ResetShellAsync();
+        var availabilityStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseAvailability = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        bool blockAvailability = false;
+        string? requestBody = null;
+        using var handler = new StubHandler(async (request, cancellationToken) =>
+        {
+            switch (request.RequestUri?.AbsolutePath)
+            {
+                case "/api/v3/user/entitlements":
+                    return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                case "/api/v3/user/ai-availability":
+                    if (blockAvailability)
+                    {
+                        availabilityStarted.TrySetResult();
+                        await releaseAvailability.Task.WaitAsync(cancellationToken);
+                    }
+                    return JsonResponse(HttpStatusCode.OK, "{ \"available\": true }");
+                case "/api/v3/ai/images":
+                    requestBody = await request.Content!.ReadAsStringAsync(cancellationToken);
+                    return JsonResponse(HttpStatusCode.OK, ImageResponseJson("seed-snapshot", "seed-file"));
+                case "/api/contents/seed-file":
+                    return ByteResponse(s_png, "image/png");
+                default:
+                    return JsonResponse(HttpStatusCode.NotFound, "{}");
+            }
+        }, handleAvailability: false);
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.Prompt.Value = "Seed snapshot";
+        viewModel.Seed.Value = 17;
+        blockAvailability = true;
+
+        Task generation = viewModel.Generate.ExecuteAsync();
+        await availabilityStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        viewModel.Seed.Value = 29;
+        releaseAvailability.TrySetResult();
+        await generation.WaitAsync(TimeSpan.FromSeconds(5));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(requestBody, Does.Contain("\"seed\":17"));
+            Assert.That(requestBody, Does.Not.Contain("\"seed\":29"));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_ClearingTheReferenceReturnsToTheJsonRequest()
+    {
+        await TestReset.ResetShellAsync();
+        string referencePath = Path.Combine(
+            Path.GetTempPath(),
+            $"beutl-ai-reference-{Guid.NewGuid():N}.png");
+        await File.WriteAllBytesAsync(referencePath, s_png);
+        bool lastRequestWasUpload = true;
+        using var handler = new StubHandler(request =>
+        {
+            switch (request.RequestUri?.AbsolutePath)
+            {
+                case "/api/v3/user/entitlements":
+                    return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                case "/api/v3/ai/images":
+                    lastRequestWasUpload = request.Content is MultipartFormDataContent;
+                    return JsonResponse(HttpStatusCode.OK, ImageResponseJson("image-job", "image-file"));
+                case "/api/contents/image-file":
+                    return ByteResponse(s_png, "image/png");
+                default:
+                    return JsonResponse(HttpStatusCode.NotFound, "{}");
+            }
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        try
+        {
+            using var viewModel = CreateImageGenerationDialog(clients);
+            await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+            viewModel.Prompt.Value = "A calm blue sky";
+            viewModel.AddReferenceImages([referencePath]);
+            Assert.That(viewModel.HasReferenceImages.Value, Is.True);
+
+            viewModel.ClearReferenceImages.Execute();
+            await viewModel.Generate.ExecuteAsync();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.HasReferenceImages.Value, Is.False);
+                Assert.That(viewModel.ReferenceImages, Is.Empty,
+                    "The preview is released with the reference it belonged to.");
+                Assert.That(lastRequestWasUpload, Is.False,
+                    "With no reference the cheaper JSON request is used again.");
+            }
+        }
+        finally
+        {
+            File.Delete(referencePath);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task VideoGeneration_SendsTheSeedItWasGiven()
+    {
+        await TestReset.ResetShellAsync();
+        string? requestBody = null;
+        using var handler = new StubHandler(async (request, cancellationToken) =>
+        {
+            switch (request.RequestUri?.AbsolutePath)
+            {
+                case "/api/v3/user/entitlements":
+                    return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                case "/api/v3/ai/videos":
+                    requestBody = await request.Content!.ReadAsStringAsync(cancellationToken);
+                    return JsonResponse(HttpStatusCode.OK, """
+                        {
+                          "jobId": "video-job",
+                          "status": "queued"
+                        }
+                        """);
+                case "/api/v3/ai/videos/video-job":
+                    return JsonResponse(HttpStatusCode.OK, """
+                        {
+                          "jobId": "video-job",
+                          "status": "succeeded",
+                          "fileId": "video-file",
+                          "url": "https://beutl.beditor.net/api/contents/video-file",
+                          "error": null
+                        }
+                        """);
+                case "/api/contents/video-file":
+                    return ByteResponse([1, 2, 3, 4], "video/mp4");
+                default:
+                    return JsonResponse(HttpStatusCode.NotFound, "{}");
+            }
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        await using AiVideoGenerationDialogViewModel viewModel = CreateVideoGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.EstimatedUsage.State.Value == AiOperationAvailabilityState.Available);
+        viewModel.Prompt.Value = "A slow camera pan";
+        viewModel.Seed.Value = 77;
+
+        await viewModel.Generate.ExecuteAsync();
+
+        Assert.That(requestBody, Does.Contain("\"seed\":77"));
+    }
+
+    [AvaloniaTest]
+    public async Task VideoGeneration_UsesTheSeedSnapshottedBeforeAvailability()
+    {
+        await TestReset.ResetShellAsync();
+        var availabilityStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseAvailability = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        bool blockAvailability = false;
+        string? requestBody = null;
+        using var handler = new StubHandler(async (request, cancellationToken) =>
+        {
+            switch (request.RequestUri?.AbsolutePath)
+            {
+                case "/api/v3/user/entitlements":
+                    return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                case "/api/v3/user/ai-availability":
+                    if (blockAvailability)
+                    {
+                        availabilityStarted.TrySetResult();
+                        await releaseAvailability.Task.WaitAsync(cancellationToken);
+                    }
+                    return JsonResponse(HttpStatusCode.OK, "{ \"available\": true }");
+                case "/api/v3/ai/videos":
+                    requestBody = await request.Content!.ReadAsStringAsync(cancellationToken);
+                    return JsonResponse(HttpStatusCode.OK, "{ \"jobId\": \"seed-video\", \"status\": \"queued\" }");
+                case "/api/v3/ai/videos/seed-video":
+                    return JsonResponse(HttpStatusCode.OK, """
+                        {
+                          "jobId": "seed-video",
+                          "status": "succeeded",
+                          "fileId": "seed-video-file",
+                          "url": "https://beutl.beditor.net/api/contents/seed-video-file",
+                          "error": null
+                        }
+                        """);
+                case "/api/contents/seed-video-file":
+                    return ByteResponse([1, 2, 3, 4], "video/mp4");
+                default:
+                    return JsonResponse(HttpStatusCode.NotFound, "{}");
+            }
+        }, handleAvailability: false);
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        await using var viewModel = CreateVideoGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.EstimatedUsage.State.Value == AiOperationAvailabilityState.Available);
+        viewModel.Prompt.Value = "Seed snapshot video";
+        viewModel.Seed.Value = 31;
+        blockAvailability = true;
+
+        Task generation = viewModel.Generate.ExecuteAsync();
+        await availabilityStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        viewModel.Seed.Value = 47;
+        releaseAvailability.TrySetResult();
+        await generation.WaitAsync(TimeSpan.FromSeconds(5));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(requestBody, Does.Contain("\"seed\":31"));
+            Assert.That(requestBody, Does.Not.Contain("\"seed\":47"));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task VideoGeneration_JobNotFoundRetiresTheCreateKeyBeforeAnotherAttempt()
+    {
+        await TestReset.ResetShellAsync();
+        var keys = new List<string?>();
+        int creates = 0;
+        using var handler = new StubHandler(request =>
+        {
+            switch (request.RequestUri?.AbsolutePath)
+            {
+                case "/api/v3/user/entitlements":
+                    return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                case "/api/v3/ai/videos":
+                    keys.Add(IdempotencyKeyOf(request));
+                    int sequence = ++creates;
+                    return JsonResponse(HttpStatusCode.OK, $$"""
+                        {
+                          "jobId": "video-{{sequence}}",
+                          "status": "queued"
+                        }
+                        """);
+                case "/api/v3/ai/videos/video-1":
+                    return JsonResponse(HttpStatusCode.NotFound, """
+                        {
+                          "error_code": "aiJobNotFound",
+                          "message": "The job no longer exists.",
+                          "documentation_url": null
+                        }
+                        """);
+                case "/api/v3/ai/videos/video-2":
+                    return JsonResponse(HttpStatusCode.OK, """
+                        {
+                          "jobId": "video-2",
+                          "status": "failed",
+                          "error": "aiProviderError"
+                        }
+                        """);
+                default:
+                    return JsonResponse(HttpStatusCode.NotFound, "{}");
+            }
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        await using AiVideoGenerationDialogViewModel viewModel =
+            CreateVideoGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.EstimatedUsage.State.Value == AiOperationAvailabilityState.Available);
+        viewModel.Prompt.Value = "A slow camera pan";
+
+        await viewModel.Generate.ExecuteAsync();
+        Assert.That(
+            viewModel.Error.Value,
+            Is.EqualTo(Beutl.Language.Strings.AiRequestWasDeleted));
+        await viewModel.Generate.ExecuteAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(keys, Has.Count.EqualTo(2));
+            Assert.That(keys[1], Is.Not.EqualTo(keys[0]));
+            Assert.That(
+                viewModel.Error.Value,
+                Is.EqualTo(Beutl.Language.Strings.AiProviderError));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task VideoGeneration_AsksUnderOneNameForTheSameFrameUnderAnotherFileName()
+    {
+        // Scene captures get a different temporary filename each time, while the server identifies
+        // frames by content and type. Including the name would turn the same-frame retry into a new charge.
+        await TestReset.ResetShellAsync();
+        string firstPath = Path.Combine(Path.GetTempPath(), $"frame-{Guid.NewGuid():N}.png");
+        string secondPath = Path.Combine(Path.GetTempPath(), $"frame-{Guid.NewGuid():N}.png");
+        await File.WriteAllBytesAsync(firstPath, s_png);
+        await File.WriteAllBytesAsync(secondPath, s_png);
+        var keys = new List<string?>();
+        bool cutFirstAttempt = true;
+        try
+        {
+            using var handler = new StubHandler(request =>
+            {
+                switch (request.RequestUri?.AbsolutePath)
+                {
+                    case "/api/v3/user/entitlements":
+                        return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                    case "/api/v3/ai/videos/frames":
+                        keys.Add(IdempotencyKeyOf(request));
+                        if (cutFirstAttempt)
+                        {
+                            cutFirstAttempt = false;
+                            // The response is lost, so the client cannot know whether work was created and charged.
+                            throw new HttpRequestException("The connection was reset.");
+                        }
+
+                        return JsonResponse(HttpStatusCode.OK, """
+                            {
+                              "jobId": "video-job",
+                              "status": "queued"
+                            }
+                            """);
+                    case "/api/v3/ai/videos/video-job":
+                        return JsonResponse(HttpStatusCode.OK, """
+                            {
+                              "jobId": "video-job",
+                              "status": "succeeded",
+                              "fileId": "video-file",
+                              "url": "https://beutl.beditor.net/api/contents/video-file",
+                              "error": null
+                            }
+                            """);
+                    case "/api/contents/video-file":
+                        return ByteResponse([1, 2, 3, 4], "video/mp4");
+                    default:
+                        return JsonResponse(HttpStatusCode.NotFound, "{}");
+                }
+            });
+            using var httpClient = new HttpClient(handler);
+            await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+            SetAuthenticatedUser(clients, httpClient);
+            await using AiVideoGenerationDialogViewModel viewModel =
+                CreateVideoGenerationDialog(clients);
+            await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+                && viewModel.EstimatedUsage.State.Value == AiOperationAvailabilityState.Available);
+            viewModel.Prompt.Value = "A slow camera pan";
+
+            viewModel.FirstFramePath.Value = firstPath;
+            await viewModel.Generate.ExecuteAsync();
+
+            // Recapture the same frame under a different temporary filename.
+            viewModel.FirstFramePath.Value = secondPath;
+            await viewModel.Generate.ExecuteAsync();
+
+            Assert.That(keys, Has.Count.EqualTo(2));
+            Assert.That(
+                keys[1],
+                Is.EqualTo(keys[0]),
+                "The same picture is the same request, whatever the file was called.");
+        }
+        finally
+        {
+            File.Delete(firstPath);
+            File.Delete(secondPath);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task VideoOptions_FollowTheChosenModel()
+    {
+        await TestReset.ResetShellAsync();
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/capabilities" => JsonResponse(
+                HttpStatusCode.OK,
+                VideoCapabilitiesJson()),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        await using AiVideoGenerationDialogViewModel viewModel =
+            CreateVideoGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.ModelPicker.Options.Count == 2);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                viewModel.ResolutionOptions.Select(option => option.Value),
+                Is.EqualTo(new[] { "720p", "1080p" }));
+            Assert.That(
+                viewModel.DurationOptions.Select(option => option.Seconds),
+                Is.EqualTo(new[] { 4, 6, 8 }));
+            Assert.That(viewModel.SupportsSeed.Value, Is.True);
+        }
+
+        viewModel.SelectedDuration.Value = viewModel.DurationOptions
+            .First(option => option.Seconds == 4);
+        viewModel.ModelPicker.Selected.Value = viewModel.ModelPicker.Options
+            .First(option => option.Id.Value == "minimax/hailuo-3");
+
+        using (Assert.EnterMultipleScope())
+        {
+            // What the model renders at, not what the dialog used to offer.
+            Assert.That(
+                viewModel.ResolutionOptions.Select(option => option.Value),
+                Is.EqualTo(new[] { "2K" }));
+            Assert.That(viewModel.SelectedResolution.Value.Value, Is.EqualTo("2K"));
+            // The lengths this model takes, not the three the dialog used to
+            // offer: 5 and 7 were unreachable before.
+            Assert.That(
+                viewModel.DurationOptions.Select(option => option.Seconds),
+                Is.EqualTo(new[] { 5, 6, 7, 8 }));
+            // 4 seconds is gone; the nearest length it does take is 5, and
+            // leaving 4 in place would be charged for and then refused.
+            Assert.That(viewModel.SelectedDuration.Value.Seconds, Is.EqualTo(5));
+            // A seed it cannot take is not offered, and never sent.
+            Assert.That(viewModel.SupportsSeed.Value, Is.False);
+            Assert.That(viewModel.Seed.Value, Is.Null);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageBackgrounds_FollowTheChosenModel()
+    {
+        await TestReset.ResetShellAsync();
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/capabilities" => JsonResponse(
+                HttpStatusCode.OK,
+                ImageCapabilitiesJson()),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using AiImageGenerationDialogViewModel viewModel =
+            CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.ModelPicker.Options.Count == 3);
+
+        using (Assert.EnterMultipleScope())
+        {
+            // What GPT Image-1 publishes, in the order the server lists it.
+            Assert.That(
+                viewModel.BackgroundOptions.Select(option => option.Value),
+                Is.EqualTo(new[] { "auto", "opaque", "transparent" }));
+            Assert.That(viewModel.HasBackgroundChoice.Value, Is.True);
+        }
+
+        viewModel.SelectedBackground.Value = viewModel.BackgroundOptions
+            .First(option => option.Value == "transparent");
+        viewModel.ModelPicker.Selected.Value = viewModel.ModelPicker.Options
+            .First(option => option.Id.Value == "openai/gpt-image-2");
+
+        using (Assert.EnterMultipleScope())
+        {
+            // GPT Image-2 fills a background in rather than cutting one out, so
+            // transparent is gone and the choice falls back to the model's own.
+            Assert.That(
+                viewModel.BackgroundOptions.Select(option => option.Value),
+                Is.EqualTo(new[] { "auto", "opaque" }));
+            Assert.That(viewModel.SelectedBackground.Value.Value, Is.EqualTo("auto"));
+        }
+
+        viewModel.ModelPicker.Selected.Value = viewModel.ModelPicker.Options
+            .First(option => option.Id.Value == "qwen/qwen-image-3-pro");
+
+        using (Assert.EnterMultipleScope())
+        {
+            // A model that publishes no background at all leaves nothing to
+            // choose, so the control is hidden and nothing is sent.
+            Assert.That(
+                viewModel.BackgroundOptions.Select(option => option.Value),
+                Is.EqualTo(new[] { "auto" }));
+            Assert.That(viewModel.HasBackgroundChoice.Value, Is.False);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ComposedPromptLimit_DisablesImageAndVideoCommandsBeforeSubmission()
+    {
+        await TestReset.ResetShellAsync();
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var image = CreateImageGenerationDialog(clients);
+        await using var video = CreateVideoGenerationDialog(clients);
+        await WaitUntilAsync(() => image.Usage.HasSnapshot.Value
+            && video.Usage.HasSnapshot.Value
+            && video.EstimatedUsage.State.Value == AiOperationAvailabilityState.Available);
+
+        image.Prompt.Value = "subject";
+        image.Style.Value = new string('s', 2_000);
+        image.Exclusions.Value = new string('x', 2_000);
+        video.Prompt.Value = "subject";
+        video.Style.Value = new string('s', 2_000);
+        video.Exclusions.Value = new string('x', 2_000);
+        HeadlessTestHelpers.Settle();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(image.PromptValidationError.Value, Does.Contain("4000"));
+            Assert.That(image.CanGenerate.Value, Is.False);
+            Assert.That(video.PromptValidationError.Value, Does.Contain("4000"));
+            Assert.That(video.CanGenerate.Value, Is.False);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageEdit_UsesResultSnapshotWhenTaskChangesBeforeImport()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-image-edit-dialog");
+        string sourcePath = Path.Combine(Path.GetTempPath(), $"source-{Guid.NewGuid():N}.png");
+        await File.WriteAllBytesAsync(sourcePath, s_png);
+        try
+        {
+            using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+            {
+                "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+                "/api/v3/ai/images/edit" => JsonResponse(HttpStatusCode.OK, ImageResponseJson("edit-job", "edit-file")),
+                "/api/contents/edit-file" => ByteResponse(s_png, "image/png"),
+                _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+            });
+            using var httpClient = new HttpClient(handler);
+            await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+            SetAuthenticatedUser(clients, httpClient);
+            using var viewModel = CreateImageEditDialog(clients, editor);
+            viewModel.SourceFilePath.Value = sourcePath;
+            await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value && viewModel.CanEdit.Value);
+
+            await viewModel.Edit.ExecuteAsync();
+            viewModel.SelectedTask.Value = viewModel.Tasks.Single(task => task.Value == "upscale");
+            await viewModel.AddToScene.ExecuteAsync();
+            HeadlessTestHelpers.Settle();
+
+            string persistedElement = CoreSerializer.SerializeToJsonObject(editor.Scene.Children.Single()).ToJsonString();
+            Assert.Multiple(() =>
+            {
+                Assert.That(persistedElement, Does.Not.Contain("edit-job"));
+                Assert.That(persistedElement, Does.Not.Contain("edit-file"));
+            });
+        }
+        finally
+        {
+            File.Delete(sourcePath);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageEdit_SaveRejectsNonPngDestinationWithoutReplacingFile()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-image-edit-save-format");
+        string sourcePath = Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "edit-source.png");
+        await File.WriteAllBytesAsync(sourcePath, s_png);
+        try
+        {
+            using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+            {
+                "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+                "/api/v3/ai/images/edit" => JsonResponse(
+                    HttpStatusCode.OK,
+                    ImageResponseJson("edit-save-job", "edit-save-file")),
+                "/api/contents/edit-save-file" => ByteResponse(s_png, "image/png"),
+                _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+            });
+            using var httpClient = new HttpClient(handler);
+            await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+            SetAuthenticatedUser(clients, httpClient);
+            using var viewModel = CreateImageEditDialog(clients, editor);
+            viewModel.SourceFilePath.Value = sourcePath;
+            await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value && viewModel.CanEdit.Value);
+            await viewModel.Edit.ExecuteAsync();
+            string destinationPath = Path.Combine(
+                BeutlHomeIsolation.CurrentHome!,
+                "existing-edit.jpg");
+            byte[] original = [9, 8, 7];
+            await File.WriteAllBytesAsync(destinationPath, original);
+            viewModel.SaveFilePicker = _ => Task.FromResult<AiSaveFileDestination?>(
+                new(destinationPath));
+
+            await viewModel.SaveToFile.ExecuteAsync();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(File.ReadAllBytes(destinationPath), Is.EqualTo(original));
+                Assert.That(viewModel.Error.Value, Is.Not.Null);
+                Assert.That(
+                    Directory.EnumerateFiles(
+                        Path.GetDirectoryName(destinationPath)!,
+                        "existing-edit.jpg.*.tmp"),
+                    Is.Empty);
+            }
+        }
+        finally
+        {
+            File.Delete(sourcePath);
+        }
+    }
+
+    [Test]
+    public void AtomicImageSave_PreservesExistingFileWhenEncodingFails()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"beutl-ai-save-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        string destinationPath = Path.Combine(directory, "existing.png");
+        byte[] original = [9, 8, 7];
+        File.WriteAllBytes(destinationPath, original);
+
+        try
+        {
+            Assert.Throws<InvalidDataException>(() => AiAtomicFileWriter.Write(
+                destinationPath,
+                stream =>
+                {
+                    stream.Write([1, 2, 3]);
+                    throw new InvalidDataException("encoding failed");
+                },
+                CancellationToken.None));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(File.ReadAllBytes(destinationPath), Is.EqualTo(original));
+                Assert.That(
+                    Directory.EnumerateFiles(directory, "existing.png.*.tmp"),
+                    Is.Empty);
+            }
+
+            byte[] replacement = [1, 2, 3, 4];
+            AiAtomicFileWriter.Write(
+                destinationPath,
+                stream => stream.Write(replacement),
+                CancellationToken.None);
+            Assert.That(File.ReadAllBytes(destinationPath), Is.EqualTo(replacement));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void AtomicImageSave_PreservesExistingUnixPermissions()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("Unix permissions are not available on Windows.");
+            return;
+        }
+
+        string directory = Path.Combine(Path.GetTempPath(), $"beutl-ai-save-mode-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        string destinationPath = Path.Combine(directory, "existing.png");
+        try
+        {
+            File.WriteAllBytes(destinationPath, [9, 8, 7]);
+            UnixFileMode mode = UnixFileMode.UserRead
+                | UnixFileMode.UserWrite
+                | UnixFileMode.GroupRead;
+            File.SetUnixFileMode(destinationPath, mode);
+
+            AiAtomicFileWriter.Write(
+                destinationPath,
+                stream => stream.Write([1, 2, 3, 4]),
+                CancellationToken.None);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(File.ReadAllBytes(destinationPath), Is.EqualTo(new byte[] { 1, 2, 3, 4 }));
+                Assert.That(File.GetUnixFileMode(destinationPath), Is.EqualTo(mode));
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task VideoGeneration_PollsResultAndDisposeRemovesPreviewFile()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-video-dialog");
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/videos" => JsonResponse(HttpStatusCode.OK, """
+                {
+                  "jobId": "video-job",
+                  "status": "queued"
+                }
+                """),
+            "/api/v3/ai/videos/video-job" => JsonResponse(HttpStatusCode.OK, """
+                {
+                  "jobId": "video-job",
+                  "status": "succeeded",
+                  "fileId": "video-file",
+                  "url": "https://beutl.beditor.net/api/contents/video-file",
+                  "error": null
+                }
+                """),
+            "/api/contents/video-file" => ByteResponse([1, 2, 3, 4], "video/mp4"),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        var viewModel = CreateVideoGenerationDialog(clients, editor);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.EstimatedUsage.State.Value == AiOperationAvailabilityState.Available);
+        viewModel.Prompt.Value = "A slow camera pan";
+
+        await viewModel.Generate.ExecuteAsync();
+
+        string resultPath = viewModel.ResultVideoPath.Value!;
+        Assert.Multiple(() =>
+        {
+            Assert.That(resultPath, Is.Not.Null);
+            Assert.That(File.Exists(resultPath), Is.True);
+            Assert.That(viewModel.StatusText.Value, Is.EqualTo(Beutl.Language.Strings.AiVideoCompleted));
+        });
+
+        await viewModel.DisposeAsync();
+        Assert.That(File.Exists(resultPath), Is.False);
+    }
+
+    [AvaloniaTest]
+    public async Task VideoGeneration_SaveRejectsMismatchedDestinationFormatWithoutReplacingFile()
+    {
+        await TestReset.ResetShellAsync();
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/videos" => JsonResponse(HttpStatusCode.OK, "{\"jobId\":\"video-save-job\",\"status\":\"queued\"}"),
+            "/api/v3/ai/videos/video-save-job" => JsonResponse(HttpStatusCode.OK, """
+                {
+                  "jobId": "video-save-job",
+                  "status": "succeeded",
+                  "fileId": "video-save-file",
+                  "url": "https://beutl.beditor.net/api/contents/video-save-file",
+                  "fileName": "generated.mp4",
+                  "contentType": "video/mp4"
+                }
+                """),
+            "/api/contents/video-save-file" => ByteResponse([1, 2, 3, 4], "video/mp4"),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        await using var viewModel = CreateVideoGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.EstimatedUsage.State.Value == AiOperationAvailabilityState.Available);
+        viewModel.Prompt.Value = "Save format validation";
+        await viewModel.Generate.ExecuteAsync();
+
+        string destinationPath = Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "existing.webm");
+        byte[] original = [9, 8, 7];
+        await File.WriteAllBytesAsync(destinationPath, original);
+        viewModel.SaveFilePicker = _ => Task.FromResult<AiSaveFileDestination?>(
+            new(destinationPath));
+
+        await viewModel.SaveToFile.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(File.ReadAllBytes(destinationPath), Is.EqualTo(original));
+            Assert.That(viewModel.Error.Value, Is.Not.Null);
+        });
+
+        // A failure while staging the replacement must also leave an existing destination intact
+        // and remove any temporary sibling created before the failure.
+        string sourcePath = viewModel.ResultVideoPath.Value!;
+        File.Delete(sourcePath);
+        string validDestinationPath = Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "existing.mp4");
+        byte[] validOriginal = [6, 5, 4];
+        await File.WriteAllBytesAsync(validDestinationPath, validOriginal);
+        viewModel.SaveFilePicker = _ => Task.FromResult<AiSaveFileDestination?>(
+            new(validDestinationPath));
+
+        await viewModel.SaveToFile.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(File.ReadAllBytes(validDestinationPath), Is.EqualTo(validOriginal));
+            Assert.That(
+                Directory.EnumerateFiles(
+                    Path.GetDirectoryName(validDestinationPath)!,
+                    "existing.mp4.*.tmp"),
+                Is.Empty);
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task VideoGeneration_SavePreservesExistingUnixPermissions()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("Unix permissions are not available on Windows.");
+            return;
+        }
+
+        await TestReset.ResetShellAsync();
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/videos" => JsonResponse(
+                HttpStatusCode.OK,
+                "{\"jobId\":\"video-mode-job\",\"status\":\"queued\"}"),
+            "/api/v3/ai/videos/video-mode-job" => JsonResponse(HttpStatusCode.OK, """
+                {
+                  "jobId": "video-mode-job",
+                  "status": "succeeded",
+                  "fileId": "video-mode-file",
+                  "url": "https://beutl.beditor.net/api/contents/video-mode-file",
+                  "fileName": "generated.mp4",
+                  "contentType": "video/mp4"
+                }
+                """),
+            "/api/contents/video-mode-file" => ByteResponse([1, 2, 3, 4], "video/mp4"),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        await using var viewModel = CreateVideoGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.EstimatedUsage.State.Value == AiOperationAvailabilityState.Available);
+        viewModel.Prompt.Value = "Preserve destination permissions";
+        await viewModel.Generate.ExecuteAsync();
+
+        string destinationPath = Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "permission-preserving-video.mp4");
+        await File.WriteAllBytesAsync(destinationPath, [9, 8, 7]);
+        UnixFileMode mode = UnixFileMode.UserRead
+            | UnixFileMode.UserWrite
+            | UnixFileMode.GroupRead;
+        File.SetUnixFileMode(destinationPath, mode);
+        viewModel.SaveFilePicker = _ => Task.FromResult<AiSaveFileDestination?>(
+            new(destinationPath));
+
+        await viewModel.SaveToFile.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(File.ReadAllBytes(destinationPath), Is.EqualTo(new byte[] { 1, 2, 3, 4 }));
+            Assert.That(viewModel.Error.Value, Is.Null);
+        });
+        Assert.That(File.GetUnixFileMode(destinationPath), Is.EqualTo(mode));
+    }
+
+    [AvaloniaTest]
+    public async Task VideoGeneration_StopWaitingCancelsTheResultDownload()
+    {
+        await TestReset.ResetShellAsync();
+        using var blockedStream = new CancellationObservingStream();
+        using var blockedContent = new StreamContent(blockedStream);
+        blockedContent.Headers.ContentType = new("video/mp4");
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/videos" => JsonResponse(
+                HttpStatusCode.OK,
+                "{\"jobId\":\"video-cancel-job\",\"status\":\"queued\"}"),
+            "/api/v3/ai/videos/video-cancel-job" => JsonResponse(HttpStatusCode.OK, """
+                {
+                  "jobId": "video-cancel-job",
+                  "status": "succeeded",
+                  "fileId": "video-cancel-file",
+                  "url": "https://beutl.beditor.net/api/contents/video-cancel-file",
+                  "fileName": "generated.mp4",
+                  "contentType": "video/mp4"
+                }
+                """),
+            "/api/contents/video-cancel-file" => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = blockedContent,
+            },
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        await using var viewModel = CreateVideoGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.EstimatedUsage.State.Value == AiOperationAvailabilityState.Available);
+        viewModel.Prompt.Value = "Cancel the result download";
+
+        Task generation = viewModel.Generate.ExecuteAsync();
+        await blockedStream.ReadStarted.WaitAsync(TimeSpan.FromSeconds(5));
+        HeadlessTestHelpers.Settle();
+        Assert.That(viewModel.StopGenerating.CanExecute(), Is.True);
+        viewModel.StopGenerating.Execute();
+        await blockedStream.CancellationObserved.WaitAsync(TimeSpan.FromSeconds(5));
+        await generation.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.ResultVideoPath.Value, Is.Null);
+            Assert.That(viewModel.IsGenerating.Value, Is.False);
+            Assert.That(viewModel.StatusText.Value, Is.EqualTo(Beutl.Language.Strings.AiVideoWaitStopped));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task VideoGeneration_UnknownStatusKeepsRecoveryKeyForLaterRefresh()
+    {
+        await TestReset.ResetShellAsync();
+        var keys = new List<string?>();
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/videos" => UnknownVideoCreate(keys, request),
+            "/api/v3/ai/videos/future-job" => JsonResponse(HttpStatusCode.OK, "{\"jobId\":\"future-job\",\"status\":\"future\"}"),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        await using var viewModel = CreateVideoGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.EstimatedUsage.State.Value == AiOperationAvailabilityState.Available);
+        viewModel.Prompt.Value = "Unknown status recovery";
+
+        await viewModel.Generate.ExecuteAsync();
+        Assert.That(viewModel.Error.Value, Is.EqualTo(Strings.AiResultUnavailable));
+        await viewModel.Generate.ExecuteAsync();
+
+        Assert.That(keys, Has.Count.EqualTo(2));
+        Assert.That(keys[1], Is.EqualTo(keys[0]));
+
+        static HttpResponseMessage UnknownVideoCreate(List<string?> keys, HttpRequestMessage request)
+        {
+            keys.Add(IdempotencyKeyOf(request));
+            return JsonResponse(HttpStatusCode.OK, "{\"jobId\":\"future-job\",\"status\":\"queued\"}");
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task VideoGeneration_PreservesWebmMetadataAndRetriesTransientPollingFailures()
+    {
+        await TestReset.ResetShellAsync();
+        int polls = 0;
+        var delays = new List<TimeSpan>();
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/videos" => JsonResponse(HttpStatusCode.OK, """
+                { "jobId": "webm-job", "status": "queued" }
+                """),
+            "/api/v3/ai/videos/webm-job" when Interlocked.Increment(ref polls) == 1 =>
+                JsonResponse(HttpStatusCode.InternalServerError, """
+                    {
+                      "error_code": "aiProviderError",
+                      "message": "Provider status is temporarily unavailable."
+                    }
+                    """),
+            "/api/v3/ai/videos/webm-job" => JsonResponse(HttpStatusCode.OK, """
+                {
+                  "jobId": "webm-job",
+                  "status": "succeeded",
+                  "fileId": "webm-file",
+                  "url": "https://beutl.beditor.net/api/contents/webm-file",
+                  "fileName": "generated.webm",
+                  "contentType": "video/webm"
+                }
+                """),
+            "/api/contents/webm-file" => ByteResponse([1, 2, 3, 4], "video/webm"),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        var viewModel = CreateVideoGenerationDialog(clients);
+        viewModel.PollDelayAsync = (delay, _) =>
+        {
+            delays.Add(delay);
+            return Task.CompletedTask;
+        };
+        viewModel.PollInterval = TimeSpan.FromMilliseconds(10);
+        viewModel.MaximumTransientPollDelay = TimeSpan.FromMilliseconds(25);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.EstimatedUsage.State.Value == AiOperationAvailabilityState.Available);
+        viewModel.Prompt.Value = "WebM output";
+        await WaitUntilAsync(() => viewModel.CanGenerate.Value);
+
+        await viewModel.Generate.ExecuteAsync();
+
+        string resultPath = viewModel.ResultVideoPath.Value!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(polls, Is.EqualTo(2));
+            Assert.That(delays, Does.Contain(TimeSpan.FromMilliseconds(10)));
+            Assert.That(resultPath, Does.EndWith(".webm"));
+            Assert.That(File.Exists(resultPath), Is.True);
+            if (!OperatingSystem.IsWindows())
+            {
+                Assert.That(
+                    File.GetUnixFileMode(resultPath),
+                    Is.EqualTo(UnixFileMode.UserRead | UnixFileMode.UserWrite));
+            }
+        }
+
+        await viewModel.DisposeAsync();
+        Assert.That(File.Exists(resultPath), Is.False);
+    }
+
+    [AvaloniaTest]
+    public async Task VideoAvailability_CancelsStaleDurationCheckAndFailsClosed()
+    {
+        await TestReset.ResetShellAsync();
+        var sixSecondCheckStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sixSecondCheckCanceled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var durations = new List<int>();
+        using var handler = new StubHandler(async (request, cancellationToken) =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/ai-availability")
+            {
+                using JsonDocument json = JsonDocument.Parse(
+                    await request.Content!.ReadAsStringAsync(cancellationToken));
+                int duration = json.RootElement.GetProperty("durationSeconds").GetInt32();
+                durations.Add(duration);
+                if (duration == 6)
+                {
+                    sixSecondCheckStarted.TrySetResult();
+                    try
+                    {
+                        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                    }
+                    finally
+                    {
+                        if (cancellationToken.IsCancellationRequested)
+                            sixSecondCheckCanceled.TrySetResult();
+                    }
+                }
+                return JsonResponse(
+                    duration == 8 ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.OK,
+                    "{ \"available\": true }");
+            }
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        }, handleAvailability: false);
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        await using var viewModel = CreateVideoGenerationDialog(clients);
+        await sixSecondCheckStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        viewModel.SelectedDuration.Value = viewModel.DurationOptions.Single(option => option.Seconds == 4);
+        await sixSecondCheckCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await WaitUntilAsync(() => viewModel.EstimatedUsage.State.Value == AiOperationAvailabilityState.Available);
+        viewModel.SelectedDuration.Value = viewModel.DurationOptions.Single(option => option.Seconds == 8);
+        Assert.That(viewModel.EstimatedUsage.State.Value, Is.EqualTo(AiOperationAvailabilityState.Unknown));
+        await Task.Delay(350);
+        HeadlessTestHelpers.Settle();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(durations, Does.Contain(4));
+            Assert.That(durations, Does.Contain(8));
+            Assert.That(viewModel.EstimatedUsage.State.Value, Is.EqualTo(AiOperationAvailabilityState.Unknown));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task VideoGeneration_ReplacingResultRemovesSupersededPreviewFile()
+    {
+        await TestReset.ResetShellAsync();
+        int submissions = 0;
+        using var handler = new StubHandler(request =>
+        {
+            string path = request.RequestUri?.AbsolutePath ?? string.Empty;
+            if (path == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (path == "/api/v3/ai/videos" && request.Method == HttpMethod.Post)
+            {
+                int number = Interlocked.Increment(ref submissions);
+                return JsonResponse(HttpStatusCode.OK, JsonSerializer.Serialize(new
+                {
+                    jobId = $"video-job-{number}",
+                    status = "queued",
+                }));
+            }
+            if (path.StartsWith("/api/v3/ai/videos/video-job-", StringComparison.Ordinal))
+            {
+                string number = path[(path.LastIndexOf('-') + 1)..];
+                return JsonResponse(HttpStatusCode.OK, JsonSerializer.Serialize(new
+                {
+                    jobId = $"video-job-{number}",
+                    status = "succeeded",
+                    fileId = $"video-file-{number}",
+                    url = $"https://beutl.beditor.net/api/contents/video-file-{number}",
+                    error = (string?)null,
+                }));
+            }
+            if (path.StartsWith("/api/contents/video-file-", StringComparison.Ordinal))
+                return ByteResponse([1, 2, 3, 4], "video/mp4");
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        var viewModel = CreateVideoGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.EstimatedUsage.State.Value == AiOperationAvailabilityState.Available);
+        viewModel.Prompt.Value = "Replace this preview";
+
+        await viewModel.Generate.ExecuteAsync();
+        string firstPath = viewModel.ResultVideoPath.Value!;
+        await viewModel.Generate.ExecuteAsync();
+        string secondPath = viewModel.ResultVideoPath.Value!;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(firstPath, Is.Not.EqualTo(secondPath));
+            Assert.That(File.Exists(firstPath), Is.False);
+            Assert.That(File.Exists(secondPath), Is.True);
+        }
+
+        await viewModel.DisposeAsync();
+        Assert.That(File.Exists(secondPath), Is.False);
+    }
+
+    [AvaloniaTest]
+    public async Task ProviderFailure_ShowsRefundSafeRetryMessage()
+    {
+        await TestReset.ResetShellAsync();
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/images" => JsonResponse(HttpStatusCode.InternalServerError, """
+                { "error_code": "aiProviderError", "message": "Provider failed.", "documentation_url": null }
+                """),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.Prompt.Value = "A prompt";
+
+        await viewModel.Generate.ExecuteAsync();
+
+        Assert.That(viewModel.Error.Value, Is.EqualTo(Beutl.Language.Strings.AiProviderError));
+    }
+
+    // The three ways one run can end, and what each one means for the key that
+    // named it: unknown keeps it, a settled failure spends it, a result spends it.
+    [AvaloniaTest]
+    public async Task ImageGeneration_RetryingAnInterruptedRunAsksForTheJobItMayHavePaidFor()
+    {
+        await TestReset.ResetShellAsync();
+        var keys = new List<string?>();
+        bool cutFirstAttempt = true;
+        using var handler = new StubHandler(request =>
+        {
+            switch (request.RequestUri?.AbsolutePath)
+            {
+                case "/api/v3/user/entitlements":
+                    return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                case "/api/v3/ai/images":
+                    keys.Add(IdempotencyKeyOf(request));
+                    if (cutFirstAttempt)
+                    {
+                        cutFirstAttempt = false;
+                        // The answer never arrives, so this client cannot know
+                        // whether the picture was made and charged for.
+                        throw new HttpRequestException("The connection was reset.");
+                    }
+
+                    return JsonResponse(HttpStatusCode.OK, ImageResponseJson("image-job", "image-file"));
+                case "/api/contents/image-file":
+                    return ByteResponse(s_png, "image/png");
+                default:
+                    return JsonResponse(HttpStatusCode.NotFound, "{}");
+            }
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.Prompt.Value = "A calm blue sky";
+
+        await viewModel.Generate.ExecuteAsync();
+        await viewModel.Generate.ExecuteAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(keys, Has.Count.EqualTo(2));
+            Assert.That(keys[1], Is.EqualTo(keys[0]),
+                "The second ask is for the job the first may already have paid for.");
+            Assert.That(viewModel.ResultImage.Value, Is.Not.Null);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_AskingAgainAfterAPictureArrivesIsANewRequest()
+    {
+        await TestReset.ResetShellAsync();
+        var keys = new List<string?>();
+        using var handler = new StubHandler(request =>
+        {
+            switch (request.RequestUri?.AbsolutePath)
+            {
+                case "/api/v3/user/entitlements":
+                    return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                case "/api/v3/ai/images":
+                    keys.Add(IdempotencyKeyOf(request));
+                    return JsonResponse(HttpStatusCode.OK, ImageResponseJson("image-job", "image-file"));
+                case "/api/contents/image-file":
+                    return ByteResponse(s_png, "image/png");
+                default:
+                    return JsonResponse(HttpStatusCode.NotFound, "{}");
+            }
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.Prompt.Value = "A calm blue sky";
+
+        await viewModel.Generate.ExecuteAsync();
+        await viewModel.Generate.ExecuteAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(keys, Has.Count.EqualTo(2));
+            // Repeating the key would hand back the first picture; asking for
+            // the same prompt again is asking for another picture.
+            Assert.That(keys[1], Is.Not.EqualTo(keys[0]));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_DoesNotRetryUnderAKeyTheServerHasSettledAsFailed()
+    {
+        await TestReset.ResetShellAsync();
+        var keys = new List<string?>();
+        bool failFirstAttempt = true;
+        using var handler = new StubHandler(request =>
+        {
+            switch (request.RequestUri?.AbsolutePath)
+            {
+                case "/api/v3/user/entitlements":
+                    return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                case "/api/v3/ai/images":
+                    keys.Add(IdempotencyKeyOf(request));
+                    if (failFirstAttempt)
+                    {
+                        failFirstAttempt = false;
+                        // Failed and refunded server-side. The job is settled,
+                        // so its key can only ever answer with that failure.
+                        return JsonResponse(HttpStatusCode.InternalServerError, """
+                            { "error_code": "aiProviderError", "message": "Provider failed." }
+                            """);
+                    }
+
+                    return JsonResponse(HttpStatusCode.OK, ImageResponseJson("image-job", "image-file"));
+                case "/api/contents/image-file":
+                    return ByteResponse(s_png, "image/png");
+                default:
+                    return JsonResponse(HttpStatusCode.NotFound, "{}");
+            }
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.Prompt.Value = "A calm blue sky";
+
+        await viewModel.Generate.ExecuteAsync();
+        Assert.That(viewModel.Error.Value, Is.EqualTo(Beutl.Language.Strings.AiProviderError));
+
+        await viewModel.Generate.ExecuteAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(keys, Has.Count.EqualTo(2));
+            Assert.That(keys[1], Is.Not.EqualTo(keys[0]));
+            Assert.That(viewModel.ResultImage.Value, Is.Not.Null);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_CollectsAPaidPictureEvenWithNothingLeftToSpend()
+    {
+        await TestReset.ResetShellAsync();
+        var keys = new List<string?>();
+        bool cutFirstAttempt = true;
+        bool anythingLeftToSpend = true;
+        using var handler = new StubHandler(
+            (request, _) =>
+            {
+                switch (request.RequestUri?.AbsolutePath)
+                {
+                    case "/api/v3/user/entitlements":
+                        return Task.FromResult(JsonResponse(HttpStatusCode.OK, EntitlementsJson()));
+                    case "/api/v3/user/ai-availability":
+                        return Task.FromResult(JsonResponse(
+                            HttpStatusCode.OK,
+                            anythingLeftToSpend
+                                ? "{ \"available\": true }"
+                                : "{ \"available\": false }"));
+                    case "/api/v3/ai/images":
+                        keys.Add(IdempotencyKeyOf(request));
+                        if (cutFirstAttempt)
+                        {
+                            cutFirstAttempt = false;
+                            // The picture was made and charged for; only the
+                            // answer went missing, and it took the last of the
+                            // allowance with it.
+                            anythingLeftToSpend = false;
+                            throw new HttpRequestException("The connection was reset.");
+                        }
+
+                        return Task.FromResult(JsonResponse(
+                            HttpStatusCode.OK,
+                            ImageResponseJson("image-job", "image-file")));
+                    case "/api/contents/image-file":
+                        return Task.FromResult(ByteResponse(s_png, "image/png"));
+                    default:
+                        return Task.FromResult(JsonResponse(HttpStatusCode.NotFound, "{}"));
+                }
+            },
+            handleAvailability: false);
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.Prompt.Value = "A calm blue sky";
+
+        await viewModel.Generate.ExecuteAsync();
+        await viewModel.Generate.ExecuteAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            // The server hands back the job this name already made before it
+            // looks at the balance, so checking the balance here would refuse to
+            // collect the very picture that emptied it.
+            Assert.That(keys, Has.Count.EqualTo(2));
+            Assert.That(keys[1], Is.EqualTo(keys[0]));
+            Assert.That(viewModel.ResultImage.Value, Is.Not.Null);
+            Assert.That(viewModel.Error.Value, Is.Null);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_AsksUnderANewNameOnceTheJobItNamedIsGone()
+    {
+        await TestReset.ResetShellAsync();
+        var keys = new List<string?>();
+        bool reportDeleted = true;
+        using var handler = new StubHandler(request =>
+        {
+            switch (request.RequestUri?.AbsolutePath)
+            {
+                case "/api/v3/user/entitlements":
+                    return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                case "/api/v3/ai/images":
+                    keys.Add(IdempotencyKeyOf(request));
+                    if (reportDeleted)
+                    {
+                        reportDeleted = false;
+                        // The job that key created was deleted, so the key can
+                        // only ever answer with this.
+                        return JsonResponse(HttpStatusCode.Conflict, """
+                            { "error_code": "aiRequestWasDeleted", "message": "Gone." }
+                            """);
+                    }
+
+                    return JsonResponse(HttpStatusCode.OK, ImageResponseJson("image-job", "image-file"));
+                case "/api/contents/image-file":
+                    return ByteResponse(s_png, "image/png");
+                default:
+                    return JsonResponse(HttpStatusCode.NotFound, "{}");
+            }
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.Prompt.Value = "A calm blue sky";
+
+        await viewModel.Generate.ExecuteAsync();
+        Assert.That(viewModel.Error.Value, Is.EqualTo(Beutl.Language.Strings.AiRequestWasDeleted));
+
+        await viewModel.Generate.ExecuteAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(keys, Has.Count.EqualTo(2));
+            Assert.That(keys[1], Is.Not.EqualTo(keys[0]),
+                "A key whose job is gone would answer with that forever.");
+            Assert.That(viewModel.ResultImage.Value, Is.Not.Null);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_KeepsTheNameOfAJobTheServerIsStillWorkingOn()
+    {
+        await TestReset.ResetShellAsync();
+        var keys = new List<string?>();
+        bool reportInProgress = true;
+        using var handler = new StubHandler(request =>
+        {
+            switch (request.RequestUri?.AbsolutePath)
+            {
+                case "/api/v3/user/entitlements":
+                    return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                case "/api/v3/ai/images":
+                    keys.Add(IdempotencyKeyOf(request));
+                    if (reportInProgress)
+                    {
+                        reportInProgress = false;
+                        // The first attempt is still running and already paid
+                        // for; its key is the only way back to it.
+                        return JsonResponse(HttpStatusCode.Conflict, """
+                            { "error_code": "aiRequestInProgress", "message": "Still running." }
+                            """);
+                    }
+
+                    return JsonResponse(HttpStatusCode.OK, ImageResponseJson("image-job", "image-file"));
+                case "/api/contents/image-file":
+                    return ByteResponse(s_png, "image/png");
+                default:
+                    return JsonResponse(HttpStatusCode.NotFound, "{}");
+            }
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.Prompt.Value = "A calm blue sky";
+
+        await viewModel.Generate.ExecuteAsync();
+        Assert.That(viewModel.Error.Value, Is.EqualTo(Beutl.Language.Strings.AiRequestInProgress));
+
+        await viewModel.Generate.ExecuteAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(keys, Has.Count.EqualTo(2));
+            Assert.That(keys[1], Is.EqualTo(keys[0]),
+                "Asking again for the running job is how its result is recovered.");
+            Assert.That(viewModel.ResultImage.Value, Is.Not.Null);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_SendsEveryReferenceAndStopsAtWhatTheModelTakes()
+    {
+        await TestReset.ResetShellAsync();
+        string[] referencePaths = Enumerable.Range(0, 3)
+            .Select(index => Path.Combine(
+                Path.GetTempPath(),
+                $"beutl-ai-reference-{index}-{Guid.NewGuid():N}.png"))
+            .ToArray();
+        foreach (string path in referencePaths)
+            await File.WriteAllBytesAsync(path, s_png);
+
+        string? uploadBody = null;
+        using var handler = new StubHandler(async (request, cancellationToken) =>
+        {
+            switch (request.RequestUri?.AbsolutePath)
+            {
+                case "/api/v3/user/entitlements":
+                    return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                case "/api/v3/ai/images":
+                    uploadBody = request.Content is null
+                        ? null
+                        : await request.Content.ReadAsStringAsync(cancellationToken);
+                    return JsonResponse(HttpStatusCode.OK, ImageResponseJson("image-job", "image-file"));
+                case "/api/contents/image-file":
+                    return ByteResponse(s_png, "image/png");
+                default:
+                    return JsonResponse(HttpStatusCode.NotFound, "{}");
+            }
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        try
+        {
+            using var viewModel = CreateImageGenerationDialog(clients);
+            await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+            viewModel.Prompt.Value = "A calm blue sky";
+            viewModel.MaxReferenceImages.Value = 2;
+
+            viewModel.AddReferenceImages(referencePaths);
+            await viewModel.Generate.ExecuteAsync();
+
+            using (Assert.EnterMultipleScope())
+            {
+                // A model that takes two is offered two, not refused after the
+                // usage has been reserved for three.
+                Assert.That(viewModel.ReferenceImages, Has.Count.EqualTo(2));
+                Assert.That(viewModel.CanAddReferenceImage.Value, Is.False);
+                Assert.That(uploadBody, Does.Contain(Path.GetFileName(referencePaths[0])));
+                Assert.That(uploadBody, Does.Contain(Path.GetFileName(referencePaths[1])));
+                Assert.That(uploadBody, Does.Not.Contain(Path.GetFileName(referencePaths[2])));
+                Assert.That(viewModel.Error.Value, Is.Null);
+            }
+        }
+        finally
+        {
+            foreach (string path in referencePaths)
+                File.Delete(path);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ClosingImageTool_CancelsInFlightRequestWithoutPostDisposeMutation()
+    {
+        await TestReset.ResetShellAsync();
+        var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = new StubHandler(async (request, cancellationToken) =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/images")
+            {
+                requestStarted.SetResult();
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                finally
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        cancellationObserved.TrySetResult();
+                    }
+                }
+            }
+
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        var viewModel = CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.Prompt.Value = "Cancel this request";
+
+        Task operation = viewModel.Generate.ExecuteAsync();
+        await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        viewModel.Dispose();
+
+        await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await operation;
+        await viewModel.DisposeAsync();
+    }
+
+    [AvaloniaTest]
+    public async Task DisposingImageDialog_AwaitsCancellationIgnoringRequestAndRejectsLateResult()
+    {
+        await TestReset.ResetShellAsync();
+        var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRequest = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int contentRequests = 0;
+        using var handler = new StubHandler(async (request, _) =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/images")
+            {
+                requestStarted.TrySetResult();
+                await releaseRequest.Task;
+                return JsonResponse(HttpStatusCode.OK, ImageResponseJson("late-job", "late-file"));
+            }
+            if (request.RequestUri?.AbsolutePath == "/api/contents/late-file")
+            {
+                Interlocked.Increment(ref contentRequests);
+                return ByteResponse(s_png, "image/png");
+            }
+
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        var viewModel = CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.Prompt.Value = "Do not publish";
+        int resultPublications = 0;
+        using IDisposable publication = viewModel.ResultImage
+            .Where(image => image is not null)
+            .Subscribe(_ => resultPublications++);
+
+        Task operation = viewModel.Generate.ExecuteAsync();
+        await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Task disposal = viewModel.DisposeAsync().AsTask();
+
+        Assert.That(disposal.IsCompleted, Is.False);
+        releaseRequest.TrySetResult();
+        await operation;
+        await disposal;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(resultPublications, Is.Zero);
+            Assert.That(contentRequests, Is.Zero);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task DisposingImageEditDialog_AwaitsOperationAndRejectsLateResult()
+    {
+        await TestReset.ResetShellAsync();
+        string sourcePath = Path.Combine(Path.GetTempPath(), $"source-{Guid.NewGuid():N}.png");
+        await File.WriteAllBytesAsync(sourcePath, s_png);
+        try
+        {
+            var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseRequest = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            int contentRequests = 0;
+            using var handler = new StubHandler(async (request, _) =>
+            {
+                if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                    return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                if (request.RequestUri?.AbsolutePath == "/api/v3/ai/images/edit")
+                {
+                    requestStarted.TrySetResult();
+                    await releaseRequest.Task;
+                    return JsonResponse(HttpStatusCode.OK, ImageResponseJson("late-edit", "late-edit-file"));
+                }
+                if (request.RequestUri?.AbsolutePath == "/api/contents/late-edit-file")
+                {
+                    Interlocked.Increment(ref contentRequests);
+                    return ByteResponse(s_png, "image/png");
+                }
+
+                return JsonResponse(HttpStatusCode.NotFound, "{}");
+            });
+            using var httpClient = new HttpClient(handler);
+            await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+            SetAuthenticatedUser(clients, httpClient);
+            var viewModel = CreateImageEditDialog(clients);
+            viewModel.SourceFilePath.Value = sourcePath;
+            await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value && viewModel.CanEdit.Value);
+            int resultPublications = 0;
+            using IDisposable publication = viewModel.ResultImage
+                .Where(image => image is not null)
+                .Subscribe(_ => resultPublications++);
+
+            Task operation = viewModel.Edit.ExecuteAsync();
+            await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Task disposal = viewModel.DisposeAsync().AsTask();
+
+            Assert.That(disposal.IsCompleted, Is.False);
+            releaseRequest.TrySetResult();
+            await operation;
+            await disposal;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(resultPublications, Is.Zero);
+                Assert.That(contentRequests, Is.Zero);
+            }
+        }
+        finally
+        {
+            File.Delete(sourcePath);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task DisposingVideoDialog_CancelsSubmissionAndLeavesNoPreviewFile()
+    {
+        await TestReset.ResetShellAsync();
+        var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        string resultDirectory = AiTemporaryFileStore.GetCategoryDirectory("results");
+        string[] filesBefore = Directory.Exists(resultDirectory)
+            ? Directory.GetFiles(resultDirectory, "ai-video-*")
+            : [];
+        using var handler = new StubHandler(async (request, cancellationToken) =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/videos")
+            {
+                requestStarted.SetResult();
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                finally
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        cancellationObserved.TrySetResult();
+                    }
+                }
+            }
+
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        var viewModel = CreateVideoGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.EstimatedUsage.State.Value == AiOperationAvailabilityState.Available);
+        viewModel.Prompt.Value = "Cancel this video";
+
+        Task operation = viewModel.Generate.ExecuteAsync();
+        await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Task disposal = viewModel.DisposeAsync().AsTask();
+
+        await operation;
+        await disposal;
+        await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(
+            Directory.Exists(resultDirectory)
+                ? Directory.GetFiles(resultDirectory, "ai-video-*")
+                : [],
+            Is.EqualTo(filesBefore));
+    }
+
+    [AvaloniaTest]
+    public async Task DisposingVideoDialog_DuringBlockedFrameRenderPublishesNoFileOrPreview()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-video-frame-capture-disposal");
+        var renderStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRender = new TaskCompletionSource<Bitmap>(TaskCreationOptions.RunContinuationsAsynchronously);
+        string inputDirectory = AiTemporaryFileStore.GetCategoryDirectory("inputs");
+        string[] filesBefore = Directory.Exists(inputDirectory)
+            ? Directory.GetFiles(inputDirectory, "frame-*.png")
+            : [];
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        var viewModel = CreateVideoGenerationDialog(clients, editor);
+        viewModel.CurrentFrameRenderer = async _ =>
+        {
+            renderStarted.TrySetResult();
+            return await releaseRender.Task;
+        };
+
+        Task operation = viewModel.CaptureCurrentFrame.ExecuteAsync();
+        await renderStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        int publishedFramePaths = 0;
+        using IDisposable publication = viewModel.FirstFramePath
+            .Where(path => path is not null)
+            .Subscribe(_ => publishedFramePaths++);
+        Task disposal = viewModel.DisposeAsync().AsTask();
+        Assert.That(disposal.IsCompleted, Is.False);
+        releaseRender.TrySetResult(new Bitmap(2, 2));
+        await operation;
+        await disposal;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(publishedFramePaths, Is.Zero);
+            Assert.That(
+                Directory.Exists(inputDirectory)
+                    ? Directory.GetFiles(inputDirectory, "frame-*.png")
+                    : [],
+                Is.EqualTo(filesBefore));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task CapturingOrClearingFrame_RemovesSupersededTemporaryInput()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-video-frame-capture-replacement");
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        await using var viewModel = CreateVideoGenerationDialog(clients, editor);
+        viewModel.CurrentFrameRenderer = _ => Task.FromResult(new Bitmap(2, 2));
+
+        await viewModel.CaptureCurrentFrame.ExecuteAsync();
+        string firstPath = viewModel.FirstFramePath.Value!;
+        await viewModel.CaptureCurrentFrame.ExecuteAsync();
+        string secondPath = viewModel.FirstFramePath.Value!;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(firstPath, Is.Not.EqualTo(secondPath));
+            Assert.That(File.Exists(firstPath), Is.False);
+            Assert.That(File.Exists(secondPath), Is.True);
+        }
+
+        viewModel.ClearFirstFrame.Execute();
+        Assert.That(File.Exists(secondPath), Is.False);
+    }
+
+    [Test]
+    public void SubtitleTranslation_ChunkBoundaryKeepsCombiningCharactersTogether()
+    {
+        const string text = "A\u0301 B";
+        int[] boundaries = AiSubtitleDialogViewModel.CreateTranslationTextElementBoundaries(text);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                AiSubtitleDialogViewModel.KeepTranslationBoundaryTogether(text, boundaries, 0, 1),
+                Is.EqualTo(0),
+                "A combining sequence must not be split after its base character.");
+            Assert.That(
+                text.Substring(0, AiSubtitleDialogViewModel.KeepTranslationBoundaryTogether(
+                    text,
+                    boundaries,
+                    0,
+                    2)),
+                Is.EqualTo("A\u0301"));
+            Assert.That(
+                text.Substring(0, AiSubtitleDialogViewModel.KeepTranslationBoundaryTogether(
+                    text,
+                    boundaries,
+                    0,
+                    3)),
+                Is.EqualTo("A\u0301 "),
+                "The separator remains with the preceding chunk.");
+        });
+    }
+
+    [Test]
+    public void SubtitleTranslation_WhitespaceBoundaryCannotSplitItsCombiningMark()
+    {
+        const string text = "A \u0301B";
+        int[] boundaries = AiSubtitleDialogViewModel.CreateTranslationTextElementBoundaries(text);
+
+        int length = AiSubtitleDialogViewModel.KeepTranslationBoundaryTogether(
+            text,
+            boundaries,
+            0,
+            3);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(boundaries, Is.EqualTo(new[] { 0, 1, 3 }));
+            Assert.That(length, Is.EqualTo(3));
+            Assert.That(text.Substring(0, length), Is.EqualTo("A \u0301"));
+        });
+    }
+
+    [Test]
+    public async Task SubtitleTranslation_CachedTextBoundariesScaleWithSmallLimits()
+    {
+        string text = new('界', 20_000);
+        int[] boundaries = AiSubtitleDialogViewModel.CreateTranslationTextElementBoundaries(text);
+
+        Task<int> split = Task.Run(() =>
+        {
+            int offset = 0;
+            int pieces = 0;
+            while (offset < text.Length)
+            {
+                int length = AiSubtitleDialogViewModel.KeepTranslationBoundaryTogether(
+                    text,
+                    boundaries,
+                    offset,
+                    1);
+                if (length <= 0)
+                    throw new InvalidOperationException("The cached boundary map stopped making progress.");
+                offset += length;
+                pieces++;
+            }
+            return pieces;
+        });
+
+        Assert.That(
+            await split.WaitAsync(TimeSpan.FromSeconds(2)),
+            Is.EqualTo(text.Length));
+    }
+
+    [AvaloniaTest]
+    public async Task SubtitleTranslation_PrefersAWordBoundaryWithinThePublishedLimit()
+    {
+        await TestReset.ResetShellAsync();
+        var sentPieces = new List<string>();
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/capabilities")
+            {
+                return JsonResponse(
+                    HttpStatusCode.OK,
+                    CaptionCapabilitiesJson(
+                        removeFirst: false,
+                        maxSegments: 10,
+                        maxCharacters: 8,
+                        maxRequestBytes: 128 * 1024));
+            }
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/translations")
+            {
+                string body = request.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+                using JsonDocument json = JsonDocument.Parse(body);
+                object[] segments = json.RootElement.GetProperty("segments")
+                    .EnumerateArray()
+                    .Select(segment =>
+                    {
+                        string text = segment.GetProperty("text").GetString()!;
+                        sentPieces.Add(text);
+                        return (object)new
+                        {
+                            id = segment.GetProperty("id").GetString(),
+                            text,
+                        };
+                    })
+                    .ToArray();
+                return JsonResponse(HttpStatusCode.OK, JsonSerializer.Serialize(new
+                {
+                    jobId = $"word-boundary-{sentPieces.Count}",
+                    segments,
+                }));
+            }
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.TranslationModelPicker.Options.Count == 2);
+        viewModel.ResultSegments.Value =
+        [
+            new AiTranscriptionSegment { Start = 0, End = 2, Text = "hello world" },
+        ];
+        await WaitUntilAsync(() => viewModel.CanTranslate.Value);
+
+        await viewModel.Translate.ExecuteAsync();
+
+        Assert.That(sentPieces, Is.EqualTo(new[] { "hello ", "world" }));
+    }
+
+    [AvaloniaTest]
+    public async Task SubtitleTranslation_BatchesAtomicallyAndImportsTranslatedCaptions()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-subtitle-translation");
+        int translationRequests = 0;
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/translations")
+            {
+                int requestNumber = Interlocked.Increment(ref translationRequests);
+                string body = request.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+                using JsonDocument json = JsonDocument.Parse(body);
+                object[] segments = json.RootElement.GetProperty("segments")
+                    .EnumerateArray()
+                    .Select(segment => (object)new
+                    {
+                        id = segment.GetProperty("id").GetString(),
+                        text = "T-" + segment.GetProperty("text").GetString(),
+                    })
+                    .ToArray();
+                return JsonResponse(HttpStatusCode.OK, JsonSerializer.Serialize(new
+                {
+                    jobId = $"translation-{requestNumber}",
+                    segments,
+                }));
+            }
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(clients, editor);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.ResultSegments.Value = Enumerable.Range(0, 201)
+            .Select(index => new AiTranscriptionSegment
+            {
+                Start = index * 2,
+                End = index * 2 + 1,
+                Text = $"line-{index}",
+            })
+            .ToArray();
+        await WaitUntilAsync(() => viewModel.CanTranslate.Value);
+
+        await viewModel.Translate.ExecuteAsync();
+        await viewModel.AddToScene.ExecuteAsync();
+        HeadlessTestHelpers.Settle();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translationRequests, Is.EqualTo(2));
+            Assert.That(viewModel.Cues, Has.Count.EqualTo(201));
+            Assert.That(viewModel.Cues[0].Text, Is.EqualTo("T-line-0"));
+            Assert.That(editor.Scene.Children, Has.Count.EqualTo(201));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task SubtitleTranslation_WrapsProviderTextWithoutValidationWarningOrDataLoss()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-subtitle-translation-wrap");
+        const string translatedText =
+            "This translated caption is intentionally longer than the default line length.";
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/translations")
+            {
+                string body = request.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+                using JsonDocument json = JsonDocument.Parse(body);
+                object[] segments = json.RootElement.GetProperty("segments")
+                    .EnumerateArray()
+                    .Select(segment => (object)new
+                    {
+                        id = segment.GetProperty("id").GetString(),
+                        // Providers may return text that exceeds the editor's
+                        // line-length limit. The imported value must be wrapped,
+                        // not rejected (or truncated) as a validation error.
+                        text = translatedText,
+                    })
+                    .ToArray();
+                return JsonResponse(HttpStatusCode.OK, JsonSerializer.Serialize(new
+                {
+                    jobId = "translation-wrap",
+                    segments,
+                }));
+            }
+
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(clients, editor);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.ResultSegments.Value =
+        [
+            new AiTranscriptionSegment { Start = 0, End = 2, Text = "source caption" },
+        ];
+        await WaitUntilAsync(() => viewModel.CanTranslate.Value);
+
+        await viewModel.Translate.ExecuteAsync();
+
+        string importedText = viewModel.Cues.Single().Text;
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.CaptionValidationMessage.Value, Is.Null,
+                "Translation used to surface the exact line-count warning after import.");
+            Assert.That(importedText.Replace("\n", " ", StringComparison.Ordinal)
+                    .Replace("  ", " ", StringComparison.Ordinal),
+                Is.EqualTo(translatedText),
+                "Wrapping must preserve the translated words.");
+            Assert.That(importedText.Split('\n'), Has.Length.LessThanOrEqualTo(2));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task SubtitleTranslation_SplitsOverlongProviderTextWithoutLineCountWarning()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-subtitle-translation-split");
+        const string translatedText =
+            "これは字幕エディターの既定の一行あたりの文字数を大きく超えるように意図的に作成された長い翻訳結果です。"
+            + "翻訳された文章の内容を一文字も失わず、読みやすい複数の字幕へ分割して表示できることを確認します。";
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/translations")
+            {
+                string body = request.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+                using JsonDocument json = JsonDocument.Parse(body);
+                object[] segments = json.RootElement.GetProperty("segments")
+                    .EnumerateArray()
+                    .Select(segment => (object)new
+                    {
+                        id = segment.GetProperty("id").GetString(),
+                        text = translatedText,
+                    })
+                    .ToArray();
+                return JsonResponse(HttpStatusCode.OK, JsonSerializer.Serialize(new
+                {
+                    jobId = "translation-split",
+                    segments,
+                }));
+            }
+
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(clients, editor);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.ResultSegments.Value =
+        [
+            new AiTranscriptionSegment { Start = 0, End = 10, Text = "source caption" },
+        ];
+        await WaitUntilAsync(() => viewModel.CanTranslate.Value);
+
+        await viewModel.Translate.ExecuteAsync();
+
+        string importedText = string.Join('\n', viewModel.Cues.Select(cue => cue.Text));
+        string importedLetters = new(importedText.Where(character => !char.IsWhiteSpace(character)).ToArray());
+        string translatedLetters = new(translatedText.Where(character => !char.IsWhiteSpace(character)).ToArray());
+        Assert.That(viewModel.Cues, Has.Count.EqualTo(2));
+        Assert.That(viewModel.Cues[0].TryCreateCue(out CaptionCue? firstCue), Is.True);
+        Assert.That(viewModel.Cues[1].TryCreateCue(out CaptionCue? secondCue), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.CaptionValidationMessage.Value, Is.Null,
+                "An overlong translation must be split into timed cues instead of leaving a line-count warning.");
+            Assert.That(firstCue!.Start, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(firstCue!.End, Is.EqualTo(secondCue!.Start));
+            Assert.That(secondCue.End, Is.EqualTo(TimeSpan.FromSeconds(10)));
+            Assert.That(viewModel.Cues.All(cue => cue.Text.Split('\n').Length <= 2), Is.True);
+            Assert.That(importedLetters, Is.EqualTo(translatedLetters),
+                "Splitting must preserve every translated non-whitespace character.");
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task SubtitleTranslation_SecondBatchFailureKeepsPaidPartialAndResumesWithoutRebilling()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-subtitle-translation-failure");
+        int translationRequests = 0;
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/translations")
+            {
+                int requestNumber = Interlocked.Increment(ref translationRequests);
+                return requestNumber is 1 or 3
+                    ? CreateTranslationResponse(request, "translation-first")
+                    : JsonResponse(HttpStatusCode.InternalServerError, """
+                        {
+                          "error_code": "aiProviderError",
+                          "message": "Provider failed.",
+                          "documentation_url": null
+                        }
+                        """);
+            }
+
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(clients, editor);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.ResultSegments.Value = CreateTranslationBatchSegments();
+        await WaitUntilAsync(() => viewModel.CanTranslate.Value);
+        string[] originalTexts = viewModel.Cues.Select(cue => cue.Text).ToArray();
+
+        await viewModel.Translate.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translationRequests, Is.EqualTo(2));
+            Assert.That(viewModel.Cues.Select(cue => cue.Text), Is.EqualTo(originalTexts));
+            Assert.That(viewModel.IsTranslating.Value, Is.False);
+            Assert.That(viewModel.Error.Value, Is.EqualTo(Beutl.Language.Strings.AiProviderError));
+            Assert.That(viewModel.HasPartialResult.Value, Is.True);
+            Assert.That(viewModel.PartialResultMessage.Value, Does.Contain("1"));
+        });
+
+        viewModel.ApplyPartialResult.Execute();
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.Cues[0].Text, Is.EqualTo("T-line-0"));
+            Assert.That(viewModel.Cues[^1].Text, Is.EqualTo("line-200"));
+        });
+
+        viewModel.RefreshAvailability();
+        await WaitUntilAsync(() => viewModel.CanTranslate.Value);
+        await viewModel.Translate.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translationRequests, Is.EqualTo(3),
+                "The completed first batch must not be submitted and billed again.");
+            Assert.That(viewModel.Cues.All(cue => cue.Text.StartsWith("T-", StringComparison.Ordinal)), Is.True);
+            Assert.That(viewModel.HasPartialResult.Value, Is.False);
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task SubtitleTranslation_PartialRunKeepsItsModelAfterRemovalAndPickerChange()
+    {
+        await TestReset.ResetShellAsync();
+        bool firstModelRemoved = false;
+        var sentModels = new List<string?>();
+        int translationRequests = 0;
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/capabilities")
+                return JsonResponse(HttpStatusCode.OK, CaptionCapabilitiesJson(firstModelRemoved));
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/translations")
+            {
+                string body = request.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+                using JsonDocument json = JsonDocument.Parse(body);
+                sentModels.Add(json.RootElement.TryGetProperty("model", out JsonElement model)
+                    ? model.GetString()
+                    : null);
+                int requestNumber = ++translationRequests;
+                return requestNumber is 1 or 3
+                    ? CreateTranslationResponse(request, $"translation-{requestNumber}")
+                    : JsonResponse(HttpStatusCode.InternalServerError, """
+                        {
+                          "error_code": "aiProviderError",
+                          "message": "Provider failed.",
+                          "documentation_url": null
+                        }
+                        """);
+            }
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.TranslationModelPicker.Options.Count == 2);
+        viewModel.ResultSegments.Value = CreateTranslationBatchSegments();
+        await WaitUntilAsync(() => viewModel.CanTranslate.Value);
+
+        await viewModel.Translate.ExecuteAsync();
+        viewModel.ApplyPartialResult.Execute();
+
+        firstModelRemoved = true;
+        IAiModelCatalogService catalog = clients.GetResource<IAiModelCatalogService>();
+        catalog.Invalidate();
+        await viewModel.TranslationModelPicker.LoadAsync(
+            AiOperations.CaptionTranslation,
+            CancellationToken.None);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                viewModel.TranslationModelPicker.SelectedModel,
+                Is.EqualTo(new AiModelId("translation-a")));
+            Assert.That(
+                viewModel.TranslationModelPicker.Selected.Value!.IsAvailable,
+                Is.False,
+                "The removed model stays visible only because the partial run still owns it.");
+        }
+        viewModel.TranslationModelPicker.Selected.Value =
+            viewModel.TranslationModelPicker.Options.First(option =>
+                option.Id == new AiModelId("translation-b"));
+
+        viewModel.RefreshAvailability();
+        await WaitUntilAsync(() => viewModel.CanTranslate.Value);
+        await viewModel.Translate.ExecuteAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(translationRequests, Is.EqualTo(3));
+            Assert.That(sentModels, Is.EqualTo(new[]
+            {
+                "translation-a",
+                "translation-a",
+                "translation-a",
+            }));
+            Assert.That(viewModel.HasPartialResult.Value, Is.False);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task SubtitleTranslation_UsesThePublishedSerializedBatchLimit()
+    {
+        await TestReset.ResetShellAsync();
+        var bodies = new List<string>();
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/capabilities")
+            {
+                return JsonResponse(
+                    HttpStatusCode.OK,
+                    CaptionCapabilitiesJson(
+                        removeFirst: false,
+                        maxSegments: 10,
+                        maxCharacters: 1_000,
+                        maxRequestBytes: 900));
+            }
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/translations")
+            {
+                bodies.Add(request.Content!.ReadAsStringAsync().GetAwaiter().GetResult());
+                return CreateTranslationResponse(request, $"limited-{bodies.Count}");
+            }
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(clients);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.TranslationModelPicker.Options.Count == 2);
+        viewModel.ResultSegments.Value = Enumerable.Range(0, 3)
+            .Select(index => new AiTranscriptionSegment
+            {
+                Start = index * 2,
+                End = index * 2 + 1,
+                Text = new string('界', 150),
+            })
+            .ToArray();
+        await WaitUntilAsync(() => viewModel.CanTranslate.Value);
+
+        await viewModel.Translate.ExecuteAsync();
+
+        Assert.That(bodies, Has.Count.EqualTo(3),
+            "The byte limit, not the larger segment or character limit, splits these requests.");
+        foreach (string body in bodies)
+        {
+            using JsonDocument json = JsonDocument.Parse(body);
+            JsonElement[] segments = json.RootElement.GetProperty("segments")
+                .EnumerateArray()
+                .ToArray();
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(segments, Has.Length.LessThanOrEqualTo(10));
+                Assert.That(
+                    segments.Sum(segment => segment.GetProperty("text").GetString()!.Length),
+                    Is.LessThanOrEqualTo(1_000));
+                Assert.That(Encoding.UTF8.GetByteCount(body), Is.LessThanOrEqualTo(900));
+            }
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task SubtitleTranslation_SecondBatchCancellationPreservesOriginalCues()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-subtitle-translation-cancel");
+        int translationRequests = 0;
+        var secondRequestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = new StubHandler(async (request, cancellationToken) =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/translations")
+            {
+                int requestNumber = Interlocked.Increment(ref translationRequests);
+                if (requestNumber == 1)
+                    return CreateTranslationResponse(request, "translation-first");
+
+                secondRequestStarted.TrySetResult();
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                finally
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        cancellationObserved.TrySetResult();
+                    }
+                }
+            }
+
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(clients, editor);
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.ResultSegments.Value = CreateTranslationBatchSegments();
+        await WaitUntilAsync(() => viewModel.CanTranslate.Value);
+        string[] originalTexts = viewModel.Cues.Select(cue => cue.Text).ToArray();
+
+        Task operation = viewModel.Translate.ExecuteAsync();
+        await secondRequestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        GetLifetimeCancellationSource(viewModel).Cancel();
+        await operation;
+        await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translationRequests, Is.EqualTo(2));
+            Assert.That(viewModel.Cues.Select(cue => cue.Text), Is.EqualTo(originalTexts));
+            Assert.That(viewModel.IsTranslating.Value, Is.False);
+            Assert.That(viewModel.Error.Value, Is.Null);
+            Assert.That(viewModel.HasPartialResult.Value, Is.True);
+        });
+
+        viewModel.ApplyPartialResult.Execute();
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.Cues[0].Text, Is.EqualTo("T-line-0"));
+            Assert.That(viewModel.Cues[^1].Text, Is.EqualTo("line-200"));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task SubtitleTranslation_PaidPartialSurvivesDialogCloseAndStillResumes()
+    {
+        await TestReset.ResetShellAsync();
+        var draftStore = new FileCaptionDraftStore(Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "translation-restart-drafts"));
+        CaptionDraftScope draftScope = new("user-a", Guid.NewGuid(), Guid.NewGuid());
+        IObservable<CaptionDraftScope?> draftScopes =
+            Observable.Return<CaptionDraftScope?>(draftScope);
+        int translationRequests = 0;
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/translations")
+            {
+                int requestNumber = Interlocked.Increment(ref translationRequests);
+                return requestNumber is 1 or 3
+                    ? CreateTranslationResponse(request, $"translation-{requestNumber}")
+                    : JsonResponse(HttpStatusCode.InternalServerError, """
+                        {
+                          "error_code": "aiProviderError",
+                          "message": "Provider failed.",
+                          "documentation_url": null
+                        }
+                        """);
+            }
+
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+
+        await using (var firstDialog = CreateSubtitleDialog(
+                   clients,
+                   draftStore: draftStore,
+                   draftScopes: draftScopes))
+        {
+            await WaitUntilAsync(() => firstDialog.Usage.HasSnapshot.Value);
+            firstDialog.ResultSegments.Value = CreateTranslationBatchSegments();
+            await WaitUntilAsync(() => firstDialog.CanTranslate.Value);
+            await firstDialog.Translate.ExecuteAsync();
+            Assert.That(firstDialog.HasPartialResult.Value, Is.True);
+        }
+        AssertStoredCaptionDraftJob(draftStore, draftScope, "translation-1");
+
+        await using var restoredDialog = CreateSubtitleDialog(
+            clients,
+            draftStore: draftStore,
+            draftScopes: draftScopes);
+        await WaitUntilAsync(() => restoredDialog.Usage.HasSnapshot.Value
+            && restoredDialog.HasPartialResult.Value);
+        Assert.That(restoredDialog.HasPartialResult.Value, Is.True);
+        restoredDialog.ApplyPartialResult.Execute();
+        await WaitUntilAsync(() => restoredDialog.CanTranslate.Value);
+        await restoredDialog.Translate.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translationRequests, Is.EqualTo(3));
+            Assert.That(restoredDialog.Cues, Has.Count.EqualTo(201));
+            Assert.That(
+                restoredDialog.Cues.All(cue => cue.Text.StartsWith("T-", StringComparison.Ordinal)),
+                Is.True);
+            Assert.That(restoredDialog.HasPartialResult.Value, Is.False);
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task SubtitleTranslation_SaveFailureAfterPaidResponsePreservesSeedForRestart()
+    {
+        await TestReset.ResetShellAsync();
+        var draftStore = new FailingCaptionDraftStore(failOnSave: 2);
+        CaptionDraftScope scope = new("user-a", Guid.NewGuid(), Guid.NewGuid());
+        IObservable<CaptionDraftScope?> scopes = Observable.Return<CaptionDraftScope?>(scope);
+        var keys = new List<string?>();
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/translations")
+            {
+                keys.Add(IdempotencyKeyOf(request));
+                return CreateTranslationResponse(request, "translation-paid");
+            }
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+
+        await using (var first = CreateSubtitleDialog(clients, draftStore: draftStore, draftScopes: scopes))
+        {
+            await WaitUntilAsync(() => first.Usage.HasSnapshot.Value);
+            first.ResultSegments.Value =
+            [new AiTranscriptionSegment { Start = 0, End = 1, Text = "paid" }];
+            await WaitUntilAsync(() => first.CanTranslate.Value);
+            await first.Translate.ExecuteAsync();
+            Assert.That(
+                first.Error.Value,
+                Is.EqualTo(Beutl.Language.Strings.AiSubtitle_RunCannotBeRecorded));
+            Assert.That(first.HasPartialResult.Value, Is.True);
+        }
+
+        draftStore.FailOnSave = null;
+        await using var restored = CreateSubtitleDialog(clients, draftStore: draftStore, draftScopes: scopes);
+        await WaitUntilAsync(() => restored.Usage.HasSnapshot.Value && restored.Cues.Count == 1);
+        restored.RefreshAvailability();
+        await WaitUntilAsync(() => restored.CanTranslate.Value);
+        await restored.Translate.ExecuteAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(keys, Has.Count.EqualTo(2));
+            Assert.That(keys[1], Is.EqualTo(keys[0]));
+            Assert.That(restored.Cues.Single().Text, Is.EqualTo("T-paid"));
+            Assert.That(restored.HasPartialResult.Value, Is.False);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task SubtitleTranslation_EditDuringDeferredResponsePreservesUserRevisionAndJobMetadata()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-subtitle-translation-stale-response");
+        var draftStore = new FileCaptionDraftStore(Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "translation-stale-drafts"));
+        CaptionDraftScope draftScope = new("user-a", Guid.NewGuid(), editor.Scene.Id);
+        var translationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseTranslation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = new StubHandler(async (request, cancellationToken) =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/translations")
+            {
+                translationStarted.TrySetResult();
+                await releaseTranslation.Task.WaitAsync(cancellationToken);
+                return CreateTranslationResponse(request, "translation-stale");
+            }
+
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(
+            clients,
+            editor,
+            draftStore,
+            Observable.Return<CaptionDraftScope?>(draftScope));
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        viewModel.ResultSegments.Value =
+        [
+            new AiTranscriptionSegment { Start = 0, End = 1, Text = "original caption" },
+        ];
+        await WaitUntilAsync(() => viewModel.CanTranslate.Value);
+
+        Task operation = viewModel.Translate.ExecuteAsync();
+        await translationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        viewModel.Cues[0].Text = "user edit while translating";
+        releaseTranslation.TrySetResult();
+        await operation;
+        AssertStoredCaptionDraftJob(draftStore, draftScope, "translation-stale");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.Cues, Has.Count.EqualTo(1));
+            Assert.That(viewModel.Cues[0].Text, Is.EqualTo("user edit while translating"));
+            Assert.That(viewModel.IsTranslating.Value, Is.False);
+            Assert.That(viewModel.Error.Value, Is.Null);
+            Assert.That(viewModel.HasPartialResult.Value, Is.True,
+                "A paid response must remain recoverable when the editor revision changes.");
+        }
+
+        viewModel.ApplyPartialResult.Execute();
+        Assert.That(viewModel.Cues[0].Text, Is.EqualTo("T-original caption"));
+    }
+
+    [AvaloniaTest]
+    public async Task SubtitleTranslation_ResponseLossSurvivesCueEditAnotherRunAndRestart()
+    {
+        await TestReset.ResetShellAsync();
+        var draftStore = new FileCaptionDraftStore(Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "translation-ledger-drafts"));
+        CaptionDraftScope draftScope = new("user-a", Guid.NewGuid(), Guid.NewGuid());
+        IObservable<CaptionDraftScope?> scopes = Observable.Return<CaptionDraftScope?>(draftScope);
+        var keys = new List<string?>();
+        int requestCount = 0;
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/translations")
+            {
+                keys.Add(IdempotencyKeyOf(request));
+                int sequence = ++requestCount;
+                if (sequence == 1)
+                {
+                    return JsonResponse(HttpStatusCode.ServiceUnavailable, """
+                        {
+                          "error_code": "aiResultUnavailable",
+                          "message": "The paid result is temporarily unavailable.",
+                          "documentation_url": null
+                        }
+                        """);
+                }
+                return CreateTranslationResponse(request, $"translation-{sequence}");
+            }
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+
+        await using (var firstDialog = CreateSubtitleDialog(
+                   clients,
+                   draftStore: draftStore,
+                   draftScopes: scopes))
+        {
+            await WaitUntilAsync(() => firstDialog.Usage.HasSnapshot.Value);
+            firstDialog.ResultSegments.Value =
+            [
+                new AiTranscriptionSegment { Start = 0, End = 1, Text = "A" },
+            ];
+            await WaitUntilAsync(() => firstDialog.CanTranslate.Value);
+
+            await firstDialog.Translate.ExecuteAsync();
+            Assert.That(firstDialog.HasOutstandingTranslationRequest.Value, Is.True);
+
+            firstDialog.Cues[0].Text = "B";
+            await WaitUntilAsync(() => firstDialog.CanTranslate.Value);
+            await firstDialog.Translate.ExecuteAsync();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(requestCount, Is.EqualTo(2));
+                Assert.That(keys[1], Is.Not.EqualTo(keys[0]));
+                Assert.That(firstDialog.Cues.Single().Text, Is.EqualTo("T-B"));
+                Assert.That(firstDialog.HasOutstandingTranslationRequest.Value, Is.True,
+                    "Settling B must leave A's paid recovery visible.");
+            }
+        }
+
+        Assert.That(draftStore.TryOpen(draftScope, out ICaptionDraftSession? storedSession), Is.True);
+        using (storedSession)
+        {
+            CaptionDraftEntry stored = storedSession!.Read().Entry!;
+            Assert.Multiple(() =>
+            {
+                Assert.That(stored.Draft.TranslationResume!.SourceCues.Single().Text, Is.EqualTo("A"));
+                Assert.That(stored.Draft.TranslationResume.RequestKeyNamePending, Is.True);
+            });
+        }
+
+        await using var restoredDialog = CreateSubtitleDialog(
+            clients,
+            draftStore: draftStore,
+            draftScopes: scopes);
+        await WaitUntilAsync(() => restoredDialog.Usage.HasSnapshot.Value);
+        await WaitUntilAsync(() => restoredDialog.Cues.Count == 1);
+        await WaitUntilAsync(() => restoredDialog.TranslationModelPicker.IsLoaded.Value);
+        restoredDialog.RefreshAvailability();
+        await WaitUntilAsync(() => restoredDialog.CanTranslate.Value);
+        Assert.That(restoredDialog.Cues.Single().Text, Is.EqualTo("A"));
+
+        await restoredDialog.Translate.ExecuteAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(requestCount, Is.EqualTo(3));
+            Assert.That(keys[2], Is.EqualTo(keys[0]),
+                "Restart recovery must ask for A under the key that may already have paid for it.");
+            Assert.That(restoredDialog.Cues.Single().Text, Is.EqualTo("T-A"));
+            Assert.That(restoredDialog.HasOutstandingTranslationRequest.Value, Is.False);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task SubtitleTranslation_CaptionImportKeepsPaidRecoveryAcrossRestart()
+    {
+        await TestReset.ResetShellAsync();
+        var draftStore = new FileCaptionDraftStore(Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "translation-import-ledger-drafts"));
+        CaptionDraftScope draftScope = new("user-a", Guid.NewGuid(), Guid.NewGuid());
+        IObservable<CaptionDraftScope?> scopes = Observable.Return<CaptionDraftScope?>(draftScope);
+        var keys = new List<string?>();
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/translations")
+            {
+                keys.Add(IdempotencyKeyOf(request));
+                return keys.Count == 1
+                    ? JsonResponse(HttpStatusCode.ServiceUnavailable, """
+                        {
+                          "error_code": "aiResultUnavailable",
+                          "message": "The paid result is temporarily unavailable.",
+                          "documentation_url": null
+                        }
+                        """)
+                    : CreateTranslationResponse(request, "translation-recovered");
+            }
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+
+        await using (var firstDialog = CreateSubtitleDialog(
+                   clients,
+                   draftStore: draftStore,
+                   draftScopes: scopes))
+        {
+            await WaitUntilAsync(() => firstDialog.Usage.HasSnapshot.Value);
+            firstDialog.ResultSegments.Value =
+            [
+                new AiTranscriptionSegment { Start = 0, End = 1, Text = "paid A" },
+            ];
+            await WaitUntilAsync(() => firstDialog.CanTranslate.Value);
+            await firstDialog.Translate.ExecuteAsync();
+
+            bool imported = firstDialog.ImportCaptionBytes(Encoding.UTF8.GetBytes("""
+                1
+                00:00:00,000 --> 00:00:01,000
+                imported B
+
+                """), CaptionFormats.Srt);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(imported, Is.True);
+                Assert.That(firstDialog.Cues.Single().Text, Is.EqualTo("imported B"));
+                Assert.That(firstDialog.HasOutstandingTranslationRequest.Value, Is.True);
+            }
+        }
+
+        await using var restoredDialog = CreateSubtitleDialog(
+            clients,
+            draftStore: draftStore,
+            draftScopes: scopes);
+        await WaitUntilAsync(() => restoredDialog.Usage.HasSnapshot.Value
+            && restoredDialog.Cues.Count == 1
+            && restoredDialog.TranslationModelPicker.IsLoaded.Value
+            && restoredDialog.HasOutstandingTranslationRequest.Value);
+        restoredDialog.RefreshAvailability();
+        await WaitUntilAsync(() => restoredDialog.CanTranslate.Value);
+        Assert.That(restoredDialog.Cues.Single().Text, Is.EqualTo("paid A"));
+
+        await restoredDialog.Translate.ExecuteAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(keys, Has.Count.EqualTo(2));
+            Assert.That(keys[1], Is.EqualTo(keys[0]));
+            Assert.That(restoredDialog.Cues.Single().Text, Is.EqualTo("T-paid A"));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task SourceFileTranscription_DeferredPaidResultPersistsResponseJobMetadata()
+    {
+        await TestReset.ResetShellAsync();
+        var draftStore = new FileCaptionDraftStore(Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "source-transcription-drafts"));
+        CaptionDraftScope draftScope = new("user-a", Guid.NewGuid(), Guid.NewGuid());
+        var transcriptionStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseTranscription = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int transcriptionRequests = 0;
+        using var handler = new StubHandler(async (request, cancellationToken) =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/transcriptions")
+            {
+                Interlocked.Increment(ref transcriptionRequests);
+                transcriptionStarted.TrySetResult();
+                await releaseTranscription.Task.WaitAsync(cancellationToken);
+                return CreateTranscriptionResponse("source-transcription-job");
+            }
+
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(
+            clients,
+            draftStore: draftStore,
+            draftScopes: Observable.Return<CaptionDraftScope?>(draftScope));
+        string sourcePath = Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "source-transcription.wav");
+        WritePcmWave(sourcePath, sampleRate: 16_000, sampleCount: 16_000);
+        try
+        {
+            await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+            var originalSource = new AudioSourceItem(
+                "Source audio",
+                sourcePath,
+                TimeSpan.FromSeconds(1));
+            viewModel.SelectedAudioSource.Value = originalSource;
+            await WaitUntilAsync(() => viewModel.CanTranscribe.Value);
+
+            Task operation = viewModel.Transcribe.ExecuteAsync();
+            await transcriptionStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            viewModel.SelectedAudioSource.Value = new AudioSourceItem(
+                "Other audio",
+                Path.Combine(BeutlHomeIsolation.CurrentHome!, "other.wav"),
+                TimeSpan.FromSeconds(1));
+            viewModel.ResultSegments.Value =
+            [
+                new AiTranscriptionSegment { Start = 0, End = 1, Text = "user edit" },
+            ];
+            releaseTranscription.TrySetResult();
+            await operation;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(viewModel.Cues.Single().Text, Is.EqualTo("user edit"));
+                Assert.That(viewModel.HasPartialResult.Value, Is.True);
+            });
+            AssertStoredCaptionDraftJob(
+                draftStore,
+                draftScope,
+                "source-transcription-job");
+
+            viewModel.SelectedAudioSource.Value = originalSource;
+            viewModel.RefreshAvailability();
+            await WaitUntilAsync(() => viewModel.CanTranscribe.Value);
+            await viewModel.Transcribe.ExecuteAsync();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(transcriptionRequests, Is.EqualTo(1),
+                    "A completed source transcription must apply without another HTTP request.");
+                Assert.That(viewModel.Cues.Single().Text, Is.EqualTo("new caption"));
+                Assert.That(viewModel.HasPartialResult.Value, Is.False);
+            }
+        }
+        finally
+        {
+            File.Delete(sourcePath);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task SourceFileTranscription_SaveFailureAfterFinalResponsePreservesSeedForRestart()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-source-save-failure");
+        var draftStore = new FailingCaptionDraftStore(failOnSave: 2);
+        CaptionDraftScope scope = new("user-a", Guid.NewGuid(), editor.Scene.Id);
+        IObservable<CaptionDraftScope?> scopes = Observable.Return<CaptionDraftScope?>(scope);
+        string sourcePath = Path.Combine(BeutlHomeIsolation.CurrentHome!, "source-save-failure.wav");
+        WritePcmWave(sourcePath, 16_000, 16_000);
+        var keys = new List<string?>();
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/transcriptions")
+            {
+                keys.Add(IdempotencyKeyOf(request));
+                return CreateTranscriptionResponse("source-paid");
+            }
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        try
+        {
+            var source = new AudioSourceItem("Source", sourcePath, TimeSpan.FromSeconds(1));
+            await using (var first = CreateSubtitleDialog(clients, editor, draftStore, scopes))
+            {
+                await WaitUntilAsync(() => first.Usage.HasSnapshot.Value);
+                first.SelectedAudioSource.Value = source;
+                await WaitUntilAsync(() => first.CanTranscribe.Value);
+                await first.Transcribe.ExecuteAsync();
+                Assert.That(
+                    first.Error.Value,
+                    Is.EqualTo(Beutl.Language.Strings.AiSubtitle_RunCannotBeRecorded));
+                Assert.That(first.HasPartialResult.Value, Is.True);
+            }
+
+            draftStore.FailOnSave = null;
+            await using var restored = CreateSubtitleDialog(clients, editor, draftStore, scopes);
+            restored.SelectedAudioSource.Value = source;
+            await WaitUntilAsync(() => restored.Usage.HasSnapshot.Value);
+            restored.RefreshAvailability();
+            await WaitUntilAsync(() => restored.CanTranscribe.Value);
+            await restored.Transcribe.ExecuteAsync();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(keys, Has.Count.EqualTo(2));
+                Assert.That(keys[1], Is.EqualTo(keys[0]));
+                Assert.That(restored.HasPartialResult.Value, Is.False);
+            }
+        }
+        finally
+        {
+            File.Delete(sourcePath);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task SceneTranscription_ResponseLossSurvivesRangeLanguageChangeAndRestart()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-scene-transcription-ledger");
+        var draftStore = new FileCaptionDraftStore(Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "scene-transcription-ledger-drafts"));
+        CaptionDraftScope draftScope = new("user-a", Guid.NewGuid(), editor.Scene.Id);
+        IObservable<CaptionDraftScope?> scopes = Observable.Return<CaptionDraftScope?>(draftScope);
+        var keys = new List<string?>();
+        int requestCount = 0;
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/transcriptions")
+            {
+                keys.Add(IdempotencyKeyOf(request));
+                int sequence = ++requestCount;
+                if (sequence == 1)
+                {
+                    return JsonResponse(HttpStatusCode.ServiceUnavailable, """
+                        {
+                          "error_code": "aiResultUnavailable",
+                          "message": "The paid result is temporarily unavailable.",
+                          "documentation_url": null
+                        }
+                        """);
+                }
+                return CreateTranscriptionResponse($"transcription-{sequence}");
+            }
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        editor.Scene.Start = TimeSpan.Zero;
+        editor.Scene.Duration = TimeSpan.FromMilliseconds(100);
+
+        await using (var firstDialog = CreateSubtitleDialog(
+                   clients,
+                   editor,
+                   draftStore,
+                   scopes))
+        {
+            ConfigureSceneMix(firstDialog);
+            await WaitUntilAsync(() => firstDialog.Usage.HasSnapshot.Value
+                && firstDialog.SelectedAudioSource.Value?.IsSceneMix == true
+                && firstDialog.CanTranscribe.Value);
+
+            await firstDialog.Transcribe.ExecuteAsync();
+            Assert.That(firstDialog.HasOutstandingTranscriptionRequest.Value, Is.True);
+
+            firstDialog.SelectedSourceLanguage.Value = firstDialog.SourceLanguages
+                .First(option => option.Code == "ja");
+            editor.Scene.Duration = TimeSpan.FromMilliseconds(50);
+            firstDialog.RefreshAvailability();
+            await WaitUntilAsync(() => firstDialog.CanTranscribe.Value);
+            await firstDialog.Transcribe.ExecuteAsync();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(requestCount, Is.EqualTo(2));
+                Assert.That(keys[1], Is.Not.EqualTo(keys[0]));
+                Assert.That(firstDialog.HasOutstandingTranscriptionRequest.Value, Is.True,
+                    "Settling the replacement run must not retire the original recovery.");
+            }
+        }
+
+        Assert.That(draftStore.TryOpen(draftScope, out ICaptionDraftSession? storedSession), Is.True);
+        using (storedSession)
+        {
+            CaptionSceneTranscriptionResume resume =
+                storedSession!.Read().Entry!.Draft.SceneTranscriptionResume!;
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(resume.Duration, Is.EqualTo(TimeSpan.FromMilliseconds(100)));
+                Assert.That(resume.RangeStart, Is.EqualTo(TimeSpan.Zero));
+                Assert.That(resume.ChunkCount, Is.EqualTo(1));
+                Assert.That(resume.Language, Is.Null);
+                Assert.That(resume.RequestKeyNamePending, Is.True);
+            }
+        }
+
+        editor.Scene.Duration = TimeSpan.FromMilliseconds(100);
+        await using var restoredDialog = CreateSubtitleDialog(
+            clients,
+            editor,
+            draftStore,
+            scopes);
+        ConfigureSceneMix(restoredDialog);
+        await WaitUntilAsync(() => restoredDialog.Usage.HasSnapshot.Value
+            && restoredDialog.SelectedAudioSource.Value?.IsSceneMix == true
+            && restoredDialog.TranscriptionModelPicker.IsLoaded.Value
+            && restoredDialog.CanTranscribe.Value);
+
+        await restoredDialog.Transcribe.ExecuteAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(requestCount, Is.EqualTo(3));
+            Assert.That(keys[2], Is.EqualTo(keys[0]));
+            Assert.That(restoredDialog.HasOutstandingTranscriptionRequest.Value, Is.False);
+        }
+
+        static void ConfigureSceneMix(AiSubtitleDialogViewModel dialog)
+        {
+            dialog.SceneMixChunkDuration = TimeSpan.FromSeconds(1);
+            dialog.SceneMixAudioComposer = (start, duration, cancellationToken) =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                int sampleCount = Math.Max(1, (int)Math.Ceiling(duration.TotalSeconds * 16_000));
+                return Task.FromResult<AudioFrameSnapshot?>(new AudioFrameSnapshot(
+                    new float[sampleCount],
+                    16_000,
+                    1,
+                    start));
+            };
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task SceneTranscription_PartialCompletedDraftStartsFreshAfterRestart()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-scene-transcription-session-fence");
+        var draftStore = new FileCaptionDraftStore(Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "scene-transcription-session-fence-drafts"));
+        CaptionDraftScope draftScope = new("user-a", Guid.NewGuid(), editor.Scene.Id);
+        IObservable<CaptionDraftScope?> scopes = Observable.Return<CaptionDraftScope?>(draftScope);
+        var keys = new List<string?>();
+        int requestCount = 0;
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/transcriptions")
+            {
+                keys.Add(IdempotencyKeyOf(request));
+                int sequence = ++requestCount;
+                if (sequence == 2)
+                {
+                    return JsonResponse(HttpStatusCode.ServiceUnavailable, """
+                        {
+                          "error_code": "aiResultUnavailable",
+                          "message": "The paid result is temporarily unavailable.",
+                          "documentation_url": null
+                        }
+                        """);
+                }
+
+                return JsonResponse(HttpStatusCode.OK, JsonSerializer.Serialize(new
+                {
+                    jobId = $"transcription-{sequence}",
+                    language = "en",
+                    segments = new[]
+                    {
+                        new
+                        {
+                            start = 0.0,
+                            end = 0.04,
+                            text = $"transcription-{sequence}",
+                        },
+                    },
+                }));
+            }
+
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        editor.Scene.Start = TimeSpan.Zero;
+        editor.Scene.Duration = TimeSpan.FromMilliseconds(200);
+
+        await using (var firstDialog = CreateSubtitleDialog(
+                         clients,
+                         editor,
+                         draftStore,
+                         scopes))
+        {
+            ConfigureSceneMix(firstDialog);
+            await WaitUntilAsync(() => firstDialog.Usage.HasSnapshot.Value
+                && firstDialog.SelectedAudioSource.Value?.IsSceneMix == true
+                && firstDialog.CanTranscribe.Value);
+
+            await firstDialog.Transcribe.ExecuteAsync();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(requestCount, Is.EqualTo(2));
+                Assert.That(firstDialog.HasPartialResult.Value, Is.True);
+            }
+        }
+
+        await using var restoredDialog = CreateSubtitleDialog(
+            clients,
+            editor,
+            draftStore,
+            scopes);
+        ConfigureSceneMix(restoredDialog);
+        await WaitUntilAsync(() => restoredDialog.Usage.HasSnapshot.Value
+            && restoredDialog.SelectedAudioSource.Value?.IsSceneMix == true
+            && restoredDialog.CanTranscribe.Value);
+
+        await restoredDialog.Transcribe.ExecuteAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(requestCount, Is.EqualTo(4));
+            Assert.That(keys[2], Is.Not.EqualTo(keys[0]),
+                "A new dialog must not append current audio to completed chunks from another session.");
+            Assert.That(
+                restoredDialog.ResultSegments.Value?.Select(segment => segment.Text),
+                Is.EqualTo(new[] { "transcription-3", "transcription-4" }));
+        }
+
+        static void ConfigureSceneMix(AiSubtitleDialogViewModel dialog)
+        {
+            dialog.SceneMixChunkDuration = TimeSpan.FromMilliseconds(100);
+            dialog.SceneMixAudioComposer = (start, duration, cancellationToken) =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                int sampleCount = Math.Max(1, (int)Math.Ceiling(duration.TotalSeconds * 16_000));
+                return Task.FromResult<AudioFrameSnapshot?>(new AudioFrameSnapshot(
+                    new float[sampleCount],
+                    16_000,
+                    1,
+                    start));
+            };
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task SceneTranscription_SaveFailureAfterFinalResponsePreservesSeedForRestart()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-scene-save-failure");
+        var draftStore = new FailingCaptionDraftStore(failOnSave: 2);
+        CaptionDraftScope scope = new("user-a", Guid.NewGuid(), editor.Scene.Id);
+        IObservable<CaptionDraftScope?> scopes = Observable.Return<CaptionDraftScope?>(scope);
+        var keys = new List<string?>();
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/transcriptions")
+            {
+                keys.Add(IdempotencyKeyOf(request));
+                return CreateTranscriptionResponse("scene-paid");
+            }
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        editor.Scene.Start = TimeSpan.Zero;
+        editor.Scene.Duration = TimeSpan.FromMilliseconds(100);
+
+        static void ConfigureSceneMix(AiSubtitleDialogViewModel dialog)
+        {
+            dialog.SceneMixChunkDuration = TimeSpan.FromSeconds(1);
+            dialog.SceneMixAudioComposer = (start, duration, cancellationToken) =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                int sampleCount = Math.Max(1, (int)Math.Ceiling(duration.TotalSeconds * 16_000));
+                return Task.FromResult<AudioFrameSnapshot?>(new AudioFrameSnapshot(
+                    new float[sampleCount], 16_000, 1, start));
+            };
+        }
+
+        await using (var first = CreateSubtitleDialog(clients, editor, draftStore, scopes))
+        {
+            ConfigureSceneMix(first);
+            await WaitUntilAsync(() => first.Usage.HasSnapshot.Value
+                && first.SelectedAudioSource.Value?.IsSceneMix == true
+                && first.CanTranscribe.Value);
+            await first.Transcribe.ExecuteAsync();
+            Assert.That(
+                first.Error.Value,
+                Is.EqualTo(Beutl.Language.Strings.AiSubtitle_RunCannotBeRecorded));
+            Assert.That(first.HasPartialResult.Value, Is.True);
+        }
+
+        draftStore.FailOnSave = null;
+        await using var restored = CreateSubtitleDialog(clients, editor, draftStore, scopes);
+        ConfigureSceneMix(restored);
+        await WaitUntilAsync(() => restored.Usage.HasSnapshot.Value
+            && restored.SelectedAudioSource.Value?.IsSceneMix == true
+            && restored.CanTranscribe.Value);
+        await restored.Transcribe.ExecuteAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(keys, Has.Count.EqualTo(2));
+            Assert.That(keys[1], Is.EqualTo(keys[0]));
+            Assert.That(restored.HasPartialResult.Value, Is.False);
+        }
+    }
+
+    private static void WritePcmWave(string path, int sampleRate, int sampleCount)
+    {
+        using var stream = new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+        using var writer = new BinaryWriter(stream, Encoding.ASCII, leaveOpen: false);
+        int dataLength = checked(sampleCount * sizeof(short));
+        writer.Write(Encoding.ASCII.GetBytes("RIFF"));
+        writer.Write(36 + dataLength);
+        writer.Write(Encoding.ASCII.GetBytes("WAVEfmt "));
+        writer.Write(16);
+        writer.Write((short)1);
+        writer.Write((short)1);
+        writer.Write(sampleRate);
+        writer.Write(sampleRate * sizeof(short));
+        writer.Write((short)sizeof(short));
+        writer.Write((short)16);
+        writer.Write(Encoding.ASCII.GetBytes("data"));
+        writer.Write(dataLength);
+        for (int index = 0; index < sampleCount; index++)
+        {
+            writer.Write((short)0);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Transcription_HoldingAName_DoesNotOpenTheTranslationButton()
+    {
+        // Transcription and translation are charged separately. Sharing one name would let a
+        // pending transcription bypass translation's balance and model checks and dispatch new
+        // work the account cannot afford.
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-subtitle-outstanding-scope");
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            // The request is still running, not settled, so its name remains held.
+            "/api/v3/ai/transcriptions" => JsonResponse(HttpStatusCode.Conflict, """
+                {
+                  "error_code": "aiRequestInProgress",
+                  "message": "The first attempt is still running.",
+                  "documentation_url": null
+                }
+                """),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(clients, editor);
+        viewModel.SceneMixChunkDuration = TimeSpan.FromMilliseconds(50);
+        viewModel.SceneMixAudioComposer = (start, duration, cancellationToken) =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            int sampleCount = Math.Max(1, (int)Math.Ceiling(duration.TotalSeconds * 16_000));
+            return Task.FromResult<AudioFrameSnapshot?>(new AudioFrameSnapshot(
+                new float[sampleCount],
+                16_000,
+                1,
+                start));
+        };
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.SelectedAudioSource.Value?.IsSceneMix == true);
+        editor.Scene.Start = TimeSpan.Zero;
+        editor.Scene.Duration = TimeSpan.FromMilliseconds(100);
+        await WaitUntilAsync(() => viewModel.CanTranscribe.Value);
+
+        await viewModel.Transcribe.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                viewModel.Error.Value,
+                Is.EqualTo(Beutl.Language.Strings.AiRequestInProgress));
+            Assert.That(
+                viewModel.HasOutstandingTranscriptionRequest.Value,
+                Is.True,
+                "The chunk that was charged for stays collectable.");
+            Assert.That(
+                viewModel.HasOutstandingTranslationRequest.Value,
+                Is.False,
+                "Nothing was named on the translation's account.");
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task SceneMixTranscription_SecondChunkFailureKeepsPaidPartialAndResumesWithoutRebilling()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-subtitle-scene-mix-failure");
+        var draftStore = new FileCaptionDraftStore(Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "scene-mix-failure-drafts"));
+        CaptionDraftScope draftScope = new("user-a", Guid.NewGuid(), editor.Scene.Id);
+        int transcriptionRequests = 0;
+        bool firstModelRemoved = false;
+        // What each chunk was sent as. A retry that names its request the way
+        // the first attempt did is the difference between recovering a paid
+        // transcription and buying it a second time.
+        var sentKeys = new List<string>();
+        var sentBodies = new List<string>();
+        string audioDirectory = AiTemporaryFileStore.GetCategoryDirectory("audio");
+        string[] filesBefore = Directory.Exists(audioDirectory)
+            ? Directory.GetFiles(audioDirectory, "scene-mix-*.wav")
+            : [];
+        using var handler = new StubHandler(async (request, cancellationToken) =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/capabilities")
+                return JsonResponse(HttpStatusCode.OK, CaptionCapabilitiesJson(firstModelRemoved));
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/transcriptions")
+            {
+                int requestNumber = Interlocked.Increment(ref transcriptionRequests);
+                sentKeys.Add(request.Headers.GetValues("Idempotency-Key").Single());
+                sentBodies.Add(request.Content is null
+                    ? string.Empty
+                    : await request.Content.ReadAsStringAsync(cancellationToken));
+                return requestNumber is 1 or 3
+                    ? CreateTranscriptionResponse("transcription-first")
+                    : JsonResponse(HttpStatusCode.InternalServerError, """
+                        {
+                          "error_code": "aiProviderError",
+                          "message": "Provider failed.",
+                          "documentation_url": null
+                        }
+                        """);
+            }
+
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(
+            clients,
+            editor,
+            draftStore,
+            Observable.Return<CaptionDraftScope?>(draftScope));
+        viewModel.SceneMixChunkDuration = TimeSpan.FromMilliseconds(50);
+        viewModel.SceneMixAudioComposer = (start, duration, cancellationToken) =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            int sampleCount = Math.Max(1, (int)Math.Ceiling(duration.TotalSeconds * 16_000));
+            return Task.FromResult<AudioFrameSnapshot?>(new AudioFrameSnapshot(
+                new float[sampleCount],
+                16_000,
+                1,
+                start));
+        };
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.SelectedAudioSource.Value?.IsSceneMix == true
+            && viewModel.TranscriptionModelPicker.Options.Count == 2);
+        editor.Scene.Start = TimeSpan.Zero;
+        editor.Scene.Duration = TimeSpan.FromMilliseconds(100);
+        var originalSegments = new[]
+        {
+            new AiTranscriptionSegment { Start = 0, End = 0.04, Text = "existing caption" },
+        };
+        viewModel.ResultSegments.Value = originalSegments;
+        await WaitUntilAsync(() => viewModel.CanTranscribe.Value && viewModel.Cues.Count == 1);
+
+        await viewModel.Transcribe.ExecuteAsync();
+        AssertStoredCaptionDraftJob(draftStore, draftScope, "transcription-first");
+
+        string[] filesAfter = Directory.Exists(audioDirectory)
+            ? Directory.GetFiles(audioDirectory, "scene-mix-*.wav")
+            : [];
+        Assert.Multiple(() =>
+        {
+            Assert.That(transcriptionRequests, Is.EqualTo(2));
+            Assert.That(viewModel.ResultSegments.Value, Is.SameAs(originalSegments));
+            Assert.That(viewModel.Cues.Select(cue => cue.Text), Is.EqualTo(new[] { "existing caption" }));
+            Assert.That(viewModel.IsTranscribing.Value, Is.False);
+            Assert.That(viewModel.Error.Value, Is.EqualTo(Beutl.Language.Strings.AiProviderError));
+            Assert.That(filesAfter, Is.EqualTo(filesBefore));
+            Assert.That(viewModel.HasPartialResult.Value, Is.True);
+        });
+
+        viewModel.ApplyPartialResult.Execute();
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.Cues.Select(cue => cue.Text), Is.EqualTo(new[] { "new caption" }));
+        });
+
+        firstModelRemoved = true;
+        IAiModelCatalogService catalog = clients.GetResource<IAiModelCatalogService>();
+        catalog.Invalidate();
+        await viewModel.TranscriptionModelPicker.LoadAsync(
+            AiOperations.Transcription,
+            CancellationToken.None);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                viewModel.TranscriptionModelPicker.SelectedModel,
+                Is.EqualTo(new AiModelId("transcription-a")));
+            Assert.That(viewModel.TranscriptionModelPicker.Selected.Value!.IsAvailable, Is.False);
+        }
+        viewModel.TranscriptionModelPicker.Selected.Value =
+            viewModel.TranscriptionModelPicker.Options.First(option =>
+                option.Id == new AiModelId("transcription-b"));
+
+        // A partial resume belongs only to the exact source/range/language
+        // tuple. Changing the scene's own range must price a first chunk for it.
+        editor.Scene.Duration = TimeSpan.FromMilliseconds(40);
+        viewModel.RefreshAvailability();
+        await WaitUntilAsync(() => viewModel.CanTranscribe.Value);
+        editor.Scene.Duration = TimeSpan.FromMilliseconds(100);
+        viewModel.RefreshAvailability();
+        await WaitUntilAsync(() => viewModel.CanTranscribe.Value);
+
+        viewModel.RefreshAvailability();
+        await WaitUntilAsync(() => viewModel.CanTranscribe.Value);
+        await viewModel.Transcribe.ExecuteAsync();
+        string[] filesAfterResume = Directory.Exists(audioDirectory)
+            ? Directory.GetFiles(audioDirectory, "scene-mix-*.wav")
+            : [];
+        Assert.Multiple(() =>
+        {
+            Assert.That(transcriptionRequests, Is.EqualTo(3),
+                "The completed first chunk must not be submitted and billed again.");
+            // The server settled this chunk as failed and refunded it. Its key
+            // can only ever answer with that failure now, so the retry asks
+            // under a new one rather than replaying a spent request.
+            Assert.That(sentKeys, Has.Count.EqualTo(3));
+            Assert.That(sentKeys[2], Is.Not.EqualTo(sentKeys[1]),
+                "A key the server has settled as failed cannot be asked again.");
+            Assert.That(sentKeys[0], Is.Not.EqualTo(sentKeys[1]),
+                "Separate chunks are separate requests and must not share a key.");
+            // The name is part of what the server fingerprints, so repeating the
+            // key with a different one would be refused as a conflict.
+            Assert.That(sentBodies[1], Does.Contain("scene-mix-chunk-0001.wav"));
+            Assert.That(sentBodies[2], Does.Contain("scene-mix-chunk-0001.wav"));
+            Assert.That(sentBodies[0], Does.Contain("scene-mix-chunk-0000.wav"));
+            Assert.That(sentBodies, Has.All.Contains("transcription-a"),
+                "Every remaining chunk must stay on the model that started the partial run.");
+            Assert.That(viewModel.Cues, Has.Count.EqualTo(2));
+            Assert.That(viewModel.HasPartialResult.Value, Is.False);
+            Assert.That(filesAfterResume, Is.EqualTo(filesBefore));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task SceneMixResumeRevision_ChangesWhenSceneContentIsEdited()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-subtitle-scene-revision");
+        using var httpClient = new HttpClient(new StubHandler(request =>
+            request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements"
+                ? JsonResponse(HttpStatusCode.OK, EntitlementsJson())
+                : JsonResponse(HttpStatusCode.NotFound, "{}")));
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        using var viewModel = CreateSubtitleDialog(clients, editor);
+        long before = viewModel.SceneAudioRevision;
+        var element = new Element
+        {
+            Start = TimeSpan.Zero,
+            Length = TimeSpan.FromSeconds(1),
+            Uri = new Uri(Path.Combine(
+                Path.GetDirectoryName(editor.Scene.Uri!.LocalPath)!,
+                $"scene-revision-{Guid.NewGuid():N}.belm")),
+        };
+
+        editor.Scene.AddChild(element, ElementOverlapHandling.Allow);
+
+        Assert.That(viewModel.SceneAudioRevision, Is.GreaterThan(before));
+    }
+
+    [AvaloniaTest]
+    public async Task AudioSourcesRefreshWithSceneEditsAndKeepTheSelectedElement()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-subtitle-live-audio-sources");
+        string sourcePath = Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "live-audio-source.wav");
+        WritePcmWave(sourcePath, sampleRate: 16_000, sampleCount: 64_000);
+        using var httpClient = new HttpClient(new StubHandler(request =>
+            request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements"
+                ? JsonResponse(HttpStatusCode.OK, EntitlementsJson())
+                : JsonResponse(HttpStatusCode.NotFound, "{}")));
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        using var viewModel = CreateSubtitleDialog(clients, editor);
+        var soundSource = new SoundSource();
+        soundSource.ReadFrom(new Uri(sourcePath));
+        var sound = new SourceSound
+        {
+            Source = { CurrentValue = soundSource },
+        };
+        var element = new Element
+        {
+            Name = "Voice",
+            Start = TimeSpan.Zero,
+            Length = TimeSpan.FromSeconds(2),
+            Uri = new Uri(Path.Combine(
+                Path.GetDirectoryName(editor.Scene.Uri!.LocalPath)!,
+                $"live-audio-{Guid.NewGuid():N}.belm")),
+        };
+        element.Objects.Add(sound);
+
+        try
+        {
+            await WaitUntilAsync(() => viewModel.AudioSources.Value.Count == 1);
+            editor.Scene.AddChild(element, ElementOverlapHandling.Allow);
+            await WaitUntilAsync(() => viewModel.AudioSources.Value.Count == 2);
+            AudioSourceItem selected = viewModel.AudioSources.Value.Single(item => !item.IsSceneMix);
+            viewModel.SelectedAudioSource.Value = selected;
+            viewModel.ResultSegments.Value =
+            [
+                new AiTranscriptionSegment { Start = 0, End = 1, Text = "Paid transcript" },
+            ];
+
+            sound.OffsetPosition.CurrentValue = TimeSpan.FromSeconds(1);
+            await WaitUntilAsync(() =>
+                viewModel.SelectedAudioSource.Value is { } current
+                && current.ElementId == element.Id
+                && current.SourceOffset == TimeSpan.FromSeconds(1));
+
+            Assert.That(viewModel.SelectedAudioSource.Value?.ElementId, Is.EqualTo(element.Id));
+
+            editor.Scene.RemoveChild(element);
+            await WaitUntilAsync(() => viewModel.AudioSources.Value.Count == 1
+                && viewModel.SelectedAudioSource.Value?.IsSceneMix == true);
+            Assert.That(viewModel.Cues.Single().Text, Is.EqualTo("Paid transcript"));
+        }
+        finally
+        {
+            File.Delete(sourcePath);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task SourceFileTranscription_UploadsOnlyTheSelectedElementWindow()
+    {
+        await TestReset.ResetShellAsync();
+        string sourcePath = Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "trimmed-transcription-source.wav");
+        const int sampleRate = 16_000;
+        WritePcmWave(sourcePath, sampleRate, sampleCount: sampleRate * 10);
+        byte[]? uploaded = null;
+        using var handler = new StubHandler(async (request, cancellationToken) =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/transcriptions")
+            {
+                uploaded = await request.Content!.ReadAsByteArrayAsync(cancellationToken);
+                return CreateTranscriptionResponse("trimmed-source-window");
+            }
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(clients);
+
+        try
+        {
+            await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+            viewModel.SelectedAudioSource.Value = new AudioSourceItem(
+                "Trimmed source",
+                sourcePath,
+                TimeSpan.FromSeconds(10),
+                elementLength: TimeSpan.FromSeconds(2),
+                sourceOffset: TimeSpan.FromSeconds(1));
+            await WaitUntilAsync(() => viewModel.CanTranscribe.Value);
+
+            await viewModel.Transcribe.ExecuteAsync();
+
+            Assert.That(
+                ReadWaveDataLength(uploaded),
+                Is.EqualTo(sampleRate * 2 * sizeof(short)),
+                "Only the two-second selected source window may be uploaded and billed.");
+        }
+        finally
+        {
+            File.Delete(sourcePath);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task SceneMixTranscription_SecondChunkCancellationPreservesResultAndDeletesTemporaryFiles()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-subtitle-scene-mix-cancel");
+        int transcriptionRequests = 0;
+        var secondRequestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        string audioDirectory = AiTemporaryFileStore.GetCategoryDirectory("audio");
+        string[] filesBefore = Directory.Exists(audioDirectory)
+            ? Directory.GetFiles(audioDirectory, "scene-mix-*.wav")
+            : [];
+        using var handler = new StubHandler(async (request, cancellationToken) =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/transcriptions")
+            {
+                int requestNumber = Interlocked.Increment(ref transcriptionRequests);
+                if (requestNumber == 1)
+                    return CreateTranscriptionResponse("transcription-first");
+
+                secondRequestStarted.TrySetResult();
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                finally
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        cancellationObserved.TrySetResult();
+                    }
+                }
+            }
+
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(clients, editor);
+        viewModel.SceneMixChunkDuration = TimeSpan.FromMilliseconds(50);
+        viewModel.SceneMixAudioComposer = (start, duration, cancellationToken) =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            int sampleCount = Math.Max(1, (int)Math.Ceiling(duration.TotalSeconds * 16_000));
+            return Task.FromResult<AudioFrameSnapshot?>(new AudioFrameSnapshot(
+                new float[sampleCount],
+                16_000,
+                1,
+                start));
+        };
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.SelectedAudioSource.Value?.IsSceneMix == true);
+        editor.Scene.Start = TimeSpan.Zero;
+        editor.Scene.Duration = TimeSpan.FromMilliseconds(100);
+        var originalSegments = new[]
+        {
+            new AiTranscriptionSegment { Start = 0, End = 0.04, Text = "existing caption" },
+        };
+        viewModel.ResultSegments.Value = originalSegments;
+        await WaitUntilAsync(() => viewModel.CanTranscribe.Value && viewModel.Cues.Count == 1);
+
+        Task operation = viewModel.Transcribe.ExecuteAsync();
+        await secondRequestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        GetLifetimeCancellationSource(viewModel).Cancel();
+        await operation;
+        await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        string[] filesAfter = Directory.Exists(audioDirectory)
+            ? Directory.GetFiles(audioDirectory, "scene-mix-*.wav")
+            : [];
+        Assert.Multiple(() =>
+        {
+            Assert.That(transcriptionRequests, Is.EqualTo(2));
+            Assert.That(viewModel.ResultSegments.Value, Is.SameAs(originalSegments));
+            Assert.That(viewModel.Cues.Select(cue => cue.Text), Is.EqualTo(new[] { "existing caption" }));
+            Assert.That(viewModel.IsTranscribing.Value, Is.False);
+            Assert.That(viewModel.Error.Value, Is.Null);
+            Assert.That(filesAfter, Is.EqualTo(filesBefore));
+            Assert.That(viewModel.HasPartialResult.Value, Is.True);
+        });
+
+        viewModel.ApplyPartialResult.Execute();
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.Cues.Select(cue => cue.Text), Is.EqualTo(new[] { "new caption" }));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task SceneMixTranscription_EditDuringFinalChunkKeepsPaidResultRecoverable()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-subtitle-scene-mix-stale-response");
+        int transcriptionRequests = 0;
+        var secondRequestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSecondRequest = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = new StubHandler(async (request, cancellationToken) =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/transcriptions")
+            {
+                int requestNumber = Interlocked.Increment(ref transcriptionRequests);
+                if (requestNumber == 2)
+                {
+                    secondRequestStarted.TrySetResult();
+                    await releaseSecondRequest.Task.WaitAsync(cancellationToken);
+                }
+                return CreateTranscriptionResponse($"transcription-{requestNumber}");
+            }
+
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(clients, editor);
+        viewModel.SceneMixChunkDuration = TimeSpan.FromMilliseconds(50);
+        viewModel.SceneMixAudioComposer = (start, duration, cancellationToken) =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            int sampleCount = Math.Max(1, (int)Math.Ceiling(duration.TotalSeconds * 16_000));
+            return Task.FromResult<AudioFrameSnapshot?>(new AudioFrameSnapshot(
+                new float[sampleCount],
+                16_000,
+                1,
+                start));
+        };
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.SelectedAudioSource.Value?.IsSceneMix == true);
+        editor.Scene.Start = TimeSpan.Zero;
+        editor.Scene.Duration = TimeSpan.FromMilliseconds(100);
+        viewModel.ResultSegments.Value =
+        [
+            new AiTranscriptionSegment { Start = 0, End = 0.04, Text = "existing caption" },
+        ];
+        await WaitUntilAsync(() => viewModel.CanTranscribe.Value && viewModel.Cues.Count == 1);
+
+        Task operation = viewModel.Transcribe.ExecuteAsync();
+        await secondRequestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        editor.Scene.Duration = TimeSpan.FromMilliseconds(80);
+        viewModel.Cues[0].Text = "user edit while transcribing";
+        releaseSecondRequest.TrySetResult();
+        await operation;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(transcriptionRequests, Is.EqualTo(2));
+            Assert.That(viewModel.Cues.Select(cue => cue.Text),
+                Is.EqualTo(new[] { "user edit while transcribing" }));
+            Assert.That(viewModel.HasPartialResult.Value, Is.True);
+        });
+
+        editor.Scene.Duration = TimeSpan.FromMilliseconds(100);
+        viewModel.RefreshAvailability();
+        await WaitUntilAsync(() => viewModel.CanTranscribe.Value);
+        await viewModel.Transcribe.ExecuteAsync();
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.Cues, Has.Count.EqualTo(2));
+            Assert.That(viewModel.HasPartialResult.Value, Is.False);
+            Assert.That(transcriptionRequests, Is.EqualTo(2),
+                "A completed scene transcription must apply without another HTTP request.");
+        });
+    }
+
+    private static AiTranscriptionSegment[] CreateTranslationBatchSegments()
+        => Enumerable.Range(0, 201)
+            .Select(index => new AiTranscriptionSegment
+            {
+                Start = index * 2,
+                End = index * 2 + 1,
+                Text = $"line-{index}",
+            })
+            .ToArray();
+
+    private static HttpResponseMessage CreateTranslationResponse(HttpRequestMessage request, string jobId)
+    {
+        string body = request.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+        using JsonDocument json = JsonDocument.Parse(body);
+        object[] segments = json.RootElement.GetProperty("segments")
+            .EnumerateArray()
+            .Select(segment => (object)new
+            {
+                id = segment.GetProperty("id").GetString(),
+                text = "T-" + segment.GetProperty("text").GetString(),
+            })
+            .ToArray();
+        return JsonResponse(HttpStatusCode.OK, JsonSerializer.Serialize(new
+        {
+            jobId,
+            segments,
+        }));
+    }
+
+    private static HttpResponseMessage CreateTranscriptionResponse(string jobId)
+        => JsonResponse(HttpStatusCode.OK, JsonSerializer.Serialize(new
+        {
+            jobId,
+            language = "en",
+            segments = new[] { new { start = 0.0, end = 0.04, text = "new caption" } },
+        }));
+
+    [AvaloniaTest]
+    public async Task SceneMixTranscription_ShowsProgressWhileAudioIsPrepared()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-subtitle-scene-mix-progress");
+        var preparationStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePreparation = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = new StubHandler((request, cancellationToken) =>
+            request.RequestUri?.AbsolutePath switch
+            {
+                "/api/v3/user/entitlements" => Task.FromResult(
+                    JsonResponse(HttpStatusCode.OK, EntitlementsJson())),
+                "/api/v3/ai/transcriptions" => Task.FromResult(
+                    CreateTranscriptionResponse("progress-transcription")),
+                _ => Task.FromResult(JsonResponse(HttpStatusCode.NotFound, "{}")),
+            });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(clients, editor);
+        viewModel.SceneMixChunkDuration = TimeSpan.FromSeconds(1);
+        viewModel.SceneMixAudioComposer = async (start, duration, cancellationToken) =>
+        {
+            preparationStarted.TrySetResult();
+            await releasePreparation.Task.WaitAsync(cancellationToken);
+            return new AudioFrameSnapshot(new float[16_000], 16_000, 1, start);
+        };
+        var view = new AiSubtitleView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 340, Height = 900 };
+
+        Task? transcription = null;
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+            await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+                && viewModel.SelectedAudioSource.Value?.IsSceneMix == true);
+            editor.Scene.Start = TimeSpan.Zero;
+            editor.Scene.Duration = TimeSpan.FromSeconds(1);
+            await WaitUntilAsync(() => viewModel.CanTranscribe.Value);
+
+            transcription = viewModel.Transcribe.ExecuteAsync();
+            await preparationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            HeadlessTestHelpers.Render();
+            ProgressRing progress = view.FindControl<ProgressRing>("TranscriptionProgressRing")!;
+            TextBlock status = view.FindControl<TextBlock>("TranscriptionStatusText")!;
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.IsTranscribing.Value, Is.True);
+                Assert.That(transcription.IsCompleted, Is.False);
+                Assert.That(progress.IsEffectivelyVisible, Is.True);
+                Assert.That(progress.IsIndeterminate, Is.True);
+                Assert.That(status.IsEffectivelyVisible, Is.True);
+                Assert.That(
+                    viewModel.TranscriptionStatusText.Value,
+                    Is.EqualTo(Strings.AiSubtitle_Transcribing));
+                Assert.That(
+                    AutomationProperties.GetName(progress),
+                    Is.EqualTo(Strings.AiSubtitle_Transcribing));
+                Assert.That(
+                    AutomationProperties.GetLiveSetting(status),
+                    Is.EqualTo(AutomationLiveSetting.Polite));
+            }
+        }
+        finally
+        {
+            releasePreparation.TrySetResult();
+            try
+            {
+                if (transcription is not null)
+                    await transcription.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            finally
+            {
+                window.Close();
+                HeadlessTestHelpers.Settle();
+            }
+        }
+
+        Assert.That(viewModel.IsTranscribing.Value, Is.False);
+    }
+
+    [AvaloniaTest]
+    public async Task SceneMixTranscription_StopsWhereItIsWhenAskedTo()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-subtitle-scene-mix-stop");
+        int transcriptionRequests = 0;
+        int composeCalls = 0;
+        using var handler = new StubHandler(async (request, cancellationToken) =>
+        {
+            switch (request.RequestUri?.AbsolutePath)
+            {
+                case "/api/v3/user/entitlements":
+                    return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                case "/api/v3/ai/transcriptions":
+                    Interlocked.Increment(ref transcriptionRequests);
+                    await request.Content!.ReadAsByteArrayAsync(cancellationToken);
+                    return CreateTranscriptionResponse("transcription-stopped");
+                default:
+                    return JsonResponse(HttpStatusCode.NotFound, "{}");
+            }
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateSubtitleDialog(clients, editor);
+        viewModel.SceneMixChunkDuration = TimeSpan.FromSeconds(60);
+        viewModel.SceneMixAudioComposer = (start, duration, cancellationToken) =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (Interlocked.Increment(ref composeCalls) == 1)
+            {
+                viewModel.StopRequest.Execute();
+            }
+
+            int sampleCount = Math.Max(1, (int)Math.Round(duration.TotalSeconds * 16_000));
+            return Task.FromResult<AudioFrameSnapshot?>(new AudioFrameSnapshot(
+                new float[sampleCount],
+                16_000,
+                1,
+                start));
+        };
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value
+            && viewModel.SelectedAudioSource.Value?.IsSceneMix == true);
+        editor.Scene.Start = TimeSpan.Zero;
+        editor.Scene.Duration = TimeSpan.FromSeconds(60);
+        await WaitUntilAsync(() => viewModel.CanTranscribe.Value);
+
+        await viewModel.Transcribe.ExecuteAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(transcriptionRequests, Is.Zero,
+                "Stopping before the upload means the account is not charged for it.");
+            Assert.That(composeCalls, Is.EqualTo(1),
+                "A minute of scene is not composed after the person has left.");
+            Assert.That(viewModel.IsTranscribing.Value, Is.False);
+            Assert.That(viewModel.Error.Value, Is.Null,
+                "Leaving on purpose is not an error to report back.");
+            Assert.That(viewModel.CanTranscribe.Value, Is.True,
+                "And it can be started again.");
+        }
+    }
+
+    // The wave is one part of a multipart upload, so its own header says how much
+    // audio actually made it into the request.
+    private static int ReadWaveDataLength(byte[]? body)
+    {
+        Assert.That(body, Is.Not.Null);
+        byte[] payload = body!;
+        int start = payload.AsSpan().IndexOf("RIFF"u8);
+        Assert.That(start, Is.GreaterThanOrEqualTo(0), "The upload carries a wave.");
+        return BitConverter.ToInt32(payload, start + 40);
+    }
+
+    private static string? IdempotencyKeyOf(HttpRequestMessage request)
+        => request.Headers.TryGetValues("Idempotency-Key", out IEnumerable<string>? values)
+            ? values.SingleOrDefault()
+            : null;
+
+    private static AiImageGenerationDialogViewModel CreateImageGenerationDialog(
+        BeutlApiApplication clients,
+        EditViewModel? editor = null,
+        AiRequestRecoveryContext? context = null)
+        => new(
+            clients.GetResource<IAiEntitlementService>(),
+            clients.GetResource<IAiOperationAvailabilityService>(),
+            clients.GetResource<IAiModelCatalogService>(),
+            CreatePlanCoordinator(clients),
+            clients.GetResource<IAiImageGenerationService>(),
+            clients.GetResource<IAuthenticatedContentService>(),
+            editor,
+            context ?? AiRetryTestContext.CreateForm());
+
+    private static AiImageEditDialogViewModel CreateImageEditDialog(
+        BeutlApiApplication clients,
+        EditViewModel? editor = null,
+        AiRequestRecoveryContext? context = null)
+        => new(
+            clients.GetResource<IAiEntitlementService>(),
+            clients.GetResource<IAiOperationAvailabilityService>(),
+            clients.GetResource<IAiModelCatalogService>(),
+            CreatePlanCoordinator(clients),
+            clients.GetResource<IAiImageEditingService>(),
+            clients.GetResource<IAuthenticatedContentService>(),
+            editor,
+            context ?? AiRetryTestContext.CreateForm());
+
+    private static AiVideoGenerationDialogViewModel CreateVideoGenerationDialog(
+        BeutlApiApplication clients,
+        EditViewModel? editor = null,
+        AiRequestRecoveryContext? context = null)
+        => new(
+            clients.GetResource<IAiEntitlementService>(),
+            clients.GetResource<IAiOperationAvailabilityService>(),
+            clients.GetResource<IAiModelCatalogService>(),
+            CreatePlanCoordinator(clients),
+            clients.GetResource<IAiVideoService>(),
+            clients.GetResource<IAuthenticatedContentService>(),
+            clients.GetResource<IAiJobKindRegistry>(),
+            clients.GetResource<IAiJobMonitor>(),
+            editor,
+            context ?? AiRetryTestContext.CreateForm());
+
+    private static AiRequestRecoveryContext CreateIdentityContext(Func<string?> account)
+        => new(
+            new FileAiRequestRecoveryStore(Path.Combine(
+                Path.GetTempPath(),
+                "Beutl.HeadlessUITests",
+                "ai-identity-switch",
+                Guid.NewGuid().ToString("N"))),
+            () => account() is { } value
+                ? new AiAuthenticatedRequestIdentity(value, User: null)
+                : null);
+
+    private static AiSubtitleDialogViewModel CreateSubtitleDialog(
+        BeutlApiApplication clients,
+        EditViewModel? editor = null,
+        ICaptionDraftStore? draftStore = null,
+        IObservable<CaptionDraftScope?>? draftScopes = null)
+        => new(
+            clients.GetResource<IAiEntitlementService>(),
+            clients.GetResource<IAiOperationAvailabilityService>(),
+            clients.GetResource<IAiModelCatalogService>(),
+            CreatePlanCoordinator(clients),
+            clients.GetResource<IAiTranscriptionService>(),
+            clients.GetResource<IAiCaptionTranslationService>(),
+            CaptionCatalog.CreateDefault("Default"),
+            draftStore ?? CaptionDraftStoreProvider.Current,
+            draftScopes ?? Observable.Return<CaptionDraftScope?>(null),
+            editor);
+
+    private static IAiPlanCoordinator CreatePlanCoordinator(BeutlApiApplication clients)
+        => new AiPlanCoordinator(clients.GetResource<IAiEntitlementService>());
+
+    private static void AssertStoredCaptionDraftJob(
+        FileCaptionDraftStore store,
+        CaptionDraftScope scope,
+        string expectedJobId)
+    {
+        using JsonDocument envelope = JsonDocument.Parse(File.ReadAllBytes(store.GetStoragePath(scope)));
+        Assert.That(envelope.RootElement.GetProperty("jobId").GetString(), Is.EqualTo(expectedJobId));
+    }
+
+    private static LifetimeCancellationSource GetLifetimeCancellationSource(
+        AiSubtitleDialogViewModel viewModel)
+        => (LifetimeCancellationSource)typeof(AiSubtitleDialogViewModel)
+            .GetField("_lifetimeCts", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(viewModel)!;
+
+    private static async Task<EditViewModel> OpenEditor(string name)
+    {
+        string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(workspace);
+        Project project = (await TestShell.Project.CreateProject(
+            640, 480, 30, 44100, name, workspace))!;
+        Scene scene = project.Items.OfType<Scene>().First();
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (!condition())
+        {
+            HeadlessTestHelpers.Settle();
+            await Task.Delay(10, cancellationTokenSource.Token);
+        }
+    }
+
+    private static void SetAuthenticatedUser(BeutlApiApplication app, HttpClient httpClient)
+    {
+        httpClient.BaseAddress = new Uri("https://beutl.beditor.net");
+        var profile = new Profile(new ProfileResponse
+        {
+            Id = "test-user",
+            Name = "test",
+            DisplayName = "Test User",
+            Bio = null,
+            IconId = null,
+            IconUrl = null,
+        }, app);
+        var user = new AuthenticatedUser(profile, new AuthResponse
+        {
+            Token = "token",
+            RefreshToken = "refresh-token",
+            Expiration = DateTime.UtcNow.AddHours(1),
+        }, app, DateTime.UtcNow);
+        FieldInfo field = typeof(BeutlApiApplication).GetField(
+            "_authenticatedUser",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        ((ReactivePropertySlim<AuthenticatedUser?>)field.GetValue(app)!).Value = user;
+    }
+
+    // Two video models with different shapes: one takes 4/6/8 seconds at 720p or
+    // 1080p, the other renders only at 2K, refuses anything under five seconds
+    // and takes no seed.
+    private static string VideoCapabilitiesJson() => """
+        {
+          "operations": {
+            "video.generate": {
+              "models": [
+                {
+                  "id": "google/veo-3.1",
+                  "displayName": "Veo 3.1",
+                  "costTier": "medium",
+                  "isDefault": true,
+                  "durationsSeconds": [4, 6, 8],
+                  "resolutions": ["720p", "1080p"],
+                  "aspectRatios": ["16:9", "9:16"],
+                  "audio": true,
+                  "seed": true
+                },
+                {
+                  "id": "minimax/hailuo-3",
+                  "displayName": "MiniMax H3",
+                  "costTier": "low",
+                  "isDefault": false,
+                  "durationsSeconds": [5, 6, 7, 8],
+                  "resolutions": ["2K"],
+                  "aspectRatios": ["16:9"],
+                  "audio": true,
+                  "seed": false
+                }
+              ],
+              "minDurationSeconds": 1,
+              "maxDurationSeconds": 60,
+              "resolutions": ["720p", "1080p", "2K"],
+              "aspectRatios": ["16:9", "9:16"]
+            }
+          }
+        }
+        """;
+
+    private static string CaptionCapabilitiesJson(
+        bool removeFirst,
+        int? maxSegments = null,
+        int? maxCharacters = null,
+        int? maxRequestBytes = null)
+    {
+        static object Model(string id, bool isDefault) => new
+        {
+            id,
+            displayName = id,
+            costTier = "low",
+            isDefault,
+        };
+
+        object[] translationModels = removeFirst
+            ? [Model("translation-b", true)]
+            : [Model("translation-a", true), Model("translation-b", false)];
+        object[] transcriptionModels = removeFirst
+            ? [Model("transcription-b", true)]
+            : [Model("transcription-a", true), Model("transcription-b", false)];
+        return JsonSerializer.Serialize(new
+        {
+            operations = new Dictionary<string, object>
+            {
+                ["subtitle.translate"] = new
+                {
+                    models = translationModels,
+                    maxSegments,
+                    maxCharacters,
+                    maxRequestBytes,
+                },
+                ["audio.transcribe"] = new { models = transcriptionModels },
+            },
+        });
+    }
+
+    // Offer two upscale models so the test can select the non-default one and verify that the
+    // model shown on screen is the one dispatched.
+    private static string ImageEditCapabilitiesJson() => """
+        {
+          "operations": {
+            "image.edit.upscale": {
+              "models": [
+                {
+                  "id": "openai/gpt-image-1",
+                  "displayName": "GPT Image-1",
+                  "costTier": "medium",
+                  "isDefault": true
+                },
+                {
+                  "id": "topaz/gigapixel-2",
+                  "displayName": "Gigapixel 2",
+                  "costTier": "low",
+                  "isDefault": false
+                }
+              ]
+            }
+          }
+        }
+        """;
+
+    private static string? ModelOfMultipart(string body)
+    {
+        const string Marker = "name=model";
+        int at = body.IndexOf(Marker, StringComparison.Ordinal);
+        if (at < 0) return null;
+
+        int start = body.IndexOf("\r\n\r\n", at, StringComparison.Ordinal);
+        if (start < 0) return null;
+
+        start += 4;
+        int end = body.IndexOf("\r\n", start, StringComparison.Ordinal);
+        return end < 0 ? null : body[start..end];
+    }
+
+    private static string ImageCapabilitiesJson() => """
+        {
+          "operations": {
+            "image.generate": {
+              "models": [
+                {
+                  "id": "openai/gpt-image-1",
+                  "displayName": "GPT Image-1",
+                  "costTier": "medium",
+                  "isDefault": true,
+                  "aspectRatios": ["1:1", "3:2", "2:3"],
+                  "backgrounds": ["auto", "opaque", "transparent"],
+                  "seed": false,
+                  "maxReferenceImages": 4
+                },
+                {
+                  "id": "openai/gpt-image-2",
+                  "displayName": "GPT Image-2",
+                  "costTier": "low",
+                  "isDefault": false,
+                  "aspectRatios": ["16:9", "1:1"],
+                  "backgrounds": ["auto", "opaque"],
+                  "seed": false,
+                  "maxReferenceImages": 4
+                },
+                {
+                  "id": "qwen/qwen-image-3-pro",
+                  "displayName": "Qwen Image 3 Pro",
+                  "costTier": "low",
+                  "isDefault": false,
+                  "aspectRatios": ["16:9", "1:1"],
+                  "backgrounds": ["auto"],
+                  "seed": false,
+                  "maxReferenceImages": 4
+                }
+              ],
+              "aspectRatios": ["16:9", "1:1", "9:16", "4:3", "3:4", "3:2", "2:3"],
+              "backgrounds": ["auto", "opaque", "transparent"]
+            }
+          }
+        }
+        """;
+
+    private static HttpResponseMessage EventStreamResponse(Stream body)
+    {
+        var content = new StreamContent(body);
+        content.Headers.ContentType = new MediaTypeHeaderValue("text/event-stream");
+        return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+    }
+
+    private static string EntitlementsJson() => """
+        {
+          "plan": "pro",
+          "subscriptionStatus": "active",
+          "currentPeriodStart": "2026-08-01T00:00:00Z",
+          "currentPeriodEnd": "2026-09-01T00:00:00Z",
+          "canUseAi": true,
+          "balance": {
+            "monthlyUsage": {
+              "usedPercent": 0,
+              "remainingPercent": 100,
+              "isExhausted": false
+            },
+            "additionalCredits": 0,
+            "hasAdditionalCreditDebt": false
+          },
+          "availability": {
+            "image.generate": true,
+            "image.edit.remove_background": true,
+            "image.edit.upscale": true,
+            "image.edit.restyle": true,
+            "image.edit.remove_object": true,
+            "image.edit.outpaint": true,
+            "audio.transcribe": true,
+            "subtitle.translate": true,
+            "video.generate": true
+          }
+        }
+        """;
+
+    private static string ImageResponseJson(string jobId, string fileId) => $$"""
+        {
+          "jobId": "{{jobId}}",
+          "fileId": "{{fileId}}",
+          "url": "https://beutl.beditor.net/api/contents/{{fileId}}"
+        }
+        """;
+
+    private static HttpResponseMessage JsonResponse(HttpStatusCode status, string json)
+        => new(status)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+
+    private static HttpResponseMessage ByteResponse(byte[] bytes, string mediaType)
+        => new(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(bytes)
+            {
+                Headers = { ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(mediaType) },
+            },
+        };
+
+    private sealed class FailingCaptionDraftStore(int? failOnSave) : ICaptionDraftStore
+    {
+        private readonly Dictionary<CaptionDraftScope, CaptionDraftEntry> _drafts = [];
+        private readonly HashSet<CaptionDraftScope> _owners = [];
+        private readonly object _gate = new();
+        private int _saveCount;
+
+        public int? FailOnSave { get; set; } = failOnSave;
+
+        public bool TryOpen(
+            CaptionDraftScope scope,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)]
+            out ICaptionDraftSession? session)
+        {
+            lock (_gate)
+            {
+                if (!_owners.Add(scope))
+                {
+                    session = null;
+                    return false;
+                }
+
+                session = new Session(this, scope);
+                return true;
+            }
+        }
+
+        private sealed class Session(FailingCaptionDraftStore owner, CaptionDraftScope scope)
+            : ICaptionDraftSession
+        {
+            private FailingCaptionDraftStore? _owner = owner;
+
+            public CaptionDraftScope Scope { get; } = scope;
+
+            public CaptionDraftReadResult Read()
+            {
+                FailingCaptionDraftStore store = GetOwner();
+                lock (store._gate)
+                {
+                    return store._drafts.GetValueOrDefault(Scope) is { } entry
+                        ? new CaptionDraftReadResult(CaptionDraftReadOutcome.Read, entry)
+                        : CaptionDraftReadResult.Absent;
+                }
+            }
+
+            public void Save(CaptionDraftEntry entry)
+            {
+                FailingCaptionDraftStore store = GetOwner();
+                lock (store._gate)
+                {
+                    int save = ++store._saveCount;
+                    if (store.FailOnSave == save)
+                        throw new IOException("Injected caption draft save failure.");
+                    store._drafts[Scope] = entry;
+                }
+            }
+
+            public void Delete()
+            {
+                FailingCaptionDraftStore store = GetOwner();
+                lock (store._gate)
+                {
+                    store._drafts.Remove(Scope);
+                }
+            }
+
+            public void Dispose()
+            {
+                FailingCaptionDraftStore? store = Interlocked.Exchange(ref _owner, null);
+                if (store is null)
+                    return;
+                lock (store._gate)
+                {
+                    store._owners.Remove(Scope);
+                }
+            }
+
+            private FailingCaptionDraftStore GetOwner()
+                => _owner ?? throw new ObjectDisposedException(nameof(Session));
+        }
+    }
+
+    private sealed class CancellationObservingStream : Stream
+    {
+        private readonly TaskCompletionSource _readStarted = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _cancellationObserved = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task ReadStarted => _readStarted.Task;
+
+        public Task CancellationObserved => _cancellationObserved.Task;
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => 1;
+
+        public override long Position
+        {
+            get => 0;
+            set => throw new NotSupportedException();
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            _readStarted.TrySetResult();
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return 0;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                _cancellationObserved.TrySetResult();
+                throw;
+            }
+        }
+
+        public override Task<int> ReadAsync(
+            byte[] buffer,
+            int offset,
+            int count,
+            CancellationToken cancellationToken)
+            => ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+            => throw new NotSupportedException();
+
+        public override void SetLength(long value)
+            => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class StubHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder,
+        bool handleAvailability = true) : HttpMessageHandler
+    {
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+            : this((request, _) => Task.FromResult(responder(request)))
+        {
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            HttpResponseMessage response = handleAvailability
+                && request.RequestUri?.AbsolutePath
+                == "/api/v3/user/ai-availability"
+                ? JsonResponse(HttpStatusCode.OK, "{ \"available\": true }")
+                : await responder(request, cancellationToken);
+            response.RequestMessage = request;
+            return response;
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiDialogWorkflowTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiDialogWorkflowTests.cs
@@ -127,6 +127,54 @@ public sealed class AiDialogWorkflowTests
     }
 
     [AvaloniaTest]
+    public async Task ImageGeneration_ReferenceRemovedDuringSizeProbeIsSkipped()
+    {
+        await TestReset.ResetShellAsync();
+        string removedPath = Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "removed-reference.png");
+        string retainedPath = Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "retained-reference.png");
+        await File.WriteAllBytesAsync(removedPath, s_png);
+        await File.WriteAllBytesAsync(retainedPath, s_png);
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/capabilities" => JsonResponse(HttpStatusCode.OK, ImageCapabilitiesJson()),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.ModelPicker.Options.Count == 3);
+        viewModel.BeforeReferenceImageSizeProbe = path =>
+        {
+            if (string.Equals(path, removedPath, StringComparison.Ordinal))
+                File.Delete(path);
+        };
+
+        try
+        {
+            Assert.DoesNotThrow(() => viewModel.AddReferenceImages([removedPath, retainedPath]));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.ReferenceImages, Has.Count.EqualTo(1));
+                Assert.That(viewModel.ReferenceImages[0].Path, Is.EqualTo(retainedPath));
+                Assert.That(viewModel.Error.Value, Is.EqualTo(Strings.AiEditSourcePreviewFailed));
+            }
+        }
+        finally
+        {
+            viewModel.BeforeReferenceImageSizeProbe = null;
+            File.Delete(removedPath);
+            File.Delete(retainedPath);
+        }
+    }
+
+    [AvaloniaTest]
     public async Task VideoGeneration_FramePickerResultFromPreviousIdentityIsIgnored()
     {
         await TestReset.ResetShellAsync();
@@ -1612,6 +1660,39 @@ public sealed class AiDialogWorkflowTests
     }
 
     [AvaloniaTest]
+    public async Task ImageGeneration_UnavailableSelectedModelDisablesANewRequest()
+    {
+        await TestReset.ResetShellAsync();
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(
+                HttpStatusCode.OK,
+                EntitlementsWithUnavailableImageModelJson()),
+            "/api/v3/ai/capabilities" => JsonResponse(HttpStatusCode.OK, ImageCapabilitiesJson()),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using AiImageGenerationDialogViewModel viewModel = CreateImageGenerationDialog(clients);
+        await WaitUntilAsync(() => viewModel.ModelPicker.Options.Count == 3);
+        viewModel.Prompt.Value = "A model availability test";
+        viewModel.ModelPicker.Selected.Value = viewModel.ModelPicker.Options
+            .First(option => option.Id.Value == "openai/gpt-image-1");
+        await WaitUntilAsync(() => viewModel.CanGenerate.Value);
+
+        viewModel.ModelPicker.Selected.Value = viewModel.ModelPicker.Options
+            .First(option => option.Id.Value == "openai/gpt-image-2");
+        await WaitUntilAsync(() => !viewModel.CanGenerate.Value);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.ModelPicker.Selected.Value!.IsAvailable, Is.False);
+            Assert.That(viewModel.Generate.CanExecute(), Is.False);
+        }
+    }
+
+    [AvaloniaTest]
     public async Task ComposedPromptLimit_DisablesImageAndVideoCommandsBeforeSubmission()
     {
         await TestReset.ResetShellAsync();
@@ -2090,29 +2171,35 @@ public sealed class AiDialogWorkflowTests
         await TestReset.ResetShellAsync();
         int polls = 0;
         var delays = new List<TimeSpan>();
+        HttpResponseMessage PollVideo()
+            => Interlocked.Increment(ref polls) switch
+            {
+                1 => JsonResponse(HttpStatusCode.InternalServerError, """
+                    {
+                      "error_code": "aiProviderError",
+                      "message": "Provider status is temporarily unavailable."
+                    }
+                    """),
+                2 => throw new TaskCanceledException("The HTTP status request timed out."),
+                3 => throw new TimeoutException("The video status request timed out."),
+                _ => JsonResponse(HttpStatusCode.OK, """
+                    {
+                      "jobId": "webm-job",
+                      "status": "succeeded",
+                      "fileId": "webm-file",
+                      "url": "https://beutl.beditor.net/api/contents/webm-file",
+                      "fileName": "generated.webm",
+                      "contentType": "video/webm"
+                    }
+                    """),
+            };
         using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
         {
             "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
             "/api/v3/ai/videos" => JsonResponse(HttpStatusCode.OK, """
                 { "jobId": "webm-job", "status": "queued" }
                 """),
-            "/api/v3/ai/videos/webm-job" when Interlocked.Increment(ref polls) == 1 =>
-                JsonResponse(HttpStatusCode.InternalServerError, """
-                    {
-                      "error_code": "aiProviderError",
-                      "message": "Provider status is temporarily unavailable."
-                    }
-                    """),
-            "/api/v3/ai/videos/webm-job" => JsonResponse(HttpStatusCode.OK, """
-                {
-                  "jobId": "webm-job",
-                  "status": "succeeded",
-                  "fileId": "webm-file",
-                  "url": "https://beutl.beditor.net/api/contents/webm-file",
-                  "fileName": "generated.webm",
-                  "contentType": "video/webm"
-                }
-                """),
+            "/api/v3/ai/videos/webm-job" => PollVideo(),
             "/api/contents/webm-file" => ByteResponse([1, 2, 3, 4], "video/webm"),
             _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
         });
@@ -2137,8 +2224,10 @@ public sealed class AiDialogWorkflowTests
         string resultPath = viewModel.ResultVideoPath.Value!;
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(polls, Is.EqualTo(2));
+            Assert.That(polls, Is.EqualTo(4));
             Assert.That(delays, Does.Contain(TimeSpan.FromMilliseconds(10)));
+            Assert.That(delays, Does.Contain(TimeSpan.FromMilliseconds(20)));
+            Assert.That(delays, Does.Contain(TimeSpan.FromMilliseconds(25)));
             Assert.That(resultPath, Does.EndWith(".webm"));
             Assert.That(File.Exists(resultPath), Is.True);
             if (!OperatingSystem.IsWindows())
@@ -5654,6 +5743,19 @@ public sealed class AiDialogWorkflowTests
           }
         }
         """;
+
+    private static string EntitlementsWithUnavailableImageModelJson()
+        => EntitlementsJson().Replace(
+            "\"availability\": {",
+            """
+            "modelAvailability": {
+              "image.generate": {
+                "openai/gpt-image-2": false
+              }
+            },
+            "availability": {
+            """,
+            StringComparison.Ordinal);
 
     private static string ImageResponseJson(string jobId, string fileId) => $$"""
         {

--- a/tests/Beutl.HeadlessUITests/AiDialogWorkflowTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiDialogWorkflowTests.cs
@@ -1111,6 +1111,132 @@ public sealed class AiDialogWorkflowTests
     }
 
     [AvaloniaTest]
+    [TestCase(true, false)]
+    [TestCase(true, true)]
+    [TestCase(false, false)]
+    public async Task Transcription_stops_before_purchasing_more_chunks_after_audio_changes(bool sceneMix, bool editElement)
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel? editor = sceneMix ? await OpenEditor("changed-scene-transcription-" + editElement) : null;
+        string path = Path.Combine(BeutlHomeIsolation.CurrentHome!, $"changed-source-{sceneMix}.wav");
+        WritePcmWave(path, 16000, 2400);
+        AiSubtitleDialogViewModel? dialog = null;
+        int requests = 0;
+        using var handler = new StubHandler(async (request, _) =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/transcriptions")
+            {
+                requests++;
+                if (requests == 1)
+                    await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
+                    {
+                        if (sceneMix && editElement)
+                            editor!.Scene.AddChild(new Element
+                            {
+                                Length = TimeSpan.FromMilliseconds(150),
+                                Uri = new Uri(Path.Combine(Path.GetDirectoryName(editor.Scene.Uri!.LocalPath)!, "changed.belm")),
+                            });
+                        else if (sceneMix)
+                            editor!.Scene.Duration = TimeSpan.FromMilliseconds(200);
+                        else
+                            dialog!.SelectedAudioSource.Value = new AudioSourceItem(
+                                "Changed", path, TimeSpan.FromMilliseconds(150),
+                                elementLength: TimeSpan.FromMilliseconds(100));
+                    });
+                return CreateTranscriptionResponse("changed-audio");
+            }
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var http = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(http, new ExtensionProvider());
+        SetAuthenticatedUser(clients, http);
+        using var viewModel = CreateSubtitleDialog(clients, editor);
+        dialog = viewModel;
+        viewModel.SceneMixChunkDuration = TimeSpan.FromMilliseconds(50);
+        viewModel.SceneMixAudioComposer = (start, duration, _) => Task.FromResult<AudioFrameSnapshot?>(
+            new AudioFrameSnapshot(new float[Math.Max(1, (int)(duration.TotalSeconds * 16000))], 16000, 1, start));
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+        if (sceneMix)
+            editor!.Scene.Duration = TimeSpan.FromMilliseconds(150);
+        else
+            viewModel.SelectedAudioSource.Value = new AudioSourceItem("Original", path, TimeSpan.FromMilliseconds(150));
+        await WaitUntilAsync(() => viewModel.CanTranscribe.Value);
+        await viewModel.Transcribe.ExecuteAsync();
+        Assert.That(requests, Is.EqualTo(1));
+        File.Delete(path);
+    }
+
+    [AvaloniaTest]
+    public async Task Rejected_successful_transcription_retires_its_key_before_retry()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("rejected-transcription-key");
+        var keys = new List<string?>();
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/transcriptions")
+            {
+                keys.Add(IdempotencyKeyOf(request));
+                return keys.Count == 1
+                    ? JsonResponse(HttpStatusCode.OK, """{"segments":[{"start":0,"end":100,"text":"invalid"}]}""")
+                    : CreateTranscriptionResponse("valid-retry");
+            }
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var http = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(http, new ExtensionProvider());
+        SetAuthenticatedUser(clients, http);
+        using var dialog = CreateSubtitleDialog(clients, editor);
+        dialog.SceneMixChunkDuration = TimeSpan.FromMilliseconds(50);
+        dialog.SceneMixAudioComposer = (start, duration, _) => Task.FromResult<AudioFrameSnapshot?>(
+            new AudioFrameSnapshot(new float[Math.Max(1, (int)(duration.TotalSeconds * 16000))], 16000, 1, start));
+        await WaitUntilAsync(() => dialog.Usage.HasSnapshot.Value && dialog.SelectedAudioSource.Value?.IsSceneMix == true);
+        editor.Scene.Duration = TimeSpan.FromMilliseconds(50);
+        await WaitUntilAsync(() => dialog.CanTranscribe.Value);
+        await dialog.Transcribe.ExecuteAsync();
+        Assert.That(dialog.Error.Value, Is.Not.Null);
+        Assert.That(dialog.HasOutstandingTranscriptionRequest.Value, Is.False);
+        await dialog.Transcribe.ExecuteAsync();
+        Assert.That(keys, Has.Count.EqualTo(2));
+        Assert.That(keys[1], Is.Not.EqualTo(keys[0]));
+    }
+
+    [AvaloniaTest]
+    public async Task Rejected_successful_translation_retires_its_key_before_retry()
+    {
+        await TestReset.ResetShellAsync();
+        var keys = new List<string?>();
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/translations")
+            {
+                keys.Add(IdempotencyKeyOf(request));
+                return JsonResponse(HttpStatusCode.OK, """{"segments":[]}""");
+            }
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var http = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(http, new ExtensionProvider());
+        SetAuthenticatedUser(clients, http);
+        using var dialog = CreateSubtitleDialog(clients);
+        await WaitUntilAsync(() => dialog.Usage.HasSnapshot.Value);
+        dialog.ResultSegments.Value = [new AiTranscriptionSegment { Start = 0, End = 1, Text = "Translate me" }];
+        await WaitUntilAsync(() => dialog.CanTranslate.Value);
+        await dialog.Translate.ExecuteAsync();
+        Assert.That(dialog.Error.Value, Is.Not.Null);
+        Assert.That(dialog.HasOutstandingTranslationRequest.Value, Is.False);
+        await dialog.Translate.ExecuteAsync();
+        Assert.That(keys, Has.Count.EqualTo(2));
+        Assert.That(keys[1], Is.Not.EqualTo(keys[0]));
+    }
+
+    [AvaloniaTest]
     public async Task ImageGeneration_SendsTheSeedAsJsonAndTheReferenceAsAnUpload()
     {
         await TestReset.ResetShellAsync();

--- a/tests/Beutl.HeadlessUITests/AiFormRecoveryTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiFormRecoveryTests.cs
@@ -1,0 +1,972 @@
+﻿using System.Net;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using Avalonia.Headless.NUnit;
+using Beutl.Api;
+using Beutl.Api.Clients;
+using Beutl.Api.Objects;
+using Beutl.Api.Services;
+using Beutl.Services;
+using Beutl.Services.AI;
+using Beutl.Services.PrimitiveImpls;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.ViewModels.Dialogs;
+using Reactive.Bindings;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public sealed class AiFormRecoveryTests
+{
+    private static readonly byte[] s_png = Convert.FromBase64String(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==");
+
+    [Test]
+    public void RecoveryRowsCarryCanonicalScalarsAndSourcesForEachForm()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "Beutl.HeadlessUITests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            byte[] bytes = [11, 22, 33, 44];
+            string sourcePath = Path.Combine(root, "input.png");
+            File.WriteAllBytes(sourcePath, bytes);
+            var store = new FileAiRequestRecoveryStore(root);
+            AiRequestRecoverySource imageSource = FileAiRequestRecoveryStore.CreateExternalSource(
+                "reference-0", sourcePath, "input.png", bytes);
+            AiRequestRecoverySource editSource = FileAiRequestRecoveryStore.CreateExternalSource(
+                "image", sourcePath, "input.png", bytes);
+            AiRequestRecoverySource frameSource = store.CreateDurableSource(
+                "first-frame", "frame.png", bytes);
+            store.WriteOrGet(new AiPendingAttempt(
+                "account",
+                "image.generate",
+                "image-fp",
+                "image-key",
+                "image-model",
+                new AiRequestFormSnapshot(
+                    Prompt: "image\nline",
+                    AspectRatio: "3:2",
+                    Background: "transparent",
+                    Seed: 17),
+                [imageSource]));
+            store.WriteOrGet(new AiPendingAttempt(
+                "account",
+                "image.edit.upscale",
+                "edit-fp",
+                "edit-key",
+                "edit-model",
+                new AiRequestFormSnapshot(
+                    Prompt: "edit\tline",
+                    Task: "upscale",
+                    SourceName: "input.png"),
+                [editSource]));
+            store.WriteOrGet(new AiPendingAttempt(
+                "account",
+                "video.generate",
+                "video-fp",
+                "video-key",
+                null,
+                new AiRequestFormSnapshot(
+                    Prompt: "video\nline",
+                    DurationSeconds: 8,
+                    Resolution: "1080p",
+                    AspectRatio: "16:9",
+                    GenerateAudio: false,
+                    Seed: 9),
+                [frameSource]));
+
+            var restarted = new FileAiRequestRecoveryStore(root);
+            AiPendingAttempt image = restarted.Find("account", "image.generate", "image-fp")!;
+            AiPendingAttempt edit = restarted.Find("account", "image.edit.upscale", "edit-fp")!;
+            AiPendingAttempt video = restarted.Find("account", "video.generate", "video-fp")!;
+            Assert.Multiple(() =>
+            {
+                Assert.That(image.Form!.Prompt, Is.EqualTo("image\nline"));
+                Assert.That(image.Form.AspectRatio, Is.EqualTo("3:2"));
+                Assert.That(image.Model, Is.EqualTo("image-model"));
+                Assert.That(edit.Form!.Prompt, Is.EqualTo("edit\tline"));
+                Assert.That(edit.EffectiveSources.Single().Path, Is.EqualTo(sourcePath));
+                Assert.That(video.Form!.DurationSeconds, Is.EqualTo(8));
+                Assert.That(video.Form.GenerateAudio, Is.False);
+                Assert.That(restarted.TryResolveSource(video.EffectiveSources.Single(), out string? resolved), Is.True);
+                Assert.That(resolved, Is.EqualTo(Path.Combine(restarted.SourceDirectory, frameSource.DurableFile!)));
+            });
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task AccountSwitchClearsBoundRecoveryAndReturningRehydratesAllForms()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "Beutl.HeadlessUITests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        string sourcePath = Path.Combine(root, "edit.png");
+        byte[] sourceBytes = [1, 2, 3];
+        await File.WriteAllBytesAsync(sourcePath, sourceBytes);
+        string? account = "account-a";
+        var store = new FileAiRequestRecoveryStore(root);
+        AiRequestRecoverySource source = FileAiRequestRecoveryStore.CreateExternalSource(
+            "image", sourcePath, "edit.png", sourceBytes);
+        store.WriteOrGet(new AiPendingAttempt(
+            "account-a",
+            "image.generate",
+            "gen-fingerprint",
+            "gen-key",
+            "gen-model",
+            new AiRequestFormSnapshot(Prompt: "generation")));
+        store.WriteOrGet(new AiPendingAttempt(
+            "account-a",
+            "image.edit.upscale",
+            "edit-fingerprint",
+            "edit-key",
+            "edit-model",
+            new AiRequestFormSnapshot(Prompt: "edit", Task: "upscale", SourceName: "edit.png"),
+            [source]));
+        store.WriteOrGet(new AiPendingAttempt(
+            "account-a",
+            "video.generate",
+            "video-fingerprint",
+            "video-key",
+            null,
+            new AiRequestFormSnapshot(Prompt: "video", DurationSeconds: 4, Resolution: "720p", AspectRatio: "16:9")));
+
+        using var handler = new RecoveryCatalogHandler();
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://beutl.beditor.net") };
+        await using var app = new BeutlApiApplication(client, new ExtensionProvider());
+        using var context = new AiRequestRecoveryContext(
+            store,
+            () => account is { } value
+                ? new AiAuthenticatedRequestIdentity(value, User: null)
+                : null);
+
+        await using var generation = CreateGeneration(app, context);
+        await using var edit = CreateEdit(app, context);
+        await using var video = CreateVideo(app, context);
+        await WaitUntilAsync(() => video.ModelPicker.IsLoaded.Value
+            && video.SelectedRecoveryAttempt.Value is not null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(generation.Prompt.Value, Is.EqualTo("generation"));
+            Assert.That(edit.Prompt.Value, Is.EqualTo("edit"));
+            Assert.That(edit.SourceFilePath.Value, Is.EqualTo(sourcePath));
+            Assert.That(video.Prompt.Value, Is.EqualTo("video"));
+            Assert.That(video.ModelPicker.SelectedModel, Is.Null,
+                "An explicit default-model recovery must not display a current named model.");
+            Assert.That(video.ModelPicker.IsSelectionEnabled.Value, Is.False);
+        });
+
+        account = "account-b";
+        context.RefreshIdentity();
+        Assert.Multiple(() =>
+        {
+            Assert.That(generation.SelectedRecoveryAttempt.Value, Is.Null);
+            Assert.That(generation.Prompt.Value, Is.Empty);
+            Assert.That(edit.SelectedRecoveryAttempt.Value, Is.Null);
+            Assert.That(edit.SourceFilePath.Value, Is.Null);
+            Assert.That(video.SelectedRecoveryAttempt.Value, Is.Null);
+            Assert.That(video.Prompt.Value, Is.Empty);
+            Assert.That(video.ModelPicker.IsSelectionEnabled.Value, Is.True);
+        });
+
+        account = "account-a";
+        context.RefreshIdentity();
+        Assert.Multiple(() =>
+        {
+            Assert.That(generation.SelectedRecoveryAttempt.Value?.Key, Is.EqualTo("gen-key"));
+            Assert.That(edit.SelectedRecoveryAttempt.Value?.Key, Is.EqualTo("edit-key"));
+            Assert.That(video.SelectedRecoveryAttempt.Value?.Key, Is.EqualTo("video-key"));
+            Assert.That(video.ModelPicker.SelectedModel, Is.Null);
+            Assert.That(video.ModelPicker.IsSelectionEnabled.Value, Is.False);
+        });
+
+        Directory.Delete(root, recursive: true);
+    }
+
+    [AvaloniaTest]
+    public async Task StaleCompletionDoesNotClearFormRecoveryOwnedByAnotherProcess()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "Beutl.HeadlessUITests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        string sourcePath = Path.Combine(root, "source.png");
+        await File.WriteAllBytesAsync(sourcePath, s_png);
+        var store = new FileAiRequestRecoveryStore(root);
+        AiRequestRecoverySource editSource = FileAiRequestRecoveryStore.CreateExternalSource(
+            "image", sourcePath, "source.png", s_png);
+        AiRequestRecoverySource frameSource = FileAiRequestRecoveryStore.CreateExternalSource(
+            "first-frame", sourcePath, "source.png", s_png);
+        store.WriteOrGet(new AiPendingAttempt(
+            "test-user",
+            "image.generate",
+            "generation-cas",
+            "generation-key",
+            "image-model",
+            new AiRequestFormSnapshot(Prompt: "generation", AspectRatio: "1:1")));
+        store.WriteOrGet(new AiPendingAttempt(
+            "test-user",
+            "image.edit.upscale",
+            "edit-cas",
+            "edit-key",
+            "edit-model",
+            new AiRequestFormSnapshot(Prompt: "edit", Task: "upscale", SourceName: "source.png"),
+            [editSource]));
+        store.WriteOrGet(new AiPendingAttempt(
+            "test-user",
+            "video.generate",
+            "video-cas",
+            "video-key",
+            "video-model",
+            new AiRequestFormSnapshot(
+                Prompt: "video",
+                DurationSeconds: 4,
+                Resolution: "720p",
+                AspectRatio: "16:9",
+                SupportsFirstFrame: true),
+            [frameSource]));
+
+        using var handler = new RecoveryCatalogHandler();
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://beutl.beditor.net") };
+        await using var app = new BeutlApiApplication(client, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        using var context = NewContext(store, "test-user");
+        await using var generation = CreateGeneration(app, context);
+        await using var edit = CreateEdit(app, context);
+        await using var video = CreateVideo(app, context);
+        await WaitUntilAsync(() => generation.SelectedRecoveryAttempt.Value is not null
+            && edit.SelectedRecoveryAttempt.Value is not null
+            && video.SelectedRecoveryAttempt.Value is not null
+            && generation.ModelPicker.IsLoaded.Value
+            && edit.ModelPicker.IsLoaded.Value
+            && video.ModelPicker.IsLoaded.Value);
+
+        AiPendingAttempt generationAttempt = generation.SelectedRecoveryAttempt.Value!;
+        AiPendingAttempt editAttempt = edit.SelectedRecoveryAttempt.Value!;
+        AiPendingAttempt videoAttempt = video.SelectedRecoveryAttempt.Value!;
+        using (var other = new FileAiRequestRecoveryStore(root))
+        {
+            ReplaceOwner(other, generationAttempt, "generation-new-owner");
+            ReplaceOwner(other, editAttempt, "edit-new-owner");
+            ReplaceOwner(other, videoAttempt, "video-new-owner");
+        }
+
+        InvokeRetireRequestName(generation, generationAttempt);
+        InvokeRetireRequestName(edit, editAttempt);
+        InvokeRetireRequestName(video, videoAttempt);
+        HeadlessTestHelpers.Settle();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(generation.SelectedRecoveryAttempt.Value?.Key, Is.EqualTo(generationAttempt.Key));
+            Assert.That(edit.SelectedRecoveryAttempt.Value?.Key, Is.EqualTo(editAttempt.Key));
+            Assert.That(video.SelectedRecoveryAttempt.Value?.Key, Is.EqualTo(videoAttempt.Key));
+            Assert.That(generation.ModelPicker.IsSelectionEnabled.Value, Is.False);
+            Assert.That(edit.ModelPicker.IsSelectionEnabled.Value, Is.False);
+            Assert.That(video.ModelPicker.IsSelectionEnabled.Value, Is.False);
+            Assert.That(edit.SourceFilePath.Value, Is.EqualTo(sourcePath));
+            Assert.That(video.FirstFramePath.Value, Is.EqualTo(sourcePath));
+            Assert.That(RequestKeyOf(generation).HasOutstandingName.Value, Is.True);
+            Assert.That(RequestKeyOf(edit).HasOutstandingName.Value, Is.True);
+            Assert.That(RequestKeyOf(video).HasOutstandingName.Value, Is.True);
+            Assert.That(store.Find("test-user", "image.generate", generationAttempt.Fingerprint)?.Key,
+                Is.EqualTo("generation-new-owner"));
+            Assert.That(store.Find("test-user", "image.edit.upscale", editAttempt.Fingerprint)?.Key,
+                Is.EqualTo("edit-new-owner"));
+            Assert.That(store.Find("test-user", "video.generate", videoAttempt.Fingerprint)?.Key,
+                Is.EqualTo("video-new-owner"));
+        });
+
+        Directory.Delete(root, recursive: true);
+
+        static void ReplaceOwner(
+            FileAiRequestRecoveryStore other,
+            AiPendingAttempt attempt,
+            string replacementKey)
+        {
+            Assert.That(other.TrySettle(
+                attempt.AccountId,
+                attempt.Operation,
+                attempt.Fingerprint,
+                attempt.Key), Is.True);
+            other.WriteOrGet(attempt with { Key = replacementKey });
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task RestartedFormsDispatchTheirPersistedKeyModelScalarsAndMultilinePrompt()
+    {
+        string root = Path.Combine(
+            Path.GetTempPath(),
+            "Beutl.HeadlessUITests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        string sourcePath = Path.Combine(root, "input.png");
+        byte[] sourceBytes = [1, 2, 3, 4];
+        await File.WriteAllBytesAsync(sourcePath, sourceBytes);
+        string imageKey;
+        string editKey;
+        string videoKey;
+        var initialStore = new FileAiRequestRecoveryStore(root);
+        using (var initialContext = NewContext(initialStore, "test-user"))
+        {
+            var imageKeyBuilder = new AiRequestKey(
+                seed: "image-seed",
+                recoveryContext: initialContext,
+                operation: "image.generate");
+            imageKey = imageKeyBuilder.NameFor(
+                "generation line one line two",
+                "3:2",
+                "transparent",
+                "17",
+                "old-image").Key;
+            AiPendingAttempt imageAttempt = initialStore.PendingFor("test-user", "image.generate").Single();
+            initialStore.TryUpdateForm(
+                "test-user",
+                imageAttempt.Operation,
+                imageAttempt.Fingerprint,
+                imageAttempt.Key,
+                new AiRequestFormSnapshot(
+                    Prompt: "generation line one line two",
+                    AspectRatio: "3:2",
+                    Background: "transparent",
+                    Seed: 17,
+                    SupportsSeed: true,
+                    MaxReferenceImages: 1,
+                    MaxReferenceTotalBytes: 1024,
+                    SupportsReferenceImage: false,
+                    HasBackgroundChoice: true),
+                []);
+
+            var editKeyBuilder = new AiRequestKey(
+                seed: "edit-seed",
+                recoveryContext: initialContext,
+                operation: "image.edit");
+            editKey = editKeyBuilder.NameFor(
+                [
+                    "restyle",
+                    "edit\tline",
+                    "old-edit",
+                    AiRequestKey.FileStamp("input.png", sourceBytes),
+                ]).Key;
+            AiPendingAttempt editAttempt = initialStore.PendingFor("test-user", "image.edit.restyle").Single();
+            initialStore.TryUpdateForm(
+                "test-user",
+                editAttempt.Operation,
+                editAttempt.Fingerprint,
+                editAttempt.Key,
+                new AiRequestFormSnapshot(
+                    Prompt: "edit\tline",
+                    Task: "restyle",
+                    SourceName: "input.png"),
+                [FileAiRequestRecoveryStore.CreateExternalSource(
+                    "image",
+                    sourcePath,
+                    "input.png",
+                    sourceBytes)]);
+
+            var videoKeyBuilder = new AiRequestKey(
+                seed: "video-seed",
+                recoveryContext: initialContext,
+                operation: "video.generate");
+            videoKey = videoKeyBuilder.NameFor(
+                "video line one line two",
+                "8",
+                "1080p",
+                "9:16",
+                "audio",
+                "9",
+                "old-video",
+                "",
+                "").Key;
+            AiPendingAttempt videoAttempt = initialStore.PendingFor("test-user", "video.generate").Single();
+            initialStore.TryUpdateForm(
+                "test-user",
+                videoAttempt.Operation,
+                videoAttempt.Fingerprint,
+                videoAttempt.Key,
+                new AiRequestFormSnapshot(
+                    Prompt: "video line one line two",
+                    DurationSeconds: 8,
+                    Resolution: "1080p",
+                    AspectRatio: "9:16",
+                    GenerateAudio: true,
+                    Seed: 9,
+                    SupportsAudio: true,
+                    SupportsSeed: true,
+                    SupportsFirstFrame: false,
+                    SupportsLastFrame: false),
+                []);
+        }
+
+        var requests = new List<(string Path, string? Key, string Body)>();
+        using var handler = new RecoveryDispatchHandler(requests, s_png);
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://beutl.beditor.net") };
+        await using var app = new BeutlApiApplication(client, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        using var context = NewContext(new FileAiRequestRecoveryStore(root), "test-user");
+        await using var generation = CreateGeneration(app, context);
+        await using var edit = CreateEdit(app, context);
+        await using var video = CreateVideo(app, context);
+        edit.SourceFilePath.Value = sourcePath;
+        edit.SelectedTask.Value = edit.Tasks.Single(task => task.Value == "restyle");
+
+        await WaitUntilAsync(() => generation.Usage.HasSnapshot.Value
+            && edit.Usage.HasSnapshot.Value
+            && video.Usage.HasSnapshot.Value
+            && generation.ModelPicker.IsLoaded.Value
+            && edit.ModelPicker.IsLoaded.Value
+            && video.ModelPicker.IsLoaded.Value);
+        Assert.Multiple(() =>
+        {
+            Assert.That(generation.CanGenerate.Value, Is.True, $"generation Error={generation.Error.Value}");
+            Assert.That(edit.CanEdit.Value, Is.True, $"edit Error={edit.Error.Value}");
+            Assert.That(video.CanGenerate.Value, Is.True, $"video Error={video.Error.Value}");
+            Assert.That(generation.ModelPicker.IsSelectionEnabled.Value, Is.False);
+            Assert.That(generation.ModelPicker.SelectedModel?.Value, Is.EqualTo("old-image"));
+            Assert.That(edit.ModelPicker.IsSelectionEnabled.Value, Is.False);
+            Assert.That(edit.ModelPicker.SelectedModel?.Value, Is.EqualTo("old-edit"));
+            Assert.That(video.ModelPicker.IsSelectionEnabled.Value, Is.False);
+            Assert.That(video.ModelPicker.SelectedModel?.Value, Is.EqualTo("old-video"));
+        });
+        await generation.Generate.ExecuteAsync();
+        await edit.Edit.ExecuteAsync();
+        await video.Generate.ExecuteAsync();
+        await WaitUntilAsync(() => requests.Count >= 3
+            || generation.Error.Value is not null
+            || edit.Error.Value is not null
+            || video.Error.Value is not null);
+        await WaitUntilAsync(() => generation.SelectedRecoveryAttempt.Value is null
+            || generation.Error.Value is not null);
+        await WaitUntilAsync(() => video.SelectedRecoveryAttempt.Value is null
+            || video.Error.Value is not null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(generation.SelectedRecoveryAttempt.Value, Is.Null,
+                $"generation Error={generation.Error.Value}");
+            Assert.That(video.SelectedRecoveryAttempt.Value, Is.Null,
+                $"video Error={video.Error.Value}");
+        });
+
+        Assert.That(
+            requests,
+            Is.Not.Empty,
+            $"generation={generation.Error.Value}; edit={edit.Error.Value}; video={video.Error.Value}; "
+                + string.Join("\n", requests.Select(request => $"{request.Path} key={request.Key} body={request.Body}")));
+        Assert.Multiple(() =>
+        {
+            Assert.That(requests.Any(request => request.Path == "/api/v3/ai/images"
+                && request.Key == imageKey
+                && request.Body.Contains("generation line one line two", StringComparison.Ordinal)
+                && request.Body.Contains("3:2", StringComparison.Ordinal)
+                && request.Body.Contains("transparent", StringComparison.Ordinal)
+                && request.Body.Contains("old-image", StringComparison.Ordinal)),
+                Is.True,
+                string.Join("\n", requests.Select(request => $"{request.Path} key={request.Key} body={request.Body}")));
+            Assert.That(requests.Any(request => request.Path == "/api/v3/ai/images/edit"
+                && request.Key == editKey
+                && request.Body.Contains("edit\tline", StringComparison.Ordinal)
+                && request.Body.Contains("old-edit", StringComparison.Ordinal)),
+                Is.True,
+                string.Join("\n", requests.Select(request => $"{request.Path} key={request.Key} body={request.Body}")));
+            Assert.That(requests.Any(request => request.Path == "/api/v3/ai/videos"
+                && request.Key == videoKey
+                && request.Body.Contains("video line one line two", StringComparison.Ordinal)
+                && request.Body.Contains("1080p", StringComparison.Ordinal)
+                && request.Body.Contains("8", StringComparison.Ordinal)
+                && request.Body.Contains("9:16", StringComparison.Ordinal)
+                && request.Body.Contains("old-video", StringComparison.Ordinal)),
+                Is.True,
+                string.Join("\n", requests.Select(request => $"{request.Path} key={request.Key} body={request.Body}")));
+            Assert.That(generation.AspectRatioOptions.Any(option => option.Value == "3:2"), Is.False);
+            Assert.That(generation.BackgroundOptions.Any(option => option.Value == "transparent"), Is.False);
+            Assert.That(video.DurationOptions.Any(option => option.Seconds == 8), Is.False);
+            Assert.That(video.ResolutionOptions.Any(option => option.Value == "1080p"), Is.False);
+            Assert.That(video.AspectRatioOptions.Any(option => option.Value == "9:16"), Is.False);
+            Assert.That(generation.ModelPicker.IsSelectionEnabled.Value, Is.True);
+            Assert.That(video.ModelPicker.IsSelectionEnabled.Value, Is.True);
+        });
+
+        Directory.Delete(root, recursive: true);
+    }
+
+    [AvaloniaTest]
+    public async Task AbandonRemovesUnsupportedRecoveredOptionsFromNewPurchases()
+    {
+        string root = Path.Combine(
+            Path.GetTempPath(),
+            "Beutl.HeadlessUITests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var store = new FileAiRequestRecoveryStore(root);
+        store.WriteOrGet(new AiPendingAttempt(
+            "test-user",
+            "image.generate",
+            "image-abandon",
+            "image-abandon-key",
+            "old-image",
+            new AiRequestFormSnapshot(
+                Prompt: "image",
+                AspectRatio: "3:2",
+                Background: "transparent")));
+        store.WriteOrGet(new AiPendingAttempt(
+            "test-user",
+            "video.generate",
+            "video-abandon",
+            "video-abandon-key",
+            "old-video",
+            new AiRequestFormSnapshot(
+                Prompt: "video",
+                DurationSeconds: 8,
+                Resolution: "1080p",
+                AspectRatio: "9:16")));
+
+        var requests = new List<(string Path, string? Key, string Body)>();
+        using var handler = new RecoveryDispatchHandler(requests, s_png);
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://beutl.beditor.net") };
+        await using var app = new BeutlApiApplication(client, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        using var context = NewContext(store, "test-user");
+        await using var generation = CreateGeneration(app, context);
+        await using var video = CreateVideo(app, context);
+
+        await WaitUntilAsync(() => generation.ModelPicker.IsLoaded.Value
+            && video.ModelPicker.IsLoaded.Value
+            && generation.SelectedRecoveryAttempt.Value is not null
+            && video.SelectedRecoveryAttempt.Value is not null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(generation.AspectRatioOptions.Any(option => option.Value == "3:2"), Is.True);
+            Assert.That(generation.BackgroundOptions.Any(option => option.Value == "transparent"), Is.True);
+            Assert.That(video.DurationOptions.Any(option => option.Seconds == 8), Is.True);
+            Assert.That(video.ResolutionOptions.Any(option => option.Value == "1080p"), Is.True);
+            Assert.That(video.AspectRatioOptions.Any(option => option.Value == "9:16"), Is.True);
+            Assert.That(generation.ModelPicker.IsSelectionEnabled.Value, Is.False);
+            Assert.That(video.ModelPicker.IsSelectionEnabled.Value, Is.False);
+        });
+
+        generation.AbandonPendingAttempt(generation.SelectedRecoveryAttempt.Value!);
+        video.AbandonPendingAttempt(video.SelectedRecoveryAttempt.Value!);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(generation.AspectRatioOptions.Any(option => option.Value == "3:2"), Is.False);
+            Assert.That(generation.BackgroundOptions.Any(option => option.Value == "transparent"), Is.False);
+            Assert.That(video.DurationOptions.Any(option => option.Seconds == 8), Is.False);
+            Assert.That(video.ResolutionOptions.Any(option => option.Value == "1080p"), Is.False);
+            Assert.That(video.AspectRatioOptions.Any(option => option.Value == "9:16"), Is.False);
+            Assert.That(generation.ModelPicker.IsSelectionEnabled.Value, Is.True);
+            Assert.That(video.ModelPicker.IsSelectionEnabled.Value, Is.True);
+            Assert.That(store.PendingFor("test-user", "image.generate"), Is.Empty);
+            Assert.That(store.PendingFor("test-user", "video.generate"), Is.Empty);
+        });
+
+        Directory.Delete(root, recursive: true);
+    }
+
+    [AvaloniaTest]
+    public async Task AccountSwitchRejectsLateNonCooperativeImageResult()
+    {
+        string root = Path.Combine(
+            Path.GetTempPath(),
+            "Beutl.HeadlessUITests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        string? account = "account-a";
+        var store = new FileAiRequestRecoveryStore(root);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = new LateAccountSwitchHandler(started, release, s_png);
+        using var client = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://beutl.beditor.net"),
+        };
+        await using var app = new BeutlApiApplication(client, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        using var context = new AiRequestRecoveryContext(
+            store,
+            () => account is { } value
+                ? new AiAuthenticatedRequestIdentity(value, User: null)
+                : null);
+        await using var generation = CreateGeneration(app, context);
+        await WaitUntilAsync(() => generation.Usage.HasSnapshot.Value
+            && generation.ModelPicker.IsLoaded.Value);
+        generation.Prompt.Value = "Account A secret";
+        await WaitUntilAsync(() => generation.CanGenerate.Value);
+
+        Task operation = generation.Generate.ExecuteAsync();
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        account = "account-b";
+        context.RefreshIdentity();
+        generation.Prompt.Value = "Account B prompt";
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(generation.IsGenerating.Value, Is.False);
+            Assert.That(generation.ResultImage.Value, Is.Null);
+            Assert.That(generation.PreviewImage.Value, Is.Null);
+            Assert.That(generation.Error.Value, Is.Null);
+        });
+
+        release.TrySetResult();
+        await operation.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(generation.Prompt.Value, Is.EqualTo("Account B prompt"));
+            Assert.That(generation.IsGenerating.Value, Is.False);
+            Assert.That(generation.ResultImage.Value, Is.Null);
+            Assert.That(generation.PreviewImage.Value, Is.Null);
+            Assert.That(generation.Error.Value, Is.Null);
+            Assert.That(store.PendingFor("account-a", "image.generate"), Has.Count.EqualTo(1));
+            Assert.That(store.PendingFor("account-b", "image.generate"), Is.Empty);
+        });
+
+        Directory.Delete(root, recursive: true);
+    }
+
+    [AvaloniaTest]
+    public async Task AccountSwitchClosesPublicationBeforeSynchronousCancellationCallbacks()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "Beutl.HeadlessUITests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        string? account = "account-a";
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = new LateAccountSwitchHandler(started, release, s_png);
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://beutl.beditor.net") };
+        await using var app = new BeutlApiApplication(client, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        using var context = new AiRequestRecoveryContext(
+            new FileAiRequestRecoveryStore(root),
+            () => account is { } value
+                ? new AiAuthenticatedRequestIdentity(value, User: null)
+                : null);
+        await using var generation = CreateGeneration(app, context);
+        await WaitUntilAsync(() => generation.Usage.HasSnapshot.Value && generation.ModelPicker.IsLoaded.Value);
+        generation.Prompt.Value = "old account prompt";
+        await WaitUntilAsync(() => generation.CanGenerate.Value);
+
+        Task request = generation.Generate.ExecuteAsync();
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        FieldInfo field = typeof(AiImageGenerationDialogViewModel).GetField(
+            "_runningRequest", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var running = (IdentityOperationLifetime.Operation)field.GetValue(generation)!;
+        bool published = true;
+        using CancellationTokenRegistration registration = running.CancellationToken.Register(() =>
+            published = running.TryPublish(() => generation.Prompt.Value = "stale callback"));
+
+        account = "account-b";
+        context.RefreshIdentity();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(published, Is.False);
+            Assert.That(generation.Prompt.Value, Is.Empty);
+            Assert.That(generation.ResultImage.Value, Is.Null);
+        });
+        release.TrySetResult();
+        await request.WaitAsync(TimeSpan.FromSeconds(5));
+        Directory.Delete(root, recursive: true);
+    }
+
+    [AvaloniaTest]
+    public async Task ManualRecoverySelectionRestoresSavedModelWhenMultipleAttemptsExist()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "Beutl.HeadlessUITests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        string sourcePath = Path.Combine(root, "source.png");
+        await File.WriteAllBytesAsync(sourcePath, s_png);
+        var store = new FileAiRequestRecoveryStore(root);
+        AiRequestRecoverySource source = FileAiRequestRecoveryStore.CreateExternalSource("reference-0", sourcePath, "source.png", s_png);
+        store.WriteOrGet(new AiPendingAttempt("test-user", "image.generate", "model-a", "key-a", "model-a", new AiRequestFormSnapshot(Prompt: "A"), [source]));
+        store.WriteOrGet(new AiPendingAttempt("test-user", "image.generate", "model-b", "key-b", "model-b", new AiRequestFormSnapshot(Prompt: "B"), [source]));
+        using var handler = new RecoveryCatalogHandler();
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://beutl.beditor.net") };
+        await using var app = new BeutlApiApplication(client, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        using var context = NewContext(store, "test-user");
+        await using var generation = CreateGeneration(app, context);
+        await WaitUntilAsync(() => generation.ModelPicker.Options.Count > 0);
+        Assert.That(generation.SelectedRecoveryAttempt.Value, Is.Null);
+        generation.ModelPicker.Selected.Value = generation.ModelPicker.Options.LastOrDefault();
+        AiPendingAttempt saved = store.Find("test-user", "image.generate", "model-a")!;
+        Assert.That(generation.TryRecoverPendingAttempt(saved), Is.True);
+        Assert.That(generation.ModelPicker.SelectedModel?.Value, Is.EqualTo("model-a"));
+        Assert.That(generation.ModelPicker.IsSelectionEnabled.Value, Is.False);
+        Directory.Delete(root, recursive: true);
+    }
+
+    private static AiImageGenerationDialogViewModel CreateGeneration(
+        BeutlApiApplication app,
+        AiRequestRecoveryContext context)
+        => new(
+            app.GetResource<IAiEntitlementService>(),
+            app.GetResource<IAiOperationAvailabilityService>(),
+            app.GetResource<IAiModelCatalogService>(),
+            new TestPlanCoordinator(),
+            app.GetResource<IAiImageGenerationService>(),
+            app.GetResource<IAuthenticatedContentService>(),
+            editViewModel: null,
+            context);
+
+    private static AiImageEditDialogViewModel CreateEdit(
+        BeutlApiApplication app,
+        AiRequestRecoveryContext context)
+        => new(
+            app.GetResource<IAiEntitlementService>(),
+            app.GetResource<IAiOperationAvailabilityService>(),
+            app.GetResource<IAiModelCatalogService>(),
+            new TestPlanCoordinator(),
+            app.GetResource<IAiImageEditingService>(),
+            app.GetResource<IAuthenticatedContentService>(),
+            editViewModel: null,
+            context);
+
+    private static AiVideoGenerationDialogViewModel CreateVideo(
+        BeutlApiApplication app,
+        AiRequestRecoveryContext context)
+        => new(
+            app.GetResource<IAiEntitlementService>(),
+            app.GetResource<IAiOperationAvailabilityService>(),
+            app.GetResource<IAiModelCatalogService>(),
+            new TestPlanCoordinator(),
+            app.GetResource<IAiVideoService>(),
+            app.GetResource<IAuthenticatedContentService>(),
+            app.GetResource<IAiJobKindRegistry>(),
+            app.GetResource<IAiJobMonitor>(),
+            editViewModel: null,
+            context);
+
+    private sealed class NotFoundHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                RequestMessage = request,
+                Content = new StringContent("{}"),
+            });
+    }
+
+    private sealed class RecoveryCatalogHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            string path = request.RequestUri?.AbsolutePath ?? string.Empty;
+            return Task.FromResult(path switch
+            {
+                "/api/v3/user/entitlements" => Json(RecoveryEntitlementsJson()),
+                "/api/v3/ai/capabilities" => Json(RecoveryCapabilitiesJson()),
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound)
+                {
+                    RequestMessage = request,
+                    Content = new StringContent("{}"),
+                },
+            });
+        }
+
+        private static HttpResponseMessage Json(string body)
+            => new(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            };
+    }
+
+    private static AiRequestRecoveryContext NewContext(FileAiRequestRecoveryStore store, string account)
+        => new(store, () => new AiAuthenticatedRequestIdentity(account, User: null));
+
+    private static AiRequestKey RequestKeyOf(object viewModel)
+        => (AiRequestKey)viewModel.GetType().GetField(
+            "_requestKey",
+            BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(viewModel)!;
+
+    private static void InvokeRetireRequestName(object viewModel, AiPendingAttempt attempt)
+        => viewModel.GetType().GetMethod(
+            "RetireRequestName",
+            BindingFlags.Instance | BindingFlags.NonPublic)!.Invoke(
+                viewModel,
+                [new AiRequestName(attempt.Key, IsRepeat: true)]);
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        while (!condition())
+        {
+            await Task.Delay(10, timeout.Token);
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    private static void SetAuthenticatedUser(BeutlApiApplication app)
+    {
+        var profile = new Profile(new ProfileResponse
+        {
+            Id = "test-user",
+            Name = "test",
+            DisplayName = "Test User",
+            Bio = null,
+            IconId = null,
+            IconUrl = null,
+        }, app);
+        var user = new AuthenticatedUser(
+            profile,
+            new AuthResponse
+            {
+                Token = "token",
+                RefreshToken = "refresh-token",
+                Expiration = DateTime.UtcNow.AddHours(1),
+            },
+            app,
+            DateTime.UtcNow);
+        FieldInfo field = typeof(BeutlApiApplication).GetField(
+            "_authenticatedUser",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        ((ReactivePropertySlim<AuthenticatedUser?>)field.GetValue(app)!).Value = user;
+    }
+
+    private static string RecoveryCapabilitiesJson() => """
+        {
+          "operations": {
+            "image.generate": {
+              "models": [{ "id": "current-image", "displayName": "Current image", "costTier": "low", "isDefault": true, "aspectRatios": ["1:1"], "backgrounds": ["auto"], "seed": false, "maxReferenceImages": 0 }],
+              "aspectRatios": ["1:1"], "backgrounds": ["auto"]
+            },
+            "image.edit.upscale": {
+              "models": [{ "id": "current-edit", "displayName": "Current edit", "costTier": "low", "isDefault": true }]
+            },
+            "video.generate": {
+              "models": [{ "id": "current-video", "displayName": "Current video", "costTier": "low", "isDefault": true, "durationsSeconds": [4], "resolutions": ["720p"], "aspectRatios": ["16:9"], "audio": false, "seed": false, "firstFrame": false, "lastFrame": false }],
+              "durationsSeconds": [4], "resolutions": ["720p"], "aspectRatios": ["16:9"]
+            }
+          }
+        }
+        """;
+
+    private static string RecoveryEntitlementsJson() => """
+        {
+          "plan":"pro","subscriptionStatus":"active","currentPeriodStart":"2026-08-01T00:00:00Z","currentPeriodEnd":"2026-09-01T00:00:00Z","canUseAi":true,
+          "balance":{"monthlyUsage":{"usedPercent":0,"remainingPercent":100,"isExhausted":false},"additionalCredits":10,"hasAdditionalCreditDebt":false},
+          "availability":{"image.generate":true,"image.edit.upscale":true,"video.generate":true}
+        }
+        """;
+
+    private sealed class RecoveryDispatchHandler(
+        List<(string Path, string? Key, string Body)> requests,
+        byte[] content) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            string path = request.RequestUri?.AbsolutePath ?? string.Empty;
+            string body = request.Content is null
+                ? string.Empty
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            if (path is "/api/v3/user/entitlements")
+                return Json(RecoveryEntitlementsJson());
+            if (path is "/api/v3/ai/capabilities")
+                return Json(RecoveryCapabilitiesJson());
+            if (path is "/api/v3/ai/images" or "/api/v3/ai/images/edit" or "/api/v3/ai/videos")
+            {
+                string? key = request.Headers.TryGetValues("Idempotency-Key", out IEnumerable<string>? values)
+                    ? values.SingleOrDefault()
+                    : null;
+                requests.Add((path, key, body));
+                if (path == "/api/v3/ai/videos")
+                    return Json("{\"jobId\":\"recovered-video-job\",\"status\":\"queued\"}");
+                return new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                {
+                    Content = new StringContent(
+                        "{\"error_code\":\"aiProviderError\",\"message\":\"Provider failed.\"}",
+                        Encoding.UTF8,
+                        "application/json"),
+                };
+            }
+            if (path == "/api/v3/ai/videos/recovered-video-job")
+                return Json("{\"jobId\":\"recovered-video-job\",\"status\":\"failed\",\"error\":\"aiProviderError\"}");
+            if (path == "/api/contents/recovered-file")
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(content)
+                    {
+                        Headers = { ContentType = new MediaTypeHeaderValue("image/png") },
+                    },
+                };
+            return new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent("{}"),
+            };
+        }
+
+        private static HttpResponseMessage Json(string body)
+            => new(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            };
+    }
+
+    private sealed class LateAccountSwitchHandler(
+        TaskCompletionSource started,
+        TaskCompletionSource release,
+        byte[] content) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            string path = request.RequestUri?.AbsolutePath ?? string.Empty;
+            if (path == "/api/v3/user/entitlements")
+                return Json(RecoveryEntitlementsJson());
+            if (path == "/api/v3/ai/capabilities")
+                return Json(RecoveryCapabilitiesJson());
+            if (path == "/api/v3/user/ai-availability")
+                return Json("{\"available\":true}");
+            if (path == "/api/v3/ai/images")
+            {
+                started.TrySetResult();
+                await release.Task;
+                return Json(
+                    "{\"jobId\":\"late-account-job\",\"fileId\":\"late-account-file\","
+                    + "\"url\":\"https://beutl.beditor.net/api/contents/late-account-file\"}");
+            }
+            if (path == "/api/contents/late-account-file")
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(content)
+                    {
+                        Headers = { ContentType = new MediaTypeHeaderValue("image/png") },
+                    },
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent("{}"),
+            };
+        }
+
+        private static HttpResponseMessage Json(string body)
+            => new(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            };
+    }
+
+    private sealed class TestPlanCoordinator : IAiPlanCoordinator
+    {
+        public void OpenAccountSettings() { }
+
+        public void OpenAiPlan() { }
+
+        public Task RefreshIfPendingAsync(CancellationToken cancellationToken)
+            => Task.CompletedTask;
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiFormRecoveryTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiFormRecoveryTests.cs
@@ -970,11 +970,17 @@ public sealed class AiFormRecoveryTests
 
     private sealed class TestPlanCoordinator : IAiPlanCoordinator
     {
+        public event EventHandler? Refreshed
+        {
+            add { }
+            remove { }
+        }
+
         public void OpenAccountSettings() { }
 
         public void OpenAiPlan() { }
 
-        public Task RefreshIfPendingAsync(CancellationToken cancellationToken)
-            => Task.CompletedTask;
+        public Task<bool> RefreshIfPendingAsync(CancellationToken cancellationToken)
+            => Task.FromResult(false);
     }
 }

--- a/tests/Beutl.HeadlessUITests/AiFormRecoveryTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiFormRecoveryTests.cs
@@ -691,13 +691,21 @@ public sealed class AiFormRecoveryTests
         SetAuthenticatedUser(app);
         using var context = NewContext(store, "test-user");
         await using var generation = CreateGeneration(app, context);
-        await WaitUntilAsync(() => generation.ModelPicker.Options.Count > 0);
+        await WaitUntilAsync(() => generation.ModelPicker.Options.Count > 0
+            && generation.Usage.HasSnapshot.Value);
         Assert.That(generation.SelectedRecoveryAttempt.Value, Is.Null);
-        generation.ModelPicker.Selected.Value = generation.ModelPicker.Options.LastOrDefault();
         AiPendingAttempt saved = store.Find("test-user", "image.generate", "model-a")!;
+        generation.Prompt.Value = "A new request must not borrow another recovery model";
+        generation.ModelPicker.Selected.Value = generation.ModelPicker.Options
+            .First(option => option.Id.Value == "model-a");
+        await WaitUntilAsync(() => !generation.CanGenerate.Value);
+        Assert.That(generation.CanGenerate.Value, Is.False);
+
         Assert.That(generation.TryRecoverPendingAttempt(saved), Is.True);
+        await WaitUntilAsync(() => generation.CanGenerate.Value);
         Assert.That(generation.ModelPicker.SelectedModel?.Value, Is.EqualTo("model-a"));
         Assert.That(generation.ModelPicker.IsSelectionEnabled.Value, Is.False);
+        Assert.That(generation.CanGenerate.Value, Is.True);
         Directory.Delete(root, recursive: true);
     }
 

--- a/tests/Beutl.HeadlessUITests/AiJobCenterTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiJobCenterTests.cs
@@ -1567,6 +1567,88 @@ public sealed class AiJobCenterTests
     }
 
     [AvaloniaTest]
+    public async Task QueuedPreviewLoadDropsAStaleGenerationBeforeDownloading()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-preview-generation");
+        var releaseDownloads = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var fourDownloadsStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        int activeDownloads = 0;
+        int contentRequests = 0;
+        int queuedItemRequests = 0;
+        using var handler = new StubHandler(async (request, cancellationToken) =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/jobs")
+                return JsonResponse(HttpStatusCode.OK, "{\"jobs\":[],\"nextCursor\":null}");
+            if (request.RequestUri?.AbsolutePath.StartsWith(
+                    "/api/contents/generation-",
+                    StringComparison.Ordinal) == true)
+            {
+                Interlocked.Increment(ref contentRequests);
+                if (request.RequestUri.AbsolutePath == "/api/contents/generation-4")
+                    Interlocked.Increment(ref queuedItemRequests);
+                if (Interlocked.Increment(ref activeDownloads) == 4)
+                    fourDownloadsStarted.TrySetResult();
+                try
+                {
+                    await releaseDownloads.Task.WaitAsync(cancellationToken);
+                    return ByteResponse(s_png, "image/png");
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref activeDownloads);
+                }
+            }
+
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateJobCenter(editor, clients);
+        AiJob[] jobs = Enumerable.Range(0, 5)
+            .Select(index => CreateJob(
+                "image",
+                "succeeded",
+                ParseInput($"{{\"prompt\":\"generation {index}\"}}"),
+                $"https://beutl.beditor.net/api/contents/generation-{index}") with
+            {
+                Id = new AiJobId($"generation-{index}"),
+                FileId = new AiContentId($"generation-{index}"),
+            })
+            .ToArray();
+        viewModel.ApplySnapshot(new AiJobMonitorSnapshot([.. jobs], null, false, null));
+        foreach (AiJobItemViewModel item in viewModel.Jobs)
+            viewModel.SetPreviewVisibility(item, true);
+
+        try
+        {
+            await fourDownloadsStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            AiJobItemViewModel queued = viewModel.Jobs.Single(item => item.Id == "generation-4");
+            viewModel.SetPreviewVisibility(queued, false);
+            viewModel.SetPreviewVisibility(queued, true);
+
+            releaseDownloads.TrySetResult();
+            await WaitUntilAsync(() => viewModel.Jobs.All(item => item.Preview is not null));
+            await WaitUntilAsync(() => Volatile.Read(ref activeDownloads) == 0);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(Volatile.Read(ref contentRequests), Is.EqualTo(5));
+                Assert.That(Volatile.Read(ref queuedItemRequests), Is.EqualTo(1));
+            }
+        }
+        finally
+        {
+            releaseDownloads.TrySetResult();
+        }
+    }
+
+    [AvaloniaTest]
     public async Task ViewRequestsPreviewsOnlyForRealizedRowsAndLoadsMoreAfterScrolling()
     {
         await TestReset.ResetShellAsync();

--- a/tests/Beutl.HeadlessUITests/AiJobCenterTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiJobCenterTests.cs
@@ -169,6 +169,30 @@ public sealed class AiJobCenterTests
     }
 
     [Test]
+    public async Task Item_PresenterCanOfferAPreviewWithoutAResultApplicator()
+    {
+        var kind = new AiJobKindId("vendor.preview-only");
+        await using IAiJobStatusResolverRegistration kindRegistration = _jobKinds.Register(
+            new AiJobStatusResolverRegistration(kind, new AiJobStatusMap([])));
+        await using IAiJobPresentationRegistration presentationRegistration = _resultHandlers.Register(
+            new AiJobPresentationRegistration(kind, new PreviewOnlyPresenter()));
+
+        using var item = new AiJobItemViewModel(
+            CreateJob(
+                kind.Value,
+                "ready",
+                url: "https://beutl.beditor.net/api/contents/preview-only"),
+            _jobKinds,
+            _resultHandlers);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(item.HasImagePreview, Is.True);
+            Assert.That(item.CanAddToScene, Is.False);
+        }
+    }
+
+    [Test]
     public async Task Item_ThrowingRetryHandlerDisablesOnlyThatJobsRetry()
     {
         var kind = new AiJobKindId("vendor.throwing-retry");
@@ -2378,6 +2402,12 @@ public sealed class AiJobCenterTests
     {
         public AiJobPresentation Present(AiJob job, AiJobStatusSemantics status)
             => new(null!, null!, null!, null!, false);
+    }
+
+    private sealed class PreviewOnlyPresenter : IAiJobPresenter
+    {
+        public AiJobPresentation Present(AiJob job, AiJobStatusSemantics status)
+            => new("Preview only", "Ready", "Preview result", string.Empty, false, HasImagePreview: true);
     }
 
     private sealed class CustomResultCapabilities(EditViewModel expectedEditor) :

--- a/tests/Beutl.HeadlessUITests/AiJobCenterTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiJobCenterTests.cs
@@ -1,0 +1,2361 @@
+﻿using System.ComponentModel;
+using System.Net;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using Avalonia.Automation;
+using Avalonia.Automation.Peers;
+using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless.NUnit;
+using Avalonia.Layout;
+using Avalonia.VisualTree;
+using Beutl.Api;
+using Beutl.Api.Clients;
+using Beutl.Api.Objects;
+using Beutl.Api.Services;
+using Beutl.Editor.Services;
+using Beutl.Editor.Services.AI;
+using Beutl.Graphics;
+using Beutl.Language;
+using Beutl.Media;
+using Beutl.Media.Source;
+using Beutl.ProjectSystem;
+using Beutl.Services.AI;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.ViewModels.Tools;
+using Beutl.Views.Tools;
+using Reactive.Bindings;
+using SkiaSharp;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture, NonParallelizable]
+public sealed class AiJobCenterTests
+{
+    private static readonly byte[] s_png = Convert.FromBase64String(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==");
+    private AiJobKindRegistry _jobKinds = null!;
+    private AiJobResultRegistry _resultHandlers = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _jobKinds = AiJobKindRegistry.CreateBuiltIn(
+            new UnusedImageGenerationService(),
+            new UnusedVideoService(),
+            new UnusedEntitlementService(),
+            new UnusedAvailabilityService(),
+            new UnusedModelCatalogService(),
+            AiRetryTestContext.Create());
+        _resultHandlers = BuiltInAiJobResultCapabilities.CreateRegistry();
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        await _resultHandlers.DisposeAsync();
+        await _jobKinds.DisposeAsync();
+    }
+
+    [Test]
+    public void Item_ParsesRetainedInputAndNormalizesServerTokens()
+    {
+        using var item = CreateItem(CreateJob(
+            kind: " IMAGE ",
+            status: " FAILED ",
+            inputParams: ParseInput("""
+                {
+                  "prompt": "  A moonlit lake  ",
+                  "size": "1024x1536"
+                }
+                """),
+            error: "  Provider failed  ",
+            canRetry: true));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(item.Kind, Is.EqualTo("image"));
+            Assert.That(item.Status, Is.EqualTo("failed"));
+            Assert.That(item.Prompt, Is.EqualTo("A moonlit lake"));
+            Assert.That(item.ImageSize, Is.EqualTo("1024x1536"));
+            Assert.That(item.Summary, Is.EqualTo("A moonlit lake"));
+            Assert.That(item.Error, Is.EqualTo("Provider failed"));
+            Assert.That(item.IsFailed, Is.True);
+            Assert.That(item.ShouldPoll, Is.False);
+            Assert.That(item.IsTerminal, Is.True);
+            Assert.That(item.CanRetry, Is.False,
+                "A displayed prompt may be normalized, but a paid retry cannot change its retained body.");
+            Assert.That(item.CanDelete, Is.True);
+            Assert.That(item.CanAddToScene, Is.False);
+        }
+    }
+
+    [Test]
+    public async Task Item_ThrowingPresenterFallsBackToGenericPresentation()
+    {
+        var kind = new AiJobKindId("vendor.throwing");
+        await using IAiJobStatusResolverRegistration kindRegistration = _jobKinds.Register(
+            new AiJobStatusResolverRegistration(kind, new AiJobStatusMap([])));
+        await using IAiJobPresentationRegistration handlerRegistration = _resultHandlers.Register(
+            new AiJobPresentationRegistration(
+                kind,
+                new ThrowingPresenter()));
+
+        using var item = new AiJobItemViewModel(
+            CreateJob("vendor.throwing", "unknown", ParseInput("{ \"prompt\": \"safe\" }")),
+            _jobKinds,
+            _resultHandlers);
+
+        Assert.That(item.Summary, Is.EqualTo("safe"));
+        Assert.That(item.CanAddToScene, Is.False);
+    }
+
+    [Test]
+    public async Task Item_NullPresenterFieldsFallBackToGenericPresentation()
+    {
+        var kind = new AiJobKindId("vendor.invalid-presentation");
+        await using IAiJobStatusResolverRegistration kindRegistration = _jobKinds.Register(
+            new AiJobStatusResolverRegistration(kind, new AiJobStatusMap([])));
+        await using IAiJobPresentationRegistration handlerRegistration = _resultHandlers.Register(
+            new AiJobPresentationRegistration(
+                kind,
+                new NullPresentationPresenter()));
+
+        using var item = new AiJobItemViewModel(
+            CreateJob(
+                "vendor.invalid-presentation",
+                "unknown",
+                ParseInput("{ \"prompt\": \"safe\" }")),
+            _jobKinds,
+            _resultHandlers);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(item.Summary, Is.EqualTo("safe"));
+            Assert.That(item.Details, Is.Not.Null);
+            Assert.That(item.KindDisplayName, Is.Not.Null);
+            Assert.That(item.StatusDisplayName, Is.Not.Null);
+            Assert.That(item.CanAddToScene, Is.False);
+        }
+    }
+
+    [Test]
+    public async Task Item_PresentationReplacementRetainsBuiltInResultApplication()
+    {
+        var presenter = new IndependentResultCapabilities();
+        await using IAiJobPresentationRegistration registration = _resultHandlers.Register(
+            new AiJobPresentationRegistration(
+                AiJobKinds.Image,
+                presenter,
+                AiJobResultRegistrationMode.Replace));
+
+        using var item = new AiJobItemViewModel(
+            CreateJob(
+                kind: AiJobKinds.Image.Value,
+                status: AiJobStatuses.Succeeded.Value,
+                inputParams: ParseInput("{ \"prompt\": \"built-in application\" }"),
+                url: "https://beutl.beditor.net/api/contents/image-result"),
+            _jobKinds,
+            _resultHandlers);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(item.Summary, Is.EqualTo("Independent result"));
+            Assert.That(item.CanAddToScene, Is.True);
+        }
+    }
+
+    [Test]
+    public async Task Item_ThrowingRetryHandlerDisablesOnlyThatJobsRetry()
+    {
+        var kind = new AiJobKindId("vendor.throwing-retry");
+        await using var registration = RegisterRetryBehavior(
+            _jobKinds,
+            kind,
+            new AiJobStatusMap(
+            [
+                KeyValuePair.Create(
+                    new AiJobStatusId("failed"),
+                    new AiJobStatusSemantics(true, false, AiJobOutcomes.Failed)),
+            ]),
+            new ThrowingRetryHandler());
+
+        AiJobItemViewModel? item = null;
+        Assert.DoesNotThrow(() => item = new AiJobItemViewModel(
+            CreateJob(
+                "vendor.throwing-retry",
+                "failed",
+                ParseInput("{ \"prompt\": \"safe\" }"),
+                canRetry: true),
+            _jobKinds,
+            _resultHandlers));
+
+        using (item!)
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(item!.Summary, Is.EqualTo("safe"));
+                Assert.That(item.CanRetry, Is.False);
+                Assert.That(item.IsTerminal, Is.True);
+            }
+        }
+    }
+
+    [Test]
+    public void Item_CanceledUsesDistinctLocalizedPresentation()
+    {
+        using var item = CreateItem(CreateJob(
+            kind: "video",
+            status: "canceled",
+            inputParams: ParseInput("""{"prompt":"Canceled render"}"""),
+            canRetry: true));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(item.StatusDisplayName, Is.EqualTo(Strings.AiJobCenter_StatusCanceled));
+            Assert.That(item.IsTerminal, Is.True);
+            Assert.That(item.ShouldPoll, Is.False);
+            Assert.That(item.IsFailed, Is.False);
+            Assert.That(item.CanRetry, Is.False);
+        }
+    }
+
+    [Test]
+    public void Item_SucceededReplayableJobHonorsAuthoritativeCanRetry()
+    {
+        using var item = CreateItem(CreateJob(
+            kind: "image",
+            status: "succeeded",
+            inputParams: ParseInput("{\"prompt\":\"Completed image\",\"aspectRatio\":\"1:1\"}"),
+            canRetry: true));
+
+        Assert.That(item.CanRetry, Is.True);
+    }
+
+    [Test]
+    public void Item_MalformedRetainedInputFallsBackWithoutThrowing()
+    {
+        AiJobItemViewModel? item = null;
+
+        Assert.DoesNotThrow(() => item = CreateItem(CreateJob(
+            kind: "video",
+            status: "failed",
+            inputParams: ParseInput("""
+                {
+                  "prompt": "   ",
+                  "durationSeconds": "six",
+                  "resolution": 720
+                }
+                """),
+            url: "   ",
+            canRetry: true)));
+
+        using (item!)
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(item!.Prompt, Is.Null);
+                Assert.That(item.DurationSeconds, Is.Null);
+                Assert.That(item.Resolution, Is.Null);
+                Assert.That(item.ContentUri, Is.Null);
+                Assert.That(item.Summary, Is.EqualTo(Strings.AiJobCenter_NoDescription));
+                Assert.That(item.CanRetry, Is.False);
+                Assert.That(item.CanAddToScene, Is.False);
+            }
+        }
+    }
+
+    [Test]
+    public void Item_DetailsOmitTheUsageCostOfTheOperation()
+    {
+        using var item = CreateItem(CreateJob(
+            kind: "video",
+            status: "succeeded",
+            inputParams: ParseInput("""
+                {
+                  "prompt": "Orbiting camera",
+                  "durationSeconds": 6,
+                  "resolution": "1080p"
+                }
+                """),
+            url: "https://beutl.beditor.net/api/contents/video-1"));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                item.Details,
+                Does.Not.Contain("20"),
+                "The history must not disclose what the operation consumed.");
+            Assert.That(item.Details, Does.Contain("1080p"));
+        }
+    }
+
+    [Test]
+    public void Item_KnownServerErrorCodeUsesLocalizedUserMessage()
+    {
+        using var item = CreateItem(CreateJob(
+            kind: "image",
+            status: "failed",
+            error: "aiProviderError"));
+
+        Assert.That(item.Error, Is.EqualTo(Strings.AiProviderError));
+    }
+
+    [Test]
+    public void Item_UpdateTransitionsActiveJobWithoutReplacingBusyState()
+    {
+        using var item = CreateItem(CreateJob(
+            kind: "video",
+            status: "running",
+            inputParams: ParseInput("""
+                {
+                  "prompt": "Orbiting camera",
+                  "durationSeconds": 6,
+                  "resolution": "1080p"
+                }
+                """)));
+        int propertyChangedCount = 0;
+        item.PropertyChanged += OnPropertyChanged;
+        using IDisposable? operation = item.TryBeginOperation();
+
+        item.Update(CreateJob(
+            kind: "video",
+            status: "succeeded",
+            inputParams: ParseInput("""
+                {
+                  "prompt": "Orbiting camera",
+                  "durationSeconds": 6,
+                  "resolution": "1080p"
+                }
+                """),
+            url: "https://beutl.beditor.net/api/contents/video-1"));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(operation, Is.Not.Null);
+            Assert.That(item.IsBusy.Value, Is.True);
+            Assert.That(item.ShouldPoll, Is.False);
+            Assert.That(item.IsTerminal, Is.True);
+            Assert.That(item.CanDelete, Is.True);
+            Assert.That(item.CanAddToScene, Is.True);
+            Assert.That(item.DurationSeconds, Is.EqualTo(6));
+            Assert.That(item.Resolution, Is.EqualTo("1080p"));
+            Assert.That(propertyChangedCount, Is.EqualTo(1));
+        }
+
+        void OnPropertyChanged(object? sender, PropertyChangedEventArgs args) => propertyChangedCount++;
+    }
+
+    [Test]
+    public void Item_SucceededCaptionResultCanBeReopenedFromPrivateHistory()
+    {
+        using var item = CreateItem(CreateJob(
+            kind: "translation",
+            status: "succeeded",
+            inputParams: ParseInput("""{ "targetLanguage": "ja" }"""),
+            url: "https://beutl.beditor.net/api/contents/caption-1"));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(item.CanAddToScene, Is.True);
+            Assert.That(item.Language, Is.EqualTo("ja"));
+        }
+    }
+
+    [Test]
+    public void Item_DisposeDuringOperationDefersBusyPropertyDisposalUntilLeaseEnds()
+    {
+        var item = CreateItem(CreateJob(kind: "image", status: "succeeded"));
+        IDisposable? operation = item.TryBeginOperation();
+        Assert.That(operation, Is.Not.Null);
+        Assert.That(item.IsBusy.Value, Is.True);
+
+        item.Dispose();
+
+        Assert.DoesNotThrow(() => operation!.Dispose());
+        Assert.That(item.TryBeginOperation(), Is.Null);
+        Assert.DoesNotThrow(item.Dispose);
+    }
+
+    [Test]
+    public void Item_PreviewClaimCanBeRetriedAfterTransientFailure()
+    {
+        using var item = CreateItem(CreateJob(
+            kind: "image",
+            status: "succeeded",
+            url: "https://beutl.beditor.net/api/contents/preview"));
+        Assert.That(item.TryClaimPreviewLoad(), Is.True);
+        item.ResetPreviewLoadClaim();
+        Assert.That(item.TryClaimPreviewLoad(), Is.True);
+    }
+
+    [AvaloniaTest]
+    public void Item_OffscreenTransitionRejectsAnEarlierPreviewLoadCompletion()
+    {
+        using var item = CreateItem(CreateJob(
+            kind: "image",
+            status: "succeeded",
+            url: "https://beutl.beditor.net/api/contents/preview"));
+        Assert.That(item.TryClaimPreviewLoad(out long loadGeneration), Is.True);
+        item.ReleasePreviewForReload();
+        var stalePreview = Ref<Bitmap>.Create(Bitmap.FromStream(new MemoryStream(s_png)));
+
+        item.SetPreview(stalePreview, loadGeneration);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(item.Preview, Is.Null);
+            Assert.That(stalePreview.Value, Is.Null);
+            Assert.That(item.TryClaimPreviewLoad(), Is.True,
+                "Returning to the viewport must be able to start a fresh preview request.");
+        }
+    }
+
+    [AvaloniaTest]
+    public void Item_DisposeLinearizesPreviewNotificationAndReleasesBitmap()
+    {
+        using var item = CreateItem(CreateJob(
+            kind: "image",
+            status: "succeeded",
+            url: "https://beutl.beditor.net/api/contents/preview"));
+        int notifications = 0;
+        item.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == nameof(item.Preview))
+                notifications++;
+        };
+        var bitmap = Ref<Bitmap>.Create(Bitmap.FromStream(new MemoryStream(s_png)));
+        item.SetPreview(bitmap);
+        item.Dispose();
+        Assert.That(notifications, Is.EqualTo(1));
+        Assert.That(item.Preview, Is.Null);
+        Assert.That(bitmap.Value, Is.Null,
+            "Disposal must release the native bitmap owned by the item.");
+    }
+
+    [Test]
+    public void Item_SetPreviewAfterDisposeDisposesIncomingBitmapWithoutNotification()
+    {
+        using var item = CreateItem(CreateJob(kind: "image", status: "succeeded", url: "https://beutl.beditor.net/api/contents/preview"));
+        int notifications = 0;
+        item.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == nameof(item.Preview)) notifications++;
+        };
+        item.Dispose();
+        var incoming = Ref<Bitmap>.Create(Bitmap.FromStream(new MemoryStream(s_png)));
+        item.SetPreview(incoming);
+        Assert.That(notifications, Is.Zero);
+        Assert.That(item.Preview, Is.Null);
+        Assert.That(incoming.Value, Is.Null,
+            "A preview delivered after disposal must be released immediately.");
+    }
+
+    [AvaloniaTest]
+    public void View_UsesItemsControlWithVirtualizingPanelAndLabelsEveryAction()
+    {
+        var view = new AiJobCenterView();
+        var viewWindow = new Window { Content = view, Width = 360, Height = 640 };
+        using var item = CreateItem(CreateJob(
+            kind: "image",
+            status: "failed",
+            inputParams: ParseInput(
+                """{ "prompt": "Accessible action", "aspectRatio": "1:1" }"""),
+            canRetry: true));
+
+        try
+        {
+            viewWindow.Show();
+            HeadlessTestHelpers.Render();
+
+            ItemsControl jobList = view.FindControl<ItemsControl>("JobList")!;
+            Assert.That(jobList, Is.Not.Null);
+            Assert.That(AutomationProperties.GetName(jobList), Is.EqualTo(Strings.AiJobCenter));
+            Assert.That(jobList, Is.TypeOf<ItemsControl>(),
+                "Job cards must not inherit ListBox selection backgrounds.");
+            ScrollViewer scrollViewer = jobList.FindAncestorOfType<ScrollViewer>()!;
+            Assert.Multiple(() =>
+            {
+                Assert.That(scrollViewer, Is.Not.Null,
+                    "The ItemsControl must remain inside an explicit scrolling container.");
+                Assert.That(scrollViewer.HorizontalScrollBarVisibility,
+                    Is.EqualTo(ScrollBarVisibility.Disabled));
+                Assert.That(scrollViewer.VerticalScrollBarVisibility,
+                    Is.EqualTo(ScrollBarVisibility.Auto));
+            });
+            Assert.That(
+                jobList.GetVisualDescendants().OfType<VirtualizingStackPanel>(),
+                Is.Not.Empty,
+                "The job list must keep its explicitly virtualizing items panel.");
+
+            AssertAction(view.FindControl<Button>("RefreshButton"), Strings.Refresh);
+            AssertAction(view.FindControl<Button>("LoadMoreButton"), Strings.AiJobCenter_LoadMore);
+
+            jobList.ItemsSource = new[] { item };
+            HeadlessTestHelpers.Render();
+
+            ContentPresenter itemContainer = (ContentPresenter)jobList.ContainerFromIndex(0)!;
+            Assert.That(itemContainer.HorizontalContentAlignment,
+                Is.EqualTo(HorizontalAlignment.Stretch));
+            AiJobCard card = itemContainer.GetVisualDescendants().OfType<AiJobCard>().Single();
+            AutomationPeer cardPeer = ControlAutomationPeer.CreatePeerForElement(card);
+            Assert.Multiple(() =>
+            {
+                Assert.That(cardPeer.GetAutomationControlType(),
+                    Is.EqualTo(AutomationControlType.ListItem));
+                Assert.That(cardPeer.GetName(), Is.EqualTo(item.Summary));
+                Assert.That(cardPeer.IsControlElement(), Is.True);
+            });
+            List<Button> buttons = itemContainer.GetVisualDescendants().OfType<Button>().ToList();
+            Button addButton = buttons.Single(button => Equals(button.Content, Strings.AiAddToScene));
+            Button retryButton = buttons.Single(button => Equals(button.Content, Strings.AiJobCenter_Retry));
+            Button deleteButton = buttons.Single(button =>
+                AutomationProperties.GetName(button) == Strings.Delete);
+            AssertAction(addButton, Strings.AiAddToScene);
+            AssertAction(
+                retryButton,
+                Strings.AiJobCenter_Retry);
+            AssertAction(deleteButton, Strings.Delete);
+            Assert.That(
+                new[] { addButton.Parent, retryButton.Parent, deleteButton.Parent },
+                Is.All.TypeOf<WrapPanel>(),
+                "Job actions must wrap instead of clipping in a narrow dock pane.");
+            var actionPanel = (WrapPanel)addButton.Parent!;
+            Assert.That(
+                new[] { addButton, retryButton, deleteButton }.Select(button => button.Bounds.Right),
+                Is.All.LessThanOrEqualTo(actionPanel.Bounds.Width + 1),
+                "Every wrapped job action must remain inside the narrow card.");
+        }
+        finally
+        {
+            viewWindow.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ViewModel_RefreshRetryAddAndDeleteUsePersistentJobWorkflow()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-operations");
+        int retryRequests = 0;
+        int deleteRequests = 0;
+        bool deleted = false;
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/user/ai-availability" => JsonResponse(
+                HttpStatusCode.OK,
+                """{ "available": true }"""),
+            "/api/v3/ai/jobs" => JsonResponse(HttpStatusCode.OK, JobsJson(deleted)),
+            "/api/v3/ai/images" => RetryImage(),
+            "/api/v3/ai/jobs/job-failed" when request.Method == HttpMethod.Delete => DeleteJob(),
+            "/api/contents/file-success" => ByteResponse(s_png, "image/png"),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateJobCenter(editor, clients);
+
+        await WaitUntilAsync(() => viewModel.Jobs.Count == 2);
+        AiJobItemViewModel completed = viewModel.Jobs.Single(item => item.Id == "job-success");
+        AiJobItemViewModel failed = viewModel.Jobs.Single(item => item.Id == "job-failed");
+
+        await viewModel.AddToSceneAsync(completed);
+        await viewModel.RequestRetryConfirmationAsync(failed);
+        await viewModel.ConfirmPendingActionAsync();
+        viewModel.RequestDeleteConfirmation(failed);
+        Assert.That(viewModel.ConfirmationTitle.Value, Does.Contain("Retry me"),
+                "The confirmation names the job, which may have scrolled out of sight below it.");
+        await viewModel.ConfirmPendingActionAsync();
+        await WaitUntilAsync(() => viewModel.Jobs.Count == 1);
+        HeadlessTestHelpers.Settle();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(retryRequests, Is.EqualTo(1));
+            Assert.That(deleteRequests, Is.EqualTo(1));
+            Assert.That(viewModel.Jobs.Single().Id, Is.EqualTo("job-success"));
+            Assert.That(viewModel.Error.Value, Is.Null);
+        }
+
+        HttpResponseMessage RetryImage()
+        {
+            Interlocked.Increment(ref retryRequests);
+            return JsonResponse(HttpStatusCode.OK, """
+                {
+                  "jobId": "retry-job",
+                  "fileId": "retry-file",
+                  "url": "https://beutl.beditor.net/api/contents/retry-file"
+                }
+                """);
+        }
+
+        HttpResponseMessage DeleteJob()
+        {
+            Interlocked.Increment(ref deleteRequests);
+            deleted = true;
+            return JsonResponse(HttpStatusCode.OK, """{ "deleted": true }""");
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task DeleteJob_NotFoundRaceRefreshesAsAlreadyDeleted()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-delete-race");
+        bool deleted = false;
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/jobs" => JsonResponse(HttpStatusCode.OK, JobsJson(deleted)),
+            "/api/v3/ai/jobs/job-failed" when request.Method == HttpMethod.Delete => MissingDelete(),
+            "/api/contents/file-success" => ByteResponse(s_png, "image/png"),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateJobCenter(editor, clients);
+        await WaitUntilAsync(() => viewModel.Jobs.Count == 2);
+        AiJobItemViewModel failed = viewModel.Jobs.Single(item => item.Id == "job-failed");
+
+        await viewModel.DeleteJobAsync(failed);
+        await WaitUntilAsync(() => viewModel.Jobs.Count == 1);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.Jobs.Single().Id, Is.EqualTo("job-success"));
+            Assert.That(viewModel.Error.Value, Is.Null);
+        }
+
+        HttpResponseMessage MissingDelete()
+        {
+            deleted = true;
+            return JsonResponse(HttpStatusCode.NotFound, """
+                {
+                  "error_code": "aiJobNotFound",
+                  "message": "The job no longer exists.",
+                  "documentation_url": null
+                }
+                """);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task AddToScene_RestoresTranscriptionHistory()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-caption-history");
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/jobs" => JsonResponse(
+                HttpStatusCode.OK,
+                """{ "jobs": [], "nextCursor": null }"""),
+            "/api/contents/caption-1" => JsonResponse(HttpStatusCode.OK, """
+                {
+                  "version": 1,
+                  "kind": "stt",
+                  "language": "en",
+                  "segments": [
+                    { "start": 0, "end": 1.5, "text": "First" },
+                    { "start": 2, "end": 3, "text": "Second" }
+                  ]
+                }
+                """),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateJobCenter(editor, clients);
+        using var item = CreateItem(CreateJob(
+            kind: "stt",
+            status: "succeeded",
+            url: "https://beutl.beditor.net/api/contents/caption-1"));
+
+        await viewModel.AddToSceneAsync(item);
+
+        Assert.That(editor.Scene.Children, Has.Count.EqualTo(2), viewModel.Error.Value);
+        Assert.That(viewModel.Error.Value, Is.Null);
+    }
+
+    [AvaloniaTest]
+    public async Task Retry_UsesCurrentPricingAndRechecksCurrentBalanceBeforeSubmission()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-retry-pricing");
+        int entitlementRequests = 0;
+        int retryRequests = 0;
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(
+                HttpStatusCode.OK,
+                Interlocked.Increment(ref entitlementRequests) < 3
+                    ? EntitlementsJson(canStartImage: true, usedPercent: 0)
+                    : EntitlementsJson(canStartImage: false, usedPercent: 50)),
+            "/api/v3/user/ai-availability" => JsonResponse(
+                HttpStatusCode.OK,
+                """{ "available": true }"""),
+            "/api/v3/ai/jobs" => JsonResponse(HttpStatusCode.OK, """{ "jobs": [], "nextCursor": null }"""),
+            "/api/v3/ai/images" => RetryImage(),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateJobCenter(editor, clients);
+        using var item = CreateItem(CreateJob(
+            kind: "image",
+            status: "failed",
+            inputParams: ParseInput(
+                """{ "prompt": "Retry at the current price", "aspectRatio": "1:1" }"""),
+            canRetry: true));
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+
+        await viewModel.RequestRetryConfirmationAsync(item);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.IsConfirmationOpen.Value, Is.True);
+            Assert.That(viewModel.CanConfirm.Value, Is.True);
+            Assert.That(
+                viewModel.ConfirmationMessage.Value,
+                Does.Contain(Strings.AiJobCenter_RetryConfirmation));
+            Assert.That(
+                viewModel.ConfirmationMessage.Value,
+                Does.Not.Contain("75"),
+                "The confirmation must not disclose the per-operation usage cost.");
+        }
+
+        await viewModel.ConfirmPendingActionAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.IsConfirmationOpen.Value, Is.False);
+            Assert.That(retryRequests, Is.Zero, "The request must be blocked after the balance recheck.");
+            Assert.That(
+                viewModel.Error.Value,
+                Is.EqualTo(Strings.AiEstimatedUsageInsufficient));
+        }
+
+        HttpResponseMessage RetryImage()
+        {
+            Interlocked.Increment(ref retryRequests);
+            return JsonResponse(HttpStatusCode.OK, ImageResponseJson());
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task VideoRetry_RechecksDurationSpecificAvailabilityBeforeSubmission()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-video-retry-availability");
+        int availabilityRequests = 0;
+        int retryRequests = 0;
+        var availabilityBodies = new List<string>();
+        using var handler = new StubHandler(request =>
+        {
+            switch (request.RequestUri?.AbsolutePath)
+            {
+                case "/api/v3/user/entitlements":
+                    return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+                case "/api/v3/user/ai-availability":
+                    availabilityRequests++;
+                    availabilityBodies.Add(request.Content!.ReadAsStringAsync().GetAwaiter().GetResult());
+                    return JsonResponse(
+                        HttpStatusCode.OK,
+                            availabilityRequests < 2
+                            ? """{ "available": true }"""
+                            : """{ "available": false }""");
+                case "/api/v3/ai/jobs":
+                    return JsonResponse(
+                        HttpStatusCode.OK,
+                        """{ "jobs": [], "nextCursor": null }""");
+                case "/api/v3/ai/videos":
+                    retryRequests++;
+                    return JsonResponse(
+                        HttpStatusCode.OK,
+                        """{ "jobId": "retry-video", "status": "queued" }""");
+                default:
+                    return JsonResponse(HttpStatusCode.NotFound, "{}");
+            }
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateJobCenter(editor, clients);
+        using var item = CreateItem(CreateJob(
+            kind: "video",
+            status: "failed",
+            inputParams: ParseInput(
+                """{ "prompt": "Retry video", "durationSeconds": 8, "resolution": "1080p" }"""),
+            canRetry: true));
+        await WaitUntilAsync(() => viewModel.Usage.HasSnapshot.Value);
+
+        await viewModel.RequestRetryConfirmationAsync(item);
+        Assert.That(viewModel.CanConfirm.Value, Is.True);
+
+        await viewModel.ConfirmPendingActionAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(availabilityRequests, Is.EqualTo(2));
+            Assert.That(retryRequests, Is.Zero);
+            Assert.That(viewModel.Error.Value, Is.EqualTo(Strings.AiEstimatedUsageInsufficient));
+            Assert.That(
+                availabilityBodies,
+                Is.All.EqualTo("""{"operation":"video.generate","durationSeconds":8}"""));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task CustomKind_ControlsPresentationRetryAndResultHandling()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-custom-kind");
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.InternalServerError, "{}"),
+            "/api/v3/ai/jobs" => JsonResponse(
+                HttpStatusCode.OK,
+                """{ "jobs": [], "nextCursor": null }"""),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+
+        IAiJobKindRegistry jobKinds = clients.GetResource<IAiJobKindRegistry>();
+        var retryHandler = new CustomRetryHandler();
+        var resultCapabilities = new CustomResultCapabilities(editor);
+        var kind = new AiJobKindId("vendor.upscale");
+        await using var registration = RegisterRetryBehavior(
+            jobKinds,
+            kind,
+            new AiJobStatusMap(
+            [
+                KeyValuePair.Create(
+                    new AiJobStatusId("retryable"),
+                    new AiJobStatusSemantics(
+                        true,
+                        false,
+                        new AiJobOutcomeId("vendor.retryable"))),
+                KeyValuePair.Create(
+                    new AiJobStatusId("ready"),
+                    new AiJobStatusSemantics(
+                        true,
+                        false,
+                        new AiJobOutcomeId("vendor.ready"))),
+            ]),
+            retryHandler);
+        await using IAiJobPresentationRegistration presentationRegistration = _resultHandlers.Register(
+            new AiJobPresentationRegistration(
+                new AiJobKindId("vendor.upscale"),
+                resultCapabilities));
+        await using IAiJobResultApplicatorRegistration applicationRegistration = _resultHandlers.Register(
+            new AiJobResultApplicatorRegistration(
+                new AiJobKindId("vendor.upscale"),
+                resultCapabilities));
+        using var viewModel = CreateJobCenter(editor, clients);
+        using var item = new AiJobItemViewModel(
+            CreateJob(
+                kind: "vendor.upscale",
+                status: "retryable",
+                inputParams: ParseInput("""{ "prompt": "Upscale this" }"""),
+                canRetry: true),
+            jobKinds,
+            _resultHandlers);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(item.KindDisplayName, Is.EqualTo("Vendor upscale"));
+            Assert.That(item.StatusDisplayName, Is.EqualTo("Ready to retry"));
+            Assert.That(item.IsFailed, Is.True);
+            Assert.That(item.CanRetry, Is.True);
+        }
+
+        await viewModel.RetryJobAsync(item);
+        item.Update(CreateJob(
+            kind: "vendor.upscale",
+            status: "ready",
+            inputParams: ParseInput("""{ "prompt": "Upscale this" }"""),
+            url: "https://beutl.beditor.net/api/contents/vendor-result"));
+        await viewModel.AddToSceneAsync(item);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(retryHandler.RetryCount, Is.EqualTo(1));
+            Assert.That(resultCapabilities.HandleCount, Is.EqualTo(1));
+            Assert.That(resultCapabilities.ResolvedSceneEditingContext, Is.True);
+            Assert.That(item.StatusDisplayName, Is.EqualTo("Ready to open"));
+            Assert.That(item.CanAddToScene, Is.True);
+            Assert.That(viewModel.Error.Value, Is.Null);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task SuccessfulPaidRetryIsNotReportedOrOfferedAgainWhenRefreshFails()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-retry-refresh-failure");
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+
+        IAiJobKindRegistry jobKinds = clients.GetResource<IAiJobKindRegistry>();
+        var retryHandler = new CustomRetryHandler();
+        var kind = new AiJobKindId("vendor.retry-refresh-failure");
+        await using var registration = RegisterRetryBehavior(
+            jobKinds,
+            kind,
+            new AiJobStatusMap(
+            [
+                KeyValuePair.Create(
+                    new AiJobStatusId("retryable"),
+                    new AiJobStatusSemantics(
+                        true,
+                        false,
+                        new AiJobOutcomeId("vendor.retryable"))),
+            ]),
+            retryHandler);
+        var monitor = new FailingRefreshJobMonitor();
+        using var viewModel = new AiJobCenterViewModel(
+            editor,
+            clients.GetResource<IAiEntitlementService>(),
+            clients.GetResource<IAuthenticatedContentService>(),
+            clients.GetResource<IAiJobClient>(),
+            monitor,
+            jobKinds,
+            _resultHandlers,
+            null);
+        using var item = new AiJobItemViewModel(
+            CreateJob(
+                kind.Value,
+                "retryable",
+                ParseInput("{\"prompt\":\"Retry exactly once\"}"),
+                canRetry: true),
+            jobKinds,
+            _resultHandlers);
+
+        await viewModel.RetryJobAsync(item);
+        await viewModel.RetryJobAsync(item);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(retryHandler.RetryCount, Is.EqualTo(1));
+            Assert.That(monitor.RefreshCount, Is.EqualTo(1));
+            Assert.That(item.CanRetry, Is.False);
+            Assert.That(viewModel.Error.Value, Is.EqualTo(Strings.AiJobCenter_LoadFailed));
+            Assert.That(viewModel.Error.Value, Is.Not.EqualTo(Strings.AiJobCenter_RetryFailed));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task IndependentResultCapabilitiesRunWithoutAJobKindDescriptor()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-independent-result-handler");
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/jobs" => JsonResponse(HttpStatusCode.OK, "{\"jobs\":[],\"nextCursor\":null}"),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        var resultCapabilities = new IndependentResultCapabilities();
+        await using IAiJobPresentationRegistration presentationRegistration = _resultHandlers.Register(
+            new AiJobPresentationRegistration(
+                new AiJobKindId("vendor.independent"),
+                resultCapabilities));
+        await using IAiJobResultApplicatorRegistration applicationRegistration = _resultHandlers.Register(
+            new AiJobResultApplicatorRegistration(
+                new AiJobKindId("vendor.independent"),
+                resultCapabilities));
+        using var viewModel = CreateJobCenter(editor, clients);
+        using var item = new AiJobItemViewModel(
+            CreateJob(
+                "vendor.independent",
+                "ready",
+                url: "https://beutl.beditor.net/api/contents/independent"),
+            clients.GetResource<IAiJobKindRegistry>(),
+            _resultHandlers);
+
+        Assert.That(item.CanAddToScene, Is.True);
+        await viewModel.AddToSceneAsync(item);
+
+        Assert.That(resultCapabilities.HandleCount, Is.EqualTo(1));
+    }
+
+    [AvaloniaTest]
+    public async Task RetryConfirmationPinsOriginatingHandlerAcrossReplacementAndCancel()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-retry-lifetime");
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.InternalServerError, "{}"),
+            "/api/v3/ai/jobs" => JsonResponse(
+                HttpStatusCode.OK,
+                """{ "jobs": [], "nextCursor": null }"""),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        IAiJobKindRegistry registry = clients.GetResource<IAiJobKindRegistry>();
+        using var viewModel = CreateJobCenter(editor, clients);
+
+        var original = new CustomRetryHandler();
+        var replacement = new CustomRetryHandler();
+        RetryBehaviorRegistration originalRegistration = RegisterRetryBehavior(
+            registry,
+            "vendor.replace",
+            original);
+        using var item = new AiJobItemViewModel(
+            CreateJob(
+                kind: "vendor.replace",
+                status: "retryable",
+                inputParams: ParseInput("""{ "prompt": "Pinned retry" }"""),
+                canRetry: true),
+            registry,
+            _resultHandlers);
+
+        await viewModel.RequestRetryConfirmationAsync(item);
+        Assert.That(viewModel.CanConfirm.Value, Is.True);
+        Task retirement = originalRegistration.DisposeAsync().AsTask();
+        Assert.That(retirement.IsCompleted, Is.False);
+        await using RetryBehaviorRegistration replacementRegistration = RegisterRetryBehavior(
+            registry,
+            "vendor.replace",
+            replacement);
+
+        await viewModel.ConfirmPendingActionAsync();
+        await retirement.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Multiple(() =>
+        {
+            Assert.That(original.RetryCount, Is.EqualTo(1));
+            Assert.That(replacement.RetryCount, Is.Zero);
+        });
+
+        var canceledOriginal = new CustomRetryHandler();
+        var canceledReplacement = new CustomRetryHandler();
+        RetryBehaviorRegistration canceledRegistration = RegisterRetryBehavior(
+            registry,
+            "vendor.cancel",
+            canceledOriginal);
+        using var canceledItem = new AiJobItemViewModel(
+            CreateJob(
+                kind: "vendor.cancel",
+                status: "retryable",
+                inputParams: ParseInput("""{ "prompt": "Canceled retry" }"""),
+                canRetry: true),
+            registry,
+            _resultHandlers);
+
+        await viewModel.RequestRetryConfirmationAsync(canceledItem);
+        Assert.That(viewModel.CanConfirm.Value, Is.True);
+        Task canceledRetirement = canceledRegistration.DisposeAsync().AsTask();
+        Assert.That(canceledRetirement.IsCompleted, Is.False);
+        await using RetryBehaviorRegistration canceledReplacementRegistration = RegisterRetryBehavior(
+            registry,
+            "vendor.cancel",
+            canceledReplacement);
+
+        viewModel.CancelConfirmation();
+        await canceledRetirement.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Multiple(() =>
+        {
+            Assert.That(canceledOriginal.RetryCount, Is.Zero);
+            Assert.That(canceledReplacement.RetryCount, Is.Zero);
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task RetryConfirmationWithoutDescriptorStopsLoading()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-missing-descriptor");
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.InternalServerError, "{}"),
+            "/api/v3/ai/jobs" => JsonResponse(HttpStatusCode.OK, "{\"jobs\":[],\"nextCursor\":null}"),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateJobCenter(editor, clients);
+        using var item = new AiJobItemViewModel(
+            CreateJob(
+                "vendor.missing",
+                "retryable",
+                ParseInput("{\"prompt\":\"missing\"}"),
+                canRetry: true),
+            clients.GetResource<IAiJobKindRegistry>(),
+            _resultHandlers);
+
+        await viewModel.RequestRetryConfirmationAsync(item);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.IsConfirmationLoading.Value, Is.False);
+            Assert.That(viewModel.CanConfirm.Value, Is.False);
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task RetryConfirmationCancellationDrainsSlowPreflightBeforeUnloading()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-slow-preflight");
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.InternalServerError, "{}"),
+            "/api/v3/ai/jobs" => JsonResponse(HttpStatusCode.OK, "{\"jobs\":[],\"nextCursor\":null}"),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        IAiJobKindRegistry registry = clients.GetResource<IAiJobKindRegistry>();
+        using var viewModel = CreateJobCenter(editor, clients);
+        var slow = new SlowRetryHandler();
+        await using RetryBehaviorRegistration registration = RegisterRetryBehavior(
+            registry,
+            "vendor.slow",
+            slow);
+        using var item = new AiJobItemViewModel(
+            CreateJob("vendor.slow", "retryable", ParseInput("{\"prompt\":\"slow\"}"), canRetry: true),
+            registry,
+            _resultHandlers);
+
+        Task confirmation = viewModel.RequestRetryConfirmationAsync(item);
+        await slow.Started.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Task unload = registration.DisposeAsync().AsTask();
+        Assert.That(unload.IsCompleted, Is.False);
+
+        viewModel.CancelConfirmation();
+        Assert.That(unload.IsCompleted, Is.False,
+            "Cancellation must not unload an extension while its preflight is still running.");
+        slow.Release.TrySetResult();
+        await confirmation;
+        await unload.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.That(slow.CancellationObserved, Is.True);
+    }
+
+    [AvaloniaTest]
+    public async Task RetryRegistrationDrainsThroughPreparedExecutionAndDisposal()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-retry-execution-lifetime");
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.InternalServerError, "{}"),
+            "/api/v3/ai/jobs" => JsonResponse(HttpStatusCode.OK, "{\"jobs\":[],\"nextCursor\":null}"),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        IAiJobKindRegistry registry = clients.GetResource<IAiJobKindRegistry>();
+        using var viewModel = CreateJobCenter(editor, clients);
+        var blocking = new BlockingExecutionRetryHandler();
+        RetryBehaviorRegistration registration = RegisterRetryBehavior(
+            registry,
+            "vendor.blocking-execution",
+            blocking);
+        using var item = new AiJobItemViewModel(
+            CreateJob(
+                "vendor.blocking-execution",
+                "retryable",
+                ParseInput("{\"prompt\":\"blocking\"}"),
+                canRetry: true),
+            registry,
+            _resultHandlers);
+
+        Task retry = viewModel.RetryJobAsync(item);
+        await blocking.ExecutionStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Task retirement = registration.DisposeAsync().AsTask();
+        Assert.That(retirement.IsCompleted, Is.False);
+
+        blocking.ReleaseExecution.TrySetResult();
+        await retry.WaitAsync(TimeSpan.FromSeconds(2));
+        await retirement.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.That(blocking.PreparationDisposed, Is.True);
+    }
+
+    [AvaloniaTest]
+    public async Task DisposeAsyncReturnsSamePendingTaskWhilePreflightDrains()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-dispose-idempotent");
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.InternalServerError, "{}"),
+            "/api/v3/ai/jobs" => JsonResponse(HttpStatusCode.OK, "{\"jobs\":[],\"nextCursor\":null}"),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        IAiJobKindRegistry registry = clients.GetResource<IAiJobKindRegistry>();
+        using var viewModel = CreateJobCenter(editor, clients);
+        var slow = new SlowRetryHandler();
+        await using RetryBehaviorRegistration registration = RegisterRetryBehavior(
+            registry,
+            "vendor.dispose",
+            slow);
+        using var item = new AiJobItemViewModel(
+            CreateJob("vendor.dispose", "retryable", ParseInput("{\"prompt\":\"slow\"}"), canRetry: true),
+            registry,
+            _resultHandlers);
+
+        Task confirmation = viewModel.RequestRetryConfirmationAsync(item);
+        await slow.Started.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Task unload = registration.DisposeAsync().AsTask();
+        viewModel.Dispose();
+        Task first = viewModel.DisposeAsync().AsTask();
+        Task second = viewModel.DisposeAsync().AsTask();
+        Assert.That(second, Is.SameAs(first));
+        Assert.That(first.IsCompleted, Is.False);
+        slow.Release.TrySetResult();
+        await confirmation;
+        await first;
+        await unload;
+    }
+
+    [AvaloniaTest]
+    public async Task DisposeAsyncDrainsNonCooperativeResultApplicator()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-result-drain");
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/jobs" => JsonResponse(HttpStatusCode.OK, "{\"jobs\":[],\"nextCursor\":null}"),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        IAiJobKindRegistry registry = clients.GetResource<IAiJobKindRegistry>();
+        using var viewModel = CreateJobCenter(editor, clients);
+        var blocking = new BlockingResultApplicator();
+        await using IAiJobStatusResolverRegistration registration = registry.Register(
+            new AiJobStatusResolverRegistration(
+                new AiJobKindId("vendor.blocking-result"),
+                new AiJobStatusMap([
+                    KeyValuePair.Create(
+                        new AiJobStatusId("ready"),
+                        new AiJobStatusSemantics(true, false, new AiJobOutcomeId("ready"))),
+                ])));
+        await using IAiJobResultApplicatorRegistration resultRegistration = _resultHandlers.Register(
+            new AiJobResultApplicatorRegistration(
+                new AiJobKindId("vendor.blocking-result"),
+                blocking));
+        using var item = new AiJobItemViewModel(CreateJob("vendor.blocking-result", "ready", ParseInput("{\"prompt\":\"x\"}"), url: "https://beutl.beditor.net/api/contents/x"), registry, _resultHandlers);
+        Task operation = viewModel.AddToSceneAsync(item);
+        await blocking.Started.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        viewModel.Dispose();
+        Task dispose = viewModel.DisposeAsync().AsTask();
+        Assert.That(dispose.IsCompleted, Is.False);
+        blocking.Release.TrySetResult();
+        await operation;
+        await dispose;
+        await registration.DisposeAsync();
+    }
+
+    [AvaloniaTest]
+    public async Task RetryConfirmationCancelAndDisposeSwallowSynchronousCancellationCallbackErrors()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-throwing-preflight");
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.InternalServerError, "{}"),
+            "/api/v3/ai/jobs" => JsonResponse(HttpStatusCode.OK, "{\"jobs\":[],\"nextCursor\":null}"),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        IAiJobKindRegistry registry = clients.GetResource<IAiJobKindRegistry>();
+        using var viewModel = CreateJobCenter(editor, clients);
+        var throwing = new ThrowingCancelRetryHandler();
+        await using RetryBehaviorRegistration registration = RegisterRetryBehavior(
+            registry,
+            "vendor.throwing-cancel",
+            throwing);
+        using var item = new AiJobItemViewModel(
+            CreateJob("vendor.throwing-cancel", "retryable", ParseInput("{\"prompt\":\"throw\"}"), canRetry: true),
+            registry,
+            _resultHandlers);
+
+        Task confirmation = viewModel.RequestRetryConfirmationAsync(item);
+        await throwing.Started.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.DoesNotThrow(viewModel.CancelConfirmation);
+        throwing.Release.TrySetResult();
+        await confirmation;
+        Assert.DoesNotThrow(viewModel.Dispose);
+        await registration.DisposeAsync();
+    }
+
+
+    [AvaloniaTest]
+    public async Task RetryConfirmationStalePreflightCannotOverwriteReplacement()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-stale-preflight");
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.InternalServerError, "{}"),
+            "/api/v3/ai/jobs" => JsonResponse(HttpStatusCode.OK, "{\"jobs\":[],\"nextCursor\":null}"),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        IAiJobKindRegistry registry = clients.GetResource<IAiJobKindRegistry>();
+        using var viewModel = CreateJobCenter(editor, clients);
+        var slow = new SlowRetryHandler();
+        var replacement = new CustomRetryHandler();
+        await using RetryBehaviorRegistration slowRegistration = RegisterRetryBehavior(
+            registry,
+            "vendor.stale.slow",
+            slow);
+        await using RetryBehaviorRegistration replacementRegistration = RegisterRetryBehavior(
+            registry,
+            "vendor.stale.fast",
+            replacement);
+        using var first = new AiJobItemViewModel(CreateJob("vendor.stale.slow", "retryable", ParseInput("{\"prompt\":\"first\"}"), canRetry: true), registry, _resultHandlers);
+        using var second = new AiJobItemViewModel(CreateJob("vendor.stale.fast", "retryable", ParseInput("{\"prompt\":\"second\"}"), canRetry: true), registry, _resultHandlers);
+
+        Task firstConfirmation = viewModel.RequestRetryConfirmationAsync(first);
+        await slow.Started.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Task secondConfirmation = viewModel.RequestRetryConfirmationAsync(second);
+        await secondConfirmation;
+        Assert.That(viewModel.CanConfirm.Value, Is.True);
+        Assert.That(viewModel.ConfirmationMessage.Value, Does.Contain("No additional charge"));
+        slow.Release.TrySetResult();
+        await firstConfirmation;
+        Assert.That(viewModel.CanConfirm.Value, Is.True);
+        Assert.That(viewModel.ConfirmationMessage.Value, Does.Contain("No additional charge"));
+        viewModel.CancelConfirmation();
+    }
+
+    private static void AssertAction(Button? button, string accessibleName)
+    {
+        Assert.That(button, Is.Not.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(AutomationProperties.GetName(button!), Is.EqualTo(accessibleName));
+            Assert.That(ToolTip.GetTip(button!), Is.EqualTo(accessibleName));
+        }
+    }
+
+    private AiJobItemViewModel CreateItem(AiJob job)
+        => new(job, _jobKinds, _resultHandlers);
+
+    private static RetryBehaviorRegistration RegisterRetryBehavior(
+        IAiJobKindRegistry registry,
+        string kind,
+        IAiJobRetryHandler retryHandler)
+        => RegisterRetryBehavior(
+            registry,
+            new AiJobKindId(kind),
+            new AiJobStatusMap(
+            [
+                KeyValuePair.Create(
+                    new AiJobStatusId("retryable"),
+                    new AiJobStatusSemantics(
+                        true,
+                        false,
+                        new AiJobOutcomeId("vendor.retryable"))),
+            ]),
+            retryHandler);
+
+    private static RetryBehaviorRegistration RegisterRetryBehavior(
+        IAiJobKindRegistry registry,
+        AiJobKindId kind,
+        IAiJobStatusResolver statusResolver,
+        IAiJobRetryHandler retryHandler)
+    {
+        IAiJobStatusResolverRegistration statusRegistration = registry.Register(
+            new AiJobStatusResolverRegistration(kind, statusResolver));
+        try
+        {
+            IAiJobRetryHandlerRegistration retryRegistration = registry.Register(
+                new AiJobRetryHandlerRegistration(kind, retryHandler));
+            return new RetryBehaviorRegistration(statusRegistration, retryRegistration);
+        }
+        catch
+        {
+            statusRegistration.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            throw;
+        }
+    }
+
+    private sealed class RetryBehaviorRegistration(
+        IAiJobStatusResolverRegistration status,
+        IAiJobRetryHandlerRegistration retry) : IAsyncDisposable
+    {
+        public async ValueTask DisposeAsync()
+        {
+            await Task.WhenAll(
+                status.DisposeAsync().AsTask(),
+                retry.DisposeAsync().AsTask());
+        }
+    }
+
+    [Test]
+    public void DecodePreview_DownsamplesWithinTheBoundedDecodeSurface()
+    {
+        using var source = new SKBitmap(2_048, 1_024, SKColorType.Rgba8888, SKAlphaType.Premul);
+        source.Erase(SKColors.CornflowerBlue);
+        using SKImage image = SKImage.FromBitmap(source);
+        using SKData encoded = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var encodedStream = new MemoryStream();
+        encoded.SaveTo(encodedStream);
+        encodedStream.Position = 0;
+
+        using Bitmap preview = AiJobCenterViewModel.DecodePreview(encodedStream);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(preview.Width, Is.EqualTo(512));
+            Assert.That(preview.Height, Is.EqualTo(256));
+        }
+    }
+
+    [Test]
+    public void AiImageDecodeValidator_RejectsDimensionsBeforeFullDecode()
+    {
+        Assert.DoesNotThrow(() => AiImageDecodeValidator.Validate(
+            new SKImageInfo(8_192, 2_048, SKColorType.Rgba8888, SKAlphaType.Premul)));
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<InvalidDataException>(() => AiImageDecodeValidator.Validate(
+                new SKImageInfo(8_193, 1, SKColorType.Rgba8888, SKAlphaType.Premul)));
+            Assert.Throws<InvalidDataException>(() => AiImageDecodeValidator.Validate(
+                new SKImageInfo(4_097, 4_097, SKColorType.Rgba8888, SKAlphaType.Premul)));
+        });
+    }
+
+    [Test]
+    public void AiImageDecodeValidator_RejectsEncodedLengthBeforeReading()
+    {
+        using var stream = new LengthGuardStream(10);
+
+        Assert.Throws<InvalidDataException>(() =>
+            AiImageDecodeValidator.ValidateEncoded(stream, maxEncodedBytes: 9));
+        Assert.That(stream.ReadCount, Is.EqualTo(0));
+    }
+
+    private sealed class LengthGuardStream(long length) : Stream
+    {
+        public int ReadCount { get; private set; }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => length;
+        public override long Position { get; set; }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            ReadCount++;
+            throw new InvalidOperationException("The validator must reject by length before reading.");
+        }
+        public override long Seek(long offset, SeekOrigin origin) => Position = offset;
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    [AvaloniaTest]
+    public async Task VisiblePreviewDownloadsUseBoundedConcurrency()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-preview-concurrency");
+        var releaseDownloads = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var fourDownloadsStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        object concurrencyGate = new();
+        int activeDownloads = 0;
+        int maximumDownloads = 0;
+        int contentRequests = 0;
+        using var handler = new StubHandler(async (request, cancellationToken) =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/jobs")
+                return JsonResponse(HttpStatusCode.OK, "{\"jobs\":[],\"nextCursor\":null}");
+            if (request.RequestUri?.AbsolutePath.StartsWith("/api/contents/preview-", StringComparison.Ordinal) == true)
+            {
+                lock (concurrencyGate)
+                {
+                    contentRequests++;
+                    activeDownloads++;
+                    maximumDownloads = Math.Max(maximumDownloads, activeDownloads);
+                    if (activeDownloads == 4)
+                        fourDownloadsStarted.TrySetResult();
+                }
+                try
+                {
+                    await releaseDownloads.Task.WaitAsync(cancellationToken);
+                    return ByteResponse(s_png, "image/png");
+                }
+                finally
+                {
+                    lock (concurrencyGate)
+                        activeDownloads--;
+                }
+            }
+
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateJobCenter(editor, clients);
+        AiJob[] jobs = Enumerable.Range(0, 10)
+            .Select(index => CreateJob(
+                "image",
+                "succeeded",
+                ParseInput($"{{\"prompt\":\"preview {index}\"}}"),
+                $"https://beutl.beditor.net/api/contents/preview-{index}") with
+            {
+                Id = new AiJobId($"preview-{index}"),
+                FileId = new AiContentId($"preview-{index}"),
+            })
+            .ToArray();
+        viewModel.ApplySnapshot(new AiJobMonitorSnapshot([.. jobs], null, false, null));
+        foreach (AiJobItemViewModel item in viewModel.Jobs)
+            viewModel.SetPreviewVisibility(item, true);
+
+        await fourDownloadsStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Task.Delay(50);
+        foreach (AiJobItemViewModel item in viewModel.Jobs.Skip(4))
+            viewModel.SetPreviewVisibility(item, false);
+        lock (concurrencyGate)
+        {
+            Assert.That(activeDownloads, Is.EqualTo(4));
+            Assert.That(maximumDownloads, Is.EqualTo(4));
+        }
+
+        releaseDownloads.TrySetResult();
+        await WaitUntilAsync(() => viewModel.Jobs.Take(4).All(item => item.Preview is not null));
+        await Task.Delay(50);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(maximumDownloads, Is.EqualTo(4));
+            Assert.That(contentRequests, Is.EqualTo(4));
+            Assert.That(viewModel.Jobs.Skip(4).All(item => item.Preview is null), Is.True);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ViewRequestsPreviewsOnlyForRealizedRowsAndLoadsMoreAfterScrolling()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-preview-viewport");
+        int contentRequests = 0;
+        int pageRequests = 0;
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/user/entitlements")
+                return JsonResponse(HttpStatusCode.OK, EntitlementsJson());
+            if (request.RequestUri?.AbsolutePath == "/api/v3/ai/jobs")
+            {
+                Interlocked.Increment(ref pageRequests);
+                return JsonResponse(HttpStatusCode.OK, "{\"jobs\":[],\"nextCursor\":null}");
+            }
+            if (request.RequestUri?.AbsolutePath.StartsWith("/api/contents/viewport-", StringComparison.Ordinal) == true)
+            {
+                Interlocked.Increment(ref contentRequests);
+                return ByteResponse(s_png, "image/png");
+            }
+
+            return JsonResponse(HttpStatusCode.NotFound, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateJobCenter(editor, clients);
+        await WaitUntilAsync(() => Volatile.Read(ref pageRequests) > 0 && !viewModel.IsLoading.Value);
+        AiJob[] jobs = Enumerable.Range(0, 50)
+            .Select(index => CreateJob(
+                "image",
+                "succeeded",
+                ParseInput($"{{\"prompt\":\"viewport {index}\"}}"),
+                $"https://beutl.beditor.net/api/contents/viewport-{index}") with
+            {
+                Id = new AiJobId($"viewport-{index}"),
+                FileId = new AiContentId($"viewport-{index}"),
+            })
+            .ToArray();
+        viewModel.ApplySnapshot(new AiJobMonitorSnapshot([.. jobs], null, false, null));
+        var view = new AiJobCenterView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 360, Height = 320 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+            await WaitUntilAsync(() => Volatile.Read(ref contentRequests) > 0);
+            await Task.Delay(50);
+            HeadlessTestHelpers.Render();
+            int initialRequests = Volatile.Read(ref contentRequests);
+            Assert.That(initialRequests, Is.LessThan(50));
+
+            ItemsControl jobList = view.FindControl<ItemsControl>("JobList")!;
+            ScrollViewer scrollViewer = jobList.FindAncestorOfType<ScrollViewer>()!;
+            scrollViewer.Offset = new Avalonia.Vector(0, scrollViewer.Extent.Height);
+            HeadlessTestHelpers.Render();
+            await WaitUntilAsync(() => Volatile.Read(ref contentRequests) > initialRequests);
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ViewModel_ShowsTheGeneratedPictureBesideItsPrompt()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-previews");
+        int contentRequests = 0;
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/user/ai-availability" => JsonResponse(
+                HttpStatusCode.OK,
+                """{ "available": true }"""),
+            "/api/v3/ai/jobs" => JsonResponse(HttpStatusCode.OK, JobsJson(deleted: false)),
+            "/api/contents/file-success" => CountedPng(ref contentRequests),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateJobCenter(editor, clients);
+
+        await WaitUntilAsync(() => viewModel.Jobs.Count == 2);
+        AiJobItemViewModel completed = viewModel.Jobs.Single(item => item.Id == "job-success");
+        AiJobItemViewModel failed = viewModel.Jobs.Single(item => item.Id == "job-failed");
+        Assert.That(contentRequests, Is.Zero, "Unrealized history rows must not download previews.");
+        viewModel.SetPreviewVisibility(completed, true);
+        await WaitUntilAsync(() => completed.Preview is not null);
+
+        int afterFirstLoad = contentRequests;
+        viewModel.ApplySnapshot(new AiJobMonitorSnapshot(
+            [completed.Job, failed.Job],
+            NextCursor: null,
+            IsLoading: false,
+            Error: null));
+        HeadlessTestHelpers.Settle();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(completed.HasImagePreview, Is.True);
+            Assert.That(completed.Preview, Is.Not.Null,
+                "A history of prompts is far slower to search than a history of pictures.");
+            Assert.That(completed.Preview!.Value.Width, Is.LessThanOrEqualTo(512));
+            Assert.That(completed.Preview!.Value.Height, Is.LessThanOrEqualTo(512));
+            Assert.That(failed.Preview, Is.Null, "A job that failed produced nothing to show.");
+            Assert.That(contentRequests, Is.EqualTo(afterFirstLoad),
+                "Polling must not fetch the same picture again.");
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ViewModel_EvictsOffscreenPreviewAndReloadsItWhenVisibleAgain()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-preview-eviction");
+        int contentRequests = 0;
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/user/ai-availability" => JsonResponse(
+                HttpStatusCode.OK,
+                """{ "available": true }"""),
+            "/api/v3/ai/jobs" => JsonResponse(HttpStatusCode.OK, JobsJson(deleted: false)),
+            "/api/contents/file-success" => CountedPng(ref contentRequests),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateJobCenter(editor, clients);
+
+        await WaitUntilAsync(() => viewModel.Jobs.Count == 2);
+        AiJobItemViewModel completed = viewModel.Jobs.Single(item => item.Id == "job-success");
+        viewModel.SetPreviewVisibility(completed, true);
+        await WaitUntilAsync(() => completed.Preview is not null);
+        Ref<Bitmap> firstPreview = completed.Preview!;
+
+        viewModel.SetPreviewVisibility(completed, false);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(completed.Preview, Is.Null);
+            Assert.That(firstPreview.Value, Is.Null,
+                "A virtualized row must release its decoded bitmap when it leaves the viewport.");
+            Assert.That(completed.IsPreviewLoadRequested, Is.False);
+        }
+
+        viewModel.SetPreviewVisibility(completed, true);
+        await WaitUntilAsync(() => completed.Preview is not null && contentRequests == 2);
+        Assert.That(completed.Preview, Is.Not.SameAs(firstPreview));
+    }
+
+    [AvaloniaTest]
+    public async Task ViewModel_DiscardsOutOfOrderSnapshots()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-snapshot-order");
+        using var handler = new StubHandler(_ => JsonResponse(HttpStatusCode.OK, "{}"));
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateJobCenter(editor, clients);
+        AiJob job = CreateJob("video", "succeeded");
+
+        viewModel.ApplySnapshot(new AiJobMonitorSnapshot([job], null, false, null), sequence: 100);
+        viewModel.ApplySnapshot(new AiJobMonitorSnapshot([], null, false, null), sequence: 99);
+
+        Assert.That(viewModel.Jobs.Select(item => item.Id).ToArray(), Is.EqualTo(new[] { "job-1" }));
+    }
+
+    [AvaloniaTest]
+    public async Task ViewModel_RetriesPreviewAfterTransientDecodeFailure()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-preview-retry");
+        int contentRequests = 0;
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/user/ai-availability" => JsonResponse(
+                HttpStatusCode.OK,
+                """{ "available": true }"""),
+            "/api/v3/ai/jobs" => JsonResponse(HttpStatusCode.OK, JobsJson(deleted: false)),
+            "/api/contents/file-success" => ++contentRequests == 1
+                ? ByteResponse([0, 1, 2], "image/png")
+                : ByteResponse(s_png, "image/png"),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateJobCenter(editor, clients);
+
+        await WaitUntilAsync(() => viewModel.Jobs.Count == 2);
+        AiJobItemViewModel completed = viewModel.Jobs.Single(item => item.Id == "job-success");
+        viewModel.SetPreviewVisibility(completed, true);
+        await WaitUntilAsync(() => contentRequests > 0);
+        await WaitUntilAsync(() => !completed.IsPreviewLoadRequested);
+        // A subsequent authoritative snapshot may retry a transiently failed
+        // preview because the failed load released its claim.
+        viewModel.ApplySnapshot(new AiJobMonitorSnapshot(
+            [completed.Job, viewModel.Jobs.Single(item => item.Id == "job-failed").Job],
+            NextCursor: null,
+            IsLoading: false,
+            Error: null));
+        await WaitUntilAsync(() => completed.Preview is not null);
+
+        Assert.That(contentRequests, Is.GreaterThanOrEqualTo(2));
+    }
+
+    [AvaloniaTest]
+    public async Task ViewModel_DatesAJobByHowLongAgoItRan()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-job-center-dates");
+        using var handler = new StubHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/user/ai-availability" => JsonResponse(
+                HttpStatusCode.OK,
+                """{ "available": true }"""),
+            "/api/v3/ai/jobs" => JsonResponse(HttpStatusCode.OK, JobsJson(deleted: false)),
+            "/api/contents/file-success" => ByteResponse(s_png, "image/png"),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(clients, httpClient);
+        using var viewModel = CreateJobCenter(editor, clients);
+
+        await WaitUntilAsync(() => viewModel.Jobs.Count == 2);
+        AiJobItemViewModel completed = viewModel.Jobs.Single(item => item.Id == "job-success");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(completed.CreatedAtText, Is.Not.Empty);
+            Assert.That(completed.CreatedAtTooltip, Is.Not.Empty,
+                "The exact time is still one hover away.");
+            Assert.That(completed.CreatedAtText, Is.Not.EqualTo(completed.CreatedAtTooltip));
+        }
+    }
+
+    [Test]
+    public void RelativeTime_ReadsAsHowLongAgoUntilTheDateIsWhatIdentifiesIt()
+    {
+        var now = new DateTimeOffset(2026, 8, 19, 12, 0, 0, TimeSpan.Zero);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(RelativeTimeText.Format(now, now), Is.EqualTo(Strings.TimeAgoJustNow));
+            Assert.That(RelativeTimeText.Format(now.AddSeconds(30), now),
+                Is.EqualTo(Strings.TimeAgoJustNow));
+            Assert.That(RelativeTimeText.Format(now.AddMinutes(-5), now),
+                Is.EqualTo(string.Format(Strings.TimeAgoMinutesFormat, 5)));
+            Assert.That(RelativeTimeText.Format(now.AddHours(-3), now),
+                Is.EqualTo(string.Format(Strings.TimeAgoHoursFormat, 3)));
+            Assert.That(RelativeTimeText.Format(now.AddDays(-2), now),
+                Is.EqualTo(string.Format(Strings.TimeAgoDaysFormat, 2)));
+            Assert.That(RelativeTimeText.Format(now.AddDays(-30), now),
+                Is.EqualTo(now.AddDays(-30).ToLocalTime().ToString("d")),
+                "Past a week the calendar date is what identifies it.");
+            Assert.That(RelativeTimeText.Format(now.AddMinutes(5), now),
+                Is.EqualTo(Strings.TimeAgoJustNow),
+                "A clock that is ahead of the server must not read as a negative age.");
+        }
+    }
+
+    private static HttpResponseMessage CountedPng(ref int requests)
+    {
+        requests++;
+        return ByteResponse(s_png, "image/png");
+    }
+
+    private AiJobCenterViewModel CreateJobCenter(
+        EditViewModel editor,
+        BeutlApiApplication clients)
+        => new(
+            editor,
+            clients.GetResource<IAiEntitlementService>(),
+            clients.GetResource<IAuthenticatedContentService>(),
+            clients.GetResource<IAiJobClient>(),
+            clients.GetResource<IAiJobMonitor>(),
+            clients.GetResource<IAiJobKindRegistry>(),
+            _resultHandlers,
+            null);
+
+    private static AiJob CreateJob(
+        string kind,
+        string status,
+        JsonElement? inputParams = null,
+        string? url = null,
+        string? error = null,
+        bool canRetry = false)
+    {
+        return new AiJob(
+            new AiJobId("job-1"),
+            new AiJobKindId(kind),
+            new AiJobStatusId(status),
+            inputParams,
+            url is null ? null : new AiContentId("file-1"),
+            string.IsNullOrWhiteSpace(url) ? null : new Uri(url),
+            error,
+            canRetry,
+            new DateTimeOffset(2026, 8, 1, 0, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 8, 1, 0, 1, 0, TimeSpan.Zero));
+    }
+
+    private static JsonElement ParseInput(string json)
+    {
+        using JsonDocument document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    private static async Task<EditViewModel> OpenEditor(string name)
+    {
+        string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(workspace);
+        Project project = (await TestShell.Project.CreateProject(
+            640, 480, 30, 44100, name, workspace))!;
+        Scene scene = project.Items.OfType<Scene>().First();
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (!condition())
+        {
+            HeadlessTestHelpers.Settle();
+            await Task.Delay(10, cancellationTokenSource.Token);
+        }
+    }
+
+    private static void SetAuthenticatedUser(BeutlApiApplication app, HttpClient httpClient)
+    {
+        httpClient.BaseAddress = new Uri("https://beutl.beditor.net");
+        var profile = new Profile(new ProfileResponse
+        {
+            Id = "test-user",
+            Name = "test",
+            DisplayName = "Test User",
+            Bio = null,
+            IconId = null,
+            IconUrl = null,
+        }, app);
+        var user = new AuthenticatedUser(
+            profile,
+            new AuthResponse
+            {
+                Token = "token",
+                RefreshToken = "refresh-token",
+                Expiration = DateTime.UtcNow.AddHours(1),
+            },
+            app,
+            DateTime.UtcNow);
+        FieldInfo field = typeof(BeutlApiApplication).GetField(
+            "_authenticatedUser",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        ((global::Reactive.Bindings.ReactivePropertySlim<AuthenticatedUser?>)field.GetValue(app)!).Value = user;
+    }
+
+    private static string EntitlementsJson(bool canStartImage = true, int usedPercent = 4) => $$"""
+        {
+          "plan": "pro",
+          "subscriptionStatus": "active",
+          "currentPeriodStart": "2026-08-01T00:00:00Z",
+          "currentPeriodEnd": "2026-09-01T00:00:00Z",
+          "canUseAi": true,
+          "balance": {
+            "monthlyUsage": {
+              "usedPercent": {{usedPercent}},
+              "remainingPercent": {{100 - usedPercent}},
+              "isExhausted": {{(usedPercent >= 100 ? "true" : "false")}}
+            },
+            "additionalCredits": 0,
+            "hasAdditionalCreditDebt": false
+          },
+          "availability": {
+            "image.generate": {{(canStartImage ? "true" : "false")}},
+            "video.generate": {{(canStartImage ? "true" : "false")}}
+          }
+        }
+        """;
+
+    private static string ImageResponseJson() => """
+        {
+          "jobId": "retry-job",
+          "fileId": "retry-file",
+          "url": "https://beutl.beditor.net/api/contents/retry-file"
+        }
+        """;
+
+    private static string JobsJson(bool deleted)
+    {
+        var jobs = new List<object>
+        {
+            new
+            {
+                id = "job-success",
+                kind = "image",
+                status = "succeeded",
+                inputParams = new { size = "1024x1024" },
+                fileId = "file-success",
+                url = "https://beutl.beditor.net/api/contents/file-success",
+                usageUnits = 20,
+                error = (string?)null,
+                canRetry = false,
+                createdAt = "2026-08-01T00:00:00Z",
+                updatedAt = "2026-08-01T00:01:00Z",
+            },
+        };
+        if (!deleted)
+        {
+            jobs.Add(new
+            {
+                id = "job-failed",
+                kind = "image",
+                status = "failed",
+                inputParams = new { prompt = "Retry me", size = "1024x1024" },
+                fileId = (string?)null,
+                url = (string?)null,
+                usageUnits = 20,
+                error = "Provider failed",
+                canRetry = true,
+                createdAt = "2026-08-01T00:02:00Z",
+                updatedAt = "2026-08-01T00:03:00Z",
+            });
+        }
+
+        return JsonSerializer.Serialize(new { jobs, nextCursor = (string?)null });
+    }
+
+    private static HttpResponseMessage JsonResponse(HttpStatusCode status, string json)
+        => new(status)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+
+    private static HttpResponseMessage ByteResponse(byte[] bytes, string mediaType)
+        => new(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(bytes)
+            {
+                Headers = { ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(mediaType) },
+            },
+        };
+
+    private sealed class StubHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder) : HttpMessageHandler
+    {
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+            : this((request, _) => Task.FromResult(responder(request)))
+        {
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            HttpResponseMessage response = await responder(request, cancellationToken);
+            response.RequestMessage = request;
+            return response;
+        }
+    }
+
+    private sealed class UnusedImageGenerationService : IAiImageGenerationService
+    {
+        public Task<AiImageResult> GenerateAsync(
+            AiImageGenerationRequest request,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<AiImageResult> GenerateAsync(
+            AiImageGenerationRequest request,
+            IProgress<AiImagePreview>? progress,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class UnusedVideoService : IAiVideoService
+    {
+        public Task<AiVideoGenerationResult> CreateAsync(
+            AiVideoGenerationRequest request,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<AiVideoJob> GetAsync(AiJobId jobId, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class UnusedEntitlementService : IAiEntitlementService
+    {
+        public IReadOnlyReactiveProperty<AiEntitlements?> Entitlements { get; } =
+            new ReactivePropertySlim<AiEntitlements?>();
+
+        public Task<AiEntitlements?> RefreshAsync(CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class UnusedAvailabilityService : IAiOperationAvailabilityService
+    {
+        public Task<bool> CheckAsync(
+            AiOperationAvailabilityRequest request,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class UnusedModelCatalogService : IAiModelCatalogService
+    {
+        public Task<AiModelCatalog> GetAsync(CancellationToken cancellationToken)
+            => Task.FromResult(AiModelCatalog.Empty);
+
+        public void Invalidate()
+        {
+        }
+    }
+
+    private sealed class CustomRetryHandler : IAiJobRetryHandler
+    {
+        public int RetryCount { get; private set; }
+
+        public bool CanRetry(AiJob job, AiJobStatusSemantics status)
+            => job.CanRetry && status.Outcome == new AiJobOutcomeId("vendor.retryable");
+
+        public ValueTask<AiJobRetryPreflight> GetPreflightAsync(
+            AiJob job,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(new AiJobRetryPreflight(
+                true,
+                true,
+                "No additional charge"));
+        }
+
+        public ValueTask<AiJobRetryPreparationResult> PrepareAsync(
+            AiJob job,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult<AiJobRetryPreparationResult>(
+                AiJobRetryPreparationResult.Ready(new CustomRetryPreparation(this)));
+        }
+
+        private sealed class CustomRetryPreparation(CustomRetryHandler owner)
+            : IAiJobRetryPreparation
+        {
+            private int _executed;
+
+            public Task ExecuteAsync(CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (Interlocked.Exchange(ref _executed, 1) != 0)
+                    throw new InvalidOperationException("The retry preparation was already executed.");
+                owner.RetryCount++;
+                return Task.CompletedTask;
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                return ValueTask.CompletedTask;
+            }
+        }
+    }
+
+    private sealed class FailingRefreshJobMonitor : IAiJobMonitor
+    {
+        public int RefreshCount { get; private set; }
+
+        public IReadOnlyReactiveProperty<AiJobMonitorSnapshot> Snapshot { get; } =
+            new ReactivePropertySlim<AiJobMonitorSnapshot>(AiJobMonitorSnapshot.Empty);
+
+        public IDisposable AcquirePolling()
+            => System.Reactive.Disposables.Disposable.Empty;
+
+        public Task RefreshAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            RefreshCount++;
+            return Task.FromException(new HttpRequestException("refresh failed"));
+        }
+
+        public Task LoadNextPageAsync(CancellationToken cancellationToken)
+            => Task.CompletedTask;
+    }
+
+    private sealed class ThrowingRetryHandler : IAiJobRetryHandler
+    {
+        public bool CanRetry(AiJob job, AiJobStatusSemantics status)
+            => throw new InvalidOperationException("eligibility failed");
+
+        public ValueTask<AiJobRetryPreflight> GetPreflightAsync(
+            AiJob job,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public ValueTask<AiJobRetryPreparationResult> PrepareAsync(
+            AiJob job,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+
+    private class SlowRetryHandler : IAiJobRetryHandler
+    {
+        public TaskCompletionSource Started { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Release { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool CancellationObserved { get; private set; }
+
+        private readonly bool _throwOnCancellation;
+
+        public SlowRetryHandler(bool throwOnCancellation = false)
+        {
+            _throwOnCancellation = throwOnCancellation;
+        }
+
+        public bool CanRetry(AiJob job, AiJobStatusSemantics status) => true;
+
+        public async ValueTask<AiJobRetryPreflight> GetPreflightAsync(
+            AiJob job,
+            CancellationToken cancellationToken)
+        {
+            Started.TrySetResult();
+            using CancellationTokenRegistration registration = cancellationToken.Register(() =>
+            {
+                CancellationObserved = true;
+                if (_throwOnCancellation)
+                    throw new InvalidOperationException("synchronous cancellation callback failure");
+            });
+            try
+            {
+                await Release.Task.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                CancellationObserved = true;
+                // Stay in-flight until the test releases the handler. This models a provider
+                // callback that observes cancellation but must still drain before its extension
+                // retry handler can be unloaded.
+                await Release.Task;
+                throw;
+            }
+
+            return new AiJobRetryPreflight(true, true, "slow");
+        }
+
+        public ValueTask<AiJobRetryPreparationResult> PrepareAsync(
+            AiJob job,
+            CancellationToken cancellationToken)
+            => ValueTask.FromResult(AiJobRetryPreparationResult.Blocked("unused"));
+    }
+
+    private sealed class ThrowingCancelRetryHandler : SlowRetryHandler
+    {
+        public ThrowingCancelRetryHandler() : base(throwOnCancellation: true) { }
+    }
+
+    private sealed class BlockingExecutionRetryHandler : IAiJobRetryHandler
+    {
+        public TaskCompletionSource ExecutionStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ReleaseExecution { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool PreparationDisposed { get; private set; }
+
+        public bool CanRetry(AiJob job, AiJobStatusSemantics status) => true;
+
+        public ValueTask<AiJobRetryPreflight> GetPreflightAsync(
+            AiJob job,
+            CancellationToken cancellationToken)
+            => ValueTask.FromResult(new AiJobRetryPreflight(true, true, "ready"));
+
+        public ValueTask<AiJobRetryPreparationResult> PrepareAsync(
+            AiJob job,
+            CancellationToken cancellationToken)
+            => ValueTask.FromResult(AiJobRetryPreparationResult.Ready(
+                new Preparation(this)));
+
+        private sealed class Preparation(BlockingExecutionRetryHandler owner)
+            : IAiJobRetryPreparation
+        {
+            public async Task ExecuteAsync(CancellationToken cancellationToken)
+            {
+                owner.ExecutionStarted.TrySetResult();
+                await owner.ReleaseExecution.Task.WaitAsync(cancellationToken);
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                owner.PreparationDisposed = true;
+                return ValueTask.CompletedTask;
+            }
+        }
+    }
+
+    private sealed class BlockingResultApplicator : IAiJobResultApplicator
+    {
+        public TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public bool CanApply(AiJob job, AiJobStatusSemantics status) => true;
+        public async Task ApplyAsync(AiJob job, IAiJobResultContext context, CancellationToken cancellationToken)
+        {
+            Started.TrySetResult();
+            await Release.Task;
+        }
+    }
+
+    private sealed class ThrowingPresenter : IAiJobPresenter
+    {
+        public AiJobPresentation Present(AiJob job, AiJobStatusSemantics status)
+            => throw new InvalidOperationException("presentation failure");
+    }
+
+    private sealed class NullPresentationPresenter : IAiJobPresenter
+    {
+        public AiJobPresentation Present(AiJob job, AiJobStatusSemantics status)
+            => new(null!, null!, null!, null!, false);
+    }
+
+    private sealed class CustomResultCapabilities(EditViewModel expectedEditor) :
+        IAiJobPresenter,
+        IAiJobResultApplicator
+    {
+        public int HandleCount { get; private set; }
+
+        public bool ResolvedSceneEditingContext { get; private set; }
+
+        public AiJobPresentation Present(AiJob job, AiJobStatusSemantics status)
+        {
+            bool retryable = status.Outcome == new AiJobOutcomeId("vendor.retryable");
+            return new AiJobPresentation(
+                "Vendor upscale",
+                retryable ? "Ready to retry" : "Ready to open",
+                "Upscale this",
+                "2×",
+                retryable);
+        }
+
+        public bool CanApply(AiJob job, AiJobStatusSemantics status)
+            => status.Outcome == new AiJobOutcomeId("vendor.ready");
+
+        public Task ApplyAsync(
+            AiJob job,
+            IAiJobResultContext context,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            HandleCount++;
+            ResolvedSceneEditingContext =
+                ReferenceEquals(context.Editor, expectedEditor)
+                && ReferenceEquals(context.Editor.Scene, expectedEditor.Scene)
+                && ReferenceEquals(
+                    context.Editor.ElementAdder,
+                    expectedEditor.GetService(typeof(IElementAdder)));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class IndependentResultCapabilities :
+        IAiJobPresenter,
+        IAiJobResultApplicator
+    {
+        public int HandleCount { get; private set; }
+
+        public AiJobPresentation Present(AiJob job, AiJobStatusSemantics status)
+            => new("Independent", "Ready", "Independent result", string.Empty, false);
+
+        public bool CanApply(AiJob job, AiJobStatusSemantics status) => true;
+
+        public Task ApplyAsync(
+            AiJob job,
+            IAiJobResultContext context,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            HandleCount++;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiJobCenterTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiJobCenterTests.cs
@@ -35,6 +35,46 @@ namespace Beutl.HeadlessUITests;
 [TestFixture, NonParallelizable]
 public sealed class AiJobCenterTests
 {
+    [AvaloniaTest]
+    public async Task Caption_presentation_targets_the_originating_editor_after_selection_changes()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel origin = await OpenEditor("caption-origin");
+        var second = new Scene(640, 480, "second")
+        {
+            Uri = new Uri(Path.Combine(Path.GetDirectoryName(origin.Scene.Uri!.LocalPath)!, "second.scene")),
+        };
+        Beutl.Serialization.CoreSerializer.StoreToUri(second, second.Uri!);
+        TestShell.Project.CurrentProject.Value!.Items.Add(second);
+        TestShell.Editor.ActivateTabItem(second);
+        HeadlessTestHelpers.Settle();
+        var selected = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
+        var result = new AiCaptionHistoryResult(new AiJobId("origin-caption"),
+            [new AiTranscriptionSegment { Start = 0, End = 1, Text = "Origin only" }], "en");
+        Assert.That(await TestShell.MainViewModel.PresentCaptionResultAsync(origin, result), Is.True);
+        Assert.That(origin.FindToolTab<AiWorkspaceViewModel>(), Is.Not.Null);
+        Assert.That(selected.FindToolTab<AiWorkspaceViewModel>(), Is.Null);
+        var originTab = TestShell.Editor.TabItems.Single(item => ReferenceEquals(item.Context.Value, origin));
+        await TestShell.Editor.CloseTabItem(originTab);
+        Assert.That(await TestShell.MainViewModel.PresentCaptionResultAsync(origin, result), Is.False);
+    }
+
+    [AvaloniaTest]
+    public async Task Caption_result_context_awaits_presentation_acceptance()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("caption-acceptance");
+        var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var context = new AiJobResultContext(editor,
+            TestShell.MainViewModel._beutlClients.GetResource<IAuthenticatedContentService>(),
+            _ => completion.Task);
+        Task<bool> presenting = context.TryPresentCaptionResultAsync(
+            new AiCaptionHistoryResult(new AiJobId("job"), [], null));
+        Assert.That(presenting.IsCompleted, Is.False);
+        completion.SetResult(false);
+        Assert.That(await presenting, Is.False);
+    }
+
     private static readonly byte[] s_png = Convert.FromBase64String(
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==");
     private AiJobKindRegistry _jobKinds = null!;

--- a/tests/Beutl.HeadlessUITests/AiJobCompletionNotifierTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiJobCompletionNotifierTests.cs
@@ -1,0 +1,338 @@
+﻿using System.Reactive.Subjects;
+using Beutl.Api.Services;
+using Beutl.Editor.Services.AI;
+using Beutl.Language;
+using Beutl.Services;
+using Beutl.Services.AI;
+using Reactive.Bindings;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture, NonParallelizable]
+public sealed class AiJobCompletionNotifierTests
+{
+    [Test]
+    public async Task ActiveToTerminalTransition_NotifiesOnceAndProvidesJobCenterAction()
+    {
+        INotificationServiceHandler? previousHandler = NotificationService.Handler;
+        var handler = new CaptureNotificationHandler();
+        NotificationService.Handler = handler;
+        try
+        {
+            using var snapshots = new Subject<AiJobMonitorSnapshot>();
+            await using AiJobKindRegistry jobKinds = CreateBuiltInRegistry();
+            await using var resultHandlers = CreateBuiltInResultRegistry();
+            int openCount = 0;
+            using var notifier = new AiJobCompletionNotifier(
+                snapshots,
+                jobKinds,
+                resultHandlers,
+                () => openCount++);
+            AiJob queued = CreateJob(AiJobStatuses.Queued);
+
+            snapshots.OnNext(new AiJobMonitorSnapshot([queued], null, false, null));
+            snapshots.OnNext(new AiJobMonitorSnapshot([queued with { Status = AiJobStatuses.Succeeded }], null, true, null));
+            Assert.That(handler.Notifications, Is.Empty);
+
+            snapshots.OnNext(new AiJobMonitorSnapshot([queued with { Status = AiJobStatuses.Succeeded }], null, false, null));
+            snapshots.OnNext(new AiJobMonitorSnapshot([queued with { Status = AiJobStatuses.Succeeded }], null, false, null));
+
+            Assert.That(handler.Notifications, Has.Count.EqualTo(1));
+            Notification notification = handler.Notifications[0];
+            Assert.Multiple(() =>
+            {
+                Assert.That(notification.Type, Is.EqualTo(NotificationType.Success));
+                Assert.That(notification.Actions, Has.Count.EqualTo(1));
+            });
+
+            notification.Actions![0].Callback();
+            Assert.That(openCount, Is.EqualTo(1));
+        }
+        finally
+        {
+            NotificationService.Handler = previousHandler ?? NullNotificationHandler.Instance;
+        }
+    }
+
+    [Test]
+    public async Task FailedTransition_ShowsUsageRestoredWarning()
+    {
+        INotificationServiceHandler? previousHandler = NotificationService.Handler;
+        var handler = new CaptureNotificationHandler();
+        NotificationService.Handler = handler;
+        try
+        {
+            using var snapshots = new Subject<AiJobMonitorSnapshot>();
+            await using AiJobKindRegistry jobKinds = CreateBuiltInRegistry();
+            await using var resultHandlers = CreateBuiltInResultRegistry();
+            using var notifier = new AiJobCompletionNotifier(
+                snapshots,
+                jobKinds,
+                resultHandlers,
+                () => { });
+            AiJob running = CreateJob(AiJobStatuses.Running);
+
+            snapshots.OnNext(new AiJobMonitorSnapshot([running], null, false, null));
+            snapshots.OnNext(new AiJobMonitorSnapshot([running with { Status = AiJobStatuses.Failed }], null, false, null));
+
+            Assert.That(handler.Notifications, Has.Count.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(handler.Notifications[0].Type, Is.EqualTo(NotificationType.Warning));
+                Assert.That(
+                    handler.Notifications[0].Message,
+                    Is.EqualTo(string.Format(
+                        Strings.AiJobCenter_FailedNotification,
+                        Strings.AiVideoGeneration)));
+            });
+        }
+        finally
+        {
+            NotificationService.Handler = previousHandler ?? NullNotificationHandler.Instance;
+        }
+    }
+
+    [Test]
+    public async Task CanceledTransition_ShowsNeutralCanceledNotification()
+    {
+        INotificationServiceHandler? previousHandler = NotificationService.Handler;
+        var handler = new CaptureNotificationHandler();
+        NotificationService.Handler = handler;
+        try
+        {
+            using var snapshots = new Subject<AiJobMonitorSnapshot>();
+            await using AiJobKindRegistry jobKinds = CreateBuiltInRegistry();
+            await using var resultHandlers = CreateBuiltInResultRegistry();
+            using var notifier = new AiJobCompletionNotifier(
+                snapshots,
+                jobKinds,
+                resultHandlers,
+                () => { });
+            AiJob running = CreateJob(AiJobStatuses.Running);
+
+            snapshots.OnNext(new AiJobMonitorSnapshot([running], null, false, null));
+            snapshots.OnNext(new AiJobMonitorSnapshot(
+                [running with { Status = AiJobStatuses.Canceled }],
+                null,
+                false,
+                null));
+
+            Assert.That(handler.Notifications, Has.Count.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(handler.Notifications[0].Type, Is.EqualTo(NotificationType.Information));
+                Assert.That(
+                    handler.Notifications[0].Message,
+                    Is.EqualTo(string.Format(
+                        Strings.AiJobCenter_CanceledNotification,
+                        Strings.AiVideoGeneration)));
+                Assert.That(
+                    handler.Notifications[0].Message,
+                    Is.Not.EqualTo(string.Format(
+                        Strings.AiJobCenter_FailedNotification,
+                        Strings.AiVideoGeneration)));
+            });
+        }
+        finally
+        {
+            NotificationService.Handler = previousHandler ?? NullNotificationHandler.Instance;
+        }
+    }
+
+    [Test]
+    public async Task CustomKind_ControlsTerminalOutcomeAndCompletion()
+    {
+        INotificationServiceHandler? previousHandler = NotificationService.Handler;
+        var notificationHandler = new CaptureNotificationHandler();
+        NotificationService.Handler = notificationHandler;
+        try
+        {
+            await using var jobKinds = new AiJobKindRegistry();
+            var kind = new AiJobKindId("vendor.upscale");
+            var statusResolver = new AiJobStatusMap(
+                [
+                    KeyValuePair.Create(
+                        new AiJobStatusId("waiting-for-gpu"),
+                        new AiJobStatusSemantics(false, false)),
+                    KeyValuePair.Create(
+                        new AiJobStatusId("ready-for-review"),
+                        new AiJobStatusSemantics(
+                            true,
+                            false,
+                            new AiJobOutcomeId("vendor.review"))),
+                ]);
+            await using IAiJobStatusResolverRegistration registration = jobKinds.Register(
+                new AiJobStatusResolverRegistration(kind, statusResolver));
+            await using var resultHandlers = new AiJobResultRegistry(
+                [],
+                [new AiJobCompletionRegistration(
+                    new AiJobKindId("vendor.upscale"),
+                    new CustomCompletionPresenter())],
+                []);
+            using var snapshots = new Subject<AiJobMonitorSnapshot>();
+            using var notifier = new AiJobCompletionNotifier(
+                snapshots,
+                jobKinds,
+                resultHandlers,
+                () => { });
+            AiJob waiting = CreateJob(
+                new AiJobStatusId("waiting-for-gpu"),
+                new AiJobKindId("vendor.upscale"));
+
+            snapshots.OnNext(new AiJobMonitorSnapshot([waiting], null, false, null));
+            snapshots.OnNext(new AiJobMonitorSnapshot(
+                [waiting with { Status = new AiJobStatusId("ready-for-review") }],
+                null,
+                false,
+                null));
+
+            Assert.That(notificationHandler.Notifications, Has.Count.EqualTo(1));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(notificationHandler.Notifications[0].Title, Is.EqualTo("Vendor review"));
+                Assert.That(notificationHandler.Notifications[0].Message, Is.EqualTo("Upscale is ready"));
+                Assert.That(notificationHandler.Notifications[0].Type, Is.EqualTo(NotificationType.Information));
+            }
+        }
+        finally
+        {
+            NotificationService.Handler = previousHandler ?? NullNotificationHandler.Instance;
+        }
+    }
+
+    [Test]
+    public async Task ThrowingCompletionHandler_DoesNotEscapeSnapshotObserver()
+    {
+        await using var jobKinds = CreateBuiltInRegistry();
+        await using var resultHandlers = new AiJobResultRegistry(
+            [],
+            [new AiJobCompletionRegistration(
+                AiJobKinds.Video,
+                new ThrowingCompletionPresenter())],
+            []);
+        using var snapshots = new Subject<AiJobMonitorSnapshot>();
+        using var notifier = new AiJobCompletionNotifier(snapshots, jobKinds, resultHandlers, () => { });
+        AiJob running = CreateJob(AiJobStatuses.Running);
+
+        Assert.DoesNotThrow(() =>
+        {
+            snapshots.OnNext(new AiJobMonitorSnapshot([running], null, false, null));
+            snapshots.OnNext(new AiJobMonitorSnapshot(
+                [running with { Status = AiJobStatuses.Succeeded }], null, false, null));
+        });
+    }
+
+    private static AiJobKindRegistry CreateBuiltInRegistry()
+        => AiJobKindRegistry.CreateBuiltIn(
+            new UnusedImageGenerationService(),
+            new UnusedVideoService(),
+            new UnusedEntitlementService(),
+            new UnusedAvailabilityService(),
+            new UnusedModelCatalogService(),
+            AiRetryTestContext.Create());
+
+    private static AiJobResultRegistry CreateBuiltInResultRegistry()
+        => BuiltInAiJobResultCapabilities.CreateRegistry();
+
+    private static AiJob CreateJob(AiJobStatusId status, AiJobKindId? kind = null)
+        => new(
+            new AiJobId("job-1"),
+            kind ?? AiJobKinds.Video,
+            status,
+            null,
+            null,
+            null,
+            null,
+            false,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+
+    private sealed class CaptureNotificationHandler : INotificationServiceHandler
+    {
+        public List<Notification> Notifications { get; } = [];
+
+        public void Show(Notification notification) => Notifications.Add(notification);
+    }
+
+    private sealed class NullNotificationHandler : INotificationServiceHandler
+    {
+        public static NullNotificationHandler Instance { get; } = new();
+
+        public void Show(Notification notification)
+        {
+        }
+    }
+
+    private sealed class CustomCompletionPresenter : IAiJobCompletionPresenter
+    {
+        public AiJobCompletionPresentation? CreateCompletion(
+            AiJob job,
+            AiJobStatusSemantics status)
+            => status.Outcome == new AiJobOutcomeId("vendor.review")
+                ? new AiJobCompletionPresentation(
+                    "Vendor review",
+                    "Upscale is ready",
+                    AiJobNotificationKind.Information)
+                : null;
+    }
+
+    private sealed class ThrowingCompletionPresenter : IAiJobCompletionPresenter
+    {
+        public AiJobCompletionPresentation? CreateCompletion(
+            AiJob job,
+            AiJobStatusSemantics status)
+            => throw new InvalidOperationException("completion failure");
+    }
+
+    private sealed class UnusedImageGenerationService : IAiImageGenerationService
+    {
+        public Task<AiImageResult> GenerateAsync(
+            AiImageGenerationRequest request,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<AiImageResult> GenerateAsync(
+            AiImageGenerationRequest request,
+            IProgress<AiImagePreview>? progress,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class UnusedVideoService : IAiVideoService
+    {
+        public Task<AiVideoGenerationResult> CreateAsync(
+            AiVideoGenerationRequest request,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<AiVideoJob> GetAsync(AiJobId jobId, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class UnusedEntitlementService : IAiEntitlementService
+    {
+        public IReadOnlyReactiveProperty<AiEntitlements?> Entitlements { get; } =
+            new ReactivePropertySlim<AiEntitlements?>();
+
+        public Task<AiEntitlements?> RefreshAsync(CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class UnusedAvailabilityService : IAiOperationAvailabilityService
+    {
+        public Task<bool> CheckAsync(
+            AiOperationAvailabilityRequest request,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class UnusedModelCatalogService : IAiModelCatalogService
+    {
+        public Task<AiModelCatalog> GetAsync(CancellationToken cancellationToken)
+            => Task.FromResult(AiModelCatalog.Empty);
+
+        public void Invalidate()
+        {
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiModelPickerLifetimeTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiModelPickerLifetimeTests.cs
@@ -1,0 +1,174 @@
+﻿using System.Collections.Immutable;
+using Avalonia.Headless.NUnit;
+using Beutl.Api.Services;
+using Beutl.ViewModels;
+using Reactive.Bindings;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture, NonParallelizable]
+public sealed class AiModelPickerLifetimeTests
+{
+    [AvaloniaTest]
+    public async Task Dispose_DropsACatalogResultThatIgnoresCancellation()
+    {
+        var catalog = new BlockingCatalog();
+        using var entitlements = new StubEntitlements();
+        var picker = new AiModelPickerViewModel(catalog, entitlements);
+
+        Task load = picker.LoadAsync(AiOperations.ImageGeneration, CancellationToken.None);
+        await catalog.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        picker.Dispose();
+        catalog.Release.TrySetResult(AiModelCatalog.Empty);
+        await load.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(picker.Options, Is.Empty);
+            Assert.That(picker.Operation, Is.EqualTo(default(AiOperationId)));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task Load_SelectsTheServerDefaultBeforeAnEarlierModel()
+    {
+        var catalog = new AiModelCatalog(
+        [
+            KeyValuePair.Create(
+                AiOperations.ImageGeneration,
+                ImmutableArray.Create(
+                    new AiModelOption(new AiModelId("first"), "First", null, false),
+                    new AiModelOption(new AiModelId("default"), "Default", null, true))),
+        ]);
+        using var entitlements = new StubEntitlements();
+        using var picker = new AiModelPickerViewModel(new FixedCatalog(catalog), entitlements);
+
+        await picker.LoadAsync(AiOperations.ImageGeneration, CancellationToken.None);
+
+        Assert.That(picker.SelectedModel, Is.EqualTo(new AiModelId("default")));
+    }
+
+    [AvaloniaTest]
+    public async Task Load_SwitchesToTheReferenceBudgetForTheCurrentOperation()
+    {
+        var firstOperation = new AiOperationId("vendor.picture.small");
+        var secondOperation = new AiOperationId("vendor.picture.large");
+        var catalog = new AiModelCatalog(
+        [
+            KeyValuePair.Create(
+                firstOperation,
+                ImmutableArray.Create(new AiModelOption(
+                    new AiModelId("small"),
+                    "Small",
+                    null,
+                    true))),
+            KeyValuePair.Create(
+                secondOperation,
+                ImmutableArray.Create(new AiModelOption(
+                    new AiModelId("large"),
+                    "Large",
+                    null,
+                    true))),
+        ],
+        imageReferenceLimits:
+        [
+            KeyValuePair.Create(firstOperation, new AiImageReferenceLimits(2 * 1024 * 1024)),
+            KeyValuePair.Create(secondOperation, new AiImageReferenceLimits(18 * 1024 * 1024)),
+        ]);
+        using var entitlements = new StubEntitlements();
+        using var picker = new AiModelPickerViewModel(new FixedCatalog(catalog), entitlements);
+
+        await picker.LoadAsync(firstOperation, CancellationToken.None);
+        long firstBudget = picker.ImageReferenceLimits.MaxTotalBytes;
+        await picker.LoadAsync(secondOperation, CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(firstBudget, Is.EqualTo(2 * 1024 * 1024));
+            Assert.That(picker.Operation, Is.EqualTo(secondOperation));
+            Assert.That(picker.ImageReferenceLimits.MaxTotalBytes,
+                Is.EqualTo(18 * 1024 * 1024));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ReconcileRecoveryModelsReappliesTheCurrentCapabilityFilter()
+    {
+        var recoveryModel = new AiModelId("recovery-only");
+        var catalog = new AiModelCatalog(
+        [
+            KeyValuePair.Create(
+                AiOperations.VideoGeneration,
+                ImmutableArray.Create(new AiModelOption(
+                    recoveryModel,
+                    "Recovery only",
+                    null,
+                    true))),
+        ]);
+        using var entitlements = new StubEntitlements();
+        using var picker = new AiModelPickerViewModel(new FixedCatalog(catalog), entitlements);
+        bool retainRecovery = true;
+        picker.Filter = model => model.Id != recoveryModel;
+        picker.KeepOffered = _ => retainRecovery ? [recoveryModel] : [];
+
+        await picker.LoadAsync(
+            AiOperations.VideoGeneration,
+            recoveryModel,
+            preferredSpecified: true,
+            CancellationToken.None);
+        Assert.That(picker.SelectedModel, Is.EqualTo(recoveryModel));
+        Assert.That(picker.OffersNothingUsable.Value, Is.False);
+
+        retainRecovery = false;
+        picker.ReconcileRecoveryModels();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(picker.Options, Is.Empty);
+            Assert.That(picker.SelectedModel, Is.Null);
+            Assert.That(picker.HasChoice.Value, Is.False);
+            Assert.That(picker.OffersNothingUsable.Value, Is.True);
+        });
+    }
+
+    private sealed class BlockingCatalog : IAiModelCatalogService
+    {
+        public TaskCompletionSource Started { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<AiModelCatalog> Release { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async Task<AiModelCatalog> GetAsync(CancellationToken cancellationToken)
+        {
+            Started.TrySetResult();
+            return await Release.Task;
+        }
+
+        public void Invalidate()
+        {
+        }
+    }
+
+    private sealed class FixedCatalog(AiModelCatalog catalog) : IAiModelCatalogService
+    {
+        public Task<AiModelCatalog> GetAsync(CancellationToken cancellationToken)
+            => Task.FromResult(catalog);
+
+        public void Invalidate()
+        {
+        }
+    }
+
+    private sealed class StubEntitlements : IAiEntitlementService, IDisposable
+    {
+        private readonly ReactivePropertySlim<AiEntitlements?> _entitlements = new();
+
+        public IReadOnlyReactiveProperty<AiEntitlements?> Entitlements => _entitlements;
+
+        public Task<AiEntitlements?> RefreshAsync(CancellationToken cancellationToken)
+            => Task.FromResult(_entitlements.Value);
+
+        public void Dispose() => _entitlements.Dispose();
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiNarrowLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiNarrowLayoutTests.cs
@@ -1,0 +1,93 @@
+﻿using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Layout;
+using Avalonia.LogicalTree;
+using Beutl.Language;
+using Beutl.Testing.Headless;
+using Beutl.Views;
+using Beutl.Views.Tools;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture, NonParallelizable]
+public sealed class AiNarrowLayoutTests
+{
+    [AvaloniaTest, SetUICulture("ja-JP")]
+    public void MainView_TitleBarActionsRemainWithinSixHundredPixels()
+    {
+        var view = new MainView();
+        view.Measure(new Size(600, 420));
+        view.Arrange(new Rect(0, 0, 600, 420));
+
+        Control titlebar = view.FindControl<Control>("Titlebar")!;
+        Control menu = view.FindControl<Control>("MenuBar")!;
+        Control actions = view.FindControl<Control>("TitlebarActions")!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(titlebar.Bounds.Width, Is.LessThanOrEqualTo(600));
+            Assert.That(menu.Bounds.Right, Is.LessThanOrEqualTo(actions.Bounds.Left + 1));
+            Assert.That(actions.Bounds.Right, Is.LessThanOrEqualTo(titlebar.Bounds.Width + 1));
+        }
+    }
+
+    [AvaloniaTest]
+    public void AiToolViews_NarrowWidthDoesNotRequireHorizontalScrolling()
+    {
+        UserControl[] views =
+        [
+            new AiImageEditView(),
+            new AiImageGenerationView(),
+            new AiSubtitleView(),
+            new AiVideoGenerationView(),
+        ];
+
+        foreach (UserControl view in views)
+        {
+            var window = new Window { Content = view, Width = 180, Height = 500 };
+            try
+            {
+                window.Show();
+                HeadlessTestHelpers.Render();
+
+                ScrollViewer scrollViewer = (ScrollViewer)view.Content!;
+                Assert.That(
+                    scrollViewer.Extent.Width,
+                    Is.LessThanOrEqualTo(scrollViewer.Viewport.Width + 1),
+                    $"{view.GetType().Name} must keep every action reachable without horizontal scrolling.");
+
+                Assert.That(
+                    view.GetLogicalDescendants().OfType<ProgressBar>(),
+                    Is.Empty,
+                    $"{view.GetType().Name} reports usage as text, which a narrow pane can trim.");
+            }
+            finally
+            {
+                window.Close();
+                HeadlessTestHelpers.Settle();
+            }
+        }
+    }
+
+    [AvaloniaTest]
+    public void AiJobCenter_NarrowActionsWrapWithinCardsAndConfirmation()
+    {
+        var view = new AiJobCenterView();
+
+        using (Assert.EnterMultipleScope())
+        {
+            WrapPanel confirmationActions = view.GetLogicalDescendants()
+                .OfType<WrapPanel>()
+                .Single(panel => panel.Children.OfType<Button>()
+                    .Any(button => AutomationProperties.GetName(button) == Strings.Cancel));
+            Assert.That(confirmationActions.Orientation, Is.EqualTo(Orientation.Horizontal));
+
+            WrapPanel footerActions = view.GetLogicalDescendants()
+                .OfType<WrapPanel>()
+                .Single(panel => panel.Children.OfType<Button>()
+                    .Any(button => button.Name == "LoadMoreButton"));
+            Assert.That(footerActions.Orientation, Is.EqualTo(Orientation.Horizontal));
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiOperationAvailabilityTrackerTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiOperationAvailabilityTrackerTests.cs
@@ -1,0 +1,103 @@
+﻿using Avalonia.Headless.NUnit;
+using Beutl.Api.Services;
+using Beutl.Services.AI;
+using Beutl.Testing.Headless;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture, NonParallelizable]
+public sealed class AiOperationAvailabilityTrackerTests
+{
+    private static readonly AiOperationAvailabilityRequest s_request =
+        new AiOperationAvailabilityRequest.Video(AiOperations.VideoGeneration, 6);
+
+    [AvaloniaTest]
+    public void BeforeAnyCheck_TheStateIsUnknownRatherThanRefused()
+    {
+        using var tracker = new AiOperationAvailabilityTracker(
+            new StubService(_ => new TaskCompletionSource<bool>().Task),
+            CancellationToken.None);
+
+        Assert.That(tracker.State.Value, Is.EqualTo(AiOperationAvailabilityState.Unknown));
+    }
+
+    [AvaloniaTest]
+    public async Task AnInFlightCheck_LeavesTheStateUnknownUntilTheServerAnswers()
+    {
+        var answer = new TaskCompletionSource<bool>();
+        using var tracker = new AiOperationAvailabilityTracker(
+            new StubService(_ => answer.Task),
+            CancellationToken.None,
+            TimeSpan.Zero);
+
+        tracker.Check(s_request);
+        Assert.That(tracker.State.Value, Is.EqualTo(AiOperationAvailabilityState.Unknown),
+            "A pending check must not read as a refusal.");
+
+        answer.SetResult(true);
+        await tracker.CurrentCheck!;
+        HeadlessTestHelpers.Settle();
+
+        Assert.That(tracker.State.Value, Is.EqualTo(AiOperationAvailabilityState.Available));
+    }
+
+    [AvaloniaTest]
+    public async Task AFailedCheck_FallsBackToUnknownRatherThanRefusing()
+    {
+        using var tracker = new AiOperationAvailabilityTracker(
+            new StubService(_ => Task.FromException<bool>(new HttpRequestException("offline"))),
+            CancellationToken.None,
+            TimeSpan.Zero);
+
+        tracker.Check(s_request);
+        await tracker.CurrentCheck!;
+        HeadlessTestHelpers.Settle();
+
+        Assert.That(tracker.State.Value, Is.EqualTo(AiOperationAvailabilityState.Unknown),
+            "A check that could not be made has not refused anything.");
+    }
+
+    [AvaloniaTest]
+    public async Task ARefusal_IsReportedAsUnavailable()
+    {
+        using var tracker = new AiOperationAvailabilityTracker(
+            new StubService(_ => Task.FromResult(false)),
+            CancellationToken.None,
+            TimeSpan.Zero);
+
+        tracker.Check(s_request);
+        await tracker.CurrentCheck!;
+        HeadlessTestHelpers.Settle();
+
+        Assert.That(tracker.State.Value, Is.EqualTo(AiOperationAvailabilityState.Unavailable));
+    }
+
+    [AvaloniaTest]
+    public async Task AskingAboutNothing_ClearsTheAnswerWithoutRefusing()
+    {
+        using var tracker = new AiOperationAvailabilityTracker(
+            new StubService(_ => Task.FromResult(true)),
+            CancellationToken.None,
+            TimeSpan.Zero);
+
+        tracker.Check(s_request);
+        await tracker.CurrentCheck!;
+        HeadlessTestHelpers.Settle();
+        Assert.That(tracker.State.Value, Is.EqualTo(AiOperationAvailabilityState.Available));
+
+        // No valid request to ask about — nothing to translate yet, say.
+        tracker.Check(null);
+        HeadlessTestHelpers.Settle();
+
+        Assert.That(tracker.State.Value, Is.EqualTo(AiOperationAvailabilityState.Unknown));
+    }
+
+    private sealed class StubService(
+        Func<AiOperationAvailabilityRequest, Task<bool>> answer) : IAiOperationAvailabilityService
+    {
+        public Task<bool> CheckAsync(
+            AiOperationAvailabilityRequest request,
+            CancellationToken cancellationToken)
+            => answer(request);
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiPlanCoordinatorTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiPlanCoordinatorTests.cs
@@ -1,0 +1,184 @@
+﻿using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Beutl.Api;
+using Beutl.Api.Services;
+using Beutl.Services;
+using Beutl.Testing.Headless;
+using Beutl.Views.Tools;
+using Reactive.Bindings;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public sealed class AiPlanCoordinatorTests
+{
+    [Test]
+    public async Task OpenPages_RefreshesOnlyOnceAfterReturn()
+    {
+        var entitlements = new StubEntitlementService();
+        var opened = new List<Uri>();
+        var coordinator = new AiPlanCoordinator(
+            entitlements,
+            opened.Add,
+            () => "ja",
+            new Uri("https://beutl.beditor.net/"));
+
+        coordinator.OpenAiPlan();
+        coordinator.OpenAccountSettings();
+        await coordinator.RefreshIfPendingAsync(CancellationToken.None);
+        await coordinator.RefreshIfPendingAsync(CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(opened, Is.EqualTo(new[]
+            {
+                new Uri("https://beutl.beditor.net/ja/account/manage/ai-plan"),
+                new Uri("https://beutl.beditor.net/account/manage"),
+            }));
+            Assert.That(entitlements.RefreshCount, Is.EqualTo(1));
+        }
+    }
+
+    // A build pointed at a local server has to open that server's plan pages;
+    // opening the live site would show a plan this build cannot act on.
+    [Test]
+    public void OpenPages_FollowTheConfiguredApiOrigin()
+    {
+        var opened = new List<Uri>();
+        var coordinator = new AiPlanCoordinator(
+            new StubEntitlementService(),
+            opened.Add,
+            () => "en");
+
+        coordinator.OpenAiPlan();
+        coordinator.OpenAccountSettings();
+
+        var expected = new Uri(BeutlApiApplication.BaseUrl, UriKind.Absolute);
+        Assert.That(opened, Is.EqualTo(new[]
+        {
+            new Uri(expected, "en/account/manage/ai-plan"),
+            new Uri(expected, "account/manage"),
+        }));
+    }
+
+    [Test]
+    public void FailedRefresh_RemainsPendingForTheNextActivation()
+    {
+        var entitlements = new StubEntitlementService
+        {
+            Failure = new InvalidOperationException("offline"),
+        };
+        var coordinator = new AiPlanCoordinator(
+            entitlements,
+            _ => { },
+            () => "en");
+        coordinator.OpenAiPlan();
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await coordinator.RefreshIfPendingAsync(CancellationToken.None));
+        entitlements.Failure = null;
+        Assert.DoesNotThrowAsync(async () =>
+            await coordinator.RefreshIfPendingAsync(CancellationToken.None));
+        Assert.That(entitlements.RefreshCount, Is.EqualTo(2));
+    }
+
+    [AvaloniaTest]
+    public async Task ReturnRefresh_LoadCyclesDoNotDuplicateAndDisposalStopsActivationCallbacks()
+    {
+        var coordinator = new RecordingPlanCoordinator();
+        var control = new Border();
+        var host = new Window { Content = control };
+        var other = new Window();
+        int refreshCallbacks = 0;
+        IDisposable subscription = AiPlanReturnRefresh.Attach(
+            control,
+            coordinator,
+            () => refreshCallbacks++);
+        try
+        {
+            host.Show();
+            other.Show();
+            HeadlessTestHelpers.Settle();
+
+            int initialCount = coordinator.RefreshCount;
+            other.Activate();
+            host.Activate();
+            await WaitUntilAsync(() => coordinator.RefreshCount == initialCount + 1);
+
+            host.Content = null;
+            HeadlessTestHelpers.Settle();
+            host.Content = control;
+            HeadlessTestHelpers.Settle();
+            int callbacksBeforeSecondActivation = refreshCallbacks;
+            other.Activate();
+            host.Activate();
+            await WaitUntilAsync(() => coordinator.RefreshCount == initialCount + 2);
+            await WaitUntilAsync(() => refreshCallbacks == callbacksBeforeSecondActivation + 1);
+
+            subscription.Dispose();
+            int disposedCount = coordinator.RefreshCount;
+            other.Activate();
+            host.Activate();
+            await Task.Delay(25);
+            HeadlessTestHelpers.Settle();
+            Assert.That(coordinator.RefreshCount, Is.EqualTo(disposedCount));
+        }
+        finally
+        {
+            subscription.Dispose();
+            other.Close();
+            host.Close();
+        }
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        for (int attempt = 0; attempt < 100 && !condition(); attempt++)
+        {
+            HeadlessTestHelpers.Settle();
+            await Task.Delay(10);
+        }
+
+        Assert.That(condition(), Is.True);
+    }
+
+    private sealed class StubEntitlementService : IAiEntitlementService
+    {
+        public IReadOnlyReactiveProperty<AiEntitlements?> Entitlements { get; }
+            = new ReactivePropertySlim<AiEntitlements?>();
+
+        public int RefreshCount { get; private set; }
+
+        public Exception? Failure { get; set; }
+
+        public Task<AiEntitlements?> RefreshAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            RefreshCount++;
+            return Failure is null
+                ? Task.FromResult<AiEntitlements?>(null)
+                : Task.FromException<AiEntitlements?>(Failure);
+        }
+
+    }
+
+    private sealed class RecordingPlanCoordinator : IAiPlanCoordinator
+    {
+        public int RefreshCount { get; private set; }
+
+        public void OpenAccountSettings()
+        {
+        }
+
+        public void OpenAiPlan()
+        {
+        }
+
+        public Task RefreshIfPendingAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            RefreshCount++;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiPlanCoordinatorTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiPlanCoordinatorTests.cs
@@ -22,11 +22,13 @@ public sealed class AiPlanCoordinatorTests
             opened.Add,
             () => "ja",
             new Uri("https://beutl.beditor.net/"));
+        int refreshedEvents = 0;
+        coordinator.Refreshed += (_, _) => refreshedEvents++;
 
         coordinator.OpenAiPlan();
         coordinator.OpenAccountSettings();
-        await coordinator.RefreshIfPendingAsync(CancellationToken.None);
-        await coordinator.RefreshIfPendingAsync(CancellationToken.None);
+        bool refreshed = await coordinator.RefreshIfPendingAsync(CancellationToken.None);
+        bool noPendingRefresh = await coordinator.RefreshIfPendingAsync(CancellationToken.None);
 
         using (Assert.EnterMultipleScope())
         {
@@ -36,6 +38,9 @@ public sealed class AiPlanCoordinatorTests
                 new Uri("https://beutl.beditor.net/account/manage"),
             }));
             Assert.That(entitlements.RefreshCount, Is.EqualTo(1));
+            Assert.That(refreshed, Is.True);
+            Assert.That(noPendingRefresh, Is.False);
+            Assert.That(refreshedEvents, Is.EqualTo(1));
         }
     }
 
@@ -72,14 +77,44 @@ public sealed class AiPlanCoordinatorTests
             entitlements,
             _ => { },
             () => "en");
+        int refreshedEvents = 0;
+        coordinator.Refreshed += (_, _) => refreshedEvents++;
         coordinator.OpenAiPlan();
 
         Assert.ThrowsAsync<InvalidOperationException>(async () =>
             await coordinator.RefreshIfPendingAsync(CancellationToken.None));
         entitlements.Failure = null;
+        bool refreshed = false;
         Assert.DoesNotThrowAsync(async () =>
-            await coordinator.RefreshIfPendingAsync(CancellationToken.None));
+        {
+            refreshed = await coordinator.RefreshIfPendingAsync(CancellationToken.None);
+        });
         Assert.That(entitlements.RefreshCount, Is.EqualTo(2));
+        Assert.That(refreshed, Is.True);
+        Assert.That(refreshedEvents, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task SuccessfulRefresh_ContinuesAfterAnEventSubscriberThrows()
+    {
+        var entitlements = new StubEntitlementService();
+        var coordinator = new AiPlanCoordinator(
+            entitlements,
+            _ => { },
+            () => "en");
+        int laterEvents = 0;
+        coordinator.Refreshed += (_, _) => throw new InvalidOperationException("observer failed");
+        coordinator.Refreshed += (_, _) => laterEvents++;
+        coordinator.OpenAiPlan();
+
+        bool refreshed = await coordinator.RefreshIfPendingAsync(CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(refreshed, Is.True);
+            Assert.That(entitlements.RefreshCount, Is.EqualTo(1));
+            Assert.That(laterEvents, Is.EqualTo(1));
+        }
     }
 
     [AvaloniaTest]
@@ -101,18 +136,29 @@ public sealed class AiPlanCoordinatorTests
             HeadlessTestHelpers.Settle();
 
             int initialCount = coordinator.RefreshCount;
+            coordinator.HasPendingRefresh = true;
             other.Activate();
             host.Activate();
             await WaitUntilAsync(() => coordinator.RefreshCount == initialCount + 1);
+            await WaitUntilAsync(() => refreshCallbacks == 1);
+
+            int callbacksBeforeUnrelatedActivation = refreshCallbacks;
+            int refreshesBeforeUnrelatedActivation = coordinator.RefreshCount;
+            other.Activate();
+            host.Activate();
+            await WaitUntilAsync(() => coordinator.RefreshCount == refreshesBeforeUnrelatedActivation + 1);
+            Assert.That(refreshCallbacks, Is.EqualTo(callbacksBeforeUnrelatedActivation));
 
             host.Content = null;
             HeadlessTestHelpers.Settle();
             host.Content = control;
             HeadlessTestHelpers.Settle();
             int callbacksBeforeSecondActivation = refreshCallbacks;
+            int refreshesBeforeSecondActivation = coordinator.RefreshCount;
+            coordinator.HasPendingRefresh = true;
             other.Activate();
             host.Activate();
-            await WaitUntilAsync(() => coordinator.RefreshCount == initialCount + 2);
+            await WaitUntilAsync(() => coordinator.RefreshCount == refreshesBeforeSecondActivation + 1);
             await WaitUntilAsync(() => refreshCallbacks == callbacksBeforeSecondActivation + 1);
 
             subscription.Dispose();
@@ -126,6 +172,51 @@ public sealed class AiPlanCoordinatorTests
         finally
         {
             subscription.Dispose();
+            other.Close();
+            host.Close();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ReturnRefresh_BroadcastsOneSuccessfulRefreshToAllLoadedControls()
+    {
+        var coordinator = new RecordingPlanCoordinator();
+        var first = new Border();
+        var second = new Border();
+        var host = new Window
+        {
+            Content = new StackPanel { Children = { first, second } },
+        };
+        var other = new Window();
+        int firstCallbacks = 0;
+        int secondCallbacks = 0;
+        using IDisposable firstSubscription = AiPlanReturnRefresh.Attach(
+            first,
+            coordinator,
+            () => firstCallbacks++);
+        using IDisposable secondSubscription = AiPlanReturnRefresh.Attach(
+            second,
+            coordinator,
+            () => secondCallbacks++);
+        try
+        {
+            host.Show();
+            other.Show();
+            HeadlessTestHelpers.Settle();
+            coordinator.HasPendingRefresh = true;
+
+            other.Activate();
+            host.Activate();
+            await WaitUntilAsync(() => firstCallbacks == 1 && secondCallbacks == 1);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(firstCallbacks, Is.EqualTo(1));
+                Assert.That(secondCallbacks, Is.EqualTo(1));
+            }
+        }
+        finally
+        {
             other.Close();
             host.Close();
         }
@@ -166,6 +257,10 @@ public sealed class AiPlanCoordinatorTests
     {
         public int RefreshCount { get; private set; }
 
+        public bool HasPendingRefresh { get; set; }
+
+        public event EventHandler? Refreshed;
+
         public void OpenAccountSettings()
         {
         }
@@ -174,11 +269,15 @@ public sealed class AiPlanCoordinatorTests
         {
         }
 
-        public Task RefreshIfPendingAsync(CancellationToken cancellationToken)
+        public Task<bool> RefreshIfPendingAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             RefreshCount++;
-            return Task.CompletedTask;
+            bool result = HasPendingRefresh;
+            HasPendingRefresh = false;
+            if (result)
+                Refreshed?.Invoke(this, EventArgs.Empty);
+            return Task.FromResult(result);
         }
     }
 }

--- a/tests/Beutl.HeadlessUITests/AiPromptComposerTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiPromptComposerTests.cs
@@ -1,0 +1,54 @@
+﻿using Beutl.Services;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public sealed class AiPromptComposerTests
+{
+    [Test]
+    public void Compose_ProducesStableLabeledSectionsAndNormalizesWhitespace()
+    {
+        string result = AiPromptComposer.Compose(new AiPromptParts(
+            "  A fox   in a forest ",
+            Style: " cinematic  watercolor ",
+            Composition: "wide shot",
+            Motion: "slow push in",
+            Exclusions: " text, logos "));
+
+        Assert.That(result, Is.EqualTo(
+            "A fox in a forest\n" +
+            "Style: cinematic watercolor\n" +
+            "Composition: wide shot\n" +
+            "Motion: slow push in\n" +
+            "Avoid: text, logos"));
+    }
+
+    [Test]
+    public void Compose_OmitsEmptyOptionalSections()
+    {
+        string result = AiPromptComposer.Compose(new AiPromptParts(
+            "Product photo",
+            Style: " ",
+            Exclusions: null));
+
+        Assert.That(result, Is.EqualTo("Product photo"));
+    }
+
+    [Test]
+    public void Compose_RejectsFinalPromptWhenOptionalSectionsCrossServerLimit()
+    {
+        var parts = new AiPromptParts(
+            "subject",
+            Style: new string('s', 2_000),
+            Exclusions: new string('x', 2_000));
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            AiPromptComposer.Compose(parts))!;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(exception.Message, Does.Contain("4000"));
+            Assert.That(AiPromptComposer.GetValidationError(parts), Does.Contain("4000"));
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiPromptLibraryPresentationTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiPromptLibraryPresentationTests.cs
@@ -1,0 +1,311 @@
+﻿using System.Windows.Input;
+using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless.NUnit;
+using Avalonia.LogicalTree;
+using Avalonia.VisualTree;
+using Beutl.Api;
+using Beutl.Api.Services;
+using Beutl.Language;
+using Beutl.Services;
+using Beutl.Services.AI;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.ViewModels.Dialogs;
+using Beutl.Views.Tools;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture, NonParallelizable]
+public sealed class AiPromptLibraryPresentationTests
+{
+    private string _storageDirectory = string.Empty;
+
+    [SetUp]
+    public void SetUp()
+        => _storageDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"beutl-prompt-presentation-{Guid.NewGuid():N}");
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_storageDirectory))
+        {
+            Directory.Delete(_storageDirectory, true);
+        }
+    }
+
+    [AvaloniaTest]
+    public void Templates_ListEachSavedPromptWithItsOwnPinAndDeleteButtons()
+    {
+        var library = CreateLibrary();
+        library.SaveTemplate("Sunset", PromptTaskKind.Image, "a calm sunset");
+        library.SaveTemplate("Neon", PromptTaskKind.Image, "a neon city");
+        string? applied = null;
+        using var viewModel = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            () => string.Empty,
+            prompt => applied = prompt,
+            library);
+        var view = new AiPromptTemplatesView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 340, Height = 400 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            ListBox list = view.GetLogicalDescendants().OfType<ListBox>().Single();
+            List<ListBoxItem> rows = list.GetRealizedContainers().OfType<ListBoxItem>().ToList();
+            Assert.That(rows, Has.Count.EqualTo(2), "Every saved template stays on screen.");
+
+            ListBoxItem row = FindRow(list, "Sunset");
+            Button apply = Apply(list, "Sunset");
+            ToggleButton pin = Pin(list, "Sunset");
+            Button delete = Delete(list, "Sunset");
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(
+                    row.GetVisualDescendants().OfType<TextBlock>().Select(text => text.Text),
+                    Does.Contain("Sunset"),
+                    "The name is text; applying is one of the row's buttons.");
+                Assert.That(pin.IsChecked, Is.False, "A template starts unpinned.");
+                Assert.That(pin.Command, Is.SameAs(viewModel.TogglePin));
+                Assert.That(delete.Command, Is.SameAs(viewModel.Delete));
+                Assert.That(apply.Command, Is.SameAs(viewModel.Apply));
+                Assert.That(apply.CommandParameter, Is.SameAs(row.DataContext));
+            }
+
+            Invoke(apply);
+            Assert.That(applied, Is.EqualTo("a calm sunset"),
+                "Clicking a template applies it rather than only selecting it.");
+
+            Invoke(pin);
+            HeadlessTestHelpers.Render();
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(
+                    viewModel.Templates.Single(choice => choice.Name == "Sunset").IsPinned,
+                    Is.True);
+                Assert.That(
+                    viewModel.Templates.Select(choice => choice.Name),
+                    Is.EqualTo(new[] { "Sunset", "Neon" }),
+                    "Pinning moves the template to the top of its own list.");
+            }
+
+            // The rows follow the reordered list, so the button has to be found again
+            // rather than reused from the container that has since been recycled.
+            Invoke(Delete(list, "Neon"));
+            Assert.That(viewModel.Templates.Select(choice => choice.Name), Is.EqualTo(new[] { "Sunset" }));
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public void Templates_KeepTheRowActionsOutOfTheWayUntilTheRowIsReachedFor()
+    {
+        var library = CreateLibrary();
+        library.SaveTemplate("Sunset", PromptTaskKind.Image, "a calm sunset");
+        using var viewModel = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            () => string.Empty,
+            _ => { },
+            library);
+        var view = new AiPromptTemplatesView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 340, Height = 400 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            ListBox list = view.GetLogicalDescendants().OfType<ListBox>().Single();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(Apply(list, "Sunset").Opacity, Is.Zero);
+                Assert.That(Pin(list, "Sunset").Opacity, Is.Zero);
+                Assert.That(Delete(list, "Sunset").Opacity, Is.Zero,
+                    "The actions stay out of a list that is read far more often than it is edited.");
+                Assert.That(
+                    FindRow(list, "Sunset").GetVisualDescendants().OfType<TextBlock>()
+                        .Single(text => text.Text == "Sunset").Opacity,
+                    Is.EqualTo(1),
+                    "The name is the row, so it is always readable.");
+            }
+
+            list.SelectedItem = FindRow(list, "Sunset").DataContext;
+            HeadlessTestHelpers.Render();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(Apply(list, "Sunset").Opacity, Is.EqualTo(1));
+                Assert.That(Pin(list, "Sunset").Opacity, Is.EqualTo(1));
+                Assert.That(Delete(list, "Sunset").Opacity, Is.EqualTo(1));
+            }
+
+            Invoke(Pin(list, "Sunset"));
+            list.SelectedItem = null;
+            HeadlessTestHelpers.Render();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(Pin(list, "Sunset").Opacity, Is.EqualTo(1),
+                    "A pinned row says so without being reached for: the pin is state, not just an action.");
+                Assert.That(Apply(list, "Sunset").Opacity, Is.Zero);
+                Assert.That(Delete(list, "Sunset").Opacity, Is.Zero);
+            }
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public void HistoryButton_KeepsThePastPromptsBehindAPopupRatherThanInThePanel()
+    {
+        var library = CreateLibrary();
+        library.Record(PromptTaskKind.Image, "an earlier prompt");
+        string? applied = null;
+        using var viewModel = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            () => string.Empty,
+            prompt => applied = prompt,
+            library);
+        var view = new AiPromptHistoryButton { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 340, Height = 400 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            ToggleButton toggle = view.GetLogicalDescendants().OfType<ToggleButton>().Single();
+            Popup popup = view.GetLogicalDescendants().OfType<Popup>().Single();
+            object? transparentButtonTheme = Application.Current!.FindResource("TransparentButton");
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(popup.IsOpen, Is.False, "The history stays out of the way until asked for.");
+                Assert.That(toggle.Theme, Is.SameAs(transparentButtonTheme));
+                Assert.That(toggle.Bounds.Width, Is.LessThanOrEqualTo(40),
+                    "The button is small enough to sit above the prompt box.");
+            }
+
+            toggle.IsChecked = true;
+            HeadlessTestHelpers.Render();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.IsHistoryOpen.Value, Is.True);
+                Assert.That(popup.IsOpen, Is.True);
+            }
+
+            ListBox list = popup.Child!.GetLogicalDescendants().OfType<ListBox>().Single();
+
+            Invoke(Apply(list, "an earlier prompt"));
+            HeadlessTestHelpers.Render();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(applied, Is.EqualTo("an earlier prompt"));
+                Assert.That(viewModel.IsHistoryOpen.Value, Is.False);
+                Assert.That(toggle.IsChecked, Is.False, "The button reflects the popup it drives.");
+            }
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImageGeneration_PutsTheHistoryButtonAboveTheRightEdgeOfThePromptBox()
+    {
+        await TestReset.ResetShellAsync();
+        BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        await using AiImageGenerationDialogViewModel viewModel = CreateImageGenerationDialog(clients);
+        var view = new AiImageGenerationView { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 420, Height = 800 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            AiPromptHistoryButton button = view.GetLogicalDescendants()
+                .OfType<AiPromptHistoryButton>()
+                .Single();
+            TextBox prompt = view.GetLogicalDescendants()
+                .OfType<TextBox>()
+                .First(box => box.AcceptsReturn);
+            Point buttonOrigin = button.TranslatePoint(default, view) ?? default;
+            Point promptOrigin = prompt.TranslatePoint(default, view) ?? default;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(buttonOrigin.Y + button.Bounds.Height, Is.LessThanOrEqualTo(promptOrigin.Y + 1),
+                    "The button sits above the box, not inside the panel below it.");
+                Assert.That(
+                    buttonOrigin.X + button.Bounds.Width,
+                    Is.GreaterThanOrEqualTo(promptOrigin.X + prompt.Bounds.Width - 1),
+                    "It is aligned with the right edge of the box it belongs to.");
+            }
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    private PersistentPromptLibrary CreateLibrary()
+        => new(Path.Combine(_storageDirectory, "prompts.json"));
+
+    private static Button Apply(ListBox list, string name)
+        => RowAction(list, name, Strings.AiPromptApply);
+
+    private static ToggleButton Pin(ListBox list, string name)
+        => FindRow(list, name).GetVisualDescendants().OfType<ToggleButton>().Single();
+
+    private static Button Delete(ListBox list, string name)
+        => RowAction(list, name, Strings.Delete);
+
+    private static Button RowAction(ListBox list, string name, string action)
+        => FindRow(list, name).GetVisualDescendants().OfType<Button>()
+            .Single(button => AutomationProperties.GetName(button) == action);
+
+    private static ListBoxItem FindRow(ListBox list, string name)
+        => list.GetRealizedContainers()
+            .OfType<ListBoxItem>()
+            .Single(item => ((AiPromptChoice)item.DataContext!).Name == name);
+
+    private static void Invoke(Button button)
+    {
+        ICommand command = button.Command!;
+        Assert.That(command.CanExecute(button.CommandParameter), Is.True);
+        command.Execute(button.CommandParameter);
+    }
+
+    private static AiImageGenerationDialogViewModel CreateImageGenerationDialog(BeutlApiApplication clients)
+        => new(
+            clients.GetResource<IAiEntitlementService>(),
+            clients.GetResource<IAiOperationAvailabilityService>(),
+            clients.GetResource<IAiModelCatalogService>(),
+            new AiPlanCoordinator(clients.GetResource<IAiEntitlementService>()),
+            clients.GetResource<IAiImageGenerationService>(),
+            clients.GetResource<IAuthenticatedContentService>(),
+            editViewModel: null,
+            requestRecoveryContext: AiRetryTestContext.CreateForm());
+}

--- a/tests/Beutl.HeadlessUITests/AiPromptLibraryViewModelTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiPromptLibraryViewModelTests.cs
@@ -1,0 +1,620 @@
+﻿using System.Windows.Input;
+
+using Avalonia.Headless;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using Beutl.Language;
+using Beutl.Services.AI;
+using Beutl.ViewModels;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public sealed class AiPromptLibraryViewModelTests
+{
+    [AvaloniaTest]
+    public async Task BackgroundConstructionDoesNotWaitForTheUiDispatcher()
+    {
+        var library = new FakePromptLibrary(
+            templates: [CreateTemplate(PromptTaskKind.Image, "Deferred", updatedMinute: 1)]);
+        Task<AiPromptLibraryViewModel> creation = Task.Run(() =>
+            new AiPromptLibraryViewModel(
+                PromptTaskKind.Image,
+                static () => string.Empty,
+                static _ => { },
+                library));
+
+        // Deliberately block the UI dispatcher. A synchronous Invoke in the
+        // constructor cannot complete until RunJobs below and fails this bound.
+        bool completedWithoutUiPump = creation.Wait(TimeSpan.FromSeconds(2));
+        Dispatcher.UIThread.RunJobs();
+        using AiPromptLibraryViewModel viewModel =
+            await creation.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(completedWithoutUiPump, Is.True);
+            Assert.That(viewModel.Templates.Select(item => item.Name), Is.EqualTo(["Deferred"]));
+        });
+    }
+
+    [AvaloniaTest]
+    public void DeferredInitialReadFailureIsContainedOnTheUiDispatcher()
+    {
+        var library = new FakePromptLibrary
+        {
+            ReadFailure = new IOException("prompt storage unavailable"),
+        };
+        Task<AiPromptLibraryViewModel> creation = Task.Run(() =>
+            new AiPromptLibraryViewModel(
+                PromptTaskKind.Image,
+                static () => string.Empty,
+                static _ => { },
+                library));
+        bool completedWithoutUiPump = creation.Wait(TimeSpan.FromSeconds(2));
+        Assert.DoesNotThrow(() => Dispatcher.UIThread.RunJobs());
+        using AiPromptLibraryViewModel viewModel = creation.GetAwaiter().GetResult();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(completedWithoutUiPump, Is.True);
+            Assert.That(viewModel.Templates, Is.Empty);
+            Assert.That(viewModel.History, Is.Empty);
+            Assert.That(viewModel.Error.Value, Is.EqualTo(Strings.AiResultUnavailable));
+        }
+    }
+
+    [Test]
+    public void TemplatesAndHistory_AreSeparateListsFilteredByTaskWithPinnedItemsFirst()
+    {
+        PromptTemplate recentTemplate = CreateTemplate(
+            PromptTaskKind.Image,
+            "Recent template",
+            updatedMinute: 40);
+        PromptTemplate pinnedTemplate = CreateTemplate(
+            PromptTaskKind.Image,
+            "Pinned template",
+            updatedMinute: 10,
+            isPinned: true);
+        PromptTemplate foreignTemplate = CreateTemplate(
+            PromptTaskKind.Video,
+            "Foreign template",
+            updatedMinute: 50,
+            isPinned: true);
+        PromptHistoryEntry recentHistory = CreateHistory(
+            PromptTaskKind.Image,
+            "recent history",
+            usedMinute: 40);
+        PromptHistoryEntry pinnedHistory = CreateHistory(
+            PromptTaskKind.Image,
+            "pinned history",
+            usedMinute: 10,
+            isPinned: true);
+        PromptHistoryEntry foreignHistory = CreateHistory(
+            PromptTaskKind.ImageEdit,
+            "foreign history",
+            usedMinute: 50,
+            isPinned: true);
+        var library = new FakePromptLibrary(
+            [recentHistory, foreignHistory, pinnedHistory],
+            [recentTemplate, foreignTemplate, pinnedTemplate]);
+
+        using var viewModel = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            () => string.Empty,
+            _ => { },
+            library,
+            dispatchToUi: static action => action());
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                viewModel.Templates.Select(choice => choice.Id),
+                Is.EqualTo(new[] { pinnedTemplate.Id, recentTemplate.Id }));
+            Assert.That(
+                viewModel.History.Select(choice => choice.Id),
+                Is.EqualTo(new[] { pinnedHistory.Id, recentHistory.Id }));
+            Assert.That(
+                viewModel.Templates.Select(choice => choice.Id),
+                Does.Not.Contain(foreignTemplate.Id));
+            Assert.That(
+                viewModel.History.Select(choice => choice.Id),
+                Does.Not.Contain(foreignHistory.Id));
+            Assert.That(viewModel.HasTemplates.Value, Is.True);
+            Assert.That(viewModel.HasHistory.Value, Is.True);
+        }
+    }
+
+    [Test]
+    public void HistorySummary_ShortensALongPromptWithoutLosingWhatIsApplied()
+    {
+        string prompt = new string('a', 120) + "\nsecond line";
+        var library = new FakePromptLibrary(history: [CreateHistory(PromptTaskKind.Image, prompt, usedMinute: 1)]);
+        string? applied = null;
+        using var viewModel = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            () => string.Empty,
+            value => applied = value,
+            library,
+            dispatchToUi: static action => action());
+
+        AiPromptChoice choice = viewModel.History.Single();
+        Execute(viewModel.Apply, choice);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(choice.Name, Has.Length.EqualTo(70));
+            Assert.That(choice.Name, Does.EndWith("\u2026"));
+            Assert.That(applied, Is.EqualTo(prompt), "The whole prompt is applied, not the summary.");
+        }
+    }
+
+    [Test]
+    public void Apply_AppliesTheFullPromptAndClosesTheHistoryPopup()
+    {
+        PromptHistoryEntry history = CreateHistory(
+            PromptTaskKind.Image,
+            "first line\nsecond line",
+            usedMinute: 1);
+        var library = new FakePromptLibrary(history: [history]);
+        string? appliedPrompt = null;
+        using var viewModel = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            () => string.Empty,
+            prompt => appliedPrompt = prompt,
+            library,
+            dispatchToUi: static action => action());
+        viewModel.Error.Value = "previous error";
+        viewModel.IsHistoryOpen.Value = true;
+
+        Execute(viewModel.Apply, viewModel.History.Single());
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(appliedPrompt, Is.EqualTo(history.Prompt));
+            Assert.That(viewModel.Error.Value, Is.Null);
+            Assert.That(viewModel.IsHistoryOpen.Value, Is.False,
+                "The popup closes over the box the prompt just landed in.");
+        }
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void TogglePin_RoutesByChoiceType(bool isTemplate)
+    {
+        var library = CreateSingleItemLibrary(isTemplate);
+        using var viewModel = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            () => string.Empty,
+            _ => { },
+            library,
+            dispatchToUi: static action => action());
+        AiPromptChoice choice = Single(viewModel, isTemplate);
+
+        Execute(viewModel.TogglePin, choice);
+
+        AiPromptChoice refreshed = Single(viewModel, isTemplate);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(refreshed.Id, Is.EqualTo(choice.Id));
+            Assert.That(refreshed.IsPinned, Is.True);
+            Assert.That(
+                isTemplate ? library.TemplatePinCalls : library.HistoryPinCalls,
+                Is.EqualTo(new[] { (choice.Id, true) }));
+            Assert.That(
+                isTemplate ? library.HistoryPinCalls : library.TemplatePinCalls,
+                Is.Empty);
+        }
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Delete_RoutesByChoiceType(bool isTemplate)
+    {
+        var library = CreateSingleItemLibrary(isTemplate);
+        using var viewModel = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            () => string.Empty,
+            _ => { },
+            library,
+            dispatchToUi: static action => action());
+        AiPromptChoice choice = Single(viewModel, isTemplate);
+
+        Execute(viewModel.Delete, choice);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.Templates, Is.Empty);
+            Assert.That(viewModel.History, Is.Empty);
+            Assert.That(viewModel.HasTemplates.Value, Is.False);
+            Assert.That(viewModel.HasHistory.Value, Is.False);
+            Assert.That(
+                isTemplate ? library.TemplateDeleteCalls : library.HistoryDeleteCalls,
+                Is.EqualTo(new[] { choice.Id }));
+            Assert.That(
+                isTemplate ? library.HistoryDeleteCalls : library.TemplateDeleteCalls,
+                Is.Empty);
+        }
+    }
+
+    [Test]
+    public void ClearHistory_LeavesTheSavedTemplatesAlone()
+    {
+        var library = new FakePromptLibrary(
+            history: [CreateHistory(PromptTaskKind.Image, "history", usedMinute: 1)],
+            templates: [CreateTemplate(PromptTaskKind.Image, "Template", updatedMinute: 1)]);
+        using var viewModel = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            () => string.Empty,
+            _ => { },
+            library,
+            dispatchToUi: static action => action());
+
+        Execute(viewModel.ClearHistory);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.History, Is.Empty);
+            Assert.That(viewModel.HasHistory.Value, Is.False);
+            Assert.That(viewModel.Templates, Has.Count.EqualTo(1));
+            Assert.That(library.Templates, Has.Count.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public void Record_AddsToHistoryWithoutTouchingTemplates()
+    {
+        PromptTemplate template = CreateTemplate(
+            PromptTaskKind.Image,
+            "Saved template",
+            updatedMinute: 1);
+        var library = new FakePromptLibrary(templates: [template]);
+        using var viewModel = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            () => string.Empty,
+            _ => { },
+            library,
+            dispatchToUi: static action => action());
+
+        viewModel.Record("new history");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                library.RecordCalls,
+                Is.EqualTo(new[] { (PromptTaskKind.Image, "new history") }));
+            Assert.That(viewModel.History.Select(choice => choice.Prompt), Is.EqualTo(new[] { "new history" }));
+            Assert.That(viewModel.Templates.Select(choice => choice.Id), Is.EqualTo(new[] { template.Id }));
+        }
+    }
+
+    [Test]
+    public void Record_StorageFailureIsContainedAndSurfaced()
+    {
+        var library = new FakePromptLibrary
+        {
+            RecordFailure = new IOException("Prompt history is unavailable."),
+        };
+        using var viewModel = new AiPromptLibraryViewModel(
+            PromptTaskKind.Video,
+            () => string.Empty,
+            _ => { },
+            library,
+            dispatchToUi: static action => action());
+
+        Assert.DoesNotThrow(() => viewModel.Record("paid prompt"));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.Error.Value, Is.EqualTo(Strings.AiResultUnavailable));
+            Assert.That(viewModel.History, Is.Empty);
+        }
+    }
+
+    [Test]
+    public void SaveTemplate_RoutesCurrentValuesAndShowsTheSavedTemplate()
+    {
+        var library = new FakePromptLibrary();
+        using var viewModel = new AiPromptLibraryViewModel(
+            PromptTaskKind.Video,
+            () => "current prompt",
+            _ => { },
+            library,
+            dispatchToUi: static action => action());
+        viewModel.TemplateName.Value = "Trailer";
+        viewModel.Error.Value = "previous error";
+
+        Execute(viewModel.SaveTemplate);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                library.SaveTemplateCalls,
+                Is.EqualTo(new[] { ("Trailer", PromptTaskKind.Video, "current prompt") }));
+            Assert.That(viewModel.TemplateName.Value, Is.Empty);
+            Assert.That(viewModel.Error.Value, Is.Null);
+            Assert.That(viewModel.Templates.Single().Id, Is.EqualTo(library.Templates.Single().Id));
+            Assert.That(viewModel.Templates.Single().IsTemplate, Is.True);
+        }
+    }
+
+    [TestCase("", "valid prompt")]
+    [TestCase("Template", "   ")]
+    public void SaveTemplate_InvalidNameOrPromptSetsLocalizedError(string templateName, string prompt)
+    {
+        string tempDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"beutl-prompt-view-model-tests-{Guid.NewGuid():N}");
+        string storagePath = Path.Combine(tempDirectory, "prompts.json");
+        try
+        {
+            var library = new PersistentPromptLibrary(storagePath);
+            using var viewModel = new AiPromptLibraryViewModel(
+                PromptTaskKind.ImageEdit,
+                () => prompt,
+                _ => { },
+                library,
+                dispatchToUi: static action => action());
+            viewModel.TemplateName.Value = templateName;
+
+            Execute(viewModel.SaveTemplate);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.Error.Value, Is.EqualTo(Strings.AiPromptTemplateInvalid));
+                Assert.That(viewModel.Templates, Is.Empty);
+                Assert.That(library.Templates, Is.Empty);
+                Assert.That(File.Exists(storagePath), Is.False);
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(tempDirectory))
+            {
+                Directory.Delete(tempDirectory, true);
+            }
+        }
+    }
+
+    [TestCase("save")]
+    [TestCase("pin")]
+    [TestCase("delete")]
+    [TestCase("clear")]
+    public void ManagementCommand_StorageFailureIsContainedAndSurfaced(string operation)
+    {
+        var library = new FakePromptLibrary(
+            templates: [CreateTemplate(PromptTaskKind.Image, "Template", updatedMinute: 1)])
+        {
+            MutationFailure = new IOException("The prompt library is unavailable."),
+        };
+        using var viewModel = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            () => "current prompt",
+            _ => { },
+            library,
+            dispatchToUi: static action => action());
+        viewModel.TemplateName.Value = "New template";
+        AiPromptChoice choice = viewModel.Templates.Single();
+        Action execute = operation switch
+        {
+            "save" => () => Execute(viewModel.SaveTemplate),
+            "pin" => () => Execute(viewModel.TogglePin, choice),
+            "delete" => () => Execute(viewModel.Delete, choice),
+            _ => () => Execute(viewModel.ClearHistory),
+        };
+
+        Assert.DoesNotThrow(execute);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.Error.Value, Is.EqualTo(Strings.AiResultUnavailable));
+            Assert.That(viewModel.Templates.Single().Id, Is.EqualTo(choice.Id));
+        }
+    }
+
+    private static FakePromptLibrary CreateSingleItemLibrary(bool isTemplate) =>
+        isTemplate
+            ? new FakePromptLibrary(templates: [CreateTemplate(PromptTaskKind.Image, "Template", updatedMinute: 1)])
+            : new FakePromptLibrary(history: [CreateHistory(PromptTaskKind.Image, "history", usedMinute: 1)]);
+
+    private static AiPromptChoice Single(AiPromptLibraryViewModel viewModel, bool isTemplate) =>
+        isTemplate ? viewModel.Templates.Single() : viewModel.History.Single();
+
+    private static PromptTemplate CreateTemplate(
+        PromptTaskKind taskKind,
+        string name,
+        int updatedMinute,
+        bool isPinned = false)
+    {
+        DateTimeOffset updatedAt = CreateTimestamp(updatedMinute);
+        return new PromptTemplate(
+            Guid.NewGuid(),
+            name,
+            taskKind,
+            $"{name} prompt",
+            updatedAt.AddMinutes(-1),
+            updatedAt,
+            isPinned);
+    }
+
+    private static PromptHistoryEntry CreateHistory(
+        PromptTaskKind taskKind,
+        string prompt,
+        int usedMinute,
+        bool isPinned = false) =>
+        new(
+            Guid.NewGuid(),
+            taskKind,
+            prompt,
+            CreateTimestamp(usedMinute),
+            1,
+            isPinned);
+
+    private static DateTimeOffset CreateTimestamp(int minute) =>
+        new DateTimeOffset(2026, 8, 9, 0, 0, 0, TimeSpan.Zero).AddMinutes(minute);
+
+    private static void Execute(ICommand command, object? parameter = null)
+    {
+        Assert.That(command.CanExecute(parameter), Is.True);
+        command.Execute(parameter);
+    }
+
+    private sealed class FakePromptLibrary : IPromptLibrary
+    {
+        private readonly List<PromptHistoryEntry> _history;
+        private readonly List<PromptTemplate> _templates;
+        private int _timestampMinute = 100;
+
+        public FakePromptLibrary(
+            IEnumerable<PromptHistoryEntry>? history = null,
+            IEnumerable<PromptTemplate>? templates = null)
+        {
+            _history = history?.ToList() ?? [];
+            _templates = templates?.ToList() ?? [];
+        }
+
+        public string StoragePath => "in-memory";
+
+        public bool RetainRecentPromptText => true;
+
+        public string? RecoveredCorruptFilePath => null;
+
+        public Exception? ReadFailure { get; init; }
+
+        public Exception? RecordFailure { get; init; }
+
+        public Exception? MutationFailure { get; init; }
+
+        public IReadOnlyList<PromptHistoryEntry> History =>
+            ReadFailure is null ? _history : throw ReadFailure;
+
+        public IReadOnlyList<PromptTemplate> Templates =>
+            ReadFailure is null ? _templates : throw ReadFailure;
+
+        public List<(PromptTaskKind TaskKind, string Prompt)> RecordCalls { get; } = [];
+
+        public List<(string Name, PromptTaskKind TaskKind, string Prompt)> SaveTemplateCalls { get; } = [];
+
+        public List<(Guid Id, bool IsPinned)> HistoryPinCalls { get; } = [];
+
+        public List<(Guid Id, bool IsPinned)> TemplatePinCalls { get; } = [];
+
+        public List<Guid> HistoryDeleteCalls { get; } = [];
+
+        public List<Guid> TemplateDeleteCalls { get; } = [];
+
+        public PromptHistoryEntry Record(PromptTaskKind taskKind, string prompt)
+        {
+            if (RecordFailure is not null)
+                throw RecordFailure;
+
+            RecordCalls.Add((taskKind, prompt));
+            var entry = new PromptHistoryEntry(
+                Guid.NewGuid(),
+                taskKind,
+                prompt,
+                CreateTimestamp(_timestampMinute++),
+                1,
+                false);
+            _history.Insert(0, entry);
+            return entry;
+        }
+
+        public PromptTemplate SaveTemplate(string name, PromptTaskKind taskKind, string prompt)
+        {
+            ThrowMutationFailure();
+            SaveTemplateCalls.Add((name, taskKind, prompt));
+            DateTimeOffset timestamp = CreateTimestamp(_timestampMinute++);
+            var template = new PromptTemplate(
+                Guid.NewGuid(),
+                name,
+                taskKind,
+                prompt,
+                timestamp,
+                timestamp,
+                false);
+            _templates.Insert(0, template);
+            return template;
+        }
+
+        public bool SetHistoryPinned(Guid id, bool isPinned)
+        {
+            ThrowMutationFailure();
+            HistoryPinCalls.Add((id, isPinned));
+            int index = _history.FindIndex(item => item.Id == id);
+            if (index < 0 || _history[index].IsPinned == isPinned)
+            {
+                return false;
+            }
+
+            _history[index] = _history[index] with { IsPinned = isPinned };
+            return true;
+        }
+
+        public bool SetTemplatePinned(Guid id, bool isPinned)
+        {
+            ThrowMutationFailure();
+            TemplatePinCalls.Add((id, isPinned));
+            int index = _templates.FindIndex(item => item.Id == id);
+            if (index < 0 || _templates[index].IsPinned == isPinned)
+            {
+                return false;
+            }
+
+            _templates[index] = _templates[index] with { IsPinned = isPinned };
+            return true;
+        }
+
+        public bool DeleteHistory(Guid id)
+        {
+            ThrowMutationFailure();
+            HistoryDeleteCalls.Add(id);
+            int index = _history.FindIndex(item => item.Id == id);
+            if (index < 0)
+            {
+                return false;
+            }
+
+            _history.RemoveAt(index);
+            return true;
+        }
+
+        public bool DeleteTemplate(Guid id)
+        {
+            ThrowMutationFailure();
+            TemplateDeleteCalls.Add(id);
+            int index = _templates.FindIndex(item => item.Id == id);
+            if (index < 0)
+            {
+                return false;
+            }
+
+            _templates.RemoveAt(index);
+            return true;
+        }
+
+        public void ClearHistory()
+        {
+            ThrowMutationFailure();
+            _history.Clear();
+        }
+
+        public void ClearTemplates()
+        {
+            ThrowMutationFailure();
+            _templates.Clear();
+        }
+
+        public void ClearAll()
+        {
+            ThrowMutationFailure();
+            _history.Clear();
+            _templates.Clear();
+        }
+
+        private void ThrowMutationFailure()
+        {
+            if (MutationFailure is not null)
+                throw MutationFailure;
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiPromptLibraryViewModelTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiPromptLibraryViewModelTests.cs
@@ -63,6 +63,31 @@ public sealed class AiPromptLibraryViewModelTests
         }
     }
 
+    [AvaloniaTest]
+    public void DeferredInitialNewerFormatFailureIsContainedOnTheUiDispatcher()
+    {
+        var library = new FakePromptLibrary
+        {
+            ReadFailure = new NotSupportedException("prompt storage is from a newer version"),
+        };
+        Task<AiPromptLibraryViewModel> creation = Task.Run(() =>
+            new AiPromptLibraryViewModel(
+                PromptTaskKind.Image,
+                static () => string.Empty,
+                static _ => { },
+                library));
+        bool completedWithoutUiPump = creation.Wait(TimeSpan.FromSeconds(2));
+        Assert.DoesNotThrow(() => Dispatcher.UIThread.RunJobs());
+        using AiPromptLibraryViewModel viewModel = creation.GetAwaiter().GetResult();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(completedWithoutUiPump, Is.True);
+            Assert.That(viewModel.Templates, Is.Empty);
+            Assert.That(viewModel.History, Is.Empty);
+            Assert.That(viewModel.Error.Value, Is.EqualTo(Strings.AiResultUnavailable));
+        }
+    }
+
     [Test]
     public void TemplatesAndHistory_AreSeparateListsFilteredByTaskWithPinnedItemsFirst()
     {
@@ -408,6 +433,46 @@ public sealed class AiPromptLibraryViewModelTests
         {
             Assert.That(viewModel.Error.Value, Is.EqualTo(Strings.AiResultUnavailable));
             Assert.That(viewModel.Templates.Single().Id, Is.EqualTo(choice.Id));
+        }
+    }
+
+    [TestCase("record")]
+    [TestCase("save")]
+    [TestCase("pin")]
+    [TestCase("delete")]
+    [TestCase("clear")]
+    public void NewerStorageFormatFailureIsContainedByMutationEntryPoints(string operation)
+    {
+        var library = new FakePromptLibrary(
+            templates: [CreateTemplate(PromptTaskKind.Image, "Template", updatedMinute: 1)])
+        {
+            RecordFailure = new NotSupportedException("newer prompt library"),
+            MutationFailure = new NotSupportedException("newer prompt library"),
+        };
+        using var viewModel = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            () => "current prompt",
+            _ => { },
+            library,
+            dispatchToUi: static action => action());
+        viewModel.TemplateName.Value = "New template";
+        AiPromptChoice choice = viewModel.Templates.Single();
+        Action execute = operation switch
+        {
+            "record" => () => viewModel.Record("new history"),
+            "save" => () => Execute(viewModel.SaveTemplate),
+            "pin" => () => Execute(viewModel.TogglePin, choice),
+            "delete" => () => Execute(viewModel.Delete, choice),
+            _ => () => Execute(viewModel.ClearHistory),
+        };
+
+        Assert.DoesNotThrow(execute);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.Error.Value, Is.EqualTo(Strings.AiResultUnavailable));
+            Assert.That(viewModel.Templates.Single().Id, Is.EqualTo(choice.Id));
+            Assert.That(viewModel.History, Is.Empty);
         }
     }
 

--- a/tests/Beutl.HeadlessUITests/AiResponseContractTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiResponseContractTests.cs
@@ -1,0 +1,95 @@
+﻿using System.Reflection;
+using Beutl.Api.Services;
+
+namespace Beutl.HeadlessUITests;
+
+// The server deliberately withholds every balance snapshot from operation
+// responses. Account entitlements still show monthly percentages and the exact
+// purchased quantity the user asked to see.
+[TestFixture]
+public sealed class AiResponseContractTests
+{
+    private static readonly string[] s_forbiddenMembers =
+    [
+        "UsageUnits",
+        "Used",
+        "Remaining",
+        "AdditionalCreditDebt",
+        "Pricing",
+        "Units",
+    ];
+
+    // Paging carries its own unrelated Limit, so only balance-shaped types are checked
+    // for the allowance size.
+    private static readonly string[] s_balanceTypes =
+    [
+        "AiBalance",
+        "AiBalanceResponse",
+        "AiMonthlyUsage",
+        "AiMonthlyUsageResponse",
+    ];
+
+    [Test]
+    public void AiContractTypes_DoNotExposeUsageCostsOrRawAllowanceAndDebtUnits()
+    {
+        Assembly assembly = typeof(AiEntitlements).Assembly;
+        var offenders = new List<string>();
+
+        foreach (Type type in assembly.GetTypes())
+        {
+            if (type.Namespace is not ("Beutl.Api.Clients" or "Beutl.Api.Services"))
+                continue;
+            if (!type.Name.StartsWith("Ai", StringComparison.Ordinal))
+                continue;
+
+            foreach (PropertyInfo property in type.GetProperties(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+            {
+                bool forbidden = s_forbiddenMembers.Contains(property.Name, StringComparer.Ordinal)
+                    || (property.Name == "Limit"
+                        && s_balanceTypes.Contains(type.Name, StringComparer.Ordinal));
+                if (forbidden)
+                {
+                    offenders.Add($"{type.Name}.{property.Name}");
+                }
+            }
+        }
+
+        Assert.That(
+            offenders,
+            Is.Empty,
+            "AI contract types must not carry usage costs or raw balances.");
+    }
+
+    [Test]
+    public void OperationResponses_DoNotExposeBalanceSnapshots()
+    {
+        Assembly assembly = typeof(AiEntitlements).Assembly;
+        Type entitlementBalance = assembly.GetType(
+            "Beutl.Api.Clients.AiBalanceResponse",
+            throwOnError: true)!;
+        string[] operationResponses =
+        [
+            "AiImageResponse",
+            "AiTranscriptionResponseDto",
+            "AiCaptionTranslationResponseDto",
+            "CreateAiVideoResponse",
+            "AiVideoJobResponse",
+        ];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                assembly.GetType("Beutl.Api.Clients.AiOperationBalanceResponse"),
+                Is.Null);
+            Assert.That(entitlementBalance.GetProperty("AdditionalCredits"), Is.Not.Null);
+            foreach (string responseName in operationResponses)
+            {
+                Type response = assembly.GetType(
+                    $"Beutl.Api.Clients.{responseName}",
+                    throwOnError: true)!;
+                Assert.That(response.GetProperty("Balance"), Is.Null, responseName);
+            }
+        });
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiResultImporterTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiResultImporterTests.cs
@@ -1,0 +1,647 @@
+﻿using System.Buffers.Binary;
+using Avalonia.Headless.NUnit;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Media;
+using Beutl.ProjectSystem;
+using Beutl.Serialization;
+using Beutl.Services;
+using Beutl.Services.AI;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.ViewModels.Dialogs;
+using Microsoft.Extensions.DependencyInjection;
+using SkiaSharp;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public sealed class AiResultImporterTests
+{
+    private static async Task<EditViewModel> OpenEditor(string name)
+    {
+        string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(workspace);
+        Project project = (await TestShell.Project.CreateProject(
+            640, 480, 30, 44100, name, workspace))!;
+        Scene scene = project.Items.OfType<Scene>().First();
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
+    }
+
+    [AvaloniaTest]
+    public async Task ImportImage_StagesProjectResource()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-result-importer");
+        using var bitmap = new Bitmap(2, 2);
+        var importer = new AiResultImporter(
+            editor.Scene,
+            editor.GetRequiredService<IElementAdder>());
+
+        ElementAddResult result = await importer.ImportImageAsync(
+            bitmap,
+            new AiResultImportOptions(
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(5),
+                0,
+                "AI image"));
+        HeadlessTestHelpers.Settle();
+
+        IReadOnlyList<Element> elements = result.Elements;
+        string resourcePath = elements.Single().Objects
+            .OfType<Beutl.Graphics.SourceImage>()
+            .Single()
+            .Source.CurrentValue!.Uri.LocalPath;
+        Assert.Multiple(() =>
+        {
+            Assert.That(resourcePath, Does.Contain(Path.Combine("resources", "ai")));
+            Assert.That(File.Exists(resourcePath), Is.True);
+            Assert.That(elements[0].Name, Is.EqualTo("AI image"));
+            Assert.That(Directory.EnumerateFiles(Path.GetDirectoryName(resourcePath)!, "*.tmp"), Is.Empty);
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task ImportImage_EncodeFailureDoesNotPublishResourceOrElement()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-result-importer-encode-failure");
+        using var bitmap = new Bitmap(new SKBitmap());
+        var adder = new CapturingElementAdder(producedElementCount: 1);
+        var importer = new AiResultImporter(editor.Scene, adder);
+        string resourceDirectory = Path.Combine(
+            Path.GetDirectoryName(editor.Scene.Uri!.LocalPath)!,
+            "resources",
+            "ai");
+
+        Assert.ThrowsAsync<IOException>(() => importer.ImportImageAsync(
+            bitmap,
+            new AiResultImportOptions(
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(5),
+                0,
+                "AI image")));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(adder.StagedPath, Is.Null);
+            Assert.That(Directory.EnumerateFiles(resourceDirectory), Is.Empty);
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task ImportImageBytes_RejectsOversizedDimensionsBeforeBitmapDecode()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-result-importer-bomb");
+        var importer = new AiResultImporter(
+            editor.Scene,
+            editor.GetRequiredService<IElementAdder>());
+        byte[] oversized = PngWithDimensions(8_193, 1);
+
+        Assert.ThrowsAsync<InvalidDataException>(() => importer.ImportImageAsync(
+            oversized,
+            new AiResultImportOptions(
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(5),
+                0,
+                "AI image")));
+        Assert.That(editor.Scene.Children, Is.Empty);
+    }
+
+    [Test]
+    public void OutpaintDimensions_RejectExpandedPixelBoundsBeforeMakeBorder()
+    {
+        Assert.That(
+            AiImageEditDialogViewModel.GetOutpaintDimensions(1_365, 1_365, 100),
+            Is.EqualTo((4_095, 4_095, 1_365, 1_365)));
+        Assert.Throws<InvalidDataException>(() =>
+            AiImageEditDialogViewModel.GetOutpaintDimensions(1_366, 1_366, 100));
+    }
+
+    private static byte[] PngWithDimensions(int width, int height)
+    {
+        using var source = new SKBitmap(1, 1, SKColorType.Rgba8888, SKAlphaType.Premul);
+        using SKImage image = SKImage.FromBitmap(source);
+        using SKData encoded = image.Encode(SKEncodedImageFormat.Png, 100);
+        byte[] bytes = encoded.ToArray();
+        BinaryPrimitives.WriteInt32BigEndian(bytes.AsSpan(16, 4), width);
+        BinaryPrimitives.WriteInt32BigEndian(bytes.AsSpan(20, 4), height);
+        BinaryPrimitives.WriteUInt32BigEndian(bytes.AsSpan(29, 4), Crc32(bytes.AsSpan(12, 17)));
+        return bytes;
+    }
+
+    private static uint Crc32(ReadOnlySpan<byte> bytes)
+    {
+        uint crc = 0xffffffff;
+        foreach (byte value in bytes)
+        {
+            crc ^= value;
+            for (int bit = 0; bit < 8; bit++)
+                crc = (crc & 1) == 0 ? crc >> 1 : 0xedb88320 ^ (crc >> 1);
+        }
+        return ~crc;
+    }
+
+    [AvaloniaTest]
+    public async Task ImportVideoBytes_StagesAndImportsEveryProducedElement()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-video-importer");
+        var adder = new CapturingElementAdder(producedElementCount: 2);
+        var importer = new AiResultImporter(editor.Scene, adder, AcceptVideoAsync);
+
+        ElementAddResult result = await importer.ImportVideoAsync(
+            new byte[] { 1, 2, 3, 4 },
+            new AiResultImportOptions(
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(4),
+                0,
+                "AI video"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(adder.StagedPath, Does.EndWith(".mp4"));
+            Assert.That(File.ReadAllBytes(adder.StagedPath!), Is.EqualTo(new byte[] { 1, 2, 3, 4 }));
+            Assert.That(result.Elements, Has.Count.EqualTo(2));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task ImportVideoPath_PreservesWebmExtension()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-webm-importer");
+        var adder = new CapturingElementAdder(producedElementCount: 1);
+        var importer = new AiResultImporter(editor.Scene, adder, AcceptVideoAsync);
+        string sourcePath = Path.Combine(Path.GetTempPath(), $"source-{Guid.NewGuid():N}.webm");
+        await File.WriteAllBytesAsync(sourcePath, [1, 2, 3]);
+        try
+        {
+            await importer.ImportVideoAsync(
+                sourcePath,
+                new AiResultImportOptions(
+                    TimeSpan.Zero,
+                    TimeSpan.FromSeconds(4),
+                    0,
+                    "AI video"));
+
+            Assert.That(adder.StagedPath, Does.EndWith(".webm"));
+        }
+        finally
+        {
+            File.Delete(sourcePath);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task RejectedVideoBatch_RemovesStagedProjectResource()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-rejected-importer");
+        var adder = new CapturingElementAdder(producedElementCount: 0);
+        var importer = new AiResultImporter(editor.Scene, adder, AcceptVideoAsync);
+
+        ElementAddResult result = await importer.ImportVideoAsync(
+            new byte[] { 1, 2, 3, 4 },
+            new AiResultImportOptions(
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(4),
+                0,
+                "AI video"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Failure, Is.TypeOf<ElementMaterializationFailure>());
+            Assert.That(result.Elements, Is.Empty);
+            Assert.That(adder.StagedPath, Is.Not.Null);
+            Assert.That(File.Exists(adder.StagedPath), Is.False);
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task ClosingUnsavedScene_RemovesOnlyItsOwnedTemporaryDirectory()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-unsaved-resource-cleanup");
+        var tab = TestShell.Editor.SelectedTabItem.Value!;
+        Scene scene = editor.Scene;
+        scene.Uri = null;
+        var adder = new CapturingElementAdder(producedElementCount: 1);
+        var importer = new AiResultImporter(scene, adder, AcceptVideoAsync);
+        string unrelatedDirectory = AiResultImporter.GetUnsavedSceneDirectory(Guid.NewGuid());
+        string unrelatedFile = Path.Combine(unrelatedDirectory, "keep.txt");
+        Directory.CreateDirectory(unrelatedDirectory);
+        await File.WriteAllTextAsync(unrelatedFile, "unrelated");
+
+        try
+        {
+            await importer.ImportVideoAsync(
+                new byte[] { 1, 2, 3, 4 },
+                new AiResultImportOptions(
+                    TimeSpan.Zero,
+                    TimeSpan.FromSeconds(4),
+                    0,
+                    "AI video"));
+            string ownedDirectory = AiResultImporter.GetUnsavedSceneDirectory(scene.Id);
+            Assert.That(File.Exists(adder.StagedPath), Is.True);
+
+            await TestShell.Editor.CloseTabItem(tab);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(Directory.Exists(ownedDirectory), Is.False);
+                Assert.That(File.Exists(unrelatedFile), Is.True);
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(unrelatedDirectory))
+                Directory.Delete(unrelatedDirectory, recursive: true);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ClosingSavedScene_RemovesTemporaryResourcesAfterHistoryIsDiscarded()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-saved-resource-preservation");
+        var tab = TestShell.Editor.SelectedTabItem.Value!;
+        Scene scene = editor.Scene;
+        Uri savedUri = scene.Uri!;
+        scene.Uri = null;
+        var adder = new CapturingElementAdder(producedElementCount: 1);
+        var importer = new AiResultImporter(scene, adder, AcceptVideoAsync);
+        string ownedDirectory = AiResultImporter.GetUnsavedSceneDirectory(scene.Id);
+
+        try
+        {
+            await importer.ImportVideoAsync(
+                new byte[] { 1, 2, 3, 4 },
+                new AiResultImportOptions(
+                    TimeSpan.Zero,
+                    TimeSpan.FromSeconds(4),
+                    0,
+                    "AI video"));
+            string resourcePath = adder.StagedPath!;
+            scene.Uri = savedUri;
+
+            await TestShell.Editor.CloseTabItem(tab);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(Directory.Exists(ownedDirectory), Is.False);
+                Assert.That(File.Exists(resourcePath), Is.False);
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(ownedDirectory))
+                Directory.Delete(ownedDirectory, recursive: true);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImportVideo_InvalidContainerIsRejectedBeforeElementMaterialization()
+    {
+        string directory = Path.Combine(
+            Path.GetTempPath(),
+            $"beutl-invalid-ai-video-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var scene = new Scene(640, 480, "invalid-video")
+        {
+            Uri = new Uri(Path.Combine(directory, "scene.scene")),
+        };
+        var adder = new CapturingElementAdder(producedElementCount: 1);
+        var importer = new AiResultImporter(scene, adder);
+        string resourceDirectory = Path.Combine(directory, "resources", "ai");
+        try
+        {
+            try
+            {
+                await importer.ImportVideoAsync(
+                    new byte[] { 1, 2, 3, 4 },
+                    new AiResultImportOptions(
+                        TimeSpan.Zero,
+                        TimeSpan.FromSeconds(4),
+                        0,
+                        "AI video"));
+                Assert.Fail("A truncated AI video must be rejected before materialization.");
+            }
+            catch (InvalidDataException)
+            {
+            }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(adder.StagedPath, Is.Null);
+                Assert.That(
+                    Directory.Exists(resourceDirectory)
+                        ? Directory.EnumerateFiles(resourceDirectory)
+                        : [],
+                    Is.Empty);
+            });
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestCase(".mp4")]
+    [TestCase(".mov")]
+    public void VideoContainerSignature_AcceptsLegalBoxesBeforeFileType(string extension)
+    {
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"beutl-leading-boxes-{Guid.NewGuid():N}{extension}");
+        var bytes = new byte[56];
+        WriteBoxHeader(bytes.AsSpan(0, 8), 8, "free"u8);
+        WriteBoxHeader(bytes.AsSpan(8, 32), 1, "uuid"u8);
+        BinaryPrimitives.WriteUInt64BigEndian(bytes.AsSpan(16, 8), 32);
+        WriteBoxHeader(bytes.AsSpan(40, 16), 16, "ftyp"u8);
+        "isom"u8.CopyTo(bytes.AsSpan(48, 4));
+        try
+        {
+            File.WriteAllBytes(path, bytes);
+
+            Assert.DoesNotThrow(() => AiResultImporter.ValidateVideoContainerSignature(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+
+        static void WriteBoxHeader(
+            Span<byte> destination,
+            uint size,
+            ReadOnlySpan<byte> type)
+        {
+            BinaryPrimitives.WriteUInt32BigEndian(destination[..4], size);
+            type.CopyTo(destination[4..8]);
+        }
+    }
+
+    [Test]
+    public void VideoContainerSignature_RejectsMalformedNormalAndExtendedBoxes()
+    {
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"beutl-malformed-box-{Guid.NewGuid():N}.mp4");
+        (string Name, byte[] Bytes)[] cases =
+        [
+            ("truncated normal header", new byte[7]),
+            ("undersized normal box", BoxHeader(7)),
+            ("oversized normal box", BoxHeader(9)),
+            ("truncated extended header", BoxHeader(1)),
+            ("undersized extended box", ExtendedBoxHeader(15)),
+            ("oversized extended box", ExtendedBoxHeader(17)),
+        ];
+        try
+        {
+            foreach ((string name, byte[] bytes) in cases)
+            {
+                File.WriteAllBytes(path, bytes);
+                Assert.Throws<InvalidDataException>(
+                    () => AiResultImporter.ValidateVideoContainerSignature(path),
+                    name);
+            }
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+
+        static byte[] BoxHeader(uint size)
+        {
+            var result = new byte[8];
+            BinaryPrimitives.WriteUInt32BigEndian(result.AsSpan(0, 4), size);
+            "free"u8.CopyTo(result.AsSpan(4, 4));
+            return result;
+        }
+
+        static byte[] ExtendedBoxHeader(ulong size)
+        {
+            var result = BoxHeader(1);
+            Array.Resize(ref result, 16);
+            BinaryPrimitives.WriteUInt64BigEndian(result.AsSpan(8, 8), size);
+            return result;
+        }
+    }
+
+    private static Task AcceptVideoAsync(string path, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Assert.That(File.Exists(path), Is.True);
+        return Task.CompletedTask;
+    }
+
+    [AvaloniaTest]
+    public async Task ImportImage_UnsavedSceneUsesRealAdderAndRehomesItsSidecarOnFirstSave()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-unsaved-real-adder");
+        EditorTabItem tab = TestShell.Editor.SelectedTabItem.Value!;
+        Scene scene = editor.Scene;
+        Uri savedSceneUri = scene.Uri!;
+        scene.Uri = null;
+        string ownedDirectory = AiResultImporter.GetUnsavedSceneDirectory(scene.Id);
+        using var bitmap = new Bitmap(2, 2);
+        var importer = new AiResultImporter(
+            scene,
+            editor.GetRequiredService<IElementAdder>());
+
+        try
+        {
+            ElementAddResult result = await importer.ImportImageAsync(
+                bitmap,
+                new AiResultImportOptions(
+                    TimeSpan.Zero,
+                    TimeSpan.FromSeconds(2),
+                    0,
+                    "Unsaved AI image"));
+            HeadlessTestHelpers.Settle();
+
+            Assert.That(
+                result.IsSuccess,
+                Is.True,
+                $"{result.Failure?.Message} {result.Failure?.Exception}");
+            Element element = result.Elements.Single();
+            Uri unsavedSidecar = element.Uri!;
+            string resourcePath = element.Objects
+                .OfType<Beutl.Graphics.SourceImage>()
+                .Single()
+                .Source.CurrentValue!.Uri.LocalPath;
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.IsSuccess, Is.True);
+                Assert.That(
+                    UnsavedSceneStorage.OwnsPath(scene.Id, unsavedSidecar.LocalPath),
+                    Is.True);
+                Assert.That(File.Exists(unsavedSidecar.LocalPath), Is.True);
+                Assert.That(File.Exists(resourcePath), Is.True);
+            }
+
+            Assert.That(editor.HistoryManager.Undo(), Is.True);
+            Assert.That(scene.Children, Is.Empty);
+            scene.Uri = savedSceneUri;
+            Assert.That(await editor.Commands!.OnSave(), Is.True);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(File.Exists(unsavedSidecar.LocalPath), Is.True,
+                    "The redo stack still owns the unsaved element sidecar.");
+                Assert.That(File.Exists(resourcePath), Is.True,
+                    "The redo stack still owns the imported resource.");
+            }
+
+            Assert.That(editor.HistoryManager.Redo(), Is.True);
+            Assert.That(scene.Children.Single(), Is.SameAs(element));
+            Assert.That(await editor.Commands.OnSave(), Is.True);
+
+            Uri savedSidecar = element.Uri!;
+            string savedResourcePath = element.Objects
+                .OfType<Beutl.Graphics.SourceImage>()
+                .Single()
+                .Source.CurrentValue!.Uri.LocalPath;
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(savedSidecar, Is.Not.EqualTo(unsavedSidecar));
+                Assert.That(
+                    Path.GetDirectoryName(savedSidecar.LocalPath),
+                    Is.EqualTo(Path.GetDirectoryName(savedSceneUri.LocalPath)));
+                Assert.That(File.Exists(savedSidecar.LocalPath), Is.True);
+                Assert.That(File.Exists(unsavedSidecar.LocalPath), Is.False);
+                Assert.That(savedResourcePath, Is.Not.EqualTo(resourcePath));
+                Assert.That(savedResourcePath, Does.StartWith(Path.Combine(
+                    Path.GetDirectoryName(savedSceneUri.LocalPath)!,
+                    "resources",
+                    "ai")));
+                Assert.That(File.Exists(savedResourcePath), Is.True);
+                Assert.That(File.Exists(resourcePath), Is.False);
+                Assert.That(Directory.Exists(ownedDirectory), Is.False);
+            }
+
+            await TestShell.Editor.CloseTabItem(tab);
+            Scene restored = CoreSerializer.RestoreFromUri<Scene>(savedSceneUri);
+            Element restoredElement = restored.Children.Single();
+            string restoredResource = restoredElement.Objects
+                .OfType<Beutl.Graphics.SourceImage>()
+                .Single()
+                .Source.CurrentValue!.Uri.LocalPath;
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(restoredElement.Uri, Is.EqualTo(savedSidecar));
+                Assert.That(File.Exists(restoredElement.Uri!.LocalPath), Is.True);
+                Assert.That(restoredResource, Is.EqualTo(savedResourcePath));
+                Assert.That(File.Exists(restoredResource), Is.True);
+                Assert.That(Directory.Exists(ownedDirectory), Is.False);
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(ownedDirectory))
+                Directory.Delete(ownedDirectory, recursive: true);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task FirstSaveFailureRestoresUnsavedElementAndResourceUris()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-unsaved-save-rollback");
+        Scene scene = editor.Scene;
+        Uri eventualSceneUri = scene.Uri!;
+        scene.Uri = null;
+        string ownedDirectory = AiResultImporter.GetUnsavedSceneDirectory(scene.Id);
+        string failureRoot = Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            $"blocked-save-{Guid.NewGuid():N}");
+        string directoryAtScenePath = Path.Combine(failureRoot, "Scene.scene");
+        Directory.CreateDirectory(directoryAtScenePath);
+        using var bitmap = new Bitmap(2, 2);
+        var importer = new AiResultImporter(
+            scene,
+            editor.GetRequiredService<IElementAdder>());
+
+        try
+        {
+            ElementAddResult result = await importer.ImportImageAsync(
+                bitmap,
+                new AiResultImportOptions(
+                    TimeSpan.Zero,
+                    TimeSpan.FromSeconds(2),
+                    0,
+                    "Unsaved AI image"));
+            Assert.That(result.IsSuccess, Is.True, result.Failure?.Message);
+            Element element = result.Elements.Single();
+            Uri originalSidecar = element.Uri!;
+            var source = element.Objects
+                .OfType<Beutl.Graphics.SourceImage>()
+                .Single()
+                .Source.CurrentValue!;
+            Uri originalResource = source.Uri;
+            scene.Uri = new Uri(Path.GetFullPath(directoryAtScenePath));
+
+            Assert.CatchAsync<Exception>(async () => await editor.Commands!.OnSave());
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(element.Uri, Is.EqualTo(originalSidecar));
+                Assert.That(source.Uri, Is.EqualTo(originalResource));
+                Assert.That(File.Exists(originalSidecar.LocalPath), Is.True);
+                Assert.That(File.Exists(originalResource.LocalPath), Is.True);
+                Assert.That(Directory.GetFiles(failureRoot, "*.belm"), Is.Empty);
+                Assert.That(
+                    Directory.Exists(Path.Combine(failureRoot, "resources", "ai"))
+                        ? Directory.GetFiles(Path.Combine(failureRoot, "resources", "ai"))
+                        : [],
+                    Is.Empty);
+            }
+
+            scene.Uri = eventualSceneUri;
+            Assert.That(await editor.Commands!.OnSave(), Is.True);
+        }
+        finally
+        {
+            if (Directory.Exists(ownedDirectory))
+                Directory.Delete(ownedDirectory, recursive: true);
+            if (Directory.Exists(failureRoot))
+                Directory.Delete(failureRoot, recursive: true);
+        }
+    }
+
+    private sealed class CapturingElementAdder(int producedElementCount) : IElementAdder
+    {
+        public IElementSourceHandlerRegistry SourceHandlers { get; } = new ElementSourceHandlerRegistry();
+
+        public string? StagedPath { get; private set; }
+
+        public ValueTask<ElementAddResult> AddAsync(
+            IReadOnlyList<ElementDescription> descriptions,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ElementDescription description = descriptions.Single();
+            StagedPath = ((ElementSource.File)description.Source).FileName;
+            var result = new List<Element>(producedElementCount);
+            for (int index = 0; index < producedElementCount; index++)
+            {
+                result.Add(new Element());
+            }
+            ElementAddResult addResult = result.Count == 0
+                ? ElementAddResult.Failed(
+                    new ElementMaterializationFailure("The test element could not be materialized."),
+                    description)
+                : ElementAddResult.Succeeded(
+                [
+                    new ElementAddItemResult(
+                        description,
+                        result[0],
+                        result.Skip(1).ToArray()),
+                ]);
+            return ValueTask.FromResult(addResult);
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiResultImporterTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiResultImporterTests.cs
@@ -18,6 +18,39 @@ namespace Beutl.HeadlessUITests;
 [TestFixture]
 public sealed class AiResultImporterTests
 {
+    [AvaloniaTest]
+    public async Task First_save_keeps_a_shared_unsaved_resource_for_an_undo_owned_source()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("undo-owned-unsaved-resource");
+        Scene scene = editor.Scene;
+        Uri savedUri = scene.Uri!;
+        scene.Uri = null;
+        using var bitmap = new Bitmap(2, 2);
+        var importer = new AiResultImporter(scene, editor.GetRequiredService<IElementAdder>());
+        ElementAddResult added = await importer.ImportImageAsync(bitmap,
+            new AiResultImportOptions(TimeSpan.Zero, TimeSpan.FromSeconds(2), 0, "Shared resource"));
+        Assert.That(added.IsSuccess, Is.True);
+        Element element = added.Elements.Single();
+        Uri original = element.Objects.OfType<Beutl.Graphics.SourceImage>().Single().Source.CurrentValue!.Uri;
+        var historySource = new Beutl.Media.Source.ImageSource();
+        historySource.ReadFrom(original);
+        var historyObject = new Beutl.Graphics.SourceImage();
+        historyObject.Source.CurrentValue = historySource;
+        element.AddObject(historyObject);
+        editor.HistoryManager.Commit("Add history source");
+        element.Objects.Remove(historyObject);
+        editor.HistoryManager.Commit("Remove history source");
+        scene.Uri = savedUri;
+        Assert.That(await editor.Commands!.OnSave(), Is.True);
+        Assert.That(editor.HistoryManager.Undo(), Is.True);
+        Assert.That(element.Objects, Does.Contain(historyObject));
+        Assert.That(historySource.Uri, Is.EqualTo(original));
+        Assert.That(File.Exists(historySource.Uri.LocalPath), Is.True);
+        await TestShell.Editor.CloseTabItem(TestShell.Editor.SelectedTabItem.Value!);
+        Assert.That(File.Exists(original.LocalPath), Is.False);
+    }
+
     private static async Task<EditViewModel> OpenEditor(string name)
     {
         string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
@@ -519,8 +552,9 @@ public sealed class AiResultImporterTests
                     "resources",
                     "ai")));
                 Assert.That(File.Exists(savedResourcePath), Is.True);
-                Assert.That(File.Exists(resourcePath), Is.False);
-                Assert.That(Directory.Exists(ownedDirectory), Is.False);
+                Assert.That(File.Exists(resourcePath), Is.True,
+                    "Distinct sources retained by undo history may still use the original URI.");
+                Assert.That(Directory.Exists(ownedDirectory), Is.True);
             }
 
             await TestShell.Editor.CloseTabItem(tab);

--- a/tests/Beutl.HeadlessUITests/AiRetryTestContext.cs
+++ b/tests/Beutl.HeadlessUITests/AiRetryTestContext.cs
@@ -1,0 +1,27 @@
+﻿using Beutl.Api.Services;
+using Beutl.Services.AI;
+
+namespace Beutl.HeadlessUITests;
+
+internal static class AiRetryTestContext
+{
+    public static AiRetryAttemptContext Create()
+        => new(
+            new FileAiRetryKeyStore(Path.Combine(
+                Path.GetTempPath(),
+                "Beutl.HeadlessUITests",
+                "retry-keys",
+                Guid.NewGuid().ToString("N"))),
+            () => new AiAuthenticatedRequestIdentity("headless-account", User: null),
+            allowSyntheticIdentity: true);
+
+    public static AiRequestRecoveryContext CreateForm()
+        => new(
+            new FileAiRequestRecoveryStore(Path.Combine(
+                Path.GetTempPath(),
+                "Beutl.HeadlessUITests",
+                "ai-request-recovery",
+                Guid.NewGuid().ToString("N"))),
+            () => new AiAuthenticatedRequestIdentity("test-user", User: null));
+
+}

--- a/tests/Beutl.HeadlessUITests/AiShellEntryPointTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiShellEntryPointTests.cs
@@ -203,6 +203,28 @@ public sealed class AiShellEntryPointTests
     }
 
     [AvaloniaTest]
+    public async Task Workspace_DisposesItsPagesWhenOpeningANewTabFails()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-workspace-open-failure");
+        var page = new StubPage();
+        var workspace = new AiWorkspaceViewModel(editor, _ => page);
+
+        bool opened = await MainViewModel.TryOpenNewAiWorkspaceAsync(
+            workspace,
+            static () => false);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(opened, Is.False);
+            Assert.That(page.IsDisposed, Is.True);
+            Assert.That(
+                () => workspace.Show(AiWorkspaceSection.Jobs),
+                Throws.TypeOf<ObjectDisposedException>());
+        }
+    }
+
+    [AvaloniaTest]
     public async Task Workspace_AsyncDisposeAwaitsChildBeforeEditorResources()
     {
         await TestReset.ResetShellAsync();

--- a/tests/Beutl.HeadlessUITests/AiShellEntryPointTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiShellEntryPointTests.cs
@@ -1,0 +1,362 @@
+﻿using System.Text.Json.Nodes;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Beutl.Language;
+using Beutl.ProjectSystem;
+using Beutl.Services.PrimitiveImpls;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.ViewModels.Dialogs;
+using Beutl.ViewModels.Tools;
+using Beutl.Views;
+using Beutl.Views.Tools;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture, NonParallelizable]
+public sealed class AiShellEntryPointTests
+{
+    [AvaloniaTest]
+    public async Task AiMenu_KeepsEveryWorkflowInOneTabAndTurnsItToTheRightPage()
+    {
+        await TestReset.ResetShellAsync();
+        MainViewModel mainViewModel = TestShell.MainViewModel;
+        EditViewModel editor = await OpenEditor("ai-shell-entry-points");
+        var mainView = new MainView { DataContext = mainViewModel };
+        try
+        {
+            string[] aiHeaders =
+            [
+                Strings.Ai,
+                Strings.AiJobCenter,
+                Strings.AiImageGeneration,
+                Strings.AiImageEdit,
+                Strings.AiSubtitle,
+                Strings.AiVideoGeneration,
+            ];
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(
+                    mainViewModel.ToolTabExtensions.Where(ext => aiHeaders.Contains(ext.Header)),
+                    Is.EqualTo(new[] { AiWorkspaceTabExtension.Instance }),
+                    "The tab list must offer one AI entry, not one per workflow.");
+                Assert.That(mainViewModel.MenuBar.ShowAiJobs.CanExecute(), Is.True);
+                Assert.That(mainViewModel.MenuBar.GenerateImage.CanExecute(), Is.True);
+                Assert.That(mainViewModel.MenuBar.EditImage.CanExecute(), Is.True);
+                Assert.That(mainViewModel.MenuBar.GenerateSubtitles.CanExecute(), Is.True);
+                Assert.That(mainViewModel.MenuBar.GenerateVideo.CanExecute(), Is.True);
+            }
+
+            AiWorkspaceViewModel? workspace = null;
+            foreach ((Action open, AiWorkspaceSection section, Type pageType) in MenuEntries(mainViewModel))
+            {
+                open();
+                HeadlessTestHelpers.Settle();
+
+                AiWorkspaceViewModel? current = editor.FindToolTab<AiWorkspaceViewModel>();
+
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(current, Is.Not.Null);
+                    Assert.That(
+                        CountAiTabs(editor),
+                        Is.EqualTo(1),
+                        "The menu turns the open tab, it never stacks another.");
+                    Assert.That(current!.SelectedSection.Value?.Id, Is.EqualTo(section));
+                    Assert.That(current.ActiveContent.Value, Is.InstanceOf(pageType));
+                    Assert.That(current.Header.Value, Is.EqualTo(current.SelectedSection.Value!.DisplayName));
+                }
+
+                workspace ??= current;
+                Assert.That(current, Is.SameAs(workspace));
+            }
+
+            Assert.That(new AiWorkspaceView(), Is.InstanceOf<UserControl>());
+        }
+        finally
+        {
+            mainView.DataContext = null;
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task AiMenu_TurnsTheTabAlreadyOnThatPageRatherThanAnother()
+    {
+        await TestReset.ResetShellAsync();
+        MainViewModel mainViewModel = TestShell.MainViewModel;
+        EditViewModel editor = await OpenEditor("ai-two-tabs");
+        var mainView = new MainView { DataContext = mainViewModel };
+        try
+        {
+            Assert.That(AiWorkspaceTabExtension.Instance.CanMultiple, Is.True);
+
+            mainViewModel.MenuBar.GenerateImage.Execute();
+            HeadlessTestHelpers.Settle();
+            AiWorkspaceViewModel first = editor.FindToolTab<AiWorkspaceViewModel>()!;
+
+            AiWorkspaceViewModel second = mainViewModel.CreateAiWorkspaceViewModel(editor);
+            Assert.That(editor.OpenToolTab(second), Is.True);
+            HeadlessTestHelpers.Settle();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(CountAiTabs(editor), Is.EqualTo(2));
+                Assert.That(
+                    second.SelectedSection.Value?.Id,
+                    Is.EqualTo(AiWorkspaceSection.ImageEdit),
+                    "A tab added beside another starts on a page that one is not showing.");
+            }
+
+            second.Show(AiWorkspaceSection.Jobs);
+            mainViewModel.MenuBar.ShowAiJobs.Execute();
+            HeadlessTestHelpers.Settle();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(
+                    CountAiTabs(editor),
+                    Is.EqualTo(2),
+                    "Asking for a page that is already open must not add a third tab.");
+                Assert.That(second.SelectedSection.Value?.Id, Is.EqualTo(AiWorkspaceSection.Jobs));
+                Assert.That(
+                    first.SelectedSection.Value?.Id,
+                    Is.EqualTo(AiWorkspaceSection.ImageGeneration),
+                    "The tab already on the page answers, so the other one keeps its own.");
+            }
+        }
+        finally
+        {
+            mainView.DataContext = null;
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Workspace_BuildsAPageTheFirstTimeItIsShownAndThenKeepsIt()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-workspace-lazy");
+        var built = new List<AiWorkspaceSection>();
+        await using var workspace = new AiWorkspaceViewModel(editor, CreatePages(built));
+
+        object firstLook = workspace.Show(AiWorkspaceSection.Subtitles);
+        workspace.Show(AiWorkspaceSection.Jobs);
+        object secondLook = workspace.Show(AiWorkspaceSection.Subtitles);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                built,
+                Is.EqualTo(new[]
+                {
+                    AiWorkspaceSection.ImageGeneration,
+                    AiWorkspaceSection.Subtitles,
+                    AiWorkspaceSection.Jobs,
+                }),
+                "A page nobody opened must not be built, and none must be built twice.");
+            Assert.That(
+                secondLook,
+                Is.SameAs(firstLook),
+                "Coming back to a page must find the work left on it.");
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Workspace_KeepsEachTabsWorkToItself()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-workspace-independent");
+        var built = new List<AiWorkspaceSection>();
+        await using var left = new AiWorkspaceViewModel(editor, CreatePages(built));
+        await using var right = new AiWorkspaceViewModel(editor, CreatePages(built));
+
+        object fromLeft = left.Show(AiWorkspaceSection.Subtitles);
+        object fromRight = right.Show(AiWorkspaceSection.Subtitles);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                fromRight,
+                Is.Not.SameAs(fromLeft),
+                "A second tab is a second workbench, so what is typed in one stays there.");
+            Assert.That(built.Count(section => section == AiWorkspaceSection.Subtitles), Is.EqualTo(2));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Workspace_ClosingATabClosesItsOwnPagesAndOnlyThose()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-workspace-dispose");
+        await using var kept = new AiWorkspaceViewModel(editor, CreatePages([]));
+        var closed = new AiWorkspaceViewModel(editor, CreatePages([]));
+        var keptPage = (StubPage)kept.Show(AiWorkspaceSection.Jobs);
+        var closedPage = (StubPage)closed.Show(AiWorkspaceSection.Jobs);
+
+        await closed.DisposeAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(closedPage.IsDisposed, Is.True);
+            Assert.That(keptPage.IsDisposed, Is.False, "The tab still open keeps the work on its own page.");
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Workspace_AsyncDisposeAwaitsChildBeforeEditorResources()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-workspace-async-dispose");
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var page = new AsyncStubPage(started, release);
+        await using var workspace = new AiWorkspaceViewModel(editor, _ => page);
+        workspace.Show(AiWorkspaceSection.Jobs);
+
+        Task disposal = workspace.DisposeAsync().AsTask();
+        await started.Task;
+        Assert.That(disposal.IsCompleted, Is.False);
+        release.TrySetResult();
+        await disposal;
+        Assert.That(page.IsDisposed, Is.True);
+    }
+
+    [AvaloniaTest]
+    public async Task Workspace_AsyncDisposeStartsAllPagesBeforePropagatingFault()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-workspace-faulting-dispose");
+        var first = new FaultingPage();
+        var second = new SignalingPage();
+        int created = 0;
+        var workspace = new AiWorkspaceViewModel(editor, _ =>
+            created++ == 0 ? first : second);
+        workspace.Show(AiWorkspaceSection.ImageGeneration);
+        workspace.Show(AiWorkspaceSection.ImageEdit);
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await workspace.DisposeAsync());
+        Assert.That(second.IsDisposed, Is.True, "all pages must start disposal even when one faults");
+    }
+
+    [AvaloniaTest]
+    public async Task Workspace_ReopensOnThePageTheLayoutWasSavedOn()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditor("ai-workspace-layout");
+        var saved = new JsonObject();
+
+        await using (var workspace = new AiWorkspaceViewModel(editor, CreatePages([])))
+        {
+            workspace.Show(AiWorkspaceSection.VideoGeneration);
+            workspace.WriteToJson(saved);
+        }
+
+        var restoredPages = new List<AiWorkspaceSection>();
+        await using var restored = new AiWorkspaceViewModel(editor, CreatePages(restoredPages));
+        restored.ReadFromJson(saved);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(restored.SelectedSection.Value?.Id, Is.EqualTo(AiWorkspaceSection.VideoGeneration));
+            Assert.That(
+                restoredPages,
+                Does.Not.Contain(AiWorkspaceSection.Subtitles),
+                "Restoring a layout must not build the pages it was not saved on.");
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task AiMenu_WithoutScene_OnlyKeepsJobHistoryEnabled()
+    {
+        await TestReset.ResetShellAsync();
+        MainViewModel mainViewModel = TestShell.MainViewModel;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(mainViewModel.MenuBar.ShowAiJobs.CanExecute(), Is.False);
+            Assert.That(mainViewModel.MenuBar.GenerateImage.CanExecute(), Is.False);
+            Assert.That(mainViewModel.MenuBar.EditImage.CanExecute(), Is.False);
+            Assert.That(mainViewModel.MenuBar.GenerateSubtitles.CanExecute(), Is.False);
+            Assert.That(mainViewModel.MenuBar.GenerateVideo.CanExecute(), Is.False);
+        }
+    }
+
+    private static (Action Open, AiWorkspaceSection Section, Type PageType)[] MenuEntries(
+        MainViewModel mainViewModel) =>
+    [
+        (mainViewModel.MenuBar.GenerateImage.Execute,
+            AiWorkspaceSection.ImageGeneration,
+            typeof(AiImageGenerationDialogViewModel)),
+        (mainViewModel.MenuBar.EditImage.Execute,
+            AiWorkspaceSection.ImageEdit,
+            typeof(AiImageEditDialogViewModel)),
+        (mainViewModel.MenuBar.GenerateVideo.Execute,
+            AiWorkspaceSection.VideoGeneration,
+            typeof(AiVideoGenerationDialogViewModel)),
+        (() => mainViewModel.MenuBar.GenerateSubtitles.Execute(),
+            AiWorkspaceSection.Subtitles,
+            typeof(AiSubtitleDialogViewModel)),
+        (mainViewModel.MenuBar.ShowAiJobs.Execute,
+            AiWorkspaceSection.Jobs,
+            typeof(AiJobCenterViewModel)),
+    ];
+
+    private static int CountAiTabs(EditViewModel editor)
+        => editor.DockHost.Factory.EnumerateTools().Count(tool => tool.ToolContext is AiWorkspaceViewModel);
+
+    private static Func<AiWorkspaceSection, IAsyncDisposable> CreatePages(List<AiWorkspaceSection> built)
+        => section =>
+        {
+            built.Add(section);
+            return new StubPage();
+        };
+
+    private sealed class StubPage : IAsyncDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public ValueTask DisposeAsync() { IsDisposed = true; return ValueTask.CompletedTask; }
+    }
+
+    private sealed class AsyncStubPage(
+        TaskCompletionSource started,
+        TaskCompletionSource release) : IAsyncDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public async ValueTask DisposeAsync()
+        {
+            started.TrySetResult();
+            await release.Task;
+            IsDisposed = true;
+        }
+    }
+
+    private sealed class FaultingPage : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync() => ValueTask.FromException(new InvalidOperationException("fault"));
+    }
+
+    private sealed class SignalingPage : IAsyncDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            IsDisposed = true;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static async Task<EditViewModel> OpenEditor(string name)
+    {
+        string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(workspace);
+        Project project = (await TestShell.Project.CreateProject(
+            640, 480, 30, 44100, name, workspace))!;
+        Scene scene = project.Items.OfType<Scene>().First();
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiSubtitleAdvancedTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiSubtitleAdvancedTests.cs
@@ -1,0 +1,868 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Reactive.Linq;
+using System.Text;
+using System.Windows.Input;
+using Avalonia.Headless.NUnit;
+using Beutl.Api;
+using Beutl.Api.Clients;
+using Beutl.Api.Services;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services.Captions;
+using Beutl.Graphics;
+using Beutl.Media;
+using Beutl.Media.Decoding;
+using Beutl.Media.Music;
+using Beutl.Media.Music.Samples;
+using Beutl.Media.Source;
+using Beutl.ProjectSystem;
+using Beutl.Services;
+using Beutl.Services.AI;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels.Dialogs;
+using Reactive.Bindings;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public sealed class AiSubtitleAdvancedTests
+{
+    [Test]
+    public void TranscriptionSegments_CannotExtendBeyondTheUploadedChunk()
+    {
+        var withinChunk = new[]
+        {
+            new AiTranscriptionSegment { Start = 0, End = 0.05, Text = "inside" },
+        };
+        var beyondChunk = new[]
+        {
+            new AiTranscriptionSegment { Start = 0, End = 0.051, Text = "outside" },
+        };
+
+        Assert.DoesNotThrow(() =>
+            AiSubtitleDialogViewModel.ValidateTranscriptionSegments(withinChunk, 0.05));
+        Assert.Throws<AiProviderErrorException>(() =>
+            AiSubtitleDialogViewModel.ValidateTranscriptionSegments(beyondChunk, 0.05));
+        Assert.Throws<AiProviderErrorException>(() =>
+            AiSubtitleDialogViewModel.ValidateTranscriptionSegments([null!], 0.05));
+    }
+
+    [Test]
+    public async Task DisposeAsync_DrainsAdmittedSubtitleOperationAndRejectsLatePublication()
+    {
+        string directory = CreateDraftDirectory();
+        try
+        {
+            var viewModel = CreateTeardownViewModel(directory);
+            await Task.Delay(25);
+            var lifetime = GetOperations(viewModel);
+            AsyncOperationLifetime.Operation operation = lifetime.TryEnter()!;
+
+            Task first = viewModel.DisposeAsync().AsTask();
+            Task second = viewModel.DisposeAsync().AsTask();
+            Assert.That(second, Is.SameAs(first));
+            Assert.That(first.IsCompleted, Is.False);
+
+            operation.Dispose();
+            await first.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(operation.TryPublish(static () => { }), Is.False);
+            await viewModel.DisposeAsync();
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task TranslateCore_NonCooperativeServiceDrainsBeforeSubtitleCleanup()
+    {
+        string directory = CreateDraftDirectory();
+        var translation = new BlockingSubtitleTranslation();
+        try
+        {
+            var viewModel = CreateTeardownViewModel(directory, translation);
+            Assert.That(
+                viewModel.ImportCaptionBytes(
+                    Encoding.UTF8.GetBytes("1\n00:00:00,000 --> 00:00:01,000\nhello\n"),
+                    CaptionFormats.Srt),
+                Is.True);
+            Task translate = (Task)typeof(AiSubtitleDialogViewModel)
+                .GetMethod("TranslateCore", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                .Invoke(viewModel, null)!;
+            await translation.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Task disposal = viewModel.DisposeAsync().AsTask();
+            Assert.That(disposal.IsCompleted, Is.False);
+            translation.Release.TrySetResult();
+            await translate.WaitAsync(TimeSpan.FromSeconds(5));
+            await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task DisposeAsync_CancellationCallbackFailureStillCleansUp()
+    {
+        string directory = CreateDraftDirectory();
+        try
+        {
+            var viewModel = CreateTeardownViewModel(directory);
+            await Task.Delay(25);
+            AsyncOperationLifetime.Operation operation = GetOperations(viewModel).TryEnter()!;
+            using CancellationTokenRegistration registration = operation.CancellationToken.Register(
+                static () => throw new InvalidOperationException("subtitle cancellation callback failed"));
+
+            Task disposal = viewModel.DisposeAsync().AsTask();
+            operation.Dispose();
+            Assert.That(
+                async () => await disposal.WaitAsync(TimeSpan.FromSeconds(5)),
+                Throws.InstanceOf<InvalidOperationException>());
+            Assert.That(viewModel.DisposeAsync().AsTask(), Is.SameAs(disposal));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void SpeechWave_DownmixesAndResamplesToCompactPcm16()
+    {
+        const int sampleRate = 48_000;
+        float[] stereo = Enumerable.Repeat(new[] { 0.5f, -0.5f }, sampleRate)
+            .SelectMany(value => value)
+            .ToArray();
+        using var stream = new MemoryStream();
+
+        var writer = new AiSubtitleDialogViewModel.SpeechWaveWriter(stream);
+        writer.Append(new AudioFrameSnapshot(stereo, sampleRate, 2, TimeSpan.Zero), CancellationToken.None);
+        writer.Complete();
+
+        byte[] bytes = stream.ToArray();
+        Assert.Multiple(() =>
+        {
+            Assert.That(Encoding.ASCII.GetString(bytes, 0, 4), Is.EqualTo("RIFF"));
+            Assert.That(BitConverter.ToInt32(bytes, 4), Is.EqualTo(bytes.Length - 8));
+            Assert.That(BitConverter.ToInt32(bytes, 24), Is.EqualTo(16_000));
+            Assert.That(BitConverter.ToInt16(bytes, 22), Is.EqualTo(1));
+            Assert.That(BitConverter.ToInt32(bytes, 40), Is.EqualTo(16_000 * sizeof(short)));
+            Assert.That(bytes.Length, Is.EqualTo(44 + (16_000 * sizeof(short))));
+        });
+    }
+
+    [Test]
+    public void SpeechWave_JoinsSlicesWithoutDroppingOrShiftingSamples()
+    {
+        const int sampleRate = 48_000;
+        using var stream = new MemoryStream();
+        var writer = new AiSubtitleDialogViewModel.SpeechWaveWriter(stream);
+
+        float[] levels = [0.5f, -0.5f, 0.25f];
+        for (int slice = 0; slice < levels.Length; slice++)
+        {
+            float[] mono = Enumerable.Repeat(levels[slice], sampleRate).ToArray();
+            writer.Append(
+                new AudioFrameSnapshot(mono, sampleRate, 1, TimeSpan.FromSeconds(slice)),
+                CancellationToken.None);
+        }
+
+        writer.Complete();
+
+        byte[] bytes = stream.ToArray();
+        short[] samples = new short[(bytes.Length - 44) / sizeof(short)];
+        Buffer.BlockCopy(bytes, 44, samples, 0, bytes.Length - 44);
+        Assert.Multiple(() =>
+        {
+            // Three one-second slices are one three-second wave: a boundary that
+            // dropped or repeated a sample would move every word after it.
+            Assert.That(samples, Has.Length.EqualTo(3 * 16_000));
+            Assert.That(BitConverter.ToInt32(bytes, 40), Is.EqualTo(3 * 16_000 * sizeof(short)));
+            for (int slice = 0; slice < levels.Length; slice++)
+            {
+                short expected = (short)Math.Round(levels[slice] * short.MaxValue);
+                Assert.That(
+                    samples.Skip(slice * 16_000).Take(16_000),
+                    Is.All.EqualTo(expected),
+                    $"Slice {slice} lands whole in the wave.");
+            }
+        });
+    }
+
+    [Test]
+    public void SpeechWave_PreCanceledRequestWritesNothing()
+    {
+        using var stream = new MemoryStream();
+        var writer = new AiSubtitleDialogViewModel.SpeechWaveWriter(stream);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() =>
+            writer.Append(
+                new AudioFrameSnapshot(new float[32_000], 16_000, 1, TimeSpan.Zero),
+                cancellationTokenSource.Token));
+        Assert.That(stream.Length, Is.Zero);
+    }
+
+    [Test]
+    public void SpeechWave_MediaReaderStreamsBlocksAndUsesDecodedSampleCount()
+    {
+        const int sampleRate = 48_000;
+        const int decodedSamples = 72_000;
+        using var reader = new StreamingAudioReader(sampleRate, decodedSamples);
+        using var stream = new MemoryStream();
+
+        SpeechWaveChunkResult result = AiSubtitleDialogViewModel.WriteSpeechWave(
+                reader,
+                startSample: 0,
+                requestedSamples: 120_000,
+                stream,
+                CancellationToken.None);
+
+        byte[] bytes = stream.ToArray();
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.SourceSampleCount, Is.EqualTo(decodedSamples));
+            Assert.That(result.OutputSampleCount, Is.EqualTo(24_000));
+            Assert.That(result.UploadedDuration, Is.EqualTo(TimeSpan.FromSeconds(1.5)));
+            Assert.That(reader.MaximumRequestedSamples, Is.EqualTo(sampleRate));
+            Assert.That(reader.ReadCount, Is.EqualTo(2));
+            Assert.That(Encoding.ASCII.GetString(bytes, 0, 4), Is.EqualTo("RIFF"));
+            Assert.That(BitConverter.ToInt32(bytes, 4), Is.EqualTo(bytes.Length - 8));
+            Assert.That(BitConverter.ToInt32(bytes, 40), Is.EqualTo(24_000 * sizeof(short)));
+            Assert.That(bytes.Length, Is.EqualTo(44 + 24_000 * sizeof(short)));
+        });
+    }
+
+    [Test]
+    public void SpeechWave_MediaReaderKeepsItsPlaceAcrossAWholeChunk()
+    {
+        const int sampleRate = 48_000;
+        const int decodedSamples = sampleRate * 4;
+        using var reader = new StreamingAudioReader(sampleRate, decodedSamples);
+        using var stream = new MemoryStream();
+
+        SpeechWaveChunkResult result = AiSubtitleDialogViewModel.WriteSpeechWave(
+            reader,
+            startSample: 0,
+            requestedSamples: decodedSamples,
+            stream,
+            CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            // The resample cursor is written samples times the source rate, which
+            // leaves int after about three seconds of 48 kHz audio. Wrapped
+            // negative, the cursor never reaches the end of the block and the
+            // loop writes until the disk is full.
+            Assert.That(result.OutputSampleCount, Is.EqualTo(4 * 16_000));
+            Assert.That(stream.Length, Is.EqualTo(44 + (4 * 16_000 * sizeof(short))));
+        });
+    }
+
+    [Test]
+    public void SpeechWave_ReportsTheActualResampledUploadDuration()
+    {
+        using var reader = new StreamingAudioReader(sampleRate: 44_100, totalSamples: 1);
+        using var stream = new MemoryStream();
+
+        SpeechWaveChunkResult result = AiSubtitleDialogViewModel.WriteSpeechWave(
+            reader,
+            startSample: 0,
+            requestedSamples: 1,
+            stream,
+            CancellationToken.None);
+        using var sceneStream = new MemoryStream();
+        var sceneWriter = new AiSubtitleDialogViewModel.SpeechWaveWriter(sceneStream);
+        sceneWriter.Append(
+            new AudioFrameSnapshot([0], 44_100, 1, TimeSpan.Zero),
+            CancellationToken.None);
+        sceneWriter.Complete();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.OutputSampleCount, Is.EqualTo(1));
+            Assert.That(
+                result.UploadedDuration,
+                Is.EqualTo(TimeSpan.FromSeconds(1 / 16_000d)));
+            Assert.That(
+                result.UploadedDuration,
+                Is.GreaterThan(TimeSpan.FromSeconds(1 / 44_100d)));
+            Assert.That(
+                sceneWriter.UploadedDuration,
+                Is.EqualTo(TimeSpan.FromSeconds(1 / 16_000d)));
+        });
+    }
+
+    [Test]
+    public void SourceAudioFingerprint_DetectsSamePathReplacement()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"source-{Guid.NewGuid():N}.wav");
+        try
+        {
+            File.WriteAllBytes(path, [1, 2, 3, 4]);
+            var original = new SourceAudioFingerprint(
+                new FileInfo(path).Length,
+                File.GetLastWriteTimeUtc(path).Ticks);
+            Assert.That(
+                AiSubtitleDialogViewModel.HasMatchingSourceAudioFingerprint(path, original),
+                Is.True);
+
+            File.WriteAllBytes(path, [1, 2, 3, 4, 5]);
+
+            Assert.That(
+                AiSubtitleDialogViewModel.HasMatchingSourceAudioFingerprint(path, original),
+                Is.False);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task CueCommands_ReflectSelectionCaretTimingAndNeighborState()
+    {
+        using var httpClient = new HttpClient();
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        using var viewModel = CreateViewModel(clients);
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.DeleteCue.CanExecute(), Is.False);
+            Assert.That(viewModel.SplitCue.CanExecute(), Is.False);
+            Assert.That(viewModel.MergeCue.CanExecute(), Is.False);
+        });
+
+        viewModel.ResultSegments.Value =
+        [
+            new AiTranscriptionSegment { Start = 0, End = 4, Text = "hello world" },
+            new AiTranscriptionSegment { Start = 5, End = 7, Text = "again" },
+        ];
+        HeadlessTestHelpers.Settle();
+
+        EditableCaptionCueViewModel first = viewModel.Cues[0];
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.CaretIndex, Is.EqualTo(first.Text.Length));
+            Assert.That(viewModel.DeleteCue.CanExecute(), Is.True);
+            Assert.That(viewModel.SplitCue.CanExecute(), Is.False);
+            Assert.That(viewModel.MergeCue.CanExecute(), Is.True);
+        });
+
+        first.CaretIndex = 5;
+        HeadlessTestHelpers.Settle();
+        Assert.That(viewModel.SplitCue.CanExecute(), Is.True);
+        viewModel.Cues[1].StartText = "invalid";
+        HeadlessTestHelpers.Settle();
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.SplitCue.CanExecute(), Is.False);
+            Assert.That(viewModel.MergeCue.CanExecute(), Is.False);
+        });
+        viewModel.Cues[1].StartText = "00:00:05.000";
+        HeadlessTestHelpers.Settle();
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.SplitCue.CanExecute(), Is.True);
+            Assert.That(viewModel.MergeCue.CanExecute(), Is.True);
+        });
+
+        ((ICommand)viewModel.SplitCue).Execute(null);
+        HeadlessTestHelpers.Settle();
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.Cues, Has.Count.EqualTo(3));
+            Assert.That(viewModel.Cues[0].Text, Is.EqualTo("hello"));
+            Assert.That(viewModel.Cues[1].Text, Is.EqualTo(" world"));
+            Assert.That(viewModel.Cues[0].EndText, Is.EqualTo("00:00:01.818"));
+        });
+
+        viewModel.SelectedCue.Value = viewModel.Cues[^1];
+        HeadlessTestHelpers.Settle();
+        Assert.That(viewModel.MergeCue.CanExecute(), Is.False);
+        viewModel.SelectedCue.Value = viewModel.Cues[0];
+        HeadlessTestHelpers.Settle();
+        ((ICommand)viewModel.MergeCue).Execute(null);
+        HeadlessTestHelpers.Settle();
+        viewModel.SelectedCue.Value!.StartText = "invalid";
+        HeadlessTestHelpers.Settle();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.Cues, Has.Count.EqualTo(2));
+            Assert.That(viewModel.DeleteCue.CanExecute(), Is.True);
+            Assert.That(viewModel.SplitCue.CanExecute(), Is.False);
+            Assert.That(viewModel.MergeCue.CanExecute(), Is.False);
+        });
+
+        viewModel.SelectedCue.Value = null;
+        HeadlessTestHelpers.Settle();
+        Assert.That(viewModel.DeleteCue.CanExecute(), Is.False);
+    }
+
+    [Test]
+    public async Task WrapCues_WrapsEditableDocument()
+    {
+        using var httpClient = new HttpClient();
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        using var viewModel = CreateViewModel(clients);
+        viewModel.MaximumLineLength.Value = 5;
+        viewModel.MaximumLineCount.Value = 10;
+        viewModel.ResultSegments.Value =
+        [
+            new AiTranscriptionSegment { Start = 0, End = 4, Text = "hello world" },
+        ];
+
+        ((ICommand)viewModel.WrapCues).Execute(null);
+
+        Assert.That(viewModel.Cues[0].Text, Does.Contain("\n"));
+    }
+
+    [Test]
+    public async Task CaptionBytes_ImportExportAndMalformedInputAreHandled()
+    {
+        using var httpClient = new HttpClient();
+        await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        using var viewModel = CreateViewModel(clients);
+        byte[] srt = Encoding.UTF8.GetBytes("""
+            1
+            00:00:01,000 --> 00:00:02,500
+            Imported caption
+
+            """);
+
+        bool imported = viewModel.ImportCaptionBytes(srt, CaptionFormats.Srt);
+        byte[] exported = viewModel.ExportCaptionBytes(CaptionFormats.WebVtt);
+        bool mixedImported = viewModel.ImportCaptionBytes(Encoding.UTF8.GetBytes("""
+            1
+            00:00:01,000 --> 00:00:02,500
+            Preserved caption
+
+            2
+            invalid timing
+            Rejected caption
+
+            """), CaptionFormats.Srt);
+        bool malformed = viewModel.ImportCaptionBytes([0xff, 0xfe], CaptionFormats.Srt);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(imported, Is.True);
+            Assert.That(Encoding.UTF8.GetString(exported), Does.StartWith("WEBVTT"));
+            Assert.That(mixedImported, Is.True);
+            Assert.That(viewModel.Cues.Select(cue => cue.Text), Is.EqualTo(new[] { "Preserved caption" }));
+            Assert.That(malformed, Is.False);
+            Assert.That(viewModel.Error.Value, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public async Task JobOwnedDraft_IsRestoredByRecreatedViewModelFromBaseScope()
+    {
+        string directory = CreateDraftDirectory();
+        try
+        {
+            CaptionDraftScope scope = new("user-a", Guid.NewGuid(), Guid.NewGuid());
+            var firstStore = new FileCaptionDraftStore(directory);
+            Assert.That(firstStore.TryOpen(scope, out ICaptionDraftSession? writer), Is.True);
+            using (writer)
+            {
+                writer!.Save(new CaptionDraftEntry("paid-job-1", CreateDraft("restored result")));
+            }
+
+            using var httpClient = new HttpClient();
+            await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+            var recreatedStore = new FileCaptionDraftStore(directory);
+            using AiSubtitleDialogViewModel viewModel = CreateViewModel(
+                clients,
+                recreatedStore,
+                Observable.Return<CaptionDraftScope?>(scope));
+
+            Assert.That(viewModel.HasPartialResult.Value, Is.True);
+            ((ICommand)viewModel.ApplyPartialResult).Execute(null);
+
+            Assert.That(viewModel.Cues.Select(cue => cue.Text),
+                Is.EqualTo(new[] { "restored result" }));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task LossySrtExport_DeclinedConfirmationDoesNotWrite()
+    {
+        await using CaptionCatalog catalog = CaptionCatalog.CreateDefault("Default");
+        var document = new CaptionDocument(
+        [
+            new CaptionCue(
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(1),
+                "caption",
+                language: "en"),
+        ]);
+        int confirmationCount = 0;
+        int writeCount = 0;
+
+        bool exported = await AiSubtitleDialogViewModel.TryWriteCaptionExportAsync(
+            document,
+            CaptionFormats.Srt,
+            catalog.Serializer,
+            _ =>
+            {
+                confirmationCount++;
+                return Task.FromResult(false);
+            },
+            (_, _) =>
+            {
+                writeCount++;
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(exported, Is.False);
+            Assert.That(confirmationCount, Is.EqualTo(1));
+            Assert.That(writeCount, Is.Zero);
+            Assert.That(document[0].Language, Is.EqualTo("en"));
+        }
+    }
+
+    [Test]
+    public async Task LossySrtExport_ConfirmedProjectionPreservesTheSourceDocument()
+    {
+        await using CaptionCatalog catalog = CaptionCatalog.CreateDefault("Default");
+        var cue = new CaptionCue(
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(2),
+            "caption",
+            speaker: "Alice",
+            language: "en",
+            metadata: CaptionMetadata.Empty.Set(CaptionMetadataKeys.AssStyle, "Default"));
+        var document = new CaptionDocument([cue]);
+        byte[]? written = null;
+
+        bool exported = await AiSubtitleDialogViewModel.TryWriteCaptionExportAsync(
+            document,
+            CaptionFormats.Srt,
+            catalog.Serializer,
+            _ => Task.FromResult(true),
+            (bytes, _) =>
+            {
+                written = bytes;
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        CaptionImportResult imported = catalog.Serializer.Import(written!, CaptionFormats.Srt);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(exported, Is.True);
+            Assert.That(written, Is.Not.Null);
+            Assert.That(document[0], Is.SameAs(cue));
+            Assert.That(document[0].Speaker, Is.EqualTo("Alice"));
+            Assert.That(document[0].Language, Is.EqualTo("en"));
+            Assert.That(document[0].Metadata.Count, Is.EqualTo(1));
+            Assert.That(imported.Document![0], Is.EqualTo(new CaptionCue(
+                cue.Start,
+                cue.End,
+                cue.Text)));
+        }
+    }
+
+    [Test]
+    public async Task LossySrtExport_CancellationAfterConfirmationDoesNotWrite()
+    {
+        using var cancellation = new CancellationTokenSource();
+        await using CaptionCatalog catalog = CaptionCatalog.CreateDefault("Default");
+        var document = new CaptionDocument(
+        [
+            new CaptionCue(
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(1),
+                "caption",
+                language: "en"),
+        ]);
+        int writeCount = 0;
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await AiSubtitleDialogViewModel.TryWriteCaptionExportAsync(
+                document,
+                CaptionFormats.Srt,
+                catalog.Serializer,
+                _ =>
+                {
+                    cancellation.Cancel();
+                    return Task.FromResult(true);
+                },
+                (_, _) =>
+                {
+                    writeCount++;
+                    return Task.CompletedTask;
+                },
+                cancellation.Token));
+
+        Assert.That(writeCount, Is.Zero);
+    }
+
+    [Test]
+    public async Task AccountSwitch_ClearsDisplayedUserStateBeforeRestoringNewUsersDraft()
+    {
+        string directory = CreateDraftDirectory();
+        try
+        {
+            Guid projectId = Guid.NewGuid();
+            Guid sceneId = Guid.NewGuid();
+            CaptionDraftScope userA = new("user-a", projectId, sceneId);
+            CaptionDraftScope userB = new("user-b", projectId, sceneId);
+            var store = new FileCaptionDraftStore(directory);
+            SaveDraft(store, userA, "job-a", "A paid caption");
+            SaveDraft(store, userB, "job-b", "B paid caption");
+
+            using var httpClient = new HttpClient();
+            await using var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
+            using var scopes = new ReactivePropertySlim<CaptionDraftScope?>(userA);
+            using AiSubtitleDialogViewModel viewModel = CreateViewModel(clients, store, scopes);
+            viewModel.ResultSegments.Value =
+            [
+                new AiTranscriptionSegment { Start = 0, End = 1, Text = "A displayed caption" },
+            ];
+            viewModel.SelectedSourceLanguage.Value = viewModel.SourceLanguages.Last();
+
+            scopes.Value = userB;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.Cues, Is.Empty,
+                    "The previous user's cues must be cleared synchronously with the scope change.");
+                Assert.That(viewModel.SelectedCue.Value, Is.Null);
+                Assert.That(viewModel.SelectedSourceLanguage.Value, Is.SameAs(viewModel.SourceLanguages[0]));
+                Assert.That(viewModel.HasPartialResult.Value, Is.True);
+            }
+
+            ((ICommand)viewModel.ApplyPartialResult).Execute(null);
+            Assert.That(viewModel.Cues.Select(cue => cue.Text),
+                Is.EqualTo(new[] { "B paid caption" }));
+
+            viewModel.Dispose();
+            Assert.That(store.TryOpen(userA, out ICaptionDraftSession? userASession), Is.True);
+            using (userASession)
+            {
+                CaptionDraftEntry? untouched = userASession!.Read().Entry;
+                Assert.Multiple(() =>
+                {
+                    Assert.That(untouched?.JobId, Is.EqualTo("job-a"));
+                    Assert.That(untouched?.Draft.Cues.Single().Text, Is.EqualTo("A paid caption"));
+                });
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static AiSubtitleDialogViewModel CreateViewModel(
+        BeutlApiApplication clients,
+        ICaptionDraftStore? draftStore = null,
+        IObservable<CaptionDraftScope?>? scopes = null)
+        => new(
+            clients.GetResource<IAiEntitlementService>(),
+            clients.GetResource<IAiOperationAvailabilityService>(),
+            clients.GetResource<IAiModelCatalogService>(),
+            new AiPlanCoordinator(clients.GetResource<IAiEntitlementService>()),
+            clients.GetResource<IAiTranscriptionService>(),
+            clients.GetResource<IAiCaptionTranslationService>(),
+            CaptionCatalog.CreateDefault("Default"),
+            draftStore ?? CaptionDraftStoreProvider.Current,
+            scopes ?? Observable.Return<CaptionDraftScope?>(null));
+
+    private static AiSubtitleDialogViewModel CreateTeardownViewModel(
+        string directory,
+        IAiCaptionTranslationService? translation = null)
+        => new(
+            new SubtitleStubEntitlements(),
+            new SubtitleStubAvailability(),
+            new SubtitleStubModelCatalog(),
+            new SubtitleStubPlanCoordinator(),
+            new SubtitleStubTranscription(),
+            translation ?? new SubtitleStubTranslation(),
+            CaptionCatalog.CreateDefault("Default"),
+            new FileCaptionDraftStore(directory),
+            Observable.Return<CaptionDraftScope?>(null));
+
+    private static AsyncOperationLifetime GetOperations(AiSubtitleDialogViewModel viewModel)
+        => (AsyncOperationLifetime)typeof(AiSubtitleDialogViewModel)
+            .GetField("_operations", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .GetValue(viewModel)!;
+
+    private sealed class SubtitleStubEntitlements : IAiEntitlementService
+    {
+        public IReadOnlyReactiveProperty<AiEntitlements?> Entitlements { get; }
+            = new ReactivePropertySlim<AiEntitlements?>();
+
+        public Task<AiEntitlements?> RefreshAsync(CancellationToken cancellationToken)
+            => Task.FromResult<AiEntitlements?>(null);
+    }
+
+    private sealed class SubtitleStubAvailability : IAiOperationAvailabilityService
+    {
+        public Task<bool> CheckAsync(
+            AiOperationAvailabilityRequest request,
+            CancellationToken cancellationToken)
+            => Task.FromResult(true);
+    }
+
+    private sealed class SubtitleStubModelCatalog : IAiModelCatalogService
+    {
+        public Task<AiModelCatalog> GetAsync(CancellationToken cancellationToken)
+            => Task.FromResult(AiModelCatalog.Empty);
+
+        public void Invalidate()
+        {
+        }
+    }
+
+    private sealed class SubtitleStubPlanCoordinator : IAiPlanCoordinator
+    {
+        public void OpenAccountSettings()
+        {
+        }
+
+        public void OpenAiPlan()
+        {
+        }
+
+        public Task RefreshIfPendingAsync(CancellationToken cancellationToken)
+            => Task.CompletedTask;
+    }
+
+    private sealed class SubtitleStubTranscription : IAiTranscriptionService
+    {
+        public Task<AiTranscriptionResponse> TranscribeAsync(
+            AiTranscriptionRequest request,
+            CancellationToken cancellationToken)
+            => Task.FromException<AiTranscriptionResponse>(
+                new InvalidOperationException("not used"));
+    }
+
+    private sealed class SubtitleStubTranslation : IAiCaptionTranslationService
+    {
+        public Task<AiCaptionTranslationResponse> TranslateAsync(
+            AiCaptionTranslationRequest request,
+            CancellationToken cancellationToken)
+            => Task.FromException<AiCaptionTranslationResponse>(
+                new InvalidOperationException("not used"));
+
+        public Task<AiCaptionTranslationResponse> TranslateAsync(
+            AiCaptionTranslationRequest request,
+            IProgress<AiCaptionTranslationSegment>? progress,
+            CancellationToken cancellationToken)
+            => Task.FromException<AiCaptionTranslationResponse>(
+                new InvalidOperationException("not used"));
+    }
+
+    private sealed class BlockingSubtitleTranslation : IAiCaptionTranslationService
+    {
+        public TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<AiCaptionTranslationResponse> TranslateAsync(
+            AiCaptionTranslationRequest request,
+            CancellationToken cancellationToken)
+            => TranslateAsync(request, progress: null, cancellationToken);
+
+        public async Task<AiCaptionTranslationResponse> TranslateAsync(
+            AiCaptionTranslationRequest request,
+            IProgress<AiCaptionTranslationSegment>? progress,
+            CancellationToken cancellationToken)
+        {
+            Started.TrySetResult();
+            await Release.Task;
+            return new AiCaptionTranslationResponse(null, []);
+        }
+    }
+
+    private static void SaveDraft(
+        ICaptionDraftStore store,
+        CaptionDraftScope scope,
+        string jobId,
+        string text)
+    {
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? session), Is.True);
+        using (session)
+        {
+            session!.Save(new CaptionDraftEntry(jobId, CreateDraft(text)));
+        }
+    }
+
+    private static CaptionDraft CreateDraft(string text)
+    {
+        var segment = new AiTranscriptionSegment { Start = 0, End = 1, Text = text };
+        return new CaptionDraft(
+            FileCaptionDraftStore.CurrentVersion,
+            [new StoredCaptionCue(0, TimeSpan.FromSeconds(1).Ticks, text, null, "en", [])],
+            "en",
+            [segment],
+            CaptionDraftKind.Transcription,
+            1,
+            1,
+            null,
+            null);
+    }
+
+    private static string CreateDraftDirectory()
+    {
+        string directory = Path.Combine(
+            Path.GetTempPath(),
+            "Beutl.HeadlessUITests",
+            nameof(AiSubtitleAdvancedTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private sealed class StreamingAudioReader(int sampleRate, int totalSamples) : MediaReader
+    {
+        public int MaximumRequestedSamples { get; private set; }
+
+        public int ReadCount { get; private set; }
+
+        public override VideoStreamInfo VideoInfo
+            => throw new InvalidOperationException("The test reader has no video stream.");
+
+        public override AudioStreamInfo AudioInfo { get; } = new(
+            "test",
+            new Rational(totalSamples, sampleRate),
+            sampleRate,
+            2);
+
+        public override bool HasVideo => false;
+
+        public override bool HasAudio => true;
+
+        public override bool ReadVideo(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
+        {
+            image = null;
+            return false;
+        }
+
+        public override bool ReadAudio(
+            int start,
+            int length,
+            [NotNullWhen(true)] out Ref<IPcm>? sound)
+        {
+            MaximumRequestedSamples = Math.Max(MaximumRequestedSamples, length);
+            int decoded = Math.Clamp(totalSamples - start, 0, length);
+            var pcm = new Pcm<Stereo32BitFloat>(sampleRate, decoded);
+            pcm.DataSpan.Fill(new Stereo32BitFloat(0.25f, -0.25f));
+            sound = Ref<IPcm>.Create(pcm);
+            ReadCount++;
+            return true;
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiSubtitleAdvancedTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiSubtitleAdvancedTests.cs
@@ -729,6 +729,12 @@ public sealed class AiSubtitleAdvancedTests
 
     private sealed class SubtitleStubPlanCoordinator : IAiPlanCoordinator
     {
+        public event EventHandler? Refreshed
+        {
+            add { }
+            remove { }
+        }
+
         public void OpenAccountSettings()
         {
         }
@@ -737,8 +743,8 @@ public sealed class AiSubtitleAdvancedTests
         {
         }
 
-        public Task RefreshIfPendingAsync(CancellationToken cancellationToken)
-            => Task.CompletedTask;
+        public Task<bool> RefreshIfPendingAsync(CancellationToken cancellationToken)
+            => Task.FromResult(false);
     }
 
     private sealed class SubtitleStubTranscription : IAiTranscriptionService

--- a/tests/Beutl.HeadlessUITests/AiSubtitleTemplateTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiSubtitleTemplateTests.cs
@@ -1,0 +1,929 @@
+﻿using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Automation.Peers;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Templates;
+using Avalonia.Headless.NUnit;
+using Avalonia.LogicalTree;
+using Avalonia.VisualTree;
+using Beutl.Api.Clients;
+using Beutl.Api.Services;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Editor.Services.Captions;
+using Beutl.Extensibility;
+using Beutl.Graphics;
+using Beutl.Graphics.Shapes;
+using Beutl.Graphics.Transformation;
+using Beutl.Media;
+using Beutl.ProjectSystem;
+using Beutl.Services.AI;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.ViewModels.Dialogs;
+using Beutl.Views.Tools;
+using SkiaSharp;
+using AvaloniaComboBox = Avalonia.Controls.ComboBox;
+using AvaloniaControl = Avalonia.Controls.Control;
+using AvaloniaListBox = Avalonia.Controls.ListBox;
+using AvaloniaTextBlock = Avalonia.Controls.TextBlock;
+using AvaloniaTextBox = Avalonia.Controls.TextBox;
+using AvaloniaWindow = Avalonia.Controls.Window;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture, NonParallelizable]
+public class AiSubtitleTemplateTests
+{
+    private const int SavedTemplatePackageId = -42_101;
+    private const int CustomTemplatePackageId = -42_102;
+    private const int PreviewTemplatePackageId = -42_103;
+
+    private static string NewWorkspace(string name)
+    {
+        string location = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(location);
+        return location;
+    }
+
+    private static async Task<EditViewModel> OpenEditorForNewScene(string name)
+    {
+        Project project = (await TestShell.Project.CreateProject(
+            640, 480, 30, 44100, name, NewWorkspace(name)))!;
+        HeadlessTestHelpers.Settle();
+        Scene scene = project.Items.OfType<Scene>().First();
+
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
+    }
+
+    private static TranslateTransform GetTranslate(TextBlock textBlock)
+    {
+        return textBlock.Transform.CurrentValue switch
+        {
+            TranslateTransform translate => translate,
+            TransformGroup group => group.Children.OfType<TranslateTransform>().Single(),
+            _ => throw new AssertionException("The subtitle does not contain a translation transform."),
+        };
+    }
+
+    [Test]
+    public async Task CreateCaptionTemplates_UsesExplicitRegistryOrderAndTextTemplatesOnly()
+    {
+        ObjectTemplateItem zulu = ObjectTemplateItem.CreateFromInstance(new TextBlock(), "Zulu");
+        ObjectTemplateItem shape = ObjectTemplateItem.CreateFromInstance(new EllipseShape(), "Shape");
+        ObjectTemplateItem alpha = ObjectTemplateItem.CreateFromInstance(new TextBlock(), "Alpha");
+
+        await using CaptionCatalog catalog = CaptionCatalog.Compose(
+            "Default",
+            [zulu, shape, alpha],
+            new ExtensionProvider());
+        IReadOnlyList<CaptionTemplateDescriptor> result = catalog.Templates.Templates;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Has.Count.EqualTo(3));
+            Assert.That(result[0].Id, Is.EqualTo(CaptionTemplateIds.DefaultText));
+            Assert.That(result.Skip(1).Select(template => template.Name),
+                Is.EqualTo(new[] { "Alpha", "Zulu" }));
+        }
+    }
+
+    [Test]
+    public void MapSegmentsToScene_AppliesElementStartTrimAndSpeed()
+    {
+        var source = new AudioSourceItem(
+            "Audio",
+            "/tmp/audio.wav",
+            TimeSpan.FromSeconds(20),
+            elementStart: TimeSpan.FromSeconds(10),
+            elementLength: TimeSpan.FromSeconds(4),
+            sourceOffset: TimeSpan.FromSeconds(2),
+            speed: 200);
+
+        AiTranscriptionSegment[] result = source.MapSegmentsToScene(
+        [
+            new AiTranscriptionSegment { Start = 0, End = 1, Text = "Before trim" },
+            new AiTranscriptionSegment { Start = 1, End = 3, Text = "Crosses trim" },
+            new AiTranscriptionSegment { Start = 4, End = 8, Text = "Middle" },
+            new AiTranscriptionSegment { Start = 9, End = 12, Text = "Crosses end" },
+        ]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Select(segment => segment.Text),
+                Is.EqualTo(new[] { "Crosses trim", "Middle", "Crosses end" }));
+            Assert.That(result.Select(segment => segment.Start),
+                Is.EqualTo(new[] { 10, 11, 13.5 }).Within(0.001));
+            Assert.That(result.Select(segment => segment.End),
+                Is.EqualTo(new[] { 10.5, 13, 14 }).Within(0.001));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task View_RendersCaptionTemplateDescriptorNameAndProvider()
+    {
+        await TestReset.ResetShellAsync();
+        using AiSubtitleDialogViewModel viewModel =
+            TestShell.MainViewModel.CreateAiSubtitleToolViewModel(null);
+        viewModel.SelectedSubtitlePageIndex.Value = 1;
+        var view = new AiSubtitleView { DataContext = viewModel };
+        var viewWindow = new AvaloniaWindow { Content = view, Width = 460, Height = 640 };
+        AvaloniaWindow? itemWindow = null;
+
+        try
+        {
+            viewWindow.Show();
+            HeadlessTestHelpers.Render();
+
+            AvaloniaComboBox templatePicker = view.GetVisualDescendants()
+                .OfType<AvaloniaComboBox>()
+                .Single(comboBox => comboBox.Name == "CaptionTemplateComboBox");
+            CaptionTemplateDescriptor descriptor = viewModel.CaptionTemplates[0];
+            IDataTemplate template = templatePicker.ItemTemplate!;
+            AvaloniaControl content = new ContentPresenter
+            {
+                Content = descriptor,
+                ContentTemplate = template,
+            };
+            itemWindow = new AvaloniaWindow { Content = content, Width = 360, Height = 120 };
+            itemWindow.Show();
+            HeadlessTestHelpers.Render();
+
+            string?[] renderedText = content.GetVisualDescendants()
+                .OfType<AvaloniaTextBlock>()
+                .Select(textBlock => textBlock.Text)
+                .ToArray();
+            Assert.Multiple(() =>
+            {
+                Assert.That(renderedText, Does.Contain(descriptor.Name));
+                Assert.That(renderedText, Does.Contain(descriptor.ProviderId.Value));
+            });
+        }
+        finally
+        {
+            itemWindow?.Close();
+            viewWindow.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task View_RendersTheSelectedCaptionTemplateOutput()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("ai-subtitle-template-preview");
+        var previewFactory = new PreviewCaptionFactory();
+        CaptionTemplateRegistrationSet template = CreateTemplate(
+            new CaptionTemplateId("beutl.tests.preview"),
+            new CaptionTemplateProviderId("beutl.tests"),
+            "Preview",
+            previewFactory,
+            DefaultCaptionPlacementPolicy.Instance);
+        AiSubtitleDialogViewModel? ownedViewModel = null;
+        AvaloniaWindow? ownedWindow = null;
+
+        try
+        {
+            TestShell.Extensions.AddExtensions(
+                PreviewTemplatePackageId,
+                CreateTemplateExtensions(template));
+            AiSubtitleDialogViewModel viewModel =
+                TestShell.MainViewModel.CreateAiSubtitleToolViewModel(editor);
+            ownedViewModel = viewModel;
+            viewModel.SelectedCaptionTemplate.Value = viewModel.CaptionTemplates
+                .Single(item => item.Id == template.DescriptorRegistration.Descriptor.Id);
+            viewModel.ResultSegments.Value =
+            [
+                new AiTranscriptionSegment { Start = 0, End = 2, Text = "Rendered cue" },
+            ];
+            await Task.Delay(200);
+            HeadlessTestHelpers.Settle();
+            Assert.That(previewFactory.CreateCount, Is.Zero,
+                "A hidden subtitle tool must not start renderer work that delays its teardown.");
+            var view = new AiSubtitleView { DataContext = viewModel };
+            var window = new AvaloniaWindow { Content = view, Width = 460, Height = 640 };
+            ownedWindow = window;
+            window.Show();
+            HeadlessTestHelpers.Render();
+            Beutl.Controls.BitmapView bitmapView = view.GetVisualDescendants()
+                .OfType<Beutl.Controls.BitmapView>()
+                .Single(item => item.Name == "CaptionTemplatePreviewBitmap");
+            AvaloniaTextBlock fallback = view.GetVisualDescendants()
+                .OfType<AvaloniaTextBlock>()
+                .Single(item => item.Name == "CaptionTemplatePreviewFallback");
+            AutomationPeer previewPeer = ControlAutomationPeer.CreatePeerForElement(bitmapView);
+            for (int attempt = 0;
+                 attempt < 30 && bitmapView.Source?.Value is null;
+                 attempt++)
+            {
+                await Task.Delay(100);
+                HeadlessTestHelpers.Settle();
+            }
+
+            Assert.That(bitmapView.Source?.Value, Is.Not.Null,
+                "The preview must contain the renderer output for the selected caption template.");
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(
+                    Math.Max(bitmapView.Source!.Value.Width, bitmapView.Source.Value.Height),
+                    Is.GreaterThan(ObjectTemplatePreviewRenderer.PreviewWidth),
+                    "Subtitle previews must retain more detail than saved object-template thumbnails.");
+                Assert.That(bitmapView.IsEffectivelyVisible, Is.True);
+                Assert.That(fallback.IsEffectivelyVisible, Is.False);
+                Assert.That(previewPeer.GetAutomationControlType(), Is.EqualTo(AutomationControlType.Image));
+                Assert.That(previewPeer.GetName(),
+                    Is.EqualTo(Beutl.Language.Strings.AiSubtitle_TemplatePreview));
+                Assert.That(previewPeer.IsContentElement(), Is.True);
+                Assert.That(previewFactory.CreateCount, Is.GreaterThan(0));
+            }
+            (bool hasRed, bool hasGreen, bool hasBlue) = GetPreviewColors(bitmapView.Source!.Value);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(hasRed, Is.True,
+                    "The selected template's rendered color was not present in the preview.");
+                Assert.That(hasGreen, Is.False);
+                Assert.That(hasBlue, Is.True,
+                    "The second element from the selected template was not rendered in the preview.");
+            }
+
+            Beutl.Media.Bitmap pagePreview = bitmapView.Source.Value;
+            int rendersBeforePageChange = previewFactory.CreateCount;
+            viewModel.SelectedSubtitlePageIndex.Value = 0;
+            HeadlessTestHelpers.Render();
+            await Task.Delay(200);
+            HeadlessTestHelpers.Settle();
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.TemplatePreviewImage.Value, Is.Null);
+                Assert.That(bitmapView.Source, Is.Null);
+                Assert.That(previewFactory.CreateCount, Is.EqualTo(rendersBeforePageChange),
+                    "A hidden Edit page must not keep rendering template previews.");
+            }
+
+            viewModel.BeforeTemplatePreviewAdmission = () =>
+                viewModel.SelectedSubtitlePageIndex.Value = 0;
+            try
+            {
+                viewModel.SelectedSubtitlePageIndex.Value = 1;
+            }
+            finally
+            {
+                viewModel.BeforeTemplatePreviewAdmission = null;
+            }
+            await Task.Delay(200);
+            HeadlessTestHelpers.Settle();
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.SelectedSubtitlePageIndex.Value, Is.Zero);
+                Assert.That(viewModel.TemplatePreviewImage.Value, Is.Null);
+                Assert.That(previewFactory.CreateCount, Is.EqualTo(rendersBeforePageChange),
+                    "A page switch that wins preview admission must prevent hidden renderer work.");
+            }
+
+            viewModel.SelectedSubtitlePageIndex.Value = 1;
+            for (int attempt = 0;
+                 attempt < 30
+                 && (bitmapView.Source?.Value is null
+                     || ReferenceEquals(bitmapView.Source.Value, pagePreview));
+                 attempt++)
+            {
+                await Task.Delay(100);
+                HeadlessTestHelpers.Settle();
+            }
+            Assert.That(bitmapView.Source?.Value, Is.Not.Null);
+            Assert.That(bitmapView.Source!.Value, Is.Not.SameAs(pagePreview));
+
+            Beutl.Media.Bitmap initialPreview = bitmapView.Source.Value;
+            editor.Scene.FrameSize = new Beutl.Media.PixelSize(640, 800);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(bitmapView.Source, Is.Null);
+                Assert.That(bitmapView.IsEffectivelyVisible, Is.False);
+                Assert.That(fallback.IsEffectivelyVisible, Is.True,
+                    "The text fallback must remain visible while a replacement preview is rendered.");
+            }
+            for (int attempt = 0;
+                 attempt < 30
+                 && (bitmapView.Source?.Value is null
+                     || ReferenceEquals(bitmapView.Source.Value, initialPreview));
+                 attempt++)
+            {
+                await Task.Delay(100);
+                HeadlessTestHelpers.Settle();
+            }
+
+            Assert.That(bitmapView.Source?.Value, Is.Not.Null);
+            Assert.That(bitmapView.Source!.Value, Is.Not.SameAs(initialPreview),
+                "Changing the scene frame must invalidate the caption template preview.");
+            (hasRed, hasGreen, hasBlue) = GetPreviewColors(bitmapView.Source.Value);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(hasRed, Is.False);
+                Assert.That(hasGreen, Is.True,
+                    "The preview did not use the updated frame-height placement context.");
+                Assert.That(hasBlue, Is.True);
+                Assert.That(bitmapView.IsEffectivelyVisible, Is.True);
+                Assert.That(fallback.IsEffectivelyVisible, Is.False);
+            }
+
+            int rendersBeforeUnload = previewFactory.CreateCount;
+            viewModel.BeforeTemplatePreviewAdmission = window.Close;
+            try
+            {
+                editor.Scene.FrameSize = new Beutl.Media.PixelSize(640, 900);
+            }
+            finally
+            {
+                viewModel.BeforeTemplatePreviewAdmission = null;
+            }
+            await Task.Delay(200);
+            HeadlessTestHelpers.Settle();
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(window.IsVisible, Is.False);
+                Assert.That(viewModel.TemplatePreviewImage.Value, Is.Null);
+                Assert.That(previewFactory.CreateCount, Is.EqualTo(rendersBeforeUnload),
+                    "The last unload must close preview admission before a concurrent refresh installs work.");
+            }
+        }
+        finally
+        {
+            try
+            {
+                ownedWindow?.Close();
+                HeadlessTestHelpers.Settle();
+            }
+            finally
+            {
+                try
+                {
+                    if (ownedViewModel is not null)
+                        await ownedViewModel.DisposeAsync();
+                }
+                finally
+                {
+                    TestShell.Extensions.RemoveExtensions(PreviewTemplatePackageId);
+                }
+            }
+        }
+    }
+
+    private static (bool Red, bool Green, bool Blue) GetPreviewColors(Beutl.Media.Bitmap bitmap)
+    {
+        using var stream = new MemoryStream();
+        bitmap.Save(stream, EncodedImageFormat.Png);
+        using SKBitmap decoded = SKBitmap.Decode(stream.ToArray());
+        bool hasRed = false;
+        bool hasGreen = false;
+        bool hasBlue = false;
+        for (int y = 0; y < decoded.Height && (!hasRed || !hasGreen || !hasBlue); y++)
+        {
+            for (int x = 0; x < decoded.Width; x++)
+            {
+                SKColor pixel = decoded.GetPixel(x, y);
+                hasRed |= pixel.Alpha > 80 && pixel.Red > 160 && pixel.Green < 120;
+                hasGreen |= pixel.Alpha > 80 && pixel.Green > 160 && pixel.Red < 120;
+                hasBlue |= pixel.Alpha > 80 && pixel.Blue > 160 && pixel.Red < 120;
+            }
+        }
+        return (hasRed, hasGreen, hasBlue);
+    }
+
+    private sealed class PreviewCaptionFactory : ICaptionElementFactory
+    {
+        private int _createCount;
+
+        public int CreateCount => Volatile.Read(ref _createCount);
+
+        public IReadOnlyList<ElementDescription> CreateElements(
+            CaptionCue cue,
+            CaptionElementContext context)
+        {
+            Interlocked.Increment(ref _createCount);
+            Color primaryColor = cue.Text != "Rendered cue"
+                ? Colors.Yellow
+                : context.DefaultPosition.Y < 200
+                    ? Colors.Red
+                    : Colors.Lime;
+            return
+            [
+                context.CreateDescription(
+                    cue,
+                    () => new TextBlock
+                    {
+                        Text = { CurrentValue = cue.Text },
+                        Size = { CurrentValue = 96 },
+                        Fill = { CurrentValue = new SolidColorBrush(primaryColor) },
+                    },
+                    position: new Beutl.Graphics.Point(-140, context.DefaultPosition.Y)),
+                context.CreateDescription(
+                    cue,
+                    () => new RectShape
+                    {
+                        Width = { CurrentValue = 80 },
+                        Height = { CurrentValue = 60 },
+                        Fill = { CurrentValue = new SolidColorBrush(Colors.Blue) },
+                    },
+                    position: new Beutl.Graphics.Point(140, context.DefaultPosition.Y)),
+            ];
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task TemplatePreview_PageChangeCancelsAnAdmittedRender()
+    {
+        await TestReset.ResetShellAsync();
+        var renderStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRenderer = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        byte[] latePng;
+        using (var bitmap = new Beutl.Media.Bitmap(2, 2))
+        using (var stream = new MemoryStream())
+        {
+            Assert.That(bitmap.Save(stream, EncodedImageFormat.Png), Is.True);
+            latePng = stream.ToArray();
+        }
+        AiSubtitleDialogViewModel viewModel =
+            TestShell.MainViewModel.CreateAiSubtitleToolViewModel(null);
+        viewModel.SelectedSubtitlePageIndex.Value = 1;
+        viewModel.TemplatePreviewRenderer = async (_, _, cancellationToken) =>
+        {
+            using CancellationTokenRegistration registration = cancellationToken.Register(
+                () => cancellationObserved.TrySetResult());
+            renderStarted.TrySetResult();
+            await releaseRenderer.Task;
+            return latePng;
+        };
+        var view = new AiSubtitleView { DataContext = viewModel };
+        var window = new AvaloniaWindow { Content = view, Width = 320, Height = 640 };
+        Task? disposal = null;
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+            await renderStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            viewModel.SelectedSubtitlePageIndex.Value = 0;
+            await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Beutl.Controls.BitmapView preview = view.GetVisualDescendants()
+                .OfType<Beutl.Controls.BitmapView>()
+                .Single(item => item.Name == "CaptionTemplatePreviewBitmap");
+            window.Close();
+            HeadlessTestHelpers.Settle();
+            disposal = viewModel.DisposeAsync().AsTask();
+            await Task.Delay(100);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(disposal.IsCompleted, Is.False,
+                    "Disposal must drain the admitted renderer even after its page is hidden.");
+                Assert.That(viewModel.TemplatePreviewImage.Value, Is.Null);
+                Assert.That(preview.Source, Is.Null);
+                Assert.That(viewModel.SelectedSubtitlePageIndex.Value, Is.Zero);
+            }
+
+            releaseRenderer.TrySetResult();
+            await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+            HeadlessTestHelpers.Settle();
+            Assert.That(preview.Source, Is.Null,
+                "Bytes returned after cancellation must not publish a late preview image.");
+        }
+        finally
+        {
+            releaseRenderer.TrySetResult();
+            if (window.IsVisible)
+                window.Close();
+            HeadlessTestHelpers.Settle();
+            disposal ??= viewModel.DisposeAsync().AsTask();
+            await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task CueEditor_NarrowWidthKeepsFieldsUsableAndBindsCaretForSplit()
+    {
+        await TestReset.ResetShellAsync();
+        using AiSubtitleDialogViewModel viewModel =
+            TestShell.MainViewModel.CreateAiSubtitleToolViewModel(null);
+        viewModel.ResultSegments.Value =
+        [
+            new AiTranscriptionSegment { Start = 0, End = 4, Text = "hello world" },
+        ];
+        var view = new AiSubtitleView { DataContext = viewModel };
+        var window = new AvaloniaWindow { Content = view, Width = 280, Height = 640 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            AvaloniaTextBox[] cueFields = view.GetVisualDescendants()
+                .OfType<AvaloniaTextBox>()
+                .Where(textBox =>
+                {
+                    string? name = AutomationProperties.GetName(textBox);
+                    return name == Beutl.Language.Strings.AiSubtitle_CueStart
+                        || name == Beutl.Language.Strings.AiSubtitle_CueEnd
+                        || name == Beutl.Language.Strings.AiSubtitle_Speaker
+                        || name == Beutl.Language.Strings.AiSubtitle_Language
+                        || name == Beutl.Language.Strings.AiSubtitle_Text;
+                })
+                .ToArray();
+            AvaloniaTextBox captionText = cueFields.Single(textBox =>
+                AutomationProperties.GetName(textBox) == Beutl.Language.Strings.AiSubtitle_Text);
+            AvaloniaListBox cueList = view.GetLogicalDescendants()
+                .OfType<AvaloniaListBox>()
+                .Single(listBox => listBox.Name == "CaptionCueList");
+            double rightmostFieldEdge = cueFields.Max(field =>
+                field.TranslatePoint(new Avalonia.Point(field.Bounds.Width, 0), cueList)?.X
+                ?? double.PositiveInfinity);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(cueFields, Has.Length.EqualTo(5));
+                Assert.That(cueFields.All(field => field.Bounds.Width > 0), Is.True);
+                Assert.That(rightmostFieldEdge,
+                    Is.LessThanOrEqualTo(cueList.Bounds.Width + 1));
+                Assert.That(viewModel.SplitCue.CanExecute(), Is.False);
+            }
+
+            captionText.CaretIndex = 5;
+            HeadlessTestHelpers.Settle();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(viewModel.Cues[0].CaretIndex, Is.EqualTo(5));
+                Assert.That(viewModel.SplitCue.CanExecute(), Is.True);
+            });
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task SelectingAnotherAudioSource_ClearsTranscriptionResult()
+    {
+        await TestReset.ResetShellAsync();
+        using AiSubtitleDialogViewModel viewModel =
+            TestShell.MainViewModel.CreateAiSubtitleToolViewModel(null);
+        var first = new AudioSourceItem("First", "/tmp/first.wav", TimeSpan.FromSeconds(10));
+        var second = new AudioSourceItem("Second", "/tmp/second.wav", TimeSpan.FromSeconds(10));
+        viewModel.SelectedAudioSource.Value = first;
+        viewModel.ResultSegments.Value =
+        [
+            new AiTranscriptionSegment { Start = 0, End = 1, Text = "Stale" },
+        ];
+
+        viewModel.SelectedAudioSource.Value = second;
+        HeadlessTestHelpers.Settle();
+
+        Assert.That(viewModel.ResultSegments.Value, Is.Null);
+        Assert.That(viewModel.CanAddToScene.Value, Is.False);
+    }
+
+    [Test]
+    public void AudioSourceResumeIdentity_RequiresEquivalentTimelineMapping()
+    {
+        Guid elementId = Guid.NewGuid();
+        var first = new AudioSourceItem(
+            "First",
+            "/tmp/source.flac",
+            TimeSpan.FromSeconds(30),
+            elementStart: TimeSpan.FromSeconds(2),
+            elementLength: TimeSpan.FromSeconds(10),
+            sourceOffset: TimeSpan.FromSeconds(1),
+            speed: 125,
+            elementId: elementId);
+        var equivalent = new AudioSourceItem(
+            "Renamed",
+            "/tmp/source.flac",
+            TimeSpan.FromSeconds(30),
+            elementStart: TimeSpan.FromSeconds(2),
+            elementLength: TimeSpan.FromSeconds(10),
+            sourceOffset: TimeSpan.FromSeconds(1),
+            speed: 125,
+            elementId: elementId);
+        var changedMapping = new AudioSourceItem(
+            "Changed",
+            "/tmp/source.flac",
+            TimeSpan.FromSeconds(30),
+            elementStart: TimeSpan.FromSeconds(3),
+            elementLength: TimeSpan.FromSeconds(10),
+            sourceOffset: TimeSpan.FromSeconds(1),
+            speed: 125,
+            elementId: elementId);
+        var anotherElement = new AudioSourceItem(
+            "Other element",
+            "/tmp/source.flac",
+            TimeSpan.FromSeconds(30),
+            elementStart: TimeSpan.FromSeconds(2),
+            elementLength: TimeSpan.FromSeconds(10),
+            sourceOffset: TimeSpan.FromSeconds(1),
+            speed: 125,
+            elementId: Guid.NewGuid());
+        string relativePath = Path.GetRelativePath(
+            Environment.CurrentDirectory,
+            Path.GetFullPath("/tmp/source.flac"));
+        var equivalentRelativePath = new AudioSourceItem(
+            "Relative",
+            relativePath,
+            TimeSpan.FromSeconds(30),
+            elementStart: TimeSpan.FromSeconds(2),
+            elementLength: TimeSpan.FromSeconds(10),
+            sourceOffset: TimeSpan.FromSeconds(1),
+            speed: 125,
+            elementId: elementId);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(AudioSourceItem.CanResume(equivalent, first), Is.True);
+            Assert.That(AudioSourceItem.CanResume(equivalentRelativePath, first), Is.True);
+            Assert.That(AudioSourceItem.CanResume(changedMapping, first), Is.False);
+            Assert.That(AudioSourceItem.CanResume(anotherElement, first), Is.False);
+            Assert.That(AudioSourceItem.CanResume(null, first), Is.False);
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task LoadHistoryResult_ConfirmsBeforeReplacingUnsavedCaptionsInTheReusedTab()
+    {
+        await TestReset.ResetShellAsync();
+        using AiSubtitleDialogViewModel viewModel =
+            TestShell.MainViewModel.CreateAiSubtitleToolViewModel(null);
+        viewModel.ResultSegments.Value =
+        [
+            new AiTranscriptionSegment { Start = 0, End = 1, Text = "Work in progress" },
+        ];
+        HeadlessTestHelpers.Settle();
+
+        viewModel.LoadHistoryResult(CreateHistoryResult("Imported from history"));
+        HeadlessTestHelpers.Settle();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.HasPendingHistoryResult.Value, Is.True);
+            Assert.That(
+                viewModel.HistoryOverwriteMessage.Value,
+                Is.EqualTo(Beutl.Language.Strings.AiSubtitle_HistoryOverwritePrompt));
+            Assert.That(
+                viewModel.ResultSegments.Value!.Single().Text,
+                Is.EqualTo("Work in progress"),
+                "The pending import must not discard unsaved captions before confirmation.");
+        }
+
+        viewModel.DiscardPendingHistoryResult();
+        HeadlessTestHelpers.Settle();
+        Assert.That(viewModel.ResultSegments.Value!.Single().Text, Is.EqualTo("Work in progress"));
+
+        viewModel.LoadHistoryResult(CreateHistoryResult("Imported from history"));
+        viewModel.ConfirmPendingHistoryResult();
+        HeadlessTestHelpers.Settle();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.HasPendingHistoryResult.Value, Is.False);
+            Assert.That(
+                viewModel.ResultSegments.Value!.Single().Text,
+                Is.EqualTo("Imported from history"));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task LoadHistoryResult_AppliesImmediatelyWhenTheTabHasNoUnsavedWork()
+    {
+        await TestReset.ResetShellAsync();
+        using AiSubtitleDialogViewModel viewModel =
+            TestShell.MainViewModel.CreateAiSubtitleToolViewModel(null);
+
+        viewModel.LoadHistoryResult(CreateHistoryResult("Imported from history"));
+        HeadlessTestHelpers.Settle();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.HasPendingHistoryResult.Value, Is.False);
+            Assert.That(
+                viewModel.ResultSegments.Value!.Single().Text,
+                Is.EqualTo("Imported from history"));
+        }
+    }
+
+    private static AiCaptionHistoryResult CreateHistoryResult(string text)
+        => new(
+            new AiJobId("caption-history-job"),
+            [new AiTranscriptionSegment { Start = 0, End = 1, Text = text }],
+            "en");
+
+    [AvaloniaTest]
+    public async Task AddToScene_WithDefaultTemplate_CreatesPositionedIndependentSubtitles()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("ai-subtitle-default-template");
+        using AiSubtitleDialogViewModel viewModel =
+            TestShell.MainViewModel.CreateAiSubtitleToolViewModel(editor);
+        viewModel.ResultSegments.Value =
+        [
+            new AiTranscriptionSegment { Start = 0, End = 1.25, Text = "First" },
+            new AiTranscriptionSegment { Start = 2, End = 2.1, Text = "Second" },
+        ];
+        HeadlessTestHelpers.Settle();
+
+        await viewModel.AddToScene.ExecuteAsync();
+        HeadlessTestHelpers.Settle();
+
+        Element[] elements = editor.Scene.Children.ToArray();
+        TextBlock[] subtitles = elements.Select(element => element.Objects.OfType<TextBlock>().Single()).ToArray();
+        float expectedY = editor.Scene.FrameSize.Height * 0.85f - editor.Scene.FrameSize.Height / 2f;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(elements, Has.Length.EqualTo(2));
+            Assert.That(elements.Select(element => element.Start),
+                Is.EqualTo(new[] { TimeSpan.Zero, TimeSpan.FromSeconds(2) }));
+            Assert.That(elements.Select(element => element.Length),
+                Is.EqualTo(new[] { TimeSpan.FromSeconds(1.25), TimeSpan.FromSeconds(0.5) }));
+            Assert.That(subtitles.Select(subtitle => subtitle.Text.CurrentValue),
+                Is.EqualTo(new[] { "First", "Second" }));
+            Assert.That(subtitles.Select(subtitle => subtitle.Id).Distinct().Count(), Is.EqualTo(2));
+            Assert.That(subtitles.All(subtitle => subtitle.Size.CurrentValue == 48), Is.True);
+            Assert.That(subtitles.All(subtitle =>
+                subtitle.FontFamily.CurrentValue?.Name == CaptionPresentationDefaults.FontFamilyName), Is.True);
+            Assert.That(subtitles.All(subtitle =>
+            {
+                TranslateTransform translate = GetTranslate(subtitle);
+                return translate.X.CurrentValue == 0
+                       && Math.Abs(translate.Y.CurrentValue - expectedY) < 0.001f;
+            }), Is.True);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task AddToScene_WithSavedTemplate_PreservesTemplateStyleAndPlacement()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("ai-subtitle-saved-template");
+        var source = new TextBlock
+        {
+            Text = { CurrentValue = "Placeholder" },
+            Size = { CurrentValue = 72 },
+            FontWeight = { CurrentValue = FontWeight.Bold },
+            Transform = { CurrentValue = new TranslateTransform(45, 60) },
+        };
+        ObjectTemplateItem item = ObjectTemplateItem.CreateFromInstance(source, "Saved subtitle");
+        CaptionTemplateRegistrationSet contribution = TextBlockCaptionTemplateAdapter.TryCreate(item)!;
+        TestShell.Extensions.AddExtensions(
+            SavedTemplatePackageId,
+            CreateTemplateExtensions(contribution));
+        try
+        {
+            using AiSubtitleDialogViewModel viewModel =
+                TestShell.MainViewModel.CreateAiSubtitleToolViewModel(editor);
+            viewModel.SelectedCaptionTemplate.Value = viewModel.CaptionTemplates
+                .Single(template => template.Id == contribution.DescriptorRegistration.Descriptor.Id);
+            viewModel.ResultSegments.Value =
+            [
+                new AiTranscriptionSegment { Start = 1, End = 3, Text = "Generated text" },
+            ];
+            HeadlessTestHelpers.Settle();
+
+            await viewModel.AddToScene.ExecuteAsync();
+            HeadlessTestHelpers.Settle();
+        }
+        finally
+        {
+            TestShell.Extensions.RemoveExtensions(SavedTemplatePackageId);
+        }
+
+        Element element = editor.Scene.Children.Single();
+        TextBlock subtitle = element.Objects.OfType<TextBlock>().Single();
+        TranslateTransform translate = GetTranslate(subtitle);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(element.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(subtitle.Text.CurrentValue, Is.EqualTo("Generated text"));
+            Assert.That(subtitle.Size.CurrentValue, Is.EqualTo(72));
+            Assert.That(subtitle.FontWeight.CurrentValue, Is.EqualTo(FontWeight.Bold));
+            Assert.That(translate.X.CurrentValue, Is.EqualTo(45));
+            Assert.That(translate.Y.CurrentValue, Is.EqualTo(60));
+            Assert.That(subtitle.Id, Is.Not.EqualTo(source.Id));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task AddToScene_WithCustomFactoryAddsEveryElementForEachCue()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("ai-subtitle-multi-template");
+        CaptionTemplateRegistrationSet template = CreateTemplate(
+            new CaptionTemplateId("beutl.tests.bilingual"),
+            new CaptionTemplateProviderId("beutl.tests"),
+            "Bilingual",
+            new BilingualCaptionFactory(),
+            DefaultCaptionPlacementPolicy.Instance);
+        TestShell.Extensions.AddExtensions(
+            CustomTemplatePackageId,
+            CreateTemplateExtensions(template));
+        try
+        {
+            using AiSubtitleDialogViewModel viewModel =
+                TestShell.MainViewModel.CreateAiSubtitleToolViewModel(editor);
+            viewModel.SelectedCaptionTemplate.Value = viewModel.CaptionTemplates
+                .Single(descriptor => descriptor.Id == template.DescriptorRegistration.Descriptor.Id);
+            viewModel.ResultSegments.Value =
+            [
+                new AiTranscriptionSegment { Start = 0, End = 2, Text = "Hello" },
+            ];
+            HeadlessTestHelpers.Settle();
+
+            await viewModel.AddToScene.ExecuteAsync();
+            HeadlessTestHelpers.Settle();
+        }
+        finally
+        {
+            TestShell.Extensions.RemoveExtensions(CustomTemplatePackageId);
+        }
+
+        Element[] elements = editor.Scene.Children.OrderBy(element => element.ZIndex).ToArray();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(elements, Has.Length.EqualTo(2));
+            Assert.That(elements.Select(element => element.ZIndex), Is.EqualTo(new[] { 0, 1 }));
+            Assert.That(
+                elements.Select(element => element.Objects.OfType<TextBlock>().Single().Text.CurrentValue),
+                Is.EqualTo(new[] { "Hello", "Hello translation" }));
+        }
+    }
+
+    private sealed class BilingualCaptionFactory : ICaptionElementFactory
+    {
+        public IReadOnlyList<ElementDescription> CreateElements(
+            CaptionCue cue,
+            CaptionElementContext context)
+            =>
+            [
+                context.CreateDescription(
+                    cue,
+                    () => new TextBlock { Text = { CurrentValue = cue.Text } }),
+                context.CreateDescription(
+                    cue,
+                    () => new TextBlock { Text = { CurrentValue = cue.Text + " translation" } },
+                    layerOffset: 1),
+            ];
+    }
+
+    private static CaptionTemplateRegistrationSet CreateTemplate(
+        CaptionTemplateId id,
+        CaptionTemplateProviderId providerId,
+        string name,
+        ICaptionElementFactory factory,
+        ICaptionPlacementPolicy placement)
+    {
+        var descriptor = new CaptionTemplateDescriptor(id, providerId, name);
+        return new CaptionTemplateRegistrationSet(
+            new CaptionTemplateDescriptorRegistration(descriptor),
+            new CaptionElementFactoryRegistration(id, factory),
+            new CaptionPlacementPolicyRegistration(id, placement));
+    }
+
+    private static Extension[] CreateTemplateExtensions(CaptionTemplateRegistrationSet template)
+        =>
+        [
+            new TestTemplateDescriptorExtension([template.DescriptorRegistration]),
+            new TestElementFactoryExtension([template.ElementFactoryRegistration]),
+            new TestPlacementExtension([template.PlacementPolicyRegistration]),
+        ];
+
+    private sealed class TestTemplateDescriptorExtension(
+        IReadOnlyCollection<CaptionTemplateDescriptorRegistration> registrations)
+        : CaptionTemplateDescriptorExtension
+    {
+        public override IReadOnlyCollection<CaptionTemplateDescriptorRegistration> Registrations
+            => registrations;
+    }
+
+    private sealed class TestElementFactoryExtension(
+        IReadOnlyCollection<CaptionElementFactoryRegistration> registrations)
+        : CaptionElementFactoryExtension
+    {
+        public override IReadOnlyCollection<CaptionElementFactoryRegistration> Registrations
+            => registrations;
+    }
+
+    private sealed class TestPlacementExtension(
+        IReadOnlyCollection<CaptionPlacementPolicyRegistration> registrations)
+        : CaptionPlacementPolicyExtension
+    {
+        public override IReadOnlyCollection<CaptionPlacementPolicyRegistration> Registrations
+            => registrations;
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiTemporaryFileStoreTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiTemporaryFileStoreTests.cs
@@ -1,0 +1,217 @@
+﻿using Beutl.Services.AI;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture, NonParallelizable]
+public sealed class AiTemporaryFileStoreTests
+{
+    [Test]
+    public void Create_UsesPrivateHomeDirectoryAndFilePermissions()
+    {
+        (string path, FileStream stream) = AiTemporaryFileStore.Create(
+            "tests",
+            "private",
+            ".png");
+        using (stream)
+        {
+            stream.WriteByte(1);
+        }
+
+        try
+        {
+            Assert.That(
+                Path.GetFullPath(path),
+                Does.StartWith(Path.GetFullPath(BeutlEnvironment.GetHomeDirectoryPath())));
+            if (!OperatingSystem.IsWindows())
+            {
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(
+                        File.GetUnixFileMode(path),
+                        Is.EqualTo(UnixFileMode.UserRead | UnixFileMode.UserWrite));
+                    Assert.That(
+                        File.GetUnixFileMode(Path.GetDirectoryName(path)!),
+                        Is.EqualTo(
+                            UnixFileMode.UserRead
+                            | UnixFileMode.UserWrite
+                            | UnixFileMode.UserExecute));
+                }
+            }
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public void Cleanup_RemovesOnlyStaleFiles()
+    {
+        string directory = AiTemporaryFileStore.GetCategoryDirectory(
+            $"cleanup-{Guid.NewGuid():N}");
+        AiTemporaryFileStore.EnsurePrivateDirectory(directory);
+        string stale = Path.Combine(directory, "stale.wav");
+        string recent = Path.Combine(directory, "recent.wav");
+        File.WriteAllBytes(stale, [1]);
+        File.WriteAllBytes(recent, [2]);
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        File.SetLastWriteTimeUtc(stale, (now - AiTemporaryFileStore.StaleAge - TimeSpan.FromMinutes(1)).UtcDateTime);
+
+        AiTemporaryFileStore.CleanStaleFiles(directory, now);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(File.Exists(stale), Is.False);
+            Assert.That(File.Exists(recent), Is.True);
+        }
+        Directory.Delete(directory, recursive: true);
+    }
+
+    [Test]
+    public void Cleanup_LeavesASessionAnotherProcessIsStillHolding()
+    {
+        string categoryRoot = AiTemporaryFileStore.GetCategoryRootDirectory(
+            $"sessions-{Guid.NewGuid():N}");
+        string live = Path.Combine(categoryRoot, "live");
+        string abandoned = Path.Combine(categoryRoot, "abandoned");
+        AiTemporaryFileStore.EnsurePrivateDirectory(live);
+        AiTemporaryFileStore.EnsurePrivateDirectory(abandoned);
+        string held = Path.Combine(live, "held.wav");
+        string orphaned = Path.Combine(abandoned, "orphaned.wav");
+        File.WriteAllBytes(held, [1]);
+        File.WriteAllBytes(orphaned, [2]);
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        DateTime stale = (now - AiTemporaryFileStore.StaleAge - TimeSpan.FromMinutes(1)).UtcDateTime;
+        File.SetLastWriteTimeUtc(held, stale);
+        File.SetLastWriteTimeUtc(orphaned, stale);
+
+        // What another running Beutl holds for as long as it is running.
+        using (var lease = new FileStream(
+                   Path.Combine(live, ".lock"),
+                   FileMode.OpenOrCreate,
+                   FileAccess.ReadWrite,
+                   FileShare.None))
+        {
+            AiTemporaryFileStore.CleanAbandonedSessions(categoryRoot, now);
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(File.Exists(held), Is.True,
+                "A file of a session still being held is not this process's to remove.");
+            Assert.That(File.Exists(orphaned), Is.False);
+        }
+
+        Directory.Delete(categoryRoot, recursive: true);
+    }
+
+    [Test]
+    public async Task Create_ClaimsSessionBeforeAConcurrentProcessCanSweepIt()
+    {
+        string category = $"creation-race-{Guid.NewGuid():N}";
+        string categoryRoot = AiTemporaryFileStore.GetCategoryRootDirectory(category);
+        using var directoryExposed = new ManualResetEventSlim();
+        using var releaseSessionClaim = new ManualResetEventSlim();
+        AiTemporaryFileStore.BeforeSessionClaim = directory =>
+        {
+            if (!string.Equals(Path.GetDirectoryName(directory), categoryRoot, StringComparison.Ordinal))
+                return;
+
+            directoryExposed.Set();
+            if (!releaseSessionClaim.Wait(TimeSpan.FromSeconds(5)))
+                throw new TimeoutException("The session claim was not released by the test.");
+        };
+
+        Task<(string Path, FileStream Stream)> creation = Task.Run(() =>
+            AiTemporaryFileStore.Create(category, "race", ".wav"));
+        try
+        {
+            Assert.That(directoryExposed.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            using var sweepStarted = new ManualResetEventSlim();
+            Task sweep = Task.Run(() =>
+            {
+                sweepStarted.Set();
+                AiTemporaryFileStore.CleanAbandonedSessions(
+                    categoryRoot,
+                    DateTimeOffset.UtcNow + AiTemporaryFileStore.StaleAge,
+                    "another-process");
+            });
+            Assert.That(sweepStarted.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+            await Task.Delay(100);
+            Assert.That(sweep.IsCompleted, Is.False,
+                "The sweeper must wait until the creator publishes its session lock.");
+
+            releaseSessionClaim.Set();
+            (string path, FileStream stream) = await creation.WaitAsync(TimeSpan.FromSeconds(5));
+            using (stream)
+            {
+                stream.WriteByte(1);
+            }
+            await sweep.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.That(File.Exists(path), Is.True,
+                "A concurrent process must not sweep a session after its creator claims it.");
+            File.Delete(path);
+        }
+        finally
+        {
+            releaseSessionClaim.Set();
+            AiTemporaryFileStore.BeforeSessionClaim = null;
+            if (!creation.IsCompleted)
+            {
+                await creation.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+        }
+    }
+
+    [Test]
+    public async Task SlowSessionCleanupDoesNotHoldTheCategoryCoordinationLock()
+    {
+        string category = $"slow-cleanup-{Guid.NewGuid():N}";
+        string categoryRoot = AiTemporaryFileStore.GetCategoryRootDirectory(category);
+        string abandoned = Path.Combine(categoryRoot, "abandoned");
+        AiTemporaryFileStore.EnsurePrivateDirectory(abandoned);
+        string stale = Path.Combine(abandoned, "stale.tmp");
+        await File.WriteAllBytesAsync(stale, [1]);
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        File.SetLastWriteTimeUtc(
+            stale,
+            (now - AiTemporaryFileStore.StaleAge - TimeSpan.FromMinutes(1)).UtcDateTime);
+        using var cleanupStarted = new ManualResetEventSlim();
+        using var releaseCleanup = new ManualResetEventSlim();
+        AiTemporaryFileStore.BeforeSessionCleanup = directory =>
+        {
+            if (!string.Equals(directory, abandoned, StringComparison.Ordinal))
+                return;
+            cleanupStarted.Set();
+            if (!releaseCleanup.Wait(TimeSpan.FromSeconds(5)))
+                throw new TimeoutException("The slow cleanup was not released by the test.");
+        };
+
+        Task cleanup = Task.Run(() => AiTemporaryFileStore.CleanAbandonedSessions(
+            categoryRoot,
+            now,
+            "another-process"));
+        try
+        {
+            Assert.That(cleanupStarted.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+            Task<(string Path, FileStream Stream)> creation = Task.Run(() =>
+                AiTemporaryFileStore.Create(category, "responsive", ".wav"));
+            (string path, FileStream stream) = await creation.WaitAsync(TimeSpan.FromSeconds(2));
+            stream.Dispose();
+            Assert.That(File.Exists(path), Is.True);
+            File.Delete(path);
+
+            releaseCleanup.Set();
+            await cleanup.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            releaseCleanup.Set();
+            AiTemporaryFileStore.BeforeSessionCleanup = null;
+            await cleanup.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiToolTabCaptureTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiToolTabCaptureTests.cs
@@ -1,0 +1,190 @@
+﻿using System.Text.Json;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.NUnit;
+using Avalonia.Media.Imaging;
+using Avalonia.Styling;
+using Beutl.Api.Services;
+using Beutl.Controls.Styling.Themes;
+using Beutl.ProjectSystem;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.ViewModels.Tools;
+using Beutl.Views.Tools;
+using FluentAvalonia.Styling;
+
+namespace Beutl.HeadlessUITests;
+
+// Produces PNG captures of the AI tool tabs that replaced the modal dialogs, so the non-modal
+// layout can be reviewed without launching the desktop shell.
+[TestFixture]
+[Explicit("Produces PNG captures for manual design review; not a regression test.")]
+public class AiToolTabCaptureTests
+{
+    private static string OutputDirectory =>
+        Environment.GetEnvironmentVariable("BEUTL_THEME_CAPTURE_DIR")
+        ?? Path.Combine(Path.GetTempPath(), "beutl-ai-captures");
+
+    [AvaloniaTest]
+    public async Task Capture_ai_tool_tabs_dark()
+    {
+        await TestReset.ResetShellAsync();
+        UseCaptureTheme();
+        EditViewModel editor = await OpenEditorForNewScene("ai-tooltab-capture");
+        MainViewModel mainViewModel = TestShell.MainViewModel;
+
+        Capture(
+            new AiImageGenerationView
+            {
+                DataContext = mainViewModel.CreateAiImageGenerationToolViewModel(editor),
+            },
+            420,
+            900,
+            "ai-image-generation-tab.png");
+
+        Capture(
+            new AiImageEditView
+            {
+                DataContext = mainViewModel.CreateAiImageEditToolViewModel(editor),
+            },
+            420,
+            900,
+            "ai-image-edit-tab.png");
+
+        Capture(
+            new AiSubtitleView
+            {
+                DataContext = mainViewModel.CreateAiSubtitleToolViewModel(editor),
+            },
+            460,
+            900,
+            "ai-subtitle-tab.png");
+
+        Capture(
+            new AiVideoGenerationView
+            {
+                DataContext = mainViewModel.CreateAiVideoGenerationToolViewModel(editor),
+            },
+            460,
+            900,
+            "ai-video-generation-tab.png");
+    }
+
+    [AvaloniaTest]
+    public async Task Capture_ai_workspace_pages_dark()
+    {
+        await TestReset.ResetShellAsync();
+        UseCaptureTheme();
+        EditViewModel editor = await OpenEditorForNewScene("ai-workspace-capture");
+        AiWorkspaceViewModel workspace = TestShell.MainViewModel.CreateAiWorkspaceViewModel(editor);
+
+        foreach (AiWorkspaceSectionViewModel section in workspace.Sections)
+        {
+            workspace.Show(section.Id);
+            HeadlessTestHelpers.Settle();
+            Capture(
+                new AiWorkspaceView { DataContext = workspace },
+                380,
+                900,
+                $"ai-workspace-{section.Id.ToString().ToLowerInvariant()}.png");
+        }
+
+        await workspace.DisposeAsync();
+    }
+
+    [AvaloniaTest]
+    public async Task Capture_ai_job_center_inline_confirmation_dark()
+    {
+        await TestReset.ResetShellAsync();
+        UseCaptureTheme();
+        EditViewModel editor = await OpenEditorForNewScene("ai-jobcenter-capture");
+        AiJobCenterViewModel viewModel = TestShell.MainViewModel.CreateAiJobCenterViewModel(editor);
+        viewModel.ApplySnapshot(new AiJobMonitorSnapshot(
+            [
+                CreateJob("job-1", "image", "succeeded", """{ "prompt": "A moonlit lake", "size": "1024x1024" }""", "https://beutl.beditor.net/api/contents/file-1"),
+                CreateJob("job-2", "video", "running", """{ "prompt": "Slow orbit around a statue", "durationSeconds": 6, "resolution": "1080p" }"""),
+                CreateJob("job-3", "image", "failed", """{ "prompt": "Neon alley in the rain" }""", error: "aiProviderError", canRetry: true),
+            ],
+            NextCursor: null,
+            IsLoading: false,
+            Error: null));
+        HeadlessTestHelpers.Settle();
+
+        Capture(new AiJobCenterView { DataContext = viewModel }, 380, 760, "ai-job-center-tab.png");
+
+        viewModel.RequestDeleteConfirmation(viewModel.Jobs.Single(job => job.Id == "job-3"));
+        HeadlessTestHelpers.Settle();
+        Capture(
+            new AiJobCenterView { DataContext = viewModel },
+            380,
+            760,
+            "ai-job-center-inline-confirmation.png");
+    }
+
+    private static AiJob CreateJob(
+        string id,
+        string kind,
+        string status,
+        string inputJson,
+        string? url = null,
+        string? error = null,
+        bool canRetry = false)
+    {
+        using JsonDocument document = JsonDocument.Parse(inputJson);
+        return new AiJob(
+            new AiJobId(id),
+            new AiJobKindId(kind),
+            new AiJobStatusId(status),
+            document.RootElement.Clone(),
+            url is null ? null : new AiContentId($"{id}-file"),
+            url is null ? null : new Uri(url),
+            error,
+            canRetry,
+            new DateTimeOffset(2026, 8, 10, 9, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 8, 10, 9, 1, 0, TimeSpan.Zero));
+    }
+
+    private static void UseCaptureTheme()
+    {
+        Application.Current!.RequestedThemeVariant = ThemeVariant.Dark;
+        Application.Current.Styles.OfType<FluentAvaloniaTheme>().Single().CustomAccentColor =
+            BeutlDarkBorderTheme.AccentColor;
+    }
+
+    private static void Capture(Control content, int width, int height, string name)
+    {
+        var window = new Window { Content = content, Width = width, Height = height };
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render(5);
+
+            using WriteableBitmap? frame = window.CaptureRenderedFrame();
+            Assert.That(frame, Is.Not.Null, "Headless frame capture returned null.");
+
+            Directory.CreateDirectory(OutputDirectory);
+            string path = Path.Combine(OutputDirectory, name);
+            frame!.Save(path);
+            TestContext.Out.WriteLine($"Saved capture: {path}");
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    private static async Task<EditViewModel> OpenEditorForNewScene(string name)
+    {
+        string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(workspace);
+        Project project = (await TestShell.Project.CreateProject(
+            640, 480, 30, 44100, name, workspace))!;
+        HeadlessTestHelpers.Settle();
+        Scene scene = project.Items.OfType<Scene>().First();
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AiUsageEstimateViewModelTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiUsageEstimateViewModelTests.cs
@@ -1,0 +1,143 @@
+﻿using System.Reactive.Subjects;
+using Beutl.Api.Services;
+using Beutl.ViewModels;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public sealed class AiUsageEstimateViewModelTests
+{
+    [Test]
+    public void Estimate_UsesMonthlyThenTopUpAndDetectsShortfall()
+    {
+        // The monthly allowance is spent, so purchased credits cover the run.
+        using var entitlements = new BehaviorSubject<AiEntitlements?>(
+            CreateEntitlements(isExhausted: true, hasAdditionalCredits: true));
+        using var available = new BehaviorSubject<AiOperationAvailabilityState>(
+            AiOperationAvailabilityState.Available);
+        using var usage = new AiUsageViewModel(entitlements);
+        using var estimate = new AiUsageEstimateViewModel(usage, available);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(estimate.CanAfford.Value, Is.True);
+            Assert.That(estimate.IsInsufficient.Value, Is.False);
+            Assert.That(
+                estimate.Explanation.Value,
+                Is.EqualTo(Beutl.Language.Strings.AiEstimatedUsageTopUp));
+            Assert.That(
+                estimate.Explanation.Value,
+                Does.Not.Contain("20"),
+                "The explanation must not disclose the per-operation usage cost.");
+        });
+
+        available.OnNext(AiOperationAvailabilityState.Unavailable);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(estimate.CanAfford.Value, Is.False);
+            Assert.That(estimate.IsInsufficient.Value, Is.True);
+            Assert.That(
+                estimate.Explanation.Value,
+                Is.EqualTo(Beutl.Language.Strings.AiEstimatedUsageInsufficient));
+            Assert.That(estimate.Explanation.Value, Does.Not.Contain("10"));
+        });
+    }
+
+    // The reported bug: a check that has not answered yet used to read as a
+    // shortfall, telling a funded account to buy credits and disabling the run.
+    [Test]
+    public void UnansweredCheck_KeepsTheRunOfferedAndClaimsNothingAboutTheBalance()
+    {
+        using var entitlements = new BehaviorSubject<AiEntitlements?>(
+            CreateEntitlements(isExhausted: false, hasAdditionalCredits: true));
+        using var available = new BehaviorSubject<AiOperationAvailabilityState>(
+            AiOperationAvailabilityState.Unknown);
+        using var usage = new AiUsageViewModel(entitlements);
+        using var estimate = new AiUsageEstimateViewModel(usage, available);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(estimate.IsInsufficient.Value, Is.False,
+                "An unanswered check is not a refusal.");
+            Assert.That(estimate.CanAfford.Value, Is.True,
+                "The run stays offered; the authoritative check runs before it is sent.");
+            Assert.That(estimate.Explanation.Value, Is.Empty);
+            Assert.That(estimate.HasExplanation.Value, Is.False);
+        }
+
+        available.OnNext(AiOperationAvailabilityState.Unavailable);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(estimate.IsInsufficient.Value, Is.True);
+            Assert.That(estimate.CanAfford.Value, Is.False);
+        }
+
+        // A re-check invalidates the previous answer without re-accusing the balance.
+        available.OnNext(AiOperationAvailabilityState.Unknown);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(estimate.IsInsufficient.Value, Is.False);
+            Assert.That(estimate.CanAfford.Value, Is.True);
+        }
+    }
+
+    [Test]
+    public void WithoutASnapshot_NothingIsClaimedAboutTheAllowance()
+    {
+        using var entitlements = new BehaviorSubject<AiEntitlements?>(null);
+        using var available = new BehaviorSubject<AiOperationAvailabilityState>(
+            AiOperationAvailabilityState.Available);
+        using var usage = new AiUsageViewModel(entitlements);
+        using var estimate = new AiUsageEstimateViewModel(usage, available);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(estimate.State.Value, Is.EqualTo(AiOperationAvailabilityState.Unknown));
+            Assert.That(estimate.Explanation.Value, Is.Empty,
+                "Without entitlements the allowance is unknown, not covered.");
+            Assert.That(estimate.CanAfford.Value, Is.False);
+        }
+    }
+
+    [Test]
+    public void MissingAuthoritativePrice_DisablesExecutionAndShowsUnavailableState()
+    {
+        // Without an active plan the server reports nothing as startable.
+        using var entitlements = new BehaviorSubject<AiEntitlements?>(
+            CreateEntitlements(isExhausted: false, hasAdditionalCredits: false, canUseAi: false));
+        using var available = new BehaviorSubject<AiOperationAvailabilityState>(
+            AiOperationAvailabilityState.Unavailable);
+        using var usage = new AiUsageViewModel(entitlements);
+        using var estimate = new AiUsageEstimateViewModel(usage, available);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(estimate.State.Value, Is.EqualTo(AiOperationAvailabilityState.Unavailable));
+            Assert.That(estimate.CanAfford.Value, Is.False);
+            Assert.That(estimate.IsInsufficient.Value, Is.False);
+            Assert.That(
+                estimate.Summary.Value,
+                Is.EqualTo(Beutl.Language.Strings.AiPricingUnavailable));
+        });
+    }
+
+    private static AiEntitlements CreateEntitlements(
+        bool isExhausted,
+        bool hasAdditionalCredits,
+        bool canUseAi = true)
+        => new(
+            canUseAi ? "pro" : null,
+            canUseAi ? "active" : null,
+            new DateTimeOffset(2026, 8, 1, 0, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 9, 1, 0, 0, 0, TimeSpan.Zero),
+            false,
+            canUseAi,
+            new AiBalance(
+                new AiMonthlyUsage(isExhausted ? 100 : 20, isExhausted ? 0 : 80, isExhausted),
+                hasAdditionalCredits ? 100 : 0,
+                false),
+            new AiOperationAvailability([]));
+}

--- a/tests/Beutl.HeadlessUITests/AiUsageViewModelTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiUsageViewModelTests.cs
@@ -1,0 +1,175 @@
+﻿using Avalonia.Headless.NUnit;
+using Beutl.Api.Services;
+using Beutl.Services;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.ViewModels.Dialogs;
+using Beutl.ViewModels.SettingsPages;
+using Reactive.Bindings;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public sealed class AiUsageViewModelTests
+{
+    [AvaloniaTest]
+    public async Task VideoDurationOptions_MatchDefaultProviderCapabilities()
+    {
+        await TestReset.ResetShellAsync();
+        Beutl.Api.BeutlApiApplication clients = TestShell.MainViewModel._beutlClients;
+        await using var viewModel = new AiVideoGenerationDialogViewModel(
+                clients.GetResource<IAiEntitlementService>(),
+                clients.GetResource<IAiOperationAvailabilityService>(),
+                clients.GetResource<IAiModelCatalogService>(),
+                new AiPlanCoordinator(clients.GetResource<IAiEntitlementService>()),
+                clients.GetResource<IAiVideoService>(),
+                clients.GetResource<IAuthenticatedContentService>(),
+                clients.GetResource<IAiJobKindRegistry>(),
+                clients.GetResource<IAiJobMonitor>(),
+                editViewModel: null,
+                requestRecoveryContext: AiRetryTestContext.CreateForm());
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.DurationOptions.Select(option => option.Seconds),
+                Is.EqualTo(new[] { 4, 6, 8 }));
+            Assert.That(viewModel.SelectedDuration.Value.Seconds, Is.EqualTo(6));
+        }
+    }
+
+    [Test]
+    public void EntitlementSnapshot_UpdatesReadOnlyUsageAndCapability()
+    {
+        using var entitlements = new ReactivePropertySlim<AiEntitlements?>();
+        using var viewModel = new AiUsageViewModel(entitlements);
+
+        entitlements.Value = CreateEntitlements(
+            canUseAi: true,
+            used: 125,
+            limit: 500,
+            additionalCredits: 40,
+            additionalCreditDebt: 15);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.CanUseAi.Value, Is.True);
+            Assert.That(viewModel.HasSnapshot.Value, Is.True);
+            Assert.That(viewModel.UsagePercent.Value, Is.EqualTo(25));
+            Assert.That(viewModel.RemainingPercent.Value, Is.EqualTo(75));
+            Assert.That(viewModel.IsMonthlyAllowanceExhausted.Value, Is.False);
+            Assert.That(viewModel.HasAdditionalCredits.Value, Is.True);
+            Assert.That(viewModel.HasAdditionalCreditDebt.Value, Is.True);
+        }
+    }
+
+    [Test]
+    public void PresentedUsage_ShowsProportionWithoutDisclosingRawUnits()
+    {
+        using var entitlements = new ReactivePropertySlim<AiEntitlements?>();
+        using var viewModel = new AiUsageViewModel(entitlements);
+
+        entitlements.Value = CreateEntitlements(
+            canUseAi: true,
+            used: 125,
+            limit: 500,
+            additionalCredits: 40,
+            additionalCreditDebt: 15);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.UsagePercent.Value, Is.EqualTo(25));
+            Assert.That(viewModel.MonthlyUsageText.Value, Does.Contain("25"));
+            Assert.That(viewModel.MonthlyRemainingText.Value, Does.Contain("75"));
+            Assert.That(
+                viewModel.MonthlyUsageText.Value,
+                Does.Not.Contain("500"),
+                "The allowance size must stay hidden so per-operation cost cannot be derived.");
+            Assert.That(
+                viewModel.AdditionalCreditsText.Value,
+                Does.Contain("40"),
+                "Purchased credits are a paid-for quantity and stay visible.");
+            Assert.That(viewModel.AdditionalCredits.Value, Is.EqualTo(40));
+            Assert.That(viewModel.AdditionalCreditDebtText.Value, Does.Not.Contain("15"));
+            Assert.That(viewModel.HasAdditionalCredits.Value, Is.True);
+        }
+    }
+
+    [Test]
+    public void ReplacingSharedSnapshot_UpdatesEveryPresentation()
+    {
+        using var entitlements = new ReactivePropertySlim<AiEntitlements?>(
+            CreateEntitlements(canUseAi: true, used: 125, limit: 500, additionalCredits: 40));
+        using var first = new AiUsageViewModel(entitlements);
+        using var second = new AiUsageViewModel(entitlements);
+
+        entitlements.Value = CreateEntitlements(canUseAi: true, used: 200, limit: 500, additionalCredits: 25);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(first.UsagePercent.Value, Is.EqualTo(40));
+            Assert.That(second.UsagePercent.Value, Is.EqualTo(40));
+            Assert.That(first.HasAdditionalCredits.Value, Is.True);
+            Assert.That(second.HasAdditionalCredits.Value, Is.True);
+        }
+    }
+
+    [Test]
+    public void ClearingSnapshot_RemovesPreviousAccountsBalance()
+    {
+        using var entitlements = new ReactivePropertySlim<AiEntitlements?>(
+            CreateEntitlements(canUseAi: true, used: 125, limit: 500, additionalCredits: 40));
+        using var viewModel = new AiUsageViewModel(entitlements);
+
+        entitlements.Value = null;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(viewModel.CanUseAi.Value, Is.False);
+            Assert.That(viewModel.HasSnapshot.Value, Is.False);
+            Assert.That(viewModel.UsagePercent.Value, Is.Zero);
+            Assert.That(viewModel.RemainingPercent.Value, Is.EqualTo(100));
+            Assert.That(viewModel.HasAdditionalCredits.Value, Is.False);
+            Assert.That(viewModel.HasAdditionalCreditDebt.Value, Is.False);
+        }
+    }
+
+    [TestCase("active", true)]
+    [TestCase("past_due", true)]
+    [TestCase("unpaid", true)]
+    [TestCase("canceled", false)]
+    [TestCase("incomplete_expired", false)]
+    [TestCase(null, false)]
+    public void SubscriptionManagement_RemainsAvailableForRecoverableStatuses(
+        string? status,
+        bool expected)
+    {
+        Assert.That(AccountSettingsPageViewModel.IsManageableSubscription(status), Is.EqualTo(expected));
+    }
+
+    private static AiEntitlements CreateEntitlements(
+        bool canUseAi,
+        int used,
+        int limit,
+        int additionalCredits,
+        int additionalCreditDebt = 0)
+    {
+        return new AiEntitlements(
+            canUseAi ? "pro" : null,
+            canUseAi ? "active" : null,
+            null,
+            null,
+            false,
+            canUseAi,
+            new AiBalance(
+                new AiMonthlyUsage(
+                    ToPercent(used, limit),
+                    100 - ToPercent(used, limit),
+                    limit > 0 && used >= limit),
+                additionalCredits,
+                additionalCreditDebt > 0),
+            new AiOperationAvailability([]));
+    }
+
+    private static int ToPercent(int used, int limit)
+        => limit <= 0 ? 0 : Math.Clamp((int)Math.Round(used * 100.0 / limit), 0, 100);
+}

--- a/tests/Beutl.HeadlessUITests/AiVideoResultDownloadTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiVideoResultDownloadTests.cs
@@ -1,0 +1,24 @@
+﻿using Beutl.Services.AI;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public sealed class AiVideoResultDownloadTests
+{
+    [Test]
+    public async Task BoundedStream_RejectsOverflowAndLeavesTheStagingStreamOpen()
+    {
+        using var destination = new MemoryStream();
+        using Stream bounded = AiVideoResultDownload.CreateBoundedStream(
+            destination,
+            maximumBytes: 4);
+
+        await bounded.WriteAsync(new byte[] { 1, 2, 3, 4 });
+        Assert.ThrowsAsync<InvalidDataException>(async () =>
+            await bounded.WriteAsync(new byte[] { 5 }));
+        bounded.Dispose();
+
+        Assert.DoesNotThrow(() => destination.WriteByte(6));
+        Assert.That(destination.ToArray(), Is.EqualTo(new byte[] { 1, 2, 3, 4, 6 }));
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AsyncOperationLifetimeTests.cs
+++ b/tests/Beutl.HeadlessUITests/AsyncOperationLifetimeTests.cs
@@ -1,0 +1,606 @@
+﻿using System.Diagnostics;
+using Beutl.Services;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public sealed class AsyncOperationLifetimeTests
+{
+    [Test]
+    public async Task Cancel_EndsOneOperationAndLeavesTheRestRunning()
+    {
+        await using var lifetime = new AsyncOperationLifetime();
+        using AsyncOperationLifetime.Operation abandoned = lifetime.TryEnter()!;
+        using AsyncOperationLifetime.Operation kept = lifetime.TryEnter()!;
+
+        abandoned.Cancel();
+        using AsyncOperationLifetime.Operation? next = lifetime.TryEnter();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(abandoned.CancellationToken.IsCancellationRequested, Is.True);
+            Assert.That(kept.CancellationToken.IsCancellationRequested, Is.False,
+                "Leaving one long request must not shut down everything else the tab is doing.");
+            Assert.That(next, Is.Not.Null,
+                "And the tab still admits the next request.");
+        }
+    }
+
+    [Test]
+    public async Task IdentitySwitchRejectsLatePublicationAndCancelsItsToken()
+    {
+        await using var lifetime = new AsyncOperationLifetime();
+        using var identity = new IdentityOperationLifetime();
+        AsyncOperationLifetime.Operation parent = lifetime.TryEnter()!;
+        using IdentityOperationLifetime.Operation operation = identity.TryEnter(parent)!;
+
+        bool cleared = false;
+        identity.Switch(() => cleared = true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cleared, Is.True);
+            Assert.That(operation.CancellationToken.IsCancellationRequested, Is.True);
+            Assert.That(operation.TryPublish(static () => { }), Is.False);
+        });
+    }
+
+    [Test]
+    public async Task DeferredIdentitySwitchFencesOldWorkBeforeUiClearRuns()
+    {
+        await using var lifetime = new AsyncOperationLifetime();
+        using var identity = new IdentityOperationLifetime();
+        using IdentityOperationLifetime.Operation oldOperation = identity.TryEnter(lifetime)!;
+        Action? scheduledClear = null;
+        bool cleared = false;
+
+        identity.SwitchDeferred(action => scheduledClear = action, () => cleared = true);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(oldOperation.TryPublish(static () => { }), Is.False);
+            Assert.That(identity.TryEnter(lifetime), Is.Null);
+            Assert.That(cleared, Is.False);
+        }
+
+        scheduledClear!();
+        using IdentityOperationLifetime.Operation? newOperation = identity.TryEnter(lifetime);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(cleared, Is.True);
+            Assert.That(newOperation, Is.Not.Null);
+        }
+    }
+
+    [Test]
+    public void DeferredIdentitySwitchSkipsQueuedUiClearAfterDisposal()
+    {
+        var identity = new IdentityOperationLifetime();
+        Action? scheduledClear = null;
+        bool cleared = false;
+        identity.SwitchDeferred(action => scheduledClear = action, () => cleared = true);
+
+        identity.Dispose();
+
+        Assert.DoesNotThrow(() => scheduledClear!());
+        Assert.That(cleared, Is.False);
+    }
+
+    [Test]
+    public async Task IdentitySwitchWaitsForPublicationAdmittedBeforeTheSwitch()
+    {
+        await using var lifetime = new AsyncOperationLifetime();
+        using var identity = new IdentityOperationLifetime();
+        AsyncOperationLifetime.Operation parent = lifetime.TryEnter()!;
+        using IdentityOperationLifetime.Operation operation = identity.TryEnter(parent)!;
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task<bool> publication = Task.Run(() => operation.TryPublish(() =>
+        {
+            entered.TrySetResult();
+            release.Task.GetAwaiter().GetResult();
+        }));
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Task switched = Task.Run(() => identity.Switch(static () => { }));
+        await Task.Delay(50);
+        Assert.That(switched.IsCompleted, Is.False);
+        release.TrySetResult();
+
+        Assert.That(await publication.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+        await switched.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(operation.TryPublish(static () => { }), Is.False);
+    }
+
+    [Test]
+    public async Task IdentitySwitchClearsWhenCancellationCallbackThrows()
+    {
+        await using var lifetime = new AsyncOperationLifetime();
+        using var identity = new IdentityOperationLifetime();
+        AsyncOperationLifetime.Operation parent = lifetime.TryEnter()!;
+        using IdentityOperationLifetime.Operation operation = identity.TryEnter(parent)!;
+        using CancellationTokenRegistration registration = operation.CancellationToken.Register(
+            static () => throw new InvalidOperationException("ignored"));
+
+        bool cleared = false;
+        identity.Switch(() => cleared = true);
+
+        Assert.That(cleared, Is.True);
+    }
+
+    [Test]
+    public async Task IdentitySwitchDoesNotWaitForBlockingCancellationCallback()
+    {
+        await using var lifetime = new AsyncOperationLifetime();
+        using var identity = new IdentityOperationLifetime();
+        AsyncOperationLifetime.Operation parent = lifetime.TryEnter()!;
+        using IdentityOperationLifetime.Operation operation = identity.TryEnter(parent)!;
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using CancellationTokenRegistration registration = operation.CancellationToken.Register(() =>
+        {
+            entered.TrySetResult();
+            release.Task.GetAwaiter().GetResult();
+        });
+
+        bool cleared = false;
+        Task switchTask = Task.Run(() => identity.Switch(() => cleared = true));
+        await switchTask.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(cleared, Is.True);
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        release.TrySetResult();
+    }
+
+    [Test]
+    public async Task Cancel_StillPublishesSoTheViewModelCanResetItsState()
+    {
+        await using var lifetime = new AsyncOperationLifetime();
+        using AsyncOperationLifetime.Operation operation = lifetime.TryEnter()!;
+
+        operation.Cancel();
+
+        Assert.That(operation.TryPublish(() => { }), Is.True,
+            "Cancelling is not shutdown, so the finally block can still clear the running flag.");
+    }
+
+    [Test]
+    public async Task ClosePublicationRejectsLateCallbacksButKeepsOperationInDrain()
+    {
+        var lifetime = new AsyncOperationLifetime();
+        AsyncOperationLifetime.Operation operation = lifetime.TryEnter()!;
+
+        operation.ClosePublication();
+        Task disposal = lifetime.DisposeAsync().AsTask();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(operation.TryPublish(static () => { }), Is.False);
+            Assert.That(disposal.IsCompleted, Is.False,
+                "Closing publication must not detach non-cooperative work from teardown draining.");
+        });
+
+        operation.Dispose();
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ClosePublicationDrainsAlreadyAdmittedCallbackBeforeReturning()
+    {
+        await using var lifetime = new AsyncOperationLifetime();
+        using AsyncOperationLifetime.Operation operation = lifetime.TryEnter()!;
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task<bool> publication = Task.Run(() => operation.TryPublish(() =>
+        {
+            entered.TrySetResult();
+            release.Task.GetAwaiter().GetResult();
+        }));
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Task close = Task.Run(operation.ClosePublication);
+        await Task.Delay(50);
+        Assert.That(close.IsCompleted, Is.False);
+        release.TrySetResult();
+        await close.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(await publication.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+        Assert.That(operation.TryPublish(static () => { }), Is.False);
+    }
+
+    [Test]
+    public async Task ClosePublicationIsReentrantFromItsOwnCallback()
+    {
+        await using var lifetime = new AsyncOperationLifetime();
+        using AsyncOperationLifetime.Operation operation = lifetime.TryEnter()!;
+        var returned = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task<bool> publication = Task.Run(() => operation.TryPublish(() =>
+        {
+            operation.ClosePublication();
+            returned.TrySetResult();
+        }));
+
+        await returned.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(await publication.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+        Assert.That(operation.TryPublish(static () => { }), Is.False);
+    }
+
+    [Test]
+    public async Task ConcurrentPublicationsForOneOperationAreSerialized()
+    {
+        await using var lifetime = new AsyncOperationLifetime();
+        using AsyncOperationLifetime.Operation operation = lifetime.TryEnter()!;
+        int active = 0;
+        int maximum = 0;
+        Task<bool>[] publications = Enumerable.Range(0, 8).Select(_ => Task.Run(() =>
+            operation.TryPublish(() =>
+            {
+                int current = Interlocked.Increment(ref active);
+                int observed;
+                do
+                {
+                    observed = Volatile.Read(ref maximum);
+                    if (observed >= current)
+                        break;
+                }
+                while (Interlocked.CompareExchange(ref maximum, current, observed) != observed);
+                Thread.Sleep(10);
+                Interlocked.Decrement(ref active);
+            }))).ToArray();
+
+        Assert.That(await Task.WhenAll(publications), Has.All.True);
+        Assert.That(maximum, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Stop_EndsEveryOperationAdmittedSoFar()
+    {
+        var lifetime = new AsyncOperationLifetime();
+        AsyncOperationLifetime.Operation first = lifetime.TryEnter()!;
+        AsyncOperationLifetime.Operation second = lifetime.TryEnter()!;
+
+        // Stopping waits for what it cancelled, so the operations are released first.
+        Task stopping = lifetime.StopAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(first.CancellationToken.IsCancellationRequested, Is.True);
+            Assert.That(second.CancellationToken.IsCancellationRequested, Is.True);
+            Assert.That(lifetime.TryEnter(), Is.Null);
+            Assert.That(first.TryPublish(() => { }), Is.False);
+        }
+
+        first.Dispose();
+        second.Dispose();
+        await stopping;
+        await lifetime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Stop_DoesNotBlockBeforeTheSharedDeadlineWhenPublicationIsInProgress()
+    {
+        var lifetime = new AsyncOperationLifetime();
+        AsyncOperationLifetime.Operation operation = lifetime.TryEnter()!;
+        var publicationEntered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePublication = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task<bool> publication = Task.Run(() => operation.TryPublish(() =>
+        {
+            publicationEntered.TrySetResult();
+            releasePublication.Task.GetAwaiter().GetResult();
+        }));
+        await publicationEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Task<Task> stopInvocation = Task.Factory.StartNew(
+            lifetime.StopAsync,
+            CancellationToken.None,
+            TaskCreationOptions.DenyChildAttach,
+            TaskScheduler.Default);
+        Task stopping = await stopInvocation.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(stopping.IsCompleted, Is.False);
+
+        // Releasing the operation handle must not wait on callback code. The
+        // admitted publication remains counted in the lifetime drain.
+        Task dispose = Task.Run(operation.Dispose);
+        await dispose.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(stopping.IsCompleted, Is.False);
+        releasePublication.TrySetResult();
+        Assert.That(await publication.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+        await stopping.WaitAsync(TimeSpan.FromSeconds(5));
+        await lifetime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Stop_RejectsPublicationAfterShutdownAdmission()
+    {
+        var lifetime = new AsyncOperationLifetime();
+        using AsyncOperationLifetime.Operation operation = lifetime.TryEnter()!;
+
+        Task stopping = lifetime.StopAsync();
+
+        Assert.That(operation.TryPublish(static () => { }), Is.False);
+
+        operation.Dispose();
+        await stopping.WaitAsync(TimeSpan.FromSeconds(5));
+        await lifetime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Stop_DrainsReentrantPublicationWithoutHoldingTheGate()
+    {
+        var lifetime = new AsyncOperationLifetime(TimeSpan.FromMilliseconds(100));
+        using AsyncOperationLifetime.Operation operation = lifetime.TryEnter()!;
+        var callbackReturned = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task<bool> publication = Task.Run(() => operation.TryPublish(() =>
+        {
+            // StopAsync must publish its task before waiting for this admitted callback,
+            // otherwise a callback that re-enters shutdown would deadlock the lifetime gate.
+            lifetime.StopAsync().GetAwaiter().GetResult();
+            callbackReturned.TrySetResult();
+        }));
+
+        Assert.That(await publication.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+        await callbackReturned.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        operation.Dispose();
+        await lifetime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Stop_DrainsPublicationWhenCallbackThrows()
+    {
+        var lifetime = new AsyncOperationLifetime(TimeSpan.FromSeconds(1));
+        using AsyncOperationLifetime.Operation operation = lifetime.TryEnter()!;
+        var callbackEntered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseCallback = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task publication = Task.Run(() => operation.TryPublish(() =>
+        {
+            callbackEntered.TrySetResult();
+            releaseCallback.Task.GetAwaiter().GetResult();
+            throw new InvalidOperationException("publication failed");
+        }));
+        await callbackEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Task stopping = lifetime.StopAsync();
+        operation.Dispose();
+        releaseCallback.TrySetResult();
+
+        Assert.That(
+            async () => await publication.WaitAsync(TimeSpan.FromSeconds(5)),
+            Throws.InstanceOf<InvalidOperationException>());
+        await stopping.WaitAsync(TimeSpan.FromSeconds(5));
+        await lifetime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Stop_PublishesTaskBeforeCancellationCallbacksCanReenter()
+    {
+        var callbackReturned = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var lifetime = new AsyncOperationLifetime(TimeSpan.FromMilliseconds(100));
+        AsyncOperationLifetime.Operation operation = lifetime.TryEnter()!;
+        using CancellationTokenRegistration registration = operation.CancellationToken.Register(() =>
+        {
+            lifetime.StopAsync().GetAwaiter().GetResult();
+            callbackReturned.TrySetResult();
+        });
+
+        var stopwatch = Stopwatch.StartNew();
+        Task stopping = lifetime.StopAsync();
+        await stopping.WaitAsync(TimeSpan.FromSeconds(5));
+        stopwatch.Stop();
+        await callbackReturned.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        operation.Dispose();
+
+        Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromMilliseconds(500)),
+            "A reentrant callback must consume at most the one shared shutdown deadline.");
+    }
+
+    [Test]
+    public async Task Stop_CompletesAtDeadlineAndContinuesDraining()
+    {
+        var lifetime = new AsyncOperationLifetime(TimeSpan.FromMilliseconds(100));
+        AsyncOperationLifetime.Operation operation = lifetime.TryEnter()!;
+
+        var stopwatch = Stopwatch.StartNew();
+        Task stopping = lifetime.StopAsync();
+        await stopping.WaitAsync(TimeSpan.FromSeconds(5));
+        stopwatch.Stop();
+
+        Task disposal = lifetime.DisposeAsync().AsTask();
+        Assert.Multiple(() =>
+        {
+            Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(2)));
+            Assert.That(stopping.IsCompletedSuccessfully, Is.True);
+            Assert.That(disposal.IsCompleted, Is.False,
+                "The deadline only releases the caller; the actual operation drain must continue.");
+        });
+
+        operation.Dispose();
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Stop_ReportsCancellationCallbackFailureAfterDrain()
+    {
+        var lifetime = new AsyncOperationLifetime();
+        AsyncOperationLifetime.Operation operation = lifetime.TryEnter()!;
+        using CancellationTokenRegistration registration = operation.CancellationToken.Register(
+            static () => throw new InvalidOperationException("callback failed"));
+
+        Task stopping = lifetime.StopAsync();
+        operation.Dispose();
+
+        Assert.That(
+            async () => await stopping.WaitAsync(TimeSpan.FromSeconds(5)),
+            Throws.InstanceOf<InvalidOperationException>());
+        Assert.That(
+            async () => await lifetime.DisposeAsync(),
+            Throws.InstanceOf<InvalidOperationException>());
+    }
+
+    [Test]
+    public async Task Cancel_AfterDisposeIsIgnored()
+    {
+        await using var lifetime = new AsyncOperationLifetime();
+        AsyncOperationLifetime.Operation operation = lifetime.TryEnter()!;
+        operation.Dispose();
+
+        Assert.DoesNotThrow(operation.Cancel);
+    }
+
+    [Test]
+    public void Cancel_ObservesCallbackFailureWithoutThrowingFromTheUiCommand()
+    {
+        var lifetime = new AsyncOperationLifetime();
+        AsyncOperationLifetime.Operation operation = lifetime.TryEnter()!;
+        bool healthyCallbackRan = false;
+        using CancellationTokenRegistration healthy = operation.CancellationToken.Register(
+            () => healthyCallbackRan = true);
+        using CancellationTokenRegistration failing = operation.CancellationToken.Register(
+            static () => throw new InvalidOperationException("callback failed"));
+
+        Assert.DoesNotThrow(operation.Cancel);
+        Assert.That(healthyCallbackRan, Is.True);
+
+        operation.Dispose();
+        Task disposal = lifetime.DisposeAsync().AsTask();
+        Assert.That(
+            async () => await disposal.WaitAsync(TimeSpan.FromSeconds(5)),
+            Throws.InstanceOf<Exception>());
+    }
+
+    [Test]
+    public async Task Dispose_PublishesTaskBeforeCancellationCallbacksCanReenter()
+    {
+        var callbackReturned = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var lifetime = new AsyncOperationLifetime(TimeSpan.FromMilliseconds(100));
+        AsyncOperationLifetime.Operation operation = lifetime.TryEnter()!;
+        using CancellationTokenRegistration registration = operation.CancellationToken.Register(() =>
+        {
+            lifetime.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            callbackReturned.TrySetResult();
+        });
+
+        var stopwatch = Stopwatch.StartNew();
+        Task disposal = lifetime.DisposeAsync().AsTask();
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+        stopwatch.Stop();
+        await callbackReturned.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        operation.Dispose();
+
+        Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(2)));
+    }
+
+    [Test]
+    public async Task Dispose_ObservesCancellationCallbackFailureAndStillDisposesExactlyOnce()
+    {
+        var lifetime = new AsyncOperationLifetime();
+        AsyncOperationLifetime.Operation operation = lifetime.TryEnter()!;
+        int disposeCount = 0;
+        using CancellationTokenRegistration registration = operation.CancellationToken.Register(
+            static () => throw new InvalidOperationException("callback failed"));
+
+        Task first = lifetime.DisposeAsync(() =>
+        {
+            Interlocked.Increment(ref disposeCount);
+            return ValueTask.CompletedTask;
+        }).AsTask();
+        Task second = lifetime.DisposeAsync(() =>
+        {
+            Interlocked.Increment(ref disposeCount);
+            return ValueTask.CompletedTask;
+        }).AsTask();
+        Assert.That(second, Is.SameAs(first));
+        operation.Dispose();
+        Assert.That(
+            async () => await first.WaitAsync(TimeSpan.FromSeconds(5)),
+            Throws.InstanceOf<Exception>());
+        Assert.That(lifetime.TryEnter(), Is.Null);
+        Assert.That(disposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Dispose_AdditionalCancellationUsesTheSharedDeadlineAndDefersCleanup()
+    {
+        var releaseCancellation = new ManualResetEventSlim();
+        var resourcesDisposed = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var lifetime = new AsyncOperationLifetime(TimeSpan.FromMilliseconds(100));
+
+        var stopwatch = Stopwatch.StartNew();
+        await lifetime.DisposeAsync(
+            () => releaseCancellation.Wait(),
+            () =>
+            {
+                resourcesDisposed.TrySetResult();
+                return ValueTask.CompletedTask;
+            });
+        stopwatch.Stop();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(2)));
+            Assert.That(resourcesDisposed.Task.IsCompleted, Is.False,
+                "Resources must remain alive until a blocking cancellation callback returns.");
+            Assert.That(lifetime.TryEnter(), Is.Null,
+                "Disposal must close admission before a blocking cancellation callback starts.");
+        });
+
+        releaseCancellation.Set();
+        await resourcesDisposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        releaseCancellation.Dispose();
+    }
+
+    [Test]
+    public void Dispose_AdditionalCancellationFailureStillDisposesResources()
+    {
+        int disposeCount = 0;
+        var lifetime = new AsyncOperationLifetime();
+
+        Task disposal = lifetime.DisposeAsync(
+            static () => throw new InvalidOperationException("callback failed"),
+            () =>
+            {
+                Interlocked.Increment(ref disposeCount);
+                return ValueTask.CompletedTask;
+            }).AsTask();
+
+        Assert.That(
+            async () => await disposal.WaitAsync(TimeSpan.FromSeconds(5)),
+            Throws.InstanceOf<InvalidOperationException>());
+        Assert.That(disposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Dispose_ReportsADeferredResourceFailureAfterTheDeadline()
+    {
+        var releaseCleanup = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var observed = new TaskCompletionSource<Exception>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var lifetime = new AsyncOperationLifetime(
+            TimeSpan.FromMilliseconds(100),
+            exception => observed.TrySetResult(exception));
+
+        Task disposal = lifetime.DisposeAsync(async () =>
+        {
+            await releaseCleanup.Task;
+            throw new InvalidOperationException("late cleanup failed");
+        }).AsTask();
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(disposal.IsCompletedSuccessfully, Is.True);
+
+        releaseCleanup.TrySetResult();
+        Exception failure = await observed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(failure, Is.TypeOf<InvalidOperationException>());
+        Assert.That(failure.Message, Is.EqualTo("late cleanup failed"));
+    }
+}

--- a/tests/Beutl.HeadlessUITests/Beutl.HeadlessUITests.csproj
+++ b/tests/Beutl.HeadlessUITests/Beutl.HeadlessUITests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Headless.NUnit" />
     <PackageReference Include="Avalonia.Skia" />
+    <PackageReference Include="Moq" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Beutl.HeadlessUITests/CaptionDraftStoreTests.cs
+++ b/tests/Beutl.HeadlessUITests/CaptionDraftStoreTests.cs
@@ -1,0 +1,72 @@
+﻿using Beutl.Services.AI;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public sealed class CaptionDraftStoreTests
+{
+    [Test]
+    public void SaveCreatesReadableDraftWithOwnerOnlyUnixPermissions()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"beutl-caption-draft-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var store = new FileCaptionDraftStore(directory);
+            var scope = new CaptionDraftScope("user", Guid.NewGuid(), Guid.NewGuid());
+            Assert.That(store.TryOpen(scope, out ICaptionDraftSession? session), Is.True);
+            using (session)
+            {
+                var cue = new StoredCaptionCue(
+                    0,
+                    TimeSpan.TicksPerSecond,
+                    "source",
+                    null,
+                    null,
+                    new Dictionary<string, string>());
+                session!.Save(new CaptionDraftEntry(
+                    null,
+                    new CaptionDraft(
+                        FileCaptionDraftStore.CurrentVersion,
+                        [cue],
+                        "en",
+                        null,
+                        CaptionDraftKind.Translation,
+                        1,
+                        1,
+                        new CaptionTranslationResume(
+                            [cue],
+                            "en",
+                            "en",
+                            "ja",
+                            new Dictionary<string, string> { ["piece"] = "translated" },
+                            1),
+                        null),
+                    []));
+            }
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(File.Exists(store.GetStoragePath(scope)), Is.True);
+                Assert.That(store.TryOpen(scope, out ICaptionDraftSession? reopened), Is.True);
+                using (reopened)
+                    Assert.That(reopened!.Read().Outcome, Is.EqualTo(CaptionDraftReadOutcome.Read));
+            }
+
+            if (!OperatingSystem.IsWindows())
+            {
+                UnixFileMode mode = File.GetUnixFileMode(store.GetStoragePath(scope));
+                Assert.That(
+                    mode & (UnixFileMode.GroupRead
+                        | UnixFileMode.GroupWrite
+                        | UnixFileMode.OtherRead
+                        | UnixFileMode.OtherWrite),
+                    Is.EqualTo(UnixFileMode.None));
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/CaptionExportStorageTests.cs
+++ b/tests/Beutl.HeadlessUITests/CaptionExportStorageTests.cs
@@ -1,0 +1,257 @@
+﻿using Avalonia.Platform.Storage;
+using Beutl.ViewModels.Dialogs;
+using Moq;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public sealed class CaptionExportStorageTests
+{
+    [Test]
+    public async Task LocalExport_PreservesExistingUnixPermissions()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("Unix permissions are not available on Windows.");
+            return;
+        }
+
+        string directory = Path.Combine(
+            Path.GetTempPath(),
+            $"beutl-caption-permissions-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        string destinationPath = Path.Combine(directory, "subtitles.srt");
+        try
+        {
+            await File.WriteAllTextAsync(destinationPath, "old captions");
+            UnixFileMode mode = UnixFileMode.UserRead
+                | UnixFileMode.UserWrite
+                | UnixFileMode.GroupRead
+                | UnixFileMode.GroupWrite
+                | UnixFileMode.OtherRead;
+            File.SetUnixFileMode(destinationPath, mode);
+            var destination = new Mock<IStorageFile>(MockBehavior.Strict);
+            destination.SetupGet(file => file.Path).Returns(new Uri(destinationPath));
+
+            await AiSubtitleDialogViewModel.WriteCaptionExportAsync(
+                destination.Object,
+                "new captions"u8.ToArray(),
+                CancellationToken.None);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(await File.ReadAllTextAsync(destinationPath), Is.EqualTo("new captions"));
+                Assert.That(File.GetUnixFileMode(destinationPath), Is.EqualTo(mode));
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task NonLocalExport_PublishesThroughProviderStaging_WithNonSeekableStreams()
+    {
+        StorageTransactionMocks storage = CreateStorageTransaction();
+        byte[]? stagedBytes = null;
+        storage.StagedFile
+            .Setup(file => file.OpenWriteAsync())
+            .ReturnsAsync(() => new NonSeekableCommitStream(bytes => stagedBytes = bytes));
+
+        await AiSubtitleDialogViewModel.WriteCaptionExportAsync(
+            storage.Destination.Object,
+            "new captions"u8.ToArray(),
+            CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(stagedBytes, Is.EqualTo("new captions"u8.ToArray()));
+            storage.Destination.Verify(
+                file => file.MoveAsync(storage.BackupFolder.Object),
+                Times.Once);
+            storage.StagedFile.Verify(
+                file => file.MoveAsync(storage.Parent.Object),
+                Times.Once);
+            storage.BackupFile.Verify(file => file.DeleteAsync(), Times.Once);
+        }
+    }
+
+    [Test]
+    public void NonLocalExport_StagingWriteFailure_DoesNotMoveExistingDestination()
+    {
+        StorageTransactionMocks storage = CreateStorageTransaction();
+        storage.StagedFile
+            .Setup(file => file.OpenWriteAsync())
+            .ReturnsAsync(() => new NonSeekableCommitStream(
+                _ => { },
+                new IOException("Injected staged write failure.")));
+
+        Assert.ThrowsAsync<IOException>(async () =>
+            await AiSubtitleDialogViewModel.WriteCaptionExportAsync(
+                storage.Destination.Object,
+                "new captions"u8.ToArray(),
+                CancellationToken.None));
+
+        storage.Destination.Verify(
+            file => file.MoveAsync(It.IsAny<IStorageFolder>()),
+            Times.Never);
+    }
+
+    [Test]
+    public void NonLocalExport_PublishFailure_RestoresExistingDestination()
+    {
+        StorageTransactionMocks storage = CreateStorageTransaction();
+        storage.StagedFile
+            .Setup(file => file.OpenWriteAsync())
+            .ReturnsAsync(() => new NonSeekableCommitStream(_ => { }));
+        storage.StagedFile
+            .Setup(file => file.MoveAsync(storage.Parent.Object))
+            .ThrowsAsync(new IOException("Injected staged publish failure."));
+
+        Assert.ThrowsAsync<IOException>(async () =>
+            await AiSubtitleDialogViewModel.WriteCaptionExportAsync(
+                storage.Destination.Object,
+                "new captions"u8.ToArray(),
+                CancellationToken.None));
+
+        storage.BackupFile.Verify(
+            file => file.MoveAsync(storage.Parent.Object),
+            Times.Once);
+        storage.BackupFile.Verify(file => file.DeleteAsync(), Times.Never);
+    }
+
+    private static StorageTransactionMocks CreateStorageTransaction()
+    {
+        var destination = new Mock<IStorageFile>(MockBehavior.Strict);
+        var parent = new Mock<IStorageFolder>(MockBehavior.Strict);
+        var stagingFolder = new Mock<IStorageFolder>(MockBehavior.Strict);
+        var backupFolder = new Mock<IStorageFolder>(MockBehavior.Strict);
+        var stagedFile = new Mock<IStorageFile>(MockBehavior.Strict);
+        var backupFile = new Mock<IStorageFile>(MockBehavior.Strict);
+        var committedFile = new Mock<IStorageFile>(MockBehavior.Strict);
+        var restoredFile = new Mock<IStorageFile>(MockBehavior.Strict);
+
+        destination.SetupGet(file => file.Path).Returns(new Uri("content://test/subtitles.srt"));
+        destination.SetupGet(file => file.Name).Returns("subtitles.srt");
+        destination.Setup(file => file.GetParentAsync()).ReturnsAsync(parent.Object);
+        destination.Setup(file => file.MoveAsync(backupFolder.Object)).ReturnsAsync(backupFile.Object);
+
+        parent.Setup(folder => folder.CreateFolderAsync(
+                It.Is<string>(name => name.EndsWith("-stage", StringComparison.Ordinal))))
+            .ReturnsAsync(stagingFolder.Object);
+        parent.Setup(folder => folder.CreateFolderAsync(
+                It.Is<string>(name => name.EndsWith("-backup", StringComparison.Ordinal))))
+            .ReturnsAsync(backupFolder.Object);
+        parent.Setup(folder => folder.GetFileAsync("subtitles.srt"))
+            .ReturnsAsync((IStorageFile?)null);
+
+        stagingFolder.Setup(folder => folder.CreateFileAsync("subtitles.srt"))
+            .ReturnsAsync(stagedFile.Object);
+        stagedFile.Setup(file => file.MoveAsync(parent.Object)).ReturnsAsync(committedFile.Object);
+        backupFile.Setup(file => file.MoveAsync(parent.Object)).ReturnsAsync(restoredFile.Object);
+
+        SetupCleanup(stagedFile);
+        SetupCleanup(backupFile);
+        SetupCleanup(stagingFolder);
+        SetupCleanup(backupFolder);
+        destination.Setup(file => file.Dispose());
+        parent.Setup(folder => folder.Dispose());
+        committedFile.Setup(file => file.Dispose());
+        restoredFile.Setup(file => file.Dispose());
+
+        return new StorageTransactionMocks(
+            destination,
+            parent,
+            stagingFolder,
+            backupFolder,
+            stagedFile,
+            backupFile);
+    }
+
+    private static void SetupCleanup<T>(Mock<T> item)
+        where T : class, IStorageItem
+    {
+        item.Setup(value => value.DeleteAsync()).Returns(Task.CompletedTask);
+        item.Setup(value => value.Dispose());
+    }
+
+    private sealed record StorageTransactionMocks(
+        Mock<IStorageFile> Destination,
+        Mock<IStorageFolder> Parent,
+        Mock<IStorageFolder> StagingFolder,
+        Mock<IStorageFolder> BackupFolder,
+        Mock<IStorageFile> StagedFile,
+        Mock<IStorageFile> BackupFile);
+
+    private sealed class NonSeekableCommitStream(
+        Action<byte[]> commit,
+        Exception? writeFailure = null) : Stream
+    {
+        private readonly MemoryStream _buffer = new();
+        private bool _completed;
+
+        public override bool CanRead => false;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => true;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin)
+            => throw new NotSupportedException();
+
+        public override void SetLength(long value)
+            => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            if (writeFailure is not null)
+                throw writeFailure;
+
+            _buffer.Write(buffer, offset, count);
+        }
+
+        public override ValueTask WriteAsync(
+            ReadOnlyMemory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (writeFailure is not null)
+                return ValueTask.FromException(writeFailure);
+
+            _buffer.Write(buffer.Span);
+            return ValueTask.CompletedTask;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !_completed)
+            {
+                _completed = true;
+                if (writeFailure is null)
+                    commit(_buffer.ToArray());
+                _buffer.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
@@ -241,11 +241,15 @@ public class DockLayoutPresetTests
         // The element property tab writes a per-element config from its serializer, but only once
         // an element is selected — so select one to arm the side effect.
         var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-        adder.AddElement(new ElementDescription(
-            Start: TimeSpan.Zero,
-            Length: TimeSpan.FromSeconds(1),
-            Layer: 0,
-            EngineObjectFactory: () => new RectShape()));
+        ElementAddResult addResult = await adder.AddAsync(
+        [
+            new ElementDescription(
+                Start: TimeSpan.Zero,
+                Length: TimeSpan.FromSeconds(1),
+                Layer: 0,
+                Source: new ElementSource.EngineObject(() => new RectShape())),
+        ], CancellationToken.None);
+        Assert.That(addResult.IsSuccess, Is.True);
         HeadlessTestHelpers.Settle();
 
         var selection = (IEditorSelection)editor.GetService(typeof(IEditorSelection))!;

--- a/tests/Beutl.HeadlessUITests/EditableCaptionCueViewModelTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditableCaptionCueViewModelTests.cs
@@ -1,0 +1,45 @@
+﻿using Beutl.Editor.Services.Captions;
+using Beutl.ViewModels.Dialogs;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public sealed class EditableCaptionCueViewModelTests
+{
+    [Test]
+    public void Cue_RoundTripsEditableFieldsAndLongTimelineTime()
+    {
+        var source = new CaptionCue(
+            TimeSpan.FromHours(27) + TimeSpan.FromMilliseconds(125),
+            TimeSpan.FromHours(27) + TimeSpan.FromSeconds(2.5),
+            "Hello",
+            "Narrator",
+            "en",
+            CaptionMetadata.Empty
+                .Set(CaptionMetadataKeys.AssStyle, "Outlined")
+                .Set("plugin.custom", "opaque"));
+        var viewModel = new EditableCaptionCueViewModel(1, source);
+
+        bool result = viewModel.TryCreateCue(out CaptionCue? restored);
+
+        Assert.That(result, Is.True);
+        Assert.That(restored, Is.EqualTo(source));
+        Assert.That(viewModel.StartText, Is.EqualTo("27:00:00.125"));
+    }
+
+    [TestCase("bad", "00:00:01.000")]
+    [TestCase("00:00:02.000", "00:00:01.000")]
+    [TestCase("-00:00:01.000", "00:00:01.000")]
+    public void InvalidTiming_IsRejected(string start, string end)
+    {
+        var viewModel = new EditableCaptionCueViewModel(
+            1,
+            new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "Text"))
+        {
+            StartText = start,
+            EndText = end,
+        };
+
+        Assert.That(viewModel.TryCreateCue(out _), Is.False);
+    }
+}

--- a/tests/Beutl.HeadlessUITests/EditorServiceTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorServiceTests.cs
@@ -462,7 +462,7 @@ public sealed class EditorServiceTests
             PasteCalls++;
             pasteStarted.TrySetResult();
             await releasePaste;
-            return new ElementPasteOutcome(true, [], default, 0);
+            return new ElementPasteOutcome(true, [], default, 0, null);
         }
     }
 

--- a/tests/Beutl.HeadlessUITests/EditorWorkflowTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorWorkflowTests.cs
@@ -37,14 +37,15 @@ public class EditorWorkflowTests
         return (EditViewModel)tab.Context.Value;
     }
 
-    private static Element AddRectangle(EditViewModel editor, TimeSpan start, int layer)
+    private static async Task<Element> AddRectangle(EditViewModel editor, TimeSpan start, int layer)
     {
         var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-        adder.AddElement(new ElementDescription(
+        await adder.AddAsync([new ElementDescription(
             Start: start,
             Length: TimeSpan.FromSeconds(2),
             Layer: layer,
-            EngineObjectFactory: () => new RectShape()));
+            Source: new ElementSource.EngineObject(() => new RectShape()))],
+            CancellationToken.None);
         HeadlessTestHelpers.Settle();
         return editor.Scene.Children[^1];
     }
@@ -70,7 +71,7 @@ public class EditorWorkflowTests
         Assert.That(editor.Scene.Children, Is.Empty);
         Assert.That(editor.HistoryManager.CanUndo, Is.False);
 
-        Element element = AddRectangle(editor, TimeSpan.Zero, layer: 0);
+        Element element = await AddRectangle(editor, TimeSpan.Zero, layer: 0);
 
         Assert.That(editor.Scene.Children, Has.Count.EqualTo(1));
         Assert.That(editor.Scene.Children[0], Is.SameAs(element));
@@ -113,7 +114,7 @@ public class EditorWorkflowTests
     {
         await ResetProjectAsync();
         EditViewModel editor = await OpenEditorForNewScene("editprop");
-        Element element = AddRectangle(editor, TimeSpan.Zero, layer: 0);
+        Element element = await AddRectangle(editor, TimeSpan.Zero, layer: 0);
         Assert.That(editor.HistoryManager.UndoCount, Is.EqualTo(1));
 
         // Exercises the observer->history pipeline (CLR setter -> CorePropertyOperationObserver ->
@@ -133,7 +134,7 @@ public class EditorWorkflowTests
     {
         await ResetProjectAsync();
         EditViewModel editor = await OpenEditorForNewScene("undoprop");
-        Element element = AddRectangle(editor, TimeSpan.Zero, layer: 0);
+        Element element = await AddRectangle(editor, TimeSpan.Zero, layer: 0);
 
         int originalZIndex = element.ZIndex;
         element.ZIndex = originalZIndex + 5;
@@ -159,7 +160,7 @@ public class EditorWorkflowTests
     {
         await ResetProjectAsync();
         EditViewModel editor = await OpenEditorForNewScene("undoadd");
-        Element element = AddRectangle(editor, TimeSpan.Zero, layer: 0);
+        Element element = await AddRectangle(editor, TimeSpan.Zero, layer: 0);
         Guid elementId = element.Id;
         Assert.That(editor.Scene.Children, Has.Count.EqualTo(1));
 
@@ -181,7 +182,7 @@ public class EditorWorkflowTests
     {
         await ResetProjectAsync();
         EditViewModel editor = await OpenEditorForNewScene("knowncmds");
-        AddRectangle(editor, TimeSpan.Zero, layer: 0);
+        await AddRectangle(editor, TimeSpan.Zero, layer: 0);
         Assert.That(editor.Scene.Children, Has.Count.EqualTo(1));
 
         IKnownEditorCommands commands = editor.Commands!;

--- a/tests/Beutl.HeadlessUITests/EditorWorkflowTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorWorkflowTests.cs
@@ -81,7 +81,7 @@ public class EditorWorkflowTests
     }
 
     [AvaloniaTest]
-    public async Task AddElement_requires_the_scene_to_have_a_saved_location()
+    public async Task AddElement_uses_temporary_storage_when_the_scene_is_unsaved()
     {
         await ResetProjectAsync();
         EditViewModel editor = await OpenEditorForNewScene("addelem-unsaved");
@@ -92,20 +92,30 @@ public class EditorWorkflowTests
         {
             editor.Scene.Uri = null;
 
-            Assert.DoesNotThrow(() => adder.AddElement(new ElementDescription(
+            ElementAddResult result = await adder.AddAsync([new ElementDescription(
                 Start: TimeSpan.Zero,
                 Length: TimeSpan.FromSeconds(2),
                 Layer: 0,
-                EngineObjectFactory: () => new RectShape())));
+                Source: new ElementSource.EngineObject(() => new RectShape()))],
+                CancellationToken.None);
+            HeadlessTestHelpers.Settle();
+
+            Element element = result.Elements.Single();
             Assert.Multiple(() =>
             {
-                Assert.That(editor.Scene.Children, Is.Empty);
-                Assert.That(editor.HistoryManager.CanUndo, Is.False);
+                Assert.That(result.IsSuccess, Is.True);
+                Assert.That(editor.Scene.Children, Has.Count.EqualTo(1));
+                Assert.That(editor.HistoryManager.CanUndo, Is.True);
+                Assert.That(
+                    UnsavedSceneStorage.OwnsPath(editor.Scene.Id, element.Uri!.LocalPath),
+                    Is.True);
+                Assert.That(File.Exists(element.Uri.LocalPath), Is.True);
             });
         }
         finally
         {
             editor.Scene.Uri = savedUri;
+            UnsavedSceneStorage.Cleanup(editor.Scene.Id);
         }
     }
 

--- a/tests/Beutl.HeadlessUITests/ElementAddEntryPointTests.cs
+++ b/tests/Beutl.HeadlessUITests/ElementAddEntryPointTests.cs
@@ -1,0 +1,543 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Specialized;
+using System.Text.Json;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Input;
+using Avalonia.Platform.Storage;
+using Beutl.Editor.Components.TimelineTab.ViewModels;
+using Beutl.Editor.Components.TimelineTab.Views;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Graphics;
+using Beutl.Graphics.Shapes;
+using Beutl.Language;
+using Beutl.Media;
+using Beutl.Media.Source;
+using Beutl.ProjectSystem;
+using Beutl.Services;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.Views;
+using AvaPoint = Avalonia.Point;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+[NonParallelizable]
+public class ElementAddEntryPointTests
+{
+    private static string NewWorkspace(string name)
+    {
+        string location = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(location);
+        return location;
+    }
+
+    private static async Task<(EditViewModel Editor, TimelineTabViewModel Timeline)> OpenEditorForNewScene(
+        string name)
+    {
+        Project project = (await TestShell.Project.CreateProject(
+            640, 480, 30, 44100, name, NewWorkspace(name)))!;
+        HeadlessTestHelpers.Settle();
+        Scene scene = project.Items.OfType<Scene>().First();
+
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+
+        EditorTabItem tab = TestShell.Editor.SelectedTabItem.Value!;
+        var editor = (EditViewModel)tab.Context.Value!;
+        TimelineTabViewModel timeline = editor.FindToolTab<TimelineTabViewModel>()
+                                            ?? throw new InvalidOperationException(
+                                                "The default editor layout did not create a timeline tab.");
+        return (editor, timeline);
+    }
+
+    [AvaloniaTest]
+    public async Task TimelineAddElement_Success_AddsAndScrollsWithoutNotification()
+    {
+        await TestReset.ResetShellAsync();
+        (EditViewModel editor, TimelineTabViewModel timeline) =
+            await OpenEditorForNewScene("timeline-add-entry-success");
+        using var notifications = new NotificationCapture();
+        var scrolls = new List<(TimeRange Range, int ZIndex)>();
+        using IDisposable subscription = timeline.ScrollTo.Subscribe(scrolls.Add);
+        var description = new ElementDescription(
+            TimeSpan.FromSeconds(3),
+            TimeSpan.FromSeconds(2),
+            4,
+            new ElementSource.EngineObject(() => new RectShape()));
+
+        await timeline.AddElement.ExecuteAsync(description);
+        HeadlessTestHelpers.Settle();
+
+        Element created = editor.Scene.Children.Single();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(created.Start, Is.EqualTo(description.Start));
+            Assert.That(created.Length, Is.EqualTo(description.Length));
+            Assert.That(created.ZIndex, Is.EqualTo(description.Layer));
+            Assert.That(created.Objects.OfType<RectShape>().Count(), Is.EqualTo(1));
+            Assert.That(scrolls, Has.Count.EqualTo(1));
+            Assert.That(scrolls[0].Range, Is.EqualTo(created.Range));
+            Assert.That(scrolls[0].ZIndex, Is.EqualTo(created.ZIndex));
+            Assert.That(notifications.Notifications, Is.Empty);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task TimelineAddElement_LockedLayer_ShowsWarningWithoutAddingOrScrolling()
+    {
+        await TestReset.ResetShellAsync();
+        (EditViewModel editor, TimelineTabViewModel timeline) =
+            await OpenEditorForNewScene("timeline-add-entry-locked");
+        using (editor.HistoryManager.SuppressRecording())
+        {
+            editor.Scene.Layers.Add(new TimelineLayer { ZIndex = 2, IsLocked = true });
+        }
+
+        using var notifications = new NotificationCapture();
+        var scrolls = new List<(TimeRange Range, int ZIndex)>();
+        using IDisposable subscription = timeline.ScrollTo.Subscribe(scrolls.Add);
+
+        await timeline.AddElement.ExecuteAsync(new ElementDescription(
+            TimeSpan.Zero,
+            TimeSpan.FromSeconds(2),
+            2,
+            new ElementSource.EngineObject(() => new RectShape())));
+        HeadlessTestHelpers.Settle();
+
+        Notification notification = notifications.Single();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(editor.Scene.Children, Is.Empty);
+            Assert.That(editor.HistoryManager.UndoCount, Is.Zero);
+            Assert.That(scrolls, Is.Empty);
+            Assert.That(notification.Type, Is.EqualTo(NotificationType.Warning));
+            Assert.That(notification.Title, Is.EqualTo(Strings.Lock));
+            Assert.That(notification.Message, Is.EqualTo(Strings.LayerIsLocked));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task TimelineAddElement_GeneralFailure_ShowsErrorWithoutAddingOrScrolling()
+    {
+        await TestReset.ResetShellAsync();
+        (EditViewModel editor, TimelineTabViewModel timeline) =
+            await OpenEditorForNewScene("timeline-add-entry-failure");
+        using var notifications = new NotificationCapture();
+        var scrolls = new List<(TimeRange Range, int ZIndex)>();
+        using IDisposable subscription = timeline.ScrollTo.Subscribe(scrolls.Add);
+
+        await timeline.AddElement.ExecuteAsync(new ElementDescription(
+            TimeSpan.Zero,
+            TimeSpan.FromSeconds(2),
+            0,
+            new ElementSource.EngineObject(
+                static () => throw new InvalidOperationException("Injected element factory failure."))));
+        HeadlessTestHelpers.Settle();
+
+        Notification notification = notifications.Single();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(editor.Scene.Children, Is.Empty);
+            Assert.That(editor.HistoryManager.UndoCount, Is.Zero);
+            Assert.That(scrolls, Is.Empty);
+            Assert.That(notification.Type, Is.EqualTo(NotificationType.Error));
+            Assert.That(notification.Title, Is.EqualTo(Strings.AddElement));
+            Assert.That(notification.Message, Is.EqualTo(MessageStrings.UnexpectedError));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task TimelineView_TemplateFileDrop_AddsCompleteTemplateAndScrollsToDropTarget()
+    {
+        await TestReset.ResetShellAsync();
+        (EditViewModel editor, TimelineTabViewModel timeline) =
+            await OpenEditorForNewScene("timeline-template-drop");
+        string templatePath = CreateElementTemplateFile(editor, "dropped-template.json");
+        using var notifications = new NotificationCapture();
+        var scrolls = new List<(TimeRange Range, int ZIndex)>();
+        using IDisposable subscription = timeline.ScrollTo.Subscribe(scrolls.Add);
+        var view = new TimelineTabView { DataContext = timeline };
+        var window = new Window { Content = view, Width = 900, Height = 600 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+            Panel timelinePanel = view.FindControl<Panel>("TimelinePanel")!;
+            Assert.That(timelinePanel, Is.Not.Null);
+            using IStorageFile storageFile = await GetStorageFile(window, templatePath);
+            using var transfer = new DataTransfer();
+            transfer.Add(DataTransferItem.CreateFile(storageFile));
+            var dropPoint = new AvaPoint(180, timeline.CalculateLayerTop(3) + 5);
+            int expectedLayer = timeline.ToLayerNumber(dropPoint.Y);
+            var args = new DragEventArgs(
+                DragDrop.DropEvent,
+                transfer,
+                timelinePanel,
+                dropPoint,
+                KeyModifiers.None);
+            Element created = await RaiseDropAndWaitForElement(editor.Scene, timelinePanel, args);
+            HeadlessTestHelpers.Settle();
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(args.Handled, Is.True);
+                Assert.That(created.Start, Is.EqualTo(timeline.ClickedFrame));
+                Assert.That(created.Length, Is.EqualTo(TimeSpan.FromSeconds(7)));
+                Assert.That(created.ZIndex, Is.EqualTo(expectedLayer));
+                Assert.That(created.Name, Is.EqualTo("Dropped template"));
+                Assert.That(created.Objects.OfType<RectShape>().Count(), Is.EqualTo(1));
+                Assert.That(scrolls, Has.Count.EqualTo(1));
+                Assert.That(scrolls[0].Range, Is.EqualTo(created.Range));
+                Assert.That(scrolls[0].ZIndex, Is.EqualTo(created.ZIndex));
+                Assert.That(notifications.Notifications, Is.Empty);
+            }
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task PlayerView_ImageFileDrop_RoutesThroughTimelineAndScrollsToAddedElement()
+    {
+        await TestReset.ResetShellAsync();
+        (EditViewModel editor, TimelineTabViewModel timeline) =
+            await OpenEditorForNewScene("player-file-drop");
+        string imagePath = CreatePngFile(editor, "dropped-image.png");
+        editor.Player.CurrentFrame.Value = TimeSpan.FromSeconds(4);
+        editor.Player.PreviewImage.Value = Ref<Bitmap>.Create(new Bitmap(
+            editor.Scene.FrameSize.Width,
+            editor.Scene.FrameSize.Height));
+        using var notifications = new NotificationCapture();
+        var scrolls = new List<(TimeRange Range, int ZIndex)>();
+        using IDisposable subscription = timeline.ScrollTo.Subscribe(scrolls.Add);
+        var view = new PlayerView { DataContext = editor.Player };
+        view.image.Width = editor.Scene.FrameSize.Width;
+        view.image.Height = editor.Scene.FrameSize.Height;
+        var window = new Window { Content = view, Width = 800, Height = 600 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+            Panel framePanel = view.FindControl<Panel>("framePanel")!;
+            Assert.That(framePanel, Is.Not.Null);
+            var previewSize = new Avalonia.Size(editor.Scene.FrameSize.Width, editor.Scene.FrameSize.Height);
+            view.image.Measure(previewSize);
+            view.image.Arrange(new Avalonia.Rect(0, 0, previewSize.Width, previewSize.Height));
+            Assert.That(view.image.Bounds.Width, Is.GreaterThan(0));
+            Assert.That(view.image.Bounds.Height, Is.GreaterThan(0));
+            using IStorageFile storageFile = await GetStorageFile(window, imagePath);
+            using var transfer = new DataTransfer();
+            transfer.Add(DataTransferItem.CreateFile(storageFile));
+            var imageCenter = new AvaPoint(view.image.Bounds.Width / 2, view.image.Bounds.Height / 2);
+            var args = new DragEventArgs(
+                DragDrop.DropEvent,
+                transfer,
+                view.image,
+                imageCenter,
+                KeyModifiers.None);
+            Element created = await RaiseDropAndWaitForElement(editor.Scene, framePanel, args);
+            HeadlessTestHelpers.Settle();
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(args.Handled, Is.True);
+                Assert.That(created.Start, Is.EqualTo(TimeSpan.FromSeconds(4)));
+                Assert.That(created.Length, Is.EqualTo(TimeSpan.FromSeconds(5)));
+                Assert.That(created.ZIndex, Is.Zero);
+                Assert.That(created.Objects.OfType<SourceImage>().Count(), Is.EqualTo(1));
+                Assert.That(scrolls, Has.Count.EqualTo(1));
+                Assert.That(scrolls[0].Range, Is.EqualTo(created.Range));
+                Assert.That(scrolls[0].ZIndex, Is.EqualTo(created.ZIndex));
+                Assert.That(notifications.Notifications, Is.Empty);
+            }
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task PlayerView_DropWithoutTimelineSurfacesLockedAndUnsupportedFailures()
+    {
+        await TestReset.ResetShellAsync();
+        (EditViewModel editor, TimelineTabViewModel timeline) =
+            await OpenEditorForNewScene("player-drop-without-timeline");
+        editor.CloseToolTab(timeline);
+        Assert.That(editor.FindToolTab<TimelineTabViewModel>(), Is.Null);
+        using (editor.HistoryManager.SuppressRecording())
+        {
+            editor.Scene.Layers.Add(new TimelineLayer { ZIndex = 0, IsLocked = true });
+        }
+        string imagePath = CreatePngFile(editor, "locked-image.png");
+        string unsupportedPath = Path.Combine(
+            Path.GetDirectoryName(editor.Scene.Uri!.LocalPath)!,
+            "unsupported.drop-test");
+        await File.WriteAllTextAsync(unsupportedPath, "unsupported");
+        editor.Player.CurrentFrame.Value = TimeSpan.Zero;
+        editor.Player.PreviewImage.Value = Ref<Bitmap>.Create(new Bitmap(
+            editor.Scene.FrameSize.Width,
+            editor.Scene.FrameSize.Height));
+        using var notifications = new NotificationCapture();
+        var view = new PlayerView { DataContext = editor.Player };
+        view.image.Width = editor.Scene.FrameSize.Width;
+        view.image.Height = editor.Scene.FrameSize.Height;
+        var window = new Window { Content = view, Width = 800, Height = 600 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+            Panel framePanel = view.FindControl<Panel>("framePanel")!;
+            var previewSize = new Avalonia.Size(editor.Scene.FrameSize.Width, editor.Scene.FrameSize.Height);
+            view.image.Measure(previewSize);
+            view.image.Arrange(new Avalonia.Rect(0, 0, previewSize.Width, previewSize.Height));
+            var imageCenter = new AvaPoint(view.image.Bounds.Width / 2, view.image.Bounds.Height / 2);
+
+            using IStorageFile lockedFile = await GetStorageFile(window, imagePath);
+            using var lockedTransfer = new DataTransfer();
+            lockedTransfer.Add(DataTransferItem.CreateFile(lockedFile));
+            var lockedDrop = new DragEventArgs(
+                DragDrop.DropEvent,
+                lockedTransfer,
+                view.image,
+                imageCenter,
+                KeyModifiers.None);
+            framePanel.RaiseEvent(lockedDrop);
+            await WaitUntilAsync(() => notifications.Notifications.Count >= 1);
+
+            editor.Scene.Layers.Single(layer => layer.ZIndex == 0).IsLocked = false;
+            using IStorageFile unsupportedFile = await GetStorageFile(window, unsupportedPath);
+            using var unsupportedTransfer = new DataTransfer();
+            unsupportedTransfer.Add(DataTransferItem.CreateFile(unsupportedFile));
+            var unsupportedDrop = new DragEventArgs(
+                DragDrop.DropEvent,
+                unsupportedTransfer,
+                view.image,
+                imageCenter,
+                KeyModifiers.None);
+            framePanel.RaiseEvent(unsupportedDrop);
+            await WaitUntilAsync(() => notifications.Notifications.Count >= 2);
+            HeadlessTestHelpers.Settle();
+
+            Notification[] shown = notifications.Notifications.ToArray();
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(lockedDrop.Handled, Is.True);
+                Assert.That(unsupportedDrop.Handled, Is.True);
+                Assert.That(editor.Scene.Children, Is.Empty);
+                Assert.That(shown[0].Type, Is.EqualTo(NotificationType.Warning));
+                Assert.That(shown[0].Title, Is.EqualTo(Strings.Lock));
+                Assert.That(shown[0].Message, Is.EqualTo(Strings.LayerIsLocked));
+                Assert.That(shown[1].Type, Is.EqualTo(NotificationType.Error));
+                Assert.That(shown[1].Title, Is.EqualTo(Strings.AddElement));
+                Assert.That(shown[1].Message, Is.EqualTo(MessageStrings.UnexpectedError));
+            }
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [Test]
+    public async Task PlayerDropContainsEditorLifecycleCancellation()
+    {
+        var description = new ElementDescription(
+            TimeSpan.Zero,
+            TimeSpan.FromSeconds(1),
+            0,
+            new ElementSource.EngineObject(() => new RectShape()));
+
+        foreach (Exception failure in new Exception[]
+                 {
+                     new OperationCanceledException(),
+                     new ObjectDisposedException("editor"),
+                 })
+        {
+            ElementAddResult? result = await PlayerView.AddPlayerDropAsync(
+                new FailingElementAdder(failure),
+                description);
+            Assert.That(result, Is.Null);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task PlayerDropThroughTimelineAwaitsAndContainsEditorLifecycleCancellation()
+    {
+        await TestReset.ResetShellAsync();
+        (EditViewModel editor, _) = await OpenEditorForNewScene("player-timeline-drop-cancellation");
+        EditorTabItem tab = TestShell.Editor.SelectedTabItem.Value!;
+        var handler = new BlockingFileSourceHandler();
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        _ = adder.SourceHandlers.Register(new ElementSourceHandlerRegistration(
+            handler,
+            ElementSourceHandlerRegistrationMode.Replace));
+        var view = new PlayerView();
+        var description = new ElementDescription(
+            TimeSpan.Zero,
+            TimeSpan.FromSeconds(1),
+            0,
+            new ElementSource.File("pending.png"));
+
+        Task drop = view.AddElement(editor, description);
+        await handler.PreflightStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(drop.IsCompleted, Is.False);
+
+        await TestShell.Editor.CloseTabItem(tab);
+        await drop.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(handler.MaterializationCalled, Is.False);
+            Assert.That(editor.Scene, Is.Null);
+        });
+    }
+
+    private static string CreateElementTemplateFile(EditViewModel editor, string fileName)
+    {
+        var source = new Element
+        {
+            Start = TimeSpan.FromSeconds(20),
+            Length = TimeSpan.FromSeconds(7),
+            ZIndex = 8,
+            Name = "Dropped template",
+        };
+        source.AddObject(new RectShape());
+        ObjectTemplateItem template = ObjectTemplateItem.CreateFromInstance(source, "Drop template");
+        string path = Path.Combine(Path.GetDirectoryName(editor.Scene.Uri!.LocalPath)!, fileName);
+        File.WriteAllText(
+            path,
+            ObjectTemplateItem.ToJson(template).ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+        return path;
+    }
+
+    private static string CreatePngFile(EditViewModel editor, string fileName)
+    {
+        const string Png =
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+        string path = Path.Combine(Path.GetDirectoryName(editor.Scene.Uri!.LocalPath)!, fileName);
+        File.WriteAllBytes(path, Convert.FromBase64String(Png));
+        return path;
+    }
+
+    private static async Task<IStorageFile> GetStorageFile(Window window, string path)
+    {
+        return await window.StorageProvider.TryGetFileFromPathAsync(path)
+               ?? throw new InvalidOperationException($"The headless storage provider did not resolve '{path}'.");
+    }
+
+    private static async Task<Element> RaiseDropAndWaitForElement(
+        Scene scene,
+        Control target,
+        DragEventArgs args)
+    {
+        var completion = new TaskCompletionSource<Element>(TaskCreationOptions.RunContinuationsAsynchronously);
+        NotifyCollectionChangedEventHandler handler = (_, eventArgs) =>
+        {
+            if (eventArgs.Action != NotifyCollectionChangedAction.Add
+                || eventArgs.NewItems?.OfType<Element>().FirstOrDefault() is not { } element)
+            {
+                return;
+            }
+
+            completion.TrySetResult(element);
+        };
+        scene.Children.CollectionChanged += handler;
+        try
+        {
+            target.RaiseEvent(args);
+            return await completion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            scene.Children.CollectionChanged -= handler;
+        }
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        const int DelayMilliseconds = 10;
+        for (int attempt = 0; attempt < 500; attempt++)
+        {
+            if (condition())
+                return;
+            await Task.Delay(DelayMilliseconds);
+        }
+
+        Assert.Fail("The expected asynchronous UI state was not reached.");
+    }
+
+    private sealed class NotificationCapture : INotificationServiceHandler, IDisposable
+    {
+        private readonly INotificationServiceHandler _previousHandler;
+
+        public NotificationCapture()
+        {
+            _previousHandler = NotificationService.Handler;
+            NotificationService.Handler = this;
+        }
+
+        public ConcurrentQueue<Notification> Notifications { get; } = new();
+
+        public void Show(Notification notification) => Notifications.Enqueue(notification);
+
+        public Notification Single()
+        {
+            Assert.That(Notifications, Has.Count.EqualTo(1));
+            return Notifications.Single();
+        }
+
+        public void Dispose()
+        {
+            NotificationService.Handler = _previousHandler;
+        }
+    }
+
+    private sealed class FailingElementAdder(Exception failure) : IElementAdder
+    {
+        public IElementSourceHandlerRegistry SourceHandlers => null!;
+
+        public ValueTask<ElementAddResult> AddAsync(
+            IReadOnlyList<ElementDescription> descriptions,
+            CancellationToken cancellationToken)
+            => ValueTask.FromException<ElementAddResult>(failure);
+    }
+
+    private sealed class BlockingFileSourceHandler : IElementSourceHandler
+    {
+        public Type SourceType => typeof(ElementSource.File);
+
+        public TaskCompletionSource PreflightStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool MaterializationCalled { get; private set; }
+
+        public async ValueTask<ElementSourcePreflightResult> PreflightAsync(
+            ElementSourcePreflightContext context,
+            CancellationToken cancellationToken)
+        {
+            PreflightStarted.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            throw new AssertionException("Canceled preflight unexpectedly resumed.");
+        }
+
+        public ValueTask<ElementSourceMaterializationResult> MaterializeAsync(
+            ElementSourceMaterializationContext context,
+            IElementSourcePreflight preflight,
+            CancellationToken cancellationToken)
+        {
+            MaterializationCalled = true;
+            throw new AssertionException("Canceled preflight must not be materialized.");
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/ElementAdderTests.cs
+++ b/tests/Beutl.HeadlessUITests/ElementAdderTests.cs
@@ -1,0 +1,1317 @@
+﻿using System.Collections.Specialized;
+using Avalonia.Headless.NUnit;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Graphics.Shapes;
+using Beutl.ProjectSystem;
+using Beutl.Serialization;
+using Beutl.Services;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class ElementAdderTests
+{
+    private static string NewWorkspace(string name)
+    {
+        string location = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(location);
+        return location;
+    }
+
+    private static async Task<EditViewModel> OpenEditorForNewScene(string name)
+    {
+        Project project = (await TestShell.Project.CreateProject(
+            640, 480, 30, 44100, name, NewWorkspace(name)))!;
+        HeadlessTestHelpers.Settle();
+        Scene scene = project.Items.OfType<Scene>().First();
+
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+
+        EditorTabItem tab = TestShell.Editor.SelectedTabItem.Value!;
+        return (EditViewModel)tab.Context.Value!;
+    }
+
+    [AvaloniaTest]
+    public async Task AddAsync_CommitsOneBatchAndUndoRedoRestoresEveryElement()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-history");
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        int initialUndoCount = editor.HistoryManager.UndoCount;
+
+        ElementAddResult result = await adder.AddAsync(
+        [
+            new ElementDescription(
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(2),
+                Layer: 0,
+                Source: new ElementSource.EngineObject(() => new RectShape())),
+            new ElementDescription(
+                TimeSpan.FromSeconds(3),
+                TimeSpan.FromSeconds(2),
+                Layer: 0,
+                Source: new ElementSource.EngineObject(() => new EllipseShape())),
+        ], CancellationToken.None);
+        HeadlessTestHelpers.Settle();
+
+        IReadOnlyList<Element> created = result.Elements;
+        Guid[] createdIds = created.Select(element => element.Id).ToArray();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(created, Has.Count.EqualTo(2));
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Items, Has.Count.EqualTo(2));
+            Assert.That(editor.Scene.Children.Select(element => element.Id), Is.EqualTo(createdIds));
+            Assert.That(editor.HistoryManager.UndoCount, Is.EqualTo(initialUndoCount + 1));
+        }
+
+        Assert.That(editor.HistoryManager.Undo(), Is.True);
+        HeadlessTestHelpers.Settle();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(editor.Scene.Children, Is.Empty);
+            Assert.That(editor.HistoryManager.UndoCount, Is.EqualTo(initialUndoCount));
+        }
+
+        Assert.That(editor.HistoryManager.Redo(), Is.True);
+        HeadlessTestHelpers.Settle();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(editor.Scene.Children.Select(element => element.Id), Is.EqualTo(createdIds));
+            Assert.That(editor.HistoryManager.UndoCount, Is.EqualTo(initialUndoCount + 1));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task AddAsync_WhenFactoryFails_AddsNothingAndStagesNoFiles()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-factory-failure");
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        string sceneDirectory = Path.GetDirectoryName(editor.Scene.Uri!.LocalPath)!;
+        string[] filesBefore = Directory.GetFiles(sceneDirectory, "*.belm", SearchOption.AllDirectories);
+
+        ElementAddResult result = await adder.AddAsync(
+        [
+            new ElementDescription(
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(2),
+                Layer: 0,
+                Source: new ElementSource.EngineObject(() => new RectShape())),
+            new ElementDescription(
+                TimeSpan.FromSeconds(3),
+                TimeSpan.FromSeconds(2),
+                Layer: 0,
+                Source: new ElementSource.EngineObject(
+                    static () => throw new InvalidOperationException("Factory failure"))),
+        ], CancellationToken.None);
+        HeadlessTestHelpers.Settle();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.Failure, Is.TypeOf<ElementMaterializationFailure>());
+            Assert.That(result.Failure!.Exception, Is.TypeOf<InvalidOperationException>());
+            Assert.That(result.Elements, Is.Empty);
+            Assert.That(editor.Scene.Children, Is.Empty);
+            Assert.That(editor.Scene.Groups, Is.Empty);
+            Assert.That(editor.HistoryManager.UndoCount, Is.Zero);
+            Assert.That(
+                Directory.GetFiles(sceneDirectory, "*.belm", SearchOption.AllDirectories),
+                Is.EqualTo(filesBefore));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task AddAsync_EmptyAndUnsupportedRequestsReturnDistinctFailures()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-preflight-failures");
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+
+        ElementAddResult empty = await adder.AddAsync([], CancellationToken.None);
+        ElementAddResult unsupported = await adder.AddAsync(
+        [
+            new ElementDescription(
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(1),
+                0,
+                new ElementSource.File("/tmp/unsupported.beutl-test")),
+        ], CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(empty.Failure, Is.TypeOf<EmptyElementAddRequestFailure>());
+            Assert.That(unsupported.Failure, Is.TypeOf<UnsupportedElementSourceFailure>());
+            Assert.That(
+                (unsupported.FailedDescription?.Source as ElementSource.File)?.FileName,
+                Does.EndWith("unsupported.beutl-test"));
+            Assert.That(editor.Scene.Children, Is.Empty);
+            Assert.That(editor.HistoryManager.UndoCount, Is.Zero);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task AddAsync_WhenTargetLayerIsLocked_RefusesEntireBatchBeforeFactoryRuns()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-locked-layer");
+        using (editor.HistoryManager.SuppressRecording())
+        {
+            editor.Scene.Layers.Add(new TimelineLayer { ZIndex = 2, IsLocked = true });
+        }
+
+        bool factoryCalled = false;
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        ElementAddResult result = await adder.AddAsync(
+        [
+            new ElementDescription(
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(2),
+                Layer: 0,
+                Source: new ElementSource.EngineObject(() => new RectShape())),
+            new ElementDescription(
+                TimeSpan.FromSeconds(3),
+                TimeSpan.FromSeconds(2),
+                Layer: 2,
+                Source: new ElementSource.EngineObject(() =>
+                {
+                    factoryCalled = true;
+                    return new EllipseShape();
+                })),
+        ], CancellationToken.None);
+        HeadlessTestHelpers.Settle();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.Failure, Is.TypeOf<LockedElementLayerFailure>());
+            Assert.That(((LockedElementLayerFailure)result.Failure!).Layer, Is.EqualTo(2));
+            Assert.That(result.Elements, Is.Empty);
+            Assert.That(factoryCalled, Is.False);
+            Assert.That(editor.Scene.Children, Is.Empty);
+            Assert.That(editor.HistoryManager.HasPendingOperations, Is.False);
+            Assert.That(editor.HistoryManager.UndoCount, Is.Zero);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ElementTemplateResolver_AddsRegeneratedCompleteElementThroughBatchPipeline()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-template");
+        var sourceShape = new RectShape();
+        var source = new Element
+        {
+            Start = TimeSpan.FromSeconds(20),
+            Length = TimeSpan.FromSeconds(7),
+            ZIndex = 9,
+            Name = "Authored template",
+        };
+        source.AddObject(sourceShape);
+        ObjectTemplateItem template = ObjectTemplateItem.CreateFromInstance(source, "Template");
+        ElementDescription description = ElementTemplateResolver.CreateDescription(
+            template,
+            TimeSpan.FromSeconds(3),
+            4);
+        ElementDescription zeroLengthDescription = ElementTemplateResolver.CreateDescription(
+            template,
+            TimeSpan.FromSeconds(11),
+            5,
+            lengthOverride: TimeSpan.Zero);
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+
+        ElementAddResult result = await adder.AddAsync(
+            [description, zeroLengthDescription],
+            CancellationToken.None);
+        HeadlessTestHelpers.Settle();
+
+        Element created = result.Items[0].PrimaryElement;
+        Element zeroLengthElement = result.Items[1].PrimaryElement;
+        RectShape createdShape = created.Objects.OfType<RectShape>().Single();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(description.Length, Is.Null);
+            Assert.That(created.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(created.Length, Is.EqualTo(TimeSpan.FromSeconds(7)));
+            Assert.That(created.ZIndex, Is.EqualTo(4));
+            Assert.That(created.Name, Is.EqualTo("Authored template"));
+            Assert.That(created.Id, Is.Not.EqualTo(source.Id));
+            Assert.That(createdShape.Id, Is.Not.EqualTo(sourceShape.Id));
+            Assert.That(File.Exists(created.Uri!.LocalPath), Is.True);
+            Assert.That(zeroLengthDescription.Length, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(zeroLengthElement.Length, Is.EqualTo(TimeSpan.Zero));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task RegisteredAsyncHandler_MaterializesGroupedElementsAndUnregistersCleanly()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-plugin-handler");
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        var handler = new GroupedTestSourceHandler();
+        int initialUndoCount = editor.HistoryManager.UndoCount;
+        var description = new ElementDescription(
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromSeconds(3),
+            4,
+            new TestElementSource("plugin"));
+
+        IElementSourceHandlerRegistration registration = adder.SourceHandlers.Register(
+            new ElementSourceHandlerRegistration(handler));
+        ElementAddResult result = await adder.AddAsync([description], CancellationToken.None);
+        await registration.DisposeAsync();
+        ElementAddResult afterUnregister = await adder.AddAsync([description], CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Elements, Has.Count.EqualTo(2));
+            Assert.That(result.Elements.Select(element => element.ZIndex), Is.EqualTo(new[] { 4, 5 }));
+            Assert.That(editor.Scene.Groups, Has.Count.EqualTo(1));
+            Assert.That(editor.Scene.Groups.Single(), Is.EquivalentTo(result.Elements.Select(element => element.Id)));
+            Assert.That(editor.HistoryManager.UndoCount, Is.EqualTo(initialUndoCount + 1));
+            Assert.That(handler.PreflightCount, Is.EqualTo(1));
+            Assert.That(handler.MaterializationCount, Is.EqualTo(1));
+            Assert.That(handler.LastPreflight!.IsDisposed, Is.True);
+            Assert.That(handler.Resource.IsDisposed, Is.True);
+            Assert.That(afterUnregister.Failure, Is.TypeOf<UnsupportedElementSourceFailure>());
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task RegisteredHandler_CanChooseLengthWhenDescriptionLeavesItUnspecified()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-handler-length");
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        var handler = new LengthPreservingTestSourceHandler();
+        await using IElementSourceHandlerRegistration registration = adder.SourceHandlers.Register(
+            new ElementSourceHandlerRegistration(handler));
+
+        ElementAddResult result = await adder.AddAsync(
+        [
+            new ElementDescription(
+                TimeSpan.FromSeconds(2),
+                null,
+                4,
+                new TestElementSource("handler-defined-length")),
+        ], CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Elements, Has.Count.EqualTo(1));
+            Assert.That(result.Elements[0].Length, Is.EqualTo(TimeSpan.FromSeconds(7)));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task BuiltInHandlers_RejectUnspecifiedLengthDuringPreflight()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-built-in-length");
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+
+        ElementAddResult engineObject = await adder.AddAsync(
+        [
+            new ElementDescription(
+                TimeSpan.Zero,
+                null,
+                0,
+                new ElementSource.EngineObject(() => new RectShape())),
+        ], CancellationToken.None);
+        ElementAddResult file = await adder.AddAsync(
+        [
+            new ElementDescription(
+                TimeSpan.Zero,
+                null,
+                0,
+                new ElementSource.File("/tmp/unused.beutl-test")),
+        ], CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(engineObject.Failure, Is.TypeOf<ElementSourcePreflightFailure>());
+            Assert.That(engineObject.Elements, Is.Empty);
+            Assert.That(file.Failure, Is.TypeOf<ElementSourcePreflightFailure>());
+            Assert.That(file.Elements, Is.Empty);
+            Assert.That(editor.Scene.Children, Is.Empty);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task RegisteredHandler_CanReturnExtensibleTypedPreflightFailure()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-plugin-failure");
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        var failure = new TestElementAddFailure("The plugin rejected this source.");
+        var handler = new RejectingTestSourceHandler(failure);
+        await using IElementSourceHandlerRegistration registration = adder.SourceHandlers.Register(
+            new ElementSourceHandlerRegistration(handler));
+
+        ElementAddResult result = await adder.AddAsync(
+        [
+            new ElementDescription(
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(1),
+                0,
+                new TestElementSource("rejected")),
+        ], CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Failure, Is.SameAs(failure));
+            Assert.That(result.Failure!.Id, Is.EqualTo(new ElementAddFailureId("example.test.rejected")));
+            Assert.That(handler.MaterializationCalled, Is.False);
+            Assert.That(editor.Scene.Children, Is.Empty);
+            Assert.That(editor.HistoryManager.UndoCount, Is.Zero);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task CancellationDuringRegisteredPreflight_LeavesPersistenceAndHistoryUntouched()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-plugin-cancellation");
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        var handler = new BlockingTestSourceHandler();
+        await using IElementSourceHandlerRegistration registration = adder.SourceHandlers.Register(
+            new ElementSourceHandlerRegistration(handler));
+        using var cancellationTokenSource = new CancellationTokenSource();
+        ValueTask<ElementAddResult> operation = adder.AddAsync(
+        [
+            new ElementDescription(
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(1),
+                0,
+                new TestElementSource("cancel")),
+        ], cancellationTokenSource.Token);
+        await handler.PreflightStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        cancellationTokenSource.Cancel();
+
+        bool canceled = false;
+        try
+        {
+            await operation;
+        }
+        catch (OperationCanceledException)
+        {
+            canceled = true;
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(canceled, Is.True);
+            Assert.That(handler.MaterializationCalled, Is.False);
+            Assert.That(editor.Scene.Children, Is.Empty);
+            Assert.That(editor.HistoryManager.HasPendingOperations, Is.False);
+            Assert.That(editor.HistoryManager.UndoCount, Is.Zero);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task RegisteredHandler_DisposalWaitsForPreflightAndMaterialization()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-handler-lease");
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        var handler = new LeaseBlockingTestSourceHandler();
+        IElementSourceHandlerRegistration registration = adder.SourceHandlers.Register(
+            new ElementSourceHandlerRegistration(handler));
+        Task<ElementAddResult> operation = adder.AddAsync(
+            [CreateTestDescription("lease", 0)],
+            CancellationToken.None).AsTask();
+        Task? disposeTask = null;
+
+        try
+        {
+            await handler.PreflightStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            disposeTask = registration.DisposeAsync().AsTask();
+            await WaitUntilAsync(IsHandlerRetired, TimeSpan.FromSeconds(5));
+            Assert.That(disposeTask.IsCompleted, Is.False);
+
+            handler.ReleasePreflight.TrySetResult();
+            await handler.MaterializationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(disposeTask.IsCompleted, Is.False);
+
+            handler.ReleaseMaterialization.TrySetResult();
+            ElementAddResult result = await operation.WaitAsync(TimeSpan.FromSeconds(5));
+            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.IsSuccess, Is.True);
+                Assert.That(editor.Scene.Children, Has.Count.EqualTo(1));
+            }
+        }
+        finally
+        {
+            handler.ReleasePreflight.TrySetResult();
+            handler.ReleaseMaterialization.TrySetResult();
+            Task finalDisposeTask = disposeTask ?? registration.DisposeAsync().AsTask();
+            try
+            {
+                await operation.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            finally
+            {
+                await finalDisposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+        }
+
+        bool IsHandlerRetired()
+        {
+            if (!adder.SourceHandlers.TryAcquire(
+                    typeof(TestElementSource),
+                    out IElementSourceHandlerLease? candidate))
+            {
+                return true;
+            }
+
+            candidate!.Dispose();
+            return false;
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task EditorDispose_OnUiThreadCancelsAwaitingHandlerAndDrainsItsLease()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-dispose-during-await");
+        EditorTabItem tab = TestShell.Editor.SelectedTabItem.Value!;
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        var handler = new BlockingTestSourceHandler();
+        _ = adder.SourceHandlers.Register(new ElementSourceHandlerRegistration(handler));
+        Task<ElementAddResult> operation = adder.AddAsync(
+            [CreateTestDescription("dispose", 0)],
+            CancellationToken.None).AsTask();
+        await handler.PreflightStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Task closeTask = TestShell.Editor.CloseTabItem(tab).AsTask();
+
+        Assert.That(closeTask.IsCompleted, Is.False);
+        OperationCanceledException? cancellation = null;
+        try
+        {
+            await operation.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        catch (OperationCanceledException ex)
+        {
+            cancellation = ex;
+        }
+        await closeTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(cancellation, Is.Not.Null);
+            Assert.That(handler.MaterializationCalled, Is.False);
+            Assert.That(TestShell.Editor.TabItems, Does.Not.Contain(tab));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task RegisteredHandler_LockedLayerReleasesPreflightLeaseBeforeReturningFailure()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-plugin-locked-lease");
+        using (editor.HistoryManager.SuppressRecording())
+        {
+            editor.Scene.Layers.Add(new TimelineLayer { ZIndex = 5, IsLocked = true });
+        }
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        var handler = new GroupedTestSourceHandler();
+        await using IElementSourceHandlerRegistration registration = adder.SourceHandlers.Register(
+            new ElementSourceHandlerRegistration(handler));
+
+        ElementAddResult result = await adder.AddAsync(
+        [
+            new ElementDescription(
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(1),
+                4,
+                new TestElementSource("locked")),
+        ], CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Failure, Is.TypeOf<LockedElementLayerFailure>());
+            Assert.That(handler.LastPreflight, Is.Not.Null);
+            Assert.That(handler.LastPreflight!.IsDisposed, Is.True);
+            Assert.That(handler.MaterializationCount, Is.Zero);
+            Assert.That(handler.Resource.IsDisposed, Is.False);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task MaterializationResource_IsReleasedAfterSuccessAndRollback()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-transfer-ownership");
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        var successfulHandler = new OwnershipTestSourceHandler();
+        await using (IElementSourceHandlerRegistration registration = adder.SourceHandlers.Register(
+                         new ElementSourceHandlerRegistration(successfulHandler)))
+        {
+            ElementAddResult success = await adder.AddAsync(
+            [
+                new ElementDescription(
+                    TimeSpan.Zero,
+                    TimeSpan.FromSeconds(1),
+                    0,
+                    new TestElementSource("commit")),
+            ], CancellationToken.None);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(success.IsSuccess, Is.True);
+                Assert.That(successfulHandler.Preflight!.IsDisposed, Is.True);
+                Assert.That(successfulHandler.Resource.IsDisposed, Is.True);
+            }
+        }
+
+        var rollbackHandler = new OwnershipTestSourceHandler();
+        await using IElementSourceHandlerRegistration rollbackRegistration = adder.SourceHandlers.Register(
+            new ElementSourceHandlerRegistration(rollbackHandler));
+        NotifyCollectionChangedEventHandler mutationFailure = (_, args) =>
+        {
+            if (args.Action == NotifyCollectionChangedAction.Add)
+                throw new InvalidOperationException("Injected mutation failure");
+        };
+        editor.Scene.Children.CollectionChanged += mutationFailure;
+        ElementAddResult rollback;
+        try
+        {
+            rollback = await adder.AddAsync(
+            [
+                new ElementDescription(
+                    TimeSpan.FromSeconds(2),
+                    TimeSpan.FromSeconds(1),
+                    1,
+                    new TestElementSource("rollback")),
+            ], CancellationToken.None);
+        }
+        finally
+        {
+            editor.Scene.Children.CollectionChanged -= mutationFailure;
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rollback.Failure, Is.TypeOf<ElementSceneMutationFailure>());
+            Assert.That(rollbackHandler.Preflight!.IsDisposed, Is.True);
+            Assert.That(rollbackHandler.Resource.IsDisposed, Is.True);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ExtensionHandler_IsComposedForOpenEditorAndRetiredOnPackageRemoval()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-extension-composition");
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        const int packageId = 98_765_432;
+        var extension = new TestSourceHandlerExtension(new GroupedTestSourceHandler());
+
+        editor.ExtensionProvider.AddExtensions(packageId, [extension]);
+        try
+        {
+            ElementAddResult result = await adder.AddAsync(
+            [
+                new ElementDescription(
+                    TimeSpan.Zero,
+                    TimeSpan.FromSeconds(1),
+                    0,
+                    new TestElementSource("extension")),
+            ], CancellationToken.None);
+
+            Assert.That(result.IsSuccess, Is.True);
+        }
+        finally
+        {
+            editor.ExtensionProvider.RemoveExtensions(packageId);
+        }
+
+        ElementAddResult afterRemoval = await adder.AddAsync(
+        [
+            new ElementDescription(
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(1),
+                0,
+                new TestElementSource("extension-removed")),
+        ], CancellationToken.None);
+
+        Assert.That(afterRemoval.Failure, Is.TypeOf<UnsupportedElementSourceFailure>());
+    }
+
+    [AvaloniaTest]
+    public async Task RegisteredHandler_RejectsDuplicateElementIdsAcrossTheBatchAndScene()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-duplicate-ids");
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        var handler = new FixedIdSourceHandler();
+        await using IElementSourceHandlerRegistration registration = adder.SourceHandlers.Register(
+            new ElementSourceHandlerRegistration(handler));
+
+        ElementAddResult duplicateBatch = await adder.AddAsync(
+        [
+            CreateTestDescription("first", 0),
+            CreateTestDescription("second", 1),
+        ], CancellationToken.None);
+        ElementAddResult first = await adder.AddAsync(
+            [CreateTestDescription("committed", 0)],
+            CancellationToken.None);
+        ElementAddResult duplicateScene = await adder.AddAsync(
+            [CreateTestDescription("duplicate", 1)],
+            CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(duplicateBatch.Failure, Is.TypeOf<InvalidElementMaterializationFailure>());
+            Assert.That(first.IsSuccess, Is.True);
+            Assert.That(duplicateScene.Failure, Is.TypeOf<InvalidElementMaterializationFailure>());
+            Assert.That(editor.Scene.Children, Has.Count.EqualTo(1));
+            Assert.That(editor.Scene.Children[0].Id, Is.EqualTo(handler.FixedId));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task RegisteredHandler_RevalidatesLayerLockAfterAsyncMaterialization()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-late-layer-lock");
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        var handler = new MutationTestSourceHandler((context, _) =>
+        {
+            using (editor.HistoryManager.SuppressRecording())
+            {
+                context.Scene.Layers.Add(new TimelineLayer
+                {
+                    ZIndex = context.Description.Layer,
+                    IsLocked = true,
+                });
+            }
+        });
+        await using IElementSourceHandlerRegistration registration = adder.SourceHandlers.Register(
+            new ElementSourceHandlerRegistration(handler));
+
+        ElementAddResult result = await adder.AddAsync(
+            [CreateTestDescription("late-lock", 3)],
+            CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Failure, Is.TypeOf<LockedElementLayerFailure>());
+            Assert.That(editor.Scene.Children, Is.Empty);
+            Assert.That(editor.HistoryManager.UndoCount, Is.Zero);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task RegisteredHandler_RevalidatesSceneIdentityAfterAsyncMaterialization()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-late-scene-change");
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        Guid originalId = editor.Scene.Id;
+        Guid changedId = Guid.NewGuid();
+        var handler = new MutationTestSourceHandler((context, _) =>
+        {
+            using (editor.HistoryManager.SuppressRecording())
+            {
+                context.Scene.Id = changedId;
+            }
+        });
+        await using IElementSourceHandlerRegistration registration = adder.SourceHandlers.Register(
+            new ElementSourceHandlerRegistration(handler));
+
+        ElementAddResult result;
+        try
+        {
+            result = await adder.AddAsync(
+                [CreateTestDescription("scene-change", 0)],
+                CancellationToken.None);
+        }
+        finally
+        {
+            using (editor.HistoryManager.SuppressRecording())
+            {
+                editor.Scene.Id = originalId;
+            }
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Failure, Is.TypeOf<ElementSceneChangedFailure>());
+            Assert.That(((ElementSceneChangedFailure)result.Failure!).ExpectedSceneId, Is.EqualTo(originalId));
+            Assert.That(((ElementSceneChangedFailure)result.Failure!).ActualSceneId, Is.EqualTo(changedId));
+            Assert.That(editor.Scene.Children, Is.Empty);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task RegisteredHandler_RevalidatesIdentifierUniquenessAfterAsyncMaterialization()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-late-id-conflict");
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        Element? competing = null;
+        var handler = new MutationTestSourceHandler((context, materialized) =>
+        {
+            competing = new Element
+            {
+                Start = TimeSpan.FromSeconds(10),
+                Length = TimeSpan.FromSeconds(1),
+                ZIndex = 10,
+                Uri = new Uri(Path.Combine(
+                    Path.GetDirectoryName(context.Scene.Uri!.LocalPath)!,
+                    $"competing-{Guid.NewGuid():N}.belm")),
+            };
+            using (editor.HistoryManager.SuppressRecording())
+            {
+                context.Scene.AddChild(competing);
+            }
+            materialized.Id = competing.Id;
+        });
+        await using IElementSourceHandlerRegistration registration = adder.SourceHandlers.Register(
+            new ElementSourceHandlerRegistration(handler));
+
+        ElementAddResult result = await adder.AddAsync(
+            [CreateTestDescription("id-conflict", 0)],
+            CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Failure, Is.TypeOf<InvalidElementMaterializationFailure>());
+            Assert.That(editor.Scene.Children, Has.Count.EqualTo(1));
+            Assert.That(editor.Scene.Children[0], Is.SameAs(competing));
+            Assert.That(editor.HistoryManager.UndoCount, Is.Zero);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ResourceReleaseFailure_DoesNotTurnACommittedBatchIntoAFailure()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-release-failure");
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        var handler = new ThrowingDisposeSourceHandler();
+        await using IElementSourceHandlerRegistration registration = adder.SourceHandlers.Register(
+            new ElementSourceHandlerRegistration(handler));
+
+        ElementAddResult result = await adder.AddAsync(
+            [CreateTestDescription("release", 0)],
+            CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(editor.Scene.Children, Has.Count.EqualTo(1));
+            Assert.That(handler.Preflight.DisposeAttempts, Is.EqualTo(1));
+            Assert.That(handler.Resource.DisposeAttempts, Is.EqualTo(1));
+        }
+    }
+
+    private static ElementDescription CreateTestDescription(string value, int layer)
+        => new(
+            TimeSpan.Zero,
+            TimeSpan.FromSeconds(1),
+            layer,
+            new TestElementSource(value));
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        const int DelayMilliseconds = 10;
+        int attempts = (int)Math.Ceiling(timeout.TotalMilliseconds / DelayMilliseconds);
+        for (int index = 0; index < attempts; index++)
+        {
+            if (condition())
+                return;
+
+            await Task.Delay(DelayMilliseconds);
+        }
+
+        Assert.Fail("The expected handler state was not reached before the timeout.");
+    }
+
+    [AvaloniaTest]
+    public async Task AddAsync_WhenSceneMutationFails_RollsBackBatchAndCleansStagedFiles()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("element-adder-mutation-failure");
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        string sceneDirectory = Path.GetDirectoryName(editor.Scene.Uri!.LocalPath)!;
+        string[] filesBefore = Directory.GetFiles(sceneDirectory, "*.belm", SearchOption.AllDirectories);
+        bool allFilesWereStaged = false;
+        bool shouldThrow = true;
+        NotifyCollectionChangedEventHandler handler = (_, args) =>
+        {
+            if (args.Action == NotifyCollectionChangedAction.Add && editor.Scene.Children.Count == 1)
+            {
+                allFilesWereStaged = Directory.GetFiles(
+                    sceneDirectory,
+                    "*.belm",
+                    SearchOption.AllDirectories).Length == filesBefore.Length + 2;
+            }
+
+            if (args.Action == NotifyCollectionChangedAction.Add
+                && editor.Scene.Children.Count == 2
+                && shouldThrow)
+            {
+                shouldThrow = false;
+                throw new InvalidOperationException("Injected collection mutation failure");
+            }
+        };
+        editor.Scene.Children.CollectionChanged += handler;
+
+        try
+        {
+            ElementAddResult result = await adder.AddAsync(
+            [
+                new ElementDescription(
+                    TimeSpan.Zero,
+                    TimeSpan.FromSeconds(2),
+                    Layer: 0,
+                    Source: new ElementSource.EngineObject(() => new RectShape())),
+                new ElementDescription(
+                    TimeSpan.FromSeconds(3),
+                    TimeSpan.FromSeconds(2),
+                    Layer: 0,
+                    Source: new ElementSource.EngineObject(() => new EllipseShape())),
+            ], CancellationToken.None);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Failure, Is.TypeOf<ElementSceneMutationFailure>());
+                Assert.That(result.Failure!.Exception, Is.TypeOf<InvalidOperationException>());
+            });
+        }
+        finally
+        {
+            editor.Scene.Children.CollectionChanged -= handler;
+        }
+        HeadlessTestHelpers.Settle();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(allFilesWereStaged, Is.True);
+            Assert.That(editor.Scene.Children, Is.Empty);
+            Assert.That(editor.Scene.Groups, Is.Empty);
+            Assert.That(editor.HistoryManager.HasPendingOperations, Is.False);
+            Assert.That(editor.HistoryManager.UndoCount, Is.Zero);
+            Assert.That(
+                Directory.GetFiles(sceneDirectory, "*.belm", SearchOption.AllDirectories),
+                Is.EqualTo(filesBefore));
+        }
+    }
+
+    private sealed record TestElementSource(string Value) : ElementSource;
+
+    private sealed class TestPreflight(int primaryLayer) : IElementSourcePreflight
+    {
+        public int PrimaryLayer { get; } = primaryLayer;
+
+        public bool IsDisposed { get; private set; }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Task.Yield();
+            IsDisposed = true;
+        }
+    }
+
+    private sealed record TestElementAddFailure : ElementAddFailure
+    {
+        public TestElementAddFailure(string message)
+            : base(new ElementAddFailureId("example.test.rejected"), message)
+        {
+        }
+    }
+
+    private sealed class GroupedTestSourceHandler : IElementSourceHandler
+    {
+        public Type SourceType => typeof(TestElementSource);
+
+        public int PreflightCount { get; private set; }
+
+        public int MaterializationCount { get; private set; }
+
+        public TrackingAsyncDisposable Resource { get; } = new();
+
+        public TestPreflight? LastPreflight { get; private set; }
+
+        public async ValueTask<ElementSourcePreflightResult> PreflightAsync(
+            ElementSourcePreflightContext context,
+            CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+            cancellationToken.ThrowIfCancellationRequested();
+            PreflightCount++;
+            LastPreflight = new TestPreflight(context.Description.Layer);
+            return ElementSourcePreflightResult.Ready(
+                LastPreflight,
+                [context.Description.Layer, context.Description.Layer + 1]);
+        }
+
+        public async ValueTask<ElementSourceMaterializationResult> MaterializeAsync(
+            ElementSourceMaterializationContext context,
+            IElementSourcePreflight preflight,
+            CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+            cancellationToken.ThrowIfCancellationRequested();
+            MaterializationCount++;
+            var state = (TestPreflight)preflight;
+            var primary = new Element
+            {
+                Start = context.Description.Start,
+                Length = context.Description.Length!.Value,
+                ZIndex = state.PrimaryLayer,
+            };
+            var companion = new Element
+            {
+                Start = context.Description.Start,
+                Length = context.Description.Length.Value,
+                ZIndex = state.PrimaryLayer + 1,
+            };
+            IReadOnlySet<Guid> group = new HashSet<Guid> { primary.Id, companion.Id };
+            return ElementSourceMaterializationResult.Materialized(
+                new ElementMaterialization(
+                    primary,
+                    [companion],
+                    [group],
+                    [ElementMaterializationResource.TemporaryAsync(Resource)]));
+        }
+    }
+
+    private sealed class LengthPreservingTestSourceHandler : IElementSourceHandler
+    {
+        public Type SourceType => typeof(TestElementSource);
+
+        public ValueTask<ElementSourcePreflightResult> PreflightAsync(
+            ElementSourcePreflightContext context,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(ElementSourcePreflightResult.Ready(
+                new TestPreflight(context.Description.Layer),
+                [context.Description.Layer]));
+        }
+
+        public ValueTask<ElementSourceMaterializationResult> MaterializeAsync(
+            ElementSourceMaterializationContext context,
+            IElementSourcePreflight preflight,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(ElementSourceMaterializationResult.Materialized(
+                new ElementMaterialization(new Element
+                {
+                    Start = context.Description.Start,
+                    Length = TimeSpan.FromSeconds(7),
+                    ZIndex = context.Description.Layer,
+                })));
+        }
+    }
+
+    private sealed class RejectingTestSourceHandler(TestElementAddFailure failure)
+        : IElementSourceHandler
+    {
+        public Type SourceType => typeof(TestElementSource);
+
+        public bool MaterializationCalled { get; private set; }
+
+        public ValueTask<ElementSourcePreflightResult> PreflightAsync(
+            ElementSourcePreflightContext context,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(ElementSourcePreflightResult.Rejected(failure));
+        }
+
+        public ValueTask<ElementSourceMaterializationResult> MaterializeAsync(
+            ElementSourceMaterializationContext context,
+            IElementSourcePreflight preflight,
+            CancellationToken cancellationToken)
+        {
+            MaterializationCalled = true;
+            throw new AssertionException("Rejected preflight must not be materialized.");
+        }
+    }
+
+    private sealed class BlockingTestSourceHandler : IElementSourceHandler
+    {
+        public Type SourceType => typeof(TestElementSource);
+
+        public TaskCompletionSource PreflightStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool MaterializationCalled { get; private set; }
+
+        public async ValueTask<ElementSourcePreflightResult> PreflightAsync(
+            ElementSourcePreflightContext context,
+            CancellationToken cancellationToken)
+        {
+            PreflightStarted.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            throw new AssertionException("Canceled preflight unexpectedly resumed.");
+        }
+
+        public ValueTask<ElementSourceMaterializationResult> MaterializeAsync(
+            ElementSourceMaterializationContext context,
+            IElementSourcePreflight preflight,
+            CancellationToken cancellationToken)
+        {
+            MaterializationCalled = true;
+            throw new AssertionException("Canceled preflight must not be materialized.");
+        }
+    }
+
+    private sealed class LeaseBlockingTestSourceHandler : IElementSourceHandler
+    {
+        public Type SourceType => typeof(TestElementSource);
+
+        public TaskCompletionSource PreflightStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ReleasePreflight { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource MaterializationStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ReleaseMaterialization { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async ValueTask<ElementSourcePreflightResult> PreflightAsync(
+            ElementSourcePreflightContext context,
+            CancellationToken cancellationToken)
+        {
+            PreflightStarted.TrySetResult();
+            await ReleasePreflight.Task.WaitAsync(cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            return ElementSourcePreflightResult.Ready(
+                new TestPreflight(context.Description.Layer),
+                [context.Description.Layer]);
+        }
+
+        public async ValueTask<ElementSourceMaterializationResult> MaterializeAsync(
+            ElementSourceMaterializationContext context,
+            IElementSourcePreflight preflight,
+            CancellationToken cancellationToken)
+        {
+            MaterializationStarted.TrySetResult();
+            await ReleaseMaterialization.Task.WaitAsync(cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            var element = new Element
+            {
+                Start = context.Description.Start,
+                Length = context.Description.Length!.Value,
+                ZIndex = context.Description.Layer,
+            };
+            return ElementSourceMaterializationResult.Materialized(
+                new ElementMaterialization(element));
+        }
+    }
+
+    private sealed class OwnershipTestSourceHandler : IElementSourceHandler
+    {
+        public Type SourceType => typeof(TestElementSource);
+
+        public TestPreflight? Preflight { get; private set; }
+
+        public TrackingDisposable Resource { get; } = new();
+
+        public ValueTask<ElementSourcePreflightResult> PreflightAsync(
+            ElementSourcePreflightContext context,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Preflight = new TestPreflight(context.Description.Layer);
+            return ValueTask.FromResult(ElementSourcePreflightResult.Ready(
+                Preflight,
+                [context.Description.Layer]));
+        }
+
+        public ValueTask<ElementSourceMaterializationResult> MaterializeAsync(
+            ElementSourceMaterializationContext context,
+            IElementSourcePreflight preflight,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var element = new Element
+            {
+                Start = context.Description.Start,
+                Length = context.Description.Length!.Value,
+                ZIndex = context.Description.Layer,
+            };
+            return ValueTask.FromResult(ElementSourceMaterializationResult.Materialized(
+                new ElementMaterialization(
+                    element,
+                    resources: [ElementMaterializationResource.Temporary(Resource)])));
+        }
+    }
+
+    private sealed class TestSourceHandlerExtension(IElementSourceHandler handler)
+        : ElementSourceHandlerExtension
+    {
+        public override IReadOnlyCollection<ElementSourceHandlerRegistration> Registrations { get; } =
+        [
+            new ElementSourceHandlerRegistration(handler),
+        ];
+    }
+
+    private sealed class FixedIdSourceHandler : IElementSourceHandler
+    {
+        public Guid FixedId { get; } = Guid.NewGuid();
+
+        public Type SourceType => typeof(TestElementSource);
+
+        public ValueTask<ElementSourcePreflightResult> PreflightAsync(
+            ElementSourcePreflightContext context,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(ElementSourcePreflightResult.Ready(
+                new TestPreflight(context.Description.Layer),
+                [context.Description.Layer]));
+        }
+
+        public ValueTask<ElementSourceMaterializationResult> MaterializeAsync(
+            ElementSourceMaterializationContext context,
+            IElementSourcePreflight preflight,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var element = new Element
+            {
+                Id = FixedId,
+                Start = context.Description.Start,
+                Length = context.Description.Length!.Value,
+                ZIndex = context.Description.Layer,
+            };
+            return ValueTask.FromResult(ElementSourceMaterializationResult.Materialized(
+                new ElementMaterialization(element)));
+        }
+    }
+
+    private sealed class MutationTestSourceHandler(
+        Action<ElementSourceMaterializationContext, Element> mutate) : IElementSourceHandler
+    {
+        public Type SourceType => typeof(TestElementSource);
+
+        public ValueTask<ElementSourcePreflightResult> PreflightAsync(
+            ElementSourcePreflightContext context,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(ElementSourcePreflightResult.Ready(
+                new TestPreflight(context.Description.Layer),
+                [context.Description.Layer]));
+        }
+
+        public async ValueTask<ElementSourceMaterializationResult> MaterializeAsync(
+            ElementSourceMaterializationContext context,
+            IElementSourcePreflight preflight,
+            CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+            cancellationToken.ThrowIfCancellationRequested();
+            var element = new Element
+            {
+                Start = context.Description.Start,
+                Length = context.Description.Length!.Value,
+                ZIndex = context.Description.Layer,
+            };
+            mutate(context, element);
+            return ElementSourceMaterializationResult.Materialized(
+                new ElementMaterialization(element));
+        }
+    }
+
+    private sealed class ThrowingDisposeSourceHandler : IElementSourceHandler
+    {
+        public ThrowingPreflight Preflight { get; } = new();
+
+        public ThrowingAsyncDisposable Resource { get; } = new();
+
+        public Type SourceType => typeof(TestElementSource);
+
+        public ValueTask<ElementSourcePreflightResult> PreflightAsync(
+            ElementSourcePreflightContext context,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(ElementSourcePreflightResult.Ready(
+                Preflight,
+                [context.Description.Layer]));
+        }
+
+        public ValueTask<ElementSourceMaterializationResult> MaterializeAsync(
+            ElementSourceMaterializationContext context,
+            IElementSourcePreflight preflight,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var element = new Element
+            {
+                Start = context.Description.Start,
+                Length = context.Description.Length!.Value,
+                ZIndex = context.Description.Layer,
+            };
+            return ValueTask.FromResult(ElementSourceMaterializationResult.Materialized(
+                new ElementMaterialization(
+                    element,
+                    resources: [ElementMaterializationResource.TemporaryAsync(Resource)])));
+        }
+    }
+
+    private sealed class ThrowingPreflight : IElementSourcePreflight
+    {
+        public int DisposeAttempts { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeAttempts++;
+            throw new InvalidOperationException("Injected preflight disposal failure");
+        }
+    }
+
+    private sealed class ThrowingAsyncDisposable : IAsyncDisposable
+    {
+        public int DisposeAttempts { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeAttempts++;
+            throw new InvalidOperationException("Injected resource disposal failure");
+        }
+    }
+
+    private sealed class TrackingDisposable : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public void Dispose() => IsDisposed = true;
+    }
+
+    private sealed class TrackingAsyncDisposable : IAsyncDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Task.Yield();
+            IsDisposed = true;
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
@@ -44,14 +44,15 @@ public class ElementViewLayoutTests
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
     }
 
-    private static void AddRectangle(EditViewModel editor)
+    private static async Task AddRectangle(EditViewModel editor)
     {
         var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-        adder.AddElement(new ElementDescription(
+        await adder.AddAsync([new ElementDescription(
             Start: TimeSpan.Zero,
             Length: TimeSpan.FromSeconds(2),
             Layer: 0,
-            EngineObjectFactory: () => new RectShape()));
+            Source: new ElementSource.EngineObject(() => new RectShape()))],
+            CancellationToken.None);
         HeadlessTestHelpers.Settle();
     }
 
@@ -59,7 +60,7 @@ public class ElementViewLayoutTests
     {
         await TestReset.ResetShellAsync();
         EditViewModel editor = await OpenEditorForNewScene(name);
-        AddRectangle(editor);
+        await AddRectangle(editor);
 
         var window = new Window { Content = new EditView { DataContext = editor }, Width = 1200, Height = 800 };
         window.Show();

--- a/tests/Beutl.HeadlessUITests/ExportTests.cs
+++ b/tests/Beutl.HeadlessUITests/ExportTests.cs
@@ -39,11 +39,13 @@ public class ExportTests
         var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
 
         var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-        adder.AddElement(new ElementDescription(
+        await adder.AddAsync([new ElementDescription(
             Start: TimeSpan.Zero,
             Length: TimeSpan.FromMilliseconds(200),
             Layer: 0,
-            EngineObjectFactory: () => new RectShape { Width = { CurrentValue = 200 }, Height = { CurrentValue = 150 } }));
+            Source: new ElementSource.EngineObject(
+                () => new RectShape { Width = { CurrentValue = 200 }, Height = { CurrentValue = 150 } }))],
+            CancellationToken.None);
         HeadlessTestHelpers.Settle();
         return editor;
     }

--- a/tests/Beutl.HeadlessUITests/LifetimeCancellationSourceTests.cs
+++ b/tests/Beutl.HeadlessUITests/LifetimeCancellationSourceTests.cs
@@ -1,8 +1,4 @@
-﻿using Avalonia.Headless.NUnit;
-using Beutl.Api;
-using Beutl.Api.Services;
-using Beutl.Services;
-using Beutl.Services.StartupTasks;
+﻿using Beutl.Services;
 
 namespace Beutl.HeadlessUITests;
 
@@ -10,66 +6,20 @@ namespace Beutl.HeadlessUITests;
 public sealed class LifetimeCancellationSourceTests
 {
     [Test]
-    public void Cancel_ThrowingCallback_StillAllowsDispose()
+    public void ConcurrentCancelAndDispose_AreIdempotentAndTokenRemainsReadable()
     {
-        var source = new LifetimeCancellationSource();
-        using var registration = source.Token.Register(static () =>
-            throw new InvalidOperationException("callback failed"));
+        for (int iteration = 0; iteration < 100; iteration++)
+        {
+            var source = new LifetimeCancellationSource();
+            CancellationToken token = source.Token;
 
-        Assert.Throws<AggregateException>(source.Cancel);
-
-        Assert.DoesNotThrow(source.Dispose);
-    }
-
-    [Test]
-    public async Task AuthenticationTask_ShutdownCancellation_IsNotReportedAsAnError()
-    {
-        using var httpClient = new HttpClient();
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
-        await app.DisposeAsync();
-
-        // RestoreUserAsync links the application lifetime, so after disposal it throws
-        // ObjectDisposedException; the task must treat that as a normal shutdown and
-        // complete without error telemetry.
-        var task = new AuthenticationTask(app);
-
-        await task.Task.WaitAsync(TimeSpan.FromSeconds(5));
-    }
-
-    [Test]
-    public async Task CheckForUpdatesTask_ShutdownCancellation_IsNotReportedAsAnError()
-    {
-        using var httpClient = new HttpClient();
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
-        await app.DisposeAsync();
-
-        // CheckForUpdatesAsync links the application lifetime, so after disposal it throws
-        // ObjectDisposedException; the task must treat that as a normal shutdown and
-        // complete without error telemetry or a timeout notification.
-        var task = new CheckForUpdatesTask(app);
-
-        await task.Task.WaitAsync(TimeSpan.FromSeconds(5));
-    }
-
-    [AvaloniaTest]
-    public async Task CheckForPackageUpdatesTask_ShutdownCancellation_IsNotReportedAsAnError()
-    {
-        using var httpClient = new HttpClient();
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
-        var editorService = new EditorService(new ExtensionProvider());
-        var projectService = new ProjectService();
-
-        // Startup must be constructed before disposal: its constructor registers all
-        // startup tasks, which lazily resolve their resources through the app.
-        var startup = new Startup(app, projectService, editorService);
-        var packageManager = app.GetResource<PackageManager>();
-        await app.DisposeAsync();
-
-        // CheckUpdate links the application lifetime, so after disposal it throws
-        // ObjectDisposedException; the task must treat that as a normal shutdown and
-        // complete without error telemetry or a notification.
-        var task = new CheckForPackageUpdatesTask(startup, packageManager, app);
-
-        await task.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.DoesNotThrow(() => Parallel.Invoke(
+                source.Cancel,
+                source.Dispose,
+                source.Cancel,
+                source.Dispose));
+            Assert.DoesNotThrow(() => _ = token.IsCancellationRequested);
+            Assert.That(token.IsCancellationRequested, Is.True);
+        }
     }
 }

--- a/tests/Beutl.HeadlessUITests/MainViewModelShutdownTests.cs
+++ b/tests/Beutl.HeadlessUITests/MainViewModelShutdownTests.cs
@@ -1,0 +1,140 @@
+﻿using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Headless.NUnit;
+using Beutl.Api.Services;
+using Beutl.ProjectSystem;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.Views;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture, NonParallelizable]
+public sealed class MainViewModelShutdownTests
+{
+    [AvaloniaTest]
+    public async Task ClosingRealShell_WaitsForPackageInstallerBeforeHandoff()
+    {
+        await TestReset.ResetShellAsync();
+        var releaseInstaller = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var installerWaitStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        bool handedOff = false;
+        var viewModel = new MainViewModel(
+            _ => handedOff = true,
+            _ =>
+            {
+                installerWaitStarted.TrySetResult();
+                return releaseInstaller.Task;
+            });
+
+        viewModel.Dispose();
+        await installerWaitStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(handedOff, Is.False);
+
+        releaseInstaller.TrySetResult();
+        await viewModel.WaitForDisposalAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(handedOff, Is.True);
+    }
+
+    [AvaloniaTest]
+    public async Task PackageWaitFailureDoesNotSkipShutdownHandoff()
+    {
+        await TestReset.ResetShellAsync();
+        bool handedOff = false;
+        var viewModel = new MainViewModel(
+            _ => handedOff = true,
+            _ => Task.FromException(new InvalidOperationException("wait failed")));
+        viewModel.Dispose();
+        await viewModel.WaitForDisposalAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(handedOff, Is.True);
+    }
+
+    [AvaloniaTest]
+    public async Task ClosingRealShell_HandsOffPackageQueueAndDisposesClientsIdempotently()
+    {
+        await TestReset.ResetShellAsync();
+        using var lifetime = new ClassicDesktopStyleApplicationLifetime();
+        PackageChangesQueue? handedOffQueue = null;
+        var viewModel = new MainViewModel(clients =>
+            handedOffQueue = clients.GetResource<PackageChangesQueue>());
+        var window = new MainWindow { DataContext = viewModel };
+        // The minimal headless TestApp does not install the production MainView's app-only
+        // chrome services. Keep the real MainWindow closing path while avoiding that unrelated
+        // visual-tree startup callback.
+        window.Content = null;
+        viewModel.RegisterExitHandler(lifetime);
+
+        try
+        {
+            window.Show();
+            window.Close();
+            await viewModel.WaitForDisposalAsync();
+            await WaitUntilAsync(() => !window.IsVisible, TimeSpan.FromSeconds(5));
+
+            Assert.That(handedOffQueue, Is.Not.Null);
+            Assert.Throws<ObjectDisposedException>(() =>
+                viewModel._beutlClients.GetResource<PackageChangesQueue>());
+            Assert.DoesNotThrow(viewModel.Dispose);
+            Assert.DoesNotThrow(viewModel.CompleteShutdown);
+        }
+        finally
+        {
+            if (window.IsVisible)
+            {
+                window.Close();
+            }
+            viewModel.Dispose();
+            viewModel.CompleteShutdown();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ClosingRealShell_WaitsForOpenEditorTabsToDispose()
+    {
+        await TestReset.ResetShellAsync();
+        using var lifetime = new ClassicDesktopStyleApplicationLifetime();
+        var viewModel = new MainViewModel();
+        var window = new MainWindow { DataContext = viewModel, Content = null };
+        viewModel.RegisterExitHandler(lifetime);
+        string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, "shutdown-editor");
+        Directory.CreateDirectory(workspace);
+        Project project = (await viewModel.ProjectService.CreateProject(
+            640, 480, 30, 44_100, "shutdown-editor", workspace))!;
+        Scene scene = project.Items.OfType<Scene>().Single();
+        viewModel.EditorService.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+
+        try
+        {
+            window.Show();
+            window.Close();
+            await viewModel.WaitForDisposalAsync().WaitAsync(TimeSpan.FromSeconds(5));
+            await WaitUntilAsync(() => !window.IsVisible, TimeSpan.FromSeconds(5));
+
+            Assert.That(viewModel.EditorService.TabItems, Is.Empty);
+        }
+        finally
+        {
+            if (window.IsVisible)
+            {
+                window.Close();
+            }
+            viewModel.Dispose();
+            await viewModel.WaitForDisposalAsync();
+            viewModel.CompleteShutdown();
+        }
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> predicate, TimeSpan timeout)
+    {
+        DateTime deadline = DateTime.UtcNow + timeout;
+        while (!predicate())
+        {
+            if (DateTime.UtcNow >= deadline)
+                throw new TimeoutException("The shell did not finish closing.");
+            await Task.Delay(10);
+        }
+    }
+
+}

--- a/tests/Beutl.HeadlessUITests/PackageReleaseResolverTests.cs
+++ b/tests/Beutl.HeadlessUITests/PackageReleaseResolverTests.cs
@@ -1,8 +1,6 @@
-﻿using System.Net;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Reactive.Concurrency;
 using System.Reactive.Subjects;
-using System.Text;
 
 using Beutl.Api;
 using Beutl.Api.Clients;
@@ -30,14 +28,8 @@ public class PackageReleaseResolverTests
     [OneTimeTearDown]
     public async Task OneTimeTearDown()
     {
-        try
-        {
-            await _clients.DisposeAsync();
-        }
-        finally
-        {
-            _httpClient.Dispose();
-        }
+        await _clients.DisposeAsync();
+        _httpClient.Dispose();
     }
 
     [Test]
@@ -290,31 +282,6 @@ public class PackageReleaseResolverTests
         });
     }
 
-    [Test]
-    public async Task GetFirstReleaseAsync_ThrowsWhenPackageHasNoReleases()
-    {
-        using var handler = new EmptyReleasesHandler();
-        using var httpClient = new HttpClient(handler);
-        var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
-        Package package = CreatePackage(clients);
-
-        Assert.ThrowsAsync<InvalidOperationException>(
-            () => PackageReleaseResolver.GetFirstReleaseAsync(package, CancellationToken.None));
-    }
-
-    [Test]
-    public async Task GetFirstReleaseAsync_ReturnsFirstRelease()
-    {
-        using var handler = new SingleReleaseHandler();
-        using var httpClient = new HttpClient(handler);
-        var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
-        Package package = CreatePackage(clients);
-
-        Release release = await PackageReleaseResolver.GetFirstReleaseAsync(package, CancellationToken.None);
-
-        Assert.That(release.Version.Value, Is.EqualTo("1.0.0"));
-    }
-
     private static PackageIdentity CreateIdentity(string version)
     {
         return new PackageIdentity("Package", NuGetVersion.Parse(version));
@@ -361,69 +328,6 @@ public class PackageReleaseResolverTests
             FileId = null,
             FileUrl = null,
         }, _clients);
-    }
-
-    private static Package CreatePackage(BeutlApiApplication clients)
-    {
-        var ownerResponse = new ProfileResponse
-        {
-            Id = "owner",
-            Name = "owner",
-            DisplayName = "Owner",
-            Bio = null,
-            IconId = null,
-            IconUrl = null,
-        };
-        var owner = new Profile(ownerResponse, clients);
-        return new Package(owner, new PackageResponse
-        {
-            Id = "package",
-            Owner = ownerResponse,
-            Name = "Package",
-            DisplayName = "Package",
-            Description = "",
-            ShortDescription = "",
-            WebSite = "",
-            Tags = [],
-            LogoId = null,
-            LogoUrl = null,
-            Screenshots = [],
-            Currency = null,
-            Price = null,
-            Paid = false,
-            Owned = true,
-        }, clients);
-    }
-
-    private sealed class EmptyReleasesHandler : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request,
-            CancellationToken cancellationToken)
-        {
-            var response = new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent("[]", Encoding.UTF8, "application/json"),
-            };
-            return Task.FromResult(response);
-        }
-    }
-
-    private sealed class SingleReleaseHandler : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request,
-            CancellationToken cancellationToken)
-        {
-            var response = new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent(
-                    """[{"id":"r1","version":"1.0.0","title":"Release","description":"","targetVersion":null,"fileId":null,"fileUrl":null}]""",
-                    Encoding.UTF8,
-                    "application/json"),
-            };
-            return Task.FromResult(response);
-        }
     }
 
     private static async Task WaitForAsync(Func<bool> condition)

--- a/tests/Beutl.HeadlessUITests/PersistentPromptLibraryTests.cs
+++ b/tests/Beutl.HeadlessUITests/PersistentPromptLibraryTests.cs
@@ -322,6 +322,30 @@ public sealed class PersistentPromptLibraryTests
     }
 
     [Test]
+    public void Loading_many_pinned_history_items_preserves_and_coalesces_each_prompt()
+    {
+        DateTimeOffset timestamp = DateTimeOffset.UtcNow;
+        var history = Enumerable.Range(0, 1024).Select(index => new
+        {
+            id = Guid.NewGuid(),
+            taskKind = "image",
+            prompt = $"Pinned {index % 512}",
+            lastUsedAtUtc = timestamp.AddSeconds(index),
+            useCount = 1,
+            isPinned = true,
+        });
+        File.WriteAllText(_storagePath, JsonSerializer.Serialize(new
+        {
+            version = PersistentPromptLibrary.CurrentStorageVersion,
+            history,
+            templates = Array.Empty<object>(),
+        }));
+        var library = new PersistentPromptLibrary(_storagePath);
+        Assert.That(library.History, Has.Count.EqualTo(512));
+        Assert.That(library.History.All(entry => entry.UseCount == 2 && entry.IsPinned), Is.True);
+    }
+
+    [Test]
     public void FutureVersion_IsRejectedWithoutChangingOrQuarantiningTheFile()
     {
         string contents = $$"""

--- a/tests/Beutl.HeadlessUITests/PersistentPromptLibraryTests.cs
+++ b/tests/Beutl.HeadlessUITests/PersistentPromptLibraryTests.cs
@@ -288,6 +288,40 @@ public sealed class PersistentPromptLibraryTests
     }
 
     [Test]
+    public void LoadingManyDistinctTemplatesPreservesEveryIndexedEntry()
+    {
+        const int TemplateCount = 512;
+        DateTimeOffset timestamp = new(2026, 8, 9, 0, 0, 0, TimeSpan.Zero);
+        var templates = Enumerable.Range(0, TemplateCount)
+            .Select(index => new
+            {
+                id = Guid.NewGuid(),
+                name = $"Template {index}",
+                taskKind = "image",
+                prompt = $"Prompt {index}",
+                createdAtUtc = timestamp,
+                updatedAtUtc = timestamp.AddSeconds(index),
+                isPinned = false,
+            })
+            .ToArray();
+        File.WriteAllText(_storagePath, JsonSerializer.Serialize(new
+        {
+            version = PersistentPromptLibrary.CurrentStorageVersion,
+            history = Array.Empty<object>(),
+            templates,
+        }));
+
+        var library = new PersistentPromptLibrary(_storagePath);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(library.Templates, Has.Count.EqualTo(TemplateCount));
+            Assert.That(library.Templates[0].Name, Is.EqualTo($"Template {TemplateCount - 1}"));
+            Assert.That(library.Templates[^1].Name, Is.EqualTo("Template 0"));
+        }
+    }
+
+    [Test]
     public void FutureVersion_IsRejectedWithoutChangingOrQuarantiningTheFile()
     {
         string contents = $$"""

--- a/tests/Beutl.HeadlessUITests/PersistentPromptLibraryTests.cs
+++ b/tests/Beutl.HeadlessUITests/PersistentPromptLibraryTests.cs
@@ -1,0 +1,543 @@
+﻿using System.Text.Json;
+
+using Beutl.Services.AI;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public sealed class PersistentPromptLibraryTests
+{
+    private string _tempDirectory = null!;
+    private string _storagePath = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"beutl-prompt-library-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDirectory);
+        _storagePath = Path.Combine(_tempDirectory, "prompts.json");
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, true);
+        }
+    }
+
+    [Test]
+    public void DefaultRetention_KeepsUnpinnedRecentPromptTextInMemoryOnly()
+    {
+        const string SensitivePrompt = "private storyboard concept";
+        var library = new PersistentPromptLibrary(_storagePath);
+
+        PromptHistoryEntry entry = library.Record(PromptTaskKind.Image, SensitivePrompt);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(library.RetainRecentPromptText, Is.False);
+            Assert.That(library.History, Is.EqualTo(new[] { entry }));
+            Assert.That(File.ReadAllText(_storagePath), Does.Not.Contain(SensitivePrompt));
+        });
+
+        var reloaded = new PersistentPromptLibrary(_storagePath);
+        Assert.That(reloaded.History, Is.Empty);
+    }
+
+    [Test]
+    public void RetainedHistory_IsBoundedAndCoalescesNormalizedDuplicates()
+    {
+        var timeProvider = new ManualTimeProvider(new DateTimeOffset(2026, 8, 9, 0, 0, 0, TimeSpan.Zero));
+        var options = new PromptLibraryOptions
+        {
+            MaxRecentItems = 2,
+            RetainRecentPromptText = true,
+        };
+        var library = new PersistentPromptLibrary(_storagePath, options, timeProvider);
+
+        PromptHistoryEntry first = library.Record(PromptTaskKind.Image, "  first\r\nprompt  ");
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+        PromptHistoryEntry duplicate = library.Record(PromptTaskKind.Image, "first\nprompt");
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+        PromptHistoryEntry second = library.Record(PromptTaskKind.ImageEdit, "second");
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+        PromptHistoryEntry third = library.Record(PromptTaskKind.Video, "third");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(duplicate.Id, Is.EqualTo(first.Id));
+            Assert.That(duplicate.UseCount, Is.EqualTo(2));
+            Assert.That(library.History.Select(item => item.Id), Is.EqualTo(new[] { third.Id, second.Id }));
+        });
+
+        var reloaded = new PersistentPromptLibrary(_storagePath, options);
+        Assert.That(reloaded.History.Select(item => item.Prompt), Is.EqualTo(new[] { "third", "second" }));
+    }
+
+    [Test]
+    public void SamePrompt_ForDifferentTaskKinds_RemainsDistinct()
+    {
+        var library = new PersistentPromptLibrary(
+            _storagePath,
+            new PromptLibraryOptions { RetainRecentPromptText = true });
+
+        library.Record(PromptTaskKind.Image, "shared prompt");
+        library.Record(PromptTaskKind.Video, "shared prompt");
+
+        Assert.That(library.History, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void Pinning_IsAnExplicitPersistenceActionAndProtectsHistoryFromTrimming()
+    {
+        var options = new PromptLibraryOptions { MaxRecentItems = 1 };
+        var library = new PersistentPromptLibrary(_storagePath, options);
+        PromptHistoryEntry pinned = library.Record(PromptTaskKind.Image, "keep me");
+
+        Assert.That(library.SetHistoryPinned(pinned.Id, true), Is.True);
+        library.Record(PromptTaskKind.Video, "discard me");
+        PromptHistoryEntry latest = library.Record(PromptTaskKind.ImageEdit, "session only");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(library.History.Select(item => item.Id), Is.EqualTo(new[] { latest.Id, pinned.Id }));
+            Assert.That(File.ReadAllText(_storagePath), Does.Contain("keep me"));
+            Assert.That(File.ReadAllText(_storagePath), Does.Not.Contain("session only"));
+        });
+
+        var reloaded = new PersistentPromptLibrary(_storagePath, options);
+        Assert.That(reloaded.History.Single().Id, Is.EqualTo(pinned.Id));
+
+        Assert.That(reloaded.SetHistoryPinned(pinned.Id, false), Is.True);
+        Assert.That(new PersistentPromptLibrary(_storagePath, options).History, Is.Empty);
+    }
+
+    [Test]
+    public void NamedTemplates_CoalesceByTaskAndNameAndPersistPinState()
+    {
+        var library = new PersistentPromptLibrary(_storagePath);
+        PromptTemplate original = library.SaveTemplate(" Hero shot ", PromptTaskKind.Image, "first version");
+        PromptTemplate updated = library.SaveTemplate("hero shot", PromptTaskKind.Image, "second version");
+        PromptTemplate video = library.SaveTemplate("Hero shot", PromptTaskKind.Video, "video version");
+
+        Assert.That(library.SetTemplatePinned(updated.Id, true), Is.True);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(updated.Id, Is.EqualTo(original.Id));
+            Assert.That(updated.CreatedAtUtc, Is.EqualTo(original.CreatedAtUtc));
+            Assert.That(library.Templates, Has.Count.EqualTo(2));
+            Assert.That(video.Id, Is.Not.EqualTo(updated.Id));
+        });
+
+        var reloaded = new PersistentPromptLibrary(_storagePath);
+        PromptTemplate reloadedImage = reloaded.Templates.Single(item => item.TaskKind == PromptTaskKind.Image);
+        Assert.Multiple(() =>
+        {
+            Assert.That(reloadedImage.Name, Is.EqualTo("hero shot"));
+            Assert.That(reloadedImage.Prompt, Is.EqualTo("second version"));
+            Assert.That(reloadedImage.IsPinned, Is.True);
+        });
+    }
+
+    [Test]
+    public void SeparateInstancesReloadBeforeWritingSoMutationsAreMerged()
+    {
+        var options = new PromptLibraryOptions { RetainRecentPromptText = true };
+        var first = new PersistentPromptLibrary(_storagePath, options);
+        var second = new PersistentPromptLibrary(_storagePath, options);
+
+        first.Record(PromptTaskKind.Image, "first process");
+        second.Record(PromptTaskKind.Video, "second process");
+
+        var reloaded = new PersistentPromptLibrary(_storagePath, options);
+        Assert.That(
+            reloaded.History.Select(item => item.Prompt),
+            Is.EquivalentTo(new[] { "first process", "second process" }));
+    }
+
+    [Test]
+    public async Task SeparateInstanceWaitsForTheCrossProcessWriteLock()
+    {
+        var options = new PromptLibraryOptions { RetainRecentPromptText = true };
+        var library = new PersistentPromptLibrary(_storagePath, options);
+        Directory.CreateDirectory(Path.GetDirectoryName(_storagePath)!);
+        using var heldLock = new FileStream(
+            _storagePath + ".lock",
+            FileMode.OpenOrCreate,
+            FileAccess.ReadWrite,
+            FileShare.None);
+
+        Task<PromptHistoryEntry> write = Task.Run(() =>
+            library.Record(PromptTaskKind.Image, "wait for the other process"));
+        await Task.Delay(50);
+        Assert.That(write.IsCompleted, Is.False);
+
+        heldLock.Dispose();
+        PromptHistoryEntry entry = await write.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.That(entry.Prompt, Is.EqualTo("wait for the other process"));
+    }
+
+    [Test]
+    public void DeleteAndClearOperationsPersistTheResult()
+    {
+        var options = new PromptLibraryOptions { RetainRecentPromptText = true };
+        var library = new PersistentPromptLibrary(_storagePath, options);
+        PromptHistoryEntry firstHistory = library.Record(PromptTaskKind.Image, "first history");
+        library.Record(PromptTaskKind.Video, "second history");
+        PromptTemplate firstTemplate = library.SaveTemplate("First", PromptTaskKind.Image, "first template");
+        library.SaveTemplate("Second", PromptTaskKind.Video, "second template");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(library.DeleteHistory(firstHistory.Id), Is.True);
+            Assert.That(library.DeleteHistory(firstHistory.Id), Is.False);
+            Assert.That(library.DeleteTemplate(firstTemplate.Id), Is.True);
+            Assert.That(library.DeleteTemplate(firstTemplate.Id), Is.False);
+        });
+
+        library.ClearHistory();
+        Assert.Multiple(() =>
+        {
+            Assert.That(library.History, Is.Empty);
+            Assert.That(library.Templates, Has.Count.EqualTo(1));
+        });
+
+        library.ClearAll();
+        var reloaded = new PersistentPromptLibrary(_storagePath, options);
+        Assert.Multiple(() =>
+        {
+            Assert.That(reloaded.History, Is.Empty);
+            Assert.That(reloaded.Templates, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void CorruptJson_IsQuarantinedAndReplacedWithCurrentVersion()
+    {
+        const string CorruptContents = "{ definitely not json";
+        File.WriteAllText(_storagePath, CorruptContents);
+
+        var library = new PersistentPromptLibrary(_storagePath);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(library.History, Is.Empty);
+            Assert.That(library.Templates, Is.Empty);
+            Assert.That(library.RecoveredCorruptFilePath, Is.Not.Null);
+            Assert.That(File.Exists(library.RecoveredCorruptFilePath), Is.True);
+            Assert.That(File.ReadAllText(library.RecoveredCorruptFilePath!), Is.EqualTo(CorruptContents));
+        });
+
+        using JsonDocument replacement = JsonDocument.Parse(File.ReadAllText(_storagePath));
+        Assert.That(
+            replacement.RootElement.GetProperty("version").GetInt32(),
+            Is.EqualTo(PersistentPromptLibrary.CurrentStorageVersion));
+    }
+
+    [Test]
+    public async Task CorruptRecoveryReloadsTheWinnerAfterTakingTheCrossProcessWriteLock()
+    {
+        const string CorruptContents = "{ definitely not json";
+        File.WriteAllText(_storagePath, CorruptContents);
+        using var initialReadCompleted = new ManualResetEventSlim();
+        using var releaseRecovery = new ManualResetEventSlim();
+        Task<PersistentPromptLibrary> delayedLoad = Task.Run(() =>
+            new PersistentPromptLibrary(
+                _storagePath,
+                beforeCorruptionWriteLock: () =>
+                {
+                    initialReadCompleted.Set();
+                    if (!releaseRecovery.Wait(TimeSpan.FromSeconds(5)))
+                        throw new TimeoutException("The delayed corruption recovery was not released.");
+                }));
+
+        try
+        {
+            Assert.That(initialReadCompleted.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            var concurrent = new PersistentPromptLibrary(_storagePath);
+            concurrent.SaveTemplate(
+                "Concurrent",
+                PromptTaskKind.Video,
+                "written after the corrupt file was recovered");
+
+            releaseRecovery.Set();
+            PersistentPromptLibrary loaded = await delayedLoad.WaitAsync(TimeSpan.FromSeconds(5));
+            var reloaded = new PersistentPromptLibrary(_storagePath);
+            string[] recoveryFiles = Directory.GetFiles(_tempDirectory, "*.corrupt-*");
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(loaded.RecoveredCorruptFilePath, Is.Null);
+                Assert.That(loaded.Templates.Select(item => item.Name), Is.EqualTo(new[] { "Concurrent" }));
+                Assert.That(reloaded.Templates.Select(item => item.Name), Is.EqualTo(new[] { "Concurrent" }));
+                Assert.That(recoveryFiles, Has.Length.EqualTo(1));
+                Assert.That(File.ReadAllText(recoveryFiles[0]), Is.EqualTo(CorruptContents));
+            }
+        }
+        finally
+        {
+            releaseRecovery.Set();
+            await delayedLoad.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [Test]
+    public void FutureVersion_IsRejectedWithoutChangingOrQuarantiningTheFile()
+    {
+        string contents = $$"""
+            {
+              "version": {{PersistentPromptLibrary.CurrentStorageVersion + 1}},
+              "history": [],
+              "templates": []
+            }
+            """;
+        File.WriteAllText(_storagePath, contents);
+
+        Assert.Throws<NotSupportedException>(() => new PersistentPromptLibrary(_storagePath));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(File.ReadAllText(_storagePath), Is.EqualTo(contents));
+            Assert.That(Directory.EnumerateFiles(_tempDirectory, "*.corrupt-*"), Is.Empty);
+        });
+    }
+
+    [Test]
+    public void VersionOne_OversizedPromptIsDroppedWithoutResettingValidEntries()
+    {
+        Guid oversizedId = Guid.NewGuid();
+        Guid validHistoryId = Guid.NewGuid();
+        Guid validTemplateId = Guid.NewGuid();
+        string oversizedPrompt = new('x', 4_001);
+        string contents = $$"""
+            {
+              "version": 1,
+              "history": [
+                {
+                  "id": "{{oversizedId}}",
+                  "taskKind": "image",
+                  "prompt": "{{oversizedPrompt}}",
+                  "lastUsedAtUtc": "2026-08-09T01:00:00Z",
+                  "useCount": 1,
+                  "isPinned": true
+                },
+                {
+                  "id": "{{validHistoryId}}",
+                  "taskKind": "video",
+                  "prompt": "keep history",
+                  "lastUsedAtUtc": "2026-08-09T00:00:00Z",
+                  "useCount": 2,
+                  "isPinned": true
+                }
+              ],
+              "templates": [
+                {
+                  "id": "{{validTemplateId}}",
+                  "name": "Keep template",
+                  "taskKind": "imageEdit",
+                  "prompt": "keep template",
+                  "createdAtUtc": "2026-08-09T00:00:00Z",
+                  "updatedAtUtc": "2026-08-09T00:00:00Z",
+                  "isPinned": false
+                }
+              ]
+            }
+            """;
+        File.WriteAllText(_storagePath, contents);
+
+        var library = new PersistentPromptLibrary(_storagePath);
+
+        using JsonDocument migrated = JsonDocument.Parse(File.ReadAllText(_storagePath));
+        Assert.Multiple(() =>
+        {
+            Assert.That(library.RecoveredCorruptFilePath, Is.Null);
+            Assert.That(library.History.Select(item => item.Id), Is.EqualTo(new[] { validHistoryId }));
+            Assert.That(library.Templates.Select(item => item.Id), Is.EqualTo(new[] { validTemplateId }));
+            Assert.That(
+                migrated.RootElement.GetProperty("version").GetInt32(),
+                Is.EqualTo(PersistentPromptLibrary.CurrentStorageVersion));
+            Assert.That(File.ReadAllText(_storagePath), Does.Not.Contain(oversizedPrompt));
+        });
+    }
+
+    [Test]
+    public async Task LoadMigrationReloadsAfterTakingTheCrossProcessWriteLock()
+    {
+        var options = new PromptLibraryOptions { RetainRecentPromptText = true };
+        var seed = new PersistentPromptLibrary(_storagePath, options);
+        seed.SaveTemplate("Original", PromptTaskKind.Image, "original prompt");
+        string versionOne = File.ReadAllText(_storagePath).Replace(
+            $"\"version\": {PersistentPromptLibrary.CurrentStorageVersion}",
+            "\"version\": 1",
+            StringComparison.Ordinal);
+        File.WriteAllText(_storagePath, versionOne);
+
+        using var initialReadCompleted = new ManualResetEventSlim();
+        using var releaseMigration = new ManualResetEventSlim();
+        Task<PersistentPromptLibrary> delayedLoad = Task.Run(() =>
+            new PersistentPromptLibrary(
+                _storagePath,
+                options,
+                beforeNormalizationWriteLock: () =>
+                {
+                    initialReadCompleted.Set();
+                    if (!releaseMigration.Wait(TimeSpan.FromSeconds(5)))
+                        throw new TimeoutException("The delayed migration was not released.");
+                }));
+
+        try
+        {
+            Assert.That(initialReadCompleted.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            var concurrent = new PersistentPromptLibrary(_storagePath, options);
+            concurrent.SaveTemplate(
+                "Concurrent",
+                PromptTaskKind.Video,
+                "written after the stale read");
+
+            releaseMigration.Set();
+            PersistentPromptLibrary loaded = await delayedLoad.WaitAsync(TimeSpan.FromSeconds(5));
+            var reloaded = new PersistentPromptLibrary(_storagePath, options);
+
+            string[] expected = ["Concurrent", "Original"];
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(loaded.Templates.Select(item => item.Name), Is.EqualTo(expected));
+                Assert.That(reloaded.Templates.Select(item => item.Name), Is.EqualTo(expected));
+            }
+        }
+        finally
+        {
+            releaseMigration.Set();
+            await delayedLoad.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [Test]
+    public void JsonSchema_ContainsNoAuthenticationOrGeneratedAssetFieldsAndLeavesNoTempFiles()
+    {
+        var library = new PersistentPromptLibrary(
+            _storagePath,
+            new PromptLibraryOptions { RetainRecentPromptText = true });
+        library.Record(PromptTaskKind.Image, "safe prompt");
+        library.SaveTemplate("Safe", PromptTaskKind.Video, "safe template");
+
+        using JsonDocument document = JsonDocument.Parse(File.ReadAllText(_storagePath));
+        string[] rootProperties = document.RootElement
+            .EnumerateObject()
+            .Select(property => property.Name)
+            .ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rootProperties, Is.EquivalentTo(new[] { "version", "history", "templates" }));
+            Assert.That(File.ReadAllText(_storagePath), Does.Not.Contain("auth").IgnoreCase);
+            Assert.That(File.ReadAllText(_storagePath), Does.Not.Contain("generatedUrl").IgnoreCase);
+            Assert.That(Directory.EnumerateFiles(_tempDirectory, "*.tmp"), Is.Empty);
+        });
+    }
+
+    [Test]
+    public void PersistedFile_OnUnix_HasUserReadWritePermissionsOnly()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("Unix file modes are not available on Windows.");
+            return;
+        }
+
+        UnixFileMode expectedMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        var library = new PersistentPromptLibrary(_storagePath);
+        library.SaveTemplate("First", PromptTaskKind.Image, "first prompt");
+
+        Assert.That(File.GetUnixFileMode(_storagePath), Is.EqualTo(expectedMode));
+
+        File.SetUnixFileMode(
+            _storagePath,
+            expectedMode | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+        library.SaveTemplate("Second", PromptTaskKind.Video, "second prompt");
+
+        Assert.That(File.GetUnixFileMode(_storagePath), Is.EqualTo(expectedMode));
+    }
+
+    [Test]
+    public void ReplacementFailure_PreservesDiskAndMemoryStateAndDeletesTemporaryFile()
+    {
+        var options = new PromptLibraryOptions { RetainRecentPromptText = true };
+        var seedLibrary = new PersistentPromptLibrary(_storagePath, options);
+        seedLibrary.Record(PromptTaskKind.Image, "existing history");
+        seedLibrary.SaveTemplate("Existing", PromptTaskKind.Video, "existing template");
+        byte[] diskBefore = File.ReadAllBytes(_storagePath);
+
+        string? observedTempPath = null;
+        string? observedDestinationPath = null;
+        bool tempExistedDuringReplacement = false;
+        var library = new PersistentPromptLibrary(
+            _storagePath,
+            options,
+            replaceFile: (tempPath, destinationPath) =>
+            {
+                observedTempPath = tempPath;
+                observedDestinationPath = destinationPath;
+                tempExistedDuringReplacement = File.Exists(tempPath);
+                throw new IOException("Injected replacement failure.");
+            });
+        PromptHistoryEntry[] historyBefore = library.History.ToArray();
+        PromptTemplate[] templatesBefore = library.Templates.ToArray();
+
+        Assert.Throws<IOException>(() => library.Record(PromptTaskKind.ImageEdit, "must not commit"));
+
+        var reloaded = new PersistentPromptLibrary(_storagePath, options);
+        Assert.Multiple(() =>
+        {
+            Assert.That(observedDestinationPath, Is.EqualTo(_storagePath));
+            Assert.That(tempExistedDuringReplacement, Is.True);
+            Assert.That(File.ReadAllBytes(_storagePath), Is.EqualTo(diskBefore));
+            Assert.That(library.History, Is.EqualTo(historyBefore));
+            Assert.That(library.Templates, Is.EqualTo(templatesBefore));
+            Assert.That(reloaded.History, Is.EqualTo(historyBefore));
+            Assert.That(reloaded.Templates, Is.EqualTo(templatesBefore));
+            Assert.That(File.Exists(observedTempPath ?? string.Empty), Is.False);
+            Assert.That(Directory.EnumerateFiles(_tempDirectory, "*.tmp"), Is.Empty);
+        });
+    }
+
+    [Test]
+    public void InvalidInputs_AreRejectedBeforeWriting()
+    {
+        var library = new PersistentPromptLibrary(_storagePath);
+
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ArgumentException>(() => library.Record(PromptTaskKind.Image, "  "));
+            Assert.Throws<ArgumentException>(() => library.SaveTemplate("  ", PromptTaskKind.Image, "prompt"));
+            Assert.Throws<ArgumentException>(() =>
+                library.SaveTemplate("line\nbreak", PromptTaskKind.Image, "prompt"));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                library.Record((PromptTaskKind)int.MaxValue, "prompt"));
+            Assert.Throws<ArgumentException>(() => library.SaveTemplate(
+                "Oversized",
+                PromptTaskKind.Video,
+                new string('x', 4_001)));
+        });
+
+        Assert.That(File.Exists(_storagePath), Is.False);
+    }
+
+    private sealed class ManualTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        private DateTimeOffset _utcNow = utcNow;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan duration)
+        {
+            _utcNow += duration;
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/PlayerViewModelDisposalTests.cs
+++ b/tests/Beutl.HeadlessUITests/PlayerViewModelDisposalTests.cs
@@ -39,14 +39,15 @@ public class PlayerViewModelDisposalTests
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
     }
 
-    private static Element AddRectangle(EditViewModel editor)
+    private static async Task<Element> AddRectangleAsync(EditViewModel editor)
     {
         var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-        adder.AddElement(new ElementDescription(
+        await adder.AddAsync([new ElementDescription(
             Start: TimeSpan.Zero,
             Length: TimeSpan.FromSeconds(4),
             Layer: 0,
-            EngineObjectFactory: () => new RectShape()));
+            Source: new ElementSource.EngineObject(() => new RectShape()))],
+            CancellationToken.None);
         HeadlessTestHelpers.Settle();
         return editor.Scene.Children[^1];
     }
@@ -81,7 +82,7 @@ public class PlayerViewModelDisposalTests
         await ResetProjectAsync();
         EditViewModel editor = await OpenEditorForNewScene("player-timer-dispose");
         PlayerViewModel player = editor.Player;
-        AddRectangle(editor);
+        await AddRectangleAsync(editor);
         IEditorClock clock = editor.GetRequiredService<IEditorClock>();
 
         var frameApplied = new TaskCompletionSource<bool>(

--- a/tests/Beutl.HeadlessUITests/PreviewRenderErrorTests.cs
+++ b/tests/Beutl.HeadlessUITests/PreviewRenderErrorTests.cs
@@ -68,14 +68,15 @@ public class PreviewRenderErrorTests
         HeadlessTestHelpers.Settle();
     }
 
-    private static void AddFaultingDrawable(EditViewModel editor)
+    private static async Task AddFaultingDrawable(EditViewModel editor)
     {
         var adder = (IElementAdder)editor.GetRequiredService<IElementAdder>();
-        adder.AddElement(new ElementDescription(
+        await adder.AddAsync([new ElementDescription(
             Start: TimeSpan.Zero,
             Length: TimeSpan.FromSeconds(2),
             Layer: 0,
-            EngineObjectFactory: () => new PreviewFaultDrawable()));
+            Source: new ElementSource.EngineObject(() => new PreviewFaultDrawable()))],
+            CancellationToken.None);
         editor.FrameCacheManager.Value.Clear();
     }
 
@@ -97,7 +98,7 @@ public class PreviewRenderErrorTests
                 .Take(1)
                 .Subscribe(message => errorReported.TrySetResult(message!));
 
-            AddFaultingDrawable(editor);
+            await AddFaultingDrawable(editor);
             editor.Player.QueuePreviewRender();
 
             string message = await errorReported.Task.WaitAsync(TimeSpan.FromSeconds(5));
@@ -138,7 +139,7 @@ public class PreviewRenderErrorTests
         try
         {
             NotificationService.Handler = notifications;
-            AddFaultingDrawable(editor);
+            await AddFaultingDrawable(editor);
             using var isPlaying = new ReactivePropertySlim<bool>(true);
             using var player = new BufferedPlayer(
                 editor, editor.Scene, isPlaying, editor.Player.GetFrameRate(), CancellationToken.None);
@@ -165,11 +166,12 @@ public class PreviewRenderErrorTests
         await ResetProjectAsync();
         EditViewModel editor = await OpenEditorForNewScene("buffered-object-disposed-error");
         var adder = (IElementAdder)editor.GetRequiredService<IElementAdder>();
-        adder.AddElement(new ElementDescription(
+        await adder.AddAsync([new ElementDescription(
             Start: TimeSpan.Zero,
             Length: TimeSpan.FromSeconds(2),
             Layer: 0,
-            EngineObjectFactory: () => new PreviewObjectDisposedFaultDrawable()));
+            Source: new ElementSource.EngineObject(() => new PreviewObjectDisposedFaultDrawable()))],
+            CancellationToken.None);
         editor.FrameCacheManager.Value.Clear();
         using var isPlaying = new ReactivePropertySlim<bool>(true);
         using var player = new BufferedPlayer(
@@ -216,11 +218,12 @@ public class PreviewRenderErrorTests
         EditViewModel editor = await OpenEditorForNewScene("canceled-rendering-buffered-player");
         var drawable = new ArmablePreviewFaultDrawable();
         var adder = (IElementAdder)editor.GetRequiredService<IElementAdder>();
-        adder.AddElement(new ElementDescription(
+        await adder.AddAsync([new ElementDescription(
             Start: TimeSpan.Zero,
             Length: TimeSpan.FromSeconds(2),
             Layer: 0,
-            EngineObjectFactory: () => drawable));
+            Source: new ElementSource.EngineObject(() => drawable))],
+            CancellationToken.None);
         HeadlessTestHelpers.Settle();
         RenderThread.Dispatcher.Invoke(static () => { });
         editor.FrameCacheManager.Value.Clear();
@@ -260,11 +263,12 @@ public class PreviewRenderErrorTests
         EditViewModel editor = await OpenEditorForNewScene("disposed-rendering-buffered-player");
         var drawable = new ArmablePreviewFaultDrawable();
         var adder = (IElementAdder)editor.GetRequiredService<IElementAdder>();
-        adder.AddElement(new ElementDescription(
+        await adder.AddAsync([new ElementDescription(
             Start: TimeSpan.Zero,
             Length: TimeSpan.FromSeconds(2),
             Layer: 0,
-            EngineObjectFactory: () => drawable));
+            Source: new ElementSource.EngineObject(() => drawable))],
+            CancellationToken.None);
         HeadlessTestHelpers.Settle();
         RenderThread.Dispatcher.Invoke(static () => { });
         editor.FrameCacheManager.Value.Clear();
@@ -307,7 +311,7 @@ public class PreviewRenderErrorTests
         try
         {
             NotificationService.Handler = notifications;
-            AddFaultingDrawable(editor);
+            await AddFaultingDrawable(editor);
             var errorReported = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
             using IDisposable subscription = editor.Player.PreviewRenderError
                 .Where(static message => !string.IsNullOrEmpty(message))
@@ -372,11 +376,12 @@ public class PreviewRenderErrorTests
         EditViewModel editor = await OpenEditorForNewScene("superseded-preview-error");
         var drawable = new SupersededPreviewFaultDrawable();
         var adder = (IElementAdder)editor.GetRequiredService<IElementAdder>();
-        adder.AddElement(new ElementDescription(
+        await adder.AddAsync([new ElementDescription(
             Start: TimeSpan.Zero,
             Length: TimeSpan.FromSeconds(2),
             Layer: 0,
-            EngineObjectFactory: () => drawable));
+            Source: new ElementSource.EngineObject(() => drawable))],
+            CancellationToken.None);
         editor.FrameCacheManager.Value.Clear();
 
         try

--- a/tests/Beutl.HeadlessUITests/PreviewRenderTests.cs
+++ b/tests/Beutl.HeadlessUITests/PreviewRenderTests.cs
@@ -40,16 +40,16 @@ public class PreviewRenderTests
         var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
 
         var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-        adder.AddElement(new ElementDescription(
+        await adder.AddAsync([new ElementDescription(
             Start: TimeSpan.Zero,
             Length: TimeSpan.FromSeconds(2),
             Layer: 0,
-            EngineObjectFactory: () => new RectShape
+            Source: new ElementSource.EngineObject(() => new RectShape
             {
                 Width = { CurrentValue = 200 },
                 Height = { CurrentValue = 150 },
                 Fill = { CurrentValue = new SolidColorBrush(Colors.Red) }
-            }));
+            }))], CancellationToken.None);
         HeadlessTestHelpers.Settle();
         return scene;
     }

--- a/tests/Beutl.HeadlessUITests/PromptLibraryProviderTests.cs
+++ b/tests/Beutl.HeadlessUITests/PromptLibraryProviderTests.cs
@@ -130,6 +130,35 @@ public sealed class PromptLibraryProviderTests
     }
 
     [Test]
+    public void AccountSwitchWithNewerFormatDoesNotAbortIdentityHandlers()
+    {
+        string? account = "account-a";
+        using var context = Context(() => account);
+        var library = new ThrowingPromptLibrary(
+            () => account == "account-b",
+            new NotSupportedException("newer prompt library"));
+        using var viewModel = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            static () => string.Empty,
+            static _ => { },
+            library,
+            context,
+            static action => action());
+        bool followingHandlerRan = false;
+        context.IdentityChanged += () => followingHandlerRan = true;
+
+        account = "account-b";
+        Assert.DoesNotThrow(context.RefreshIdentity);
+        Assert.Multiple(() =>
+        {
+            Assert.That(followingHandlerRan, Is.True);
+            Assert.That(viewModel.History, Is.Empty);
+            Assert.That(viewModel.Templates, Is.Empty);
+            Assert.That(viewModel.Error.Value, Is.EqualTo(Strings.AiResultUnavailable));
+        });
+    }
+
+    [Test]
     public async Task IdentityChangeDuringInitialSnapshotCannotPublishThePreviousAccount()
     {
         string? account = "account-a";
@@ -527,13 +556,17 @@ public sealed class PromptLibraryProviderTests
                 ? new AiAuthenticatedRequestIdentity(id, User: null)
                 : null);
 
-    private sealed class ThrowingPromptLibrary(Func<bool> shouldThrow) : IPromptLibrary
+    private sealed class ThrowingPromptLibrary(
+        Func<bool> shouldThrow,
+        Exception? failure = null) : IPromptLibrary
     {
         public string StoragePath => string.Empty;
         public bool RetainRecentPromptText => false;
         public string? RecoveredCorruptFilePath => null;
         public IReadOnlyList<PromptHistoryEntry> History
-            => shouldThrow() ? throw new InvalidDataException("corrupt") : Array.Empty<PromptHistoryEntry>();
+            => shouldThrow()
+                ? throw failure ?? new InvalidDataException("corrupt")
+                : Array.Empty<PromptHistoryEntry>();
         public IReadOnlyList<PromptTemplate> Templates => Array.Empty<PromptTemplate>();
         public PromptHistoryEntry Record(PromptTaskKind taskKind, string prompt) => throw new NotSupportedException();
         public PromptTemplate SaveTemplate(string name, PromptTaskKind taskKind, string prompt) => throw new NotSupportedException();

--- a/tests/Beutl.HeadlessUITests/PromptLibraryProviderTests.cs
+++ b/tests/Beutl.HeadlessUITests/PromptLibraryProviderTests.cs
@@ -1,0 +1,644 @@
+﻿using System.Collections.Specialized;
+
+using Beutl.Api.Services;
+using Beutl.Language;
+using Beutl.Services.AI;
+using Beutl.ViewModels;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture, NonParallelizable]
+public sealed class PromptLibraryProviderTests
+{
+    private string _home = null!;
+    private string _storePath = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _home = Path.Combine(Path.GetTempPath(), $"beutl-prompt-provider-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_home);
+        _storePath = Path.Combine(_home, "recovery.json");
+        PromptLibraryProvider.ConfigureRootForTests(Path.Combine(_home, "ai-prompts"));
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        PromptLibraryProvider.ResetRootAfterTests();
+        if (Directory.Exists(_home))
+            Directory.Delete(_home, recursive: true);
+    }
+
+    [Test]
+    public void UnauthenticatedReadsEmptyAndWritesReject()
+    {
+        string? account = null;
+        using var context = Context(() => account);
+        IPromptLibrary library = PromptLibraryProvider.For(context);
+
+        Assert.That(library.History, Is.Empty);
+        Assert.That(() => library.Record(PromptTaskKind.Image, "private"),
+            Throws.TypeOf<AuthenticationRequiredException>());
+    }
+
+    [Test]
+    public void AccountsAreIsolatedAndSwitchBackRetainsOwnData()
+    {
+        string? account = "account-a";
+        using var context = Context(() => account);
+        IPromptLibrary library = PromptLibraryProvider.For(context);
+        library.Record(PromptTaskKind.Image, "A prompt");
+        library.SaveTemplate("A template", PromptTaskKind.Image, "A body");
+
+        account = "account-b";
+        IPromptLibrary other = PromptLibraryProvider.For(context);
+        Assert.That(other.History, Is.Empty);
+        Assert.That(other.Templates, Is.Empty);
+        other.Record(PromptTaskKind.Image, "B prompt");
+        Assert.That(other.DeleteHistory(other.History[0].Id), Is.True);
+
+        account = "account-a";
+        Assert.That(library.History.Select(item => item.Prompt), Is.EqualTo(["A prompt"]));
+        Assert.That(library.Templates.Select(item => item.Name), Is.EqualTo(["A template"]));
+    }
+
+    [Test]
+    public void AccountSwitchClearsVisiblePromptsAndSurfacesCorruptMigrationMarker()
+    {
+        string? account = "account-a";
+        using var context = Context(() => account);
+        IPromptLibrary library = PromptLibraryProvider.For(context);
+        library.Record(PromptTaskKind.Image, "A private prompt");
+        using var viewModel = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            static () => string.Empty,
+            static _ => { },
+            library,
+            context,
+            static action => action());
+        Assert.That(viewModel.History.Select(item => item.Prompt),
+            Is.EqualTo(["A private prompt"]));
+
+        File.WriteAllText(Path.Combine(_home, "ai-prompts.migrated"), "invalid");
+        viewModel.TemplateName.Value = "A private template name";
+        viewModel.IsHistoryOpen.Value = true;
+        account = "account-b";
+
+        Assert.DoesNotThrow(context.RefreshIdentity);
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.History, Is.Empty);
+            Assert.That(viewModel.Templates, Is.Empty);
+            Assert.That(viewModel.HasHistory.Value, Is.False);
+            Assert.That(viewModel.HasTemplates.Value, Is.False);
+            Assert.That(viewModel.IsHistoryOpen.Value, Is.False);
+            Assert.That(viewModel.TemplateName.Value, Is.Empty);
+            Assert.That(viewModel.Error.Value, Is.EqualTo(Strings.AiResultUnavailable));
+        });
+    }
+
+    [Test]
+    public void AccountSwitchWithCorruptDestinationDoesNotAbortIdentityHandlers()
+    {
+        string? account = "account-a";
+        using var context = Context(() => account);
+        var library = new ThrowingPromptLibrary(() => account == "account-b");
+        using var viewModel = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            static () => string.Empty,
+            static _ => { },
+            library,
+            context,
+            static action => action());
+        viewModel.TemplateName.Value = "old account";
+        viewModel.IsHistoryOpen.Value = true;
+        bool followingHandlerRan = false;
+        context.IdentityChanged += () => followingHandlerRan = true;
+
+        account = "account-b";
+        Assert.DoesNotThrow(context.RefreshIdentity);
+        Assert.Multiple(() =>
+        {
+            Assert.That(followingHandlerRan, Is.True);
+            Assert.That(viewModel.History, Is.Empty);
+            Assert.That(viewModel.Templates, Is.Empty);
+            Assert.That(viewModel.TemplateName.Value, Is.Empty);
+            Assert.That(viewModel.IsHistoryOpen.Value, Is.False);
+            Assert.That(viewModel.Error.Value, Is.EqualTo(Strings.AiResultUnavailable));
+        });
+    }
+
+    [Test]
+    public async Task IdentityChangeDuringInitialSnapshotCannotPublishThePreviousAccount()
+    {
+        string? account = "account-a";
+        using var context = Context(() => account);
+        using var initialSnapshotStarted = new ManualResetEventSlim();
+        using var releaseInitialSnapshot = new ManualResetEventSlim();
+        using var identityPublished = new ManualResetEventSlim();
+        context.IdentityChanged += identityPublished.Set;
+        var library = new BlockingAccountPromptLibrary(
+            () => account,
+            initialSnapshotStarted,
+            releaseInitialSnapshot);
+        Task<AiPromptLibraryViewModel> creation = Task.Run(() =>
+            new AiPromptLibraryViewModel(
+                PromptTaskKind.Image,
+                static () => string.Empty,
+                static _ => { },
+                library,
+                context,
+                static action => action()));
+
+        try
+        {
+            Assert.That(initialSnapshotStarted.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            account = "account-b";
+            Task identityChange = Task.Run(context.RefreshIdentity);
+            Assert.That(identityPublished.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+            releaseInitialSnapshot.Set();
+            using AiPromptLibraryViewModel viewModel =
+                await creation.WaitAsync(TimeSpan.FromSeconds(5));
+            await identityChange.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.That(
+                viewModel.Templates.Select(item => item.Name),
+                Is.EqualTo(["Account B"]));
+        }
+        finally
+        {
+            releaseInitialSnapshot.Set();
+            if (creation.IsCompletedSuccessfully)
+                creation.Result.Dispose();
+        }
+    }
+
+    [Test]
+    public void SameAccountViewModelsRefreshAfterEverySharedLibraryMutation()
+    {
+        using var context = Context(() => "account-a");
+        IPromptLibrary writer = PromptLibraryProvider.For(context);
+        using var first = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            static () => string.Empty,
+            static _ => { },
+            PromptLibraryProvider.For(context),
+            context,
+            static action => action());
+        using var second = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            static () => string.Empty,
+            static _ => { },
+            PromptLibraryProvider.For(context),
+            context,
+            static action => action());
+
+        PromptTemplate template = writer.SaveTemplate(
+            "Shared",
+            PromptTaskKind.Image,
+            "shared template");
+        PromptHistoryEntry history = writer.Record(
+            PromptTaskKind.Image,
+            "shared history");
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Templates.Select(item => item.Id), Is.EqualTo([template.Id]));
+            Assert.That(second.Templates.Select(item => item.Id), Is.EqualTo([template.Id]));
+            Assert.That(first.History.Select(item => item.Id), Is.EqualTo([history.Id]));
+            Assert.That(second.History.Select(item => item.Id), Is.EqualTo([history.Id]));
+        });
+
+        Assert.That(writer.SetTemplatePinned(template.Id, true), Is.True);
+        Assert.That(writer.SetHistoryPinned(history.Id, true), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Templates.Single().IsPinned, Is.True);
+            Assert.That(second.Templates.Single().IsPinned, Is.True);
+            Assert.That(first.History.Single().IsPinned, Is.True);
+            Assert.That(second.History.Single().IsPinned, Is.True);
+        });
+
+        Assert.That(writer.DeleteTemplate(template.Id), Is.True);
+        writer.ClearHistory();
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Templates, Is.Empty);
+            Assert.That(second.Templates, Is.Empty);
+            Assert.That(first.History, Is.Empty);
+            Assert.That(second.History, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task BackgroundMutationIsAppliedThroughTheCapturedUiDispatcher()
+    {
+        using var context = Context(() => "account-a");
+        IPromptLibrary writer = PromptLibraryProvider.For(context);
+        var dispatcher = new QueuedUiDispatcher();
+        using var first = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            static () => string.Empty,
+            static _ => { },
+            PromptLibraryProvider.For(context),
+            context,
+            dispatcher.Dispatch);
+        using var second = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            static () => string.Empty,
+            static _ => { },
+            PromptLibraryProvider.For(context),
+            context,
+            dispatcher.Dispatch);
+        bool notificationRanDuringUiDrain = false;
+        ((INotifyCollectionChanged)second.Templates).CollectionChanged += (_, _) =>
+            notificationRanDuringUiDrain = dispatcher.IsDraining;
+
+        dispatcher.Defer = true;
+        await Task.Run(() =>
+        {
+            writer.SaveTemplate("Background", PromptTaskKind.Image, "background prompt");
+        });
+        Assert.That(second.Templates, Is.Empty);
+
+        dispatcher.Drain();
+        Assert.Multiple(() =>
+        {
+            Assert.That(second.Templates.Select(item => item.Name), Is.EqualTo(["Background"]));
+            Assert.That(notificationRanDuringUiDrain, Is.True);
+        });
+    }
+
+    [Test]
+    public void SharedLibrarySubscriptionFollowsAccountSwitchAndStopsAfterDispose()
+    {
+        string? account = "account-a";
+        using var context = Context(() => account);
+        IPromptLibrary writer = PromptLibraryProvider.For(context);
+        using var active = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            static () => string.Empty,
+            static _ => { },
+            PromptLibraryProvider.For(context),
+            context,
+            static action => action());
+        var disposed = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            static () => string.Empty,
+            static _ => { },
+            PromptLibraryProvider.For(context),
+            context,
+            static action => action());
+
+        writer.SaveTemplate("Account A", PromptTaskKind.Image, "private A");
+        account = "account-b";
+        context.RefreshIdentity();
+        Assert.Multiple(() =>
+        {
+            Assert.That(active.Templates, Is.Empty);
+            Assert.That(disposed.Templates, Is.Empty);
+        });
+
+        writer.SaveTemplate("Account B", PromptTaskKind.Image, "private B");
+        Assert.Multiple(() =>
+        {
+            Assert.That(active.Templates.Select(item => item.Name), Is.EqualTo(["Account B"]));
+            Assert.That(disposed.Templates.Select(item => item.Name), Is.EqualTo(["Account B"]));
+        });
+
+        disposed.Dispose();
+        writer.SaveTemplate("Account B 2", PromptTaskKind.Image, "private B 2");
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                active.Templates.Select(item => item.Name),
+                Is.EqualTo(["Account B 2", "Account B"]));
+            Assert.That(
+                disposed.Templates.Select(item => item.Name),
+                Is.EqualTo(["Account B"]));
+        });
+
+        account = "account-a";
+        context.RefreshIdentity();
+        Assert.Multiple(() =>
+        {
+            Assert.That(active.Templates.Select(item => item.Name), Is.EqualTo(["Account A"]));
+            Assert.That(disposed.Templates.Select(item => item.Name), Is.EqualTo(["Account B"]));
+        });
+    }
+
+    [Test]
+    public async Task QueuedLibraryRefreshRechecksAccountGenerationAndDisposal()
+    {
+        string? account = "account-a";
+        using var context = Context(() => account);
+        IPromptLibrary writer = PromptLibraryProvider.For(context);
+        var dispatcher = new QueuedUiDispatcher();
+        using var active = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            static () => string.Empty,
+            static _ => { },
+            PromptLibraryProvider.For(context),
+            context,
+            dispatcher.Dispatch);
+        var disposed = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            static () => string.Empty,
+            static _ => { },
+            PromptLibraryProvider.For(context),
+            context,
+            dispatcher.Dispatch);
+        writer.SaveTemplate("Account A", PromptTaskKind.Image, "private A");
+
+        dispatcher.Defer = true;
+        await Task.Run(() =>
+            writer.SaveTemplate("Stale A", PromptTaskKind.Image, "stale A"));
+        account = "account-b";
+        context.RefreshIdentity();
+        disposed.Dispose();
+        dispatcher.Drain();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(active.Templates, Is.Empty,
+                "The queued account-A refresh must not publish after the account-B transition.");
+            Assert.That(
+                disposed.Templates.Select(item => item.Name),
+                Is.EqualTo(["Account A"]),
+                "A queued refresh must not mutate a disposed ViewModel.");
+        });
+    }
+
+    [Test]
+    public void SharedViewModelsRecoverAfterTransientAccountLibraryBindingFailure()
+    {
+        string? account = "account-a";
+        using var context = Context(() => account);
+        IPromptLibrary writer = PromptLibraryProvider.For(context);
+        using var first = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            static () => string.Empty,
+            static _ => { },
+            PromptLibraryProvider.For(context),
+            context,
+            static action => action());
+        using var second = new AiPromptLibraryViewModel(
+            PromptTaskKind.Image,
+            static () => string.Empty,
+            static _ => { },
+            PromptLibraryProvider.For(context),
+            context,
+            static action => action());
+        writer.SaveTemplate("Account A", PromptTaskKind.Image, "private A");
+
+        account = "account-b";
+        string migrationLockPath = Path.Combine(_home, "ai-prompts.migrated.lock");
+        using (var heldMigrationLock = new FileStream(
+                   migrationLockPath,
+                   FileMode.OpenOrCreate,
+                   FileAccess.ReadWrite,
+                   FileShare.None))
+        {
+            context.RefreshIdentity();
+            Assert.Multiple(() =>
+            {
+                Assert.That(first.Templates, Is.Empty);
+                Assert.That(second.Templates, Is.Empty);
+                Assert.That(first.Error.Value, Is.EqualTo(Strings.AiResultUnavailable));
+                Assert.That(second.Error.Value, Is.EqualTo(Strings.AiResultUnavailable));
+            });
+        }
+
+        // No second identity event occurs. The first successful mutation must publish
+        // through the account-scoped hub and refresh every still-live workspace.
+        PromptTemplate recovered = writer.SaveTemplate(
+            "Recovered B",
+            PromptTaskKind.Image,
+            "private B");
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Templates.Select(item => item.Id), Is.EqualTo([recovered.Id]));
+            Assert.That(second.Templates.Select(item => item.Id), Is.EqualTo([recovered.Id]));
+            Assert.That(first.Error.Value, Is.Null);
+            Assert.That(second.Error.Value, Is.Null);
+        });
+    }
+
+    [Test]
+    public void LegacyFileIsClaimedOnceByFirstAuthenticatedAccount()
+    {
+        string legacy = Path.Combine(_home, "ai-prompts.json");
+        var seed = new PersistentPromptLibrary(legacy, new PromptLibraryOptions { RetainRecentPromptText = true });
+        seed.SaveTemplate("legacy", PromptTaskKind.Image, "legacy prompt");
+
+        string? account = "account-a";
+        using var context = Context(() => account);
+        IPromptLibrary first = PromptLibraryProvider.For(context);
+        Assert.That(first.Templates.Select(item => item.Prompt), Is.EqualTo(["legacy prompt"]));
+        string marker = Path.Combine(_home, "ai-prompts.migrated");
+        Assert.That(File.Exists(marker), Is.True);
+        Assert.That(File.ReadAllText(marker), Is.EqualTo(Convert.ToHexString(
+            System.Security.Cryptography.SHA256.HashData(
+                System.Text.Encoding.UTF8.GetBytes("account-a")))));
+
+        account = "account-b";
+        IPromptLibrary second = PromptLibraryProvider.For(context);
+        Assert.That(second.History, Is.Empty);
+        Assert.That(second.Templates, Is.Empty);
+    }
+
+    [Test]
+    public void LegacyMigrationFailureIsFailClosedAndOwnerCanRetry()
+    {
+        string legacy = Path.Combine(_home, "ai-prompts.json");
+        var seed = new PersistentPromptLibrary(legacy);
+        seed.SaveTemplate("legacy", PromptTaskKind.Image, "legacy prompt");
+
+        // Block the owner's destination. Marker ownership is still durable,
+        // while the legacy move fails closed without exposing its data.
+        string marker = Path.Combine(_home, "ai-prompts.migrated");
+        string? account = "account-a";
+        using var context = Context(() => account);
+        string accountFile = Convert.ToHexString(
+            System.Security.Cryptography.SHA256.HashData(
+                System.Text.Encoding.UTF8.GetBytes("account-a"))) + ".json";
+        Directory.CreateDirectory(Path.Combine(_home, "ai-prompts"));
+        Directory.CreateDirectory(Path.Combine(_home, "ai-prompts", accountFile));
+        IPromptLibrary first = PromptLibraryProvider.For(context);
+        Assert.That(() => first.Templates, Throws.TypeOf<IOException>());
+        Assert.That(File.ReadAllText(marker), Is.EqualTo(accountFile[..^5]));
+        Assert.That(File.Exists(Path.Combine(_home, "ai-prompts", accountFile)), Is.False);
+
+        Directory.Delete(Path.Combine(_home, "ai-prompts", accountFile));
+        account = "account-b";
+        IPromptLibrary other = PromptLibraryProvider.For(context);
+        other.Record(PromptTaskKind.Image, "B only");
+        Assert.That(File.Exists(legacy), Is.True);
+        account = "account-a";
+        PromptLibraryProvider.ConfigureRootForTests(Path.Combine(_home, "ai-prompts"));
+        IPromptLibrary retried = PromptLibraryProvider.For(context);
+        Assert.That(retried.Templates.Select(item => item.Prompt), Is.EqualTo(["legacy prompt"]));
+        Assert.That(File.Exists(marker), Is.True);
+    }
+
+    [Test]
+    public void InvalidMigrationMarkerFailsClosedWhileLegacyRemains()
+    {
+        string legacy = Path.Combine(_home, "ai-prompts.json");
+        _ = new PersistentPromptLibrary(legacy).SaveTemplate("legacy", PromptTaskKind.Image, "private");
+        File.WriteAllText(Path.Combine(_home, "ai-prompts.migrated"), "invalid");
+        using var context = Context(() => "account-a");
+        Assert.That(() => PromptLibraryProvider.For(context).Templates, Throws.TypeOf<InvalidDataException>());
+        Assert.That(File.Exists(legacy), Is.True);
+    }
+
+    [Test]
+    public void PendingOwnerMarkerWithLegacyRetriesMove()
+    {
+        string legacy = Path.Combine(_home, "ai-prompts.json");
+        _ = new PersistentPromptLibrary(legacy).SaveTemplate("legacy", PromptTaskKind.Image, "pending");
+        string owner = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(
+            System.Text.Encoding.UTF8.GetBytes("account-a")));
+        File.WriteAllText(Path.Combine(_home, "ai-prompts.migrated"), owner);
+        using var context = Context(() => "account-a");
+        IPromptLibrary library = PromptLibraryProvider.For(context);
+        Assert.That(library.Templates.Select(item => item.Prompt), Is.EqualTo(["pending"]));
+        Assert.That(File.Exists(legacy), Is.False);
+    }
+
+    [Test]
+    public void PendingOwnerMarkerWithAccountPathCompletesWithoutLegacy()
+    {
+        string owner = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(
+            System.Text.Encoding.UTF8.GetBytes("account-a")));
+        File.WriteAllText(Path.Combine(_home, "ai-prompts.migrated"), owner);
+        string path = Path.Combine(_home, "ai-prompts", owner + ".json");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        _ = new PersistentPromptLibrary(path).SaveTemplate("existing", PromptTaskKind.Image, "path");
+        using var context = Context(() => "account-a");
+        Assert.That(PromptLibraryProvider.For(context).Templates.Select(item => item.Prompt), Is.EqualTo(["path"]));
+    }
+
+    private AiRequestRecoveryContext Context(Func<string?> account)
+        => new(
+            new FileAiRequestRecoveryStore(_storePath),
+            () => account() is { } id
+                ? new AiAuthenticatedRequestIdentity(id, User: null)
+                : null);
+
+    private sealed class ThrowingPromptLibrary(Func<bool> shouldThrow) : IPromptLibrary
+    {
+        public string StoragePath => string.Empty;
+        public bool RetainRecentPromptText => false;
+        public string? RecoveredCorruptFilePath => null;
+        public IReadOnlyList<PromptHistoryEntry> History
+            => shouldThrow() ? throw new InvalidDataException("corrupt") : Array.Empty<PromptHistoryEntry>();
+        public IReadOnlyList<PromptTemplate> Templates => Array.Empty<PromptTemplate>();
+        public PromptHistoryEntry Record(PromptTaskKind taskKind, string prompt) => throw new NotSupportedException();
+        public PromptTemplate SaveTemplate(string name, PromptTaskKind taskKind, string prompt) => throw new NotSupportedException();
+        public bool SetHistoryPinned(Guid id, bool isPinned) => false;
+        public bool SetTemplatePinned(Guid id, bool isPinned) => false;
+        public bool DeleteHistory(Guid id) => false;
+        public bool DeleteTemplate(Guid id) => false;
+        public void ClearHistory() { }
+        public void ClearTemplates() { }
+        public void ClearAll() { }
+    }
+
+    private sealed class BlockingAccountPromptLibrary(
+        Func<string?> account,
+        ManualResetEventSlim initialSnapshotStarted,
+        ManualResetEventSlim releaseInitialSnapshot)
+        : IPromptLibrary, IPromptLibraryChangeSource
+    {
+        private int _templateReads;
+
+        public string StoragePath => string.Empty;
+        public bool RetainRecentPromptText => false;
+        public string? RecoveredCorruptFilePath => null;
+        public IReadOnlyList<PromptHistoryEntry> History => [];
+        public IReadOnlyList<PromptTemplate> Templates
+        {
+            get
+            {
+                string name = account() == "account-a" ? "Account A" : "Account B";
+                PromptTemplate[] snapshot =
+                [
+                    new PromptTemplate(
+                        Guid.Parse("f1570c99-2514-4e24-ad69-350f745924b6"),
+                        name,
+                        PromptTaskKind.Image,
+                        name,
+                        DateTimeOffset.UnixEpoch,
+                        DateTimeOffset.UnixEpoch,
+                        false),
+                ];
+                if (Interlocked.Increment(ref _templateReads) == 1)
+                {
+                    initialSnapshotStarted.Set();
+                    if (!releaseInitialSnapshot.Wait(TimeSpan.FromSeconds(5)))
+                        throw new TimeoutException("The initial prompt snapshot was not released.");
+                }
+                return snapshot;
+            }
+        }
+
+        public IDisposable SubscribeChanged(Action callback) => new MemoryStream();
+        public PromptHistoryEntry Record(PromptTaskKind taskKind, string prompt) => throw new NotSupportedException();
+        public PromptTemplate SaveTemplate(string name, PromptTaskKind taskKind, string prompt) => throw new NotSupportedException();
+        public bool SetHistoryPinned(Guid id, bool isPinned) => false;
+        public bool SetTemplatePinned(Guid id, bool isPinned) => false;
+        public bool DeleteHistory(Guid id) => false;
+        public bool DeleteTemplate(Guid id) => false;
+        public void ClearHistory() { }
+        public void ClearTemplates() { }
+        public void ClearAll() { }
+    }
+
+    private sealed class QueuedUiDispatcher
+    {
+        private readonly object _gate = new();
+        private readonly Queue<Action> _queued = new();
+
+        public bool Defer { get; set; }
+
+        public bool IsDraining { get; private set; }
+
+        public void Dispatch(Action action)
+        {
+            lock (_gate)
+            {
+                if (Defer)
+                {
+                    _queued.Enqueue(action);
+                    return;
+                }
+            }
+            action();
+        }
+
+        public void Drain()
+        {
+            IsDraining = true;
+            try
+            {
+                while (true)
+                {
+                    Action? action;
+                    lock (_gate)
+                    {
+                        action = _queued.Count > 0 ? _queued.Dequeue() : null;
+                    }
+                    if (action is null)
+                        return;
+                    action();
+                }
+            }
+            finally
+            {
+                IsDraining = false;
+            }
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/SaveRoundTripTests.cs
+++ b/tests/Beutl.HeadlessUITests/SaveRoundTripTests.cs
@@ -37,12 +37,14 @@ public class SaveRoundTripTests
         var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
 
         var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-        adder.AddElement(new ElementDescription(
+        await adder.AddAsync([new ElementDescription(
             Start: TimeSpan.FromSeconds(1),
             Length: TimeSpan.FromSeconds(3),
             Layer: 2,
-            Name: "RoundTripRect",
-            EngineObjectFactory: () => new RectShape { Width = { CurrentValue = 321 } }));
+            Source: new ElementSource.EngineObject(
+                () => new RectShape { Width = { CurrentValue = 321 } }),
+            Name: "RoundTripRect")],
+            CancellationToken.None);
         HeadlessTestHelpers.Settle();
 
         Element element = editor.Scene.Children.Single();
@@ -85,11 +87,12 @@ public class SaveRoundTripTests
         var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
 
         var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-        adder.AddElement(new ElementDescription(
+        await adder.AddAsync([new ElementDescription(
             Start: TimeSpan.Zero,
             Length: TimeSpan.FromSeconds(2),
             Layer: 0,
-            EngineObjectFactory: () => new RectShape()));
+            Source: new ElementSource.EngineObject(() => new RectShape()))],
+            CancellationToken.None);
         HeadlessTestHelpers.Settle();
 
         Element element = editor.Scene.Children.Single();

--- a/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
+++ b/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
@@ -43,8 +43,8 @@ public class SceneEditorContextServicesTests
             Assert.That(services.TryGetService<EditorService>(out EditorService? resolvedEditor), Is.True);
             Assert.That(resolvedEditor, Is.SameAs(editorService));
 
-            Assert.That(services.TryGetService<ExtensionProvider>(out ExtensionProvider? resolvedProvider), Is.True);
-            Assert.That(resolvedProvider, Is.SameAs(extensionProvider));
+            Assert.That(services.TryGetService<ExtensionProvider>(out ExtensionProvider? resolvedProvider), Is.False);
+            Assert.That(resolvedProvider, Is.Null);
 
             Assert.That(services.TryGetService<IExtensionProvider>(out IExtensionProvider? resolvedInterface), Is.True);
             Assert.That(resolvedInterface, Is.SameAs(extensionProvider));

--- a/tests/Beutl.HeadlessUITests/SharedFilePickerOptionsTests.cs
+++ b/tests/Beutl.HeadlessUITests/SharedFilePickerOptionsTests.cs
@@ -1,0 +1,25 @@
+﻿using Avalonia.Platform.Storage;
+using Moq;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public sealed class SharedFilePickerOptionsTests
+{
+    [Test]
+    public void StorageFileOwnership_ReleasesEveryPickerResultAndIsIdempotent()
+    {
+        var first = new Mock<IStorageFile>(MockBehavior.Strict);
+        var second = new Mock<IStorageFile>(MockBehavior.Strict);
+        first.Setup(file => file.Dispose()).Throws(new IOException("release failed"));
+        second.Setup(file => file.Dispose());
+        IDisposable ownership = SharedFilePickerOptions.OwnStorageFiles(
+            [first.Object, second.Object]);
+
+        Assert.DoesNotThrow(ownership.Dispose);
+        Assert.DoesNotThrow(ownership.Dispose);
+
+        first.Verify(file => file.Dispose(), Times.Once);
+        second.Verify(file => file.Dispose(), Times.Once);
+    }
+}

--- a/tests/Beutl.HeadlessUITests/TestApp.axaml.cs
+++ b/tests/Beutl.HeadlessUITests/TestApp.axaml.cs
@@ -27,6 +27,7 @@ public sealed class TestApp : Application
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
+        App.RegisterBundledEngineFonts();
         // EditView's Timeline tool view (LayerHeader) resolves {StaticResource PaletteColors}, which the
         // real App sets in App.Initialize; without it the tool view fails to load once it actually inflates.
         Resources["PaletteColors"] = AppHelpers.GetPaletteColors();

--- a/tests/Beutl.HeadlessUITests/TestReset.cs
+++ b/tests/Beutl.HeadlessUITests/TestReset.cs
@@ -1,5 +1,7 @@
-﻿using Beutl.Configuration;
+﻿using System.Diagnostics.CodeAnalysis;
+using Beutl.Configuration;
 using Beutl.Services;
+using Beutl.Services.AI;
 using Beutl.Testing.Headless;
 
 namespace Beutl.HeadlessUITests;
@@ -24,6 +26,7 @@ internal static class TestReset
 
         await TestShell.Project.CloseProjectAsync();
         BeutlApplication.Current.Items.Clear();
+        CaptionDraftStoreProvider.SetCurrentForTesting(new TestCaptionDraftStore());
         HeadlessTestHelpers.Settle();
     }
 
@@ -38,5 +41,81 @@ internal static class TestReset
         }
 
         HeadlessTestHelpers.Settle();
+    }
+
+    private sealed class TestCaptionDraftStore : ICaptionDraftStore
+    {
+        private readonly Dictionary<CaptionDraftScope, CaptionDraftEntry> _drafts = [];
+        private readonly HashSet<CaptionDraftScope> _owners = [];
+        private readonly object _gate = new();
+
+        public bool TryOpen(
+            CaptionDraftScope scope,
+            [NotNullWhen(true)] out ICaptionDraftSession? session)
+        {
+            lock (_gate)
+            {
+                if (!_owners.Add(scope))
+                {
+                    session = null;
+                    return false;
+                }
+
+                session = new Session(this, scope);
+                return true;
+            }
+        }
+
+        private sealed class Session(TestCaptionDraftStore owner, CaptionDraftScope scope)
+            : ICaptionDraftSession
+        {
+            private TestCaptionDraftStore? _owner = owner;
+
+            public CaptionDraftScope Scope { get; } = scope;
+
+            public CaptionDraftReadResult Read()
+            {
+                TestCaptionDraftStore store = GetOwner();
+                lock (store._gate)
+                {
+                    return store._drafts.GetValueOrDefault(Scope) is { } entry
+                        ? new CaptionDraftReadResult(CaptionDraftReadOutcome.Read, entry)
+                        : CaptionDraftReadResult.Absent;
+                }
+            }
+
+            public void Save(CaptionDraftEntry entry)
+            {
+                TestCaptionDraftStore store = GetOwner();
+                lock (store._gate)
+                {
+                    store._drafts[Scope] = entry;
+                }
+            }
+
+            public void Delete()
+            {
+                TestCaptionDraftStore store = GetOwner();
+                lock (store._gate)
+                {
+                    store._drafts.Remove(Scope);
+                }
+            }
+
+            public void Dispose()
+            {
+                TestCaptionDraftStore? store = Interlocked.Exchange(ref _owner, null);
+                if (store is null)
+                    return;
+
+                lock (store._gate)
+                {
+                    store._owners.Remove(Scope);
+                }
+            }
+
+            private TestCaptionDraftStore GetOwner()
+                => _owner ?? throw new ObjectDisposedException(nameof(Session));
+        }
     }
 }

--- a/tests/Beutl.HeadlessUITests/ThemeCaptureTests.cs
+++ b/tests/Beutl.HeadlessUITests/ThemeCaptureTests.cs
@@ -85,14 +85,15 @@ public class ThemeCaptureTests
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
     }
 
-    private static void AddRectangle(EditViewModel editor, TimeSpan start, int layer)
+    private static async Task AddRectangle(EditViewModel editor, TimeSpan start, int layer)
     {
         var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-        adder.AddElement(new ElementDescription(
+        await adder.AddAsync([new ElementDescription(
             Start: start,
             Length: TimeSpan.FromSeconds(2),
             Layer: layer,
-            EngineObjectFactory: () => new RectShape()));
+            Source: new ElementSource.EngineObject(() => new RectShape()))],
+            CancellationToken.None);
         HeadlessTestHelpers.Settle();
     }
 
@@ -233,7 +234,7 @@ public class ThemeCaptureTests
         EditViewModel editor = await OpenEditorForNewScene("themecapture");
         for (int layer = 0; layer < 3; layer++)
         {
-            AddRectangle(editor, TimeSpan.FromSeconds(layer * 0.5), layer);
+            await AddRectangle(editor, TimeSpan.FromSeconds(layer * 0.5), layer);
         }
 
         var window = new Window
@@ -306,11 +307,12 @@ public class ThemeCaptureTests
         EditViewModel editor = await OpenEditorForNewScene("inspectorcapture");
 
         var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-        adder.AddElement(new ElementDescription(
+        await adder.AddAsync([new ElementDescription(
             Start: TimeSpan.Zero,
             Length: TimeSpan.FromSeconds(2),
             Layer: 0,
-            EngineObjectFactory: CreateDecoratedRect));
+            Source: new ElementSource.EngineObject(CreateDecoratedRect))],
+            CancellationToken.None);
         HeadlessTestHelpers.Settle();
 
         Element element = editor.Scene.Children.First();

--- a/tests/Beutl.HeadlessUITests/UIFontResourceTests.cs
+++ b/tests/Beutl.HeadlessUITests/UIFontResourceTests.cs
@@ -43,4 +43,24 @@ public class UIFontResourceTests
             Assert.That(AssetLoader.Exists(uri), Is.True);
         }
     }
+
+    [AvaloniaTest]
+    public void NotoSansJP_is_registered_with_the_rendering_engine()
+    {
+        var family = new Beutl.Media.FontFamily("Noto Sans JP");
+        Beutl.Media.Typeface[] typefaces =
+            [.. Beutl.Media.FontManager.Instance.GetTypefaces(family)];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(typefaces.Select(typeface => typeface.Weight),
+                Does.Contain(Beutl.Media.FontWeight.Regular));
+            Assert.That(typefaces.Select(typeface => typeface.Weight),
+                Does.Contain(Beutl.Media.FontWeight.Medium));
+            Assert.That(typefaces.Select(typeface => typeface.Weight),
+                Does.Contain(Beutl.Media.FontWeight.SemiBold));
+            Assert.That(typefaces.Select(typeface => typeface.Weight),
+                Does.Contain(Beutl.Media.FontWeight.Bold));
+        });
+    }
 }

--- a/tests/Beutl.HeadlessUITests/VersionControlRestoreTests.cs
+++ b/tests/Beutl.HeadlessUITests/VersionControlRestoreTests.cs
@@ -5360,7 +5360,7 @@ public class VersionControlRestoreTests
             (Project project, EditViewModel editor) = await CreateTrackedProjectAsync(
                 "version-control-branch-in-memory-save");
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-            AddRectangle(adder, layer: 0);
+            await AddRectangleAsync(adder, layer: 0);
             HeadlessTestHelpers.Settle();
             WorkspaceStatus statusAfterEdit = await TestShell.VersionControl.CurrentService!
                 .GetStatusAsync(CancellationToken.None);
@@ -6004,7 +6004,7 @@ public class VersionControlRestoreTests
             await RunGitAsync(gitPath, projectRoot, "switch", "existing");
             await RunGitAsync(gitPath, projectRoot, "switch", "main");
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-            AddRectangle(adder, layer: 0);
+            await AddRectangleAsync(adder, layer: 0);
             project.Variables[RestoreStateKey] = "unsaved-state";
             CoreSerializer.StoreToUri(project, project.Uri!);
             Assert.That(
@@ -9643,7 +9643,7 @@ public class VersionControlRestoreTests
             await RunGitAsync(gitPath, projectRoot, "switch", "existing");
             await RunGitAsync(gitPath, projectRoot, "switch", "main");
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-            AddRectangle(adder, layer: 0);
+            await AddRectangleAsync(adder, layer: 0);
             project.Variables[RestoreStateKey] = "unsaved-state";
             CoreSerializer.StoreToUri(project, project.Uri!);
             Assert.That(
@@ -9885,11 +9885,11 @@ public class VersionControlRestoreTests
                 .First(commit => commit.Kind == SnapshotKind.Save);
 
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-            AddRectangle(adder, layer: 0);
+            await AddRectangleAsync(adder, layer: 0);
             project.Variables[RestoreStateKey] = "version-two";
             await TestShell.MainViewModel.MenuBar.SaveAll.ExecuteAsync();
 
-            AddRectangle(adder, layer: 1);
+            await AddRectangleAsync(adder, layer: 1);
             project.Variables[RestoreStateKey] = "pre-restore";
             CoreSerializer.StoreToUri(project, project.Uri!);
             Scene preRestoreScene = project.Items.OfType<Scene>().Single();
@@ -10670,13 +10670,15 @@ public class VersionControlRestoreTests
         Assert.That(condition(), Is.True, "The expected state was not reached.");
     }
 
-    private static void AddRectangle(IElementAdder adder, int layer)
+    private static async Task AddRectangleAsync(IElementAdder adder, int layer)
     {
-        adder.AddElement(new ElementDescription(
+        ElementAddResult result = await adder.AddAsync([new ElementDescription(
             Start: TimeSpan.Zero,
             Length: TimeSpan.FromSeconds(1),
             Layer: layer,
-            EngineObjectFactory: () => new RectShape()));
+            Source: new ElementSource.EngineObject(() => new RectShape()))],
+            CancellationToken.None);
+        Assert.That(result.IsSuccess, Is.True, result.Failure?.Message);
         HeadlessTestHelpers.Settle();
     }
 

--- a/tests/Beutl.HeadlessUITests/VersionControlSaveTests.cs
+++ b/tests/Beutl.HeadlessUITests/VersionControlSaveTests.cs
@@ -158,11 +158,7 @@ public class VersionControlSaveTests
             HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-            adder.AddElement(new ElementDescription(
-                Start: TimeSpan.Zero,
-                Length: TimeSpan.FromSeconds(1),
-                Layer: 0,
-                EngineObjectFactory: () => new RectShape()));
+            await AddRectangleAsync(adder);
             HeadlessTestHelpers.Settle();
             Element element = scene.Children.Single();
             element.Name = "saved-without-auto-save";
@@ -226,11 +222,7 @@ public class VersionControlSaveTests
                 Is.SameAs(TestShell.VersionControl.CurrentService));
 
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-            adder.AddElement(new ElementDescription(
-                Start: TimeSpan.Zero,
-                Length: TimeSpan.FromSeconds(1),
-                Layer: 0,
-                EngineObjectFactory: () => new RectShape()));
+            await AddRectangleAsync(adder);
             HeadlessTestHelpers.Settle();
 
             await TestShell.MainViewModel.MenuBar.Save.ExecuteAsync();
@@ -320,11 +312,7 @@ public class VersionControlSaveTests
             HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-            adder.AddElement(new ElementDescription(
-                Start: TimeSpan.Zero,
-                Length: TimeSpan.FromSeconds(1),
-                Layer: 0,
-                EngineObjectFactory: () => new RectShape()));
+            await AddRectangleAsync(adder);
             HeadlessTestHelpers.Settle();
 
             string hookPath = Path.Combine(projectRoot, ".git", "hooks", "pre-commit");
@@ -795,11 +783,7 @@ public class VersionControlSaveTests
             HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-            adder.AddElement(new ElementDescription(
-                Start: TimeSpan.Zero,
-                Length: TimeSpan.FromSeconds(1),
-                Layer: 0,
-                EngineObjectFactory: () => new RectShape()));
+            await AddRectangleAsync(adder);
             HeadlessTestHelpers.Settle();
 
             bool initialized = await TestShell.VersionControl.InitializeCurrentProjectAsync(
@@ -879,11 +863,7 @@ public class VersionControlSaveTests
             HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-            adder.AddElement(new ElementDescription(
-                Start: TimeSpan.Zero,
-                Length: TimeSpan.FromSeconds(1),
-                Layer: 0,
-                EngineObjectFactory: () => new RectShape()));
+            await AddRectangleAsync(adder);
             HeadlessTestHelpers.Settle();
 
             TestShell.MainViewModel.MenuBar.CloseProject.Execute();
@@ -1288,6 +1268,17 @@ public class VersionControlSaveTests
             config.GitExecutablePath = oldGitPath;
             config.UseLfsWhenAvailable = oldUseLfs;
         }
+    }
+
+    private static async Task AddRectangleAsync(IElementAdder adder)
+    {
+        ElementAddResult result = await adder.AddAsync([new ElementDescription(
+            Start: TimeSpan.Zero,
+            Length: TimeSpan.FromSeconds(1),
+            Layer: 0,
+            Source: new ElementSource.EngineObject(() => new RectShape()))],
+            CancellationToken.None);
+        Assert.That(result.IsSuccess, Is.True, result.Failure?.Message);
     }
 
     private static string ProbeGitOrIgnore()

--- a/tests/Beutl.HeadlessUITests/VideoFileImportTests.cs
+++ b/tests/Beutl.HeadlessUITests/VideoFileImportTests.cs
@@ -4,13 +4,16 @@ using Beutl.Audio;
 using Beutl.Editor.Models;
 using Beutl.Editor.Services;
 using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
 using Beutl.Media;
 using Beutl.Media.Decoding;
 using Beutl.Media.Music;
 using Beutl.Media.Source;
 using Beutl.ProjectSystem;
+using Beutl.Serialization;
 using Beutl.Services;
 using Beutl.Testing.Headless;
+using Beutl.Threading;
 using Beutl.ViewModels;
 
 namespace Beutl.HeadlessUITests;
@@ -70,11 +73,12 @@ public class VideoFileImportTests
         string path = CreateImportFile("sample", withAudio: false);
 
         var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-        adder.AddElement(new ElementDescription(
+        await adder.AddAsync([new ElementDescription(
             Start: TimeSpan.Zero,
             Length: TimeSpan.FromSeconds(5),
             Layer: 0,
-            FileName: path));
+            Source: new ElementSource.File(path))],
+            CancellationToken.None);
         HeadlessTestHelpers.Settle();
 
         Assert.That(editor.Scene.Children, Has.Count.EqualTo(1),
@@ -99,11 +103,12 @@ public class VideoFileImportTests
         string path = CreateImportFile("sample", withAudio: true);
 
         var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-        adder.AddElement(new ElementDescription(
+        await adder.AddAsync([new ElementDescription(
             Start: TimeSpan.Zero,
             Length: TimeSpan.FromSeconds(5),
             Layer: 0,
-            FileName: path));
+            Source: new ElementSource.File(path))],
+            CancellationToken.None);
         HeadlessTestHelpers.Settle();
 
         Assert.That(editor.Scene.Children, Has.Count.EqualTo(2),
@@ -112,6 +117,113 @@ public class VideoFileImportTests
         Assert.That(editor.Scene.Children.Count(c => c.Objects.OfType<SourceSound>().Any()), Is.EqualTo(1));
         Assert.That(editor.Scene.Groups, Has.Count.EqualTo(1),
             "音声要素がある場合は従来どおりグループ化する");
+    }
+
+    [AvaloniaTest]
+    public async Task ImportVideoWithAudioTrack_CreatesBothProducedElements()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("videoaudio-prepare");
+        RegisterImportDecoder();
+        string path = CreateImportFile("prepared", withAudio: true);
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        ElementAddResult result = await adder.AddAsync(
+        [
+            new ElementDescription(
+                Start: TimeSpan.Zero,
+                Length: TimeSpan.FromSeconds(5),
+                Layer: 0,
+                Source: new ElementSource.File(path)),
+        ], CancellationToken.None);
+        HeadlessTestHelpers.Settle();
+
+        IReadOnlyList<Element> created = result.Elements;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Items, Has.Count.EqualTo(1));
+            Assert.That(result.Items[0].CompanionElements, Has.Count.EqualTo(1));
+            Assert.That(created, Has.Count.EqualTo(2));
+            Assert.That(
+                created.Select(element => element.Objects.Single().GetType()),
+                Is.EqualTo(new[] { typeof(SourceVideo), typeof(SourceSound) }));
+        }
+    }
+
+    [AvaloniaTest, NonParallelizable]
+    public async Task ImportVideoWithAudioTrack_ReleasesVideoResourceWhenCompanionCreationFails()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("videoaudio-companion-failure");
+        RegisterImportDecoder();
+        string path = CreateImportFile("companion-failure", withAudio: true);
+        var adder = (ElementAdderImpl)editor.GetService(typeof(IElementAdder))!;
+        adder.BeforeCompanionAudioMaterialization = () =>
+            throw new InvalidOperationException("companion creation failed");
+
+        try
+        {
+            ElementAddResult result = await adder.AddAsync(
+            [
+                new ElementDescription(
+                    TimeSpan.Zero,
+                    TimeSpan.FromSeconds(5),
+                    0,
+                    new ElementSource.File(path)),
+            ], CancellationToken.None);
+            RenderThread.Dispatcher.Invoke(static () => { }, DispatchPriority.Low);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Failure, Is.TypeOf<ElementMaterializationFailure>());
+                Assert.That(result.Elements, Is.Empty);
+                Assert.That(editor.Scene.Children, Is.Empty);
+                Assert.That(ImportTestReader.ActiveCount, Is.Zero);
+            });
+        }
+        finally
+        {
+            adder.BeforeCompanionAudioMaterialization = null;
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ImportVideoWithAudioTrack_WhenCompanionLayerIsLocked_RefusesEntireImport()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("videoaudio-locked-companion");
+        RegisterImportDecoder();
+        string path = CreateImportFile("locked", withAudio: true);
+        using (editor.HistoryManager.SuppressRecording())
+        {
+            editor.Scene.Layers.Add(new TimelineLayer { ZIndex = 1, IsLocked = true });
+        }
+
+        string sceneDirectory = Path.GetDirectoryName(editor.Scene.Uri!.LocalPath)!;
+        string[] filesBefore = Directory.GetFiles(sceneDirectory, "*.belm", SearchOption.AllDirectories);
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        ElementAddResult result = await adder.AddAsync([
+            new ElementDescription(
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(5),
+                Layer: 0,
+                Source: new ElementSource.File(path)),
+        ], CancellationToken.None);
+        HeadlessTestHelpers.Settle();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Failure, Is.TypeOf<LockedElementLayerFailure>());
+            Assert.That(((LockedElementLayerFailure)result.Failure!).Layer, Is.EqualTo(1));
+            Assert.That(result.Elements, Is.Empty);
+            Assert.That(editor.Scene.Children, Is.Empty);
+            Assert.That(editor.Scene.Groups, Is.Empty);
+            Assert.That(editor.HistoryManager.HasPendingOperations, Is.False);
+            Assert.That(editor.HistoryManager.UndoCount, Is.Zero);
+            Assert.That(
+                Directory.GetFiles(sceneDirectory, "*.belm", SearchOption.AllDirectories),
+                Is.EqualTo(filesBefore));
+        }
     }
 
     private static void RegisterImportDecoder()
@@ -158,11 +270,15 @@ public class VideoFileImportTests
     // reader was not created with the corresponding stream, exactly like FFmpegReaderProxy.
     private sealed class ImportTestReader : MediaReader
     {
+        private int _disposed;
         private readonly VideoStreamInfo? _videoInfo;
         private readonly AudioStreamInfo? _audioInfo;
 
+        public static int ActiveCount;
+
         public ImportTestReader(bool hasVideo, bool hasAudio)
         {
+            Interlocked.Increment(ref ActiveCount);
             HasVideo = hasVideo;
             HasAudio = hasAudio;
             if (hasVideo)
@@ -201,6 +317,13 @@ public class VideoFileImportTests
         {
             sound = null;
             return false;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+                Interlocked.Decrement(ref ActiveCount);
+            base.Dispose(disposing);
         }
     }
 }

--- a/tests/Beutl.PublicApiContractTests/Beutl.PublicApiContractTests.csproj
+++ b/tests/Beutl.PublicApiContractTests/Beutl.PublicApiContractTests.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Refit" />
   </ItemGroup>
 
   <ItemGroup>
@@ -22,6 +23,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Beutl.Engine\Beutl.Engine.csproj" />
+    <ProjectReference Include="..\..\src\Beutl.Extensibility\Beutl.Extensibility.csproj" />
+    <ProjectReference Include="..\..\src\Beutl.Api\Beutl.Api.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Editor\Beutl.Editor.csproj" />
     <!-- Match the analyzer reference used by out-of-tree plugins. -->
     <ProjectReference Include="..\..\src\Beutl.Engine.SourceGenerators\Beutl.Engine.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />

--- a/tests/Beutl.PublicApiContractTests/ExtensionAndCaptionAuthoringContractTests.cs
+++ b/tests/Beutl.PublicApiContractTests/ExtensionAndCaptionAuthoringContractTests.cs
@@ -1,0 +1,520 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Beutl.Api.Services;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Editor.Services.AI;
+using Beutl.Editor.Services.Captions;
+using Beutl.Extensibility;
+using Beutl.Graphics;
+
+namespace Beutl.PublicApiContractTests;
+
+public sealed class ExtensionAndCaptionAuthoringContractTests
+{
+    [Test]
+    public void ExtensionProviderSurface_ExposesMetadataAndLeaseOnly()
+    {
+        Type provider = typeof(IExtensionProvider);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(provider.GetProperty(nameof(IExtensionProvider.Extensions)), Is.Not.Null);
+            Assert.That(provider.GetEvent(nameof(IExtensionProvider.ExtensionsChanged)), Is.Not.Null);
+            Assert.That(provider.GetProperty("AllExtensions"), Is.Null);
+            Assert.That(provider.GetMethod("GetExtensions"), Is.Null);
+            Assert.That(provider.GetMethod("MatchEditorExtension"), Is.Null);
+            Assert.That(typeof(ExtensionProvider).GetProperty("AllExtensions"), Is.Null);
+            Assert.That(typeof(ExtensionProvider).GetMethod("GetExtensions"), Is.Null);
+            Assert.That(
+                typeof(ExtensionDescriptor).GetProperties().Select(property => property.PropertyType),
+                Does.Not.Contain(typeof(Type)).And.Not.Contain(typeof(Extension)));
+            Assert.That(
+                typeof(ElementSourceHandlerDescriptor).GetProperties()
+                    .Select(property => property.PropertyType),
+                Does.Not.Contain(typeof(Type)).And.Not.Contain(typeof(IElementSourceHandler)));
+        }
+    }
+
+    [Test]
+    public async Task CaptionCatalogSurface_DoesNotExposeMutableRegistries()
+    {
+        await using CaptionCatalog catalog = CaptionCatalog.CreateDefault("Default");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(catalog.Codecs, Is.InstanceOf<ICaptionCodecProvider>());
+            Assert.That(catalog.Codecs, Is.Not.InstanceOf<CaptionCodecRegistry>());
+            Assert.That(catalog.Templates, Is.InstanceOf<ICaptionTemplateProvider>());
+            Assert.That(catalog.Templates, Is.Not.InstanceOf<CaptionTemplateRegistry>());
+            Assert.That(typeof(CaptionDocumentSerializer).GetProperty("Codecs"), Is.Null);
+        }
+    }
+
+    [Test]
+    public async Task CaptionCodecCapabilities_CanBeRegisteredIndependently()
+    {
+        var format = new CaptionFormatId("vendor.caption");
+        var codec = new CustomCaptionCodec();
+        var descriptorRegistration = new CaptionCodecDescriptorRegistration(
+            new CaptionCodecDescriptor(format, [".vendor-caption"]));
+        var decoderRegistration = new CaptionDecoderRegistration(format, codec);
+        var encoderRegistration = new CaptionEncoderRegistration(format, codec);
+        var descriptorExtension = new CustomCaptionCodecDescriptorExtension(
+            descriptorRegistration);
+        var decoderExtension = new CustomCaptionDecoderExtension(decoderRegistration);
+        var encoderExtension = new CustomCaptionEncoderExtension(encoderRegistration);
+        await using var registry = new CaptionCodecRegistry();
+        await using ICaptionCodecDescriptorRegistration descriptor = registry.Register(
+            descriptorRegistration);
+        await using ICaptionDecoderRegistration decoder = registry.Register(
+            decoderRegistration);
+        await using ICaptionEncoderRegistration encoder = registry.Register(
+            encoderRegistration);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(registry.Codecs.Single().CanDecode, Is.True);
+            Assert.That(registry.Codecs.Single().CanEncode, Is.True);
+            Assert.That(descriptorExtension.Registrations.Single(),
+                Is.SameAs(descriptorRegistration));
+            Assert.That(decoderExtension.Registrations.Single(),
+                Is.SameAs(decoderRegistration));
+            Assert.That(encoderExtension.Registrations.Single(),
+                Is.SameAs(encoderRegistration));
+            Assert.That(
+                Enum.GetValues<CaptionCodecRegistrationMode>(),
+                Is.EqualTo(new[]
+                {
+                    CaptionCodecRegistrationMode.Add,
+                    CaptionCodecRegistrationMode.Replace,
+                }));
+            Assert.That(typeof(CaptionCodecRegistry).Assembly.GetType(
+                "Beutl.Editor.Services.Captions.CaptionCodecContribution"), Is.Null);
+            Assert.That(typeof(CaptionCodecRegistry).Assembly.GetType(
+                "Beutl.Editor.Services.Captions.CaptionCodecRegistration"), Is.Null);
+            Assert.That(typeof(CaptionCodecRegistry).Assembly.GetType(
+                "Beutl.Editor.Services.Captions.CaptionCodecExtension"), Is.Null);
+        }
+    }
+
+    [Test]
+    public async Task CustomElementSource_CanDelegateLengthToItsHandler()
+    {
+        var handler = new CustomSourceHandler();
+        await using var registry = new ElementSourceHandlerRegistry();
+        await using IElementSourceHandlerRegistration registration = registry.Register(
+            new ElementSourceHandlerRegistration(handler));
+        var description = new ElementDescription(
+            TimeSpan.Zero,
+            null,
+            0,
+            new CustomSource());
+
+        Assert.That(description.Length, Is.Null);
+        Assert.That(registry.Handlers, Is.SameAs(registry.Handlers));
+        Assert.That(registry.Handlers.Single().SourceTypeName, Is.EqualTo(typeof(CustomSource).AssemblyQualifiedName));
+        Assert.That(registry.TryAcquire(typeof(CustomSource), out IElementSourceHandlerLease? lease), Is.True);
+        using (lease)
+        {
+            Assert.That(lease!.Handler, Is.SameAs(handler));
+        }
+    }
+
+    [Test]
+    public void MetadataTypes_CanBeCreatedByExternalProviderImplementations()
+    {
+        var extension = new ExtensionDescriptor(
+            new ExtensionId(Guid.NewGuid()),
+            "Example.Extension, Example.Package");
+        IExtensionProvider provider = new MetadataExtensionProvider(extension);
+        var handler = new ElementSourceHandlerDescriptor(
+            "Example.Source, Example.Package",
+            order: 10);
+        var captionFormat = new CaptionFormatId("example");
+        var codecDescriptor = new CaptionCodecDescriptor(
+            captionFormat,
+            [".example"],
+            order: 20);
+        var codec = new CaptionCodecInfo(
+            captionFormat,
+            [".example"],
+            canDecode: true,
+            canEncode: false,
+            order: 20);
+        var template = new CaptionTemplateDescriptor(
+            new CaptionTemplateId("example.template"),
+            new CaptionTemplateProviderId("example"),
+            "Example template",
+            order: 30);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(provider.Extensions.Single(), Is.SameAs(extension));
+            Assert.That(handler.SourceTypeName, Is.EqualTo("Example.Source, Example.Package"));
+            Assert.That(codecDescriptor.Order, Is.EqualTo(20));
+            Assert.That(codec.FileExtensions, Is.EqualTo(new[] { ".example" }));
+            Assert.That(template.Name, Is.EqualTo("Example template"));
+        }
+    }
+
+    [Test]
+    public void CustomFixedAvailabilityOperation_PreservesTheOpenOperationAndModelIds()
+    {
+        var operation = new AiOperationId("vendor.custom");
+        var model = new AiModelId("vendor-model");
+        var request = new AiOperationAvailabilityRequest.Fixed(operation, model);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(request.Operation, Is.EqualTo(operation));
+            Assert.That(request.Model, Is.EqualTo(model));
+            Assert.Throws<ArgumentException>(() =>
+                new AiOperationAvailabilityRequest.Fixed(default));
+        }
+    }
+
+    [Test]
+    public void CustomVariableAvailabilityOperations_PreserveTheOpenOperationIdsAndQuantities()
+    {
+        var model = new AiModelId("vendor-model");
+        var video = new AiOperationAvailabilityRequest.Video(
+            new AiOperationId("vendor.video"),
+            4,
+            model);
+        var transcription = new AiOperationAvailabilityRequest.Transcription(
+            new AiOperationId("vendor.transcription"),
+            1.5,
+            model);
+        var translation = new AiOperationAvailabilityRequest.Translation(
+            new AiOperationId("vendor.translation"),
+            123,
+            model);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(video.Operation.Value, Is.EqualTo("vendor.video"));
+            Assert.That(video.DurationSeconds, Is.EqualTo(4));
+            Assert.That(video.Model, Is.EqualTo(model));
+            Assert.That(transcription.Operation.Value, Is.EqualTo("vendor.transcription"));
+            Assert.That(transcription.DurationSeconds, Is.EqualTo(1.5));
+            Assert.That(transcription.Model, Is.EqualTo(model));
+            Assert.That(translation.Operation.Value, Is.EqualTo("vendor.translation"));
+            Assert.That(translation.CharacterCount, Is.EqualTo(123));
+            Assert.That(translation.Model, Is.EqualTo(model));
+        }
+    }
+
+    [Test]
+    public async Task AiJobResultCapabilities_CanBeRegisteredAndResolvedIndependently()
+    {
+        var kind = new AiJobKindId("vendor.result");
+        var capabilities = new CustomAiJobResultCapabilities();
+        await using var registry = new AiJobResultRegistry(
+            [new AiJobPresentationRegistration(kind, capabilities)],
+            [new AiJobCompletionRegistration(kind, capabilities)],
+            [new AiJobResultApplicatorRegistration(kind, capabilities)]);
+
+        Assert.That(registry.TryAcquirePresenter(kind, out IAiJobPresenterLease? presenter), Is.True);
+        using (presenter)
+        {
+            Assert.That(presenter!.Presenter, Is.SameAs(capabilities));
+        }
+
+        Assert.That(registry.TryAcquireCompletionPresenter(
+            kind,
+            out IAiJobCompletionPresenterLease? completion), Is.True);
+        using (completion)
+        {
+            Assert.That(completion!.Presenter, Is.SameAs(capabilities));
+        }
+
+        Assert.That(registry.TryAcquireApplicator(
+            kind,
+            out IAiJobResultApplicatorLease? applicator), Is.True);
+        using (applicator)
+        {
+            Assert.That(applicator!.Applicator, Is.SameAs(capabilities));
+        }
+
+        Assert.That(
+            typeof(AiJobResultRegistry).Assembly.GetType(
+                "Beutl.Editor.Services.AI.IAiJobResultHandler"),
+            Is.Null);
+    }
+
+    [Test]
+    public void CustomOperations_SelectSupportedCapabilitySchemas()
+    {
+        var operation = new AiOperationId("vendor.video");
+        var imageOperation = new AiOperationId("vendor.image");
+        var registration = new AiOperationCapabilitySchemaRegistration(
+            operation,
+            AiModelCapabilitySchema.Video);
+        var extension = new CustomCapabilitySchemaExtension(registration);
+        var catalog = new AiModelCatalog(
+            [],
+            capabilitySchemas:
+            [
+                KeyValuePair.Create(operation, AiModelCapabilitySchema.Video),
+                KeyValuePair.Create(imageOperation, AiModelCapabilitySchema.Image),
+            ],
+            imageReferenceLimits:
+            [
+                KeyValuePair.Create(imageOperation, new AiImageReferenceLimits(12 * 1024 * 1024)),
+            ]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(extension.Registrations.Single(), Is.SameAs(registration));
+            Assert.That(catalog.GetCapabilitySchema(operation),
+                Is.EqualTo(AiModelCapabilitySchema.Video));
+            Assert.That(catalog.GetCapabilitySchema(new AiOperationId("vendor.generic")),
+                Is.EqualTo(AiModelCapabilitySchema.Generic));
+            Assert.That(catalog.GetImageReferenceLimits(imageOperation).MaxTotalBytes,
+                Is.EqualTo(12 * 1024 * 1024));
+            Assert.That(
+                Enum.GetValues<AiModelCapabilitySchema>(),
+                Is.EqualTo(new[]
+                {
+                    AiModelCapabilitySchema.Generic,
+                    AiModelCapabilitySchema.Image,
+                    AiModelCapabilitySchema.Video,
+                }));
+            Assert.That(typeof(AiModelCatalog).Assembly.GetType(
+                "Beutl.Api.Services.AiModelCapabilitySchemaId"), Is.Null);
+        }
+    }
+
+    [Test]
+    public async Task AiJobBehaviors_CanBeRegisteredAndLeasedIndependently()
+    {
+        var kind = new AiJobKindId("vendor.job");
+        var behavior = new CustomAiJobBehavior();
+        await using var registry = new AiJobKindRegistry(
+            [new AiJobStatusResolverRegistration(kind, behavior)],
+            [new AiJobRefreshHandlerRegistration(kind, behavior)],
+            [new AiJobRetryHandlerRegistration(kind, behavior)]);
+
+        Assert.That(registry.TryAcquireStatusResolver(
+            kind,
+            out IAiJobStatusResolverLease? status), Is.True);
+        Assert.That(registry.TryAcquireRefreshHandler(
+            kind,
+            out IAiJobRefreshHandlerLease? refresh), Is.True);
+        Assert.That(registry.TryAcquireRetryHandler(
+            kind,
+            out IAiJobRetryHandlerLease? retry), Is.True);
+        using (status)
+        using (refresh)
+        using (retry)
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(status!.Resolver, Is.SameAs(behavior));
+            Assert.That(refresh!.Handler, Is.SameAs(behavior));
+            Assert.That(retry!.Handler, Is.SameAs(behavior));
+            Assert.That(typeof(AiJobKindRegistry).Assembly.GetType(
+                "Beutl.Api.Services.AiJobKindDescriptor"), Is.Null);
+            Assert.That(typeof(AiJobKindRegistry).Assembly.GetType(
+                "Beutl.Api.Services.AiJobKindExtension"), Is.Null);
+            Assert.That(typeof(AiJobKindRegistry).Assembly.GetType(
+                "Beutl.Api.Services.AiJobKindRegistrationMode"), Is.Null);
+            Assert.That(typeof(AiJobKindRegistry).Assembly.GetType(
+                "Beutl.Api.Services.IAiJobKindRegistration"), Is.Null);
+            Assert.That(typeof(AiJobKindRegistry).Assembly.GetType(
+                "Beutl.Api.Services.IAiJobKindLease"), Is.Null);
+        }
+    }
+
+    [Test]
+    public async Task CaptionTemplateCapabilities_ComposeWithoutExposingSourcesToPlacement()
+    {
+        var id = new CaptionTemplateId("vendor.caption");
+        var factory = new CustomCaptionFactory();
+        var placement = new CustomCaptionPlacement();
+        var registrations = new CaptionTemplateRegistrationSet(
+            new CaptionTemplateDescriptorRegistration(new CaptionTemplateDescriptor(
+                id,
+                new CaptionTemplateProviderId("vendor"),
+                "Vendor caption")),
+            new CaptionElementFactoryRegistration(id, factory),
+            new CaptionPlacementPolicyRegistration(id, placement));
+        await using var registry = new CaptionTemplateRegistry(
+            [registrations.DescriptorRegistration],
+            [registrations.ElementFactoryRegistration],
+            [registrations.PlacementPolicyRegistration]);
+        using CaptionTemplateLease lease = registry.Acquire(id);
+
+        ElementDescription result = lease.CreateElements(
+            new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "text"),
+            new CaptionElementContext(2, "Caption")).Single();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Source, Is.SameAs(factory.Source));
+            Assert.That(result.Layer, Is.EqualTo(8));
+            Assert.That(result.Position, Is.EqualTo(new Point(10, 20)));
+            Assert.That(
+                typeof(CaptionElementPlacement).GetProperties()
+                    .Select(property => property.PropertyType),
+                Does.Not.Contain(typeof(ElementSource)));
+            Assert.That(typeof(CaptionTemplateRegistry).Assembly.GetType(
+                "Beutl.Editor.Services.Captions.CaptionTemplateContribution"), Is.Null);
+            Assert.That(typeof(CaptionTemplateRegistry).Assembly.GetType(
+                "Beutl.Editor.Services.Captions.CaptionTemplateRegistration"), Is.Null);
+            Assert.That(typeof(CaptionTemplateRegistry).Assembly.GetType(
+                "Beutl.Editor.Services.Captions.CaptionTemplateExtension"), Is.Null);
+        }
+    }
+
+    private sealed record CustomSource : ElementSource;
+
+    private sealed class CustomCapabilitySchemaExtension(
+        params AiOperationCapabilitySchemaRegistration[] registrations)
+        : AiOperationCapabilitySchemaExtension
+    {
+        public override IReadOnlyCollection<AiOperationCapabilitySchemaRegistration> Registrations
+        { get; } = registrations;
+    }
+
+    private sealed class MetadataExtensionProvider(ExtensionDescriptor descriptor) : IExtensionProvider
+    {
+        public event EventHandler? ExtensionsChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public IReadOnlyList<ExtensionDescriptor> Extensions { get; } = [descriptor];
+
+        public IReadOnlyList<ExtensionDescriptor> GetDescriptors<TExtension>()
+            where TExtension : Extension
+            => Extensions;
+
+        public bool TryAcquire<TExtension>(
+            ExtensionId id,
+            [NotNullWhen(true)] out IExtensionLease<TExtension>? lease)
+            where TExtension : Extension
+        {
+            lease = null;
+            return false;
+        }
+    }
+
+    private sealed class CustomSourceHandler : IElementSourceHandler
+    {
+        public Type SourceType => typeof(CustomSource);
+
+        public ValueTask<ElementSourcePreflightResult> PreflightAsync(
+            ElementSourcePreflightContext context,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public ValueTask<ElementSourceMaterializationResult> MaterializeAsync(
+            ElementSourceMaterializationContext context,
+            IElementSourcePreflight preflight,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class CustomAiJobResultCapabilities :
+        IAiJobPresenter,
+        IAiJobCompletionPresenter,
+        IAiJobResultApplicator
+    {
+        public AiJobPresentation Present(AiJob job, AiJobStatusSemantics status)
+            => new("Vendor", "Ready", "Result", string.Empty, false);
+
+        public AiJobCompletionPresentation? CreateCompletion(
+            AiJob job,
+            AiJobStatusSemantics status)
+            => null;
+
+        public bool CanApply(AiJob job, AiJobStatusSemantics status) => true;
+
+        public Task ApplyAsync(
+            AiJob job,
+            IAiJobResultContext context,
+            CancellationToken cancellationToken)
+            => Task.CompletedTask;
+    }
+
+    private sealed class CustomAiJobBehavior :
+        IAiJobStatusResolver,
+        IAiJobRefreshHandler,
+        IAiJobRetryHandler
+    {
+        public AiJobStatusSemantics Resolve(AiJobStatusId status)
+            => AiJobStatusSemantics.Unknown;
+
+        public Task RefreshAsync(AiJob job, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public bool CanRetry(AiJob job, AiJobStatusSemantics status) => false;
+
+        public ValueTask<AiJobRetryPreflight> GetPreflightAsync(
+            AiJob job,
+            CancellationToken cancellationToken)
+            => ValueTask.FromResult(new AiJobRetryPreflight(false, false, "unavailable"));
+
+        public ValueTask<AiJobRetryPreparationResult> PrepareAsync(
+            AiJob job,
+            CancellationToken cancellationToken)
+            => ValueTask.FromResult(AiJobRetryPreparationResult.Blocked("unavailable"));
+    }
+
+    private sealed class CustomCaptionFactory : ICaptionElementFactory
+    {
+        public ElementSource Source { get; } =
+            new ElementSource.EngineObject(() => new Beutl.Graphics.Shapes.TextBlock());
+
+        public IReadOnlyList<ElementDescription> CreateElements(
+            CaptionCue cue,
+            CaptionElementContext context)
+            => [new ElementDescription(cue.Start, cue.End - cue.Start, context.Layer, Source)];
+    }
+
+    private sealed class CustomCaptionPlacement : ICaptionPlacementPolicy
+    {
+        public CaptionElementPlacement Place(
+            CaptionCue cue,
+            CaptionElementContext context,
+            CaptionElementPlacement placement,
+            int elementIndex)
+            => placement with { Layer = 8, Position = new Point(10, 20) };
+    }
+
+    private sealed class CustomCaptionCodec : ICaptionDecoder, ICaptionEncoder
+    {
+        public CaptionImportResult Decode(string content)
+            => CaptionImportResult.Imported(new CaptionDocument(
+            [
+                new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), content),
+            ]));
+
+        public string Encode(CaptionDocument document) => document[0].Text;
+    }
+
+    private sealed class CustomCaptionCodecDescriptorExtension(
+        params CaptionCodecDescriptorRegistration[] registrations)
+        : CaptionCodecDescriptorExtension
+    {
+        public override IReadOnlyCollection<CaptionCodecDescriptorRegistration> Registrations
+        { get; } = registrations;
+    }
+
+    private sealed class CustomCaptionDecoderExtension(
+        params CaptionDecoderRegistration[] registrations)
+        : CaptionDecoderExtension
+    {
+        public override IReadOnlyCollection<CaptionDecoderRegistration> Registrations
+        { get; } = registrations;
+    }
+
+    private sealed class CustomCaptionEncoderExtension(
+        params CaptionEncoderRegistration[] registrations)
+        : CaptionEncoderExtension
+    {
+        public override IReadOnlyCollection<CaptionEncoderRegistration> Registrations
+        { get; } = registrations;
+    }
+}

--- a/tests/Beutl.UnitTests/Api/AiAvailabilityContractTests.cs
+++ b/tests/Beutl.UnitTests/Api/AiAvailabilityContractTests.cs
@@ -1,0 +1,158 @@
+﻿using System.Collections.Immutable;
+using System.Text.Json;
+using Beutl.Api.Clients;
+
+namespace Beutl.UnitTests.Api;
+
+// The server never sends its price catalog. It reports which operations may be
+// started and monthly usage as a proportion.
+[TestFixture]
+public sealed class AiAvailabilityContractTests
+{
+    private const string BalanceJson = """
+        "balance": {
+          "monthlyUsage": {
+            "usedPercent": 10,
+            "remainingPercent": 90,
+            "isExhausted": false
+          },
+          "additionalCredits": 0,
+          "hasAdditionalCreditDebt": false
+        }
+        """;
+
+    [Test]
+    public void EntitlementsWithoutAvailability_AreRejectedInsteadOfUsingClientFallbacks()
+    {
+        string json = $$"""
+            {
+              "plan": "pro",
+              "subscriptionStatus": "active",
+              "currentPeriodStart": "2026-08-01T00:00:00Z",
+              "currentPeriodEnd": "2026-09-01T00:00:00Z",
+              "cancelAtPeriodEnd": false,
+              "canUseAi": true,
+              {{BalanceJson}}
+            }
+            """;
+
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<EntitlementsResponse>(json));
+    }
+
+    [Test]
+    public void ServerAvailability_DeserializesIntoAnImmutableMap()
+    {
+        string json = $$"""
+            {
+              "plan": "pro",
+              "subscriptionStatus": "active",
+              "currentPeriodStart": "2026-08-01T00:00:00Z",
+              "currentPeriodEnd": "2026-09-01T00:00:00Z",
+              "cancelAtPeriodEnd": false,
+              "canUseAi": true,
+              {{BalanceJson}},
+              "availability": {
+                "image.generate": true,
+                "video.generate": false
+              }
+            }
+            """;
+
+        EntitlementsResponse? result = JsonSerializer.Deserialize<EntitlementsResponse>(json);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.Not.Null);
+            Assert.That(
+                result!.Availability,
+                Is.InstanceOf<ImmutableDictionary<string, bool>>());
+            Assert.That(result.Availability["image.generate"], Is.True);
+            Assert.That(result.Availability["video.generate"], Is.False);
+        });
+    }
+
+    [Test]
+    public void AProportionOutsideZeroToOneHundred_FailsClosed()
+    {
+        var response = new EntitlementsResponse
+        {
+            Plan = "pro",
+            SubscriptionStatus = "active",
+            CurrentPeriodStart = null,
+            CurrentPeriodEnd = null,
+            CanUseAi = true,
+            Balance = new AiBalanceResponse
+            {
+                MonthlyUsage = new AiMonthlyUsageResponse
+                {
+                    UsedPercent = 120,
+                    RemainingPercent = 0,
+                    IsExhausted = true,
+                },
+                AdditionalCredits = 0,
+            },
+            Availability = ImmutableDictionary<string, bool>.Empty,
+        };
+
+        Assert.That(response.TryNormalize(out _), Is.False);
+    }
+
+    [Test]
+    public void ANegativeCreditBalance_FailsClosed()
+    {
+        var response = new EntitlementsResponse
+        {
+            Plan = "pro",
+            SubscriptionStatus = "active",
+            CurrentPeriodStart = null,
+            CurrentPeriodEnd = null,
+            CanUseAi = true,
+            Balance = new AiBalanceResponse
+            {
+                MonthlyUsage = new AiMonthlyUsageResponse
+                {
+                    UsedPercent = 0,
+                    RemainingPercent = 100,
+                    IsExhausted = false,
+                },
+                AdditionalCredits = -1,
+            },
+            Availability = ImmutableDictionary<string, bool>.Empty,
+        };
+
+        Assert.That(response.TryNormalize(out _), Is.False);
+    }
+
+    [Test]
+    public void AValidResponse_NormalizesSuccessfully()
+    {
+        var response = new EntitlementsResponse
+        {
+            Plan = "pro",
+            SubscriptionStatus = "active",
+            CurrentPeriodStart = null,
+            CurrentPeriodEnd = null,
+            CancelAtPeriodEnd = true,
+            CanUseAi = true,
+            Balance = new AiBalanceResponse
+            {
+                MonthlyUsage = new AiMonthlyUsageResponse
+                {
+                    UsedPercent = 40,
+                    RemainingPercent = 60,
+                    IsExhausted = false,
+                },
+                AdditionalCredits = 25,
+            },
+            Availability = ImmutableDictionary<string, bool>.Empty
+                .Add("image.generate", true),
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(response.TryNormalize(out EntitlementsResponse? normalized), Is.True);
+            Assert.That(normalized!.CancelAtPeriodEnd, Is.True);
+            Assert.That(normalized.Balance.AdditionalCredits, Is.EqualTo(25));
+        });
+    }
+}

--- a/tests/Beutl.UnitTests/Api/AiErrorConverterTests.cs
+++ b/tests/Beutl.UnitTests/Api/AiErrorConverterTests.cs
@@ -1,0 +1,145 @@
+﻿using System.Diagnostics;
+using System.Net;
+using System.Text;
+using Beutl.Api.Clients;
+using Beutl.Api.Services;
+using Refit;
+
+namespace Beutl.UnitTests.Api;
+
+[TestFixture]
+public sealed class AiErrorConverterTests
+{
+    [TestCase("authenticationIsRequired", typeof(AuthenticationRequiredException))]
+    [TestCase("aiPlanRequired", typeof(AiPlanRequiredException))]
+    [TestCase("aiUsageLimitExceeded", typeof(AiUsageLimitExceededException))]
+    [TestCase("fileIsTooLarge", typeof(AiFileTooLargeException))]
+    [TestCase("aiProviderError", typeof(AiProviderErrorException))]
+    [TestCase("aiJobNotFound", typeof(AiJobNotFoundException))]
+    [TestCase("aiJobIsActive", typeof(AiJobIsActiveException))]
+    [TestCase("aiJobLimitReached", typeof(AiJobLimitReachedException))]
+    [TestCase("aiRequestInProgress", typeof(AiRequestInProgressException))]
+    [TestCase("aiRequestWasDeleted", typeof(AiRequestWasDeletedException))]
+    public async Task ConvertAsync_MapsEveryKnownAiError(
+        string errorCode,
+        Type expectedType)
+    {
+        ApiException source = await CreateApiException($$"""
+            {
+              "error_code": "{{errorCode}}",
+              "message": "Server message",
+              "documentation_url": null
+            }
+            """);
+        using var activity = new Activity("test").Start();
+
+        AiException result = await AiErrorConverter.ConvertAsync(source, activity);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.TypeOf(expectedType));
+            Assert.That(result.InnerException, Is.SameAs(source));
+            Assert.That(activity.Status, Is.EqualTo(ActivityStatusCode.Error));
+            if (result is AuthenticationRequiredException authentication)
+            {
+                Assert.That(
+                    authentication.CurrentAttemptReservationIsKnownAbsent,
+                    Is.True);
+            }
+        }
+    }
+
+    [TestCase("unknown")]
+    [TestCase("doNotHavePermissions")]
+    public async Task ConvertAsync_UsesServerMessageForUnmappedCodes(string errorCode)
+    {
+        ApiException source = await CreateApiException($$"""
+            {
+              "error_code": "{{errorCode}}",
+              "message": "A safe server message",
+              "documentation_url": null
+            }
+            """);
+
+        AiException result = await AiErrorConverter.ConvertAsync(source, null);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.TypeOf<AiException>());
+            Assert.That(result.Message, Is.EqualTo("A safe server message"));
+            Assert.That(result.InnerException, Is.SameAs(source));
+        }
+    }
+
+    [TestCase("{not-json")]
+    [TestCase("{\"error_code\":\"futureAiError\",\"message\":\"Future\"}")]
+    public async Task ConvertAsync_MalformedOrUnknownPayloadPreservesApiException(
+        string content)
+    {
+        ApiException source = await CreateApiException(content);
+
+        AiException result = await AiErrorConverter.ConvertAsync(source, null);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.TypeOf<AiException>());
+            Assert.That(result.InnerException, Is.SameAs(source));
+            Assert.That(result.Data[nameof(Exception)], Is.Null);
+            Assert.That(result.Data["parseException"], Is.InstanceOf<Exception>());
+        }
+    }
+
+    [Test]
+    public async Task ConvertAsync_EmptyPayloadAtBodyLimitMapsFromHttpStatus()
+    {
+        ApiException source = await CreateApiException(
+            string.Empty,
+            HttpStatusCode.RequestEntityTooLarge);
+
+        AiException result = await AiErrorConverter.ConvertAsync(source, null);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.TypeOf<AiFileTooLargeException>());
+            Assert.That(result.InnerException, Is.SameAs(source));
+        }
+    }
+
+    [Test]
+    public void Convert_StreamingAuthenticationRefusalMarksCurrentReservationAbsent()
+    {
+        AiException result = AiErrorConverter.Convert(
+            (int)HttpStatusCode.InternalServerError,
+            new ApiErrorResponse
+            {
+                ErrorCode = ApiErrorCode.AuthenticationIsRequired,
+                Message = "Sign in again.",
+                DocumentationUrl = null,
+            },
+            innerException: null);
+
+        Assert.That(result, Is.TypeOf<AuthenticationRequiredException>());
+        Assert.That(
+            ((AuthenticationRequiredException)result).CurrentAttemptReservationIsKnownAbsent,
+            Is.True);
+    }
+
+    private static async Task<ApiException> CreateApiException(
+        string content,
+        HttpStatusCode statusCode = HttpStatusCode.BadRequest)
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            "https://beutl.beditor.net/api/v3/ai/images");
+        using var response = new HttpResponseMessage(statusCode)
+        {
+            RequestMessage = request,
+            Content = new StringContent(content, Encoding.UTF8, "application/json"),
+        };
+        return await ApiException.Create(
+            request,
+            HttpMethod.Post,
+            response,
+            new RefitSettings());
+    }
+}

--- a/tests/Beutl.UnitTests/Api/AiJobKindAbstractionsTests.cs
+++ b/tests/Beutl.UnitTests/Api/AiJobKindAbstractionsTests.cs
@@ -1,0 +1,373 @@
+﻿using Beutl.Api.Services;
+using Beutl.Editor.Services.AI;
+
+namespace Beutl.UnitTests.Api;
+
+[TestFixture]
+public sealed class AiJobKindAbstractionsTests
+{
+    [Test]
+    public void PluginContracts_SeparateServerJobKindsFromEditorResultCapabilities()
+    {
+        System.Reflection.Assembly contracts = typeof(AiJobStatusResolverExtension).Assembly;
+        System.Reflection.Assembly editorContracts = typeof(IAiJobPresenter).Assembly;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(contracts.GetName().Name, Is.EqualTo("Beutl.Api"));
+            Assert.That(typeof(AiJobStatusResolverRegistration).Assembly, Is.SameAs(contracts));
+            Assert.That(typeof(AiJobRefreshHandlerRegistration).Assembly, Is.SameAs(contracts));
+            Assert.That(typeof(AiJobRetryHandlerRegistration).Assembly, Is.SameAs(contracts));
+            Assert.That(typeof(AiJobStatusSemantics).Assembly, Is.SameAs(contracts));
+            Assert.That(typeof(AiJob).Assembly, Is.SameAs(contracts));
+            Assert.That(editorContracts.GetName().Name, Is.EqualTo("Beutl.Editor"));
+            Assert.That(typeof(IAiJobCompletionPresenter).Assembly, Is.SameAs(editorContracts));
+            Assert.That(typeof(IAiJobResultApplicator).Assembly, Is.SameAs(editorContracts));
+            Assert.That(typeof(IAiJobResultContext).Assembly, Is.SameAs(editorContracts));
+            Assert.That(typeof(IAiJobResultEditorContext).Assembly, Is.SameAs(editorContracts));
+            Assert.That(typeof(AiJobKindRegistry).Assembly, Is.SameAs(contracts));
+            Assert.That(contracts.GetType("Beutl.Api.Services.AiJobKindDescriptor"), Is.Null);
+            Assert.That(contracts.GetType("Beutl.Api.Services.AiJobKindExtension"), Is.Null);
+            Assert.That(contracts.GetType("Beutl.Api.Services.AiJobKindRegistrationMode"), Is.Null);
+            Assert.That(contracts.GetType("Beutl.Api.Services.IAiJobKindRegistration"), Is.Null);
+            Assert.That(contracts.GetType("Beutl.Api.Services.IAiJobKindLease"), Is.Null);
+            Assert.That(contracts.GetType("Beutl.Api.Services.IAiJobResultHandler"), Is.Null);
+            Assert.That(editorContracts.GetType("Beutl.Editor.Services.AI.IAiJobResultHandler"), Is.Null);
+            Assert.That(contracts.GetType("Beutl.Api.Services.IAiJobResultDispatcher"), Is.Null);
+            Assert.That(contracts.GetType("Beutl.Api.Services.IAiJobPresentationProvider"), Is.Null);
+            Assert.That(contracts.GetType("Beutl.Api.Services.IAiJobCompletionHandler"), Is.Null);
+            Assert.That(contracts.GetType("Beutl.Api.Services.AiJobPresentation"), Is.Null);
+            Assert.That(contracts.GetType("Beutl.Api.Services.AiJobCompletionPresentation"), Is.Null);
+            Assert.That(
+                typeof(IAiJobRetryHandler)
+                    .GetMethods()
+                    .SelectMany(method => method.GetParameters())
+                    .Select(parameter => parameter.ParameterType),
+                Does.Not.Contain(typeof(IServiceProvider)));
+        }
+    }
+
+    [Test]
+    public async Task RegistryDisposalRetiresAndDrainsDirectRegistrations()
+    {
+        var registry = new AiJobKindRegistry();
+        IAiJobStatusResolverRegistration registration = registry.Register(
+            new AiJobStatusResolverRegistration(
+            new AiJobKindId("tests.direct-disposal"),
+            new AiJobStatusMap([])));
+        Assert.That(registry.TryAcquireStatusResolver(
+            new AiJobKindId("tests.direct-disposal"),
+            out IAiJobStatusResolverLease? lease), Is.True);
+
+        Task disposal = registry.DisposeAsync().AsTask();
+        Assert.That(disposal.IsCompleted, Is.False);
+
+        lease!.Dispose();
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.DoesNotThrowAsync(async () => await registration.DisposeAsync());
+    }
+
+    [Test]
+    public async Task RegistryDisposalJoinsAConcurrentDirectRegistrationRetirement()
+    {
+        var registry = new AiJobKindRegistry();
+        IAiJobStatusResolverRegistration registration = registry.Register(
+            new AiJobStatusResolverRegistration(
+            new AiJobKindId("tests.concurrent-direct-disposal"),
+            new AiJobStatusMap([])));
+        Assert.That(registry.TryAcquireStatusResolver(
+            new AiJobKindId("tests.concurrent-direct-disposal"),
+            out IAiJobStatusResolverLease? lease), Is.True);
+
+        Task registrationDisposal = registration.DisposeAsync().AsTask();
+        Assert.That(registrationDisposal.IsCompleted, Is.False);
+        Task registryDisposal = registry.DisposeAsync().AsTask();
+        Assert.That(registryDisposal.IsCompleted, Is.False);
+
+        lease!.Dispose();
+        await Task.WhenAll(registrationDisposal, registryDisposal)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ResultRegistryDisposalJoinsAConcurrentApplicatorRetirement()
+    {
+        var registry = new AiJobResultRegistry([], [], []);
+        IAiJobResultApplicatorRegistration registration = registry.Register(
+            new AiJobResultApplicatorRegistration(
+                new AiJobKindId("tests.concurrent-result-disposal"),
+                new TestCapabilities("application")));
+        Assert.That(registry.TryAcquireApplicator(
+            new AiJobKindId("tests.concurrent-result-disposal"),
+            out IAiJobResultApplicatorLease? lease), Is.True);
+
+        Task registrationDisposal = registration.DisposeAsync().AsTask();
+        Assert.That(registrationDisposal.IsCompleted, Is.False);
+        Task registryDisposal = registry.DisposeAsync().AsTask();
+        Assert.That(registryDisposal.IsCompleted, Is.False);
+
+        lease!.Dispose();
+        await Task.WhenAll(registrationDisposal, registryDisposal)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task PresentationAndCompletionReplaceIndependentlyOfApplication()
+    {
+        var original = new TestCapabilities("original");
+        var presentationReplacement = new TestCapabilities("presentation");
+        var completionReplacement = new TestCapabilities("completion");
+        var kind = new AiJobKindId("tests.result");
+        await using var registry = new AiJobResultRegistry(
+            [new AiJobPresentationRegistration(kind, original)],
+            [new AiJobCompletionRegistration(kind, original)],
+            [new AiJobResultApplicatorRegistration(kind, original)]);
+
+        IAiJobPresentationRegistration presentationRegistration = registry.Register(
+            new AiJobPresentationRegistration(
+                kind,
+                presentationReplacement,
+                AiJobResultRegistrationMode.Replace));
+        IAiJobCompletionRegistration completionRegistration = registry.Register(
+            new AiJobCompletionRegistration(
+                kind,
+                completionReplacement,
+                AiJobResultRegistrationMode.Replace));
+        try
+        {
+            AssertCapabilities(
+                registry,
+                kind,
+                presentationReplacement,
+                completionReplacement,
+                original);
+
+            await presentationRegistration.DisposeAsync();
+            AssertCapabilities(registry, kind, original, completionReplacement, original);
+
+            await completionRegistration.DisposeAsync();
+            AssertCapabilities(registry, kind, original, original, original);
+        }
+        finally
+        {
+            await presentationRegistration.DisposeAsync();
+            await completionRegistration.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task EachCapabilityHasIndependentCollisionSemantics()
+    {
+        var kind = new AiJobKindId("tests.independent-slots");
+        var capabilities = new TestCapabilities("base");
+        await using var registry = new AiJobResultRegistry(
+            [new AiJobPresentationRegistration(kind, capabilities)],
+            [],
+            []);
+
+        Assert.DoesNotThrow(() => registry.Register(
+            new AiJobCompletionRegistration(kind, capabilities)));
+        Assert.DoesNotThrow(() => registry.Register(
+            new AiJobResultApplicatorRegistration(kind, capabilities)));
+        Assert.Throws<ArgumentException>(() => registry.Register(
+            new AiJobPresentationRegistration(kind, capabilities)));
+        Assert.Throws<ArgumentException>(() => registry.Register(
+            new AiJobPresentationRegistration(
+                new AiJobKindId("tests.missing-slot"),
+                capabilities,
+                AiJobResultRegistrationMode.Replace)));
+    }
+
+    [Test]
+    public async Task PresenterExtensionsComposeReplacementAfterLaterBase()
+    {
+        var extensions = new ExtensionProvider();
+        var original = new TestCapabilities("original");
+        var replacement = new TestCapabilities("replacement");
+        var kind = new AiJobKindId("tests.package-result");
+        var replaceExtension = new TestPresentationExtension(
+            new AiJobPresentationRegistration(
+                kind,
+                replacement,
+                AiJobResultRegistrationMode.Replace));
+        var addExtension = new TestPresentationExtension(
+            new AiJobPresentationRegistration(kind, original));
+        await using var registry = new AiJobResultRegistry([], [], [], extensions, null);
+
+        extensions.AddExtensions(200, [replaceExtension, addExtension]);
+        AssertPresenter(registry, kind, replacement);
+
+        var unrelated = new TestPresentationExtension(
+            new AiJobPresentationRegistration(
+                new AiJobKindId("tests.unrelated-result"),
+                new TestCapabilities("unrelated")));
+        extensions.AddExtensions(201, [unrelated]);
+        AssertPresenter(registry, kind, replacement);
+
+        await extensions.RemoveExtensions(200).DrainAsync();
+        await extensions.RemoveExtensions(201).DrainAsync();
+    }
+
+    [Test]
+    public async Task RemovingPresenterExtensionActivatesRejectedPeerAndDrainsItsLease()
+    {
+        var extensions = new ExtensionProvider();
+        var failures = new List<AiJobResultExtensionFailure>();
+        var outgoing = new TestCapabilities("outgoing");
+        var waiting = new TestCapabilities("waiting");
+        var kind = new AiJobKindId("tests.handoff-result");
+        var outgoingExtension = new TestPresentationExtension(
+            new AiJobPresentationRegistration(kind, outgoing));
+        var waitingExtension = new TestPresentationExtension(
+            new AiJobPresentationRegistration(kind, waiting));
+        await using var registry = new AiJobResultRegistry([], [], [], extensions, failures.Add);
+
+        extensions.AddExtensions(203, [outgoingExtension]);
+        extensions.AddExtensions(204, [waitingExtension]);
+        Assert.That(failures, Has.Count.EqualTo(1));
+        Assert.That(registry.TryAcquirePresenter(kind, out IAiJobPresenterLease? outgoingLease), Is.True);
+
+        Task? removal = null;
+        try
+        {
+            Assert.That(outgoingLease!.Presenter, Is.SameAs(outgoing));
+            removal = extensions.RemoveExtensions(203).DrainAsync().AsTask();
+            AssertPresenter(registry, kind, waiting);
+            Assert.That(removal.IsCompleted, Is.False);
+        }
+        finally
+        {
+            outgoingLease?.Dispose();
+        }
+
+        await removal!.WaitAsync(TimeSpan.FromSeconds(5));
+        await extensions.RemoveExtensions(204).DrainAsync();
+    }
+
+    [Test]
+    public async Task FailedPresenterExtensionCompositionRollsBackItsProvisionalAdd()
+    {
+        var extensions = new ExtensionProvider();
+        var failures = new List<AiJobResultExtensionFailure>();
+        var provisional = new TestCapabilities("provisional");
+        var healthy = new TestCapabilities("healthy");
+        var kind = new AiJobKindId("tests.invalid-provisional");
+        var invalidExtension = new TestPresentationExtension(
+            new AiJobPresentationRegistration(kind, provisional),
+            new AiJobPresentationRegistration(
+                new AiJobKindId("tests.missing-replacement"),
+                provisional,
+                AiJobResultRegistrationMode.Replace));
+        var healthyExtension = new TestPresentationExtension(
+            new AiJobPresentationRegistration(kind, healthy));
+        await using var registry = new AiJobResultRegistry([], [], [], extensions, failures.Add);
+
+        extensions.AddExtensions(205, [invalidExtension, healthyExtension]);
+
+        AssertPresenter(registry, kind, healthy);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(failures, Has.Count.EqualTo(1));
+            Assert.That(failures[0].ExtensionType, Is.EqualTo(invalidExtension.GetType().FullName));
+            Assert.That(
+                failures[0].Capability,
+                Is.EqualTo(AiJobResultCapability.Presentation));
+        }
+
+        await extensions.RemoveExtensions(205).DrainAsync();
+    }
+
+    [Test]
+    public void PresentationAndCompletionExtensionsSupportLiveUnloadButApplicatorsRequireRestart()
+    {
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(new TestPresentationExtension(), Is.InstanceOf<ILiveUnloadExtension>());
+            Assert.That(new TestCompletionExtension(), Is.InstanceOf<ILiveUnloadExtension>());
+            Assert.That(new TestApplicatorExtension(), Is.Not.InstanceOf<ILiveUnloadExtension>());
+        }
+    }
+
+    private static void AssertCapabilities(
+        AiJobResultRegistry registry,
+        AiJobKindId kind,
+        IAiJobPresenter presenter,
+        IAiJobCompletionPresenter completionPresenter,
+        IAiJobResultApplicator applicator)
+    {
+        Assert.That(registry.TryAcquirePresenter(kind, out IAiJobPresenterLease? presenterLease), Is.True);
+        using (presenterLease)
+        {
+            Assert.That(presenterLease!.Presenter, Is.SameAs(presenter));
+        }
+
+        Assert.That(registry.TryAcquireCompletionPresenter(
+            kind,
+            out IAiJobCompletionPresenterLease? completionLease), Is.True);
+        using (completionLease)
+        {
+            Assert.That(completionLease!.Presenter, Is.SameAs(completionPresenter));
+        }
+
+        Assert.That(registry.TryAcquireApplicator(kind, out IAiJobResultApplicatorLease? applicatorLease), Is.True);
+        using (applicatorLease)
+        {
+            Assert.That(applicatorLease!.Applicator, Is.SameAs(applicator));
+        }
+    }
+
+    private static void AssertPresenter(
+        AiJobResultRegistry registry,
+        AiJobKindId kind,
+        IAiJobPresenter presenter)
+    {
+        Assert.That(registry.TryAcquirePresenter(kind, out IAiJobPresenterLease? lease), Is.True);
+        using (lease)
+        {
+            Assert.That(lease!.Presenter, Is.SameAs(presenter));
+        }
+    }
+
+    private sealed class TestCapabilities(string name) :
+        IAiJobPresenter,
+        IAiJobCompletionPresenter,
+        IAiJobResultApplicator
+    {
+        public AiJobPresentation Present(AiJob job, AiJobStatusSemantics status)
+            => new(name, job.Status.Value, name, string.Empty, false);
+
+        public AiJobCompletionPresentation? CreateCompletion(
+            AiJob job,
+            AiJobStatusSemantics status)
+            => new(name, name, AiJobNotificationKind.Information);
+
+        public bool CanApply(AiJob job, AiJobStatusSemantics status) => true;
+
+        public Task ApplyAsync(
+            AiJob job,
+            IAiJobResultContext context,
+            CancellationToken cancellationToken)
+            => Task.CompletedTask;
+    }
+
+    private sealed class TestPresentationExtension(
+        params AiJobPresentationRegistration[] registrations) : AiJobPresentationExtension
+    {
+        public override IReadOnlyCollection<AiJobPresentationRegistration> Registrations { get; } =
+            registrations;
+    }
+
+    private sealed class TestCompletionExtension(
+        params AiJobCompletionRegistration[] registrations) : AiJobCompletionExtension
+    {
+        public override IReadOnlyCollection<AiJobCompletionRegistration> Registrations { get; } =
+            registrations;
+    }
+
+    private sealed class TestApplicatorExtension(
+        params AiJobResultApplicatorRegistration[] registrations) : AiJobResultApplicatorExtension
+    {
+        public override IReadOnlyCollection<AiJobResultApplicatorRegistration> Registrations { get; } =
+            registrations;
+    }
+}

--- a/tests/Beutl.UnitTests/Api/AiJobRetryContractTests.cs
+++ b/tests/Beutl.UnitTests/Api/AiJobRetryContractTests.cs
@@ -1,0 +1,78 @@
+﻿using Beutl.Api.Services;
+using NUnit.Framework;
+
+namespace Beutl.UnitTests.Api;
+
+[TestFixture]
+public sealed class AiJobRetryContractTests
+{
+    [Test]
+    public async Task BlockedResultHasNoPreparationAndIsIdempotentlyDisposable()
+    {
+        AiJobRetryPreparationResult result = AiJobRetryPreparationResult.Blocked("not eligible");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsReady, Is.False);
+            Assert.That(result.Explanation, Is.EqualTo("not eligible"));
+        }
+
+        Assert.Throws<InvalidOperationException>(() => result.TakePreparation());
+        await result.DisposeAsync();
+        await result.DisposeAsync();
+    }
+
+    [Test]
+    public async Task ReadyResultTransfersPreparationOnce()
+    {
+        var preparation = new CountingPreparation();
+        AiJobRetryPreparationResult result = AiJobRetryPreparationResult.Ready(preparation);
+
+        IAiJobRetryPreparation transferred = result.TakePreparation();
+        Assert.That(transferred, Is.SameAs(preparation));
+        Assert.Throws<InvalidOperationException>(() => result.TakePreparation());
+
+        // The result no longer owns the transferred preparation.
+        await result.DisposeAsync();
+        Assert.That(preparation.DisposeCount, Is.Zero);
+        await transferred.DisposeAsync();
+        Assert.That(preparation.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task UntakenPreparationIsDisposedExactlyOnce()
+    {
+        var preparation = new CountingPreparation();
+        AiJobRetryPreparationResult result = AiJobRetryPreparationResult.Ready(preparation);
+
+        await result.DisposeAsync();
+        await result.DisposeAsync();
+
+        Assert.That(preparation.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void FactoriesRejectInvalidStates()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ArgumentException>(() => AiJobRetryPreparationResult.Blocked(""));
+            Assert.Throws<ArgumentException>(() => AiJobRetryPreparationResult.Blocked("   "));
+            Assert.Throws<ArgumentNullException>(() => AiJobRetryPreparationResult.Ready(null!));
+        });
+    }
+
+    private sealed class CountingPreparation : IAiJobRetryPreparation
+    {
+        public int DisposeCount { get; private set; }
+
+        public Task ExecuteAsync(CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Api/AiJobRetryHandlerTests.cs
+++ b/tests/Beutl.UnitTests/Api/AiJobRetryHandlerTests.cs
@@ -1,0 +1,744 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Text.Json;
+using Beutl.Api.Services;
+using Beutl.Language;
+using Moq;
+using NUnit.Framework;
+
+namespace Beutl.UnitTests.Api;
+
+/// <summary>
+/// A retry has to reproduce the job it repeats. The server records the shape it
+/// was asked for, and these cover the two ways that can go wrong: reading a key
+/// that is no longer written, and repeating a request whose upload was never
+/// retained.
+/// </summary>
+public class AiJobRetryHandlerTests
+{
+    [Test]
+    public async Task ImageRetry_ReusesIdempotencyKeyAcrossAmbiguousResponse()
+    {
+        var images = new Mock<IAiImageGenerationService>();
+        var keys = new List<string?>();
+        images.Setup(s => s.GenerateAsync(It.IsAny<AiImageGenerationRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<AiImageGenerationRequest, CancellationToken>((request, _) => keys.Add(request.IdempotencyKey))
+            .ThrowsAsync(new IOException("response lost"));
+        var handler = new AiImageJobRetryHandler(images.Object, EntitlementService(), AvailabilityService(true), ModelCatalogService(), RetryContext());
+        AiJob job = Job("image", "{\"prompt\":\"a harbor\",\"aspectRatio\":\"1:1\"}");
+
+        Assert.ThrowsAsync<IOException>(() => RunRetryAsync(handler, job));
+        Assert.ThrowsAsync<IOException>(() => RunRetryAsync(handler, job));
+
+        Assert.That(keys, Has.Count.EqualTo(2));
+        Assert.That(keys[1], Is.EqualTo(keys[0]));
+    }
+
+    [Test]
+    public async Task JobLimitRefusalRetiresTheUnreservedKeyBeforeRetry()
+    {
+        var images = new Mock<IAiImageGenerationService>();
+        var keys = new List<string?>();
+        images
+            .Setup(service => service.GenerateAsync(
+                It.IsAny<AiImageGenerationRequest>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<AiImageGenerationRequest, CancellationToken>((request, _) =>
+            {
+                keys.Add(request.IdempotencyKey);
+                return keys.Count == 1
+                    ? Task.FromException<AiImageResult>(new AiJobLimitReachedException())
+                    : Task.FromResult<AiImageResult>(null!);
+            });
+        var handler = new AiImageJobRetryHandler(
+            images.Object,
+            EntitlementService(),
+            AvailabilityService(available: true),
+            ModelCatalogService(),
+            RetryContext());
+        AiJob job = Job("image", "{\"prompt\":\"a harbor\",\"aspectRatio\":\"1:1\"}");
+
+        Assert.ThrowsAsync<AiJobLimitReachedException>(() => RunRetryAsync(handler, job));
+        await RunRetryAsync(handler, job);
+
+        Assert.That(keys, Has.Count.EqualTo(2));
+        Assert.That(keys[1], Is.Not.EqualTo(keys[0]));
+    }
+
+    [Test]
+    public void AuthenticationSessionChangeRetainsTheIssuedRetryKey()
+    {
+        var images = new Mock<IAiImageGenerationService>();
+        var keys = new List<string?>();
+        images.Setup(service => service.GenerateAsync(
+                It.IsAny<AiImageGenerationRequest>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<AiImageGenerationRequest, CancellationToken>((request, _) =>
+                keys.Add(request.IdempotencyKey))
+            .ThrowsAsync(new AuthenticationRequiredException());
+        var handler = new AiImageJobRetryHandler(
+            images.Object,
+            EntitlementService(),
+            AvailabilityService(true),
+            ModelCatalogService(),
+            RetryContext());
+        AiJob job = Job("image", "{\"prompt\":\"a harbor\",\"aspectRatio\":\"1:1\"}");
+
+        Assert.ThrowsAsync<AuthenticationRequiredException>(() => RunRetryAsync(handler, job));
+        Assert.ThrowsAsync<AuthenticationRequiredException>(() => RunRetryAsync(handler, job));
+
+        Assert.That(keys, Has.Count.EqualTo(2));
+        Assert.That(keys[1], Is.EqualTo(keys[0]));
+    }
+
+    [Test]
+    public async Task ConcurrentRetriesForOneJobUseOneKey()
+    {
+        var images = new Mock<IAiImageGenerationService>();
+        var keys = new ConcurrentBag<string?>();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        images.Setup(s => s.GenerateAsync(It.IsAny<AiImageGenerationRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<AiImageGenerationRequest, CancellationToken>((request, _) => keys.Add(request.IdempotencyKey))
+            .Returns(async () =>
+            {
+                entered.TrySetResult();
+                await release.Task;
+                return null!;
+            });
+        var handler = new AiImageJobRetryHandler(images.Object, EntitlementService(), AvailabilityService(true), ModelCatalogService(), RetryContext());
+        AiJob job = Job("image", "{\"prompt\":\"a harbor\",\"aspectRatio\":\"1:1\"}");
+
+        AiJobRetryPreparationResult firstResult = await handler.PrepareAsync(job, CancellationToken.None);
+        AiJobRetryPreparationResult secondResult = await handler.PrepareAsync(job, CancellationToken.None);
+        IAiJobRetryPreparation firstPreparation = firstResult.TakePreparation();
+        IAiJobRetryPreparation secondPreparation = secondResult.TakePreparation();
+        Task first = firstPreparation.ExecuteAsync(CancellationToken.None);
+        await entered.Task;
+        Task second = secondPreparation.ExecuteAsync(CancellationToken.None);
+        release.TrySetResult();
+        await Task.WhenAll(first, second);
+        await firstPreparation.DisposeAsync();
+        await secondPreparation.DisposeAsync();
+        await firstResult.DisposeAsync();
+        await secondResult.DisposeAsync();
+
+        Assert.That(keys, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public async Task CallerCancellationDoesNotReleasePreparationBeforePaidFlightDrains()
+    {
+        var images = new Mock<IAiImageGenerationService>();
+        var started = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        images
+            .Setup(service => service.GenerateAsync(
+                It.IsAny<AiImageGenerationRequest>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(async () =>
+            {
+                started.TrySetResult();
+                await release.Task;
+                return null!;
+            });
+        var handler = new AiImageJobRetryHandler(
+            images.Object,
+            EntitlementService(),
+            AvailabilityService(true),
+            ModelCatalogService(),
+            RetryContext());
+        AiJob job = Job("image", "{\"prompt\":\"slow\",\"aspectRatio\":\"1:1\"}");
+
+        AiJobRetryPreparationResult prepared = await handler.PrepareAsync(
+            job,
+            CancellationToken.None);
+        IAiJobRetryPreparation preparation = prepared.TakePreparation();
+        using var cancellation = new CancellationTokenSource();
+        Task execution = preparation.ExecuteAsync(cancellation.Token);
+        await started.Task;
+
+        cancellation.Cancel();
+        Assert.That(execution.IsCompleted, Is.False);
+
+        release.TrySetResult();
+        Assert.CatchAsync<OperationCanceledException>(() => execution);
+        await preparation.DisposeAsync();
+        await prepared.DisposeAsync();
+    }
+
+    [Test]
+    public async Task PreparedRetryRejectsSecondExecuteThroughPublicContract()
+    {
+        var images = new Mock<IAiImageGenerationService>();
+        images.Setup(s => s.GenerateAsync(It.IsAny<AiImageGenerationRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => null!);
+        var handler = new AiImageJobRetryHandler(
+            images.Object,
+            EntitlementService(),
+            AvailabilityService(true),
+            ModelCatalogService(),
+            RetryContext());
+
+        AiJobRetryPreparationResult result = await handler.PrepareAsync(
+            Job("image", "{\"prompt\":\"once\",\"aspectRatio\":\"1:1\"}"),
+            CancellationToken.None);
+        IAiJobRetryPreparation preparation = result.TakePreparation();
+        await preparation.ExecuteAsync(CancellationToken.None);
+
+        Assert.ThrowsAsync<AiJobRetryPreparationRejectedException>(() =>
+            preparation.ExecuteAsync(CancellationToken.None));
+        await preparation.DisposeAsync();
+        await result.DisposeAsync();
+    }
+
+    [Test]
+    public async Task RetryAfterASettledAttemptStartsANewGeneration()
+    {
+        var images = new Mock<IAiImageGenerationService>();
+        var keys = new List<string?>();
+        images.Setup(s => s.GenerateAsync(It.IsAny<AiImageGenerationRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<AiImageGenerationRequest, CancellationToken>((request, _) => keys.Add(request.IdempotencyKey))
+            .ReturnsAsync(() => null!);
+        var handler = new AiImageJobRetryHandler(
+            images.Object,
+            EntitlementService(),
+            AvailabilityService(true),
+            ModelCatalogService(),
+            RetryContext());
+        AiJob job = Job("image", "{\"prompt\":\"a harbor\",\"aspectRatio\":\"1:1\"}");
+
+        await RunRetryAsync(handler, job);
+        await RunRetryAsync(handler, job);
+
+        Assert.That(keys, Has.Count.EqualTo(2));
+        Assert.That(keys[1], Is.Not.EqualTo(keys[0]));
+    }
+
+    [Test]
+    public void RetryWithoutAnAuthenticatedAccountDoesNotIssueAKey()
+    {
+        var images = new Mock<IAiImageGenerationService>();
+        var handler = new AiImageJobRetryHandler(
+            images.Object,
+            EntitlementService(),
+            AvailabilityService(true),
+            ModelCatalogService(),
+            RetryContext(accountId: null));
+
+        AiJob job = Job("image", "{\"prompt\":\"a harbor\",\"aspectRatio\":\"1:1\"}");
+        Assert.ThrowsAsync<AuthenticationRequiredException>(async () =>
+        {
+            AiJobRetryPreparationResult prepared = await handler.PrepareAsync(job, CancellationToken.None);
+            await using (prepared)
+            {
+                IAiJobRetryPreparation preparation = prepared.TakePreparation();
+                await using (preparation)
+                {
+                    await preparation.ExecuteAsync(CancellationToken.None);
+                }
+            }
+        });
+        images.Verify(
+            service => service.GenerateAsync(
+                It.IsAny<AiImageGenerationRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Test]
+    public void RetryStore_DoesNotReuseKeyAcrossAccounts()
+    {
+        var store = new InMemoryAiRetryKeyStore();
+        AiJob job = Job("image", "{\"prompt\":\"a harbor\",\"aspectRatio\":\"1:1\"}");
+        string first = store.GetOrCreate(job, "account-a", out bool firstRepeat);
+        string second = store.GetOrCreate(job, "account-b", out bool secondRepeat);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstRepeat, Is.False);
+            Assert.That(secondRepeat, Is.False);
+            Assert.That(second, Is.Not.EqualTo(first));
+        });
+    }
+
+    [Test]
+    public async Task PersistedRetryBypassesCurrentBalanceModelAndAvailabilityPreflight()
+    {
+        var store = new InMemoryAiRetryKeyStore();
+        AiRetryAttemptContext context = RetryContext(store);
+        AiJob job = Job("image", "{\"prompt\":\"a harbor\",\"aspectRatio\":\"1:1\"}") with
+        {
+            Model = new AiModelId("removed/model"),
+        };
+        store.GetOrCreate(job, "test-account", out _);
+        var handler = new AiImageJobRetryHandler(
+            Mock.Of<IAiImageGenerationService>(),
+            EntitlementService(),
+            AvailabilityService(available: false),
+            ModelCatalogService(AiModelCatalog.Empty),
+            context);
+
+        AiJobRetryPreflight preflight = await handler.GetPreflightAsync(
+            job,
+            CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(preflight.CanSubmit, Is.True);
+            Assert.That(preflight.IsAvailable, Is.False);
+            Assert.That(preflight.Explanation, Is.EqualTo(Strings.AiResultUnavailable));
+        });
+    }
+
+    [Test]
+    public async Task RetiredRecoveryConfirmationDoesNotIssueAnotherPaidRequest()
+    {
+        var images = new Mock<IAiImageGenerationService>();
+        var store = new InMemoryAiRetryKeyStore();
+        AiJob job = Job("image", "{\"prompt\":\"a harbor\",\"aspectRatio\":\"1:1\"}");
+        store.GetOrCreate(job, "test-account", out _);
+        var handler = new AiImageJobRetryHandler(
+            images.Object,
+            EntitlementService(),
+            AvailabilityService(true),
+            ModelCatalogService(),
+            RetryContext(store));
+
+        AiJobRetryPreparationResult prepared = await handler.PrepareAsync(job, CancellationToken.None);
+        IAiJobRetryPreparation preparation = prepared.TakePreparation();
+        store.Retire(job, "test-account");
+
+        Assert.ThrowsAsync<AiJobRetryPreparationRejectedException>(() =>
+            preparation.ExecuteAsync(CancellationToken.None));
+        await preparation.DisposeAsync();
+        await prepared.DisposeAsync();
+        images.Verify(
+            service => service.GenerateAsync(
+                It.IsAny<AiImageGenerationRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        Assert.That(store.TryGet(job, "test-account", out _), Is.False);
+    }
+
+    [Test]
+    public async Task RecoveryConfirmationRejectsAnAuthenticatedAccountSwitch()
+    {
+        var images = new Mock<IAiImageGenerationService>();
+        var store = new InMemoryAiRetryKeyStore();
+        string account = "account-a";
+        AiJob job = Job("image", "{\"prompt\":\"a harbor\",\"aspectRatio\":\"1:1\"}");
+        string original = store.GetOrCreate(job, account, out _);
+        var context = new AiRetryAttemptContext(
+            store,
+            () => new AiAuthenticatedRequestIdentity(account, User: null),
+            allowSyntheticIdentity: true);
+        var handler = new AiImageJobRetryHandler(
+            images.Object,
+            EntitlementService(),
+            AvailabilityService(true),
+            ModelCatalogService(),
+            context);
+
+        AiJobRetryPreparationResult prepared = await handler.PrepareAsync(job, CancellationToken.None);
+        IAiJobRetryPreparation preparation = prepared.TakePreparation();
+        account = "account-b";
+
+        Assert.ThrowsAsync<AiJobRetryPreparationRejectedException>(() =>
+            preparation.ExecuteAsync(CancellationToken.None));
+        await preparation.DisposeAsync();
+        await prepared.DisposeAsync();
+        images.Verify(
+            service => service.GenerateAsync(
+                It.IsAny<AiImageGenerationRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        Assert.That(store.TryGet(job, "account-a", out string retained), Is.True);
+        Assert.That(retained, Is.EqualTo(original));
+    }
+
+    [Test]
+    public void ProductionRetryContextRejectsSyntheticIdentity()
+    {
+        var context = new AiRetryAttemptContext(
+            new InMemoryAiRetryKeyStore(),
+            () => new AiAuthenticatedRequestIdentity("account-a", User: null));
+
+        Assert.Throws<AuthenticationRequiredException>(() => context.GetRequiredIdentity());
+    }
+
+    [TestCase("""{"prompt":"a harbor","aspectRatio":"16:9"}""", "16:9")]
+    [TestCase("""{"prompt":"a harbor","size":"1536x1024"}""", "3:2")]
+    [TestCase("""{"prompt":"a harbor","size":"1024x1536"}""", "2:3")]
+    [TestCase("""{"prompt":"a harbor","size":"1024x1024"}""", "1:1")]
+    public async Task ImageRetry_ReproducesTheShapeTheJobWasAskedFor(
+        string inputParameters,
+        string expectedAspectRatio)
+    {
+        var images = new Mock<IAiImageGenerationService>();
+        AiImageGenerationRequest? sent = null;
+        images
+            .Setup(service => service.GenerateAsync(
+                It.IsAny<AiImageGenerationRequest>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<AiImageGenerationRequest, CancellationToken>((request, _) => sent = request)
+            .ReturnsAsync(() => null!);
+
+        var handler = new AiImageJobRetryHandler(
+            images.Object,
+            EntitlementService(),
+            AvailabilityService(available: true),
+            ModelCatalogService(),
+            RetryContext());
+
+        await RunRetryAsync(handler, Job("image", inputParameters));
+
+        Assert.That(sent!.AspectRatio.Value, Is.EqualTo(expectedAspectRatio));
+    }
+
+    [Test]
+    public void ImageRetry_RefusesAGenerationGuidedByAReferenceImage()
+    {
+        var handler = new AiImageJobRetryHandler(
+            Mock.Of<IAiImageGenerationService>(),
+            EntitlementService(),
+            AvailabilityService(available: true),
+            ModelCatalogService(),
+            RetryContext());
+
+        // The picture itself was never retained, so repeating this would make
+        // something else and charge the same price for it.
+        Assert.ThrowsAsync<AiRetryAttemptRejectedException>(() => RunRetryAsync(
+            handler,
+            Job("image", """{"prompt":"a harbor","aspectRatio":"1:1","reference":{"filename":"style.png"}}""")));
+    }
+
+    [Test]
+    public async Task VideoRetry_CarriesTheShapeAudioAndSeedItRanWith()
+    {
+        var videos = new Mock<IAiVideoService>();
+        AiVideoGenerationRequest? sent = null;
+        videos
+            .Setup(service => service.CreateAsync(
+                It.IsAny<AiVideoGenerationRequest>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<AiVideoGenerationRequest, CancellationToken>((request, _) => sent = request)
+            .ReturnsAsync(() => null!);
+
+        var handler = new AiVideoJobRetryHandler(
+            videos.Object,
+            EntitlementService(),
+            AvailabilityService(available: true),
+            ModelCatalogService(),
+            RetryContext());
+
+        await RunRetryAsync(
+            handler,
+            Job(
+                "video",
+                """
+                {"prompt":"waves","durationSeconds":8,"resolution":"1080p",
+                 "aspectRatio":"9:16","generateAudio":false,"seed":7}
+                """));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(sent!.AspectRatio.Value, Is.EqualTo("9:16"));
+            Assert.That(sent.GenerateAudio, Is.False);
+            Assert.That(sent.Seed, Is.EqualTo(7));
+            Assert.That(sent.Resolution.Value, Is.EqualTo("1080p"));
+        }
+    }
+
+    [Test]
+    public async Task VideoRetry_DefaultsMatchWhatTheEndpointAppliesToAnOlderJob()
+    {
+        var videos = new Mock<IAiVideoService>();
+        AiVideoGenerationRequest? sent = null;
+        videos
+            .Setup(service => service.CreateAsync(
+                It.IsAny<AiVideoGenerationRequest>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<AiVideoGenerationRequest, CancellationToken>((request, _) => sent = request)
+            .ReturnsAsync(() => null!);
+
+        var handler = new AiVideoJobRetryHandler(
+            videos.Object,
+            EntitlementService(),
+            AvailabilityService(available: true),
+            ModelCatalogService(),
+            RetryContext());
+
+        // Recorded before these fields existed: repeating it must run it the
+        // way it originally ran.
+        await RunRetryAsync(
+            handler,
+            Job("video", """{"prompt":"waves"}"""));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(sent!.AspectRatio.Value, Is.EqualTo("16:9"));
+            Assert.That(sent.GenerateAudio, Is.True);
+            Assert.That(sent.Seed, Is.Null);
+            Assert.That(sent.DurationSeconds, Is.EqualTo(4));
+            Assert.That(sent.Resolution.Value, Is.EqualTo("720p"));
+        }
+    }
+
+    [Test]
+    public void VideoRetry_CanRetryRejectsSourceFramesAndMalformedInput()
+    {
+        var handler = new AiVideoJobRetryHandler(
+            Mock.Of<IAiVideoService>(),
+            EntitlementService(),
+            AvailabilityService(available: true),
+            ModelCatalogService(),
+            RetryContext());
+        AiJobStatusSemantics failed = new(
+            isTerminal: true,
+            shouldPoll: false,
+            outcome: AiJobOutcomes.Failed);
+
+        Assert.That(handler.CanRetry(Job("video", "{\"prompt\":\"waves\",\"firstFrame\":{\"filename\":\"a.png\",\"mimeType\":\"image/png\"}}"), failed), Is.False);
+        Assert.That(handler.CanRetry(Job("video", "{\"prompt\":\"waves\",\"durationSeconds\":\"four\"}"), failed), Is.False);
+        Assert.That(handler.CanRetry(Job("video", "{\"prompt\":\"waves\",\"seed\":-1}"), failed), Is.False);
+        Assert.That(handler.CanRetry(Job("video", "{\"prompt\":\" waves \"}"), failed), Is.False);
+        Assert.That(handler.CanRetry(Job("video", "{\"prompt\":\"" + new string('x', 4001) + "\"}"), failed), Is.False);
+        Assert.That(handler.CanRetry(Job("video", "{\"prompt\":\"waves\",\"ignored\":true}"), failed), Is.False);
+        Assert.That(handler.CanRetry(Job("video", "{\"prompt\":\"waves\",\"aspectRatio\":\"3x2\"}"), failed), Is.False);
+        Assert.That(handler.CanRetry(Job("video", "{\"prompt\":\"waves\",\"aspectRatio\":\"0:2\"}"), failed), Is.False);
+        Assert.That(handler.CanRetry(Job("video", "{\"prompt\":\"waves\",\"aspectRatio\":\"3:0\"}"), failed), Is.False);
+        Assert.That(handler.CanRetry(Job("video", "{\"prompt\":\"waves\",\"aspectRatio\":\"3:4\"}"), failed), Is.True);
+        Assert.That(handler.CanRetry(Job("video", "{\"prompt\":\"waves\"}"), failed), Is.True);
+    }
+
+    [Test]
+    public async Task VideoRetry_AcceptsAnAspectRatioPublishedByTheCurrentModel()
+    {
+        var catalog = new AiModelCatalog([
+            KeyValuePair.Create(AiOperations.VideoGeneration, ImmutableArray.Create(new AiModelOption(
+                new AiModelId("video/model"), "Video", AiModelCostTier.Low, true,
+                Video: new AiVideoModelCapabilities(
+                    AiCapabilityDimension<int>.Supported([4]),
+                    AiCapabilityDimension<string>.Supported(["720p"]),
+                    AiCapabilityDimension<string>.Supported(["21:9"]), true, true))))]);
+        var handler = new AiVideoJobRetryHandler(
+            Mock.Of<IAiVideoService>(),
+            EntitlementService(),
+            AvailabilityService(available: true),
+            ModelCatalogService(catalog),
+            RetryContext());
+        AiJob job = Job(
+            "video",
+            "{\"prompt\":\"waves\",\"durationSeconds\":4,\"resolution\":\"720p\",\"aspectRatio\":\"21:9\"}")
+            with
+        {
+            Model = new AiModelId("video/model"),
+        };
+        AiJobStatusSemantics failed = new(
+            isTerminal: true,
+            shouldPoll: false,
+            outcome: AiJobOutcomes.Failed);
+
+        AiJobRetryPreflight preflight = await handler.GetPreflightAsync(job, CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(handler.CanRetry(job, failed), Is.True);
+            Assert.That(preflight.CanSubmit, Is.True);
+        }
+    }
+
+    [Test]
+    public void Retry_UsesAuthoritativeCanRetryForSucceededJobsOnlyWhenReplayable()
+    {
+        var image = new AiImageJobRetryHandler(
+            Mock.Of<IAiImageGenerationService>(),
+            EntitlementService(),
+            AvailabilityService(true),
+            ModelCatalogService(),
+            RetryContext());
+        AiJob succeeded = Job("image", "{\"prompt\":\"done\",\"aspectRatio\":\"1:1\"}") with
+        {
+            Status = new AiJobStatusId("succeeded"),
+            CanRetry = true,
+        };
+        AiJob notAuthoritativelyRetryable = succeeded with { CanRetry = false };
+        AiJob active = succeeded with { Status = new AiJobStatusId("running") };
+        AiJob canceled = succeeded with { Status = new AiJobStatusId("canceled") };
+        AiJob missingShape = succeeded with
+        {
+            InputParameters = JsonDocument.Parse("{\"prompt\":\"done\"}").RootElement.Clone(),
+        };
+        AiJob conflictingShape = succeeded with
+        {
+            InputParameters = JsonDocument.Parse(
+                "{\"prompt\":\"done\",\"size\":\"1024x1024\",\"aspectRatio\":\"1:1\"}")
+                .RootElement.Clone(),
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(image.CanRetry(succeeded, new AiJobStatusSemantics(true, false, AiJobOutcomes.Succeeded)), Is.True);
+            Assert.That(image.CanRetry(notAuthoritativelyRetryable, new AiJobStatusSemantics(true, false, AiJobOutcomes.Succeeded)), Is.False);
+            Assert.That(image.CanRetry(active, new AiJobStatusSemantics(false, true)), Is.False);
+            Assert.That(image.CanRetry(canceled, new AiJobStatusSemantics(true, false, AiJobOutcomes.Canceled)), Is.False);
+            Assert.That(image.CanRetry(missingShape, new AiJobStatusSemantics(true, false, AiJobOutcomes.Succeeded)), Is.False);
+            Assert.That(image.CanRetry(conflictingShape, new AiJobStatusSemantics(true, false, AiJobOutcomes.Succeeded)), Is.False);
+        });
+    }
+
+    [Test]
+    public async Task ImageRetry_PreflightWithdrawsChangedCapabilities()
+    {
+        var catalog = new AiModelCatalog([
+            KeyValuePair.Create(AiOperations.ImageGeneration, ImmutableArray.Create(new AiModelOption(
+                new AiModelId("image/model"), "Image", AiModelCostTier.Low, true,
+                Image: new AiImageModelCapabilities(
+                    AiCapabilityDimension<string>.Supported(["1:1"]),
+                    AiCapabilityDimension<string>.Supported(["opaque"]), false, 0))))]);
+        var availability = new Mock<IAiOperationAvailabilityService>();
+        var handler = new AiImageJobRetryHandler(Mock.Of<IAiImageGenerationService>(), EntitlementService(), availability.Object, ModelCatalogService(catalog), RetryContext());
+        AiJob job = Job("image", "{\"prompt\":\"x\",\"aspectRatio\":\"3:2\",\"background\":\"transparent\",\"seed\":7}") with { Model = new AiModelId("image/model") };
+
+        AiJobRetryPreflight result = await handler.GetPreflightAsync(job, CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.CanSubmit, Is.False);
+            Assert.That(result.Explanation, Is.EqualTo(Strings.AiModelDoesNotSupportRequest));
+            availability.Verify(service => service.CheckAsync(It.IsAny<AiOperationAvailabilityRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        });
+    }
+
+    [Test]
+    public async Task VideoRetry_PreflightWithdrawsChangedCapabilities()
+    {
+        var catalog = new AiModelCatalog([
+            KeyValuePair.Create(AiOperations.VideoGeneration, ImmutableArray.Create(new AiModelOption(
+                new AiModelId("video/model"), "Video", AiModelCostTier.Low, true,
+                Video: new AiVideoModelCapabilities(
+                    AiCapabilityDimension<int>.Supported([4]),
+                    AiCapabilityDimension<string>.Supported(["720p"]),
+                    AiCapabilityDimension<string>.Supported(["16:9"]), false, false))))]);
+        var availability = new Mock<IAiOperationAvailabilityService>();
+        var handler = new AiVideoJobRetryHandler(Mock.Of<IAiVideoService>(), EntitlementService(), availability.Object, ModelCatalogService(catalog), RetryContext());
+        AiJob job = Job("video", "{\"prompt\":\"x\",\"durationSeconds\":4,\"resolution\":\"1080p\",\"generateAudio\":true,\"seed\":7}") with { Model = new AiModelId("video/model") };
+
+        AiJobRetryPreflight result = await handler.GetPreflightAsync(job, CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.CanSubmit, Is.False);
+            Assert.That(result.Explanation, Is.EqualTo(Strings.AiModelDoesNotSupportRequest));
+            availability.Verify(service => service.CheckAsync(It.IsAny<AiOperationAvailabilityRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        });
+    }
+
+    [Test]
+    public void VideoRetry_RefusesAClipConditionedOnSourceFrames()
+    {
+        var handler = new AiVideoJobRetryHandler(
+            Mock.Of<IAiVideoService>(),
+            EntitlementService(),
+            AvailabilityService(available: true),
+            ModelCatalogService(),
+            RetryContext());
+
+        Assert.ThrowsAsync<AiRetryAttemptRejectedException>(() => RunRetryAsync(handler,
+            Job(
+                "video",
+                """
+                {"prompt":"waves","durationSeconds":4,"resolution":"720p",
+                 "firstFrame":{"filename":"a.png","mimeType":"image/png"}}
+                """)));
+    }
+
+    private static AiJob Job(string kind, string inputParameters) => new(
+        new AiJobId("job-1"),
+        new AiJobKindId(kind),
+        new AiJobStatusId("failed"),
+        JsonDocument.Parse(inputParameters).RootElement.Clone(),
+        FileId: null,
+        ContentUri: null,
+        Error: "aiProviderError",
+        CanRetry: true,
+        CreatedAt: DateTimeOffset.UnixEpoch,
+        UpdatedAt: DateTimeOffset.UnixEpoch);
+
+    private static async Task RunRetryAsync(IAiJobRetryHandler handler, AiJob job)
+    {
+        AiJobRetryPreflight preflight = await handler.GetPreflightAsync(job, CancellationToken.None);
+        if (!preflight.CanSubmit)
+            throw new AiRetryAttemptRejectedException();
+
+        AiJobRetryPreparationResult prepared = await handler.PrepareAsync(
+            job,
+            CancellationToken.None);
+        await using (prepared)
+        {
+            if (!prepared.IsReady)
+                throw new AiRetryAttemptRejectedException();
+            IAiJobRetryPreparation preparation = prepared.TakePreparation();
+            await using (preparation)
+            {
+                await preparation.ExecuteAsync(CancellationToken.None);
+            }
+        }
+    }
+
+    private static IAiEntitlementService EntitlementService()
+    {
+        var mock = new Mock<IAiEntitlementService>();
+        mock
+            .Setup(service => service.RefreshAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AiEntitlements(
+                Plan: "pro",
+                SubscriptionStatus: "active",
+                CurrentPeriodStart: null,
+                CurrentPeriodEnd: null,
+                CancelAtPeriodEnd: false,
+                CanUseAi: true,
+                Balance: new AiBalance(
+                    new AiMonthlyUsage(0, 100, IsExhausted: false),
+                    AdditionalCredits: 100,
+                    HasAdditionalCreditDebt: false),
+                Availability: new AiOperationAvailability([])));
+        return mock.Object;
+    }
+
+    // An empty catalog is what a client that could not read the model list
+    // holds, and it says nothing about any model, so these tests exercise the
+    // retry path itself rather than the model check.
+    private static IAiModelCatalogService ModelCatalogService(AiModelCatalog? catalog = null)
+    {
+        var mock = new Mock<IAiModelCatalogService>();
+        mock
+            .Setup(service => service.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(catalog ?? AiModelCatalog.Empty);
+        return mock.Object;
+    }
+
+    private static IAiOperationAvailabilityService AvailabilityService(bool available)
+    {
+        var mock = new Mock<IAiOperationAvailabilityService>();
+        mock
+            .Setup(service => service.CheckAsync(
+                It.IsAny<AiOperationAvailabilityRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(available);
+        return mock.Object;
+    }
+
+    private static AiRetryAttemptContext RetryContext(
+        IAiRetryKeyStore? store = null,
+        string? accountId = "test-account")
+        => new(
+            store ?? new InMemoryAiRetryKeyStore(),
+            () => accountId is null
+                ? null
+                : new AiAuthenticatedRequestIdentity(accountId, User: null),
+            allowSyntheticIdentity: true);
+}

--- a/tests/Beutl.UnitTests/Api/AiJobRetryHandlerTests.cs
+++ b/tests/Beutl.UnitTests/Api/AiJobRetryHandlerTests.cs
@@ -614,6 +614,41 @@ public class AiJobRetryHandlerTests
     }
 
     [Test]
+    public async Task ImageRetry_AcceptsAnAspectRatioPublishedByTheCurrentModel()
+    {
+        var catalog = new AiModelCatalog([
+            KeyValuePair.Create(AiOperations.ImageGeneration, ImmutableArray.Create(new AiModelOption(
+                new AiModelId("image/model"), "Image", AiModelCostTier.Low, true,
+                Image: new AiImageModelCapabilities(
+                    AiCapabilityDimension<string>.Supported(["21:9"]),
+                    AiCapabilityDimension<string>.Supported(["auto"]),
+                    SupportsSeed: true,
+                    MaxReferenceImages: 0))))]);
+        var handler = new AiImageJobRetryHandler(
+            Mock.Of<IAiImageGenerationService>(),
+            EntitlementService(),
+            AvailabilityService(available: true),
+            ModelCatalogService(catalog),
+            RetryContext());
+        AiJob job = Job("image", "{\"prompt\":\"panorama\",\"aspectRatio\":\"21:9\"}") with
+        {
+            Model = new AiModelId("image/model"),
+        };
+        AiJobStatusSemantics failed = new(
+            isTerminal: true,
+            shouldPoll: false,
+            outcome: AiJobOutcomes.Failed);
+
+        AiJobRetryPreflight preflight = await handler.GetPreflightAsync(job, CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(handler.CanRetry(job, failed), Is.True);
+            Assert.That(preflight.CanSubmit, Is.True);
+        }
+    }
+
+    [Test]
     public async Task VideoRetry_PreflightWithdrawsChangedCapabilities()
     {
         var catalog = new AiModelCatalog([

--- a/tests/Beutl.UnitTests/Api/AiJobServiceTests.cs
+++ b/tests/Beutl.UnitTests/Api/AiJobServiceTests.cs
@@ -1,0 +1,1412 @@
+﻿using System.Collections.Specialized;
+using System.Net;
+using System.Reactive;
+using System.Reactive.Subjects;
+using System.Reflection;
+using System.Text;
+using Beutl.Api;
+using Beutl.Api.Clients;
+using Beutl.Api.Objects;
+using Beutl.Api.Services;
+using Beutl.Extensibility;
+using Reactive.Bindings;
+
+namespace Beutl.UnitTests.Api;
+
+[TestFixture]
+public sealed class AiJobMonitorTests
+{
+    [Test]
+    public async Task PublishedSnapshot_IsBackedByReadOnlyReactiveAndImmutableJobState()
+    {
+        using var handler = new StubHandler(_ => JsonResponse(HttpStatusCode.OK, "{}"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        IAiJobMonitor service = app.GetResource<IAiJobMonitor>();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                service.Snapshot,
+                Is.Not.InstanceOf<ReactivePropertySlim<AiJobMonitorSnapshot>>());
+            Assert.That(service.Snapshot.Value.Jobs.IsDefault, Is.False);
+            Assert.That(service.Snapshot.Value.Jobs, Is.Empty);
+        }
+    }
+
+    [Test]
+    public async Task RefreshAsync_WhenSignedOut_PublishesAuthenticationStateWithoutRequest()
+    {
+        using var handler = new StubHandler(_ => JsonResponse(HttpStatusCode.OK, "{}"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        IAiJobMonitor service = app.GetResource<IAiJobMonitor>();
+
+        await service.RefreshAsync(CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(service.Snapshot.Value.Jobs, Is.Empty);
+            Assert.That(service.Snapshot.Value.IsLoading, Is.False);
+            Assert.That(service.Snapshot.Value.Error, Is.TypeOf<AuthenticationRequiredException>());
+            Assert.That(handler.Requests, Is.Empty);
+        }
+    }
+
+    [Test]
+    public async Task SigningOut_CancelsInFlightAuthenticationOwnedRefresh()
+    {
+        var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = new StubHandler(async (_, cancellationToken) =>
+        {
+            requestStarted.TrySetResult();
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+            finally
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    cancellationObserved.TrySetResult();
+                }
+            }
+
+            return JsonResponse(HttpStatusCode.OK, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        IAiJobMonitor service = app.GetResource<IAiJobMonitor>();
+
+        SetAuthenticatedUser(app, httpClient);
+        await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        app.SignOut(deleteFile: false);
+        await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await WaitUntilAsync(
+            () => service.Snapshot.Value.Error is AuthenticationRequiredException,
+            TimeSpan.FromSeconds(5));
+
+        Assert.That(service.Snapshot.Value.Jobs, Is.Empty);
+    }
+
+    [Test]
+    public async Task RefreshAsync_AppendsPageAndReplacesDuplicateWithNewestState()
+    {
+        using var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri?.Query.Contains("cursor=next-page", StringComparison.Ordinal) == true)
+            {
+                return JsonResponse(HttpStatusCode.OK, """
+                    {
+                      "jobs": [
+                        {
+                          "id": "job-1",
+                          "kind": "video",
+                          "status": "succeeded",
+                          "inputParams": { "prompt": "First job", "durationSeconds": 6 },
+                          "fileId": "file-1",
+                          "url": "https://beutl.beditor.net/api/contents/file-1",
+                          "usageUnits": 25,
+                          "error": null,
+                          "canRetry": false,
+                          "createdAt": "2026-08-01T00:00:00Z",
+                          "updatedAt": "2026-08-01T00:01:00Z"
+                        },
+                        {
+                          "id": "job-2",
+                          "kind": "image",
+                          "status": "failed",
+                          "inputParams": { "prompt": "Second job" },
+                          "fileId": null,
+                          "url": null,
+                          "usageUnits": 20,
+                          "error": "Provider failed",
+                          "canRetry": true,
+                          "createdAt": "2026-08-02T00:00:00Z",
+                          "updatedAt": "2026-08-02T00:01:00Z"
+                        }
+                      ],
+                      "nextCursor": null
+                    }
+                    """);
+            }
+
+            return JsonResponse(HttpStatusCode.OK, """
+                {
+                  "jobs": [
+                    {
+                      "id": "job-1",
+                      "kind": "video",
+                      "status": "running",
+                      "inputParams": { "prompt": "First job", "durationSeconds": 6 },
+                      "fileId": null,
+                      "url": null,
+                      "usageUnits": 25,
+                      "error": null,
+                      "canRetry": false,
+                      "createdAt": "2026-08-01T00:00:00Z",
+                      "updatedAt": "2026-08-01T00:00:30Z"
+                    }
+                  ],
+                  "nextCursor": "next-page"
+                }
+                """);
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        IAiJobMonitor service = app.GetResource<IAiJobMonitor>();
+        SetAuthenticatedUser(app, httpClient);
+        await service.RefreshAsync(CancellationToken.None);
+
+        await service.LoadNextPageAsync(CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(service.Snapshot.Value.Jobs.Select(job => job.Id.Value),
+                Is.EqualTo(new[] { "job-1", "job-2" }));
+            Assert.That(service.Snapshot.Value.Jobs[0].Status, Is.EqualTo(AiJobStatuses.Succeeded));
+            Assert.That(service.Snapshot.Value.NextCursor, Is.Null);
+            Assert.That(service.Snapshot.Value.IsLoading, Is.False);
+            Assert.That(service.Snapshot.Value.Error, Is.Null);
+            Assert.That(handler.Requests.Any(uri => uri.Contains("cursor=next-page", StringComparison.Ordinal)),
+                Is.True);
+        }
+    }
+
+    [Test]
+    public async Task RefreshAsync_WhenRequestFails_PreservesLastSuccessfulPage()
+    {
+        bool failRequests = false;
+        using var handler = new StubHandler(_ => failRequests
+            ? JsonResponse(HttpStatusCode.InternalServerError, "{}")
+            : JsonResponse(HttpStatusCode.OK, """
+                {
+                  "jobs": [
+                    {
+                      "id": "job-1",
+                      "kind": "image",
+                      "status": "succeeded",
+                      "inputParams": { "prompt": "Keep me" },
+                      "fileId": "file-1",
+                      "url": "https://beutl.beditor.net/api/contents/file-1",
+                      "usageUnits": 20,
+                      "error": null,
+                      "canRetry": false,
+                      "createdAt": "2026-08-01T00:00:00Z",
+                      "updatedAt": "2026-08-01T00:01:00Z"
+                    }
+                  ],
+                  "nextCursor": "next-page"
+                }
+                """));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        IAiJobMonitor service = app.GetResource<IAiJobMonitor>();
+        SetAuthenticatedUser(app, httpClient);
+        await service.RefreshAsync(CancellationToken.None);
+        failRequests = true;
+
+        await service.RefreshAsync(CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(service.Snapshot.Value.Jobs.Select(job => job.Id.Value), Is.EqualTo(new[] { "job-1" }));
+            Assert.That(service.Snapshot.Value.NextCursor, Is.EqualTo("next-page"));
+            Assert.That(service.Snapshot.Value.IsLoading, Is.False);
+            Assert.That(service.Snapshot.Value.Error, Is.Not.Null);
+        }
+    }
+
+    [Test]
+    public async Task InitialHistoryFailure_IsRetriedWithoutAnOpenJobCenter()
+    {
+        using var handler = new StubHandler(_ => JsonResponse(HttpStatusCode.OK, "{}"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var client = new RecordingJobClient();
+        client.PageProvider = _ =>
+        {
+            if (Volatile.Read(ref client.PageRequests) <= 2)
+                throw new HttpRequestException("transient");
+            return new AiJobPage([], null);
+        };
+        await using var jobKinds = new AiJobKindRegistry();
+        using var changes = new Subject<Unit>();
+        using var service = new AiJobMonitor(app, client, jobKinds, changes, TimeSpan.FromMilliseconds(10));
+
+        SetAuthenticatedUser(app, httpClient);
+        await WaitUntilAsync(() => Volatile.Read(ref client.PageRequests) >= 3, TimeSpan.FromSeconds(5));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(client.PageRequests, Is.GreaterThanOrEqualTo(3));
+            Assert.That(service.Snapshot.Value.Error, Is.Null);
+        }
+    }
+
+    [Test]
+    public async Task PermanentInitialHistoryFailureIsNotRetriedInTheBackground()
+    {
+        using var handler = new StubHandler(_ => JsonResponse(HttpStatusCode.OK, "{}"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var client = new RecordingJobClient
+        {
+            PageProvider = _ => throw new InvalidDataException("invalid job contract"),
+        };
+        await using var jobKinds = new AiJobKindRegistry();
+        using var changes = new Subject<Unit>();
+        using var service = new AiJobMonitor(
+            app,
+            client,
+            jobKinds,
+            changes,
+            TimeSpan.FromMilliseconds(10));
+
+        SetAuthenticatedUser(app, httpClient);
+        await WaitUntilAsync(() => Volatile.Read(ref client.PageRequests) == 1, TimeSpan.FromSeconds(5));
+        await Task.Delay(100);
+
+        Assert.That(client.PageRequests, Is.EqualTo(1));
+        Assert.That(service.Snapshot.Value.Error, Is.TypeOf<InvalidDataException>());
+    }
+
+    [Test]
+    public async Task RetryForANewAccountIsNotBlockedByThePreviousAccountsDelay()
+    {
+        using var handler = new StubHandler(_ => JsonResponse(HttpStatusCode.OK, "{}"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var client = new RecordingJobClient();
+        client.PageProvider = _ => Volatile.Read(ref client.PageRequests) <= 2
+            ? throw new HttpRequestException("transient")
+            : new AiJobPage([], null);
+        var firstDelayStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondDelayStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstDelay = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSecondDelay = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int delayCount = 0;
+        Task RetryDelay(TimeSpan _, CancellationToken cancellationToken)
+        {
+            int current = Interlocked.Increment(ref delayCount);
+            if (current == 1)
+            {
+                firstDelayStarted.TrySetResult();
+                return releaseFirstDelay.Task;
+            }
+
+            secondDelayStarted.TrySetResult();
+            return releaseSecondDelay.Task;
+        }
+        await using var jobKinds = new AiJobKindRegistry();
+        using var changes = new Subject<Unit>();
+        using var service = new AiJobMonitor(
+            app,
+            client,
+            jobKinds,
+            changes,
+            TimeSpan.FromSeconds(1),
+            RetryDelay);
+
+        SetAuthenticatedUser(app, httpClient, "account-a");
+        await firstDelayStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        SetAuthenticatedUser(app, httpClient, "account-b");
+        await secondDelayStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        releaseSecondDelay.TrySetResult();
+        await WaitUntilAsync(() => Volatile.Read(ref client.PageRequests) >= 3, TimeSpan.FromSeconds(5));
+        releaseFirstDelay.TrySetResult();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(delayCount, Is.EqualTo(2));
+            Assert.That(service.Snapshot.Value.Error, Is.Null);
+        }
+    }
+
+    [Test]
+    public async Task PollingRefresh_PreservesPreviouslyLoadedHistoryTail()
+    {
+        using var handler = new StubHandler(_ => JsonResponse(HttpStatusCode.OK, "{}"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var client = new RecordingJobClient();
+        bool pollingRefresh = false;
+        client.PageProvider = request => request.Cursor == "tail"
+            ? new AiJobPage([Job("tail", AiJobStatuses.Succeeded)], null)
+            : new AiJobPage([
+                Job("active", pollingRefresh ? AiJobStatuses.Succeeded : AiJobStatuses.Running),
+            ], "tail");
+        await using var jobKinds = new AiJobKindRegistry();
+        await using IAiJobStatusResolverRegistration registration = jobKinds.Register(
+            new AiJobStatusResolverRegistration(
+                new AiJobKindId("video"),
+                new AiJobStatusMap([
+                    KeyValuePair.Create(AiJobStatuses.Running, new AiJobStatusSemantics(false, true)),
+                    KeyValuePair.Create(AiJobStatuses.Succeeded, new AiJobStatusSemantics(true, false)),
+                ])));
+        using var changes = new Subject<Unit>();
+        using var service = new AiJobMonitor(app, client, jobKinds, changes, TimeSpan.FromMilliseconds(10));
+
+        SetAuthenticatedUser(app, httpClient);
+        await WaitUntilAsync(() => client.PageRequests >= 1, TimeSpan.FromSeconds(5));
+        await service.LoadNextPageAsync(CancellationToken.None);
+        Assert.That(service.Snapshot.Value.Jobs.Select(job => job.Id.Value), Is.EqualTo(new[] { "active", "tail" }));
+
+        pollingRefresh = true;
+        await service.RefreshPollingAsync(CancellationToken.None);
+        Assert.That(service.Snapshot.Value.Jobs.Select(job => job.Id.Value), Is.EqualTo(new[] { "active", "tail" }));
+
+        static AiJob Job(string id, AiJobStatusId status)
+            => new(new AiJobId(id), new AiJobKindId("video"), status,
+                null, null, null, null, false, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+    }
+
+    [Test]
+    public async Task PollingRefresh_RefreshesLoadedDepthInServerOrder()
+    {
+        using var handler = new StubHandler(_ => JsonResponse(HttpStatusCode.OK, "{}"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        DateTimeOffset createdAt = new(2026, 9, 6, 0, 0, 0, TimeSpan.Zero);
+        AiJob first = Job("first", AiJobStatuses.Running, createdAt.AddMinutes(1));
+        AiJob second = Job("second", AiJobStatuses.Running, createdAt);
+        AiJob tailFirst = Job("tail-first", AiJobStatuses.Succeeded, createdAt.AddMinutes(-1));
+        AiJob tailSecond = Job("tail-second", AiJobStatuses.Succeeded, createdAt.AddMinutes(-2));
+        AiJob leading = Job("leading", AiJobStatuses.Queued, createdAt.AddMinutes(2));
+        AiJob refreshedSecond = Job("second", AiJobStatuses.Succeeded, createdAt);
+        AiJob refreshedFirst = Job("first", AiJobStatuses.Failed, createdAt.AddMinutes(1));
+        int phase = 0;
+        var client = new RecordingJobClient
+        {
+            PageProvider = request => (Volatile.Read(ref phase), request.Cursor) switch
+            {
+                (0, null) => new AiJobPage([first, second], "initial-tail"),
+                (0, "initial-tail") => new AiJobPage([tailFirst, tailSecond], "initial-older"),
+                (1, null) => new AiJobPage([leading, refreshedSecond], "refreshed-tail"),
+                (1, "refreshed-tail") => new AiJobPage([refreshedFirst, tailFirst], "refreshed-older"),
+                (2, null) => new AiJobPage([leading, refreshedSecond], null),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected page request in phase {Volatile.Read(ref phase)}: {request.Cursor}"),
+            },
+        };
+        await using var jobKinds = new AiJobKindRegistry();
+        using var changes = new Subject<Unit>();
+        using var service = new AiJobMonitor(
+            app,
+            client,
+            jobKinds,
+            changes,
+            TimeSpan.FromHours(1));
+
+        SetAuthenticatedUser(app, httpClient);
+        await WaitUntilAsync(
+            () => service.Snapshot.Value.Jobs.Select(job => job.Id.Value)
+                .SequenceEqual(["first", "second"]),
+            TimeSpan.FromSeconds(5));
+        await service.LoadNextPageAsync(CancellationToken.None);
+        Assert.That(
+            service.Snapshot.Value.Jobs.Select(job => job.Id.Value),
+            Is.EqualTo(new[] { "first", "second", "tail-first", "tail-second" }));
+
+        int requestsBeforePolling = Volatile.Read(ref client.PageRequests);
+        Volatile.Write(ref phase, 1);
+        await service.RefreshPollingAsync(CancellationToken.None);
+
+        AiJobMonitorSnapshot refreshed = service.Snapshot.Value;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                refreshed.Jobs.Select(job => job.Id.Value),
+                Is.EqualTo(new[] { "leading", "second", "first", "tail-first" }));
+            Assert.That(refreshed.Jobs.Select(job => job.Id).Distinct().Count(), Is.EqualTo(4));
+            Assert.That(refreshed.Jobs[0], Is.SameAs(leading));
+            Assert.That(refreshed.Jobs[1], Is.SameAs(refreshedSecond));
+            Assert.That(refreshed.Jobs[2], Is.SameAs(refreshedFirst));
+            Assert.That(refreshed.Jobs[3], Is.SameAs(tailFirst));
+            Assert.That(refreshed.Jobs, Does.Not.Contain(tailSecond));
+            Assert.That(refreshed.NextCursor, Is.EqualTo("refreshed-older"));
+            Assert.That(client.PageRequests - requestsBeforePolling, Is.EqualTo(2));
+        }
+
+        Volatile.Write(ref phase, 2);
+        await service.RefreshAsync(CancellationToken.None);
+
+        AiJobMonitorSnapshot replaced = service.Snapshot.Value;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                replaced.Jobs.Select(job => job.Id.Value),
+                Is.EqualTo(new[] { "leading", "second" }));
+            Assert.That(replaced.Jobs[1], Is.SameAs(refreshedSecond));
+            Assert.That(replaced.NextCursor, Is.Null);
+            Assert.That(replaced.IsLoading, Is.False);
+            Assert.That(replaced.Error, Is.Null);
+        }
+
+        static AiJob Job(string id, AiJobStatusId status, DateTimeOffset createdAt)
+            => new(
+                new AiJobId(id),
+                AiJobKinds.Video,
+                status,
+                null,
+                null,
+                null,
+                null,
+                false,
+                createdAt,
+                createdAt);
+    }
+
+    [Test]
+    public async Task PollingRefresh_DropsDeletedHeadJobsWhileKeepingRefreshedTail()
+    {
+        using var handler = new StubHandler(_ => JsonResponse(HttpStatusCode.OK, "{}"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        DateTimeOffset createdAt = new(2026, 9, 6, 0, 0, 0, TimeSpan.Zero);
+        AiJob active = Job("active", AiJobStatuses.Running, createdAt.AddMinutes(2));
+        AiJob deleted = Job("deleted", AiJobStatuses.Succeeded, createdAt.AddMinutes(1));
+        AiJob old = Job("old", AiJobStatuses.Succeeded, createdAt);
+        AiJob refreshedActive = Job("active", AiJobStatuses.Succeeded, createdAt.AddMinutes(2));
+        int phase = 0;
+        var client = new RecordingJobClient
+        {
+            PageProvider = request => (Volatile.Read(ref phase), request.Cursor) switch
+            {
+                (0, null) => new AiJobPage([active, deleted], "initial-tail"),
+                (0, "initial-tail") => new AiJobPage([old], null),
+                (1, null) => new AiJobPage([refreshedActive], "refreshed-tail"),
+                (1, "refreshed-tail") => new AiJobPage([old], null),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected page request in phase {Volatile.Read(ref phase)}: {request.Cursor}"),
+            },
+        };
+        await using var jobKinds = new AiJobKindRegistry();
+        using var changes = new Subject<Unit>();
+        using var service = new AiJobMonitor(
+            app,
+            client,
+            jobKinds,
+            changes,
+            TimeSpan.FromHours(1));
+
+        SetAuthenticatedUser(app, httpClient);
+        await WaitUntilAsync(
+            () => service.Snapshot.Value.Jobs.Select(job => job.Id.Value)
+                .SequenceEqual(["active", "deleted"]),
+            TimeSpan.FromSeconds(5));
+        await service.LoadNextPageAsync(CancellationToken.None);
+
+        int requestsBeforePolling = Volatile.Read(ref client.PageRequests);
+        Volatile.Write(ref phase, 1);
+        await service.RefreshPollingAsync(CancellationToken.None);
+
+        AiJobMonitorSnapshot refreshed = service.Snapshot.Value;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                refreshed.Jobs.Select(job => job.Id.Value),
+                Is.EqualTo(new[] { "active", "old" }));
+            Assert.That(refreshed.Jobs[0], Is.SameAs(refreshedActive));
+            Assert.That(refreshed.Jobs[1], Is.SameAs(old));
+            Assert.That(refreshed.Jobs, Does.Not.Contain(deleted));
+            Assert.That(refreshed.NextCursor, Is.Null);
+            Assert.That(client.PageRequests - requestsBeforePolling, Is.EqualTo(2));
+        }
+
+        static AiJob Job(string id, AiJobStatusId status, DateTimeOffset createdAt)
+            => new(
+                new AiJobId(id),
+                AiJobKinds.Video,
+                status,
+                null,
+                null,
+                null,
+                null,
+                false,
+                createdAt,
+                createdAt);
+    }
+
+    [Test]
+    public async Task JobChangeNotification_PreservesTheLoadedHistoryDepth()
+    {
+        using var handler = new StubHandler(_ => JsonResponse(HttpStatusCode.OK, "{}"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        int phase = 0;
+        var client = new RecordingJobClient
+        {
+            PageProvider = request => (Volatile.Read(ref phase), request.Cursor) switch
+            {
+                (0, null) => new AiJobPage([Job("head")], "tail"),
+                (0, "tail") => new AiJobPage([Job("old-tail")], null),
+                (1, null) => new AiJobPage([Job("new-head")], "new-tail"),
+                (1, "new-tail") => new AiJobPage([Job("old-tail")], null),
+                _ => throw new InvalidOperationException("Unexpected history page request."),
+            },
+        };
+        await using var jobKinds = new AiJobKindRegistry();
+        using var changes = new Subject<Unit>();
+        using var service = new AiJobMonitor(
+            app,
+            client,
+            jobKinds,
+            changes,
+            TimeSpan.FromHours(1));
+
+        SetAuthenticatedUser(app, httpClient);
+        await WaitUntilAsync(
+            () => service.Snapshot.Value.Jobs.Select(job => job.Id.Value).SequenceEqual(["head"]),
+            TimeSpan.FromSeconds(5));
+        await service.LoadNextPageAsync(CancellationToken.None);
+        int requestsBeforeNotification = Volatile.Read(ref client.PageRequests);
+
+        Volatile.Write(ref phase, 1);
+        changes.OnNext(Unit.Default);
+
+        await WaitUntilAsync(
+            () => service.Snapshot.Value.Jobs.Select(job => job.Id.Value)
+                .SequenceEqual(["new-head", "old-tail"]),
+            TimeSpan.FromSeconds(5));
+        Assert.That(client.PageRequests - requestsBeforeNotification, Is.EqualTo(2));
+
+        static AiJob Job(string id) => new(
+            new AiJobId(id),
+            AiJobKinds.Image,
+            AiJobStatuses.Succeeded,
+            null,
+            null,
+            null,
+            null,
+            false,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+    }
+
+    [Test]
+    public async Task RefreshAsync_WhenUserSignsOutDuringRequest_DoesNotRestoreStaleJobs()
+    {
+        var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = new StubHandler(async _ =>
+        {
+            requestStarted.TrySetResult();
+            await releaseResponse.Task;
+            return JsonResponse(HttpStatusCode.OK, """
+                {
+                  "jobs": [
+                    {
+                      "id": "stale-job",
+                      "kind": "image",
+                      "status": "succeeded",
+                      "inputParams": { "prompt": "Must not reappear" },
+                      "fileId": "file-1",
+                      "url": "https://beutl.beditor.net/api/contents/file-1",
+                      "usageUnits": 20,
+                      "error": null,
+                      "canRetry": false,
+                      "createdAt": "2026-08-01T00:00:00Z",
+                      "updatedAt": "2026-08-01T00:01:00Z"
+                    }
+                  ],
+                  "nextCursor": null
+                }
+                """);
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        IAiJobMonitor service = app.GetResource<IAiJobMonitor>();
+
+        SetAuthenticatedUser(app, httpClient);
+        await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Task queuedRefresh = service.RefreshAsync(CancellationToken.None);
+        app.SignOut(deleteFile: false);
+        releaseResponse.TrySetResult();
+        await queuedRefresh.WaitAsync(TimeSpan.FromSeconds(5));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(service.Snapshot.Value.Jobs, Is.Empty);
+            Assert.That(service.Snapshot.Value.IsLoading, Is.False);
+            Assert.That(service.Snapshot.Value.Error, Is.TypeOf<AuthenticationRequiredException>());
+        }
+    }
+
+    [Test]
+    public async Task ActiveJob_IsPolledToCompletionWithoutUiPollingLease()
+    {
+        int requestCount = 0;
+        using var handler = new StubHandler(_ =>
+        {
+            int current = Interlocked.Increment(ref requestCount);
+            string status = current == 1 ? "queued" : "succeeded";
+            return JsonResponse(HttpStatusCode.OK, $$"""
+                {
+                  "jobs": [
+                    {
+                      "id": "job-1",
+                      "kind": "video",
+                      "status": "{{status}}",
+                      "inputParams": { "prompt": "A clip", "durationSeconds": 4 },
+                      "fileId": {{(status == "succeeded" ? "\"file-1\"" : "null")}},
+                      "url": {{(status == "succeeded" ? "\"https://example.com/video.mp4\"" : "null")}},
+                      "usageUnits": 160,
+                      "error": null,
+                      "canRetry": false,
+                      "createdAt": "2026-08-01T00:00:00Z",
+                      "updatedAt": "2026-08-01T00:01:00Z"
+                    }
+                  ],
+                  "nextCursor": null
+                }
+                """);
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        using var service = new AiJobMonitor(
+            app,
+            app.GetResource<IAiJobClient>(),
+            app.GetResource<IAiJobKindRegistry>(),
+            app.GetResource<AiJobChangeNotifier>().Changes,
+            TimeSpan.FromMilliseconds(10));
+
+        SetAuthenticatedUser(app, httpClient);
+
+        await WaitUntilAsync(
+            () => service.Snapshot.Value.Jobs.SingleOrDefault()?.Status == AiJobStatuses.Succeeded,
+            TimeSpan.FromSeconds(3));
+        Assert.That(requestCount, Is.GreaterThanOrEqualTo(2));
+    }
+
+    [Test]
+    public async Task PollingLease_PeriodicallyDiscoversJobsCreatedByAnotherClient()
+    {
+        using var handler = new StubHandler(_ => JsonResponse(HttpStatusCode.OK, "{}"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var client = new RecordingJobClient();
+        client.PageProvider = _ => Volatile.Read(ref client.PageRequests) >= 3
+            ? new AiJobPage([
+                    new AiJob(
+                        new AiJobId("external-job"),
+                        AiJobKinds.Image,
+                        AiJobStatuses.Succeeded,
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        DateTimeOffset.UtcNow,
+                        DateTimeOffset.UtcNow),
+                ], null)
+            : new AiJobPage([], null);
+        await using var jobKinds = new AiJobKindRegistry();
+        using var changes = new Subject<Unit>();
+        using var service = new AiJobMonitor(
+            app,
+            client,
+            jobKinds,
+            changes,
+            TimeSpan.FromMilliseconds(10));
+
+        SetAuthenticatedUser(app, httpClient);
+        await WaitUntilAsync(() => Volatile.Read(ref client.PageRequests) == 1, TimeSpan.FromSeconds(5));
+        using IDisposable polling = service.AcquirePolling();
+
+        await WaitUntilAsync(
+            () => service.Snapshot.Value.Jobs.SingleOrDefault()?.Id.Value == "external-job",
+            TimeSpan.FromSeconds(5));
+
+        Assert.That(client.PageRequests, Is.GreaterThanOrEqualTo(3));
+    }
+
+    [Test]
+    public async Task PollingLease_DoesNotRepeatHistoryRequestsAfterAuthenticationFailure()
+    {
+        using var handler = new StubHandler(_ => JsonResponse(HttpStatusCode.OK, "{}"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var client = new RecordingJobClient();
+        client.PageProvider = _ => Volatile.Read(ref client.PageRequests) == 1
+            ? new AiJobPage([], null)
+            : throw new AuthenticationRequiredException();
+        await using var jobKinds = new AiJobKindRegistry();
+        using var changes = new Subject<Unit>();
+        using var service = new AiJobMonitor(
+            app,
+            client,
+            jobKinds,
+            changes,
+            TimeSpan.FromMilliseconds(10));
+
+        SetAuthenticatedUser(app, httpClient);
+        await WaitUntilAsync(() => Volatile.Read(ref client.PageRequests) == 1, TimeSpan.FromSeconds(5));
+        using IDisposable polling = service.AcquirePolling();
+        await WaitUntilAsync(
+            () => service.Snapshot.Value.Error is AuthenticationRequiredException,
+            TimeSpan.FromSeconds(5));
+        int requestsAfterFailure = Volatile.Read(ref client.PageRequests);
+
+        await Task.Delay(100);
+
+        Assert.That(client.PageRequests, Is.EqualTo(requestsAfterFailure));
+    }
+
+    [Test]
+    public async Task UnknownStatus_IsPublishedButDoesNotStartUnboundedPolling()
+    {
+        using var handler = new StubHandler(_ => JsonResponse(HttpStatusCode.OK, "{}"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var client = new RecordingJobClient
+        {
+            Page = new AiJobPage(
+            [
+                new AiJob(
+                    new AiJobId("future-job"),
+                    AiJobKinds.Video,
+                    new AiJobStatusId("provider-paused"),
+                    null,
+                    null,
+                    null,
+                    null,
+                    false,
+                    DateTimeOffset.UtcNow,
+                    DateTimeOffset.UtcNow),
+            ],
+            null),
+        };
+        using var changes = new Subject<Unit>();
+        using var service = new AiJobMonitor(
+            app,
+            client,
+            app.GetResource<IAiJobKindRegistry>(),
+            changes,
+            TimeSpan.FromMilliseconds(10));
+
+        SetAuthenticatedUser(app, httpClient);
+        await WaitUntilAsync(() => Volatile.Read(ref client.PageRequests) == 1, TimeSpan.FromSeconds(5));
+        await Task.Delay(100);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(client.PageRequests, Is.EqualTo(1));
+            Assert.That(service.Snapshot.Value.Jobs.Single().Status.Value, Is.EqualTo("provider-paused"));
+        }
+    }
+
+    [Test]
+    public async Task InjectedTransportAndJobChangeStream_AreIndependentSubstitutionSeams()
+    {
+        using var handler = new StubHandler(_ => JsonResponse(HttpStatusCode.OK, "{}"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app, httpClient);
+        var client = new RecordingJobClient();
+        await using var jobKinds = new AiJobKindRegistry();
+        using var changes = new Subject<Unit>();
+        using var service = new AiJobMonitor(
+            app,
+            client,
+            jobKinds,
+            changes,
+            TimeSpan.FromHours(1));
+
+        await WaitUntilAsync(() => Volatile.Read(ref client.PageRequests) >= 1, TimeSpan.FromSeconds(5));
+        int beforeNotification = Volatile.Read(ref client.PageRequests);
+        changes.OnNext(Unit.Default);
+        await WaitUntilAsync(
+            () => Volatile.Read(ref client.PageRequests) > beforeNotification,
+            TimeSpan.FromSeconds(5));
+
+        Assert.That(client.PageRequests, Is.GreaterThan(beforeNotification));
+    }
+
+    [Test]
+    public async Task CustomKindDescriptor_DrivesPollingWithoutBuiltInStatusesOrVideo()
+    {
+        using var handler = new StubHandler(_ => JsonResponse(HttpStatusCode.OK, "{}"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app, httpClient);
+        var client = new ExtensibleJobClient();
+        await using var jobKinds = new AiJobKindRegistry();
+        var refreshHandler = new ExtensibleRefreshHandler(client);
+        var kind = new AiJobKindId("vendor.render");
+        var statusResolver = new AiJobStatusMap(
+            [
+                KeyValuePair.Create(
+                    new AiJobStatusId("vendor-waiting"),
+                    new AiJobStatusSemantics(false, true)),
+                KeyValuePair.Create(
+                    new AiJobStatusId("vendor-done"),
+                    new AiJobStatusSemantics(
+                        true,
+                        false,
+                        new AiJobOutcomeId("vendor.complete"))),
+            ]);
+        await using IAiJobStatusResolverRegistration statusRegistration = jobKinds.Register(
+            new AiJobStatusResolverRegistration(kind, statusResolver));
+        await using IAiJobRefreshHandlerRegistration refreshRegistration = jobKinds.Register(
+            new AiJobRefreshHandlerRegistration(kind, refreshHandler));
+        using var changes = new Subject<Unit>();
+        using var service = new AiJobMonitor(
+            app,
+            client,
+            jobKinds,
+            changes,
+            TimeSpan.FromMilliseconds(10));
+
+        await WaitUntilAsync(
+            () => service.Snapshot.Value.Jobs.SingleOrDefault()?.Status
+                == new AiJobStatusId("vendor-done"),
+            TimeSpan.FromSeconds(3));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(refreshHandler.RefreshCount, Is.GreaterThanOrEqualTo(1));
+            Assert.That(service.Snapshot.Value.Error, Is.Null);
+            Assert.That(jobKinds.GetStatus(service.Snapshot.Value.Jobs.Single()).Outcome,
+                Is.EqualTo(new AiJobOutcomeId("vendor.complete")));
+        }
+    }
+
+    [Test]
+    public async Task ThrowingStatusResolver_DoesNotAbortMonitorPollingPredicates()
+    {
+        using var handler = new StubHandler(_ => JsonResponse(HttpStatusCode.OK, "{}"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app, httpClient);
+        var client = new RecordingJobClient
+        {
+            Page = new AiJobPage([
+                new AiJob(
+                    new AiJobId("throwing"),
+                    new AiJobKindId("vendor.throwing"),
+                    new AiJobStatusId("pending"),
+                    null, null, null, null, false,
+                    DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+            ], null),
+        };
+        await using var jobKinds = new AiJobKindRegistry();
+        await using IAiJobStatusResolverRegistration registration = jobKinds.Register(
+            new AiJobStatusResolverRegistration(
+                new AiJobKindId("vendor.throwing"),
+                new ThrowingStatusResolver()));
+        using var changes = new Subject<Unit>();
+        using var service = new AiJobMonitor(
+            app, client, jobKinds, changes, TimeSpan.FromMilliseconds(10));
+
+        await service.RefreshAsync(CancellationToken.None);
+        using var polling = service.AcquirePolling();
+        await Task.Delay(50);
+        Assert.That(client.PageRequests, Is.GreaterThanOrEqualTo(1));
+    }
+
+    [Test]
+    public async Task JobBehaviorSlotsReplaceAndRestoreIndependently()
+    {
+        var kind = new AiJobKindId("vendor.render");
+        var status = new EphemeralStatusResolver();
+        var refresh = new NoOpRefreshHandler();
+        var retry = new NoOpRetryHandler();
+        var retryReplacement = new NoOpRetryHandler();
+        await using var registry = new AiJobKindRegistry(
+            [new AiJobStatusResolverRegistration(kind, status)],
+            [new AiJobRefreshHandlerRegistration(kind, refresh)],
+            [new AiJobRetryHandlerRegistration(kind, retry)]);
+
+        await using IAiJobRetryHandlerRegistration replacement = registry.Register(
+            new AiJobRetryHandlerRegistration(
+                kind,
+                retryReplacement,
+                AiJobBehaviorRegistrationMode.Replace));
+
+        AssertJobBehaviors(registry, kind, status, refresh, retryReplacement);
+        await replacement.DisposeAsync();
+        AssertJobBehaviors(registry, kind, status, refresh, retry);
+    }
+
+    [Test]
+    public async Task RefreshReplacementRetiresImmediatelyAndDrainsOnlyItsLease()
+    {
+        var kind = new AiJobKindId("vendor.render");
+        var status = new EphemeralStatusResolver();
+        var fallback = new NoOpRefreshHandler();
+        var replacement = new NoOpRefreshHandler();
+        var retry = new NoOpRetryHandler();
+        await using var registry = new AiJobKindRegistry(
+            [new AiJobStatusResolverRegistration(kind, status)],
+            [new AiJobRefreshHandlerRegistration(kind, fallback)],
+            [new AiJobRetryHandlerRegistration(kind, retry)]);
+        IAiJobRefreshHandlerRegistration registration = registry.Register(
+            new AiJobRefreshHandlerRegistration(
+                kind,
+                replacement,
+                AiJobBehaviorRegistrationMode.Replace));
+        Assert.That(registry.TryAcquireRefreshHandler(
+            kind,
+            out IAiJobRefreshHandlerLease? activeLease), Is.True);
+
+        Task retirement = registration.DisposeAsync().AsTask();
+        try
+        {
+            AssertJobBehaviors(registry, kind, status, fallback, retry);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(retirement.IsCompleted, Is.False);
+                Assert.That(activeLease!.Handler, Is.SameAs(replacement));
+            }
+        }
+        finally
+        {
+            activeLease!.Dispose();
+        }
+
+        await retirement.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Throws<ObjectDisposedException>(() => _ = activeLease!.Handler);
+    }
+
+    [Test]
+    public async Task RetryExtensionRemovalDrainsItsLeaseBeforeUnload()
+    {
+        var extensions = new ExtensionProvider();
+        await using var registry = new AiJobKindRegistry([], [], [], extensions);
+        var kind = new AiJobKindId("vendor.package");
+        var handler = new NoOpRetryHandler();
+        var extension = new TestAiJobRetryHandlerExtension(
+            new AiJobRetryHandlerRegistration(kind, handler));
+        extensions.AddExtensions(101, [extension]);
+        Assert.That(registry.TryAcquireRetryHandler(
+            kind,
+            out IAiJobRetryHandlerLease? lease), Is.True);
+
+        ExtensionRemoval removal = extensions.RemoveExtensions(101);
+        Task drain = removal.DrainAsync().AsTask();
+        try
+        {
+            Assert.That(registry.TryAcquireRetryHandler(kind, out _), Is.False);
+            Assert.That(drain.IsCompleted, Is.False);
+            Assert.That(lease!.Handler, Is.SameAs(handler));
+        }
+        finally
+        {
+            lease!.Dispose();
+        }
+
+        await drain.WaitAsync(TimeSpan.FromSeconds(5));
+        extension.Unload();
+        Assert.That(extension.UnloadCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task RetryExtensionIsNotPublishedBeforeTheProviderCommitsItsBatch()
+    {
+        var extensions = new ExtensionProvider();
+        await using var registry = new AiJobKindRegistry([], [], [], extensions);
+        var kind = new AiJobKindId("vendor.provisional");
+        var extension = new TestAiJobRetryHandlerExtension(
+            new AiJobRetryHandlerRegistration(kind, new NoOpRetryHandler()));
+        extensions.AllExtensions.CollectionChanged += (sender, args) =>
+        {
+            if (args.Action != NotifyCollectionChangedAction.Add)
+                return;
+
+            Assert.That(registry.TryAcquireRetryHandler(kind, out _), Is.False);
+            throw new InvalidOperationException("later composition failed");
+        };
+
+        Assert.Throws<ExtensionRegistrationNotificationException>(() =>
+            extensions.AddExtensions(103, [extension]));
+
+        Assert.That(registry.TryAcquireRetryHandler(kind, out _), Is.False);
+    }
+
+    [Test]
+    public async Task RetryRegistryConstructionWaitsForAnExtensionBatchToCommit()
+    {
+        var extensions = new ExtensionProvider();
+        var kind = new AiJobKindId("vendor.constructor-race");
+        var extension = new TestAiJobRetryHandlerExtension(
+            new AiJobRetryHandlerRegistration(kind, new NoOpRetryHandler()));
+        using var observerEntered = new ManualResetEventSlim();
+        using var releaseObserver = new ManualResetEventSlim();
+        using var constructorStarted = new ManualResetEventSlim();
+        using var constructorFinished = new ManualResetEventSlim();
+        extensions.AllExtensions.CollectionChanged += (sender, args) =>
+        {
+            if (args.Action != NotifyCollectionChangedAction.Add)
+                return;
+
+            observerEntered.Set();
+            releaseObserver.Wait(TimeSpan.FromSeconds(5));
+            throw new InvalidOperationException("later composition failed");
+        };
+
+        Task<Exception?> addition = Task.Run(() =>
+        {
+            try
+            {
+                extensions.AddExtensions(104, [extension]);
+                return null;
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
+        });
+        Assert.That(observerEntered.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+        Task<AiJobKindRegistry> construction = Task.Run(() =>
+        {
+            constructorStarted.Set();
+            var result = new AiJobKindRegistry([], [], [], extensions);
+            constructorFinished.Set();
+            return result;
+        });
+
+        try
+        {
+            Assert.That(constructorStarted.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            Assert.That(constructorFinished.Wait(TimeSpan.FromMilliseconds(200)), Is.False);
+        }
+        finally
+        {
+            releaseObserver.Set();
+        }
+
+        Assert.That(await addition, Is.TypeOf<ExtensionRegistrationNotificationException>());
+        await using AiJobKindRegistry registry = await construction.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(registry.TryAcquireRetryHandler(kind, out _), Is.False);
+    }
+
+    [Test]
+    public async Task RetryExtensionsComposeReplacementAfterBaseInOneChange()
+    {
+        var extensions = new ExtensionProvider();
+        await using var registry = new AiJobKindRegistry([], [], [], extensions);
+        var kind = new AiJobKindId("vendor.fixed-point");
+        var fallback = new NoOpRetryHandler();
+        var replacement = new NoOpRetryHandler();
+        var replaceExtension = new TestAiJobRetryHandlerExtension(
+            new AiJobRetryHandlerRegistration(
+                kind,
+                replacement,
+                AiJobBehaviorRegistrationMode.Replace));
+        var addExtension = new TestAiJobRetryHandlerExtension(
+            new AiJobRetryHandlerRegistration(kind, fallback));
+
+        extensions.AddExtensions(102, [replaceExtension, addExtension]);
+
+        Assert.That(registry.TryAcquireRetryHandler(
+            kind,
+            out IAiJobRetryHandlerLease? lease), Is.True);
+        using (lease)
+        {
+            Assert.That(lease!.Handler, Is.SameAs(replacement));
+        }
+
+        await extensions.RemoveExtensions(102).DrainAsync();
+    }
+
+    [Test]
+    public void StatusSemantics_KeepTerminalityPollingAndOpenOutcomeIndependent()
+    {
+        var resolver = new AiJobStatusMap(
+        [
+            KeyValuePair.Create(
+                new AiJobStatusId("vendor-waiting"),
+                new AiJobStatusSemantics(false, true)),
+            KeyValuePair.Create(
+                new AiJobStatusId("vendor-paused"),
+                new AiJobStatusSemantics(false, false)),
+            KeyValuePair.Create(
+                new AiJobStatusId("vendor-finished"),
+                new AiJobStatusSemantics(
+                    true,
+                    false,
+                    new AiJobOutcomeId("vendor.review-required"))),
+        ]);
+
+        AiJobStatusSemantics waiting = resolver.Resolve(new AiJobStatusId("VENDOR-WAITING"));
+        AiJobStatusSemantics paused = resolver.Resolve(new AiJobStatusId("vendor-paused"));
+        AiJobStatusSemantics finished = resolver.Resolve(new AiJobStatusId("vendor-finished"));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(waiting.IsTerminal, Is.False);
+            Assert.That(waiting.ShouldPoll, Is.True);
+            Assert.That(waiting.Outcome, Is.Null);
+            Assert.That(paused.IsTerminal, Is.False);
+            Assert.That(paused.ShouldPoll, Is.False);
+            Assert.That(finished.IsTerminal, Is.True);
+            Assert.That(finished.ShouldPoll, Is.False);
+            Assert.That(finished.Outcome, Is.EqualTo(new AiJobOutcomeId("vendor.review-required")));
+            Assert.That(
+                resolver.Resolve(new AiJobStatusId("vendor-unknown")),
+                Is.EqualTo(AiJobStatusSemantics.Unknown));
+        }
+    }
+
+    [Test]
+    public async Task UnregisteredKind_HasUnknownSemanticsAndNoBehaviorLeases()
+    {
+        await using var registry = new AiJobKindRegistry();
+        var job = new AiJob(
+            new AiJobId("unknown-job"),
+            new AiJobKindId("vendor.unknown"),
+            new AiJobStatusId("mystery"),
+            null,
+            null,
+            null,
+            null,
+            false,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(registry.GetStatus(job), Is.EqualTo(AiJobStatusSemantics.Unknown));
+            Assert.That(registry.TryAcquireStatusResolver(job.Kind, out _), Is.False);
+            Assert.That(registry.TryAcquireRefreshHandler(job.Kind, out _), Is.False);
+            Assert.That(registry.TryAcquireRetryHandler(job.Kind, out _), Is.False);
+        }
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        using var cancellationTokenSource = new CancellationTokenSource(timeout);
+        while (!condition())
+        {
+            await Task.Delay(10, cancellationTokenSource.Token);
+        }
+    }
+
+    private static void AssertJobBehaviors(
+        AiJobKindRegistry registry,
+        AiJobKindId kind,
+        IAiJobStatusResolver status,
+        IAiJobRefreshHandler refresh,
+        IAiJobRetryHandler retry)
+    {
+        Assert.That(registry.TryAcquireStatusResolver(
+            kind,
+            out IAiJobStatusResolverLease? statusLease), Is.True);
+        using (statusLease)
+        {
+            Assert.That(statusLease!.Resolver, Is.SameAs(status));
+        }
+
+        Assert.That(registry.TryAcquireRefreshHandler(
+            kind,
+            out IAiJobRefreshHandlerLease? refreshLease), Is.True);
+        using (refreshLease)
+        {
+            Assert.That(refreshLease!.Handler, Is.SameAs(refresh));
+        }
+
+        Assert.That(registry.TryAcquireRetryHandler(
+            kind,
+            out IAiJobRetryHandlerLease? retryLease), Is.True);
+        using (retryLease)
+        {
+            Assert.That(retryLease!.Handler, Is.SameAs(retry));
+        }
+    }
+
+    private static void SetAuthenticatedUser(
+        BeutlApiApplication app,
+        HttpClient httpClient,
+        string id = "test-user")
+    {
+        var profileResponse = new ProfileResponse
+        {
+            Id = id,
+            Name = "test",
+            DisplayName = "Test User",
+            Bio = null,
+            IconId = null,
+            IconUrl = null,
+        };
+        var profile = new Profile(profileResponse, app);
+        var authResponse = new AuthResponse
+        {
+            Token = "token",
+            RefreshToken = "refresh-token",
+            Expiration = DateTime.UtcNow.AddHours(1),
+        };
+        var user = new AuthenticatedUser(profile, authResponse, app, DateTime.UtcNow);
+
+        FieldInfo field = typeof(BeutlApiApplication).GetField(
+            "_authenticatedUser",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var property = (ReactivePropertySlim<AuthenticatedUser?>)field.GetValue(app)!;
+        property.Value = user;
+    }
+
+    private static HttpResponseMessage JsonResponse(HttpStatusCode status, string json)
+    {
+        return new HttpResponseMessage(status)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+    }
+
+    private sealed class StubHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder) : HttpMessageHandler
+    {
+        private readonly object _requestsGate = new();
+        private readonly List<string> _requests = [];
+
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+            : this((request, _) => Task.FromResult(responder(request)))
+        {
+        }
+
+        public StubHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> responder)
+            : this((request, _) => responder(request))
+        {
+        }
+
+        public IReadOnlyList<string> Requests
+        {
+            get
+            {
+                lock (_requestsGate)
+                {
+                    return _requests.ToArray();
+                }
+            }
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            lock (_requestsGate)
+            {
+                _requests.Add(request.RequestUri?.PathAndQuery ?? string.Empty);
+            }
+
+            HttpResponseMessage response = await responder(request, cancellationToken);
+            response.RequestMessage = request;
+            return response;
+        }
+    }
+
+    private sealed class RecordingJobClient : IAiJobClient
+    {
+        public int PageRequests;
+
+        public AiJobPage Page { get; init; } = new([], null);
+        public Func<AiJobPageRequest, AiJobPage>? PageProvider { get; set; }
+
+        public Task<AiJobPage> GetPageAsync(
+            AiJobPageRequest request,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref PageRequests);
+            return Task.FromResult(PageProvider?.Invoke(request) ?? Page);
+        }
+
+        public Task DeleteAsync(AiJobId jobId, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class ExtensibleJobClient : IAiJobClient
+    {
+        private int _completed;
+
+        public void Complete() => Volatile.Write(ref _completed, 1);
+
+        public Task<AiJobPage> GetPageAsync(
+            AiJobPageRequest request,
+            CancellationToken cancellationToken)
+        {
+            AiJobStatusId status = Volatile.Read(ref _completed) == 0
+                ? new AiJobStatusId("vendor-waiting")
+                : new AiJobStatusId("vendor-done");
+            var job = new AiJob(
+                new AiJobId("vendor-job"),
+                new AiJobKindId("vendor.render"),
+                status,
+                null,
+                null,
+                null,
+                null,
+                false,
+                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow);
+            return Task.FromResult(new AiJobPage([job], null));
+        }
+
+        public Task DeleteAsync(AiJobId jobId, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class ExtensibleRefreshHandler(ExtensibleJobClient client) : IAiJobRefreshHandler
+    {
+        private int _refreshCount;
+
+        public int RefreshCount => Volatile.Read(ref _refreshCount);
+
+        public Task RefreshAsync(AiJob job, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _refreshCount);
+            client.Complete();
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class EphemeralStatusResolver : IAiJobStatusResolver
+    {
+        public AiJobStatusSemantics Resolve(AiJobStatusId status)
+            => AiJobStatusSemantics.Unknown;
+    }
+
+    private sealed class ThrowingStatusResolver : IAiJobStatusResolver
+    {
+        public AiJobStatusSemantics Resolve(AiJobStatusId status)
+            => throw new InvalidOperationException("status resolver failure");
+    }
+
+    private sealed class NoOpRefreshHandler : IAiJobRefreshHandler
+    {
+        public Task RefreshAsync(AiJob job, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+    }
+
+    private sealed class NoOpRetryHandler : IAiJobRetryHandler
+    {
+        public bool CanRetry(AiJob job, AiJobStatusSemantics status) => true;
+
+        public ValueTask<AiJobRetryPreflight> GetPreflightAsync(
+            AiJob job,
+            CancellationToken cancellationToken)
+            => ValueTask.FromResult(new AiJobRetryPreflight(true, true, "ready"));
+
+        public ValueTask<AiJobRetryPreparationResult> PrepareAsync(
+            AiJob job,
+            CancellationToken cancellationToken)
+            => ValueTask.FromResult(AiJobRetryPreparationResult.Blocked("unused"));
+    }
+
+    private sealed class TestAiJobRetryHandlerExtension(
+        params AiJobRetryHandlerRegistration[] registrations) : AiJobRetryHandlerExtension
+    {
+        public int UnloadCount { get; private set; }
+
+        public override IReadOnlyCollection<AiJobRetryHandlerRegistration> Registrations { get; } =
+            registrations;
+
+        public override void Unload()
+        {
+            UnloadCount++;
+            base.Unload();
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Api/AiModelCatalogTests.cs
+++ b/tests/Beutl.UnitTests/Api/AiModelCatalogTests.cs
@@ -1331,6 +1331,35 @@ public class AiModelCatalogTests
     }
 
     [Test]
+    public async Task Retry_RefusesAModelWhenTheOperationExplicitlyOffersNoModels()
+    {
+        var images = new Mock<IAiImageGenerationService>();
+        var catalog = new AiModelCatalog(
+            [],
+            withoutModels: [AiOperations.ImageGeneration]);
+        var handler = new AiImageJobRetryHandler(
+            images.Object,
+            EntitlementService(),
+            AvailabilityService(),
+            ModelCatalogService(catalog),
+            RetryContext());
+        AiJob job = ImageJob("withdrawn/model");
+
+        AiJobRetryPreflight preflight = await handler.GetPreflightAsync(
+            job,
+            CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(preflight.CanSubmit, Is.False);
+            Assert.That(preflight.Explanation, Is.EqualTo(Strings.AiModelUnavailable));
+        }
+        images.Verify(service => service.GenerateAsync(
+            It.IsAny<AiImageGenerationRequest>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
     public void Retry_ProceedsWhenTheCatalogCouldNotBeRead()
     {
         var images = new Mock<IAiImageGenerationService>();

--- a/tests/Beutl.UnitTests/Api/AiModelCatalogTests.cs
+++ b/tests/Beutl.UnitTests/Api/AiModelCatalogTests.cs
@@ -186,6 +186,30 @@ public class AiModelCatalogTests
         ]));
     }
 
+    [TestCase(0)]
+    [TestCase(61)]
+    public void Catalog_RejectsInvalidVideoDurationsFromCustomProviders(int durationSeconds)
+    {
+        var operation = new AiOperationId("vendor.invalid-video-duration");
+
+        Assert.Throws<ArgumentException>(() => new AiModelCatalog(
+        [
+            KeyValuePair.Create(
+                operation,
+                ImmutableArray.Create(new AiModelOption(
+                    new AiModelId("vendor/video"),
+                    "Vendor Video",
+                    AiModelCostTier.Medium,
+                    IsDefault: true,
+                    Video: new AiVideoModelCapabilities(
+                        AiCapabilityDimension<int>.Supported([durationSeconds]),
+                        AiCapabilityDimension<string>.Unspecified,
+                        AiCapabilityDimension<string>.Unspecified,
+                        SupportsAudio: true,
+                        SupportsSeed: true)))),
+        ]));
+    }
+
     [Test]
     public void Catalog_TreatsAFullyFilteredModelListAsExplicitlyUnavailable()
     {

--- a/tests/Beutl.UnitTests/Api/AiModelCatalogTests.cs
+++ b/tests/Beutl.UnitTests/Api/AiModelCatalogTests.cs
@@ -171,6 +171,22 @@ public class AiModelCatalogTests
     }
 
     [Test]
+    public void Catalog_RejectsDuplicateModelIdsWithinAnOperation()
+    {
+        var operation = new AiOperationId("vendor.duplicate-model-id");
+        var modelId = new AiModelId("same-model");
+
+        Assert.Throws<ArgumentException>(() => new AiModelCatalog(
+        [
+            KeyValuePair.Create(
+                operation,
+                ImmutableArray.Create(
+                    new AiModelOption(modelId, "First", AiModelCostTier.Low, IsDefault: true),
+                    new AiModelOption(modelId, "Second", AiModelCostTier.High, IsDefault: false))),
+        ]));
+    }
+
+    [Test]
     public void Catalog_TreatsAFullyFilteredModelListAsExplicitlyUnavailable()
     {
         AiModelCatalog catalog = AiModelMapper.ToModel(Capabilities(

--- a/tests/Beutl.UnitTests/Api/AiModelCatalogTests.cs
+++ b/tests/Beutl.UnitTests/Api/AiModelCatalogTests.cs
@@ -210,6 +210,98 @@ public class AiModelCatalogTests
         ]));
     }
 
+    [TestCase("video-resolution")]
+    [TestCase("video-aspect-ratio")]
+    [TestCase("image-aspect-ratio")]
+    [TestCase("image-background")]
+    public void Catalog_RejectsInvalidStringCapabilitiesFromCustomProviders(string dimension)
+    {
+        string? invalidValue = dimension switch
+        {
+            "video-resolution" => null,
+            "video-aspect-ratio" => " ",
+            "image-aspect-ratio" => string.Empty,
+            "image-background" => new string('x', 257),
+            _ => throw new ArgumentOutOfRangeException(nameof(dimension)),
+        };
+        AiVideoModelCapabilities? video = dimension switch
+        {
+            "video-resolution" => AiVideoModelCapabilities.Unrestricted with
+            {
+                Resolutions = AiCapabilityDimension<string>.Supported([invalidValue!]),
+            },
+            "video-aspect-ratio" => AiVideoModelCapabilities.Unrestricted with
+            {
+                AspectRatios = AiCapabilityDimension<string>.Supported([invalidValue!]),
+            },
+            _ => null,
+        };
+        AiImageModelCapabilities? image = dimension switch
+        {
+            "image-aspect-ratio" => AiImageModelCapabilities.Unrestricted with
+            {
+                AspectRatios = AiCapabilityDimension<string>.Supported([invalidValue!]),
+            },
+            "image-background" => AiImageModelCapabilities.Unrestricted with
+            {
+                Backgrounds = AiCapabilityDimension<string>.Supported([invalidValue!]),
+            },
+            _ => null,
+        };
+
+        Assert.Throws<ArgumentException>(() => new AiModelCatalog(
+        [
+            KeyValuePair.Create(
+                new AiOperationId("vendor.invalid-string-capability"),
+                ImmutableArray.Create(new AiModelOption(
+                    new AiModelId("vendor/model"),
+                    "Vendor Model",
+                    AiModelCostTier.Medium,
+                    IsDefault: true,
+                    Video: video,
+                    Image: image))),
+        ]));
+    }
+
+    [Test]
+    public void Catalog_RejectsDuplicateStringCapabilities()
+    {
+        Assert.Throws<ArgumentException>(() => new AiModelCatalog(
+        [
+            KeyValuePair.Create(
+                new AiOperationId("vendor.duplicate-resolution"),
+                ImmutableArray.Create(new AiModelOption(
+                    new AiModelId("vendor/video"),
+                    "Vendor Video",
+                    AiModelCostTier.Medium,
+                    IsDefault: true,
+                    Video: AiVideoModelCapabilities.Unrestricted with
+                    {
+                        Resolutions = AiCapabilityDimension<string>.Supported(
+                            ["720p", "720p"]),
+                    }))),
+        ]));
+    }
+
+    [Test]
+    public void Catalog_RejectsNonCanonicalStringCapabilities()
+    {
+        Assert.Throws<ArgumentException>(() => new AiModelCatalog(
+        [
+            KeyValuePair.Create(
+                new AiOperationId("vendor.noncanonical-resolution"),
+                ImmutableArray.Create(new AiModelOption(
+                    new AiModelId("vendor/video"),
+                    "Vendor Video",
+                    AiModelCostTier.Medium,
+                    IsDefault: true,
+                    Video: AiVideoModelCapabilities.Unrestricted with
+                    {
+                        Resolutions = AiCapabilityDimension<string>.Supported([" 720p "]),
+                    }))),
+        ]));
+    }
+
     [Test]
     public void Catalog_TreatsAFullyFilteredModelListAsExplicitlyUnavailable()
     {

--- a/tests/Beutl.UnitTests/Api/AiModelCatalogTests.cs
+++ b/tests/Beutl.UnitTests/Api/AiModelCatalogTests.cs
@@ -1,0 +1,1542 @@
+﻿using System.Collections.Immutable;
+using System.Text.Json;
+using Beutl.Api.Clients;
+using Beutl.Api.Services;
+using Beutl.Extensibility;
+using Beutl.Language;
+using Moq;
+using NUnit.Framework;
+
+namespace Beutl.UnitTests.Api;
+
+/// <summary>
+/// The models an operation offers are registered on the server, so unlike every
+/// other list this client holds they arrive over the wire. These cover reading
+/// that list and the one rule that costs money if it goes wrong: a rerun must
+/// repeat the model the job ran on, or not run at all.
+/// </summary>
+public class AiModelCatalogTests
+{
+    [TestCase("", false, TestName = "Omitted image model dimension is unspecified")]
+    [TestCase("\"aspectRatios\":null", false, TestName = "Null image model dimension is unspecified")]
+    [TestCase("\"aspectRatios\":[]", true, TestName = "Empty image model dimension is unsupported")]
+    public void CapabilityJson_PreservesOmittedNullAndEmptyImageModelDimensions(string dimensionJson, bool unsupported)
+    {
+        string model = "{\"id\":\"m\"" + (string.IsNullOrEmpty(dimensionJson) ? "" : "," + dimensionJson) + "}";
+        string json = "{\"operations\":{\"image.generate\":{\"models\":[" + model + "]}}}";
+        AiCapabilitiesResponse response = JsonSerializer.Deserialize<AiCapabilitiesResponse>(
+            json,
+            new JsonSerializerOptions(JsonSerializerDefaults.Web))!;
+        AiImageModelCapabilities image = AiModelMapper.ToModel(response).ModelsFor(AiOperations.ImageGeneration)[0].Image!;
+        Assert.That(
+            image.AspectRatios,
+            Is.EqualTo(unsupported
+                ? AiCapabilityDimension<string>.Unsupported
+                : AiCapabilityDimension<string>.Unspecified));
+    }
+
+    [TestCase("", false, TestName = "Omitted image operation dimension is unspecified")]
+    [TestCase("\"aspectRatios\":null", false, TestName = "Null image operation dimension is unspecified")]
+    [TestCase("\"aspectRatios\":[]", true, TestName = "Empty image operation dimension is unsupported")]
+    public void CapabilityJson_PreservesOmittedNullAndEmptyImageOperationDimensions(string dimensionJson, bool unsupported)
+    {
+        string operationProperties = string.IsNullOrEmpty(dimensionJson) ? "" : dimensionJson + ",";
+        string json = "{\"operations\":{\"image.generate\":{" + operationProperties + "\"models\":[{\"id\":\"m\"}]}}}";
+        AiCapabilitiesResponse response = JsonSerializer.Deserialize<AiCapabilitiesResponse>(
+            json,
+            new JsonSerializerOptions(JsonSerializerDefaults.Web))!;
+        AiImageModelCapabilities image = AiModelMapper.ToModel(response).ModelsFor(AiOperations.ImageGeneration)[0].Image!;
+        Assert.That(
+            image.AspectRatios,
+            Is.EqualTo(unsupported
+                ? AiCapabilityDimension<string>.Unsupported
+                : AiCapabilityDimension<string>.Unspecified));
+    }
+
+    [TestCase("", false, TestName = "Omitted video model dimension is unspecified")]
+    [TestCase("\"resolutions\":null", false, TestName = "Null video model dimension is unspecified")]
+    [TestCase("\"resolutions\":[]", true, TestName = "Empty video model dimension is unsupported")]
+    public void CapabilityJson_PreservesOmittedNullAndEmptyVideoModelDimensions(string dimensionJson, bool unsupported)
+    {
+        string model = "{\"id\":\"m\"" + (string.IsNullOrEmpty(dimensionJson) ? "" : "," + dimensionJson) + "}";
+        string json = "{\"operations\":{\"video.generate\":{\"models\":[" + model + "]}}}";
+        AiCapabilitiesResponse response = JsonSerializer.Deserialize<AiCapabilitiesResponse>(
+            json,
+            new JsonSerializerOptions(JsonSerializerDefaults.Web))!;
+        AiVideoModelCapabilities video = AiModelMapper.ToModel(response).ModelsFor(AiOperations.VideoGeneration)[0].Video!;
+        Assert.That(
+            video.Resolutions,
+            Is.EqualTo(unsupported
+                ? AiCapabilityDimension<string>.Unsupported
+                : AiCapabilityDimension<string>.Unspecified));
+    }
+
+    [TestCase("", false, TestName = "Omitted video operation dimension is unspecified")]
+    [TestCase("\"resolutions\":null", false, TestName = "Null video operation dimension is unspecified")]
+    [TestCase("\"resolutions\":[]", true, TestName = "Empty video operation dimension is unsupported")]
+    public void CapabilityJson_PreservesOmittedNullAndEmptyVideoOperationDimensions(string dimensionJson, bool unsupported)
+    {
+        string operationProperties = string.IsNullOrEmpty(dimensionJson) ? "" : dimensionJson + ",";
+        string json = "{\"operations\":{\"video.generate\":{" + operationProperties + "\"models\":[{\"id\":\"m\"}]}}}";
+        AiCapabilitiesResponse response = JsonSerializer.Deserialize<AiCapabilitiesResponse>(
+            json,
+            new JsonSerializerOptions(JsonSerializerDefaults.Web))!;
+        AiVideoModelCapabilities video = AiModelMapper.ToModel(response).ModelsFor(AiOperations.VideoGeneration)[0].Video!;
+        Assert.That(
+            video.Resolutions,
+            Is.EqualTo(unsupported
+                ? AiCapabilityDimension<string>.Unsupported
+                : AiCapabilityDimension<string>.Unspecified));
+    }
+    [Test]
+    public void Catalog_ReadsTheModelsAndTheirRelativeCost()
+    {
+        AiModelCatalog catalog = AiModelMapper.ToModel(Capabilities(
+            ("image.generate", [
+                Model("cheap/model", null, "low", isDefault: true),
+                Model("dear/model", "Dear", "high", isDefault: false),
+            ])));
+
+        ImmutableArray<AiModelOption> models = catalog.ModelsFor(AiOperations.ImageGeneration);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(models.Select(model => model.Id.Value),
+                Is.EqualTo(new[] { "cheap/model", "dear/model" }));
+            // A model with no name of its own shows its id rather than nothing.
+            Assert.That(models[0].DisplayName, Is.EqualTo("cheap/model"));
+            Assert.That(models[1].DisplayName, Is.EqualTo("Dear"));
+            Assert.That(models[0].CostTier, Is.EqualTo(AiModelCostTier.Low));
+            Assert.That(models[1].CostTier, Is.EqualTo(AiModelCostTier.High));
+            Assert.That(catalog.DefaultFor(AiOperations.ImageGeneration)!.Id.Value,
+                Is.EqualTo("cheap/model"));
+        }
+    }
+
+    [Test]
+    public void Catalog_ReportsAnUnknownTierAsNoneRatherThanGuessing()
+    {
+        AiModelCatalog catalog = AiModelMapper.ToModel(Capabilities(
+            ("video.generate", [Model("a/model", null, "cheapest", isDefault: true)])));
+
+        // Guessing would send someone to the pricier model believing it is the
+        // cheaper one.
+        Assert.That(catalog.ModelsFor(AiOperations.VideoGeneration)[0].CostTier, Is.Null);
+    }
+
+    [Test]
+    public void Catalog_IsEmptyForAnOperationTheServerDidNotDescribe()
+    {
+        AiModelCatalog catalog = AiModelMapper.ToModel(Capabilities(
+            ("image.generate", [])));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(catalog.ModelsFor(AiOperations.ImageGeneration), Is.Empty);
+            Assert.That(catalog.OffersNoModel(AiOperations.ImageGeneration), Is.True);
+            Assert.That(catalog.DefaultFor(AiOperations.ImageGeneration), Is.Null);
+        }
+    }
+
+    [Test]
+    public void Catalog_NormalizesDefaultModelArraysFromCustomProviders()
+    {
+        var operation = new AiOperationId("vendor.default-array");
+        var catalog = new AiModelCatalog(
+        [
+            KeyValuePair.Create(operation, default(ImmutableArray<AiModelOption>)),
+        ]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(catalog.ModelsFor(operation), Is.Empty);
+            Assert.That(catalog.Operations[operation].IsDefault, Is.False);
+        });
+    }
+
+    [Test]
+    public void Catalog_RejectsDefaultModelIdsFromCustomProviders()
+    {
+        var operation = new AiOperationId("vendor.default-model-id");
+
+        Assert.Throws<ArgumentException>(() => new AiModelCatalog(
+        [
+            KeyValuePair.Create(
+                operation,
+                ImmutableArray.Create(new AiModelOption(
+                    default,
+                    "Missing ID",
+                    null,
+                    IsDefault: true))),
+        ]));
+    }
+
+    [Test]
+    public void Catalog_TreatsAFullyFilteredModelListAsExplicitlyUnavailable()
+    {
+        AiModelCatalog catalog = AiModelMapper.ToModel(Capabilities(
+            ("image.generate",
+            [
+                new AiModelDescriptionResponse { Id = string.Empty },
+                new AiModelDescriptionResponse { Id = "   " },
+            ])));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(catalog.ModelsFor(AiOperations.ImageGeneration), Is.Empty);
+            Assert.That(catalog.OffersNoModel(AiOperations.ImageGeneration), Is.True);
+            Assert.That(catalog.DefaultFor(AiOperations.ImageGeneration), Is.Null);
+        }
+    }
+
+    [Test]
+    public void Catalog_KeepsAnOmittedModelListAsPermissiveLegacyFallback()
+    {
+        AiModelCatalog catalog = AiModelMapper.ToModel(new AiCapabilitiesResponse
+        {
+            Operations = new Dictionary<string, AiOperationCapabilityResponse>
+            {
+                [AiOperations.ImageGeneration.Value] = new() { Models = null },
+            }.ToImmutableDictionary(),
+        });
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(catalog.ModelsFor(AiOperations.ImageGeneration), Is.Empty);
+            Assert.That(catalog.OffersNoModel(AiOperations.ImageGeneration), Is.False);
+            Assert.That(catalog.DefaultFor(AiOperations.ImageGeneration), Is.Null);
+        }
+    }
+
+    [Test]
+    public void Catalog_CustomVideoSchemaPreservesPublishedVideoCapabilities()
+    {
+        var extensions = new ExtensionProvider();
+        using var schemas = new AiOperationCapabilitySchemaRegistry(extensions);
+        var operation = new AiOperationId("vendor.video");
+        extensions.AddExtensions(1,
+        [
+            new TestCapabilitySchemaExtension(
+                new AiOperationCapabilitySchemaRegistration(
+                    operation,
+                    AiModelCapabilitySchema.Video)),
+        ]);
+        var response = new AiCapabilitiesResponse
+        {
+            Operations = new Dictionary<string, AiOperationCapabilityResponse>
+            {
+                [operation.Value] = new()
+                {
+                    Models = [new AiModelDescriptionResponse
+                    {
+                        Id = "vendor/video-model",
+                        IsDefault = true,
+                        DurationsSeconds = [4, 8],
+                        Resolutions = ["720p"],
+                        AspectRatios = ["16:9"],
+                        Audio = true,
+                        Seed = true,
+                        FirstFrame = true,
+                        LastFrame = false,
+                    }],
+                    MinDurationSeconds = 4,
+                    MaxDurationSeconds = 8,
+                    Resolutions = ["720p"],
+                    AspectRatios = ["16:9"],
+                },
+            }.ToImmutableDictionary(),
+        };
+
+        AiModelCatalog catalog = AiModelMapper.ToModel(response, schemas);
+        AiModelOption model = catalog.ModelsFor(operation).Single();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(catalog.GetCapabilitySchema(operation),
+                Is.EqualTo(AiModelCapabilitySchema.Video));
+            Assert.That(model.Video, Is.Not.Null);
+            Assert.That(model.Video!.DurationsSeconds.Values, Is.EqualTo(new[] { 4, 8 }));
+            Assert.That(model.Video.Resolutions.Values, Is.EqualTo(new[] { "720p" }));
+            Assert.That(model.Image, Is.Null);
+        }
+    }
+
+    [Test]
+    public void CapabilitySchemas_ComposeReplacementBeforeBaseAndRestoreFallbacks()
+    {
+        var extensions = new ExtensionProvider();
+        using var schemas = new AiOperationCapabilitySchemaRegistry(extensions);
+        var operation = new AiOperationId("vendor.replaced-shape");
+        var replacement = new TestCapabilitySchemaExtension(
+            new AiOperationCapabilitySchemaRegistration(
+                operation,
+                AiModelCapabilitySchema.Video,
+                AiOperationCapabilitySchemaRegistrationMode.Replace));
+        var @base = new TestCapabilitySchemaExtension(
+            new AiOperationCapabilitySchemaRegistration(
+                operation,
+                AiModelCapabilitySchema.Image));
+
+        extensions.AddExtensions(10, [replacement]);
+        Assert.That(schemas.GetSchema(operation), Is.EqualTo(AiModelCapabilitySchema.Generic));
+
+        extensions.AddExtensions(11, [@base]);
+        Assert.That(schemas.GetSchema(operation), Is.EqualTo(AiModelCapabilitySchema.Video));
+
+        extensions.RemoveExtensions(10);
+        Assert.That(schemas.GetSchema(operation), Is.EqualTo(AiModelCapabilitySchema.Image));
+
+        extensions.RemoveExtensions(11);
+        Assert.That(schemas.GetSchema(operation), Is.EqualTo(AiModelCapabilitySchema.Generic));
+
+        var builtInReplacement = new TestCapabilitySchemaExtension(
+            new AiOperationCapabilitySchemaRegistration(
+                AiOperations.VideoGeneration,
+                AiModelCapabilitySchema.Image,
+                AiOperationCapabilitySchemaRegistrationMode.Replace));
+        extensions.AddExtensions(12, [builtInReplacement]);
+        Assert.That(
+            schemas.GetSchema(AiOperations.VideoGeneration),
+            Is.EqualTo(AiModelCapabilitySchema.Image));
+
+        extensions.RemoveExtensions(12);
+        Assert.That(
+            schemas.GetSchema(AiOperations.VideoGeneration),
+            Is.EqualTo(AiModelCapabilitySchema.Video));
+    }
+
+    [Test]
+    public void CapabilitySchemas_ReevaluateHealthyContributorAfterAtomicRejection()
+    {
+        var extensions = new ExtensionProvider();
+        var reportedFailures = new List<Exception>();
+        using var schemas = new AiOperationCapabilitySchemaRegistry(
+            extensions,
+            (_, exception) => reportedFailures.Add(exception));
+        var operation = new AiOperationId("vendor.healthy-shape");
+        var invalid = new TestCapabilitySchemaExtension(
+            new AiOperationCapabilitySchemaRegistration(
+                operation,
+                AiModelCapabilitySchema.Image),
+            new AiOperationCapabilitySchemaRegistration(
+                new AiOperationId("vendor.missing-shape"),
+                AiModelCapabilitySchema.Video,
+                AiOperationCapabilitySchemaRegistrationMode.Replace));
+        var healthy = new TestCapabilitySchemaExtension(
+            new AiOperationCapabilitySchemaRegistration(
+                operation,
+                AiModelCapabilitySchema.Video));
+
+        extensions.AddExtensions(13, [invalid]);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(schemas.GetSchema(operation),
+                Is.EqualTo(AiModelCapabilitySchema.Generic));
+            Assert.That(reportedFailures, Has.Count.EqualTo(1));
+        }
+
+        reportedFailures.Clear();
+        extensions.AddExtensions(14, [healthy]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(schemas.GetSchema(operation), Is.EqualTo(AiModelCapabilitySchema.Video));
+            Assert.That(reportedFailures, Has.Count.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public async Task CapabilitySchemas_SerializeInitialSnapshotWithConcurrentRemoval()
+    {
+        var extensions = new ExtensionProvider();
+        var operation = new AiOperationId("vendor.blocking-schema");
+        var extension = new BlockingCapabilitySchemaExtension(
+            new AiOperationCapabilitySchemaRegistration(
+                operation,
+                AiModelCapabilitySchema.Video));
+        extensions.AddExtensions(15, [extension]);
+        Task<AiOperationCapabilitySchemaRegistry> construction = Task.Run(
+            () => new AiOperationCapabilitySchemaRegistry(extensions));
+        await extension.ReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Task removal = Task.Run(async () =>
+        {
+            ExtensionRemoval ticket = extensions.RemoveExtensions(15);
+            await ticket.DrainAsync();
+            foreach (Extension removed in ticket.Extensions)
+                removed.Unload();
+        });
+
+        try
+        {
+            await Task.Delay(50);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(removal.IsCompleted, Is.False);
+                Assert.That(extension.UnloadCount, Is.Zero);
+            }
+        }
+        finally
+        {
+            extension.ReleaseRead.TrySetResult();
+        }
+
+        using AiOperationCapabilitySchemaRegistry schemas =
+            await construction.WaitAsync(TimeSpan.FromSeconds(5));
+        await removal.WaitAsync(TimeSpan.FromSeconds(5));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(schemas.GetSchema(operation),
+                Is.EqualTo(AiModelCapabilitySchema.Generic));
+            Assert.That(extension.UnloadCount, Is.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public void Catalog_CustomImageAndGenericSchemasDoNotInferFromSharedFields()
+    {
+        var extensions = new ExtensionProvider();
+        using var schemas = new AiOperationCapabilitySchemaRegistry(extensions);
+        var imageOperation = new AiOperationId("vendor.picture");
+        var genericOperation = new AiOperationId("vendor.shared-fields");
+        extensions.AddExtensions(1,
+        [
+            new TestCapabilitySchemaExtension(
+                new AiOperationCapabilitySchemaRegistration(
+                    imageOperation,
+                    AiModelCapabilitySchema.Image)),
+        ]);
+        var response = new AiCapabilitiesResponse
+        {
+            Operations = new Dictionary<string, AiOperationCapabilityResponse>
+            {
+                [imageOperation.Value] = new()
+                {
+                    Models = [new AiModelDescriptionResponse
+                    {
+                        Id = "vendor/image-model",
+                        IsDefault = true,
+                        AspectRatios = ["1:1"],
+                    }],
+                    AspectRatios = ["1:1"],
+                    MaxReferenceImagesTotalBytes = 7 * 1024 * 1024,
+                },
+                [genericOperation.Value] = new()
+                {
+                    Models = [new AiModelDescriptionResponse
+                    {
+                        Id = "vendor/generic-model",
+                        IsDefault = true,
+                        AspectRatios = ["1:1"],
+                        Seed = true,
+                    }],
+                    MaxReferenceImagesTotalBytes = 19 * 1024 * 1024,
+                },
+            }.ToImmutableDictionary(),
+        };
+
+        AiModelCatalog catalog = AiModelMapper.ToModel(response, schemas);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(catalog.ModelsFor(imageOperation).Single().Image, Is.Not.Null);
+            Assert.That(catalog.ModelsFor(imageOperation).Single().Video, Is.Null);
+            Assert.That(catalog.GetImageReferenceLimits(imageOperation).MaxTotalBytes,
+                Is.EqualTo(7 * 1024 * 1024));
+            Assert.That(catalog.GetImageReferenceLimits(genericOperation),
+                Is.EqualTo(AiImageReferenceLimits.Default));
+            Assert.That(catalog.ImageReferenceLimitsByOperation.ContainsKey(genericOperation),
+                Is.False);
+            Assert.That(catalog.GetCapabilitySchema(genericOperation),
+                Is.EqualTo(AiModelCapabilitySchema.Generic));
+            Assert.That(catalog.ModelsFor(genericOperation).Single().Image, Is.Null);
+            Assert.That(catalog.ModelsFor(genericOperation).Single().Video, Is.Null);
+        }
+    }
+
+    [Test]
+    public void Catalog_KeepsReferenceBudgetsScopedToEachImageOperation()
+    {
+        var extensions = new ExtensionProvider();
+        using var schemas = new AiOperationCapabilitySchemaRegistry(extensions);
+        var firstOperation = new AiOperationId("vendor.picture.small");
+        var secondOperation = new AiOperationId("vendor.picture.large");
+        extensions.AddExtensions(17,
+        [
+            new TestCapabilitySchemaExtension(
+                new AiOperationCapabilitySchemaRegistration(
+                    firstOperation,
+                    AiModelCapabilitySchema.Image),
+                new AiOperationCapabilitySchemaRegistration(
+                    secondOperation,
+                    AiModelCapabilitySchema.Image)),
+        ]);
+        var response = new AiCapabilitiesResponse
+        {
+            Operations = new Dictionary<string, AiOperationCapabilityResponse>
+            {
+                [firstOperation.Value] = new()
+                {
+                    Models = [new AiModelDescriptionResponse { Id = "vendor/small" }],
+                    MaxReferenceImagesTotalBytes = 3 * 1024 * 1024,
+                },
+                [secondOperation.Value] = new()
+                {
+                    Models = [new AiModelDescriptionResponse { Id = "vendor/large" }],
+                    MaxReferenceImagesTotalBytes = 15 * 1024 * 1024,
+                },
+            }.ToImmutableDictionary(),
+        };
+
+        AiModelCatalog catalog = AiModelMapper.ToModel(response, schemas);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(catalog.ImageReferenceLimitsByOperation.Keys,
+                Is.EquivalentTo(new[] { firstOperation, secondOperation }));
+            Assert.That(catalog.GetImageReferenceLimits(firstOperation).MaxTotalBytes,
+                Is.EqualTo(3 * 1024 * 1024));
+            Assert.That(catalog.GetImageReferenceLimits(secondOperation).MaxTotalBytes,
+                Is.EqualTo(15 * 1024 * 1024));
+        }
+    }
+
+    [Test]
+    public void CapabilitySchemas_RejectUnsupportedEnumValuesAtPublicBoundaries()
+    {
+        var operation = new AiOperationId("vendor.invalid-shape");
+        var invalid = (AiModelCapabilitySchema)int.MaxValue;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new AiOperationCapabilitySchemaRegistration(operation, invalid));
+            Assert.Throws<ArgumentException>(() => new AiModelCatalog(
+                [],
+                capabilitySchemas: [KeyValuePair.Create(operation, invalid)]));
+        }
+    }
+
+    [Test]
+    public void Catalog_RejectsOperationsThatAlsoExplicitlyOfferNoModels()
+    {
+        var operation = new AiOperationId("vendor.contradictory");
+        var model = new AiModelOption(
+            new AiModelId("vendor/model"),
+            "Model",
+            null,
+            true);
+
+        Assert.Throws<ArgumentException>(() => new AiModelCatalog(
+            [KeyValuePair.Create(operation, ImmutableArray.Create(model))],
+            [operation]));
+    }
+
+    [Test]
+    public void Catalog_AllowsCapabilitySchemaForAnOperationThatOffersNoModels()
+    {
+        var operation = new AiOperationId("vendor.disabled-video");
+
+        var catalog = new AiModelCatalog(
+            [],
+            [operation],
+            [KeyValuePair.Create(operation, AiModelCapabilitySchema.Video)]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(catalog.OffersNoModel(operation), Is.True);
+            Assert.That(catalog.GetCapabilitySchema(operation),
+                Is.EqualTo(AiModelCapabilitySchema.Video));
+        }
+    }
+
+    [Test]
+    public void Catalog_ReadsWhatEachVideoModelWillTake()
+    {
+        // What a video request may carry differs per model, and a fixed set of
+        // options produces requests the server refuses after the usage is
+        // reserved: MiniMax H3 renders only at 2K and takes nothing under five
+        // seconds.
+        AiModelCatalog catalog = AiModelMapper.ToModel(VideoCapabilities(
+            resolutions: ["480p", "720p", "1080p", "2K"],
+            aspectRatios: ["16:9", "9:16", "1:1"],
+            minDurationSeconds: 1,
+            maxDurationSeconds: 60,
+            models: [
+                VideoModel(
+                    "minimax/hailuo-3",
+                    durations: [5, 6, 7],
+                    resolutions: ["2K"],
+                    aspectRatios: ["16:9", "9:16"],
+                    audio: true,
+                    seed: false),
+            ]));
+
+        AiVideoModelCapabilities video =
+            catalog.ModelsFor(AiOperations.VideoGeneration)[0].Video!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(video.DurationsSeconds.Values, Is.EqualTo(new[] { 5, 6, 7 }));
+            Assert.That(video.Resolutions.Values, Is.EqualTo(new[] { "2K" }));
+            Assert.That(video.SupportsAudio, Is.True);
+            Assert.That(video.SupportsSeed, Is.False);
+        }
+    }
+
+    [Test]
+    public void Catalog_KeepsAVideoModelWithinWhatTheOperationAccepts()
+    {
+        // 4K is the model's; this client cannot ask the server for it, and a
+        // resolution the server would refuse must never reach the dialog.
+        AiModelCatalog catalog = AiModelMapper.ToModel(VideoCapabilities(
+            resolutions: ["720p", "1080p"],
+            aspectRatios: ["16:9"],
+            minDurationSeconds: 4,
+            maxDurationSeconds: 8,
+            models: [
+                VideoModel(
+                    "bytedance/seedance-2.0",
+                    durations: [4, 6, 8, 12],
+                    resolutions: ["720p", "1080p", "4K"],
+                    aspectRatios: ["16:9", "21:9"],
+                    audio: true,
+                    seed: true),
+            ]));
+
+        AiVideoModelCapabilities video =
+            catalog.ModelsFor(AiOperations.VideoGeneration)[0].Video!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(video.DurationsSeconds.Values, Is.EqualTo(new[] { 4, 6, 8 }));
+            Assert.That(video.Resolutions.Values, Is.EqualTo(new[] { "720p", "1080p" }));
+            Assert.That(video.AspectRatios.Values, Is.EqualTo(new[] { "16:9" }));
+        }
+    }
+
+    [Test]
+    public void Catalog_LeavesAModelUnrestrictedWhenTheServerSaysNothing()
+    {
+        AiModelCatalog catalog = AiModelMapper.ToModel(Capabilities(
+            ("video.generate", [Model("a/model", null, "low", isDefault: true)])));
+
+        // A server that publishes no shapes is one this client asked before they
+        // existed; typed Unspecified dimensions preserve that unrestricted state.
+        AiVideoModelCapabilities video =
+            catalog.ModelsFor(AiOperations.VideoGeneration)[0].Video!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(video.Resolutions.IsSpecified, Is.False);
+            Assert.That(video.AspectRatios.IsSpecified, Is.False);
+            Assert.That(video.DurationsSeconds.IsSpecified, Is.False);
+            Assert.That(video.CanServeAnything(), Is.True);
+        }
+    }
+
+    [Test]
+    public void Capabilities_RuleOutAModelThatSharesNothingWithTheDialog()
+    {
+        var hailuo = new AiVideoModelCapabilities(
+            AiCapabilityDimension<int>.Supported([5, 6]),
+            AiCapabilityDimension<string>.Supported(["2K"]),
+            AiCapabilityDimension<string>.Supported(["16:9"]),
+            SupportsAudio: true,
+            SupportsSeed: false);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(hailuo.CanServeAnything(), Is.True);
+            // Nothing left after narrowing means every request naming it would
+            // be refused, so offering it is worse than hiding it.
+            Assert.That((hailuo with { Resolutions = AiCapabilityDimension<string>.Unsupported }).CanServeAnything(), Is.False);
+            Assert.That((hailuo with { AspectRatios = AiCapabilityDimension<string>.Unsupported }).CanServeAnything(), Is.False);
+            Assert.That((hailuo with { DurationsSeconds = AiCapabilityDimension<int>.Unsupported }).CanServeAnything(), Is.False);
+            Assert.That(AiVideoModelCapabilities.Unrestricted.CanServeAnything(), Is.True);
+        }
+    }
+
+    [Test]
+    public void CapabilityDimensions_NormalizeDefaultAndCompareByValue()
+    {
+        AiCapabilityDimension<string> omitted = default;
+        AiCapabilityDimension<string> first =
+            AiCapabilityDimension<string>.Supported(["720p", "1080p"]);
+        AiCapabilityDimension<string> second =
+            AiCapabilityDimension<string>.Supported(["720p", "1080p"]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(omitted, Is.EqualTo(AiCapabilityDimension<string>.Unspecified));
+            Assert.That(omitted.Values, Is.Empty);
+            Assert.That(first, Is.EqualTo(second));
+            Assert.That(first.GetHashCode(), Is.EqualTo(second.GetHashCode()));
+        }
+    }
+
+    [Test]
+    public void Catalog_ReadsValidatedRequestLimitSnapshots()
+    {
+        AiModelCatalog catalog = AiModelMapper.ToModel(new AiCapabilitiesResponse
+        {
+            Operations = new Dictionary<string, AiOperationCapabilityResponse>
+            {
+                [AiOperations.ImageGeneration.Value] = new()
+                {
+                    Models = [],
+                    MaxReferenceImagesTotalBytes = 30L * 1024 * 1024,
+                },
+                [AiOperations.CaptionTranslation.Value] = new()
+                {
+                    Models = [],
+                    MaxSegments = 150,
+                    MaxCharacters = 12_000,
+                    MaxRequestBytes = 96 * 1024,
+                },
+            }.ToImmutableDictionary(),
+        });
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(catalog.GetImageReferenceLimits(AiOperations.ImageGeneration).MaxTotalBytes,
+                Is.EqualTo(30L * 1024 * 1024));
+            Assert.That(catalog.CaptionTranslationLimits.MaxSegments, Is.EqualTo(150));
+            Assert.That(catalog.CaptionTranslationLimits.MaxCharacters, Is.EqualTo(12_000));
+            Assert.That(catalog.CaptionTranslationLimits.MaxRequestBytes, Is.EqualTo(96 * 1024));
+            Assert.That(AiImageReferenceLimits.Default,
+                Is.EqualTo(new AiImageReferenceLimits(AiRequestLimits.MaxImageReferencesTotalBytes)));
+            Assert.That(AiCaptionTranslationLimits.Default,
+                Is.EqualTo(new AiCaptionTranslationLimits(
+                    AiRequestLimits.MaxTranslationSegments,
+                    AiRequestLimits.MaxTranslationCharacters,
+                    AiRequestLimits.MaxTranslationRequestBytes)));
+        }
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = new AiImageReferenceLimits(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ =
+            new AiCaptionTranslationLimits(0, 1, 1));
+    }
+
+    [Test]
+    public void Catalog_RulesOutAModelWithAnExplicitlyEmptyDurationList()
+    {
+        AiModelCatalog catalog = AiModelMapper.ToModel(VideoCapabilities(
+            resolutions: ["720p"],
+            aspectRatios: ["16:9"],
+            minDurationSeconds: 4,
+            maxDurationSeconds: 8,
+            models:
+            [
+                VideoModel(
+                    "empty/durations",
+                    durations: [],
+                    resolutions: ["720p"],
+                    aspectRatios: ["16:9"],
+                    audio: true,
+                    seed: true),
+            ]));
+
+        AiVideoModelCapabilities video =
+            catalog.ModelsFor(AiOperations.VideoGeneration).Single().Video!;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(video.DurationsSeconds.Values, Is.Empty);
+            Assert.That(video.DurationsSeconds.IsSpecified, Is.True);
+            Assert.That(video.CanServeAnything(), Is.False);
+        }
+    }
+
+    [Test]
+    public void Catalog_FiltersExplicitVideoDurationsAndPreservesTriState()
+    {
+        AiModelDescriptionResponse omitted = VideoModel(
+            "omitted/durations",
+            durations: [4],
+            resolutions: ["720p"],
+            aspectRatios: ["16:9"],
+            audio: true,
+            seed: true) with
+        {
+            DurationsSeconds = null,
+        };
+        AiModelCatalog catalog = AiModelMapper.ToModel(Capabilities(
+            ("video.generate",
+            [
+                VideoModel(
+                    "mixed/durations",
+                    durations: [-1, 0, 1, 4, 60, 61],
+                    resolutions: ["720p"],
+                    aspectRatios: ["16:9"],
+                    audio: true,
+                    seed: true),
+                VideoModel(
+                    "invalid/durations",
+                    durations: [-1, 0, 61],
+                    resolutions: ["720p"],
+                    aspectRatios: ["16:9"],
+                    audio: true,
+                    seed: true),
+                omitted,
+            ])));
+
+        IReadOnlyDictionary<string, AiVideoModelCapabilities> videos = catalog
+            .ModelsFor(AiOperations.VideoGeneration)
+            .ToDictionary(option => option.Id.Value, option => option.Video!);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(videos["mixed/durations"].DurationsSeconds.Values,
+                Is.EqualTo(new[] { 1, 4, 60 }));
+            Assert.That(videos["mixed/durations"].DurationsSeconds.IsSpecified, Is.True);
+            Assert.That(videos["invalid/durations"].DurationsSeconds.Values, Is.Empty);
+            Assert.That(videos["invalid/durations"].DurationsSeconds.IsSpecified, Is.True);
+            Assert.That(videos["invalid/durations"].CanServeAnything(), Is.False);
+            Assert.That(videos["omitted/durations"].DurationsSeconds.Values, Is.Empty);
+            Assert.That(videos["omitted/durations"].DurationsSeconds.IsSpecified, Is.False);
+        }
+    }
+
+    [Test]
+    public void Catalog_UsesOperationBoundsWhenDurationListIsOmitted()
+    {
+        AiModelDescriptionResponse model = VideoModel(
+            "omitted/durations",
+            durations: [4],
+            resolutions: ["720p"],
+            aspectRatios: ["16:9"],
+            audio: true,
+            seed: true) with
+        {
+            DurationsSeconds = null,
+        };
+        AiModelCatalog catalog = AiModelMapper.ToModel(VideoCapabilities(
+            resolutions: ["720p"],
+            aspectRatios: ["16:9"],
+            minDurationSeconds: 4,
+            maxDurationSeconds: 8,
+            models: [model]));
+
+        AiVideoModelCapabilities video =
+            catalog.ModelsFor(AiOperations.VideoGeneration).Single().Video!;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(video.DurationsSeconds.Values, Is.EqualTo(new[] { 4, 5, 6, 7, 8 }));
+            Assert.That(video.DurationsSeconds.IsSpecified, Is.True);
+            Assert.That(video.CanServeAnything(), Is.True);
+        }
+    }
+
+    [Test]
+    public void Catalog_DistinguishesOmittedAndExplicitlyEmptyVideoShapes()
+    {
+        AiModelDescriptionResponse omitted = VideoModel(
+            "omitted/shapes",
+            durations: [4],
+            resolutions: ["720p"],
+            aspectRatios: ["16:9"],
+            audio: true,
+            seed: true) with
+        {
+            Resolutions = null,
+            AspectRatios = null,
+        };
+        AiModelDescriptionResponse empty = VideoModel(
+            "empty/shapes",
+            durations: [4],
+            resolutions: [],
+            aspectRatios: [],
+            audio: true,
+            seed: true);
+        AiModelCatalog catalog = AiModelMapper.ToModel(VideoCapabilities(
+            resolutions: ["720p", "1080p"],
+            aspectRatios: ["16:9", "9:16"],
+            minDurationSeconds: 4,
+            maxDurationSeconds: 8,
+            models: [omitted, empty]));
+
+        AiVideoModelCapabilities omittedResult = catalog.ModelsFor(AiOperations.VideoGeneration)[0].Video!;
+        AiVideoModelCapabilities emptyResult = catalog.ModelsFor(AiOperations.VideoGeneration)[1].Video!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(omittedResult.Resolutions.Values, Is.EqualTo(new[] { "720p", "1080p" }));
+            Assert.That(omittedResult.AspectRatios.Values, Is.EqualTo(new[] { "16:9", "9:16" }));
+            Assert.That(omittedResult.CanServeAnything(), Is.True);
+            Assert.That(emptyResult.Resolutions.Values, Is.Empty);
+            Assert.That(emptyResult.AspectRatios.Values, Is.Empty);
+            Assert.That(emptyResult.CanServeAnything(), Is.False);
+        }
+    }
+
+    [Test]
+    public void Catalog_TreatsExplicitlyEmptyVideoOperationShapeAsUnsupported()
+    {
+        AiModelCatalog catalog = AiModelMapper.ToModel(new AiCapabilitiesResponse
+        {
+            Operations = new Dictionary<string, AiOperationCapabilityResponse>
+            {
+                [AiOperations.VideoGeneration.Value] = new()
+                {
+                    Models = [VideoModel(
+                        "empty/operation",
+                        durations: [4],
+                        resolutions: ["720p"],
+                        aspectRatios: ["16:9"],
+                        audio: true,
+                        seed: true)],
+                    Resolutions = [],
+                    AspectRatios = [],
+                },
+            }.ToImmutableDictionary(),
+        });
+
+        AiVideoModelCapabilities video =
+            catalog.ModelsFor(AiOperations.VideoGeneration)[0].Video!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(video.Resolutions, Is.EqualTo(AiCapabilityDimension<string>.Unsupported));
+            Assert.That(video.AspectRatios, Is.EqualTo(AiCapabilityDimension<string>.Unsupported));
+            Assert.That(video.CanServeAnything(), Is.False);
+        }
+    }
+
+    [Test]
+    public void Catalog_AppliesVideoOperationDimensionsWhenModelFieldsAreAllNull()
+    {
+        AiModelDescriptionResponse model = Model("legacy/video", null, "low", true);
+        AiModelCatalog empty = AiModelMapper.ToModel(new AiCapabilitiesResponse
+        {
+            Operations = new Dictionary<string, AiOperationCapabilityResponse>
+            {
+                [AiOperations.VideoGeneration.Value] = new()
+                {
+                    Models = [model],
+                    Resolutions = [],
+                    AspectRatios = [],
+                },
+            }.ToImmutableDictionary(),
+        });
+        AiModelCatalog offered = AiModelMapper.ToModel(new AiCapabilitiesResponse
+        {
+            Operations = new Dictionary<string, AiOperationCapabilityResponse>
+            {
+                [AiOperations.VideoGeneration.Value] = new()
+                {
+                    Models = [model],
+                    Resolutions = ["720p"],
+                    AspectRatios = ["16:9"],
+                },
+            }.ToImmutableDictionary(),
+        });
+        AiModelCatalog omitted = AiModelMapper.ToModel(Capabilities(
+            (AiOperations.VideoGeneration.Value, [model])));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(empty.ModelsFor(AiOperations.VideoGeneration)[0].Video!.CanServeAnything(), Is.False);
+            Assert.That(offered.ModelsFor(AiOperations.VideoGeneration)[0].Video!.Resolutions.Values,
+                Is.EqualTo(new[] { "720p" }));
+            Assert.That(offered.ModelsFor(AiOperations.VideoGeneration)[0].Video!.AspectRatios.Values,
+                Is.EqualTo(new[] { "16:9" }));
+            Assert.That(omitted.ModelsFor(AiOperations.VideoGeneration)[0].Video!.Resolutions.IsSpecified,
+                Is.False);
+            Assert.That(omitted.ModelsFor(AiOperations.VideoGeneration)[0].Video!.AspectRatios.IsSpecified,
+                Is.False);
+        }
+    }
+
+    [Test]
+    public void Catalog_ReadsWhatEachImageModelWillTake()
+    {
+        // GPT Image-1 renders 1:1, 3:2 and 2:3 and refuses everything else, so
+        // a fixed set of shapes produces requests it rejects after the usage is
+        // reserved. 21:9 is the model's; the operation does not offer it.
+        AiModelCatalog catalog = AiModelMapper.ToModel(ImageCapabilities(
+            aspectRatios: ["1:1", "16:9", "3:2", "2:3"],
+            models: [
+                ImageModel(
+                    "openai/gpt-image-1",
+                    aspectRatios: ["1:1", "3:2", "2:3", "21:9"],
+                    backgrounds: ["auto", "opaque", "transparent"],
+                    seed: false,
+                    maxReferenceImages: 4),
+            ]));
+
+        AiImageModelCapabilities image =
+            catalog.ModelsFor(AiOperations.ImageGeneration)[0].Image!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(image.AspectRatios.Values, Is.EqualTo(new[] { "1:1", "3:2", "2:3" }));
+            Assert.That(image.SupportsSeed, Is.False);
+            Assert.That(image.MaxReferenceImages, Is.EqualTo(4));
+            // The model publishes three and the operation takes the same three.
+            Assert.That(
+                image.Backgrounds.Values,
+                Is.EqualTo(new[] { "auto", "opaque", "transparent" }));
+        }
+    }
+
+    [Test]
+    public void Catalog_DistinguishesNullAndEmptyImageDimensions()
+    {
+        AiModelDescriptionResponse omitted = new()
+        {
+            Id = "omitted/image",
+            IsDefault = false,
+            Seed = false,
+            Resolution = false,
+        };
+        AiModelDescriptionResponse empty = new()
+        {
+            Id = "empty/image",
+            IsDefault = false,
+            AspectRatios = [],
+            Backgrounds = [],
+        };
+        AiModelCatalog catalog = AiModelMapper.ToModel(new AiCapabilitiesResponse
+        {
+            Operations = new Dictionary<string, AiOperationCapabilityResponse>
+            {
+                [AiOperations.ImageGeneration.Value] = new()
+                {
+                    Models = [omitted, empty],
+                    AspectRatios = ["1:1"],
+                    Backgrounds = ["auto"],
+                },
+            }.ToImmutableDictionary(),
+        });
+
+        AiImageModelCapabilities omittedResult =
+            catalog.ModelsFor(AiOperations.ImageGeneration)[0].Image!;
+        AiImageModelCapabilities emptyResult =
+            catalog.ModelsFor(AiOperations.ImageGeneration)[1].Image!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(omittedResult.AspectRatios.IsSpecified, Is.True);
+            Assert.That(omittedResult.AspectRatios.Values, Is.EqualTo(new[] { "1:1" }));
+            Assert.That(omittedResult.Backgrounds.IsSpecified, Is.True);
+            Assert.That(omittedResult.Backgrounds.Values, Is.EqualTo(new[] { "auto" }));
+            Assert.That(omittedResult.SupportsSeed, Is.False);
+            Assert.That(omittedResult.SupportsResolution, Is.False);
+            Assert.That(emptyResult.AspectRatios, Is.EqualTo(AiCapabilityDimension<string>.Unsupported));
+            Assert.That(emptyResult.Backgrounds, Is.EqualTo(AiCapabilityDimension<string>.Unsupported));
+            Assert.That(emptyResult.CanServeAnything(false), Is.False);
+        }
+    }
+
+    [Test]
+    public void Catalog_AppliesImageOperationDimensionsWhenModelFieldsAreAllNull()
+    {
+        AiModelDescriptionResponse model = Model("legacy/image", null, "low", true);
+        AiModelCatalog empty = AiModelMapper.ToModel(new AiCapabilitiesResponse
+        {
+            Operations = new Dictionary<string, AiOperationCapabilityResponse>
+            {
+                [AiOperations.ImageGeneration.Value] = new()
+                {
+                    Models = [model],
+                    AspectRatios = [],
+                    Backgrounds = [],
+                },
+            }.ToImmutableDictionary(),
+        });
+        AiModelCatalog offered = AiModelMapper.ToModel(new AiCapabilitiesResponse
+        {
+            Operations = new Dictionary<string, AiOperationCapabilityResponse>
+            {
+                [AiOperations.ImageGeneration.Value] = new()
+                {
+                    Models = [model],
+                    AspectRatios = ["1:1"],
+                    Backgrounds = ["auto"],
+                },
+            }.ToImmutableDictionary(),
+        });
+        AiModelCatalog omitted = AiModelMapper.ToModel(Capabilities(
+            (AiOperations.ImageGeneration.Value, [model])));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(empty.ModelsFor(AiOperations.ImageGeneration)[0].Image!.CanServeAnything(false), Is.False);
+            Assert.That(offered.ModelsFor(AiOperations.ImageGeneration)[0].Image!.AspectRatios.Values,
+                Is.EqualTo(new[] { "1:1" }));
+            Assert.That(offered.ModelsFor(AiOperations.ImageGeneration)[0].Image!.Backgrounds.Values,
+                Is.EqualTo(new[] { "auto" }));
+            Assert.That(omitted.ModelsFor(AiOperations.ImageGeneration)[0].Image!.AspectRatios.IsSpecified,
+                Is.False);
+            Assert.That(omitted.ModelsFor(AiOperations.ImageGeneration)[0].Image!.Backgrounds.IsSpecified,
+                Is.False);
+        }
+    }
+
+    [Test]
+    public void Catalog_AppliesVideoOperationDurationBoundsWhenModelDurationsAreUnspecified()
+    {
+        AiModelCatalog catalog = AiModelMapper.ToModel(new AiCapabilitiesResponse
+        {
+            Operations = new Dictionary<string, AiOperationCapabilityResponse>
+            {
+                [AiOperations.VideoGeneration.Value] = new()
+                {
+                    Models = [Model("bounded/video", null, "low", true)],
+                    MinDurationSeconds = 10,
+                    MaxDurationSeconds = 12,
+                },
+            }.ToImmutableDictionary(),
+        });
+
+        AiCapabilityDimension<int> durations = catalog
+            .ModelsFor(AiOperations.VideoGeneration)
+            .Single().Video!.DurationsSeconds;
+
+        Assert.That(durations.Values, Is.EqualTo(new[] { 10, 11, 12 }));
+    }
+
+    [Test]
+    public void Catalog_LeavesImageDimensionUnspecifiedWhenOperationIsOmitted()
+    {
+        AiModelCatalog catalog = AiModelMapper.ToModel(new AiCapabilitiesResponse
+        {
+            Operations = new Dictionary<string, AiOperationCapabilityResponse>
+            {
+                [AiOperations.ImageGeneration.Value] = new()
+                {
+                    Models = [ImageModel(
+                        "image/model",
+                        aspectRatios: ["16:9"],
+                        backgrounds: ["auto"],
+                        seed: true,
+                        maxReferenceImages: 1)],
+                },
+            }.ToImmutableDictionary(),
+        });
+
+        AiImageModelCapabilities image =
+            catalog.ModelsFor(AiOperations.ImageGeneration)[0].Image!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(image.AspectRatios.Values, Is.EqualTo(new[] { "16:9" }));
+            Assert.That(image.Backgrounds.Values, Is.EqualTo(new[] { "auto" }));
+        }
+    }
+
+    [Test]
+    public void Catalog_TreatsExplicitlyEmptyImageOperationDimensionsAsUnsupported()
+    {
+        AiModelCatalog catalog = AiModelMapper.ToModel(new AiCapabilitiesResponse
+        {
+            Operations = new Dictionary<string, AiOperationCapabilityResponse>
+            {
+                [AiOperations.ImageGeneration.Value] = new()
+                {
+                    Models = [new AiModelDescriptionResponse
+                    {
+                        Id = "empty/operation",
+                        IsDefault = false,
+                        Seed = false,
+                    }],
+                    AspectRatios = [],
+                    Backgrounds = [],
+                },
+            }.ToImmutableDictionary(),
+        });
+
+        AiImageModelCapabilities image =
+            catalog.ModelsFor(AiOperations.ImageGeneration)[0].Image!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(image.AspectRatios, Is.EqualTo(AiCapabilityDimension<string>.Unsupported));
+            Assert.That(image.Backgrounds, Is.EqualTo(AiCapabilityDimension<string>.Unsupported));
+            Assert.That(image.CanServeAnything(false), Is.False);
+        }
+    }
+
+    [Test]
+    public void Catalog_HidesImageModelWhenDimensionsDoNotOverlap()
+    {
+        AiModelCatalog catalog = AiModelMapper.ToModel(new AiCapabilitiesResponse
+        {
+            Operations = new Dictionary<string, AiOperationCapabilityResponse>
+            {
+                [AiOperations.ImageGeneration.Value] = new()
+                {
+                    Models = [ImageModel(
+                        "image/model",
+                        aspectRatios: ["16:9"],
+                        backgrounds: ["transparent"],
+                        seed: true,
+                        maxReferenceImages: 1)],
+                    AspectRatios = ["1:1"],
+                    Backgrounds = ["opaque"],
+                },
+            }.ToImmutableDictionary(),
+        });
+
+        AiImageModelCapabilities image =
+            catalog.ModelsFor(AiOperations.ImageGeneration)[0].Image!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(image.AspectRatios, Is.EqualTo(AiCapabilityDimension<string>.Unsupported));
+            Assert.That(image.Backgrounds, Is.EqualTo(AiCapabilityDimension<string>.Unsupported));
+            Assert.That(image.CanServeAnything(false), Is.False);
+        }
+    }
+
+    [Test]
+    public void Catalog_RecognizesImageModelWithOnlySeedOrResolution()
+    {
+        AiModelDescriptionResponse seedOnly = new()
+        {
+            Id = "seed-only",
+            IsDefault = false,
+            Seed = false,
+        };
+        AiModelDescriptionResponse resolutionOnly = new()
+        {
+            Id = "resolution-only",
+            IsDefault = false,
+            Resolution = false,
+        };
+        AiModelCatalog catalog = AiModelMapper.ToModel(new AiCapabilitiesResponse
+        {
+            Operations = new Dictionary<string, AiOperationCapabilityResponse>
+            {
+                [AiOperations.ImageGeneration.Value] = new()
+                {
+                    Models = [seedOnly, resolutionOnly],
+                },
+            }.ToImmutableDictionary(),
+        });
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(catalog.ModelsFor(AiOperations.ImageGeneration), Has.Length.EqualTo(2));
+            Assert.That(catalog.ModelsFor(AiOperations.ImageGeneration)[0].Image!.SupportsSeed, Is.False);
+            Assert.That(catalog.ModelsFor(AiOperations.ImageGeneration)[1].Image!.SupportsResolution, Is.False);
+            Assert.That(catalog.ModelsFor(AiOperations.ImageGeneration)[0].Image!.AspectRatios.IsSpecified, Is.False);
+            Assert.That(catalog.ModelsFor(AiOperations.ImageGeneration)[1].Image!.Backgrounds.IsSpecified, Is.False);
+        }
+    }
+
+    [Test]
+    public void ImageCapabilities_RuleOutAModelAnEditCannotHandAPictureTo()
+    {
+        var noReferences = new AiImageModelCapabilities(
+            AiCapabilityDimension<string>.Supported(["1:1"]),
+            Backgrounds: AiCapabilityDimension<string>.Supported(["auto"]),
+            SupportsSeed: true,
+            MaxReferenceImages: 0);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(noReferences.CanServeAnything(false), Is.True);
+            // Every edit sends the picture being edited.
+            Assert.That(noReferences.CanServeAnything(true), Is.False);
+            Assert.That(
+                (noReferences with
+                {
+                    AspectRatios = AiCapabilityDimension<string>.Unsupported,
+                }).CanServeAnything(false),
+                Is.False);
+        }
+    }
+
+    [Test]
+    public void ImageCapabilities_UnrestrictedHasNoContradictoryEmptyDimensions()
+    {
+        AiImageModelCapabilities unrestricted = AiImageModelCapabilities.Unrestricted;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(unrestricted.CanServeAnything(false), Is.True);
+            Assert.That(unrestricted.AspectRatios.IsSpecified, Is.False);
+            Assert.That(unrestricted.Backgrounds.IsSpecified, Is.False);
+        }
+    }
+
+    [Test]
+    public void Retry_RepeatsTheModelTheJobRanOn()
+    {
+        var images = new Mock<IAiImageGenerationService>();
+        AiImageGenerationRequest? sent = null;
+        images
+            .Setup(service => service.GenerateAsync(
+                It.IsAny<AiImageGenerationRequest>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<AiImageGenerationRequest, CancellationToken>((request, _) => sent = request)
+            .ReturnsAsync(() => null!);
+
+        AiModelCatalog catalog = AiModelMapper.ToModel(Capabilities(
+            ("image.generate", [
+                Model("cheap/model", null, "low", isDefault: true),
+                Model("dear/model", null, "high", isDefault: false),
+            ])));
+        var handler = new AiImageJobRetryHandler(
+            images.Object,
+            EntitlementService(),
+            AvailabilityService(),
+            ModelCatalogService(catalog),
+            RetryContext());
+
+        Assert.DoesNotThrowAsync(() => RunRetryAsync(handler, ImageJob("dear/model")));
+        // Not the default, which is cheaper and would produce a different picture.
+        Assert.That(sent!.Model!.Value.Value, Is.EqualTo("dear/model"));
+    }
+
+    [Test]
+    public async Task Retry_RefusesAModelTheServerNoLongerOffers()
+    {
+        var images = new Mock<IAiImageGenerationService>();
+        AiModelCatalog catalog = AiModelMapper.ToModel(Capabilities(
+            ("image.generate", [Model("cheap/model", null, "low", isDefault: true)])));
+        var handler = new AiImageJobRetryHandler(
+            images.Object,
+            EntitlementService(),
+            AvailabilityService(),
+            ModelCatalogService(catalog),
+            RetryContext());
+
+        // Quietly rerunning on the default would charge the default's price for
+        // a model the user never chose.
+        AiJob job = ImageJob("withdrawn/model");
+        AiJobRetryPreflight preflight = await handler.GetPreflightAsync(
+            job,
+            CancellationToken.None);
+        await using AiJobRetryPreparationResult prepared = await handler.PrepareAsync(
+            job,
+            CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(preflight.CanSubmit, Is.False);
+            Assert.That(prepared.IsReady, Is.False);
+            Assert.That(prepared.Explanation, Is.EqualTo(Strings.AiModelUnavailable));
+        }
+        images.Verify(service => service.GenerateAsync(
+            It.IsAny<AiImageGenerationRequest>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public void Retry_ProceedsWhenTheCatalogCouldNotBeRead()
+    {
+        var images = new Mock<IAiImageGenerationService>();
+        images
+            .Setup(service => service.GenerateAsync(
+                It.IsAny<AiImageGenerationRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => null!);
+
+        var handler = new AiImageJobRetryHandler(
+            images.Object,
+            EntitlementService(),
+            AvailabilityService(),
+            ModelCatalogService(AiModelCatalog.Empty),
+            RetryContext());
+
+        // An empty catalog says nothing about any model, and the server has the
+        // last word; refusing here would break reruns whenever the capabilities
+        // endpoint is unreachable.
+        Assert.DoesNotThrowAsync(() => RunRetryAsync(handler, ImageJob("dear/model")));
+    }
+
+    private static async Task RunRetryAsync(IAiJobRetryHandler handler, AiJob job)
+    {
+        AiJobRetryPreflight preflight = await handler.GetPreflightAsync(job, CancellationToken.None);
+        if (!preflight.CanSubmit)
+            throw new InvalidOperationException("Retry preflight blocked the request.");
+        AiJobRetryPreparationResult prepared = await handler.PrepareAsync(job, CancellationToken.None);
+        await using (prepared)
+        {
+            if (!prepared.IsReady)
+                throw new InvalidOperationException("Retry preparation blocked the request.");
+            IAiJobRetryPreparation preparation = prepared.TakePreparation();
+            await using (preparation)
+            {
+                await preparation.ExecuteAsync(CancellationToken.None);
+            }
+        }
+    }
+
+    private static AiJob ImageJob(string model) => new(
+        new AiJobId("job-1"),
+        AiJobKinds.Image,
+        new AiJobStatusId("failed"),
+        System.Text.Json.JsonDocument
+            .Parse("""{"prompt":"a harbor","aspectRatio":"1:1"}""")
+            .RootElement.Clone(),
+        FileId: null,
+        ContentUri: null,
+        Error: "aiProviderError",
+        CanRetry: true,
+        CreatedAt: DateTimeOffset.UnixEpoch,
+        UpdatedAt: DateTimeOffset.UnixEpoch)
+    {
+        Model = new AiModelId(model),
+    };
+
+    private static AiModelDescriptionResponse Model(
+        string id,
+        string? displayName,
+        string? costTier,
+        bool isDefault)
+        => new()
+        {
+            Id = id,
+            DisplayName = displayName,
+            CostTier = costTier,
+            IsDefault = isDefault,
+        };
+
+    private sealed class TestCapabilitySchemaExtension(
+        params AiOperationCapabilitySchemaRegistration[] registrations)
+        : AiOperationCapabilitySchemaExtension
+    {
+        public override IReadOnlyCollection<AiOperationCapabilitySchemaRegistration> Registrations
+        { get; } = registrations;
+    }
+
+    private sealed class BlockingCapabilitySchemaExtension(
+        params AiOperationCapabilitySchemaRegistration[] registrations)
+        : AiOperationCapabilitySchemaExtension
+    {
+        public TaskCompletionSource ReadStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ReleaseRead { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int UnloadCount { get; private set; }
+
+        public override IReadOnlyCollection<AiOperationCapabilitySchemaRegistration> Registrations
+        {
+            get
+            {
+                ReadStarted.TrySetResult();
+                ReleaseRead.Task.GetAwaiter().GetResult();
+                return registrations;
+            }
+        }
+
+        public override void Unload() => UnloadCount++;
+    }
+
+    private static AiModelDescriptionResponse VideoModel(
+        string id,
+        ImmutableArray<int> durations,
+        ImmutableArray<string> resolutions,
+        ImmutableArray<string> aspectRatios,
+        bool audio,
+        bool seed)
+        => new()
+        {
+            Id = id,
+            IsDefault = false,
+            DurationsSeconds = durations,
+            Resolutions = resolutions,
+            AspectRatios = aspectRatios,
+            Audio = audio,
+            Seed = seed,
+        };
+
+    private static AiModelDescriptionResponse ImageModel(
+        string id,
+        ImmutableArray<string> aspectRatios,
+        ImmutableArray<string> backgrounds,
+        bool seed,
+        int maxReferenceImages)
+        => new()
+        {
+            Id = id,
+            IsDefault = false,
+            AspectRatios = aspectRatios,
+            Backgrounds = backgrounds,
+            Seed = seed,
+            MaxReferenceImages = maxReferenceImages,
+        };
+
+    private static AiCapabilitiesResponse ImageCapabilities(
+        ImmutableArray<string> aspectRatios,
+        ImmutableArray<AiModelDescriptionResponse> models)
+        => new()
+        {
+            Operations = new Dictionary<string, AiOperationCapabilityResponse>
+            {
+                ["image.generate"] = new()
+                {
+                    Models = models,
+                    AspectRatios = aspectRatios,
+                },
+            }.ToImmutableDictionary(),
+        };
+
+    private static AiCapabilitiesResponse VideoCapabilities(
+        ImmutableArray<string> resolutions,
+        ImmutableArray<string> aspectRatios,
+        int minDurationSeconds,
+        int maxDurationSeconds,
+        ImmutableArray<AiModelDescriptionResponse> models)
+        => new()
+        {
+            Operations = new Dictionary<string, AiOperationCapabilityResponse>
+            {
+                ["video.generate"] = new()
+                {
+                    Models = models,
+                    Resolutions = resolutions,
+                    AspectRatios = aspectRatios,
+                    MinDurationSeconds = minDurationSeconds,
+                    MaxDurationSeconds = maxDurationSeconds,
+                },
+            }.ToImmutableDictionary(),
+        };
+
+    private static AiCapabilitiesResponse Capabilities(
+        params (string Operation, ImmutableArray<AiModelDescriptionResponse> Models)[] operations)
+        => new()
+        {
+            Operations = operations.ToImmutableDictionary(
+                entry => entry.Operation,
+                entry => new AiOperationCapabilityResponse { Models = entry.Models }),
+        };
+
+    private static IAiOperationAvailabilityService AvailabilityService()
+    {
+        var mock = new Mock<IAiOperationAvailabilityService>();
+        mock
+            .Setup(service => service.CheckAsync(
+                It.IsAny<AiOperationAvailabilityRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        return mock.Object;
+    }
+
+    private static IAiEntitlementService EntitlementService()
+    {
+        var mock = new Mock<IAiEntitlementService>();
+        mock
+            .Setup(service => service.RefreshAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AiEntitlements(
+                "pro",
+                "active",
+                null,
+                null,
+                false,
+                true,
+                new AiBalance(new AiMonthlyUsage(0, 100, false), 100, false),
+                new AiOperationAvailability([])));
+        return mock.Object;
+    }
+
+    private static IAiModelCatalogService ModelCatalogService(AiModelCatalog catalog)
+    {
+        var mock = new Mock<IAiModelCatalogService>();
+        mock
+            .Setup(service => service.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(catalog);
+        return mock.Object;
+    }
+
+    private static AiRetryAttemptContext RetryContext()
+        => new(
+            new InMemoryAiRetryKeyStore(),
+            () => new AiAuthenticatedRequestIdentity("test-account", User: null),
+            allowSyntheticIdentity: true);
+}

--- a/tests/Beutl.UnitTests/Api/AiRetryKeyStoreTests.cs
+++ b/tests/Beutl.UnitTests/Api/AiRetryKeyStoreTests.cs
@@ -1,0 +1,471 @@
+﻿using System.Text.Json;
+using System.Text.Json.Nodes;
+using Beutl.Api.Services;
+
+namespace Beutl.UnitTests.Api;
+
+[TestFixture]
+public sealed class AiRetryKeyStoreTests
+{
+    private string _directory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), "Beutl.UnitTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_directory);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_directory))
+            Directory.Delete(_directory, recursive: true);
+    }
+
+    [Test]
+    public void RestartAndTwoInstancesReuseExactIdentityWithoutClobberingOthers()
+    {
+        var first = new FileAiRetryKeyStore(_directory);
+        AiJob jobA = Job("job-a", "prompt-a");
+        AiJob jobB = Job("job-b", "prompt-b");
+        string keyA = first.GetOrCreate(jobA, "account", out bool repeatA);
+        var second = new FileAiRetryKeyStore(_directory);
+        string keyB = second.GetOrCreate(jobB, "account", out bool repeatB);
+        var restarted = new FileAiRetryKeyStore(_directory);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(repeatA, Is.False);
+            Assert.That(repeatB, Is.False);
+            Assert.That(restarted.GetOrCreate(jobA, "account", out bool againA), Is.EqualTo(keyA));
+            Assert.That(againA, Is.True);
+            Assert.That(restarted.GetOrCreate(jobB, "account", out bool againB), Is.EqualTo(keyB));
+            Assert.That(againB, Is.True);
+        });
+    }
+
+    [Test]
+    public void AccountAndCanonicalPayloadAreSeparateIdentities()
+    {
+        var store = new FileAiRetryKeyStore(_directory);
+        AiJob firstBody = Job("job", "first");
+        AiJob changedBody = Job("job", "second");
+
+        string first = store.GetOrCreate(firstBody, "account-a", out _);
+        string otherAccount = store.GetOrCreate(firstBody, "account-b", out bool accountRepeat);
+        Assert.Throws<AiRetryAttemptRejectedException>(() =>
+            store.GetOrCreate(changedBody, "account-a", out _));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(accountRepeat, Is.False);
+            Assert.That(otherAccount, Is.Not.EqualTo(first));
+        });
+    }
+
+    [Test]
+    public void RetireRemovesOnlyTheMatchingIdentity()
+    {
+        var store = new FileAiRetryKeyStore(_directory);
+        AiJob firstJob = Job("first", "one");
+        AiJob secondJob = Job("second", "two");
+        string first = store.GetOrCreate(firstJob, "account", out _);
+        string second = store.GetOrCreate(secondJob, "account", out _);
+
+        store.Retire(firstJob, "account");
+        var restarted = new FileAiRetryKeyStore(_directory);
+        string nextFirst = restarted.GetOrCreate(firstJob, "account", out bool firstRepeat);
+        string sameSecond = restarted.GetOrCreate(secondJob, "account", out bool secondRepeat);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstRepeat, Is.False);
+            Assert.That(nextFirst, Is.Not.EqualTo(first));
+            Assert.That(secondRepeat, Is.True);
+            Assert.That(sameSecond, Is.EqualTo(second));
+        });
+    }
+
+    [Test]
+    public void RecoveryAttemptRetireRaceFailsWithoutCreatingAnotherKey()
+    {
+        var first = new FileAiRetryKeyStore(_directory);
+        AiJob job = Job("recovery-race", "prompt");
+        string original = first.GetOrCreate(job, "account", out _);
+        AiRetryAttempt attempt = first.PrepareAttempt(job, "account");
+
+        new FileAiRetryKeyStore(_directory).Retire(job, "account");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                first.TryConsumeAttempt(attempt, job, "account", out _, out _),
+                Is.False);
+            Assert.That(first.TryGet(job, "account", out _), Is.False);
+        });
+
+        string fresh = first.GetOrCreate(job, "account", out bool isRepeat);
+        Assert.That(isRepeat, Is.False);
+        Assert.That(fresh, Is.Not.EqualTo(original));
+    }
+
+    [Test]
+    public void AttemptIsBoundToTheAuthenticatedAccount()
+    {
+        var store = new FileAiRetryKeyStore(_directory);
+        AiJob job = Job("account-binding", "prompt");
+        string original = store.GetOrCreate(job, "account-a", out _);
+        AiRetryAttempt attempt = store.PrepareAttempt(job, "account-a");
+
+        Assert.That(
+            store.TryConsumeAttempt(attempt, job, "account-b", out _, out _),
+            Is.False);
+        Assert.That(store.TryGet(job, "account-a", out string retained), Is.True);
+        Assert.That(retained, Is.EqualTo(original));
+    }
+
+    [Test]
+    public async Task TwoStoreInstancesConsumeOnePendingAttempt()
+    {
+        var first = new FileAiRetryKeyStore(_directory);
+        var second = new FileAiRetryKeyStore(_directory);
+        AiJob job = Job("concurrent-confirm", "prompt");
+        AiRetryAttempt firstAttempt = first.PrepareAttempt(job, "account");
+        AiRetryAttempt secondAttempt = second.PrepareAttempt(job, "account");
+
+        (bool First, string FirstKey, bool Second, string SecondKey) result = await Task.WhenAll(
+                Task.Run(() => Consume(first, firstAttempt)),
+                Task.Run(() => Consume(second, secondAttempt)))
+            .ContinueWith(static task =>
+            {
+                (bool Success, string Key)[] values = task.Result;
+                return (values[0].Success, values[0].Key, values[1].Success, values[1].Key);
+            });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(new[] { result.First, result.Second }.Count(value => value), Is.EqualTo(1));
+            Assert.That(
+                result.First ? result.FirstKey : result.SecondKey,
+                Does.StartWith("history-retry:concurrent-confirm:"));
+        });
+
+        static (bool Success, string Key) Consume(
+            FileAiRetryKeyStore store,
+            AiRetryAttempt attempt)
+            => store.TryConsumeAttempt(
+                attempt,
+                Job("concurrent-confirm", "prompt"),
+                "account",
+                out string key,
+                out _)
+                ? (true, key)
+                : (false, string.Empty);
+    }
+
+    [Test]
+    public void ExpiredClaimCanRecoverTheExactKeyAfterRestart()
+    {
+        var store = new FileAiRetryKeyStore(_directory);
+        AiJob job = Job("expired-claim", "prompt");
+        AiRetryAttempt purchase = store.PrepareAttempt(job, "account");
+        Assert.That(
+            store.TryConsumeAttempt(purchase, job, "account", out string key, out bool repeat),
+            Is.True);
+        Assert.That(repeat, Is.False);
+
+        string path = Path.Combine(_directory, "retry-keys.json");
+        JsonObject root = JsonNode.Parse(File.ReadAllText(path))!.AsObject();
+        foreach (JsonNode? node in root["entries"]!.AsArray())
+        {
+            node!.AsObject()["inFlightUntil"] = DateTimeOffset.UtcNow.AddMinutes(-1);
+        }
+        File.WriteAllText(path, root.ToJsonString());
+
+        var restarted = new FileAiRetryKeyStore(_directory);
+        AiRetryAttempt recovery = restarted.PrepareAttempt(job, "account");
+        Assert.Multiple(() =>
+        {
+            Assert.That(recovery.Kind, Is.EqualTo(AiRetryAttemptKind.Recovery));
+            Assert.That(recovery.Key, Is.EqualTo(key));
+            Assert.That(
+                restarted.TryConsumeAttempt(recovery, job, "account", out string retryKey, out bool retryRepeat),
+                Is.True);
+            Assert.That(retryKey, Is.EqualTo(key));
+            Assert.That(retryRepeat, Is.True);
+        });
+    }
+
+    [Test]
+    public void AmbiguousResponseReleasesClaimWithoutChangingTheKey()
+    {
+        var store = new FileAiRetryKeyStore(_directory);
+        AiJob job = Job("response-loss", "prompt");
+        AiRetryAttempt purchase = store.PrepareAttempt(job, "account");
+        Assert.That(store.TryConsumeAttempt(purchase, job, "account", out string key, out _), Is.True);
+        Assert.That(
+            store.TryRelease(job, "account", key, purchase.Generation + 1, purchase.Token),
+            Is.True);
+
+        AiRetryAttempt recovery = store.PrepareAttempt(job, "account");
+        Assert.That(recovery.Key, Is.EqualTo(key));
+        Assert.That(recovery.Kind, Is.EqualTo(AiRetryAttemptKind.Recovery));
+    }
+
+    [Test]
+    public void NewPurchaseAttemptCreatesOnlyWhenConfirmed()
+    {
+        var store = new FileAiRetryKeyStore(_directory);
+        AiJob job = Job("new-purchase", "prompt");
+        AiRetryAttempt attempt = store.PrepareAttempt(job, "account");
+        Assert.That(store.TryGet(job, "account", out _), Is.False);
+        Assert.That(store.TryConsumeAttempt(attempt, job, "account", out string key, out bool repeat), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(repeat, Is.False);
+            Assert.That(store.TryGet(job, "account", out string persisted), Is.True);
+            Assert.That(persisted, Is.EqualTo(key));
+        });
+    }
+
+    [Test]
+    public void SemanticPayloadFormattingKeepsKey()
+    {
+        var store = new FileAiRetryKeyStore(_directory);
+        AiJob first = JobWithInput("semantic", "{\"prompt\":\"same\",\"seed\":1}");
+        AiJob equivalent = JobWithInput("semantic", "{ \"seed\": 1.0e0, \"prompt\": \"same\" }");
+        string key = store.GetOrCreate(first, "account", out _);
+
+        Assert.That(store.GetOrCreate(equivalent, "account", out bool repeat), Is.EqualTo(key));
+        Assert.That(repeat, Is.True);
+    }
+
+    [Test]
+    public void ChangedPayloadRejectsPreparedAttempt()
+    {
+        var store = new FileAiRetryKeyStore(_directory);
+        AiJob original = JobWithInput("changed", "{\"prompt\":\"before\"}");
+        AiJob changed = JobWithInput("changed", "{\"prompt\":\"after\"}");
+        store.GetOrCreate(original, "account", out _);
+        AiRetryAttempt attempt = store.PrepareAttempt(original, "account");
+
+        Assert.That(
+            store.TryConsumeAttempt(attempt, changed, "account", out _, out _),
+            Is.False);
+        Assert.That(store.TryGet(original, "account", out _), Is.True);
+    }
+
+    [Test]
+    public void CanceledConfirmationsDoNotFillStore()
+    {
+        var store = new FileAiRetryKeyStore(_directory);
+        for (int index = 0; index < 300; index++)
+        {
+            AiJob job = JobWithInput($"cancel-{index}", "{\"prompt\":\"same\"}");
+            AiRetryAttempt attempt = store.PrepareAttempt(job, "account");
+            attempt.Dispose();
+        }
+
+        Assert.That(
+            store.PrepareAttempt(JobWithInput("after-cancel", "{\"prompt\":\"same\"}"), "account"),
+            Is.Not.Null);
+    }
+
+    [Test]
+    public void ExpiredPendingIsPrunedOnRestart()
+    {
+        var store = new FileAiRetryKeyStore(_directory);
+        AiRetryAttempt attempt = store.PrepareAttempt(JobWithInput("expired", "{\"prompt\":\"same\"}"), "account");
+        string path = Path.Combine(_directory, "retry-keys.json");
+        JsonObject root = JsonNode.Parse(File.ReadAllText(path))!.AsObject();
+        root["attempts"]!.AsArray()[0]!["createdAt"] = DateTimeOffset.UtcNow.AddMinutes(-2).ToString("O");
+        root["attempts"]!.AsArray()[0]!["expiresAt"] = DateTimeOffset.UtcNow.AddMinutes(-1).ToString("O");
+        File.WriteAllText(path, root.ToJsonString());
+
+        var restarted = new FileAiRetryKeyStore(_directory);
+        Assert.That(
+            restarted.PrepareAttempt(JobWithInput("expired", "{\"prompt\":\"same\"}"), "account").Token,
+            Is.Not.EqualTo(attempt.Token));
+    }
+
+    [Test]
+    public void MoreThanGenerationLimitOfSettledDistinctJobsSucceeds()
+    {
+        var store = new FileAiRetryKeyStore(_directory);
+        for (int index = 0; index < 600; index++)
+        {
+            AiJob job = JobWithInput($"settled-{index}", "{\"prompt\":\"same\"}");
+            string key = store.GetOrCreate(job, "account", out _);
+            AiRetryAttempt attempt = store.PrepareAttempt(job, "account");
+            Assert.That(store.TryConsumeAttempt(attempt, job, "account", out _, out _), Is.True);
+            Assert.That(store.TryRetire(job, "account", key, attempt.Generation, attempt.Token), Is.True);
+        }
+
+        AiJob active = JobWithInput("active", "{\"prompt\":\"same\"}");
+        string activeKey = store.GetOrCreate(active, "account", out _);
+        Assert.That(store.TryGet(active, "account", out string retained), Is.True);
+        Assert.That(retained, Is.EqualTo(activeKey));
+    }
+
+    [Test]
+    public void DisposingAttemptUnderLockIsNonThrowing()
+    {
+        var store = new FileAiRetryKeyStore(_directory);
+        AiRetryAttempt attempt = store.PrepareAttempt(JobWithInput("locked", "{\"prompt\":\"same\"}"), "account");
+        using (new FileStream(
+            Path.Combine(_directory, "retry-keys.json.lock"),
+            FileMode.OpenOrCreate,
+            FileAccess.ReadWrite,
+            FileShare.None))
+        {
+            Assert.DoesNotThrow(attempt.Dispose);
+        }
+    }
+
+    [TestCase("{")]
+    [TestCase("{\"version\":2,\"entries\":[]}")]
+    [TestCase("{\"version\":1,\"entries\":[],\"unexpected\":true}")]
+    public void CorruptFutureAndUnknownShapeFailClosed(string contents)
+    {
+        File.WriteAllText(Path.Combine(_directory, "retry-keys.json"), contents);
+        var store = new FileAiRetryKeyStore(_directory);
+
+        Assert.Throws<AiRetryStoreUnavailableException>(() =>
+            store.GetOrCreate(Job("job", "prompt"), "account", out _));
+    }
+
+    [Test]
+    public void OversizeAndDuplicateDataFailClosed()
+    {
+        string path = Path.Combine(_directory, "retry-keys.json");
+        File.WriteAllBytes(path, new byte[1024 * 1024 + 1]);
+        var oversized = new FileAiRetryKeyStore(_directory);
+        Assert.Throws<AiRetryStoreUnavailableException>(() =>
+            oversized.GetOrCreate(Job("job", "prompt"), "account", out _));
+
+        string identity = new('A', 64);
+        File.WriteAllText(path, JsonSerializer.Serialize(new
+        {
+            version = 1,
+            entries = new[]
+            {
+                new { identity, key = "key-one" },
+                new { identity, key = "key-two" },
+            },
+        }));
+        var duplicate = new FileAiRetryKeyStore(_directory);
+        Assert.Throws<AiRetryStoreUnavailableException>(() =>
+            duplicate.GetOrCreate(Job("job", "prompt"), "account", out _));
+    }
+
+    [Test]
+    public void LockContentionFailsClosedBeforeIssuingAKey()
+    {
+        var store = new FileAiRetryKeyStore(_directory);
+        using var lease = new FileStream(
+            Path.Combine(_directory, "retry-keys.json.lock"),
+            FileMode.OpenOrCreate,
+            FileAccess.ReadWrite,
+            FileShare.None);
+
+        Assert.Throws<AiRetryStoreUnavailableException>(() =>
+            store.GetOrCreate(Job("job", "prompt"), "account", out _));
+    }
+
+    [Test]
+    public void FullStoreRejectsNewIdentityWithoutEvictingUnresolvedKeys()
+    {
+        var store = new FileAiRetryKeyStore(_directory);
+        AiJob firstJob = Job("job-000", "prompt-000");
+        string first = store.GetOrCreate(firstJob, "account", out _);
+        for (int index = 1; index < 256; index++)
+            store.GetOrCreate(Job($"job-{index:000}", $"prompt-{index:000}"), "account", out _);
+
+        Assert.Throws<AiRetryStoreUnavailableException>(() =>
+            store.GetOrCreate(Job("overflow", "overflow"), "account", out _));
+
+        var restarted = new FileAiRetryKeyStore(_directory);
+        Assert.That(restarted.GetOrCreate(firstJob, "account", out bool repeat), Is.EqualTo(first));
+        Assert.That(repeat, Is.True);
+    }
+
+    [Test]
+    public void StoreFilesArePrivateOnUnix()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("Unix modes are not available on Windows.");
+            return;
+        }
+        var store = new FileAiRetryKeyStore(_directory);
+        store.GetOrCreate(Job("job", "prompt"), "account", out _);
+
+#pragma warning disable CA1416 // Guarded above; these APIs are unavailable only on Windows.
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                File.GetUnixFileMode(_directory),
+                Is.EqualTo(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute));
+            Assert.That(
+                File.GetUnixFileMode(Path.Combine(_directory, "retry-keys.json")),
+                Is.EqualTo(UnixFileMode.UserRead | UnixFileMode.UserWrite));
+        });
+#pragma warning restore CA1416
+    }
+
+    [Test]
+    public void RestartSweepsOnlyOldRetryStoreTemporaryFiles()
+    {
+        string stale = Path.Combine(_directory, "retry-keys.json.abc.tmp");
+        string fresh = Path.Combine(_directory, "retry-keys.json.def.tmp");
+        File.WriteAllText(stale, "stale");
+        File.WriteAllText(fresh, "fresh");
+        File.SetLastWriteTimeUtc(stale, DateTime.UtcNow.AddHours(-2));
+
+        _ = new FileAiRetryKeyStore(_directory);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(File.Exists(stale), Is.False);
+            Assert.That(File.Exists(fresh), Is.True);
+        });
+    }
+
+    [Test]
+    public void RestartDoesNotDeleteAnOldRetryTempStillHeldOpen()
+    {
+        string path = Path.Combine(_directory, "retry-keys.json.held.tmp");
+        File.WriteAllText(path, "in-progress");
+        File.SetLastWriteTimeUtc(path, DateTime.UtcNow.AddHours(-2));
+        using FileStream held = new(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+
+        _ = new FileAiRetryKeyStore(_directory);
+
+        Assert.That(File.Exists(path), Is.True);
+    }
+
+    private static AiJob Job(string id, string prompt) => new(
+        new AiJobId(id),
+        AiJobKinds.Image,
+        AiJobStatuses.Failed,
+        JsonDocument.Parse($$"""{"prompt":"{{prompt}}","aspectRatio":"1:1"}""").RootElement.Clone(),
+        FileId: null,
+        ContentUri: null,
+        Error: "aiProviderError",
+        CanRetry: true,
+        CreatedAt: DateTimeOffset.UnixEpoch,
+        UpdatedAt: DateTimeOffset.UnixEpoch);
+
+    private static AiJob JobWithInput(string id, string input) => new(
+        new AiJobId(id),
+        AiJobKinds.Image,
+        AiJobStatuses.Failed,
+        JsonDocument.Parse(input).RootElement.Clone(),
+        null,
+        null,
+        "aiProviderError",
+        true,
+        DateTimeOffset.UnixEpoch,
+        DateTimeOffset.UnixEpoch);
+}

--- a/tests/Beutl.UnitTests/Api/AiServiceTests.cs
+++ b/tests/Beutl.UnitTests/Api/AiServiceTests.cs
@@ -1,0 +1,2260 @@
+﻿using System.Collections.Specialized;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Beutl.Api;
+using Beutl.Api.Clients;
+using Beutl.Api.Objects;
+using Beutl.Api.Services;
+using Reactive.Bindings;
+
+namespace Beutl.UnitTests.Api;
+
+[TestFixture]
+public sealed class AiCapabilityServiceTests
+{
+    // Monthly usage is proportional; the exact purchased balance appears only
+    // in this account snapshot, not in ordinary operation responses.
+    private const string EntitlementBalanceJson = """
+        {
+          "monthlyUsage": {
+            "usedPercent": 12,
+            "remainingPercent": 88,
+            "isExhausted": false
+          },
+          "additionalCredits": 7,
+          "hasAdditionalCreditDebt": false
+        }
+        """;
+
+    [Test]
+    public async Task Application_RegistersEachCapabilityIndependently()
+    {
+        using var handler = new RecordingHandler(_ => JsonResponse(HttpStatusCode.OK, "{}"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+
+        object[] services =
+        [
+            app.GetResource<IAiEntitlementService>(),
+            app.GetResource<IAiOperationAvailabilityService>(),
+            app.GetResource<IAiImageGenerationService>(),
+            app.GetResource<IAiImageEditingService>(),
+            app.GetResource<IAiTranscriptionService>(),
+            app.GetResource<IAiCaptionTranslationService>(),
+            app.GetResource<IAiVideoService>(),
+            app.GetResource<IAuthenticatedContentService>(),
+            app.GetResource<IAiJobClient>(),
+            app.GetResource<IAiJobMonitor>(),
+        ];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(services.Distinct().Count(), Is.EqualTo(services.Length));
+            Assert.That(
+                typeof(IAiImageGenerationService).GetMethods()
+                    .Concat(typeof(IAiImageEditingService).GetMethods())
+                    .Select(method => method.ReturnType.ToString()),
+                Has.None.Contains("Beutl.Api.Clients"));
+            Assert.That(
+                typeof(IAiTranscriptionService).GetMethods()
+                    .Concat(typeof(IAiCaptionTranslationService).GetMethods())
+                    .SelectMany(method => method.GetParameters())
+                    .Select(parameter => parameter.ParameterType.Namespace),
+                Has.None.EqualTo("Beutl.Api.Clients"));
+        }
+    }
+
+    [Test]
+    public async Task InteractiveAuthenticationDoesNotHoldApplicationLockWhileWaiting()
+    {
+        using var handler = new RecordingHandler(_ => JsonResponse(HttpStatusCode.OK, "{}"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var authenticationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseAuthentication = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        AuthenticatedUser user = CreateAuthenticatedUser(app);
+        Task<AuthenticatedUser> authentication = app.RunInteractiveAuthenticationAsync(
+            async cancellationToken =>
+            {
+                authenticationStarted.TrySetResult();
+                await releaseAuthentication.Task.WaitAsync(cancellationToken);
+                return user;
+            },
+            CancellationToken.None);
+
+        try
+        {
+            await authenticationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            using var lockTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            using IDisposable applicationLock = await app.Lock.LockAsync(lockTimeout.Token);
+            Assert.That(authentication.IsCompleted, Is.False,
+                "Package operations must be able to acquire the application lock while OAuth waits in the browser.");
+        }
+        finally
+        {
+            releaseAuthentication.TrySetResult();
+        }
+
+        Assert.That(
+            await authentication.WaitAsync(TimeSpan.FromSeconds(5)),
+            Is.SameAs(user));
+    }
+
+    [Test]
+    public async Task InteractiveAuthenticationDoesNotPublishAUserWhenPersistenceFails()
+    {
+        using var handler = new RecordingHandler(_ => JsonResponse(HttpStatusCode.OK, "{}"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(
+            httpClient,
+            new ExtensionProvider(),
+            static () => new HttpClient(),
+            _ => throw new IOException("The user file is unavailable."));
+        AuthenticatedUser previous = CreateAuthenticatedUser(app, "previous-token");
+        SetAuthenticatedUser(app, previous);
+        AuthenticatedUser replacement = CreateAuthenticatedUser(app, "replacement-token");
+
+        Assert.ThrowsAsync<IOException>(() => app.RunInteractiveAuthenticationAsync(
+            _ => Task.FromResult(replacement),
+            CancellationToken.None));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(app.AuthenticatedUser.Value, Is.SameAs(previous));
+            Assert.That(
+                httpClient.DefaultRequestHeaders.Authorization?.ToString(),
+                Is.EqualTo("Bearer previous-token"));
+        });
+    }
+
+    [Test]
+    public async Task Availability_SerializesEachDiscriminatedRequestWithoutPricingOrIdempotency()
+    {
+        using var handler = new RecordingHandler(_ => JsonResponse(
+            HttpStatusCode.OK,
+            "{ \"available\": true }"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        IAiOperationAvailabilityService service =
+            app.GetResource<IAiOperationAvailabilityService>();
+
+        bool[] results =
+        [
+            await service.CheckAsync(
+                new AiOperationAvailabilityRequest.Fixed(AiOperations.ImageGeneration),
+                CancellationToken.None),
+            await service.CheckAsync(
+                new AiOperationAvailabilityRequest.Video(
+                    new AiOperationId("vendor.video"),
+                    4),
+                CancellationToken.None),
+            await service.CheckAsync(
+                new AiOperationAvailabilityRequest.Transcription(
+                    new AiOperationId("vendor.transcription"),
+                    1.5),
+                CancellationToken.None),
+            await service.CheckAsync(
+                new AiOperationAvailabilityRequest.Translation(
+                    new AiOperationId("vendor.translation"),
+                    123),
+                CancellationToken.None),
+            await service.CheckAsync(
+                new AiOperationAvailabilityRequest.Fixed(new AiOperationId("vendor.custom")),
+                CancellationToken.None),
+        ];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(results, Is.All.True);
+            Assert.That(handler.Requests.Select(request => request.Body), Is.EqualTo(new[]
+            {
+                "{\"operation\":\"image.generate\"}",
+                "{\"operation\":\"vendor.video\",\"durationSeconds\":4}",
+                "{\"operation\":\"vendor.transcription\",\"durationSeconds\":1.5}",
+                "{\"operation\":\"vendor.translation\",\"characterCount\":123}",
+                "{\"operation\":\"vendor.custom\"}",
+            }));
+            Assert.That(handler.Requests, Has.All.Property(nameof(RecordedRequest.IdempotencyKey)).Null);
+        }
+    }
+
+    [Test]
+    public async Task PaidPosts_SendOneUniqueUuidPerLogicalInvocation_AndGetsDoNot()
+    {
+        using var handler = new RecordingHandler(request => request.Path switch
+        {
+            "/api/v3/ai/images" or "/api/v3/ai/images/edit" => JsonResponse(HttpStatusCode.OK, """
+                {
+                  "jobId": "image-job",
+                  "fileId": "image-file",
+                  "url": "https://beutl.beditor.net/api/contents/image-file"
+                }
+                """),
+            "/api/v3/ai/transcriptions" => JsonResponse(HttpStatusCode.OK, """
+                { "jobId": "transcription-job", "segments": [], "language": "en" }
+                """),
+            "/api/v3/ai/translations" => JsonResponse(HttpStatusCode.OK, """
+                { "jobId": "translation-job", "segments": [] }
+                """),
+            "/api/v3/ai/videos" or "/api/v3/ai/videos/frames" => JsonResponse(HttpStatusCode.OK, """
+                { "jobId": "video-job", "status": "queued" }
+                """),
+            "/api/v3/ai/videos/video-job" => JsonResponse(HttpStatusCode.OK, """
+                { "jobId": "video-job", "status": "running" }
+                """),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        AiUploadSource Upload(string name, string mediaType) => new(
+            name,
+            mediaType,
+            _ => ValueTask.FromResult<Stream>(new MemoryStream([1, 2, 3])),
+            3);
+
+        IAiImageGenerationService images = app.GetResource<IAiImageGenerationService>();
+        await images.GenerateAsync(
+            new AiImageGenerationRequest("first", new AiImageAspectRatioId("1:1")),
+            CancellationToken.None);
+        await images.GenerateAsync(
+            new AiImageGenerationRequest("second", new AiImageAspectRatioId("1:1")),
+            CancellationToken.None);
+        await app.GetResource<IAiImageEditingService>().EditAsync(
+            new AiImageEditRequest(Upload("image.png", "image/png"), new AiImageEditTaskId("upscale")),
+            CancellationToken.None);
+        await app.GetResource<IAiTranscriptionService>().TranscribeAsync(
+            new AiTranscriptionRequest(Upload("audio.wav", "audio/wav")),
+            CancellationToken.None);
+        await app.GetResource<IAiCaptionTranslationService>().TranslateAsync(
+            new AiCaptionTranslationRequest(
+                [new AiCaptionTranslationSegment { Id = "1", Text = "Hello" }],
+                "ja"),
+            CancellationToken.None);
+        IAiVideoService videos = app.GetResource<IAiVideoService>();
+        await videos.CreateAsync(
+            new AiVideoGenerationRequest(
+                "plain",
+                4,
+                new AiVideoResolutionId("720p"),
+                new AiVideoAspectRatioId("16:9")),
+            CancellationToken.None);
+        await videos.CreateAsync(
+            new AiVideoGenerationRequest(
+                "framed",
+                8,
+                new AiVideoResolutionId("1080p"),
+                new AiVideoAspectRatioId("16:9"),
+                firstFrame: Upload("frame.png", "image/png")),
+            CancellationToken.None);
+        await videos.GetAsync(new AiJobId("video-job"), CancellationToken.None);
+
+        RecordedRequest[] paid = handler.Requests
+            .Where(request => request.Method == HttpMethod.Post)
+            .ToArray();
+        string[] keys = paid.Select(request => request.IdempotencyKey!).ToArray();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(paid, Has.Length.EqualTo(7));
+            Assert.That(keys, Has.All.Not.Null.And.Not.Empty);
+            Assert.That(keys.Select(Guid.Parse).Count(), Is.EqualTo(7));
+            Assert.That(keys.Distinct(StringComparer.Ordinal).Count(), Is.EqualTo(7));
+            Assert.That(
+                handler.Requests.Single(request => request.Method == HttpMethod.Get).IdempotencyKey,
+                Is.Null);
+        }
+    }
+
+    [Test]
+    public async Task Entitlements_WhenSignedOut_ReturnsNullWithoutTransportRequest()
+    {
+        using var handler = new RecordingHandler(_ => JsonResponse(HttpStatusCode.OK, "{}"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+
+        AiEntitlements? result = await app.GetResource<IAiEntitlementService>()
+            .RefreshAsync(CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.Null);
+            Assert.That(handler.Requests, Is.Empty);
+        }
+    }
+
+    [Test]
+    public async Task Entitlements_MapsServerDtoIntoDomainModelAndPublishesIt()
+    {
+        using var handler = new RecordingHandler(_ => JsonResponse(HttpStatusCode.OK, $$"""
+            {
+              "plan": "pro",
+              "subscriptionStatus": "active",
+              "currentPeriodStart": "2026-08-01T00:00:00Z",
+              "currentPeriodEnd": "2026-09-01T00:00:00Z",
+              "canUseAi": true,
+              "balance": {{EntitlementBalanceJson}},
+              "availability": {
+                "image.generate": true,
+                "vendor.custom": false
+              }
+            }
+            """));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        IAiEntitlementService service = app.GetResource<IAiEntitlementService>();
+
+        AiEntitlements? result = await service.RefreshAsync(CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result!.CanUseAi, Is.True);
+            Assert.That(result.Balance.MonthlyUsage.RemainingPercent, Is.EqualTo(88));
+            Assert.That(
+                result.Availability.GetState(AiOperations.ImageGeneration),
+                Is.EqualTo(AiOperationAvailabilityState.Available));
+            Assert.That(
+                AiOperations.ImageEdit(new AiImageEditTaskId("remove_background")),
+                Is.EqualTo(new AiOperationId("image.edit.remove_background")));
+            Assert.That(
+                result.Availability.GetState(new AiOperationId("vendor.custom")),
+                Is.EqualTo(AiOperationAvailabilityState.Unavailable),
+                "A reported false is an actual refusal.");
+            Assert.That(
+                result.Availability.GetState(AiOperations.VideoGeneration),
+                Is.EqualTo(AiOperationAvailabilityState.Unknown),
+                "An operation the server never mentioned has not been refused.");
+            Assert.That(service.Entitlements.Value, Is.SameAs(result));
+            Assert.That(handler.Requests.Single().Authorization, Is.EqualTo("Bearer token"));
+        }
+    }
+
+    [Test]
+    public async Task ImageGeneration_UsesOperationRequestAndReturnsDomainIdentifiers()
+    {
+        using var handler = new RecordingHandler(request => request.Path switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/images" => JsonResponse(HttpStatusCode.OK, $$"""
+                {
+                  "jobId": "job-image-1",
+                  "fileId": "file-image-1",
+                  "url": "https://beutl.beditor.net/api/contents/file-image-1"
+                }
+                """),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        IAiEntitlementService entitlements = app.GetResource<IAiEntitlementService>();
+        await entitlements.RefreshAsync(CancellationToken.None);
+
+        AiImageResult result = await app.GetResource<IAiImageGenerationService>().GenerateAsync(
+            new AiImageGenerationRequest(
+                "A moonlit harbor",
+                new AiImageAspectRatioId("16:9"),
+                new AiImageBackgroundId("transparent"),
+                seed: 42),
+            CancellationToken.None);
+
+        RecordedRequest request = handler.Requests.Single(item => item.Path == "/api/v3/ai/images");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(request.Method, Is.EqualTo(HttpMethod.Post));
+            Assert.That(request.Body, Does.Contain("A moonlit harbor"));
+            // The three things a fixed size could not express: a widescreen
+            // shape, an alpha channel, and a reproducible result.
+            Assert.That(request.Body, Does.Contain("\"aspectRatio\":\"16:9\""));
+            Assert.That(request.Body, Does.Contain("\"background\":\"transparent\""));
+            Assert.That(request.Body, Does.Contain("\"seed\":42"));
+            Assert.That(result.JobId, Is.EqualTo(new AiJobId("job-image-1")));
+            Assert.That(result.FileId, Is.EqualTo(new AiContentId("file-image-1")));
+            Assert.That(
+                entitlements.Entitlements.Value!.Balance.MonthlyUsage.UsedPercent,
+                Is.EqualTo(12));
+            Assert.That(
+                entitlements.Entitlements.Value.Balance.AdditionalCredits,
+                Is.EqualTo(7));
+        }
+    }
+
+    [Test]
+    public async Task OperationWithoutBalance_PreservesLastEntitlementSnapshot()
+    {
+        using var handler = new RecordingHandler(request => request.Path switch
+        {
+            "/api/v3/user/entitlements" => JsonResponse(HttpStatusCode.OK, EntitlementsJson()),
+            "/api/v3/ai/images" => JsonResponse(HttpStatusCode.OK, """
+                {
+                  "jobId": "job-image-2",
+                  "fileId": "file-image-2",
+                  "url": "https://beutl.beditor.net/api/contents/file-image-2"
+                }
+                """),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        IAiEntitlementService entitlements = app.GetResource<IAiEntitlementService>();
+        await entitlements.RefreshAsync(CancellationToken.None);
+
+        await app.GetResource<IAiImageGenerationService>().GenerateAsync(
+            new AiImageGenerationRequest("Exhaust credits", new AiImageAspectRatioId("1:1")),
+            CancellationToken.None);
+
+        AiBalance balance = entitlements.Entitlements.Value!.Balance;
+        Assert.Multiple(() =>
+        {
+            Assert.That(balance.AdditionalCredits, Is.EqualTo(7));
+            Assert.That(balance.MonthlyUsage.UsedPercent, Is.EqualTo(12));
+            Assert.That(balance.HasAdditionalCreditDebt, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task Translation_MapsTypedSegmentsWithoutExposingWireDtos()
+    {
+        using var handler = new RecordingHandler(request => request.Path switch
+        {
+            "/api/v3/ai/translations" => JsonResponse(HttpStatusCode.OK, $$"""
+                {
+                  "jobId": "job-translate-1",
+                  "segments": [
+                    { "id": "cue-1", "text": "Bonjour" },
+                    { "id": "cue-2", "text": "Monde" }
+                  ]
+                }
+                """),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+
+        AiCaptionTranslationResponse result = await app.GetResource<IAiCaptionTranslationService>()
+            .TranslateAsync(
+                new AiCaptionTranslationRequest(
+                    [
+                        new AiCaptionTranslationSegment
+                        {
+                            Id = "cue-1",
+                            Text = "Hello",
+                            Context = new AiCaptionTranslationSegmentContext(
+                                "cue-1",
+                                0,
+                                TimeSpan.FromSeconds(1.5),
+                                TimeSpan.FromSeconds(3)),
+                        },
+                        new AiCaptionTranslationSegment { Id = "cue-2", Text = "World" },
+                    ],
+                    " FR ",
+                    " EN ",
+                    new AiCaptionTranslationStyle(
+                        new Dictionary<string, string> { ["Beutl"] = "Beutl" },
+                        maxCharactersPerLine: 42,
+                        maxLines: 2)),
+                CancellationToken.None);
+
+        RecordedRequest request = handler.Requests.Single();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(request.Body, Does.Contain("\"targetLanguage\":\"fr\""));
+            Assert.That(request.Body, Does.Contain("\"sourceLanguage\":\"en\""));
+            // A line that does not fit its cue is unreadable however good the
+            // wording is, and a series keeps its own names for things.
+            Assert.That(request.Body, Does.Contain("\"maxCharactersPerLine\":42"));
+            Assert.That(request.Body, Does.Contain("\"maxLines\":2"));
+            Assert.That(request.Body, Does.Contain("\"glossary\":{\"Beutl\":\"Beutl\"}"));
+            Assert.That(request.Body, Does.Contain(
+                "\"context\":{\"groupId\":\"cue-1\",\"partIndex\":0,\"start\":1.5,\"end\":3}"));
+            Assert.That(result.JobId, Is.EqualTo(new AiJobId("job-translate-1")));
+            Assert.That(result.Segments.Select(segment => segment.Text),
+                Is.EqualTo(new[] { "Bonjour", "Monde" }));
+        }
+    }
+
+    [Test]
+    public async Task Translation_AcceptsWebEquivalentCjkBodyAndSendsUtf8Json()
+    {
+        using var handler = new RecordingHandler(_ => JsonResponse(HttpStatusCode.OK,
+            "{\"jobId\":\"job-cjk\",\"segments\":[]}"));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+
+        AiCaptionTranslationSegment[] segments = Enumerable.Range(0, AiRequestLimits.MaxTranslationSegments)
+            .Select(index => new AiCaptionTranslationSegment
+            {
+                Id = $"cue-{index:D3}",
+                Text = new string('界', AiRequestLimits.MaxTranslationCharacters / AiRequestLimits.MaxTranslationSegments),
+            })
+            .ToArray();
+        await app.GetResource<IAiCaptionTranslationService>().TranslateAsync(
+            new AiCaptionTranslationRequest(segments, "ja"),
+            CancellationToken.None);
+
+        RecordedRequest request = handler.Requests.Single();
+        Assert.That(request.Body, Does.Contain("\"text\":\"界界"));
+        Assert.That(Encoding.UTF8.GetByteCount(request.Body), Is.LessThanOrEqualTo(
+            AiRequestLimits.MaxTranslationRequestBytes));
+    }
+
+    // A streamed answer as the server sends one: `data:` lines, blank-line
+    // separated, ending in the event that carries the answer itself.
+    private static HttpResponseMessage EventStream(params (string Event, string Data)[] events)
+    {
+        string body = string.Concat(
+            events.Select(item => $"event: {item.Event}\ndata: {item.Data}\n\n"));
+        var content = new StringContent(body, Encoding.UTF8);
+        content.Headers.ContentType = new MediaTypeHeaderValue("text/event-stream")
+        {
+            CharSet = "utf-8",
+        };
+        return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+    }
+
+    [Test]
+    public async Task Translation_ReportsEachSubtitleAndReturnsTheWholeAnswer()
+    {
+        using var handler = new RecordingHandler(_ => EventStream(
+            ("segment", "{not json"),
+            ("segment", """{"id":17,"text":"wrong id type"}"""),
+            ("segment", """{"id":"","text":"missing id"}"""),
+            ("segment", """{"id":"line-1","text":"こんにちは"}"""),
+            ("segment", """{"id":"line-2","text":"世界"}"""),
+            ("result", """
+                {"jobId":"job-1","segments":[{"id":"line-1","text":"こんにちは"},{"id":"line-2","text":"世界"}]}
+                """.Trim())));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        var reported = new RecordingProgress<AiCaptionTranslationSegment>();
+
+        AiCaptionTranslationResponse result = await app
+            .GetResource<IAiCaptionTranslationService>()
+            .TranslateAsync(
+                new AiCaptionTranslationRequest(
+                [
+                    new AiCaptionTranslationSegment { Id = "line-1", Text = "Hello" },
+                    new AiCaptionTranslationSegment { Id = "line-2", Text = "World" },
+                ],
+                    "ja"),
+                reported,
+                CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Reported as it arrived, and the answer is still the whole set.
+            Assert.That(
+                reported.Reports.Select(segment => segment.Text),
+                Is.EqualTo(new[] { "こんにちは", "世界" }));
+            Assert.That(result.Segments.Select(segment => segment.Text),
+                Is.EqualTo(new[] { "こんにちは", "世界" }));
+            Assert.That(result.JobId, Is.EqualTo(new AiJobId("job-1")));
+            Assert.That(handler.Requests.Single().Accept, Does.Contain("text/event-stream"));
+        }
+    }
+
+    [Test]
+    public async Task Translation_ReportsEachRequestedSegmentAtMostOnce()
+    {
+        using var handler = new RecordingHandler(_ => EventStream(
+            ("segment", """{"id":"unexpected","text":"ignored"}"""),
+            ("segment", """{"id":"line-1","text":"first"}"""),
+            ("segment", """{"id":"line-1","text":"duplicate"}"""),
+            ("segment", """{"id":"line-2","text":"second"}"""),
+            ("segment", """{"id":"line-2","text":"duplicate"}"""),
+            ("result", """
+                {"jobId":"job-bounded","segments":[{"id":"line-1","text":"first"},{"id":"line-2","text":"second"}]}
+                """.Trim())));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        var reported = new RecordingProgress<AiCaptionTranslationSegment>();
+
+        await app.GetResource<IAiCaptionTranslationService>().TranslateAsync(
+            new AiCaptionTranslationRequest(
+            [
+                new AiCaptionTranslationSegment { Id = "line-1", Text = "Hello" },
+                new AiCaptionTranslationSegment { Id = "line-2", Text = "World" },
+            ],
+                "ja"),
+            reported,
+            CancellationToken.None);
+
+        Assert.That(
+            reported.Reports.Select(segment => (segment.Id, segment.Text)),
+            Is.EqualTo(new[] { ("line-1", "first"), ("line-2", "second") }));
+    }
+
+    [Test]
+    public async Task Translation_MalformedTerminalResultStillFailsClosed()
+    {
+        using var handler = new RecordingHandler(_ => EventStream(
+            ("segment", """{"id":"line-1","text":"preview"}"""),
+            ("result", "{not json")));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        var reported = new RecordingProgress<AiCaptionTranslationSegment>();
+
+        Assert.ThrowsAsync<JsonException>(async () =>
+            await app.GetResource<IAiCaptionTranslationService>().TranslateAsync(
+                new AiCaptionTranslationRequest(
+                    [new AiCaptionTranslationSegment { Id = "line-1", Text = "Hello" }],
+                    "ja"),
+                reported,
+                CancellationToken.None));
+        Assert.That(reported.Reports.Select(segment => segment.Text), Is.EqualTo(["preview"]));
+    }
+
+    [Test]
+    public void EventStream_RejectsAnOversizedLineBeforeBuildingAnEvent()
+    {
+        string body = "data: " + new string('x', 32 * 1024 * 1024 + 1);
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(body));
+
+        Assert.ThrowsAsync<AiException>(async () =>
+        {
+            await foreach (AiServerSentEvent _ in AiEventStream.ReadAsync(
+                               stream,
+                               CancellationToken.None))
+            {
+            }
+        });
+    }
+
+    [TestCase("\r")]
+    [TestCase("\r\n")]
+    public async Task EventStream_AcceptsAllSseLineEndingsAcrossReadBoundaries(string newline)
+    {
+        byte[] body = Encoding.UTF8.GetBytes(
+            $"event: result{newline}data: {{}}{newline}{newline}");
+        await using var stream = new OneByteAtATimeStream(body);
+
+        var events = new List<AiServerSentEvent>();
+        await foreach (AiServerSentEvent item in AiEventStream.ReadAsync(
+                           stream,
+                           CancellationToken.None))
+        {
+            events.Add(item);
+        }
+
+        Assert.That(events, Is.EqualTo(new[] { new AiServerSentEvent("result", "{}") }));
+    }
+
+    [Test]
+    public async Task Translation_TakesAOnePieceAnswerFromAServerThatDoesNotStream()
+    {
+        // Asking to be shown the work is not a requirement: a server that
+        // answers in one piece is answering the same request.
+        using var handler = new RecordingHandler(_ => JsonResponse(HttpStatusCode.OK, """
+            {"jobId":"job-3","segments":[{"id":"line-1","text":"こんにちは"}]}
+            """));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        var reported = new RecordingProgress<AiCaptionTranslationSegment>();
+
+        AiCaptionTranslationResponse result = await app
+            .GetResource<IAiCaptionTranslationService>()
+            .TranslateAsync(
+                new AiCaptionTranslationRequest(
+                    [new AiCaptionTranslationSegment { Id = "line-1", Text = "Hello" }],
+                    "ja"),
+                reported,
+                CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Segments.Single().Text, Is.EqualTo("こんにちは"));
+            Assert.That(reported.Reports, Is.Empty);
+        }
+    }
+
+    [Test]
+    public async Task Translation_RejectsAnOversizedOnePieceAnswerWithoutAContentLength()
+    {
+        using var content = new StreamContent(new RepeatingReadStream(
+            AiMeteredCapabilityService.MaximumResponseBodyBytes + 1L));
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/json")
+        {
+            CharSet = "utf-8",
+        };
+        using var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = content,
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+
+        Assert.ThrowsAsync<AiException>(async () =>
+            await app.GetResource<IAiCaptionTranslationService>().TranslateAsync(
+                new AiCaptionTranslationRequest(
+                    [new AiCaptionTranslationSegment { Id = "line-1", Text = "Hello" }],
+                    "ja"),
+                CancellationToken.None));
+    }
+
+    [Test]
+    public async Task Translation_TellsAnInterruptedAnswerApartFromAFailedOne()
+    {
+        // Neither of the two closing events arrived: the run may well have
+        // finished and been charged for, which is not the same as a failure.
+        using var handler = new RecordingHandler(_ => EventStream(
+            ("segment", """{"id":"line-1","text":"こんにちは"}""")));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+
+        Assert.ThrowsAsync<AiRequestInterruptedException>(async () =>
+            await app.GetResource<IAiCaptionTranslationService>().TranslateAsync(
+                new AiCaptionTranslationRequest(
+                    [new AiCaptionTranslationSegment { Id = "line-1", Text = "Hello" }],
+                    "ja"),
+                new Progress<AiCaptionTranslationSegment>(_ => { }),
+                CancellationToken.None));
+    }
+
+    [Test]
+    public async Task Translation_ReadsAFailureCarriedByTheStream()
+    {
+        using var handler = new RecordingHandler(_ => EventStream(
+            ("error", """{"error_code":"aiProviderError","message":"the provider gave up"}""")));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+
+        // Told apart exactly as the same failure would be on the ordinary path.
+        Assert.ThrowsAsync<AiProviderErrorException>(async () =>
+            await app.GetResource<IAiCaptionTranslationService>().TranslateAsync(
+                new AiCaptionTranslationRequest(
+                    [new AiCaptionTranslationSegment { Id = "line-1", Text = "Hello" }],
+                    "ja"),
+                new Progress<AiCaptionTranslationSegment>(_ => { }),
+                CancellationToken.None));
+    }
+
+    [Test]
+    public async Task FailedRequest_PropagatesCancellationWhileReadingTheErrorBody()
+    {
+        using var cancellation = new CancellationTokenSource();
+        using var content = new CancellationBlockedContent(cancellation.Token);
+        using var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = content,
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+
+        Task<AiImageResult> request = app.GetResource<IAiImageGenerationService>()
+            .GenerateAsync(
+                new AiImageGenerationRequest("a lighthouse", new AiImageAspectRatioId("16:9")),
+                new Progress<AiImagePreview>(_ => { }),
+                cancellation.Token);
+        await content.ReadStarted.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+
+        OperationCanceledException error = Assert.CatchAsync<OperationCanceledException>(async () =>
+            await request.WaitAsync(TimeSpan.FromSeconds(5)))!;
+        Assert.That(error.CancellationToken.IsCancellationRequested, Is.True);
+    }
+
+    [Test]
+    public async Task ImageGeneration_ReportsEachRoughPictureAndReturnsTheFinishedOne()
+    {
+        using var handler = new RecordingHandler(_ => EventStream(
+            ("partial", "{not json"),
+            ("partial", """{"index":"zero","image":"AAECAw=="}"""),
+            ("partial", """{"image":"AAECAw=="}"""),
+            ("partial", """{"index":-1,"image":"AAECAw=="}"""),
+            ("partial", """{"index":0,"image":"AAECAw=="}"""),
+            ("partial", """{"index":1,"image":"not base64!"}"""),
+            ("result", """
+                {"jobId":"job-2","fileId":"file-2","url":"http://localhost/api/contents/file-2"}
+                """.Trim())));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        var previews = new RecordingProgress<AiImagePreview>();
+
+        AiImageResult result = await app.GetResource<IAiImageGenerationService>()
+            .GenerateAsync(
+                new AiImageGenerationRequest("a lighthouse", new AiImageAspectRatioId("16:9")),
+                previews,
+                CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            // A rough version that cannot be decoded is passed over rather than
+            // failing a run that is still going to produce a picture.
+            Assert.That(previews.Reports, Has.Count.EqualTo(1));
+            Assert.That(previews.Reports[0].Index, Is.Zero);
+            Assert.That(previews.Reports[0].Bytes.ToArray(), Is.EqualTo(new byte[] { 0, 1, 2, 3 }));
+            Assert.That(result.FileId, Is.EqualTo(new AiContentId("file-2")));
+        }
+    }
+
+    [Test]
+    public async Task ImageGeneration_BoundsTheNumberOfQueuedPreviewPayloads()
+    {
+        using var handler = new RecordingHandler(_ => EventStream(
+            ("partial", """{"index":0,"image":"AAECAw=="}"""),
+            ("partial", """{"index":1,"image":"AAECAw=="}"""),
+            ("partial", """{"index":2,"image":"AAECAw=="}"""),
+            ("partial", """{"index":3,"image":"AAECAw=="}"""),
+            ("partial", """{"index":4,"image":"AAECAw=="}"""),
+            ("result", """{"jobId":"job-preview-budget","fileId":"file-2","url":"http://localhost/api/contents/file-2"}""")));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        var previews = new RecordingProgress<AiImagePreview>();
+
+        await app.GetResource<IAiImageGenerationService>().GenerateAsync(
+            new AiImageGenerationRequest("a lighthouse", new AiImageAspectRatioId("16:9")),
+            previews,
+            CancellationToken.None);
+
+        Assert.That(previews.Reports.Select(preview => preview.Index),
+            Is.EqualTo(new[] { 0, 1, 2, 3 }));
+    }
+
+    [Test]
+    public void ImagePreviewBudget_AcceptsTheExactByteLimitAndRejectsTheNextPayload()
+    {
+        var budget = new AiImageGenerationService.ImagePreviewBudget();
+        long half = AiRequestLimits.MaxImageUploadBytes / 2;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(budget.TryReserve(half), Is.True);
+            Assert.That(
+                budget.TryReserve(AiRequestLimits.MaxImageUploadBytes - half),
+                Is.True);
+            Assert.That(budget.TryReserve(1), Is.False);
+        }
+    }
+
+    [Test]
+    public async Task ImageGeneration_MalformedTerminalResultStillFailsClosed()
+    {
+        using var handler = new RecordingHandler(_ => EventStream(
+            ("partial", """{"index":0,"image":"AAECAw=="}"""),
+            ("result", "{not json")));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        var previews = new RecordingProgress<AiImagePreview>();
+
+        Assert.ThrowsAsync<JsonException>(async () =>
+            await app.GetResource<IAiImageGenerationService>().GenerateAsync(
+                new AiImageGenerationRequest(
+                    "a lighthouse",
+                    new AiImageAspectRatioId("16:9")),
+                previews,
+                CancellationToken.None));
+        Assert.That(previews.Reports, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Transcription_SendsTheCallersKeyAndUploadName()
+    {
+        using var handler = new RecordingHandler(request => request.Path switch
+        {
+            "/api/v3/ai/transcriptions" => JsonResponse(HttpStatusCode.OK, """
+                {
+                  "jobId": "job-stt-1",
+                  "segments": [ { "start": 0, "end": 1, "text": "Hello" } ]
+                }
+                """),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        IAiTranscriptionService transcription = app.GetResource<IAiTranscriptionService>();
+        AiUploadSource Upload(string name, string mediaType) => new(
+            name,
+            mediaType,
+            _ => ValueTask.FromResult<Stream>(new MemoryStream([1, 2, 3])),
+            3);
+
+        // A chunk sent twice under one key: the second ask is for the
+        // transcription the first was charged for, not for another one.
+        await transcription.TranscribeAsync(
+            new AiTranscriptionRequest(
+                Upload("chunk-0003.wav", "audio/wav"),
+                idempotencyKey: "run-7-chunk-3"),
+            CancellationToken.None);
+        await transcription.TranscribeAsync(
+            new AiTranscriptionRequest(
+                Upload("chunk-0003.wav", "audio/wav"),
+                idempotencyKey: "run-7-chunk-3"),
+            CancellationToken.None);
+        await transcription.TranscribeAsync(
+            new AiTranscriptionRequest(Upload("chunk-0004.wav", "audio/wav")),
+            CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(handler.Requests[0].IdempotencyKey, Is.EqualTo("run-7-chunk-3"));
+            Assert.That(handler.Requests[1].IdempotencyKey, Is.EqualTo("run-7-chunk-3"));
+            Assert.That(handler.Requests[0].Body, Does.Contain("chunk-0003.wav"));
+            // Without a key of its own a request is a new one every time, which
+            // is what a caller with nothing to resume wants.
+            Assert.That(handler.Requests[2].IdempotencyKey, Is.Not.Null);
+            Assert.That(
+                handler.Requests[2].IdempotencyKey,
+                Is.Not.EqualTo("run-7-chunk-3"));
+        }
+    }
+
+    [Test]
+    public async Task MeteredRequests_SendTheCallersKeyWhenItHasOne()
+    {
+        using var handler = new RecordingHandler(request => request.Path switch
+        {
+            "/api/v3/ai/images" or "/api/v3/ai/images/edit" => JsonResponse(HttpStatusCode.OK, """
+                {
+                  "jobId": "image-job",
+                  "fileId": "image-file",
+                  "url": "https://beutl.beditor.net/api/contents/image-file"
+                }
+                """),
+            "/api/v3/ai/translations" => JsonResponse(HttpStatusCode.OK, """
+                { "jobId": "translation-job", "segments": [] }
+                """),
+            "/api/v3/ai/videos" => JsonResponse(HttpStatusCode.OK, """
+                { "jobId": "video-job", "status": "queued" }
+                """),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        AiUploadSource Upload(string name, string mediaType) => new(
+            name,
+            mediaType,
+            _ => ValueTask.FromResult<Stream>(new MemoryStream([1, 2, 3])),
+            3);
+
+        // Every metered operation, asked for twice under one key: the second
+        // ask is for the job the first was charged for, not for another one.
+        for (int attempt = 0; attempt < 2; attempt++)
+        {
+            await app.GetResource<IAiImageGenerationService>().GenerateAsync(
+                new AiImageGenerationRequest(
+                    "a calm sky",
+                    new AiImageAspectRatioId("1:1"),
+                    idempotencyKey: "run-1-image"),
+                CancellationToken.None);
+            await app.GetResource<IAiImageEditingService>().EditAsync(
+                new AiImageEditRequest(
+                    Upload("image.png", "image/png"),
+                    new AiImageEditTaskId("upscale"),
+                    idempotencyKey: "run-1-edit"),
+                CancellationToken.None);
+            await app.GetResource<IAiCaptionTranslationService>().TranslateAsync(
+                new AiCaptionTranslationRequest(
+                    [new AiCaptionTranslationSegment { Id = "1", Text = "Hello" }],
+                    "ja",
+                    idempotencyKey: "run-1-translation"),
+                CancellationToken.None);
+            await app.GetResource<IAiVideoService>().CreateAsync(
+                new AiVideoGenerationRequest(
+                    "a calm sky",
+                    4,
+                    new AiVideoResolutionId("720p"),
+                    new AiVideoAspectRatioId("16:9"),
+                    idempotencyKey: "run-1-video"),
+                CancellationToken.None);
+        }
+
+        string[] expected =
+        [
+            "run-1-image", "run-1-edit", "run-1-translation", "run-1-video",
+            "run-1-image", "run-1-edit", "run-1-translation", "run-1-video",
+        ];
+        Assert.That(
+            handler.Requests.Select(request => request.IdempotencyKey),
+            Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ImageGeneration_SendsEveryReferenceUnderTheSameFieldName()
+    {
+        using var handler = new RecordingHandler(_ => JsonResponse(HttpStatusCode.OK, """
+            {
+              "jobId": "image-job",
+              "fileId": "image-file",
+              "url": "https://beutl.beditor.net/api/contents/image-file"
+            }
+            """));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        AiUploadSource Upload(string name) => new(
+            name,
+            "image/png",
+            _ => ValueTask.FromResult<Stream>(new MemoryStream([1, 2, 3])),
+            3);
+
+        await app.GetResource<IAiImageGenerationService>().GenerateAsync(
+            new AiImageGenerationRequest(
+                "a calm sky",
+                new AiImageAspectRatioId("1:1"),
+                references: [Upload("first.png"), Upload("second.png"), Upload("third.png")]),
+            CancellationToken.None);
+
+        RecordedRequest request = handler.Requests.Single();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(request.ContentType, Does.StartWith("multipart/form-data"));
+            // The server reads a repeated "reference[]" as the list of pictures
+            // guiding one generation, in the order they arrive.
+            Assert.That(Regex.Matches(request.Body, @"reference\[\]"), Has.Count.EqualTo(3));
+            Assert.That(request.Body.IndexOf("first.png", StringComparison.Ordinal),
+                Is.LessThan(request.Body.IndexOf("second.png", StringComparison.Ordinal)));
+            Assert.That(request.Body, Does.Contain("third.png"));
+        }
+    }
+
+    [Test]
+    public async Task ImageGeneration_DisposesEveryReferenceWhenOneCleanupFails()
+    {
+        using var handler = new RecordingHandler(_ => JsonResponse(HttpStatusCode.OK, """
+            {
+              "jobId": "image-job",
+              "fileId": "image-file",
+              "url": "https://beutl.beditor.net/api/contents/image-file"
+            }
+            """));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        var throwing = new ThrowingDisposeMemoryStream([1, 2, 3]);
+        var trailing = new TrackingMemoryStream([4, 5, 6]);
+        AiUploadSource Upload(string name, Stream stream) => new(
+            name,
+            "image/png",
+            _ => ValueTask.FromResult(stream),
+            stream.Length);
+
+        AggregateException? exception = Assert.ThrowsAsync<AggregateException>(async () =>
+            await app.GetResource<IAiImageGenerationService>().GenerateAsync(
+                new AiImageGenerationRequest(
+                    "a calm sky",
+                    new AiImageAspectRatioId("1:1"),
+                    references:
+                    [
+                        Upload("throwing.png", throwing),
+                        Upload("trailing.png", trailing),
+                    ]),
+                CancellationToken.None));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(exception!.InnerExceptions, Has.One.InstanceOf<IOException>());
+            Assert.That(throwing.DisposeAttempts, Is.EqualTo(1));
+            Assert.That(trailing.IsDisposed, Is.True);
+        }
+    }
+
+    [Test]
+    public void ImageGeneration_RefusesReferencesThatComeToMoreThanTheServerHolds()
+    {
+        AiUploadSource Upload(string name, long length) => new(
+            name,
+            "image/png",
+            _ => ValueTask.FromResult<Stream>(new MemoryStream()),
+            length);
+        long half = AiRequestLimits.MaxImageReferencesTotalBytes / 2;
+
+        // Each picture is inside the per-picture limit; together they are past
+        // what the server can hold, and it is better said here than after the
+        // whole set has gone out.
+        Assert.Throws<AiFileTooLargeException>(() => _ = new AiImageGenerationRequest(
+            "a calm sky",
+            new AiImageAspectRatioId("1:1"),
+            references: [Upload("first.png", half + 1), Upload("second.png", half + 1)]));
+        Assert.DoesNotThrow(() => _ = new AiImageGenerationRequest(
+            "a calm sky",
+            new AiImageAspectRatioId("1:1"),
+            references: [Upload("first.png", half), Upload("second.png", half)]));
+    }
+
+    [Test]
+    public void ImageGeneration_PreservesThePublishedReferenceTotalLimit()
+    {
+        AiUploadSource Upload(long length) => new(
+            "reference.png",
+            "image/png",
+            _ => ValueTask.FromResult<Stream>(new MemoryStream()),
+            length);
+
+        const long publishedLimit = 30L * 1024 * 1024;
+        var limits = new AiImageReferenceLimits(publishedLimit);
+        AiImageGenerationRequest request = new(
+            "a calm sky",
+            new AiImageAspectRatioId("1:1"),
+            references: [Upload(15L * 1024 * 1024), Upload(15L * 1024 * 1024)],
+            referenceLimits: limits);
+
+        Assert.That(request.ReferenceLimits, Is.EqualTo(limits));
+    }
+
+    [Test]
+    public async Task ImageGeneration_ServiceUsesThePublishedReferenceTotalLimit()
+    {
+        const int referenceLength = 11 * 1024 * 1024;
+        var handler = new ArrivalHandler(JsonResponse(HttpStatusCode.OK, """
+            {
+              "jobId": "image-dynamic-limit",
+              "fileId": "image-dynamic-limit-file",
+              "url": "https://beutl.beditor.net/api/contents/image-dynamic-limit-file"
+            }
+            """));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+
+        AiUploadSource Upload(string name) => new(
+            name,
+            "image/png",
+            _ => ValueTask.FromResult<Stream>(
+                new MemoryStream(new byte[referenceLength], writable: false)),
+            referenceLength);
+        var limits = new AiImageReferenceLimits(24L * 1024 * 1024);
+
+        await app.GetResource<IAiImageGenerationService>().GenerateAsync(
+            new AiImageGenerationRequest(
+                "a calm sky",
+                new AiImageAspectRatioId("1:1"),
+                references: [Upload("first.png"), Upload("second.png")],
+                referenceLimits: limits),
+            CancellationToken.None);
+
+        Assert.That(handler.RequestCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Translation_EnforcesPublishedRequestLimits()
+    {
+        AiCaptionTranslationSegment Segment(string id, string text) =>
+            new() { Id = id, Text = text };
+
+        Assert.Throws<ArgumentException>(() => _ = new AiCaptionTranslationRequest(
+            Enumerable.Range(0, AiRequestLimits.MaxTranslationSegments + 1)
+                .Select(index => Segment($"cue-{index}", "x"))
+                .ToArray(),
+            "ja"));
+        Assert.Throws<ArgumentException>(() => _ = new AiCaptionTranslationRequest(
+            [Segment("cue-1", new string('x', AiRequestLimits.MaxTranslationCharacters + 1))],
+            "ja"));
+
+        var smaller = new AiCaptionTranslationLimits(1, 5, 4 * 1024);
+        Assert.Throws<ArgumentException>(() => _ = new AiCaptionTranslationRequest(
+            [Segment("cue-1", "one"), Segment("cue-2", "two")],
+            "ja",
+            limits: smaller));
+        Assert.Throws<ArgumentException>(() => _ = new AiCaptionTranslationRequest(
+            [Segment("cue-1", "123456")],
+            "ja",
+            limits: smaller));
+        Assert.Throws<ArgumentException>(() => _ = new AiCaptionTranslationRequest(
+            [Segment("cue-1", "x")],
+            "ja",
+            limits: new AiCaptionTranslationLimits(1, 1, 32)));
+    }
+
+    [Test]
+    public void Translation_RejectsOversizedSerializedBodyWhenTheRequestIsConstructed()
+    {
+        AiCaptionTranslationSegment[] segments = Enumerable.Range(
+                0,
+                AiRequestLimits.MaxTranslationSegments)
+            .Select(index => new AiCaptionTranslationSegment
+            {
+                Id = $"cue-{index:D3}{new string('x', 56)}",
+                Text = string.Concat(Enumerable.Repeat(
+                    "😀",
+                    AiRequestLimits.MaxTranslationCharacters /
+                        AiRequestLimits.MaxTranslationSegments / 2)),
+                Context = new AiCaptionTranslationSegmentContext(
+                    new string('g', 64),
+                    index,
+                    TimeSpan.Zero,
+                    TimeSpan.MaxValue),
+            })
+            .ToArray();
+        Assert.Throws<ArgumentException>(() => _ =
+            new AiCaptionTranslationRequest(segments, "ja"));
+    }
+
+    [Test]
+    public void Translation_ValidatesLanguagesAndContextBoundariesLikeWeb()
+    {
+        AiCaptionTranslationSegment Segment(string id, string text) =>
+            new() { Id = id, Text = text };
+
+        AiCaptionTranslationSegment atBoundary = new()
+        {
+            Id = "cue-1",
+            Text = "x",
+            Context = new AiCaptionTranslationSegmentContext(
+                "cue-1",
+                AiRequestLimits.MaxTranslationSegments - 1,
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(1)),
+        };
+        AiCaptionTranslationRequest accepted = new([atBoundary], " EN ", " JA ");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(accepted.TargetLanguage, Is.EqualTo("en"));
+            Assert.That(accepted.SourceLanguage, Is.EqualTo("ja"));
+        }
+
+        Assert.Throws<ArgumentException>(() => _ = new AiCaptionTranslationRequest(
+            [Segment("cue-1", "x")], "zz"));
+        Assert.Throws<ArgumentException>(() => _ = new AiCaptionTranslationRequest(
+            [Segment("cue-1", "x")], "en", "zz"));
+        Assert.Throws<ArgumentException>(() => _ = new AiCaptionTranslationRequest(
+            [Segment("cue-1", "x")], "en", " "));
+        var extendedContext = new AiCaptionTranslationSegmentContext(
+            "cue-1",
+            AiRequestLimits.MaxTranslationSegments,
+            TimeSpan.Zero,
+            TimeSpan.FromSeconds(1));
+        Assert.Throws<ArgumentException>(() => _ = new AiCaptionTranslationRequest(
+            [new AiCaptionTranslationSegment
+            {
+                Id = "cue-1",
+                Text = "x",
+                Context = extendedContext,
+            }],
+            "en"));
+        Assert.DoesNotThrow(() => _ = new AiCaptionTranslationRequest(
+            [new AiCaptionTranslationSegment
+            {
+                Id = "cue-1",
+                Text = "x",
+                Context = extendedContext,
+            }],
+            "en",
+            limits: new AiCaptionTranslationLimits(
+                AiRequestLimits.MaxTranslationSegments + 1,
+                AiRequestLimits.MaxTranslationCharacters,
+                AiRequestLimits.MaxTranslationRequestBytes)));
+        Assert.Throws<ArgumentException>(() => _ =
+            new AiCaptionTranslationSegmentContext(" cue-1", 0, TimeSpan.Zero, TimeSpan.FromSeconds(1)));
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ =
+            new AiCaptionTranslationSegmentContext("cue-1", 0, TimeSpan.FromMilliseconds(-1), TimeSpan.FromSeconds(1)));
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ =
+            new AiCaptionTranslationSegmentContext("cue-1", 0, TimeSpan.Zero, TimeSpan.Zero));
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ =
+            new AiCaptionTranslationSegmentContext("cue-1", 0, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1)));
+    }
+
+    [Test]
+    public void ImageGeneration_RefusesMoreReferencesThanThePriceCovers()
+    {
+        AiUploadSource Upload(string name) => new(
+            name,
+            "image/png",
+            _ => ValueTask.FromResult<Stream>(new MemoryStream()),
+            0);
+        AiUploadSource[] references = Enumerable
+            .Range(0, AiRequestLimits.MaxImageReferences + 1)
+            .Select(index => Upload($"{index}.png"))
+            .ToArray();
+
+        Assert.Throws<ArgumentException>(() => _ = new AiImageGenerationRequest(
+            "a calm sky",
+            new AiImageAspectRatioId("1:1"),
+            references: references));
+        Assert.DoesNotThrow(() => _ = new AiImageGenerationRequest(
+            "a calm sky",
+            new AiImageAspectRatioId("1:1"),
+            references: references[..AiRequestLimits.MaxImageReferences]));
+    }
+
+    [Test]
+    public async Task ModelCatalog_IsAskedForAgainOnceItsFreshnessRunsOut()
+    {
+        int fetches = 0;
+        using var handler = new RecordingHandler(_ =>
+        {
+            fetches++;
+            return JsonResponse(HttpStatusCode.OK, "{ \"operations\": {} }");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        var clock = new StepTimeProvider();
+        using var catalog = new AiModelCatalogService(app, clock);
+
+        await catalog.GetAsync(CancellationToken.None);
+        await catalog.GetAsync(CancellationToken.None);
+        // A model the operator disables has to stop being offered without the
+        // editor being restarted, so the list does not live forever.
+        clock.Advance(TimeSpan.FromMinutes(10));
+        await catalog.GetAsync(CancellationToken.None);
+
+        Assert.That(fetches, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task ModelCatalog_CustomSchemaChangeInvalidatesTheCachedShape()
+    {
+        using var handler = new RecordingHandler(_ => JsonResponse(HttpStatusCode.OK, """
+            {
+              "operations": {
+                "vendor.video": {
+                  "models": [{ "id": "vendor/model", "isDefault": true }],
+                  "minDurationSeconds": 4,
+                  "maxDurationSeconds": 8,
+                  "resolutions": ["720p"]
+                }
+              }
+            }
+            """));
+        using var httpClient = new HttpClient(handler);
+        var extensions = new ExtensionProvider();
+        await using var app = new BeutlApiApplication(httpClient, extensions);
+        SetAuthenticatedUser(app);
+        IAiModelCatalogService service = app.GetResource<IAiModelCatalogService>();
+        var operation = new AiOperationId("vendor.video");
+
+        AiModelCatalog before = await service.GetAsync(CancellationToken.None);
+        extensions.AddExtensions(901,
+        [
+            new TestCapabilitySchemaExtension(
+                new AiOperationCapabilitySchemaRegistration(
+                    operation,
+                    AiModelCapabilitySchema.Video)),
+        ]);
+        AiModelCatalog after = await service.GetAsync(CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(before.GetCapabilitySchema(operation),
+                Is.EqualTo(AiModelCapabilitySchema.Generic));
+            Assert.That(before.ModelsFor(operation).Single().Video, Is.Null);
+            Assert.That(after.GetCapabilitySchema(operation),
+                Is.EqualTo(AiModelCapabilitySchema.Video));
+            Assert.That(after.ModelsFor(operation).Single().Video, Is.Not.Null);
+            Assert.That(handler.Requests, Has.Count.EqualTo(2));
+        }
+    }
+
+    [Test]
+    public async Task ModelCatalog_SchemaChangeBeforePublicationRemapsTheSameResponse()
+    {
+        using var handler = new RecordingHandler(_ => JsonResponse(HttpStatusCode.OK, """
+            {
+              "operations": {
+                "vendor.image": {
+                  "models": [{ "id": "vendor/model", "isDefault": true }],
+                  "aspectRatios": ["1:1"],
+                  "maxReferenceImagesTotalBytes": 11534336
+                }
+              }
+            }
+            """));
+        using var httpClient = new HttpClient(handler);
+        var extensions = new ExtensionProvider();
+        await using var app = new BeutlApiApplication(httpClient, extensions);
+        SetAuthenticatedUser(app);
+        var service = (AiModelCatalogService)app.GetResource<IAiModelCatalogService>();
+        var operation = new AiOperationId("vendor.image");
+        service.BeforeCachePublication = () =>
+        {
+            service.BeforeCachePublication = null;
+            extensions.AddExtensions(902,
+            [
+                new TestCapabilitySchemaExtension(
+                    new AiOperationCapabilitySchemaRegistration(
+                        operation,
+                        AiModelCapabilitySchema.Image)),
+            ]);
+        };
+
+        AiModelCatalog first = await service.GetAsync(CancellationToken.None);
+        AiModelCatalog cached = await service.GetAsync(CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(first.GetCapabilitySchema(operation),
+                Is.EqualTo(AiModelCapabilitySchema.Image));
+            Assert.That(first.ModelsFor(operation).Single().Image, Is.Not.Null);
+            Assert.That(first.GetImageReferenceLimits(operation).MaxTotalBytes,
+                Is.EqualTo(11 * 1024 * 1024));
+            Assert.That(cached, Is.SameAs(first));
+            Assert.That(cached.GetImageReferenceLimits(operation).MaxTotalBytes,
+                Is.EqualTo(11 * 1024 * 1024));
+            Assert.That(handler.Requests, Has.Count.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public async Task ModelCatalog_DoesNotPublishASchemaFromARolledBackExtensionBatch()
+    {
+        using var handler = new RecordingHandler(_ => JsonResponse(HttpStatusCode.OK, """
+            {
+              "operations": {
+                "video.generate": {
+                  "models": [{ "id": "video/model", "isDefault": true }],
+                  "durationsSeconds": [4],
+                  "resolutions": ["720p"]
+                }
+              }
+            }
+            """));
+        using var httpClient = new HttpClient(handler);
+        var extensions = new ExtensionProvider();
+        await using var app = new BeutlApiApplication(httpClient, extensions);
+        SetAuthenticatedUser(app);
+        IAiModelCatalogService service = app.GetResource<IAiModelCatalogService>();
+        var observerEntered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseObserver = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        NotifyCollectionChangedEventHandler failingObserver = (_, args) =>
+        {
+            if (args.Action != NotifyCollectionChangedAction.Add)
+                return;
+            observerEntered.TrySetResult();
+            releaseObserver.Task.GetAwaiter().GetResult();
+            throw new InvalidOperationException("Injected extension observer failure.");
+        };
+        extensions.AllExtensions.CollectionChanged += failingObserver;
+        Task<Exception?> addition = Task.Run(() =>
+        {
+            try
+            {
+                extensions.AddExtensions(903,
+                [
+                    new TestCapabilitySchemaExtension(
+                        new AiOperationCapabilitySchemaRegistration(
+                            AiOperations.VideoGeneration,
+                            AiModelCapabilitySchema.Generic,
+                            AiOperationCapabilitySchemaRegistrationMode.Replace)),
+                ]);
+                return null;
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
+        });
+
+        try
+        {
+            await observerEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            AiModelCatalog duringProvisionalAdd = await service.GetAsync(CancellationToken.None);
+            releaseObserver.TrySetResult();
+            Exception? failure = await addition.WaitAsync(TimeSpan.FromSeconds(5));
+            AiModelCatalog afterRollback = await service.GetAsync(CancellationToken.None);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(failure, Is.TypeOf<ExtensionRegistrationNotificationException>());
+                Assert.That(
+                    duringProvisionalAdd.GetCapabilitySchema(AiOperations.VideoGeneration),
+                    Is.EqualTo(AiModelCapabilitySchema.Video));
+                Assert.That(
+                    duringProvisionalAdd.ModelsFor(AiOperations.VideoGeneration).Single().Video,
+                    Is.Not.Null);
+                Assert.That(afterRollback, Is.SameAs(duringProvisionalAdd));
+                Assert.That(handler.Requests, Has.Count.EqualTo(1));
+            }
+        }
+        finally
+        {
+            releaseObserver.TrySetResult();
+            extensions.AllExtensions.CollectionChanged -= failingObserver;
+            await addition.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [Test]
+    public async Task ModelCatalog_DisposeDoesNotFaultAnActiveRequestOnGateRelease()
+    {
+        var response = new TaskCompletionSource<HttpResponseMessage>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = new DeferredResponseHandler(response.Task);
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        var catalog = new AiModelCatalogService(app, new StepTimeProvider());
+
+        Task<AiModelCatalog> request = catalog.GetAsync(CancellationToken.None);
+        await handler.RequestStarted.WaitAsync(TimeSpan.FromSeconds(5));
+        catalog.Dispose();
+        response.SetResult(JsonResponse(HttpStatusCode.OK, "{ \"operations\": {} }"));
+
+        Assert.DoesNotThrowAsync(async () =>
+            await request.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            await catalog.GetAsync(CancellationToken.None));
+    }
+
+    [Test]
+    public async Task ModelCatalog_IsNotCarriedOverToAnotherAccount()
+    {
+        int fetches = 0;
+        using var handler = new RecordingHandler(_ =>
+        {
+            fetches++;
+            return JsonResponse(HttpStatusCode.OK, "{ \"operations\": {} }");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        using var catalog = new AiModelCatalogService(app, new StepTimeProvider());
+
+        await catalog.GetAsync(CancellationToken.None);
+        // What one account may pay for is not what the next one may.
+        SetAuthenticatedUser(app);
+        await catalog.GetAsync(CancellationToken.None);
+
+        Assert.That(fetches, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task ModelCatalog_DoesNotPublishAResponseAfterTheAccountChanges()
+    {
+        int fetches = 0;
+        using var handler = new RecordingHandler(_ =>
+        {
+            fetches++;
+            return JsonResponse(HttpStatusCode.OK, "{ \"operations\": {} }");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        using var catalog = new AiModelCatalogService(app, new StepTimeProvider());
+        catalog.BeforeCachePublication = () =>
+        {
+            catalog.BeforeCachePublication = null;
+            SetAuthenticatedUser(app);
+        };
+
+        AiModelCatalog stale = await catalog.GetAsync(CancellationToken.None);
+        await catalog.GetAsync(CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(stale, Is.SameAs(AiModelCatalog.Empty));
+            Assert.That(fetches, Is.EqualTo(2));
+        }
+    }
+
+    [Test]
+    public async Task ModelCatalog_ReadsWhichFramesAndSizesEachModelTakes()
+    {
+        using var handler = new RecordingHandler(_ => JsonResponse(HttpStatusCode.OK, """
+            {
+              "operations": {
+                "video.generate": {
+                  "models": [
+                    {
+                      "id": "first/only",
+                      "displayName": "First only",
+                      "isDefault": true,
+                      "durationsSeconds": [4],
+                      "resolutions": ["720p"],
+                      "aspectRatios": ["16:9"],
+                      "audio": true,
+                      "seed": true,
+                      "firstFrame": true,
+                      "lastFrame": false
+                    }
+                  ]
+                },
+                "image.edit.upscale": {
+                  "models": [
+                    {
+                      "id": "no/upscale",
+                      "displayName": "No upscale",
+                      "isDefault": true,
+                      "aspectRatios": ["1:1"],
+                      "backgrounds": ["auto"],
+                      "seed": true,
+                      "maxReferenceImages": 1,
+                      "resolution": false
+                    }
+                  ]
+                }
+              }
+            }
+            """));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        using var service = new AiModelCatalogService(app, new StepTimeProvider());
+
+        AiModelCatalog catalog = await service.GetAsync(CancellationToken.None);
+        AiVideoModelCapabilities video = catalog
+            .ModelsFor(new AiOperationId("video.generate"))
+            .Single().Video!;
+        AiImageModelCapabilities image = catalog
+            .ModelsFor(new AiOperationId("image.edit.upscale"))
+            .Single().Image!;
+
+        using (Assert.EnterMultipleScope())
+        {
+            // A model that conditions on a starting frame does not necessarily
+            // take an ending one, and offering both produces a request refused
+            // after the shape has been checked.
+            Assert.That(video.SupportsFirstFrame, Is.True);
+            Assert.That(video.SupportsLastFrame, Is.False);
+            // Asking for a size is what an upscale is.
+            Assert.That(image.SupportsResolution, Is.False);
+            Assert.That(
+                image.CanServeAnything(requiresReferenceImages: true, requiresResolution: true),
+                Is.False);
+            Assert.That(
+                image.CanServeAnything(requiresReferenceImages: true, requiresResolution: false),
+                Is.True);
+        }
+    }
+
+    [Test]
+    public void ErrorCode_ReadsOneThisClientHasNeverHeardOfAsUnknown()
+    {
+        // A code with no handling of its own must still leave the status and the
+        // message readable rather than throwing the whole body away.
+        ApiErrorResponse? unknown = JsonSerializer.Deserialize<ApiErrorResponse>(
+            """{ "error_code": "somethingAddedLater", "message": "Later.", "documentation_url": null }""",
+            AiStreamJson.Options);
+        ApiErrorResponse? known = JsonSerializer.Deserialize<ApiErrorResponse>(
+            """{ "error_code": "aiModelDoesNotSupportRequest", "message": "No.", "documentation_url": null }""",
+            AiStreamJson.Options);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(unknown!.ErrorCode, Is.EqualTo(ApiErrorCode.Unknown));
+            Assert.That(unknown.Message, Is.EqualTo("Later."));
+            Assert.That(known!.ErrorCode, Is.EqualTo(ApiErrorCode.AiModelDoesNotSupportRequest));
+        }
+    }
+
+    [Test]
+    public void ModelRefusal_IsToldApartFromAnUnexpectedFailure()
+    {
+        AiException converted = AiErrorConverter.Convert(
+            400,
+            new ApiErrorResponse
+            {
+                ErrorCode = ApiErrorCode.AiModelDoesNotSupportRequest,
+                Message = "The model does not take this aspect ratio.",
+                DocumentationUrl = null,
+            },
+            null);
+
+        Assert.That(converted, Is.InstanceOf<AiModelDoesNotSupportRequestException>());
+    }
+
+    [Test]
+    public void Transcription_RefusesAnUploadLargerThanTheEndpointTakes()
+    {
+        AiUploadSource oversized = new(
+            "chunk.wav",
+            "audio/wav",
+            _ => ValueTask.FromResult<Stream>(new MemoryStream()),
+            AiRequestLimits.MaxTranscriptionUploadBytes + 1);
+
+        // Refused here rather than after twenty-five megabytes have been sent
+        // for the server to refuse.
+        Assert.Throws<AiFileTooLargeException>(
+            () => _ = new AiTranscriptionRequest(oversized));
+        Assert.DoesNotThrow(() => _ = new AiTranscriptionRequest(new AiUploadSource(
+            "chunk.wav",
+            "audio/wav",
+            _ => ValueTask.FromResult<Stream>(new MemoryStream()),
+            AiRequestLimits.MaxTranscriptionUploadBytes)));
+    }
+
+    [Test]
+    public void UploadSource_KeepsTheNameTheCallerChoseOverTheFileOnDisk()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"beutl-upload-{Guid.NewGuid():N}.wav");
+        File.WriteAllBytes(path, [1, 2, 3]);
+        try
+        {
+            AiUploadSource named = AiUploadSource.FromFile(path, "scene-mix-chunk-0002.wav");
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(named.FileName, Is.EqualTo("scene-mix-chunk-0002.wav"));
+                Assert.That(named.Length, Is.EqualTo(3));
+                Assert.That(
+                    AiUploadSource.FromFile(path).FileName,
+                    Is.EqualTo(Path.GetFileName(path)));
+            }
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task Transcription_UsesMediaRequestAndReturnsDomainSegments()
+    {
+        using var handler = new RecordingHandler(request => request.Path switch
+        {
+            "/api/v3/ai/transcriptions" => JsonResponse(HttpStatusCode.OK, $$"""
+                {
+                  "jobId": "job-stt-1",
+                  "segments": [ { "start": 0.5, "end": 1.75, "text": "Hello" } ],
+                  "language": "en",
+                  "words": [ { "start": 0.5, "end": 1.0, "word": "Hello" } ]
+                }
+                """),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        var stream = new TrackingMemoryStream([1, 2, 3]);
+        var source = new AiUploadSource(
+            "speech.custom",
+            "audio/x-beutl-test",
+            _ => ValueTask.FromResult<Stream>(stream),
+            3);
+
+        AiTranscriptionResponse result = await app.GetResource<IAiTranscriptionService>()
+            .TranscribeAsync(new AiTranscriptionRequest(source, "en"), CancellationToken.None);
+        RecordedRequest request = handler.Requests.Single();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.JobId, Is.EqualTo(new AiJobId("job-stt-1")));
+            Assert.That(result.Segments.Single().Text, Is.EqualTo("Hello"));
+            Assert.That(result.Words!.Single().Word, Is.EqualTo("Hello"));
+            Assert.That(request.ContentType, Does.StartWith("multipart/form-data"));
+            Assert.That(request.Body, Does.Contain("speech.custom"));
+            Assert.That(request.Body, Does.Contain("audio/x-beutl-test"));
+            Assert.That(stream.IsDisposed, Is.True);
+        }
+    }
+
+    [Test]
+    public async Task VideoCapability_OwnsCreationAndLookup()
+    {
+        using var handler = new RecordingHandler(request => request.Path switch
+        {
+            "/api/v3/ai/videos" => JsonResponse(HttpStatusCode.OK, $$"""
+                {
+                  "jobId": "video-job-1",
+                  "status": "queued"
+                }
+                """),
+            "/api/v3/ai/videos/video-job-1" => JsonResponse(HttpStatusCode.OK, $$"""
+                {
+                  "jobId": "video-job-1",
+                  "status": "succeeded",
+                  "fileId": "video-file-1",
+                  "url": "https://beutl.beditor.net/api/contents/video-file-1",
+                  "fileName": "generated-video.webm",
+                  "contentType": "video/webm",
+                  "error": null
+                }
+                """),
+            _ => JsonResponse(HttpStatusCode.NotFound, "{}"),
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        IAiVideoService service = app.GetResource<IAiVideoService>();
+
+        AiVideoGenerationResult created = await service.CreateAsync(
+            new AiVideoGenerationRequest(
+                "Ocean waves",
+                6,
+                new AiVideoResolutionId("720p"),
+                new AiVideoAspectRatioId("9:16"),
+                generateAudio: false,
+                seed: 11),
+            CancellationToken.None);
+        AiVideoJob completed = await service.GetAsync(created.JobId, CancellationToken.None);
+
+        RecordedRequest submission = handler.Requests.First(
+            item => item is { Method.Method: "POST", Path: "/api/v3/ai/videos" });
+        using (Assert.EnterMultipleScope())
+        {
+            // A vertical clip and a silent one could not be asked for at all
+            // before; the resolution alone says nothing about shape.
+            Assert.That(submission.Body, Does.Contain("\"aspectRatio\":\"9:16\""));
+            Assert.That(submission.Body, Does.Contain("\"generateAudio\":false"));
+            Assert.That(submission.Body, Does.Contain("\"seed\":11"));
+            Assert.That(created.Status, Is.EqualTo(AiJobStatuses.Queued));
+            Assert.That(completed.Status, Is.EqualTo(AiJobStatuses.Succeeded));
+            Assert.That(completed.FileId, Is.EqualTo(new AiContentId("video-file-1")));
+            Assert.That(completed.ContentMetadata?.FileName, Is.EqualTo("generated-video.webm"));
+            Assert.That(completed.ContentMetadata?.ContentType, Is.EqualTo("video/webm"));
+            Assert.That(completed.ContentMetadata?.GetFileExtension(".mp4", "video"), Is.EqualTo(".webm"));
+            Assert.That(
+                new AiContentMetadata("generated-video", "video/mp4")
+                    .GetFileExtension(".webm", "video"),
+                Is.EqualTo(".mp4"));
+            Assert.Throws<AiException>(() =>
+                new AiContentMetadata("payload.png", "image/png")
+                    .GetFileExtension(".mp4", "video"));
+            Assert.Throws<AiException>(() =>
+                new AiContentMetadata("payload.webm", "application/octet-stream")
+                    .GetFileExtension(".mp4", "video"));
+            Assert.That(handler.Requests.Select(request => request.Path),
+                Does.Contain("/api/v3/ai/videos/video-job-1"));
+        }
+    }
+
+    [Test]
+    public async Task JobClient_IsPureAsyncHistoryAndDeleteClient()
+    {
+        using var handler = new RecordingHandler(request => request.Method == HttpMethod.Delete
+            ? JsonResponse(HttpStatusCode.OK, "{ \"deleted\": true }")
+            : JsonResponse(HttpStatusCode.OK, """
+                {
+                  "jobs": [
+                    {
+                      "id": "job-1",
+                      "kind": "vendor-kind",
+                      "status": "vendor-status",
+                      "inputParams": { "prompt": "Hello" },
+                      "fileId": null,
+                      "url": null,
+                      "error": null,
+                      "canRetry": false,
+                      "createdAt": "2026-08-01T00:00:00Z",
+                      "updatedAt": "2026-08-01T00:01:00Z"
+                    }
+                  ],
+                  "nextCursor": "next"
+                }
+                """));
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        IAiJobClient client = app.GetResource<IAiJobClient>();
+
+        AiJobPage page = await client.GetPageAsync(new AiJobPageRequest("cursor-value", 25), CancellationToken.None);
+        await client.DeleteAsync(page.Jobs.Single().Id, CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(page.NextCursor, Is.EqualTo("next"));
+            Assert.That(page.Jobs.Single().Kind, Is.EqualTo(new AiJobKindId("vendor-kind")));
+            Assert.That(page.Jobs.Single().Status, Is.EqualTo(new AiJobStatusId("vendor-status")));
+            Assert.That(handler.Requests[0].Query, Does.Contain("cursor=cursor-value"));
+            Assert.That(handler.Requests[0].Query, Does.Contain("limit=25"));
+            Assert.That(handler.Requests[1].Method, Is.EqualTo(HttpMethod.Delete));
+        }
+    }
+
+    [Test]
+    public async Task AuthenticatedContent_SaysWhenAPaidResultCannotBeFetched()
+    {
+        using var handler = new RecordingHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent("""{"message":"ファイルが見つかりません"}"""),
+            });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        using var destination = new MemoryStream();
+
+        // By the time a result is fetched the job has run and been charged for,
+        // so this is not the request failing: it is the result being out of
+        // reach, and the caller can point the user at the job history.
+        AiContentUnavailableException error = Assert.ThrowsAsync<AiContentUnavailableException>(
+            async () => await app.GetResource<IAuthenticatedContentService>().CopyToAsync(
+                new Uri(app.HttpClient.BaseAddress!, "/api/contents/file-1"),
+                destination,
+                CancellationToken.None))!;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(error.StatusCode, Is.EqualTo(404));
+            Assert.That(error.IsTransient, Is.False);
+        }
+    }
+
+    [Test]
+    public async Task AuthenticatedContent_RejectsForeignOriginsAndUsesCapturedBearer()
+    {
+        using var handler = new RecordingHandler(_ =>
+        {
+            var content = new ByteArrayContent([4, 5, 6]);
+            content.Headers.ContentType = new("video/webm");
+            content.Headers.ContentDisposition = new("attachment")
+            {
+                FileNameStar = "UTF-8''generated-video.webm",
+            };
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        IAuthenticatedContentService service = app.GetResource<IAuthenticatedContentService>();
+
+        using var destination = new MemoryStream();
+        Assert.ThrowsAsync<ArgumentException>(async () =>
+            await service.CopyToAsync(
+                new Uri("https://example.com/api/contents/file-1"),
+                destination,
+                CancellationToken.None));
+        // Derive the accepted origin from the client so the assertion holds for
+        // both the local and production API base addresses.
+        AiContentDownload download = await service.CopyToAsync(
+            new Uri(app.HttpClient.BaseAddress!, "/api/contents/file-1"),
+            destination,
+            CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(destination.ToArray(), Is.EqualTo(new byte[] { 4, 5, 6 }));
+            Assert.That(handler.Requests.Single().Authorization, Is.EqualTo("Bearer token"));
+            Assert.That(download.Metadata?.FileName, Is.EqualTo("generated-video.webm"));
+            Assert.That(download.Metadata?.ContentType, Is.EqualTo("video/webm"));
+        }
+    }
+
+    [Test]
+    public void RequestValidation_EnforcesPromptVideoDurationAndKnownFrameSize()
+    {
+        var size = new AiImageAspectRatioId("1:1");
+        Assert.DoesNotThrow(() => new AiImageGenerationRequest(new string('a', 4_000), size));
+        ArgumentException promptError = Assert.Throws<ArgumentException>(() =>
+            new AiImageGenerationRequest(new string('a', 4_001), size))!;
+        Assert.That(promptError.Message, Does.Contain("4000"));
+
+        Assert.DoesNotThrow(() => new AiVideoGenerationRequest(
+            "prompt",
+            4,
+            new AiVideoResolutionId("720p"),
+            new AiVideoAspectRatioId("16:9")));
+        // Five seconds is a length some models take and others refuse, which
+        // their own capability lists decide; this checks only the span the
+        // server considers at all.
+        Assert.DoesNotThrow(() => new AiVideoGenerationRequest(
+            "prompt",
+            5,
+            new AiVideoResolutionId("720p"),
+            new AiVideoAspectRatioId("16:9")));
+        foreach (int durationSeconds in new[] { 0, 61 })
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new AiVideoGenerationRequest(
+                "prompt",
+                durationSeconds,
+                new AiVideoResolutionId("720p"),
+                new AiVideoAspectRatioId("16:9")));
+        }
+
+        var oversized = new AiUploadSource(
+            "frame.png",
+            "image/png",
+            _ => ValueTask.FromResult<Stream>(Stream.Null),
+            AiRequestLimits.MaxFrameUploadBytes + 1);
+        Assert.Throws<AiFileTooLargeException>(() => new AiVideoGenerationRequest(
+            "prompt",
+            4,
+            new AiVideoResolutionId("720p"),
+            new AiVideoAspectRatioId("16:9"),
+            firstFrame: oversized));
+    }
+
+    private static string EntitlementsJson() => $$"""
+        {
+          "plan": "pro",
+          "subscriptionStatus": "active",
+          "currentPeriodStart": null,
+          "currentPeriodEnd": null,
+          "canUseAi": true,
+          "balance": {{EntitlementBalanceJson}},
+          "availability": {}
+        }
+        """;
+
+    private static void SetAuthenticatedUser(BeutlApiApplication app)
+    {
+        AuthenticatedUser user = CreateAuthenticatedUser(app);
+        SetAuthenticatedUser(app, user);
+    }
+
+    private static void SetAuthenticatedUser(BeutlApiApplication app, AuthenticatedUser user)
+    {
+        FieldInfo field = typeof(BeutlApiApplication).GetField(
+            "_authenticatedUser",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        ((ReactivePropertySlim<AuthenticatedUser?>)field.GetValue(app)!).Value = user;
+    }
+
+    private static AuthenticatedUser CreateAuthenticatedUser(
+        BeutlApiApplication app,
+        string token = "token")
+    {
+        var profile = new Profile(new ProfileResponse
+        {
+            Id = "test-user",
+            Name = "test",
+            DisplayName = "Test User",
+            Bio = null,
+            IconId = null,
+            IconUrl = null,
+        }, app);
+        var user = new AuthenticatedUser(profile, new AuthResponse
+        {
+            Token = token,
+            RefreshToken = $"{token}-refresh",
+            Expiration = DateTime.UtcNow.AddHours(1),
+        }, app, DateTime.UtcNow);
+        return user;
+    }
+
+    private static HttpResponseMessage JsonResponse(HttpStatusCode statusCode, string json)
+        => new(statusCode)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+
+    private sealed record RecordedRequest(
+        HttpMethod Method,
+        string Path,
+        string Query,
+        string? Authorization,
+        string? IdempotencyKey,
+        string? ContentType,
+        string Body,
+        string? Accept = null);
+
+    private sealed class TestCapabilitySchemaExtension(
+        params AiOperationCapabilitySchemaRegistration[] registrations)
+        : AiOperationCapabilitySchemaExtension
+    {
+        public override IReadOnlyCollection<AiOperationCapabilitySchemaRegistration> Registrations
+        { get; } = registrations;
+    }
+
+    private sealed class RecordingHandler(
+        Func<RecordedRequest, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        private readonly List<RecordedRequest> _requests = [];
+
+        public IReadOnlyList<RecordedRequest> Requests => _requests;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var recorded = new RecordedRequest(
+                request.Method,
+                request.RequestUri?.AbsolutePath ?? string.Empty,
+                request.RequestUri?.Query ?? string.Empty,
+                request.Headers.Authorization?.ToString(),
+                request.Headers.TryGetValues("Idempotency-Key", out IEnumerable<string>? values)
+                    ? values.SingleOrDefault()
+                    : null,
+                request.Content?.Headers.ContentType?.ToString(),
+                request.Content is null
+                    ? string.Empty
+                    : await request.Content.ReadAsStringAsync(cancellationToken),
+                request.Headers.Accept.Count == 0
+                    ? null
+                    : request.Headers.Accept.ToString());
+            _requests.Add(recorded);
+            HttpResponseMessage response = responder(recorded);
+            response.RequestMessage = request;
+            return response;
+        }
+    }
+
+    private sealed class ArrivalHandler(HttpResponseMessage response) : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            response.RequestMessage = request;
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class DeferredResponseHandler(Task<HttpResponseMessage> response) : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource _requestStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task RequestStarted => _requestStarted.Task;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            _requestStarted.TrySetResult();
+            HttpResponseMessage result = await response.WaitAsync(cancellationToken);
+            result.RequestMessage = request;
+            return result;
+        }
+    }
+
+    // System.Progress posts each report to the thread pool when there is no
+    // synchronization context, so two reports can be observed out of the order
+    // the service made them in. What is under test is the order the service
+    // reports in, so the reports are taken where they are made.
+    private sealed class RecordingProgress<T> : IProgress<T>
+    {
+        private readonly List<T> _reports = [];
+
+        public IReadOnlyList<T> Reports
+        {
+            get
+            {
+                lock (_reports)
+                    return _reports.ToArray();
+            }
+        }
+
+        public void Report(T value)
+        {
+            lock (_reports)
+                _reports.Add(value);
+        }
+    }
+
+    // Freshness is measured, not waited for.
+    private sealed class StepTimeProvider : TimeProvider
+    {
+        private long _timestamp;
+
+        public void Advance(TimeSpan amount)
+            => _timestamp += (long)(amount.TotalSeconds * TimestampFrequency);
+
+        public override long GetTimestamp() => _timestamp;
+    }
+
+    private sealed class TrackingMemoryStream(byte[] buffer) : MemoryStream(buffer)
+    {
+        public bool IsDisposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class ThrowingDisposeMemoryStream(byte[] buffer) : MemoryStream(buffer)
+    {
+        public int DisposeAttempts { get; private set; }
+
+        public override ValueTask DisposeAsync()
+        {
+            DisposeAttempts++;
+            base.Dispose(disposing: true);
+            return ValueTask.FromException(new IOException("Injected reference cleanup failure."));
+        }
+    }
+
+    private sealed class OneByteAtATimeStream(byte[] buffer) : MemoryStream(buffer)
+    {
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> destination,
+            CancellationToken cancellationToken = default)
+            => base.ReadAsync(destination[..Math.Min(destination.Length, 1)], cancellationToken);
+    }
+
+    private sealed class RepeatingReadStream(long length) : Stream
+    {
+        private long _remaining = length;
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int read = (int)Math.Min(count, _remaining);
+            Array.Fill(buffer, (byte)' ', offset, read);
+            _remaining -= read;
+            return read;
+        }
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            int read = (int)Math.Min(buffer.Length, _remaining);
+            buffer.Span[..read].Fill((byte)' ');
+            _remaining -= read;
+            return ValueTask.FromResult(read);
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private sealed class CancellationBlockedContent(CancellationToken readCancellation) : HttpContent
+    {
+        private readonly TaskCompletionSource _readStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task ReadStarted => _readStarted.Task;
+
+        protected override Task SerializeToStreamAsync(
+            Stream stream,
+            TransportContext? context)
+            => BlockReadAsync(readCancellation);
+
+        protected override async Task SerializeToStreamAsync(
+            Stream stream,
+            TransportContext? context,
+            CancellationToken cancellationToken)
+            => await BlockReadAsync(readCancellation);
+
+        private async Task BlockReadAsync(CancellationToken cancellationToken)
+        {
+            _readStarted.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Api/AiServiceTests.cs
+++ b/tests/Beutl.UnitTests/Api/AiServiceTests.cs
@@ -16,6 +16,37 @@ namespace Beutl.UnitTests.Api;
 [TestFixture]
 public sealed class AiCapabilityServiceTests
 {
+    [Test]
+    public void Transcription_rejects_excessive_segment_counts_before_deserializing_segments()
+    {
+        string body = "{\"segments\":[" + string.Join(",", Enumerable.Repeat("{}", 10001)) + "]}";
+        var error = Assert.Throws<AiProviderErrorException>(() => AiTranscriptionService.ReadTranscriptionResult(body));
+        Assert.That(error!.InnerException!.Message, Does.Contain("segment count"));
+    }
+
+    [TestCase("[]")]
+    [TestCase("null")]
+    [TestCase("{}")]
+    public void Transcription_rejects_invalid_response_shapes(string body)
+    {
+        Assert.Throws<AiProviderErrorException>(() => AiTranscriptionService.ReadTranscriptionResult(body));
+    }
+
+    [Test]
+    public async Task Transcription_bounds_response_bytes_without_a_content_length()
+    {
+        using var content = new StreamContent(new RepeatingReadStream(
+            AiMeteredCapabilityService.MaximumResponseBodyBytes + 1L));
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        using var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+        using var http = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(http, new ExtensionProvider());
+        SetAuthenticatedUser(app);
+        Assert.ThrowsAsync<AiException>(async () => await app.GetResource<IAiTranscriptionService>()
+            .TranscribeAsync(new AiTranscriptionRequest(
+                AiUploadSource.FromBytes("audio.wav", "audio/wav", new byte[] { 1 })), CancellationToken.None));
+    }
+
     // Monthly usage is proportional; the exact purchased balance appears only
     // in this account snapshot, not in ordinary operation responses.
     private const string EntitlementBalanceJson = """

--- a/tests/Beutl.UnitTests/Api/AiServiceTests.cs
+++ b/tests/Beutl.UnitTests/Api/AiServiceTests.cs
@@ -876,6 +876,68 @@ public sealed class AiCapabilityServiceTests
         }
     }
 
+    [TestCase("AA==", 1)]
+    [TestCase("AAA=", 2)]
+    [TestCase("AAAA", 3)]
+    [TestCase(" A\tA\r=\n= ", 1)]
+    public void ImagePreviewBudget_DecodesPaddingAndWhitespace(string image, int length)
+    {
+        var budget = new AiImageGenerationService.ImagePreviewBudget();
+        Assert.That(budget.TryDecode(image, out byte[] bytes), Is.True);
+        Assert.That(bytes, Has.Length.EqualTo(length));
+    }
+
+    [Test]
+    public void ImagePreviewBudget_RejectsOversizedImageWithoutDecodedAllocation()
+    {
+        var budget = new AiImageGenerationService.ImagePreviewBudget();
+        string image = new('A', checked((int)((AiRequestLimits.MaxImageUploadBytes / 3 + 1) * 4)));
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        bool accepted = budget.TryDecode(image, out byte[] bytes);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.That(accepted, Is.False);
+        Assert.That(bytes, Is.Empty);
+        Assert.That(allocated, Is.LessThan(1024 * 1024));
+        Assert.That(budget.TryDecode("AA==", out _), Is.True);
+    }
+
+    [Test]
+    public void ImagePreviewBudget_ChecksRemainingBudgetBeforeDecoding()
+    {
+        var budget = new AiImageGenerationService.ImagePreviewBudget();
+        Assert.That(budget.TryReserve(AiRequestLimits.MaxImageUploadBytes - 1), Is.True);
+        Assert.That(budget.TryDecode("AAA=", out _), Is.False);
+        Assert.That(budget.TryDecode("AA==", out _), Is.True);
+        Assert.That(budget.TryDecode("AA==", out _), Is.False);
+    }
+
+    [Test]
+    public void ImagePreviewBudget_InvalidImageDoesNotConsumeBudget()
+    {
+        var budget = new AiImageGenerationService.ImagePreviewBudget();
+        Assert.That(budget.TryDecode("!AAA", out _), Is.False);
+        for (int index = 0; index < 4; index++)
+            Assert.That(budget.TryDecode("AA==", out _), Is.True);
+        Assert.That(budget.TryDecode("AA==", out _), Is.False);
+    }
+
+    [Test]
+    public void ImagePreviewBudget_ExhaustedCountDoesNotAllocateDecodedImage()
+    {
+        var budget = new AiImageGenerationService.ImagePreviewBudget();
+        for (int index = 0; index < 4; index++)
+            Assert.That(budget.TryReserve(1), Is.True);
+        string image = new('A', 4 * 1024 * 1024);
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        bool accepted = budget.TryDecode(image, out byte[] bytes);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.That(accepted, Is.False);
+        Assert.That(bytes, Is.Empty);
+        Assert.That(allocated, Is.LessThan(1024 * 1024));
+    }
+
     [Test]
     public async Task ImageGeneration_MalformedTerminalResultStillFailsClosed()
     {

--- a/tests/Beutl.UnitTests/Api/AiUploadSourceContractTests.cs
+++ b/tests/Beutl.UnitTests/Api/AiUploadSourceContractTests.cs
@@ -1,0 +1,195 @@
+﻿using System.Reflection;
+using Beutl.Api.Services;
+
+namespace Beutl.UnitTests.Api;
+
+[TestFixture]
+public sealed class AiUploadSourceContractTests
+{
+    [Test]
+    public async Task OpenReadAsync_IsPublicForExternalCapabilityImplementations()
+    {
+        MethodInfo? method = typeof(AiUploadSource).GetMethod(
+            nameof(AiUploadSource.OpenReadAsync),
+            BindingFlags.Instance | BindingFlags.Public,
+            binder: null,
+            types: [typeof(CancellationToken)],
+            modifiers: null);
+        ConstructorInfo? constructor = typeof(AiUploadSource).GetConstructor(
+            [typeof(string), typeof(string), typeof(Func<CancellationToken, ValueTask<Stream>>), typeof(long)]);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        CancellationToken observedToken = default;
+        var expectedStream = new MemoryStream([1, 2, 3]);
+        var source = new AiUploadSource(
+            "input.bin",
+            "application/octet-stream",
+            cancellationToken =>
+            {
+                observedToken = cancellationToken;
+                return ValueTask.FromResult<Stream>(expectedStream);
+            },
+            expectedStream.Length);
+
+        await using Stream stream = await source.OpenReadAsync(cancellationTokenSource.Token);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(method, Is.Not.Null);
+            Assert.That(constructor, Is.Not.Null);
+            Assert.That(constructor!.GetParameters().Last().IsOptional, Is.False);
+            Assert.That(typeof(AiUploadSource).GetProperty(nameof(AiUploadSource.Length))!.PropertyType,
+                Is.EqualTo(typeof(long)));
+            Assert.That(method!.ReturnType, Is.EqualTo(typeof(ValueTask<Stream>)));
+            Assert.That(method.GetParameters().Single().HasDefaultValue, Is.False);
+            Assert.That(stream, Is.SameAs(expectedStream));
+            Assert.That(observedToken, Is.EqualTo(cancellationTokenSource.Token));
+        });
+    }
+
+    [Test]
+    public async Task FromBytesSnapshotsMutableCallerMemoryAtConstruction()
+    {
+        byte[] callerBuffer = [1, 2, 3];
+        AiUploadSource source = AiUploadSource.FromBytes(
+            "snapshot.bin",
+            "application/octet-stream",
+            callerBuffer);
+        callerBuffer[0] = 9;
+
+        await using Stream first = await source.OpenReadAsync(CancellationToken.None);
+        await using Stream second = await source.OpenReadAsync(CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(await ReadAllAsync(first), Is.EqualTo(new byte[] { 1, 2, 3 }));
+            Assert.That(await ReadAllAsync(second), Is.EqualTo(new byte[] { 1, 2, 3 }));
+        }
+    }
+
+    [Test]
+    public void Validation_RejectsASeekableStreamThatExceedsItsDeclaredLength()
+    {
+        var source = new AiUploadSource(
+            "input.bin",
+            "application/octet-stream",
+            _ => ValueTask.FromResult<Stream>(new MemoryStream(new byte[4], writable: false)),
+            length: 3);
+
+        Assert.ThrowsAsync<AiFileTooLargeException>(async () =>
+        {
+            await using Stream _ = await AiUploadValidation.OpenAsync(
+                source,
+                10,
+                CancellationToken.None);
+        });
+    }
+
+    [Test]
+    public async Task Validation_BuffersAndMeasuresANonSeekableStream()
+    {
+        var original = new NonSeekableStream([1, 2, 3]);
+        var source = new AiUploadSource(
+            "input.bin",
+            "application/octet-stream",
+            _ => ValueTask.FromResult<Stream>(original),
+            length: 3);
+
+        await using Stream validated = await AiUploadValidation.OpenAsync(
+            source,
+            maximumBytes: 3,
+            CancellationToken.None);
+
+        using var copy = new MemoryStream();
+        await validated.CopyToAsync(copy);
+        Assert.Multiple(() =>
+        {
+            Assert.That(copy.ToArray(), Is.EqualTo(new byte[] { 1, 2, 3 }));
+            Assert.That(original.WasDisposed, Is.True);
+        });
+    }
+
+    [TestCase(2, 3)]
+    [TestCase(3, 2)]
+    public void Validation_RejectsANonSeekableStreamBeyondTheDeclaredOrRouteLimit(
+        long declaredLength,
+        long maximumBytes)
+    {
+        var original = new NonSeekableStream([1, 2, 3]);
+        var source = new AiUploadSource(
+            "input.bin",
+            "application/octet-stream",
+            _ => ValueTask.FromResult<Stream>(original),
+            declaredLength);
+
+        Assert.ThrowsAsync<AiFileTooLargeException>(async () =>
+        {
+            await using Stream _ = await AiUploadValidation.OpenAsync(
+                source,
+                maximumBytes,
+                CancellationToken.None);
+        });
+        Assert.That(original.WasDisposed, Is.True);
+    }
+
+    private static async Task<byte[]> ReadAllAsync(Stream stream)
+    {
+        using var destination = new MemoryStream();
+        await stream.CopyToAsync(destination);
+        return destination.ToArray();
+    }
+
+    private sealed class NonSeekableStream(byte[] bytes) : Stream
+    {
+        private readonly MemoryStream _inner = new(bytes, writable: false);
+
+        public bool WasDisposed { get; private set; }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => throw new NotSupportedException();
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => _inner.Read(buffer, offset, count);
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+            => _inner.ReadAsync(buffer, cancellationToken);
+
+        public override long Seek(long offset, SeekOrigin origin)
+            => throw new NotSupportedException();
+
+        public override void SetLength(long value)
+            => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            WasDisposed = true;
+            if (disposing)
+                _inner.Dispose();
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            WasDisposed = true;
+            await _inner.DisposeAsync();
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Api/AiUploadSourceContractTests.cs
+++ b/tests/Beutl.UnitTests/Api/AiUploadSourceContractTests.cs
@@ -6,6 +6,13 @@ namespace Beutl.UnitTests.Api;
 [TestFixture]
 public sealed class AiUploadSourceContractTests
 {
+    [TestCase("dir/frame.png")]
+    [TestCase(@"dir\frame.png")]
+    public void Upload_names_reject_both_path_separator_styles(string name)
+    {
+        Assert.Throws<ArgumentException>(() => AiUploadSource.FromBytes(name, "image/png", new byte[] { 1 }));
+    }
+
     [Test]
     public async Task OpenReadAsync_IsPublicForExternalCapabilityImplementations()
     {

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -1,11 +1,11 @@
 ﻿using System.Net;
-using System.Net.Http.Json;
+using System.Reflection;
 using System.Text;
 using Beutl.Api;
 using Beutl.Api.Clients;
 using Beutl.Api.Objects;
 using Beutl.Api.Services;
-using Beutl.Testing.Headless;
+using Reactive.Bindings;
 
 namespace Beutl.UnitTests.Api;
 
@@ -14,17 +14,88 @@ namespace Beutl.UnitTests.Api;
 public sealed class BeutlApiApplicationTests
 {
     [Test]
-    public void Constructor_RegistersProvidedExtensionProvider()
+    public async Task Constructor_RegistersProvidedExtensionProvider()
     {
         using var httpClient = new HttpClient();
         var extensionProvider = new ExtensionProvider();
-        var app = new BeutlApiApplication(httpClient, extensionProvider);
+        await using var app = new BeutlApiApplication(httpClient, extensionProvider);
 
         ExtensionProvider registeredProvider = app.GetResource<ExtensionProvider>();
         PackageManager packageManager = app.GetResource<PackageManager>();
 
         Assert.That(registeredProvider, Is.SameAs(extensionProvider));
-        Assert.That(packageManager.ExtensionProvider, Is.SameAs(extensionProvider));
+        Assert.That(packageManager.ExtensionRegistry, Is.SameAs(extensionProvider));
+        Assert.That(
+            app.AuthenticatedUser,
+            Is.Not.InstanceOf<global::Reactive.Bindings.ReactivePropertySlim<
+                Beutl.Api.Objects.AuthenticatedUser?>>());
+    }
+
+    [Test]
+    public async Task DisposeAsync_DisposesPackageInstallerOwnedHttpClient()
+    {
+        using var apiHttpClient = new HttpClient();
+        var packageHandler = new DisposalTrackingHandler();
+        var app = new BeutlApiApplication(
+            apiHttpClient,
+            new ExtensionProvider(),
+            () => new HttpClient(packageHandler));
+        _ = app.GetResource<PackageInstaller>();
+
+        await app.DisposeAsync();
+
+        Assert.That(packageHandler.IsDisposed, Is.True);
+    }
+
+    [Test]
+    public async Task Constructor_UsesProductionApiOrigin()
+    {
+        using var httpClient = new HttpClient();
+
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(httpClient.BaseAddress, Is.EqualTo(new Uri("https://beutl.beditor.net/")));
+            Assert.That(BeutlApiApplication.UserFileName, Is.EqualTo("user.json"));
+        }
+    }
+
+    [Test]
+    public async Task Constructor_RegistersBuiltInJobBehaviorsThroughIndependentSlots()
+    {
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        IAiJobKindRegistry registry = app.GetResource<IAiJobKindRegistry>();
+        var runningVideo = new AiJob(
+            new AiJobId("job-1"),
+            AiJobKinds.Video,
+            AiJobStatuses.Running,
+            null,
+            null,
+            null,
+            null,
+            false,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+
+        AiJobStatusSemantics status = registry.GetStatus(runningVideo);
+        Assert.That(registry.TryAcquireRefreshHandler(
+            AiJobKinds.Video,
+            out IAiJobRefreshHandlerLease? refreshLease), Is.True);
+        Assert.That(registry.TryAcquireRetryHandler(
+            AiJobKinds.Video,
+            out IAiJobRetryHandlerLease? retryLease), Is.True);
+        using (refreshLease)
+        using (retryLease)
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(status.IsTerminal, Is.False);
+            Assert.That(status.ShouldPoll, Is.True);
+            Assert.That(status.Outcome, Is.Null);
+            Assert.That(refreshLease!.Handler, Is.Not.Null);
+            Assert.That(retryLease!.Handler, Is.Not.Null);
+        }
     }
 
     [Test]
@@ -53,20 +124,18 @@ public sealed class BeutlApiApplicationTests
     [TestCase("debian")]
     [TestCase("installer")]
     [TestCase("app")]
-    public void ToServerType_KnownType_PassesThrough(string type)
+    public void ToServerType_ArchiveType_PassesThrough(string type)
     {
         Assert.That(BeutlApiApplication.ToServerType(type), Is.EqualTo(type));
     }
 
     [Test]
-    public async Task CheckForUpdatesAsync_WithFlatpakMetadata_SendsZipType()
+    public async Task CheckForUpdatesAsync_WithFlatpakMetadata_SendsZipQueryType()
     {
-        // LoadMetadata reads asset_metadata.json from AppContext.BaseDirectory (cached per process).
         string metadataPath = Path.Combine(AppContext.BaseDirectory, "asset_metadata.json");
-        string? originalContent = File.Exists(metadataPath) ? File.ReadAllText(metadataPath) : null;
         try
         {
-            File.WriteAllText(metadataPath, """
+            await File.WriteAllTextAsync(metadataPath, """
                 {
                   "id": "test-id",
                   "os": "linux",
@@ -78,373 +147,23 @@ public sealed class BeutlApiApplicationTests
                 """);
             var handler = new CapturingHandler();
             using var httpClient = new HttpClient(handler);
-            var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+            await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
 
             var (v1, v3) = await app.CheckForUpdatesAsync("2.0.0-preview.6", CancellationToken.None);
 
-            Assert.That(handler.LastRequestUri, Is.Not.Null);
-            Assert.That(handler.LastRequestUri!.Query, Does.Contain("type=zip"));
-            Assert.That(handler.LastRequestUri!.Query, Does.Not.Contain("type=flatpak"));
-            Assert.That(v3, Is.Not.Null);
-            Assert.That(v1, Is.Null);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(handler.LastRequestUri, Is.Not.Null);
+                Assert.That(handler.LastRequestUri!.Query, Does.Contain("type=zip"));
+                Assert.That(handler.LastRequestUri.Query, Does.Not.Contain("type=flatpak"));
+                Assert.That(v1, Is.Null);
+                Assert.That(v3, Is.Not.Null);
+            }
         }
         finally
         {
-            if (originalContent != null)
-            {
-                File.WriteAllText(metadataPath, originalContent);
-            }
-            else
-            {
-                File.Delete(metadataPath);
-            }
+            File.Delete(metadataPath);
         }
-    }
-
-    [Test]
-    public async Task CheckForUpdatesAsync_PreCanceledTokenStopsBeforeMetadataRead()
-    {
-        // LoadMetadata reads asset_metadata.json from AppContext.BaseDirectory (cached per process).
-        string metadataPath = Path.Combine(AppContext.BaseDirectory, "asset_metadata.json");
-        string? originalContent = File.Exists(metadataPath) ? File.ReadAllText(metadataPath) : null;
-        try
-        {
-            File.WriteAllText(metadataPath, """
-                {
-                  "id": "test-id",
-                  "os": "linux",
-                  "arch": "x64",
-                  "version": "2.0.0-preview.6",
-                  "standalone": "true",
-                  "type": "flatpak"
-                }
-                """);
-            using var httpClient = new HttpClient();
-            var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
-            using var cancellationTokenSource = new CancellationTokenSource();
-            cancellationTokenSource.Cancel();
-
-            Assert.CatchAsync<OperationCanceledException>(async () =>
-                await app.CheckForUpdatesAsync("2.0.0-preview.6", cancellationTokenSource.Token));
-        }
-        finally
-        {
-            if (originalContent != null)
-            {
-                File.WriteAllText(metadataPath, originalContent);
-            }
-            else
-            {
-                File.Delete(metadataPath);
-            }
-        }
-    }
-
-    [Test]
-    public async Task CompleteSignInAsync_RestoresAuthorization_WhenGetSelfIsCanceled()
-    {
-        using var cancellationTokenSource = new CancellationTokenSource();
-        using var handler = new DelegateHandler((request, cancellationToken) =>
-        {
-            cancellationTokenSource.Cancel();
-            throw new OperationCanceledException(cancellationToken);
-        });
-        using var httpClient = new HttpClient(handler);
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
-        var authResponse = new AuthResponse
-        {
-            Token = "new-token",
-            RefreshToken = "new-refresh",
-            Expiration = DateTime.UtcNow.AddHours(1)
-        };
-
-        Assert.CatchAsync<OperationCanceledException>(async () =>
-            await app.CompleteSignInAsync(authResponse, cancellationTokenSource.Token));
-
-        Assert.That(httpClient.DefaultRequestHeaders.Authorization, Is.Null,
-            "the new bearer token must not remain after a canceled sign-in");
-    }
-
-    [Test]
-    public async Task CompleteSignInAsync_RestoresAuthenticatedUser_WhenPersistenceFails()
-    {
-        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
-        string userFile = Path.Combine(Helper.AppRoot, BeutlApiApplication.UserFileName);
-        Directory.CreateDirectory(userFile); // SaveUser's File.Create fails on a directory.
-        try
-        {
-            using var handler = new DelegateHandler((request, cancellationToken) =>
-                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = JsonContent.Create(new ProfileResponse
-                    {
-                        Id = "new-profile",
-                        Name = "new-name",
-                        DisplayName = "New Name",
-                        Bio = null,
-                        IconId = null,
-                        IconUrl = null,
-                    })
-                }));
-            using var httpClient = new HttpClient(handler);
-            var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
-            var authResponse = new AuthResponse
-            {
-                Token = "new-token",
-                RefreshToken = "new-refresh",
-                Expiration = DateTime.UtcNow.AddHours(1)
-            };
-
-            Assert.CatchAsync<Exception>(async () =>
-                await app.CompleteSignInAsync(authResponse, CancellationToken.None));
-
-            Assert.That(app.AuthenticatedUser.Value, Is.Null,
-                "the failed sign-in must not leave a signed-in user");
-            Assert.That(httpClient.DefaultRequestHeaders.Authorization, Is.Null,
-                "the new bearer token must not remain after a failed sign-in");
-        }
-        finally
-        {
-            Directory.Delete(userFile, recursive: true);
-        }
-    }
-
-    [Test]
-    public async Task CompleteSignInAsync_DoesNotResurrectUser_WhenSignedOutDuringGetSelf()
-    {
-        var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var releaseRequest = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var handler = new DelegateHandler(async (request, cancellationToken) =>
-        {
-            requestStarted.TrySetResult();
-            await releaseRequest.Task;
-            throw new HttpRequestException("request failed");
-        });
-        using var httpClient = new HttpClient(handler);
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
-        var authResponse = new AuthResponse
-        {
-            Token = "new-token",
-            RefreshToken = "new-refresh",
-            Expiration = DateTime.UtcNow.AddHours(1)
-        };
-
-        Task<AuthenticatedUser> signIn = app.CompleteSignInAsync(authResponse, CancellationToken.None);
-        await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-
-        // SignOut while GetSelf is pending; the failing attempt must not resurrect the user.
-        app.SignOut(false);
-        releaseRequest.TrySetResult();
-
-        Assert.CatchAsync<Exception>(async () =>
-            await signIn.WaitAsync(TimeSpan.FromSeconds(5)));
-        Assert.That(app.AuthenticatedUser.Value, Is.Null,
-            "SignOut must not be undone by the failing sign-in");
-    }
-
-    [Test]
-    public async Task CompleteSignInAsync_RestoresAuthorization_WhenCancelledAfterGetSelf()
-    {
-        var requestCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var cancellation = new CancellationTokenSource();
-        using var handler = new DelegateHandler((request, cancellationToken) =>
-        {
-            requestCompleted.TrySetResult();
-            // Cancel while the response is being processed, so the recheck after GetSelf
-            // throws before the new token is committed.
-            cancellation.Cancel();
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = JsonContent.Create(new ProfileResponse
-                {
-                    Id = "new-profile",
-                    Name = "new-name",
-                    DisplayName = "New Name",
-                    Bio = null,
-                    IconId = null,
-                    IconUrl = null,
-                })
-            });
-        });
-        using var httpClient = new HttpClient(handler);
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
-        var authResponse = new AuthResponse
-        {
-            Token = "new-token",
-            RefreshToken = "new-refresh",
-            Expiration = DateTime.UtcNow.AddHours(1)
-        };
-
-        Task<AuthenticatedUser> signIn = app.CompleteSignInAsync(authResponse, cancellation.Token);
-        await requestCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-
-        Assert.CatchAsync<OperationCanceledException>(async () =>
-            await signIn.WaitAsync(TimeSpan.FromSeconds(5)));
-        Assert.That(httpClient.DefaultRequestHeaders.Authorization, Is.Null,
-            "the uncommitted new token must not remain after a canceled re-sign-in");
-    }
-
-    [Test]
-    public async Task RestoreUserAsync_RestoresAuthorization_WhenProfileRefreshIsCanceled()
-    {
-        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
-        string userFile = Path.Combine(Helper.AppRoot, BeutlApiApplication.UserFileName);
-        string original = """
-            {
-              "token": "restored-token",
-              "refresh_token": "restored-refresh",
-              "expiration": "2027-01-01T00:00:00Z",
-              "profile": {
-                "id": "restored-profile",
-                "name": "restored-name",
-                "displayName": "Restored Name",
-                "bio": null,
-                "iconId": null,
-                "iconUrl": null
-              }
-            }
-            """;
-        File.WriteAllText(userFile, original);
-        try
-        {
-            using var cancellationTokenSource = new CancellationTokenSource();
-            using var handler = new DelegateHandler((request, cancellationToken) =>
-            {
-                if (request.RequestUri!.PathAndQuery.StartsWith("/api/v3/user"))
-                {
-                    cancellationTokenSource.Cancel();
-                    throw new OperationCanceledException(cancellationToken);
-                }
-
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = JsonContent.Create(new ProfileResponse
-                    {
-                        Id = "restored-profile",
-                        Name = "restored-name",
-                        DisplayName = "Restored Name",
-                        Bio = null,
-                        IconId = null,
-                        IconUrl = null,
-                    })
-                });
-            });
-            using var httpClient = new HttpClient(handler);
-            var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
-
-            Assert.CatchAsync<OperationCanceledException>(async () =>
-                await app.RestoreUserAsync(null, cancellationTokenSource.Token));
-
-            Assert.That(httpClient.DefaultRequestHeaders.Authorization, Is.Null,
-                "the restored bearer token must not remain after a canceled restoration");
-            Assert.That(app.AuthenticatedUser.Value, Is.Null,
-                "the restored user must not remain after a canceled restoration");
-        }
-        finally
-        {
-            File.Delete(userFile);
-        }
-    }
-
-    [Test]
-    public async Task RestoreUserAsync_Rethrows_WhenCancelledAfterProfileRefresh()
-    {
-        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
-        string userFile = Path.Combine(Helper.AppRoot, BeutlApiApplication.UserFileName);
-        File.WriteAllText(userFile, """
-            {
-              "token": "restored-token",
-              "refresh_token": "restored-refresh",
-              "expiration": "2027-01-01T00:00:00Z",
-              "profile": {
-                "id": "restored-profile",
-                "name": "restored-name",
-                "displayName": "Restored Name",
-                "bio": null,
-                "iconId": null,
-                "iconUrl": null
-              }
-            }
-            """);
-        try
-        {
-            var requestCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            BeutlApiApplication? appRef = null;
-            using var handler = new DelegateHandler((request, cancellationToken) =>
-            {
-                requestCompleted.TrySetResult();
-                // Dispose while the profile response is being processed, so the lifetime
-                // token is cancelled before RestoreUserAsync publishes the restored state.
-                appRef?.DisposeAsync().AsTask().GetAwaiter().GetResult();
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = JsonContent.Create(new ProfileResponse
-                    {
-                        Id = "restored-profile",
-                        Name = "restored-name",
-                        DisplayName = "Restored Name",
-                        Bio = null,
-                        IconId = null,
-                        IconUrl = null,
-                    })
-                });
-            });
-            using var httpClient = new HttpClient(handler);
-            var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
-            appRef = app;
-
-            Task restore = app.RestoreUserAsync(null, CancellationToken.None);
-            await requestCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-
-            Assert.CatchAsync<OperationCanceledException>(async () =>
-                await restore.WaitAsync(TimeSpan.FromSeconds(5)));
-        }
-        finally
-        {
-            File.Delete(userFile);
-        }
-    }
-
-    [Test]
-    public async Task CompleteSignInAsync_Rethrows_WhenCancelledAfterProfileResponse()
-    {
-        var requestCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        BeutlApiApplication? appRef = null;
-        using var handler = new DelegateHandler((request, cancellationToken) =>
-        {
-            requestCompleted.TrySetResult();
-            // Dispose while the profile response is being processed, so the lifetime token
-            // is cancelled before CompleteSignInAsync publishes the signed-in state.
-            appRef?.DisposeAsync().AsTask().GetAwaiter().GetResult();
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = JsonContent.Create(new ProfileResponse
-                {
-                    Id = "new-profile",
-                    Name = "new-name",
-                    DisplayName = "New Name",
-                    Bio = null,
-                    IconId = null,
-                    IconUrl = null,
-                })
-            });
-        });
-        using var httpClient = new HttpClient(handler);
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
-        appRef = app;
-        var authResponse = new AuthResponse
-        {
-            Token = "new-token",
-            RefreshToken = "new-refresh",
-            Expiration = DateTime.UtcNow.AddHours(1)
-        };
-
-        using CancellationTokenSource lifetimeCts = app.CreateLifetimeLinkedTokenSource(CancellationToken.None);
-        Task<AuthenticatedUser> signIn = app.CompleteSignInAsync(authResponse, lifetimeCts.Token);
-        await requestCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-
-        Assert.CatchAsync<OperationCanceledException>(async () =>
-            await signIn.WaitAsync(TimeSpan.FromSeconds(5)));
     }
 
     [Test]
@@ -464,69 +183,275 @@ public sealed class BeutlApiApplicationTests
     {
         using var httpClient = new HttpClient();
         await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
-        _ = app.GetResource<PackageManager>();
+        _ = app.GetResource<IAiJobMonitor>();
 
         Assert.DoesNotThrowAsync(async () => await app.DisposeAsync());
         Assert.DoesNotThrowAsync(async () => await app.DisposeAsync());
-        Assert.Throws<ObjectDisposedException>(() => app.GetResource<DiscoverService>());
+        Assert.Throws<ObjectDisposedException>(() => app.GetResource<IAiImageGenerationService>());
     }
 
     [Test]
-    public async Task CheckForUpdatesAsync_Rethrows_WhenCancelledAfterResponse()
+    public async Task DisposeAsync_WaitsForActiveJobBehaviorLease()
     {
-        // LoadMetadata reads asset_metadata.json from AppContext.BaseDirectory (cached per process).
-        string metadataPath = Path.Combine(AppContext.BaseDirectory, "asset_metadata.json");
-        string? originalContent = File.Exists(metadataPath) ? File.ReadAllText(metadataPath) : null;
-        try
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        IAiJobKindRegistry registry = app.GetResource<IAiJobKindRegistry>();
+        Assert.That(registry.TryAcquireRetryHandler(
+            AiJobKinds.Video,
+            out IAiJobRetryHandlerLease? lease), Is.True);
+
+        Task disposal = app.DisposeAsync().AsTask();
+        await Task.Yield();
+
+        Assert.That(disposal.IsCompleted, Is.False);
+        lease!.Dispose();
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Throws<ObjectDisposedException>(() => app.GetResource<IAiJobKindRegistry>());
+    }
+
+    [Test]
+    public async Task DisposeAsync_PublishesOneTaskBeforeLifetimeCancellationCanReenter()
+    {
+        using var httpClient = new HttpClient();
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var resource = new ProbeResource();
+        RegisterResource(app, resource);
+        using CancellationTokenSource lifetime =
+            app.CreateLifetimeLinkedTokenSource(CancellationToken.None);
+        Task? reentrantDisposal = null;
+        using CancellationTokenRegistration registration = lifetime.Token.Register(() =>
+            reentrantDisposal = app.DisposeAsync().AsTask());
+
+        Task disposal = app.DisposeAsync().AsTask();
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+
+        using (Assert.EnterMultipleScope())
         {
-            File.WriteAllText(metadataPath, """
+            Assert.That(reentrantDisposal, Is.SameAs(disposal));
+            Assert.That(resource.DisposeCount, Is.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public async Task DisposeAsync_SynchronousLifetimeCallbackWaitCompletesAtTheSharedDeadline()
+    {
+        using var httpClient = new HttpClient();
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider())
+        {
+            DisposalDeadline = TimeSpan.FromMilliseconds(100),
+        };
+        var resource = new ProbeResource();
+        RegisterResource(app, resource);
+        using CancellationTokenSource lifetime =
+            app.CreateLifetimeLinkedTokenSource(CancellationToken.None);
+        var callbackReturned = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using CancellationTokenRegistration registration = lifetime.Token.Register(() =>
+        {
+            app.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            callbackReturned.TrySetResult();
+        });
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        await app.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        stopwatch.Stop();
+        await callbackReturned.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await WaitUntilAsync(() => resource.DisposeCount == 1, TimeSpan.FromSeconds(5));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(2)));
+            Assert.That(resource.DisposeCount, Is.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public async Task DisposeAsync_CancellationCallbackFailureCannotSkipResources()
+    {
+        using var httpClient = new HttpClient();
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var resource = new ProbeResource();
+        RegisterResource(app, resource);
+        using CancellationTokenSource lifetime =
+            app.CreateLifetimeLinkedTokenSource(CancellationToken.None);
+        using CancellationTokenRegistration registration = lifetime.Token.Register(static () =>
+            throw new InvalidOperationException("callback failed"));
+
+        Assert.CatchAsync<Exception>(async () =>
+            await app.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+
+        Assert.That(resource.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task DisposeAsync_DeadlineLeavesAnActiveResourceAliveUntilItsLeaseDrains()
+    {
+        using var httpClient = new HttpClient();
+        var app = new BeutlApiApplication(httpClient, new ExtensionProvider())
+        {
+            DisposalDeadline = TimeSpan.FromMilliseconds(100),
+        };
+        var resource = new BlockingResource();
+        RegisterResource(app, resource);
+
+        Task disposal = app.DisposeAsync().AsTask();
+        await resource.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(resource.DisposeCompleted, Is.False,
+            "The shutdown deadline must not tear down a resource while its lease is active.");
+
+        resource.Release.TrySetResult();
+        await resource.Disposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(resource.DisposeCompleted, Is.True);
+    }
+
+    [Test]
+    public async Task AuthenticatedRequest_KeepsCapturedBearerAndEndsWithItsSession()
+    {
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app, "first-user", "first-token");
+        var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        string? authorization = null;
+
+        Task operation = app.SendAuthenticatedAsync(
+            async (capturedAuthorization, cancellationToken) =>
+            {
+                authorization = capturedAuthorization;
+                requestStarted.TrySetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return 1;
+            },
+            CancellationToken.None);
+        await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        SetAuthenticatedUser(app, "second-user", "second-token");
+
+        AuthenticationRequiredException? failure =
+            Assert.ThrowsAsync<AuthenticationRequiredException>(async () => await operation);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(failure!.CurrentAttemptReservationIsKnownAbsent, Is.False);
+            Assert.That(authorization, Is.EqualTo("Bearer first-token"));
+        }
+    }
+
+    [Test]
+    public async Task AuthenticatedRequestScopeRejectsAccountSwitchBeforeDispatch()
+    {
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        AuthenticatedUser first = SetAuthenticatedUser(app, "first-user", "first-token");
+        using IDisposable scope = AiAuthenticatedRequestScope.Enter(first);
+        SetAuthenticatedUser(app, "second-user", "second-token");
+        bool invoked = false;
+
+        AuthenticationRequiredException? failure = Assert.ThrowsAsync<AuthenticationRequiredException>(() =>
+            app.SendAuthenticatedAsync(
+                (_, _) =>
                 {
-                  "id": "test-id",
-                  "os": "linux",
-                  "arch": "x64",
-                  "version": "2.0.0-preview.6",
-                  "standalone": "true",
-                  "type": "zip"
-                }
-                """);
-            var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            var releaseResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            var handler = new DelegateHandler(async (request, cancellationToken) =>
+                    invoked = true;
+                    return Task.FromResult(1);
+                },
+                CancellationToken.None));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(failure!.CurrentAttemptReservationIsKnownAbsent, Is.True);
+            Assert.That(invoked, Is.False);
+        }
+    }
+
+    [Test]
+    public async Task AuthenticatedRequest_AccountSwitchAfterSendKeepsReservationOutcomeUnknown()
+    {
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app, "first-user", "first-token");
+
+        AuthenticationRequiredException? failure =
+            Assert.ThrowsAsync<AuthenticationRequiredException>(() =>
+                app.SendAuthenticatedAsync(
+                    (_, _) =>
+                    {
+                        SetAuthenticatedUser(app, "second-user", "second-token");
+                        return Task.FromResult(1);
+                    },
+                    CancellationToken.None));
+
+        Assert.That(failure!.CurrentAttemptReservationIsKnownAbsent, Is.False);
+    }
+
+    [Test]
+    public async Task Dispose_CancelsActiveAuthenticatedRequestAndDisposesAiCapabilities()
+    {
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        SetAuthenticatedUser(app, "test-user", "token");
+        IAiEntitlementService service = app.GetResource<IAiEntitlementService>();
+        var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task operation = app.SendAuthenticatedAsync(
+            async (_, cancellationToken) =>
             {
                 requestStarted.TrySetResult();
-                await releaseResponse.Task.WaitAsync(cancellationToken);
-                return new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new StringContent(
-                        """{"latestVersion":"2.0.0-preview.7","url":"https://example.com","downloadUrl":null,"isLatest":false,"mustLatest":false}""",
-                        Encoding.UTF8,
-                        "application/json")
-                };
-            });
-            using var httpClient = new HttpClient(handler);
-            var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return 1;
+            },
+            CancellationToken.None);
+        await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-            // Dispose after the response completes but before the continuation runs: the
-            // lifetime token is cancelled, so the method must recheck it before returning.
-            Task<(CheckForUpdatesResponse? V1, AppUpdateResponse? V3)> check
-                = app.CheckForUpdatesAsync("2.0.0-preview.6", CancellationToken.None);
-            await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-            await app.DisposeAsync().AsTask();
-            releaseResponse.TrySetResult();
+        await app.DisposeAsync();
 
-            Assert.CatchAsync<OperationCanceledException>(async () =>
-                await check.WaitAsync(TimeSpan.FromSeconds(5)));
-        }
-        finally
+        Assert.CatchAsync<OperationCanceledException>(async () => await operation);
+        Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            await service.RefreshAsync(CancellationToken.None));
+    }
+
+    private static AuthenticatedUser SetAuthenticatedUser(
+        BeutlApiApplication app,
+        string userId,
+        string token)
+    {
+        var profile = new Profile(new ProfileResponse
         {
-            if (originalContent != null)
-            {
-                File.WriteAllText(metadataPath, originalContent);
-            }
-            else
-            {
-                File.Delete(metadataPath);
-            }
+            Id = userId,
+            Name = userId,
+            DisplayName = userId,
+            Bio = null,
+            IconId = null,
+            IconUrl = null,
+        }, app);
+        var user = new AuthenticatedUser(profile, new AuthResponse
+        {
+            Token = token,
+            RefreshToken = $"{token}-refresh",
+            Expiration = DateTime.UtcNow.AddHours(1),
+        }, app, DateTime.UtcNow);
+        FieldInfo field = typeof(BeutlApiApplication).GetField(
+            "_authenticatedUser",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        ((ReactivePropertySlim<AuthenticatedUser?>)field.GetValue(app)!).Value = user;
+        return user;
+    }
+
+    private static void RegisterResource<T>(BeutlApiApplication app, T resource)
+        where T : class, IBeutlApiResource
+    {
+        FieldInfo field = typeof(BeutlApiApplication).GetField(
+            "_services",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var services = (Dictionary<Type, Lazy<object>>)field.GetValue(app)!;
+        services.Add(typeof(T), new Lazy<object>(() => resource));
+        _ = app.GetResource<T>();
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        using var cancellation = new CancellationTokenSource(timeout);
+        while (!condition())
+        {
+            await Task.Delay(10, cancellation.Token);
         }
     }
 
@@ -535,141 +460,69 @@ public sealed class BeutlApiApplicationTests
         public Uri? LastRequestUri { get; private set; }
 
         protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request, CancellationToken cancellationToken)
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
         {
             LastRequestUri = request.RequestUri;
-            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent(
                     """
-                    {"latestVersion":"2.0.0-preview.7","url":"https://github.com/b-editor/beutl/releases/tag/v2.0.0-preview.7","downloadUrl":null,"isLatest":false,"mustLatest":false}
+                    {"latestVersion":"2.0.0-preview.7","url":"https://example.test/release","downloadUrl":null,"isLatest":false,"mustLatest":false}
                     """,
                     Encoding.UTF8,
-                    "application/json")
-            };
-            return Task.FromResult(response);
-        }
-    }
-
-    [Test]
-    public async Task RemovePackage_Rethrows_WhenCancelledAfterDelete()
-    {
-        var requestCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        BeutlApiApplication? appRef = null;
-        using var handler = new DelegateHandler((request, cancellationToken) =>
-        {
-            requestCompleted.TrySetResult();
-            // Dispose while the delete response is being processed, so the lifetime token
-            // is cancelled before RemovePackage returns.
-            appRef?.DisposeAsync().AsTask().GetAwaiter().GetResult();
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent("{}")
+                    "application/json"),
             });
-        });
-        using var httpClient = new HttpClient(handler);
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
-        appRef = app;
-        var library = app.GetResource<LibraryService>();
-        var owner = new Profile(CreateProfileResponse(), app);
-        var package = new Package(owner, CreatePackageResponse(), app);
-
-        Task remove = library.RemovePackage(package, CancellationToken.None);
-        await requestCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-
-        Assert.CatchAsync<OperationCanceledException>(async () =>
-            await remove.WaitAsync(TimeSpan.FromSeconds(5)));
-    }
-
-    [Test]
-    public async Task DisposeAsync_ReentrantCallback_ObservesTheOriginalTeardown()
-    {
-        using var httpClient = new HttpClient();
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
-        _ = app.GetResource<PackageManager>();
-
-        Task? reentrantTask = null;
-        using CancellationTokenSource linked = app.CreateLifetimeLinkedTokenSource(CancellationToken.None);
-        using var registration = linked.Token.Register(() =>
-        {
-            // A cancellation callback that re-enters DisposeAsync must observe the
-            // original disposal task instead of starting a second pipeline.
-            reentrantTask = app.DisposeAsync().AsTask();
-        });
-
-        Task outer = app.DisposeAsync().AsTask();
-        await outer.WaitAsync(TimeSpan.FromSeconds(5));
-
-        Assert.That(reentrantTask, Is.Not.Null);
-        Assert.That(reentrantTask, Is.SameAs(outer),
-            "the reentrant call must observe the original disposal task");
-    }
-
-    [Test]
-    public void Subclass_CanAdmitWorkThroughTheLifetimePrimitive()
-    {
-        using var httpClient = new HttpClient();
-        var app = new LifetimeAdmissionSubclass(httpClient, new ExtensionProvider());
-
-        using CancellationTokenSource linked = app.AdmitOperation();
-        Assert.That(app.IsDisposed, Is.False);
-
-        app.DisposeAsync().AsTask().GetAwaiter().GetResult();
-        Assert.That(app.IsDisposed, Is.True);
-    }
-
-    private sealed class DelegateHandler(
-        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
-        : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request, CancellationToken cancellationToken)
-            => handler(request, cancellationToken);
-    }
-
-    private sealed class LifetimeAdmissionSubclass : BeutlApiApplication
-    {
-        public LifetimeAdmissionSubclass(HttpClient httpClient, ExtensionProvider extensionProvider)
-            : base(httpClient, extensionProvider)
-        {
         }
-
-        public CancellationTokenSource AdmitOperation()
-            => CreateLifetimeLinkedTokenSource(CancellationToken.None);
     }
 
-    private static ProfileResponse CreateProfileResponse()
+    private sealed class DisposalTrackingHandler : HttpMessageHandler
     {
-        return new ProfileResponse
+        public bool IsDisposed { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
         {
-            Id = "profile-id",
-            Name = "profile-name",
-            DisplayName = "Profile Name",
-            Bio = null,
-            IconId = null,
-            IconUrl = null,
-        };
+            IsDisposed = disposing;
+            base.Dispose(disposing);
+        }
     }
 
-    private static PackageResponse CreatePackageResponse()
+    private sealed class ProbeResource : IBeutlApiResource, IAsyncDisposable
     {
-        return new PackageResponse
+        public int DisposeCount { get; private set; }
+
+        public ValueTask DisposeAsync()
         {
-            Id = "package-id",
-            Owner = CreateProfileResponse(),
-            Name = "package-name",
-            DisplayName = "Package Name",
-            Description = "Description",
-            ShortDescription = "Short description",
-            WebSite = null,
-            Tags = [],
-            LogoId = null,
-            LogoUrl = null,
-            Screenshots = [],
-            Currency = null,
-            Price = null,
-            Paid = false,
-            Owned = false,
-        };
+            DisposeCount++;
+            return ValueTask.CompletedTask;
+        }
     }
+
+    private sealed class BlockingResource : IBeutlApiResource, IAsyncDisposable
+    {
+        public TaskCompletionSource DisposeStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Release { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Disposed { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool DisposeCompleted { get; private set; }
+
+        public async ValueTask DisposeAsync()
+        {
+            DisposeStarted.TrySetResult();
+            await Release.Task;
+            DisposeCompleted = true;
+            Disposed.TrySetResult();
+        }
+    }
+
 }

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -14,6 +14,22 @@ namespace Beutl.UnitTests.Api;
 public sealed class BeutlApiApplicationTests
 {
     [Test]
+    public async Task Resource_admission_keeps_the_application_cancellation_token_with_the_resource()
+    {
+        using var http = new HttpClient();
+        var app = new BeutlApiApplication(http, new ExtensionProvider());
+        var (resource, lifetime) = app.GetResourceWithLifetime<DiscoverService>(CancellationToken.None);
+        using (lifetime)
+        {
+            Assert.That(resource, Is.SameAs(app.GetResource<DiscoverService>()));
+            await app.DisposeAsync();
+            Assert.That(lifetime.IsCancellationRequested, Is.True);
+            Assert.Throws<ObjectDisposedException>(() =>
+                app.GetResourceWithLifetime<DiscoverService>(CancellationToken.None));
+        }
+    }
+
+    [Test]
     public async Task Constructor_RegistersProvidedExtensionProvider()
     {
         using var httpClient = new HttpClient();

--- a/tests/Beutl.UnitTests/Api/ExtensionProviderTests.cs
+++ b/tests/Beutl.UnitTests/Api/ExtensionProviderTests.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.Api.Services;
+﻿using System.Collections.Specialized;
+using Beutl.Api.Services;
 using Beutl.Extensibility;
 
 namespace Beutl.UnitTests.Api;
@@ -11,29 +12,35 @@ public sealed class ExtensionProviderTests
     private sealed class OtherStubExtension : Extension;
 
     [Test]
-    public void ExtensionProvider_ImplementsIExtensionProvider()
+    public void ExtensionProvider_ImplementsMutableRegistryAbstraction()
     {
         var provider = new ExtensionProvider();
 
+        Assert.That(provider, Is.InstanceOf<IExtensionRegistry>());
         Assert.That(provider, Is.InstanceOf<IExtensionProvider>());
     }
 
     [Test]
-    public void IExtensionProvider_AllExtensions_ReflectsAddedExtensions()
+    public void IExtensionProvider_ExtensionsExposeCopiedMetadataOnly()
     {
         var provider = new ExtensionProvider();
         IExtensionProvider abstraction = provider;
 
-        Assert.That(abstraction.AllExtensions, Is.Empty);
+        Assert.That(abstraction.Extensions, Is.Empty);
 
         var ext = new StubExtension();
         provider.AddExtensions(1, [ext]);
 
-        Assert.That(abstraction.AllExtensions, Has.Member(ext));
+        ExtensionDescriptor descriptor = abstraction.Extensions.Single();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(descriptor.TypeName, Is.EqualTo(typeof(StubExtension).AssemblyQualifiedName));
+            Assert.That(descriptor, Is.Not.SameAs(ext));
+        }
     }
 
     [Test]
-    public void IExtensionProvider_GetExtensions_FiltersByType()
+    public void IExtensionProvider_GetDescriptorsFiltersByTypeAndRequiresLeaseForExecution()
     {
         var provider = new ExtensionProvider();
         IExtensionProvider abstraction = provider;
@@ -43,16 +50,207 @@ public sealed class ExtensionProviderTests
         provider.AddExtensions(1, [first]);
         provider.AddExtensions(2, [second]);
 
-        StubExtension[] matched = abstraction.GetExtensions<StubExtension>();
+        ExtensionDescriptor[] matched = abstraction.GetDescriptors<StubExtension>().ToArray();
 
-        Assert.That(matched, Is.EquivalentTo(new[] { first }));
+        Assert.That(matched, Has.Length.EqualTo(1));
+        Assert.That(
+            abstraction.TryAcquire(
+                matched[0].Id,
+                out IExtensionLease<StubExtension>? lease),
+            Is.True);
+        using (lease)
+        {
+            Assert.That(lease!.Extension, Is.SameAs(first));
+        }
     }
 
     [Test]
-    public void IExtensionProvider_MatchEditorExtension_ReturnsNullForUnknownFile()
+    public void IExtensionProvider_TryAcquireReturnsFalseForUnknownDescriptor()
     {
         IExtensionProvider abstraction = new ExtensionProvider();
 
-        Assert.That(abstraction.MatchEditorExtension("unknown.bogus"), Is.Null);
+        Assert.That(
+            abstraction.TryAcquire(
+                new ExtensionId(Guid.NewGuid()),
+                out IExtensionLease<StubExtension>? lease),
+            Is.False);
+        Assert.That(lease, Is.Null);
+    }
+
+    [Test]
+    public void IExtensionProvider_ChangeNotificationPublishesOnlyCommittedMetadata()
+    {
+        var provider = new ExtensionProvider();
+        IExtensionProvider abstraction = provider;
+        var extension = new StubExtension();
+        var snapshots = new List<(ExtensionDescriptor[] Descriptors, bool CanAcquire)>();
+        ExtensionId extensionId = default;
+        abstraction.ExtensionsChanged += (_, _) =>
+        {
+            ExtensionDescriptor[] descriptors = abstraction.Extensions.ToArray();
+            if (descriptors.Length > 0)
+            {
+                extensionId = descriptors.Single().Id;
+            }
+
+            bool canAcquire = abstraction.TryAcquire(
+                extensionId,
+                out IExtensionLease<StubExtension>? lease);
+            lease?.Dispose();
+            snapshots.Add((descriptors, canAcquire));
+        };
+
+        provider.AddExtensions(1, [extension]);
+        _ = provider.RemoveExtensions(1);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(snapshots, Has.Count.EqualTo(2));
+            Assert.That(snapshots[0].Descriptors.Single().TypeName,
+                Is.EqualTo(typeof(StubExtension).AssemblyQualifiedName));
+            Assert.That(snapshots[0].CanAcquire, Is.True);
+            Assert.That(snapshots[1].Descriptors, Is.Empty);
+            Assert.That(snapshots[1].CanAcquire, Is.False);
+        }
+    }
+
+    [Test]
+    public void IExtensionProvider_ObserverFailureCannotAbortPackageMutation()
+    {
+        var provider = new ExtensionProvider();
+        IExtensionProvider abstraction = provider;
+        abstraction.ExtensionsChanged += (_, _) =>
+            throw new InvalidOperationException("public observer failure");
+
+        Assert.DoesNotThrow(() => provider.AddExtensions(1, [new StubExtension()]));
+        Assert.That(abstraction.Extensions, Has.Count.EqualTo(1));
+        Assert.DoesNotThrow(() => _ = provider.RemoveExtensions(1));
+        Assert.That(abstraction.Extensions, Is.Empty);
+    }
+
+    [Test]
+    public async Task IExtensionProvider_FailedInternalCompositionNeverPublishesProvisionalMetadata()
+    {
+        var provider = new ExtensionProvider();
+        IExtensionProvider abstraction = provider;
+        using var observerStarted = new ManualResetEventSlim();
+        using var releaseObserver = new ManualResetEventSlim();
+        int publicNotifications = 0;
+        abstraction.ExtensionsChanged += (_, _) => publicNotifications++;
+        provider.AllExtensions.CollectionChanged += (_, args) =>
+        {
+            if (args.Action != NotifyCollectionChangedAction.Add)
+                return;
+
+            observerStarted.Set();
+            if (!releaseObserver.Wait(TimeSpan.FromSeconds(5)))
+                throw new TimeoutException("The composition observer was not released.");
+            throw new InvalidOperationException("internal composition failure");
+        };
+
+        Task<ExtensionRegistrationNotificationException?> registration = Task.Run(() =>
+            Assert.Throws<ExtensionRegistrationNotificationException>(() =>
+                provider.AddExtensions(1, [new StubExtension()])));
+        Assert.That(observerStarted.Wait(TimeSpan.FromSeconds(5)), Is.True);
+        try
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(abstraction.Extensions, Is.Empty);
+                Assert.That(abstraction.GetDescriptors<StubExtension>(), Is.Empty);
+                Assert.That(publicNotifications, Is.Zero);
+            }
+        }
+        finally
+        {
+            releaseObserver.Set();
+        }
+
+        Assert.That(await registration.WaitAsync(TimeSpan.FromSeconds(5)), Is.Not.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(abstraction.Extensions, Is.Empty);
+            Assert.That(publicNotifications, Is.Zero);
+        }
+    }
+
+    [Test]
+    public void AddExtensions_ObserverFailureRollsBackAuthoritativeState()
+    {
+        var provider = new ExtensionProvider();
+        provider.AllExtensions.CollectionChanged += (_, _) =>
+            throw new InvalidOperationException("observer failure");
+
+        var exception = Assert.Throws<ExtensionRegistrationNotificationException>(() =>
+            provider.AddExtensions(1, [new StubExtension()]));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(exception!.InnerException, Is.InstanceOf<Exception>());
+            Assert.That(provider.GetExtensions<StubExtension>(), Is.Empty);
+            Assert.That(provider.GetPackageExtensions(1), Is.Empty);
+        }
+    }
+
+    [Test]
+    public async Task AddExtensions_ObserverFailureProvidesDrainTicketForRetiredLeases()
+    {
+        var provider = new ExtensionProvider();
+        var extension = new StubExtension();
+        var releaseLease = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        provider.AllExtensions.CollectionChanged += (_, _) =>
+            throw new InvalidOperationException("observer failure");
+        var registered = false;
+        var observedRemoval = false;
+        provider.AllExtensions.CollectionChanged += (_, args) =>
+        {
+            if (args.Action == NotifyCollectionChangedAction.Add)
+            {
+                registered = true;
+            }
+            else if (args.Action == NotifyCollectionChangedAction.Remove && registered)
+            {
+                observedRemoval = true;
+                ExtensionRegistrationLifetimes.Retire(
+                    extension,
+                    () => new ValueTask(releaseLease.Task));
+            }
+        };
+
+        var exception = Assert.Throws<ExtensionRegistrationNotificationException>(() =>
+            provider.AddExtensions(1, [extension]));
+        Task drain = exception!.Removal.DrainAsync().AsTask();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(registered, Is.True);
+            Assert.That(observedRemoval, Is.True);
+            Assert.That(drain.IsCompleted, Is.False);
+        }
+        releaseLease.SetResult();
+        await drain.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task RemoveExtensions_ObserverFailureStillSealsDrainTicket()
+    {
+        var provider = new ExtensionProvider();
+        var extension = new StubExtension();
+        provider.AddExtensions(1, [extension]);
+        provider.AllExtensions.CollectionChanged += (_, _) =>
+            throw new InvalidOperationException("observer failure");
+
+        var exception = Assert.Throws<ExtensionRemovalNotificationException>(() =>
+            provider.RemoveExtensions(1));
+
+        Assert.That(exception, Is.Not.Null);
+        await exception!.Removal.DrainAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(exception.Removal.Extensions, Is.EqualTo(new[] { extension }));
+            Assert.That(provider.GetExtensions<StubExtension>(), Is.Empty);
+            Assert.That(provider.GetPackageExtensions(1), Is.Empty);
+        }
     }
 }

--- a/tests/Beutl.UnitTests/Api/InMemoryAiRetryKeyStore.cs
+++ b/tests/Beutl.UnitTests/Api/InMemoryAiRetryKeyStore.cs
@@ -1,0 +1,294 @@
+﻿using Beutl.Api.Services;
+
+namespace Beutl.UnitTests.Api;
+
+internal sealed class InMemoryAiRetryKeyStore : IAiRetryKeyStore
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<string, Entry> _entries = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, long> _generations = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, AiRetryAttempt> _attempts = new(StringComparer.Ordinal);
+
+    public bool TryGet(AiJob job, string accountId, out string key)
+    {
+        lock (_gate)
+        {
+            if (_entries.TryGetValue(Identity(job, accountId), out Entry? entry))
+            {
+                key = entry.Key;
+                return true;
+            }
+
+            key = string.Empty;
+            return false;
+        }
+    }
+
+    public string GetOrCreate(AiJob job, string accountId, out bool isRepeat)
+    {
+        lock (_gate)
+        {
+            string identity = Identity(job, accountId);
+            if (_entries.TryGetValue(identity, out Entry? entry))
+            {
+                isRepeat = true;
+                return entry.Key;
+            }
+
+            isRepeat = false;
+            string key = $"test-{Guid.NewGuid():N}";
+            _entries[identity] = new Entry(key, Advance(identity), null);
+            return key;
+        }
+    }
+
+    public void Retire(AiJob job, string accountId)
+    {
+        lock (_gate)
+        {
+            string identity = Identity(job, accountId);
+            if (_entries.Remove(identity))
+                Advance(identity);
+            RemoveAttempts(identity);
+        }
+    }
+
+    public void AbandonAttempt(AiRetryAttempt attempt)
+    {
+        lock (_gate)
+        {
+            _attempts.Remove(attempt.Token);
+        }
+    }
+
+    public AiRetryAttempt PrepareAttempt(AiJob job, string accountId)
+    {
+        lock (_gate)
+        {
+            string identity = Identity(job, accountId);
+            if (_entries.TryGetValue(identity, out Entry? entry))
+            {
+                if (entry.InFlight)
+                    throw new AiRetryAttemptRejectedException();
+                return ExistingAttempt(job, accountId, identity, entry.Key, entry.Generation, AiRetryAttemptKind.Recovery);
+            }
+
+            long generation = _generations.GetValueOrDefault(identity);
+            AiRetryAttempt? pending = _attempts.Values.FirstOrDefault(candidate =>
+                candidate.AccountId == accountId
+                && candidate.CanonicalIdentity == identity
+                && candidate.Generation == generation
+                && candidate.Kind == AiRetryAttemptKind.NewPurchase);
+            if (pending is not null)
+                return pending;
+
+            string key = $"test-{Guid.NewGuid():N}";
+            return ExistingAttempt(job, accountId, identity, key, generation, AiRetryAttemptKind.NewPurchase);
+        }
+    }
+
+    public bool TryPrepareRecoveryAttempt(AiJob job, string accountId, out AiRetryAttempt attempt)
+    {
+        lock (_gate)
+        {
+            string identity = Identity(job, accountId);
+            if (!_entries.TryGetValue(identity, out Entry? entry))
+            {
+                attempt = null!;
+                return false;
+            }
+
+            if (entry.InFlight)
+                throw new AiRetryAttemptRejectedException();
+            attempt = ExistingAttempt(
+                job,
+                accountId,
+                identity,
+                entry.Key,
+                entry.Generation,
+                AiRetryAttemptKind.Recovery);
+            return true;
+        }
+    }
+
+    public bool TryConsumeAttempt(
+        AiRetryAttempt attempt,
+        AiJob job,
+        string accountId,
+        out string key,
+        out bool isRepeat)
+    {
+        lock (_gate)
+        {
+            key = string.Empty;
+            isRepeat = false;
+            string identity = Identity(job, accountId);
+            if (!StringComparer.Ordinal.Equals(attempt.AccountId, accountId)
+                || !StringComparer.Ordinal.Equals(attempt.CanonicalIdentity, identity)
+                || !_attempts.TryGetValue(attempt.Token, out AiRetryAttempt? stored)
+                || !Same(stored, attempt))
+            {
+                return false;
+            }
+
+            long generation = _generations.GetValueOrDefault(identity);
+            if (generation != attempt.Generation)
+            {
+                _attempts.Remove(attempt.Token);
+                return false;
+            }
+
+            if (attempt.Kind == AiRetryAttemptKind.Recovery)
+            {
+                if (!_entries.TryGetValue(identity, out Entry? entry)
+                    || entry.InFlight
+                    || entry.Generation != attempt.Generation
+                    || entry.Key != attempt.Key)
+                {
+                    _attempts.Remove(attempt.Token);
+                    return false;
+                }
+
+                _entries[identity] = entry with { Owner = attempt.Token };
+                key = entry.Key;
+                isRepeat = true;
+            }
+            else
+            {
+                if (_entries.ContainsKey(identity))
+                {
+                    _attempts.Remove(attempt.Token);
+                    return false;
+                }
+
+                long next = Advance(identity);
+                _entries.Add(identity, new Entry(attempt.Key, next, attempt.Token));
+                key = attempt.Key;
+            }
+
+            _attempts.Remove(attempt.Token);
+            return true;
+        }
+    }
+
+    public bool TryRelease(
+        AiJob job,
+        string accountId,
+        string key,
+        long generation,
+        string ownerToken)
+    {
+        lock (_gate)
+        {
+            string identity = Identity(job, accountId);
+            if (!_entries.TryGetValue(identity, out Entry? entry)
+                || entry.Owner is null
+                || entry.Generation != generation
+                || entry.Key != key
+                || entry.Owner != ownerToken)
+            {
+                return false;
+            }
+
+            _entries[identity] = entry with { Owner = null };
+            return true;
+        }
+    }
+
+    public bool TryRetire(
+        AiJob job,
+        string accountId,
+        string key,
+        long generation,
+        string ownerToken)
+    {
+        lock (_gate)
+        {
+            string identity = Identity(job, accountId);
+            if (!_entries.TryGetValue(identity, out Entry? entry)
+                || entry.Owner is null
+                || entry.Generation != generation
+                || entry.Key != key
+                || entry.Owner != ownerToken)
+            {
+                return false;
+            }
+
+            _entries.Remove(identity);
+            Advance(identity);
+            RemoveAttempts(identity);
+            return true;
+        }
+    }
+
+    private AiRetryAttempt ExistingAttempt(
+        AiJob job,
+        string accountId,
+        string identity,
+        string key,
+        long generation,
+        AiRetryAttemptKind kind)
+    {
+        foreach (AiRetryAttempt attempt in _attempts.Values)
+        {
+            if (attempt.AccountId == accountId
+                && attempt.CanonicalIdentity == identity
+                && attempt.Key == key
+                && attempt.Generation == generation
+                && attempt.Kind == kind)
+            {
+                return attempt;
+            }
+        }
+
+        DateTimeOffset createdAt = DateTimeOffset.UtcNow;
+        var created = new AiRetryAttempt(
+            Guid.NewGuid().ToString("N"),
+            accountId,
+            identity,
+            key,
+            generation,
+            kind,
+            FileAiRetryKeyStore.PayloadDigest(job),
+            1,
+            createdAt,
+            createdAt.AddMinutes(5),
+            AbandonAttempt);
+        _attempts.Add(created.Token, created);
+        return created;
+    }
+
+    private long Advance(string identity)
+    {
+        long next = _generations.GetValueOrDefault(identity) + 1;
+        _generations[identity] = next;
+        return next;
+    }
+
+    private void RemoveAttempts(string identity)
+    {
+        foreach (string token in _attempts.Values
+                     .Where(attempt => attempt.CanonicalIdentity == identity)
+                     .Select(attempt => attempt.Token)
+                     .ToArray())
+        {
+            _attempts.Remove(token);
+        }
+    }
+
+    private static bool Same(AiRetryAttempt left, AiRetryAttempt right)
+        => left.Token == right.Token
+            && left.AccountId == right.AccountId
+            && left.CanonicalIdentity == right.CanonicalIdentity
+            && left.Key == right.Key
+            && left.Generation == right.Generation
+            && left.Kind == right.Kind;
+
+    private static string Identity(AiJob job, string accountId)
+        => FileAiRetryKeyStore.CanonicalIdentity(job, accountId);
+
+    private sealed record Entry(string Key, long Generation, string? Owner)
+    {
+        public bool InFlight => Owner is not null;
+    }
+}

--- a/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerDisposeTests.cs
@@ -498,6 +498,141 @@ public sealed class PackageInstallerDisposeTests
         Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(3)));
     }
 
+    [Test]
+    public async Task WaitUntilIdleAsync_PublishesFallbackBeforeReturningAtTheDeadline()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new PackageInstaller(
+            httpClient,
+            ownsHttpClient: false,
+            new InstalledPackageRepository(),
+            app);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int fallbackCount = 0;
+        Task operation = installer.TrackInstallOperationWithShutdownFallbackAsync(
+            () => release.Task,
+            () => Interlocked.Increment(ref fallbackCount));
+
+        await installer.WaitUntilIdleAsync(TimeSpan.FromMilliseconds(100));
+        await installer.WaitUntilIdleAsync(TimeSpan.FromMilliseconds(50));
+
+        Assert.That(fallbackCount, Is.EqualTo(1));
+
+        release.TrySetResult();
+        await operation.WaitAsync(TimeSpan.FromSeconds(5));
+        await installer.DisposeAsync();
+    }
+
+    [Test]
+    public async Task SuccessfulInstallDisarmsFallbackBeforeShutdownSnapshot()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new PackageInstaller(
+            httpClient,
+            ownsHttpClient: false,
+            new InstalledPackageRepository(),
+            app);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var fallbackDisarmed = new ManualResetEventSlim();
+        int fallbackCount = 0;
+        Task operation = installer.TrackInstallOperationWithShutdownFallbackAsync(
+            () => release.Task,
+            () => Interlocked.Increment(ref fallbackCount));
+        installer.AfterSuccessfulInstallFallbackDisarmed = fallbackDisarmed.Set;
+        installer.BeforeShutdownFallbackSnapshot = () =>
+        {
+            release.TrySetResult();
+            Assert.That(fallbackDisarmed.Wait(TimeSpan.FromSeconds(5)), Is.True);
+        };
+        installer.BeginShutdown();
+
+        await installer.WaitUntilIdleAsync(TimeSpan.Zero)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        await operation.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(fallbackCount, Is.Zero);
+        await installer.DisposeAsync();
+    }
+
+    [Test]
+    public async Task FaultedInstallPublishesFallbackBeforeItsTaskCompletes()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new PackageInstaller(
+            httpClient,
+            ownsHttpClient: false,
+            new InstalledPackageRepository(),
+            app);
+        int fallbackCount = 0;
+
+        Task operation = installer.TrackInstallOperationWithShutdownFallbackAsync(
+            () => Task.FromException(new InvalidOperationException("install failed")),
+            () => Interlocked.Increment(ref fallbackCount));
+
+        Assert.ThrowsAsync<InvalidOperationException>(() => operation);
+        Assert.That(fallbackCount, Is.EqualTo(1));
+        await installer.DisposeAsync();
+    }
+
+    [Test]
+    public async Task NormalInstallCancellationDoesNotPublishShutdownFallback()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new PackageInstaller(
+            httpClient,
+            ownsHttpClient: false,
+            new InstalledPackageRepository(),
+            app);
+        int fallbackCount = 0;
+
+        Task operation = installer.TrackInstallOperationWithShutdownFallbackAsync(
+            () => Task.FromCanceled(new CancellationToken(canceled: true)),
+            () => Interlocked.Increment(ref fallbackCount));
+
+        Assert.CatchAsync<OperationCanceledException>(() => operation);
+        Assert.That(fallbackCount, Is.Zero);
+        await installer.DisposeAsync();
+    }
+
+    [Test]
+    public async Task InstallCancellationAfterShutdownStartsButBeforeIdleWaitPublishesFallback()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        using var httpClient = new HttpClient();
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var installer = new PackageInstaller(
+            httpClient,
+            ownsHttpClient: false,
+            new InstalledPackageRepository(),
+            app);
+        var cancellation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int fallbackCount = 0;
+        Task operation = installer.TrackInstallOperationWithShutdownFallbackAsync(
+            () => cancellation.Task,
+            () => Interlocked.Increment(ref fallbackCount));
+        installer.BeginShutdown();
+
+        cancellation.TrySetCanceled();
+        Assert.CatchAsync<OperationCanceledException>(() => operation);
+        await installer.WaitUntilIdleAsync(TimeSpan.FromSeconds(1));
+
+        Assert.That(fallbackCount, Is.EqualTo(1));
+        await installer.DisposeAsync();
+    }
+
     private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
     {
         long deadline = Environment.TickCount64 + (long)timeout.TotalMilliseconds;

--- a/tests/Beutl.UnitTests/Api/PackageManagerExtensionLifecycleTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageManagerExtensionLifecycleTests.cs
@@ -1,5 +1,15 @@
-﻿using Beutl.Api.Services;
+﻿using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
+using Beutl.Api.Services;
+using Beutl.Collections;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Editor.Services.AI;
+using Beutl.Editor.Services.Captions;
+using Beutl.Engine;
 using Beutl.Extensibility;
+using Beutl.Graphics.Shapes;
+using Beutl.ProjectSystem;
 
 namespace Beutl.UnitTests.Api;
 
@@ -7,11 +17,25 @@ namespace Beutl.UnitTests.Api;
 [NonParallelizable]
 public class PackageManagerExtensionLifecycleTests
 {
+    private static readonly CaptionFormatId s_blockingCaptionFormat = new("beutl.tests.blocking");
+    private static readonly CaptionTemplateId s_restartOnlyCaptionTemplate =
+        new("beutl.tests.restart-only-template");
+
     [SetUp]
     public void SetUp()
     {
         SuccessfulViewExtension.Reset();
         FailingViewExtension.Reset();
+        BlockingCaptionDecoderExtension.Reset();
+        RestartOnlyCaptionElementFactoryExtension.Reset();
+        RestartOnlyAiJobResultApplicatorExtension.Reset();
+        LeaseManagedAiJobPresentationExtension.Reset();
+        LeaseManagedAiJobCompletionExtension.Reset();
+        LeaseManagedCaptionTemplateDescriptorExtension.Reset();
+        LeaseManagedCaptionPlacementExtension.Reset();
+        FaultedDrainViewExtension.Reset();
+        LeaseManagedAiJobStatusResolverExtension.Reset();
+        MaterializingElementSourceHandlerExtension.Reset();
     }
 
     [Test]
@@ -89,8 +113,8 @@ public class PackageManagerExtensionLifecycleTests
             loadContext: null,
             [typeof(SuccessfulViewExtension)]);
 
-        // Drop only the provider entry so the second load passes AddExtensions but trips the
-        // _loadedPackages.TryAdd guard, exercising the "already loaded" rollback branch.
+        // Drop only the provider entry. The second load rejects the already tracked package
+        // before exposing its new extensions to observers.
         provider.RemoveExtensions(package.LocalId);
         SuccessfulViewExtension.Reset();
 
@@ -103,10 +127,215 @@ public class PackageManagerExtensionLifecycleTests
                 [typeof(SuccessfulViewExtension)]));
 
         Assert.That(exception!.Message, Does.Contain("already loaded"));
-        Assert.That(SuccessfulViewExtension.LoadCount, Is.EqualTo(1));
-        Assert.That(SuccessfulViewExtension.UnloadCount, Is.EqualTo(1));
+        Assert.That(SuccessfulViewExtension.LoadCount, Is.Zero);
+        Assert.That(SuccessfulViewExtension.UnloadCount, Is.Zero);
         Assert.That(provider.GetExtensions<SuccessfulViewExtension>(), Is.Empty);
-        Assert.That(commandManager.GetDefinitions(typeof(SuccessfulViewExtension)), Is.Empty);
+        Assert.That(commandManager.GetDefinitions(typeof(SuccessfulViewExtension)), Is.Not.Empty);
+    }
+
+    [Test]
+    public void LoadExtensionsAndRegister_UnloadsTheLoadContextOfARejectedDuplicate()
+    {
+        PackageManager manager = CreatePackageManager(out _, out _);
+        var package = new LocalPackage { Name = "DuplicateWithContext" };
+        manager.LoadExtensionsAndRegister(
+            activity: null,
+            package,
+            assemblies: [],
+            loadContext: null,
+            [typeof(SuccessfulViewExtension)]);
+
+        // The assemblies of a second load are resolved into a collectible
+        // context before the duplicate is noticed. Left loaded, that context —
+        // and everything in it — stays for the life of the process.
+        var loadContext = new PluginLoadContext(AppContext.BaseDirectory);
+        var unloaded = false;
+        loadContext.Unloading += _ => unloaded = true;
+
+        Assert.Throws<InvalidOperationException>(() =>
+            manager.LoadExtensionsAndRegister(
+                activity: null,
+                package,
+                assemblies: [],
+                loadContext: loadContext,
+                [typeof(SuccessfulViewExtension)]));
+
+        Assert.That(unloaded, Is.True);
+    }
+
+    [Test]
+    public async Task LoadExtensionsAndRegister_DoesNotExecutePluginCodeForConcurrentDuplicateLoad()
+    {
+        PackageManager manager = CreatePackageManager(out _, out _);
+        var package = new LocalPackage { Name = "ConcurrentDuplicate" };
+        using var loadStarted = new ManualResetEventSlim();
+        using var releaseLoad = new ManualResetEventSlim();
+        BlockingLoadViewExtension.Configure(loadStarted, releaseLoad);
+
+        Task first = Task.Run(() => manager.LoadExtensionsAndRegister(
+            activity: null,
+            package,
+            assemblies: [],
+            loadContext: null,
+            [typeof(BlockingLoadViewExtension)]));
+        Assert.That(loadStarted.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            manager.LoadExtensionsAndRegister(
+                activity: null,
+                package,
+                assemblies: [],
+                loadContext: null,
+                [typeof(SuccessfulViewExtension)]));
+        releaseLoad.Set();
+        await first.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(exception!.Message, Does.Contain("loading"));
+        Assert.That(SuccessfulViewExtension.LoadCount, Is.Zero);
+    }
+
+    [Test]
+    public async Task LoadExtensionsAndRegister_DrainsObserverLeaseBeforeRollbackUnload()
+    {
+        PackageManager manager = CreatePackageManager(
+            out _,
+            out ExtensionProvider provider);
+        var package = new LocalPackage { Name = "ObserverRollback" };
+        var releaseLease = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        provider.AllExtensions.CollectionChanged += (_, _) =>
+        {
+            if (provider.GetExtensions<LeaseManagedAiJobStatusResolverExtension>().SingleOrDefault() is { } extension)
+            {
+                ExtensionRegistrationLifetimes.Retire(
+                    extension,
+                    () => new ValueTask(releaseLease.Task));
+            }
+        };
+        provider.AllExtensions.CollectionChanged += (_, _) =>
+            throw new InvalidOperationException("observer failure");
+
+        Assert.Throws<ExtensionRegistrationNotificationException>(() =>
+            manager.LoadExtensionsAndRegister(
+                activity: null,
+                package,
+                assemblies: [],
+                loadContext: null,
+                [typeof(LeaseManagedAiJobStatusResolverExtension)]));
+
+        Assert.That(LeaseManagedAiJobStatusResolverExtension.UnloadCount, Is.Zero);
+        releaseLease.SetResult();
+        Assert.That(
+            SpinWait.SpinUntil(
+                () => LeaseManagedAiJobStatusResolverExtension.UnloadCount == 1,
+                TimeSpan.FromSeconds(5)),
+            Is.True);
+        await Task.Yield();
+        Assert.That(manager.LoadedPackage, Is.Empty);
+    }
+
+    [Test]
+    public async Task LoadExtensionsAndRegister_DoesNotPublishProvisionalRestartOnlyHandler()
+    {
+        PackageManager manager = CreatePackageManager(
+            out _,
+            out ExtensionProvider provider);
+        await using var handlers = new ElementSourceHandlerRegistry([], provider);
+        var package = new LocalPackage { Name = "ProvisionalMaterialization" };
+        bool provisionalAcquired = false;
+        int metadataChanges = 0;
+        handlers.Handlers.CollectionChanged += (_, _) => metadataChanges++;
+        provider.AllExtensions.CollectionChanged += (_, args) =>
+        {
+            if (args.Action != NotifyCollectionChangedAction.Add)
+                return;
+
+            provisionalAcquired = handlers.TryAcquire(
+                typeof(MaterializedSource),
+                out IElementSourceHandlerLease? lease);
+            if (lease is not null)
+            {
+                lease.Dispose();
+            }
+        };
+        provider.AllExtensions.CollectionChanged += (_, args) =>
+        {
+            if (args.Action == NotifyCollectionChangedAction.Add)
+                throw new InvalidOperationException("observer failure after materialization");
+        };
+
+        Assert.Throws<ExtensionRegistrationNotificationException>(() =>
+            manager.LoadExtensionsAndRegister(
+                activity: null,
+                package,
+                assemblies: [],
+                loadContext: null,
+                [typeof(MaterializingElementSourceHandlerExtension)]));
+        await Task.Delay(100);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(provisionalAcquired, Is.False);
+            Assert.That(handlers.Handlers, Is.Empty);
+            Assert.That(metadataChanges, Is.Zero);
+            Assert.That(MaterializingElementSourceHandlerExtension.UnloadCount, Is.Zero);
+            Assert.That(manager.LoadedPackage, Is.Empty);
+        }
+        InvalidOperationException? retry = Assert.Throws<InvalidOperationException>(() =>
+            manager.LoadExtensionsAndRegister(
+                activity: null,
+                package,
+                assemblies: [],
+                loadContext: null,
+                [typeof(MaterializingElementSourceHandlerExtension)]));
+        Assert.That(retry!.Message, Does.Contain("quarantined"));
+    }
+
+    [Test]
+    public async Task LoadExtensionsAndRegister_QuarantinesCommittedRestartOnlyMaterializationOnLaterFailure()
+    {
+        PackageManager manager = CreatePackageManager(
+            out _,
+            out ExtensionProvider provider);
+        await using var handlers = new ElementSourceHandlerRegistry([], provider);
+        var package = new LocalPackage { Name = "CommittedMaterialization" };
+        Element? retainedGraph = null;
+        int metadataChanges = 0;
+        handlers.Handlers.CollectionChanged += (_, _) => metadataChanges++;
+        manager.AfterExtensionRegistration = () =>
+        {
+            retainedGraph = MaterializePackageGraph(handlers);
+            throw new InvalidOperationException("failure after extension registration");
+        };
+
+        Assert.Throws<InvalidOperationException>(() =>
+            manager.LoadExtensionsAndRegister(
+                activity: null,
+                package,
+                assemblies: [],
+                loadContext: null,
+                [typeof(MaterializingElementSourceHandlerExtension)]));
+        await Task.Delay(100);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(retainedGraph, Is.Not.Null);
+            Assert.That(
+                retainedGraph!.Objects.Single(),
+                Is.TypeOf<MaterializedPackageObject>());
+            Assert.That(handlers.Handlers, Is.Empty);
+            Assert.That(metadataChanges, Is.EqualTo(2));
+            Assert.That(MaterializingElementSourceHandlerExtension.UnloadCount, Is.Zero);
+            Assert.That(manager.LoadedPackage, Is.Empty);
+        }
+        InvalidOperationException? retry = Assert.Throws<InvalidOperationException>(() =>
+            manager.LoadExtensionsAndRegister(
+                activity: null,
+                package,
+                assemblies: [],
+                loadContext: null,
+                [typeof(MaterializingElementSourceHandlerExtension)]));
+        Assert.That(retry!.Message, Does.Contain("quarantined"));
     }
 
     [Test]
@@ -116,7 +345,11 @@ public class PackageManagerExtensionLifecycleTests
         PackageManager manager = CreatePackageManager(diagnostics, out _, out _);
         var package = new LocalPackage { Name = "CleanUnload" };
         manager.LoadExtensionsAndRegister(
-            activity: null, package, assemblies: [], loadContext: null, [typeof(SuccessfulViewExtension)]);
+            activity: null,
+            package,
+            assemblies: [],
+            loadContext: null,
+            [typeof(LeaseManagedAiJobStatusResolverExtension)]);
 
         bool unloaded = await manager.Unload(package);
 
@@ -126,6 +359,383 @@ public class PackageManagerExtensionLifecycleTests
             Assert.That(unloaded, Is.True);
             Assert.That(diagnostics.InvokeCount, Is.EqualTo(0));
         });
+    }
+
+    [Test]
+    public async Task Unload_WaitsForPublicExtensionLeaseBeforeCallingExtensionUnload()
+    {
+        PackageManager manager = CreatePackageManager(out _, out ExtensionProvider provider);
+        IExtensionProvider publicProvider = provider;
+        var package = new LocalPackage { Name = "PublicLease" };
+        manager.LoadExtensionsAndRegister(
+            activity: null,
+            package,
+            assemblies: [],
+            loadContext: null,
+            [typeof(LeaseManagedAiJobStatusResolverExtension)]);
+        ExtensionDescriptor descriptor = publicProvider
+            .GetDescriptors<LeaseManagedAiJobStatusResolverExtension>()
+            .Single();
+        Assert.That(
+            publicProvider.TryAcquire(
+                descriptor.Id,
+                out IExtensionLease<LeaseManagedAiJobStatusResolverExtension>? lease),
+            Is.True);
+
+        Task<bool> unload = manager.Unload(package).AsTask();
+        try
+        {
+            await Task.Delay(100);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(unload.IsCompleted, Is.False);
+                Assert.That(LeaseManagedAiJobStatusResolverExtension.UnloadCount, Is.Zero);
+                Assert.That(publicProvider.Extensions, Is.Empty);
+                Assert.That(
+                    publicProvider.TryAcquire(
+                        descriptor.Id,
+                        out IExtensionLease<LeaseManagedAiJobStatusResolverExtension>? retiredLease),
+                    Is.False);
+                Assert.That(retiredLease, Is.Null);
+            }
+        }
+        finally
+        {
+            lease!.Dispose();
+        }
+
+        Assert.That(await unload.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+        Assert.That(LeaseManagedAiJobStatusResolverExtension.UnloadCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Unload_SupportsAlternativeExtensionRegistryImplementations()
+    {
+        var registry = new DelegatingExtensionRegistry();
+        PackageManager manager = CreatePackageManager(registry, out _);
+        var package = new LocalPackage { Name = "AlternativeRegistry" };
+        manager.LoadExtensionsAndRegister(
+            activity: null,
+            package,
+            assemblies: [],
+            loadContext: null,
+            [typeof(LeaseManagedAiJobStatusResolverExtension)]);
+
+        bool unloaded = await manager.Unload(package);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(unloaded, Is.True);
+            Assert.That(registry.SynchronizationCount, Is.GreaterThan(0));
+            Assert.That(registry.GetExtensions<LeaseManagedAiJobStatusResolverExtension>(), Is.Empty);
+            Assert.That(LeaseManagedAiJobStatusResolverExtension.UnloadCount, Is.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public async Task Unload_DrainsIndependentPresentationAndCompletionLeases()
+    {
+        PackageManager manager = CreatePackageManager(out _, out ExtensionProvider provider);
+        await using var results = new AiJobResultRegistry([], [], [], provider, null);
+        var package = new LocalPackage { Name = "LiveAiResultPresentation" };
+        manager.LoadExtensionsAndRegister(
+            activity: null,
+            package,
+            assemblies: [],
+            loadContext: null,
+            [
+                typeof(LeaseManagedAiJobPresentationExtension),
+                typeof(LeaseManagedAiJobCompletionExtension),
+            ]);
+
+        Assert.That(results.TryAcquirePresenter(
+            LeaseManagedAiJobPresentationExtension.Kind,
+            out IAiJobPresenterLease? presentationLease), Is.True);
+        Assert.That(results.TryAcquireCompletionPresenter(
+            LeaseManagedAiJobCompletionExtension.Kind,
+            out IAiJobCompletionPresenterLease? completionLease), Is.True);
+
+        Task<bool> unload = manager.Unload(package).AsTask();
+        await Task.Delay(100);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(unload.IsCompleted, Is.False);
+            Assert.That(LeaseManagedAiJobPresentationExtension.UnloadCount, Is.Zero);
+            Assert.That(LeaseManagedAiJobCompletionExtension.UnloadCount, Is.Zero);
+        }
+
+        presentationLease!.Dispose();
+        await Task.Delay(100);
+        Assert.That(unload.IsCompleted, Is.False);
+        completionLease!.Dispose();
+
+        Assert.That(await unload.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(LeaseManagedAiJobPresentationExtension.UnloadCount, Is.EqualTo(1));
+            Assert.That(LeaseManagedAiJobCompletionExtension.UnloadCount, Is.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public async Task Unload_DrainsLiveCaptionDescriptorAndPlacementLeases()
+    {
+        PackageManager manager = CreatePackageManager(out _, out ExtensionProvider provider);
+        await using CaptionCatalog catalog = CaptionCatalog.Compose("Default", [], provider);
+        var package = new LocalPackage { Name = "LiveCaptionPresentation" };
+        manager.LoadExtensionsAndRegister(
+            activity: null,
+            package,
+            assemblies: [],
+            loadContext: null,
+            [
+                typeof(LeaseManagedCaptionTemplateDescriptorExtension),
+                typeof(LeaseManagedCaptionPlacementExtension),
+            ]);
+        using ICaptionTemplateLease lease = catalog.Templates.Acquire(
+            CaptionTemplateIds.DefaultText);
+
+        Task<bool> unload = manager.Unload(package).AsTask();
+        await Task.Delay(100);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(unload.IsCompleted, Is.False);
+            Assert.That(LeaseManagedCaptionTemplateDescriptorExtension.UnloadCount, Is.Zero);
+            Assert.That(LeaseManagedCaptionPlacementExtension.UnloadCount, Is.Zero);
+            Assert.That(
+                catalog.Templates.GetRequired(CaptionTemplateIds.DefaultText).Name,
+                Is.EqualTo("Default"));
+        }
+
+        lease.Dispose();
+        Assert.That(await unload.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(LeaseManagedCaptionTemplateDescriptorExtension.UnloadCount, Is.EqualTo(1));
+            Assert.That(LeaseManagedCaptionPlacementExtension.UnloadCount, Is.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public async Task Unload_RequiresRestartForLongLivedExtensionFamilies()
+    {
+        PackageManager manager = CreatePackageManager(out _, out ExtensionProvider provider);
+        var package = new LocalPackage { Name = "LongLivedView" };
+        manager.LoadExtensionsAndRegister(
+            activity: null,
+            package,
+            assemblies: [],
+            loadContext: null,
+            [typeof(SuccessfulViewExtension)]);
+
+        bool unloaded = await manager.Unload(package);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(unloaded, Is.False);
+            Assert.That(SuccessfulViewExtension.UnloadCount, Is.Zero);
+            Assert.That(provider.GetExtensions<SuccessfulViewExtension>(), Has.Length.EqualTo(1));
+            Assert.That(manager.LoadedPackage, Does.Contain(package));
+        }
+    }
+
+    [Test]
+    public async Task Unload_RequiresRestartForElementSourceHandlerExtensions()
+    {
+        PackageManager manager = CreatePackageManager(out _, out ExtensionProvider provider);
+        var package = new LocalPackage { Name = "MaterializedElementGraph" };
+        manager.LoadExtensionsAndRegister(
+            activity: null,
+            package,
+            assemblies: [],
+            loadContext: null,
+            [typeof(MaterializingElementSourceHandlerExtension)]);
+
+        bool unloaded = await manager.Unload(package);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(unloaded, Is.False);
+            Assert.That(MaterializingElementSourceHandlerExtension.UnloadCount, Is.Zero);
+            Assert.That(
+                provider.GetExtensions<MaterializingElementSourceHandlerExtension>(),
+                Has.Length.EqualTo(1));
+            Assert.That(manager.LoadedPackage, Does.Contain(package));
+        }
+    }
+
+    [Test]
+    public async Task Unload_WaitsForActiveCaptionLeaseBeforeCallingExtensionUnload()
+    {
+        PackageManager manager = CreatePackageManager(out _, out ExtensionProvider provider);
+        await using CaptionCatalog catalog = CaptionCatalog.Compose("Default", [], provider);
+        var package = new LocalPackage { Name = "BlockingCaption" };
+        manager.LoadExtensionsAndRegister(
+            activity: null,
+            package,
+            assemblies: [],
+            loadContext: null,
+            [typeof(BlockingCaptionDecoderExtension)]);
+
+        Task<CaptionImportResult> decodeTask = Task.Run(() =>
+            catalog.Serializer.Import("caption"u8, s_blockingCaptionFormat));
+        Assert.That(
+            BlockingCaptionDecoderExtension.WaitForDecode(TimeSpan.FromSeconds(5)),
+            Is.True,
+            "The test codec did not begin decoding.");
+
+        Task<bool> unloadTask = Task.Run(async () => await manager.Unload(package));
+        try
+        {
+            Assert.That(
+                SpinWait.SpinUntil(
+                    () => provider.GetExtensions<BlockingCaptionDecoderExtension>().Length == 0,
+                    TimeSpan.FromSeconds(5)),
+                Is.True,
+                "Package removal did not begin.");
+            Assert.Multiple(() =>
+            {
+                Assert.That(unloadTask.IsCompleted, Is.False);
+                Assert.That(BlockingCaptionDecoderExtension.UnloadCount, Is.EqualTo(0));
+            });
+        }
+        finally
+        {
+            BlockingCaptionDecoderExtension.ReleaseDecode();
+        }
+
+        CaptionImportResult decoded = await decodeTask.WaitAsync(TimeSpan.FromSeconds(5));
+        bool unloaded = await unloadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(decoded.IsSuccess, Is.True);
+            Assert.That(unloaded, Is.True);
+            Assert.That(BlockingCaptionDecoderExtension.UnloadCount, Is.EqualTo(1));
+            Assert.Throws<NotSupportedException>(() =>
+                catalog.Serializer.Import("after unload"u8, s_blockingCaptionFormat));
+        });
+    }
+
+    [Test]
+    public async Task Unload_RequiresRestartForCaptionElementFactoryExtensions()
+    {
+        PackageManager manager = CreatePackageManager(out _, out ExtensionProvider provider);
+        var package = new LocalPackage { Name = "RestartOnlyCaptionTemplate" };
+        manager.LoadExtensionsAndRegister(
+            activity: null,
+            package,
+            assemblies: [],
+            loadContext: null,
+            [typeof(RestartOnlyCaptionElementFactoryExtension)]);
+
+        bool unloaded = await manager.Unload(package);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(unloaded, Is.False);
+            Assert.That(RestartOnlyCaptionElementFactoryExtension.UnloadCount, Is.Zero);
+            Assert.That(
+                provider.GetExtensions<RestartOnlyCaptionElementFactoryExtension>(),
+                Has.Length.EqualTo(1));
+            Assert.That(manager.LoadedPackage, Does.Contain(package));
+        });
+    }
+
+    [Test]
+    public async Task Unload_RequiresRestartForAiJobResultApplicatorExtensions()
+    {
+        PackageManager manager = CreatePackageManager(out _, out ExtensionProvider provider);
+        var package = new LocalPackage { Name = "PersistentAiResultGraph" };
+        manager.LoadExtensionsAndRegister(
+            activity: null,
+            package,
+            assemblies: [],
+            loadContext: null,
+            [typeof(RestartOnlyAiJobResultApplicatorExtension)]);
+
+        bool unloaded = await manager.Unload(package);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(unloaded, Is.False);
+            Assert.That(RestartOnlyAiJobResultApplicatorExtension.UnloadCount, Is.Zero);
+            Assert.That(
+                provider.GetExtensions<RestartOnlyAiJobResultApplicatorExtension>(),
+                Has.Length.EqualTo(1));
+            Assert.That(manager.LoadedPackage, Does.Contain(package));
+        });
+    }
+
+    [Test]
+    public async Task Unload_QuarantinesPackageWithoutCallingUnload_WhenRegistrationDrainFails()
+    {
+        PackageManager manager = CreatePackageManager(
+            out ContextCommandManager commandManager,
+            out ExtensionProvider provider);
+        var package = new LocalPackage { Name = "FaultedDrain" };
+        manager.LoadExtensionsAndRegister(
+            activity: null,
+            package,
+            assemblies: [],
+            loadContext: null,
+            [typeof(FaultedDrainViewExtension)]);
+        FaultedDrainViewExtension extension = provider
+            .GetExtensions<FaultedDrainViewExtension>()
+            .Single();
+        ExtensionRegistrationLifetimes.Retire(
+            extension,
+            () => new ValueTask(Task.FromException(
+                new InvalidOperationException("synthetic drain failure"))));
+
+        bool unloaded = await manager.Unload(package);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(unloaded, Is.False);
+            Assert.That(FaultedDrainViewExtension.UnloadCount, Is.Zero);
+            Assert.That(provider.GetExtensions<FaultedDrainViewExtension>(), Is.Empty);
+            Assert.That(manager.LoadedPackage, Does.Contain(package));
+        }
+
+        Assert.That(await manager.Unload(package), Is.False);
+        Assert.That(FaultedDrainViewExtension.UnloadCount, Is.Zero);
+    }
+
+    private static Element MaterializePackageGraph(IElementSourceHandlerRegistry handlers)
+    {
+        if (!handlers.TryAcquire(
+                typeof(MaterializedSource),
+                out IElementSourceHandlerLease? lease))
+        {
+            throw new InvalidOperationException(
+                "The committed element source handler was not available.");
+        }
+
+        using (lease)
+        {
+            var scene = new Scene(640, 480, "rollback");
+            var description = new ElementDescription(
+                TimeSpan.Zero,
+                null,
+                0,
+                new MaterializedSource());
+            ElementSourcePreflightResult preflight = lease.Handler.PreflightAsync(
+                new ElementSourcePreflightContext(scene, description),
+                CancellationToken.None).GetAwaiter().GetResult();
+            try
+            {
+                ElementSourceMaterializationResult materialized = lease.Handler.MaterializeAsync(
+                    new ElementSourceMaterializationContext(scene, description),
+                    preflight.Preflight!,
+                    CancellationToken.None).GetAwaiter().GetResult();
+                return materialized.Materialization!.PrimaryElement;
+            }
+            finally
+            {
+                preflight.Preflight!.DisposeAsync().GetAwaiter().GetResult();
+            }
+        }
     }
 
     private static PackageManager CreatePackageManager(
@@ -151,6 +761,70 @@ public class PackageManagerExtensionLifecycleTests
             commandManager,
             apiApplication: null!,
             diagnostics);
+    }
+
+    private static PackageManager CreatePackageManager(
+        IExtensionRegistry extensionRegistry,
+        out ContextCommandManager commandManager)
+    {
+        commandManager = new ContextCommandManager(
+            new ContextCommandSettingsStore(),
+            new ContextCommandHandlerRegistry());
+        return new PackageManager(
+            new InstalledPackageRepository(),
+            extensionRegistry,
+            commandManager,
+            apiApplication: null!);
+    }
+
+    private sealed class DelegatingExtensionRegistry : IExtensionRegistry
+    {
+        private readonly ExtensionProvider _inner = new();
+
+        public int SynchronizationCount { get; private set; }
+
+        public ICoreReadOnlyList<Extension> AllExtensions => _inner.AllExtensions;
+
+        public event EventHandler? ExtensionsChanged
+        {
+            add => _inner.ExtensionsChanged += value;
+            remove => _inner.ExtensionsChanged -= value;
+        }
+
+        public IReadOnlyList<ExtensionDescriptor> Extensions
+            => ((IExtensionProvider)_inner).Extensions;
+
+        public IReadOnlyList<ExtensionDescriptor> GetDescriptors<TExtension>()
+            where TExtension : Extension
+            => ((IExtensionProvider)_inner).GetDescriptors<TExtension>();
+
+        public bool TryAcquire<TExtension>(
+            ExtensionId id,
+            [NotNullWhen(true)] out IExtensionLease<TExtension>? lease)
+            where TExtension : Extension
+            => ((IExtensionProvider)_inner).TryAcquire(id, out lease);
+
+        public void AddExtensions(int packageId, IReadOnlyList<Extension> extensions)
+            => _inner.AddExtensions(packageId, extensions);
+
+        public IReadOnlyList<Extension> GetPackageExtensions(int packageId)
+            => _inner.GetPackageExtensions(packageId);
+
+        public TExtension[] GetExtensions<TExtension>()
+            where TExtension : Extension
+            => _inner.GetExtensions<TExtension>();
+
+        public EditorExtension? MatchEditorExtension(string file)
+            => _inner.MatchEditorExtension(file);
+
+        public ExtensionRemoval RemoveExtensions(int packageId)
+            => _inner.RemoveExtensions(packageId);
+
+        public void SynchronizeMutation(Action action)
+        {
+            SynchronizationCount++;
+            _inner.SynchronizeMutation(action);
+        }
     }
 
     private sealed class RecordingUnloadDiagnostics : ILoadContextUnloadDiagnostics
@@ -220,4 +894,333 @@ public class PackageManagerExtensionLifecycleTests
             UnloadCount++;
         }
     }
+
+    [Export]
+    private sealed class FaultedDrainViewExtension : AiJobStatusResolverExtension
+    {
+        public static int UnloadCount { get; private set; }
+
+        public override IReadOnlyCollection<AiJobStatusResolverRegistration> Registrations { get; } =
+        [
+            new AiJobStatusResolverRegistration(
+                new AiJobKindId("beutl.tests.faulted-drain"),
+                new AiJobStatusMap([])),
+        ];
+
+        public static void Reset() => UnloadCount = 0;
+
+        public override void Unload() => UnloadCount++;
+    }
+
+    [Export]
+    private sealed class LeaseManagedAiJobStatusResolverExtension : AiJobStatusResolverExtension
+    {
+        public static int UnloadCount { get; private set; }
+
+        public override IReadOnlyCollection<AiJobStatusResolverRegistration> Registrations { get; } =
+        [
+            new AiJobStatusResolverRegistration(
+                new AiJobKindId("beutl.tests.lease-managed"),
+                new AiJobStatusMap([])),
+        ];
+
+        public override void Unload() => UnloadCount++;
+
+        public static void Reset() => UnloadCount = 0;
+    }
+
+    private sealed record MaterializedSource : ElementSource;
+
+    [Export]
+    private sealed class MaterializingElementSourceHandlerExtension : ElementSourceHandlerExtension
+    {
+        public static int UnloadCount { get; private set; }
+
+        public override IReadOnlyCollection<ElementSourceHandlerRegistration> Registrations { get; } =
+        [
+            new ElementSourceHandlerRegistration(new MaterializingElementSourceHandler()),
+        ];
+
+        public override void Unload() => UnloadCount++;
+
+        public static void Reset() => UnloadCount = 0;
+    }
+
+    private sealed class MaterializingElementSourceHandler : IElementSourceHandler
+    {
+        public Type SourceType => typeof(MaterializedSource);
+
+        public ValueTask<ElementSourcePreflightResult> PreflightAsync(
+            ElementSourcePreflightContext context,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(ElementSourcePreflightResult.Ready(
+                MaterializedSourcePreflight.Instance,
+                [context.Description.Layer]));
+        }
+
+        public ValueTask<ElementSourceMaterializationResult> MaterializeAsync(
+            ElementSourceMaterializationContext context,
+            IElementSourcePreflight preflight,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var element = new Element
+            {
+                Start = context.Description.Start,
+                Length = TimeSpan.FromSeconds(3),
+                ZIndex = context.Description.Layer,
+            };
+            element.AddObject(new MaterializedPackageObject());
+            return ValueTask.FromResult(ElementSourceMaterializationResult.Materialized(
+                new ElementMaterialization(element)));
+        }
+    }
+
+    private sealed class MaterializedSourcePreflight : IElementSourcePreflight
+    {
+        public static MaterializedSourcePreflight Instance { get; } = new();
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    [Export]
+    private sealed class BlockingLoadViewExtension : ViewExtension
+    {
+        private static ManualResetEventSlim? s_loadStarted;
+        private static ManualResetEventSlim? s_releaseLoad;
+
+        public static void Configure(
+            ManualResetEventSlim loadStarted,
+            ManualResetEventSlim releaseLoad)
+        {
+            s_loadStarted = loadStarted;
+            s_releaseLoad = releaseLoad;
+        }
+
+        public override void Load()
+        {
+            s_loadStarted!.Set();
+            if (!s_releaseLoad!.Wait(TimeSpan.FromSeconds(10)))
+                throw new TimeoutException("The blocking extension load was not released.");
+        }
+    }
+
+    [Export]
+    private sealed class BlockingCaptionDecoderExtension : CaptionDecoderExtension, ICaptionDecoder
+    {
+        private static readonly ManualResetEventSlim s_decodeStarted = new();
+        private static readonly ManualResetEventSlim s_releaseDecode = new();
+        private readonly IReadOnlyCollection<CaptionDecoderRegistration> _registrations;
+
+        public BlockingCaptionDecoderExtension()
+        {
+            _registrations =
+            [
+                new CaptionDecoderRegistration(s_blockingCaptionFormat, this),
+            ];
+        }
+
+        public static int UnloadCount { get; private set; }
+
+        public override IReadOnlyCollection<CaptionDecoderRegistration> Registrations
+            => _registrations;
+
+        public CaptionImportResult Decode(string content)
+        {
+            s_decodeStarted.Set();
+            if (!s_releaseDecode.Wait(TimeSpan.FromSeconds(10)))
+                throw new TimeoutException("The blocking caption codec was not released.");
+
+            return CaptionImportResult.Imported(new CaptionDocument(
+            [
+                new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), content),
+            ]));
+        }
+
+        public override void Unload()
+        {
+            UnloadCount++;
+        }
+
+        public static bool WaitForDecode(TimeSpan timeout) => s_decodeStarted.Wait(timeout);
+
+        public static void ReleaseDecode() => s_releaseDecode.Set();
+
+        public static void Reset()
+        {
+            UnloadCount = 0;
+            s_decodeStarted.Reset();
+            s_releaseDecode.Reset();
+        }
+    }
+
+    [Export]
+    private sealed class LeaseManagedCaptionTemplateDescriptorExtension :
+        CaptionTemplateDescriptorExtension
+    {
+        public static int UnloadCount { get; private set; }
+
+        public override IReadOnlyCollection<CaptionTemplateDescriptorRegistration> Registrations
+        { get; } =
+        [
+            new CaptionTemplateDescriptorRegistration(
+                new CaptionTemplateDescriptor(
+                    CaptionTemplateIds.DefaultText,
+                    new CaptionTemplateProviderId("beutl.tests"),
+                    "Replacement"),
+                CaptionTemplateRegistrationMode.Replace),
+        ];
+
+        public override void Unload() => UnloadCount++;
+
+        public static void Reset() => UnloadCount = 0;
+    }
+
+    [Export]
+    private sealed class LeaseManagedCaptionPlacementExtension :
+        CaptionPlacementPolicyExtension,
+        ICaptionPlacementPolicy
+    {
+        public static int UnloadCount { get; private set; }
+
+        public override IReadOnlyCollection<CaptionPlacementPolicyRegistration> Registrations
+        { get; }
+
+        public LeaseManagedCaptionPlacementExtension()
+        {
+            Registrations =
+            [
+                new CaptionPlacementPolicyRegistration(
+                    CaptionTemplateIds.DefaultText,
+                    this,
+                    CaptionTemplateRegistrationMode.Replace),
+            ];
+        }
+
+        public CaptionElementPlacement Place(
+            CaptionCue cue,
+            CaptionElementContext context,
+            CaptionElementPlacement placement,
+            int elementIndex)
+            => placement with { Position = new Beutl.Graphics.Point(12, 34) };
+
+        public override void Unload() => UnloadCount++;
+
+        public static void Reset() => UnloadCount = 0;
+    }
+
+    [Export]
+    private sealed class RestartOnlyCaptionElementFactoryExtension :
+        CaptionElementFactoryExtension,
+        ICaptionElementFactory
+    {
+        private readonly IReadOnlyCollection<CaptionElementFactoryRegistration> _registrations;
+
+        public RestartOnlyCaptionElementFactoryExtension()
+        {
+            _registrations =
+            [
+                new CaptionElementFactoryRegistration(
+                    s_restartOnlyCaptionTemplate,
+                    this),
+            ];
+        }
+
+        public static int UnloadCount { get; private set; }
+
+        public override IReadOnlyCollection<CaptionElementFactoryRegistration> Registrations
+            => _registrations;
+
+        public IReadOnlyList<ElementDescription> CreateElements(
+            CaptionCue cue,
+            CaptionElementContext context)
+            =>
+            [
+                context.CreateDescription(
+                    cue,
+                    () => new TextBlock { Text = { CurrentValue = cue.Text } }),
+            ];
+
+        public override void Unload()
+        {
+            UnloadCount++;
+        }
+
+        public static void Reset()
+        {
+            UnloadCount = 0;
+        }
+    }
+
+    [Export]
+    private sealed class LeaseManagedAiJobPresentationExtension :
+        AiJobPresentationExtension,
+        IAiJobPresenter
+    {
+        public static AiJobKindId Kind { get; } = new("beutl.tests.presentation");
+
+        public static int UnloadCount { get; private set; }
+
+        public override IReadOnlyCollection<AiJobPresentationRegistration> Registrations { get; }
+
+        public LeaseManagedAiJobPresentationExtension()
+        {
+            Registrations = [new AiJobPresentationRegistration(Kind, this)];
+        }
+
+        public AiJobPresentation Present(AiJob job, AiJobStatusSemantics status)
+            => new("Test", "Ready", "Test", string.Empty, false);
+
+        public override void Unload() => UnloadCount++;
+
+        public static void Reset() => UnloadCount = 0;
+    }
+
+    [Export]
+    private sealed class LeaseManagedAiJobCompletionExtension :
+        AiJobCompletionExtension,
+        IAiJobCompletionPresenter
+    {
+        public static AiJobKindId Kind { get; } = new("beutl.tests.completion");
+
+        public static int UnloadCount { get; private set; }
+
+        public override IReadOnlyCollection<AiJobCompletionRegistration> Registrations { get; }
+
+        public LeaseManagedAiJobCompletionExtension()
+        {
+            Registrations = [new AiJobCompletionRegistration(Kind, this)];
+        }
+
+        public AiJobCompletionPresentation? CreateCompletion(
+            AiJob job,
+            AiJobStatusSemantics status)
+            => null;
+
+        public override void Unload() => UnloadCount++;
+
+        public static void Reset() => UnloadCount = 0;
+    }
+
+    [Export]
+    private sealed class RestartOnlyAiJobResultApplicatorExtension : AiJobResultApplicatorExtension
+    {
+        public static int UnloadCount { get; private set; }
+
+        public override IReadOnlyCollection<AiJobResultApplicatorRegistration> Registrations { get; } = [];
+
+        public override void Unload()
+        {
+            UnloadCount++;
+        }
+
+        public static void Reset()
+        {
+            UnloadCount = 0;
+        }
+    }
 }
+
+public sealed partial class MaterializedPackageObject : EngineObject;

--- a/tests/Beutl.UnitTests/Api/ProfileLifetimeTests.cs
+++ b/tests/Beutl.UnitTests/Api/ProfileLifetimeTests.cs
@@ -143,7 +143,7 @@ public sealed class ProfileLifetimeTests
                 RefreshToken = "stale-refresh",
                 Expiration = DateTime.UtcNow.AddDays(1)
             };
-            var user = new AuthenticatedUser(profile, authResponse, app, httpClient, DateTime.UtcNow.AddDays(-1));
+            var user = new AuthenticatedUser(profile, authResponse, app, DateTime.UtcNow.AddDays(-1));
 
             // A stale write-time forces the persisted-file branch; a pre-canceled token
             // makes the cancellation point deterministic instead of racing the file read.

--- a/tests/Beutl.UnitTests/Api/ProfileTests.cs
+++ b/tests/Beutl.UnitTests/Api/ProfileTests.cs
@@ -1,0 +1,231 @@
+﻿using System.Net;
+using System.Reactive.Linq;
+using System.Reflection;
+using System.Text;
+using Beutl.Api;
+using Beutl.Api.Clients;
+using Beutl.Api.Objects;
+using Beutl.Api.Services;
+using Reactive.Bindings;
+
+namespace Beutl.UnitTests.Api;
+
+[TestFixture]
+public sealed class ProfileTests
+{
+    [Test]
+    public async Task RefreshSelf_UsesCapturedBearerAndCommitsOnlyCompletedResponse()
+    {
+        string? authorization = null;
+        using var handler = new StubHandler((request, _) =>
+        {
+            authorization = request.Headers.Authorization?.ToString();
+            return Task.FromResult(JsonResponse(HttpStatusCode.OK, """
+                {
+                  "id": "test-user",
+                  "name": "updated-name",
+                  "displayName": "Updated User",
+                  "bio": null,
+                  "iconId": null,
+                  "iconUrl": null
+                }
+                """));
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        Profile profile = SetAuthenticatedUser(app);
+        string? nameObservedWithResponse = null;
+        using IDisposable subscription = profile.Response.Skip(1).Subscribe(_ =>
+            nameObservedWithResponse = profile.Name);
+
+        await profile.RefreshAsync(CancellationToken.None, self: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(authorization, Is.EqualTo("Bearer token"));
+            Assert.That(profile.Name, Is.EqualTo("updated-name"));
+            Assert.That(nameObservedWithResponse, Is.EqualTo("updated-name"));
+            Assert.That(profile.DisplayName.Value, Is.EqualTo("Updated User"));
+        });
+    }
+
+    [Test]
+    public async Task RefreshSelf_CancellationDoesNotMutateProfile()
+    {
+        var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = new StubHandler(async (_, cancellationToken) =>
+        {
+            requestStarted.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return JsonResponse(HttpStatusCode.OK, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        Profile profile = SetAuthenticatedUser(app);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        Task refresh = profile.RefreshAsync(cancellationTokenSource.Token, self: true);
+        await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellationTokenSource.Cancel();
+
+        Assert.CatchAsync<OperationCanceledException>(async () => await refresh);
+        Assert.Multiple(() =>
+        {
+            Assert.That(profile.Name, Is.EqualTo("test"));
+            Assert.That(profile.DisplayName.Value, Is.EqualTo("Test User"));
+        });
+    }
+
+    [Test]
+    public async Task ConcurrentRefreshes_CannotCommitAnOlderResponseLast()
+    {
+        int requestCount = 0;
+        var firstRequestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondRequestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstResponse = new TaskCompletionSource<HttpResponseMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondResponse = new TaskCompletionSource<HttpResponseMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = new StubHandler(async (_, cancellationToken) =>
+        {
+            int request = Interlocked.Increment(ref requestCount);
+            if (request == 1)
+            {
+                firstRequestStarted.TrySetResult();
+                return await firstResponse.Task.WaitAsync(cancellationToken);
+            }
+
+            secondRequestStarted.TrySetResult();
+            return await secondResponse.Task.WaitAsync(cancellationToken);
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var profile = new Profile(CreateProfileResponse("test", "Original"), app);
+
+        Task olderRefresh = profile.RefreshAsync(CancellationToken.None);
+        await firstRequestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Task newerRefresh = profile.RefreshAsync(CancellationToken.None);
+        await secondRequestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        secondResponse.TrySetResult(JsonResponse(HttpStatusCode.OK, ProfileJson("newest", "Newest")));
+        await newerRefresh;
+        firstResponse.TrySetResult(JsonResponse(HttpStatusCode.OK, ProfileJson("older", "Older")));
+        await olderRefresh;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(profile.Name, Is.EqualTo("newest"));
+            Assert.That(profile.DisplayName.Value, Is.EqualTo("Newest"));
+        });
+    }
+
+    [Test]
+    public async Task GetPackagesAsync_CancelsEveryPackageDetailRequest()
+    {
+        var detailRequestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var detailCancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = new StubHandler(async (request, cancellationToken) =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/v3/users/test/packages")
+            {
+                return JsonResponse(HttpStatusCode.OK, $$"""
+                    [
+                      {
+                        "id": "package-id",
+                        "owner": {{ProfileJson("test", "Test User")}},
+                        "name": "package-name",
+                        "displayName": "Package",
+                        "shortDescription": "Package",
+                        "tags": [],
+                        "logoId": null,
+                        "logoUrl": null,
+                        "currency": null,
+                        "price": null,
+                        "paid": false,
+                        "owned": false
+                      }
+                    ]
+                    """);
+            }
+
+            detailRequestStarted.TrySetResult();
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+            finally
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    detailCancellationObserved.TrySetResult();
+                }
+            }
+
+            return JsonResponse(HttpStatusCode.OK, "{}");
+        });
+        using var httpClient = new HttpClient(handler);
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        var profile = new Profile(CreateProfileResponse("test", "Test User"), app);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        Task operation = profile.GetPackagesAsync(cancellationTokenSource.Token);
+        await detailRequestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellationTokenSource.Cancel();
+
+        Assert.CatchAsync<OperationCanceledException>(async () => await operation);
+        await detailCancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    private static Profile SetAuthenticatedUser(BeutlApiApplication app)
+    {
+        var profile = new Profile(CreateProfileResponse("test", "Test User"), app);
+        var user = new AuthenticatedUser(profile, new AuthResponse
+        {
+            Token = "token",
+            RefreshToken = "refresh-token",
+            Expiration = DateTime.UtcNow.AddHours(1),
+        }, app, DateTime.UtcNow);
+        FieldInfo field = typeof(BeutlApiApplication).GetField(
+            "_authenticatedUser",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        ((ReactivePropertySlim<AuthenticatedUser?>)field.GetValue(app)!).Value = user;
+        return profile;
+    }
+
+    private static ProfileResponse CreateProfileResponse(string name, string displayName)
+        => new()
+        {
+            Id = "test-user",
+            Name = name,
+            DisplayName = displayName,
+            Bio = null,
+            IconId = null,
+            IconUrl = null,
+        };
+
+    private static string ProfileJson(string name, string displayName)
+        => $$"""
+            {
+              "id": "test-user",
+              "name": "{{name}}",
+              "displayName": "{{displayName}}",
+              "bio": null,
+              "iconId": null,
+              "iconUrl": null
+            }
+            """;
+
+    private static HttpResponseMessage JsonResponse(HttpStatusCode status, string json)
+        => new(status) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    private sealed class StubHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            HttpResponseMessage response = await responder(request, cancellationToken);
+            response.RequestMessage = request;
+            return response;
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Api/PublicApiCancellationTests.cs
+++ b/tests/Beutl.UnitTests/Api/PublicApiCancellationTests.cs
@@ -5,6 +5,7 @@ using Beutl.Api;
 using Beutl.Api.Clients;
 using Beutl.Api.Objects;
 using Beutl.Api.Services;
+using Beutl.Editor.Services;
 
 namespace Beutl.UnitTests.Api;
 
@@ -23,12 +24,6 @@ public sealed class PublicApiCancellationTests
     private static readonly string[] s_releaseOperations =
         ["RefreshAsync", "GetAssetAsync"];
 
-    private static readonly string[] s_profileOperations =
-        ["RefreshAsync", "GetPackagesAsync"];
-
-    private static readonly string[] s_authenticatedUserOperations =
-        ["RefreshAsync"];
-
     [Test]
     public void HighLevelOperations_RequireCancellationTokens()
     {
@@ -36,23 +31,8 @@ public sealed class PublicApiCancellationTests
         AssertRequiredCancellationTokens(typeof(LibraryService), s_libraryOperations);
         AssertRequiredCancellationTokens(typeof(Package), s_packageOperations);
         AssertRequiredCancellationTokens(typeof(Release), s_releaseOperations);
-        AssertRequiredCancellationTokens(typeof(Profile), s_profileOperations);
-        AssertRequiredCancellationTokens(typeof(AuthenticatedUser), s_authenticatedUserOperations);
-        AssertRequiredCancellationTokens(typeof(BeutlApiApplication), ["CheckForUpdatesAsync"]);
         AssertRequiredCancellationTokens(typeof(IFilesClient), ["GetFile"]);
-    }
-
-    [Test]
-    public void ClientInterfaces_RequireCancellationTokens()
-    {
-        AssertRequiredCancellationTokens(typeof(IAccountClient), ["CreateAuthUri", "Refresh", "Exchange"]);
-        AssertRequiredCancellationTokens(typeof(IDiscoverClient), ["Search", "GetFeatured"]);
-        AssertRequiredCancellationTokens(typeof(IFilesClient), ["GetFile"]);
-        AssertRequiredCancellationTokens(typeof(ILibraryClient), ["AcquirePackage", "GetLibrary", "DeleteLibraryPackage"]);
-        AssertRequiredCancellationTokens(typeof(IPackagesClient), ["GetPackage"]);
-        AssertRequiredCancellationTokens(typeof(IReleasesClient), ["GetReleases", "GetRelease"]);
-        AssertRequiredCancellationTokens(typeof(IUsersClient), ["GetUser", "GetSelf", "GetUserPackages"]);
-        AssertRequiredCancellationTokens(typeof(IAppClient), ["CheckForUpdates", "GetUpdate"]);
+        AssertRequiredCancellationTokens(typeof(IElementAdder), ["AddAsync"]);
     }
 
     [Test]
@@ -73,11 +53,11 @@ public sealed class PublicApiCancellationTests
             Assert.That(
                 cancellationTokens,
                 Has.Length.EqualTo(1),
-                $"{method.Name} must require a CancellationToken.");
+                $"PackageManager.{method.Name} must require a CancellationToken.");
             Assert.That(
                 cancellationTokens[0].HasDefaultValue,
                 Is.False,
-                $"{method.Name} must not default its CancellationToken.");
+                $"PackageManager.{method.Name} must not default its CancellationToken.");
         }
     }
 
@@ -94,23 +74,6 @@ public sealed class PublicApiCancellationTests
             await manager.CheckUpdate(cancellationTokenSource.Token));
         Assert.ThrowsAsync<OperationCanceledException>(async () =>
             await manager.CheckUpdate("package-name", cancellationTokenSource.Token));
-    }
-
-    [Test]
-    public async Task PackageManagerCheckUpdate_RejectsAdmissionAfterDisposal()
-    {
-        using var httpClient = new HttpClient();
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
-        PackageManager manager = app.GetResource<PackageManager>();
-        await app.DisposeAsync();
-
-        // The resource lookup and the lifetime lease both take the dispose gate, so a
-        // disposed application must reject the update check at admission instead of
-        // failing halfway through with an unexpected error.
-        Assert.ThrowsAsync<ObjectDisposedException>(async () =>
-            await manager.CheckUpdate(CancellationToken.None));
-        Assert.ThrowsAsync<ObjectDisposedException>(async () =>
-            await manager.CheckUpdate("package-name", CancellationToken.None));
     }
 
     [TestCaseSource(nameof(s_discoverOperations))]
@@ -218,68 +181,36 @@ public sealed class PublicApiCancellationTests
         await handler.CancellationObserved.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
-    [TestCase(false)]
-    [TestCase(true)]
-    public async Task ProfileRefreshAsync_PropagatesCancellationToTransport(bool self)
+    [Test]
+    public async Task DiscoverFeatured_PropagatesCancellationToPackageDetailRequests()
     {
-        using var handler = new BlockingHandler();
+        using var handler = new BlockingHandler(request =>
+            request.RequestUri?.AbsolutePath == "/api/v3/discover/featured"
+                ? JsonResponse(HttpStatusCode.OK, $"[{SimplePackageJson}]")
+                : null);
         using var httpClient = new HttpClient(handler);
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
         using var cancellationTokenSource = new CancellationTokenSource();
-        Profile profile = CreateProfile(app);
+        var service = new DiscoverService(app);
 
-        Task operation = profile.RefreshAsync(cancellationTokenSource.Token, self);
+        Task operation = service.GetFeatured(cancellationTokenSource.Token);
 
         await AssertTransportCancellation(operation, handler, cancellationTokenSource);
     }
 
     [Test]
-    public async Task ProfileGetPackagesAsync_PropagatesCancellationToTransport()
+    public async Task LibraryPackages_PropagatesCancellationToPackageDetailRequests()
     {
-        using var handler = new BlockingHandler();
+        using var handler = new BlockingHandler(request =>
+            request.RequestUri?.AbsolutePath == "/api/v3/account/library"
+                ? JsonResponse(HttpStatusCode.OK, $"[{{\"package\":{SimplePackageJson},\"latestRelease\":null}}]")
+                : null);
         using var httpClient = new HttpClient(handler);
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
+        await using var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
         using var cancellationTokenSource = new CancellationTokenSource();
-        Profile profile = CreateProfile(app);
+        var service = new LibraryService(app);
 
-        Task operation = profile.GetPackagesAsync(cancellationTokenSource.Token);
-
-        await AssertTransportCancellation(operation, handler, cancellationTokenSource);
-    }
-
-    [Test]
-    public async Task AuthenticatedUserRefreshAsync_PropagatesCancellationToTransport()
-    {
-        using var handler = new BlockingHandler();
-        using var httpClient = new HttpClient(handler);
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
-        using var cancellationTokenSource = new CancellationTokenSource();
-        var user = new AuthenticatedUser(
-            CreateProfile(app),
-            new AuthResponse
-            {
-                Token = "token",
-                RefreshToken = "refresh-token",
-                Expiration = DateTime.UtcNow.AddMinutes(-1),
-            },
-            app,
-            httpClient,
-            DateTime.UtcNow);
-
-        Task operation = user.RefreshAsync(cancellationTokenSource.Token, force: true).AsTask();
-
-        await AssertTransportCancellation(operation, handler, cancellationTokenSource);
-    }
-
-    [Test]
-    public async Task CheckForUpdatesAsync_PropagatesCancellationToTransport()
-    {
-        using var handler = new BlockingHandler();
-        using var httpClient = new HttpClient(handler);
-        var app = new BeutlApiApplication(httpClient, new ExtensionProvider());
-        using var cancellationTokenSource = new CancellationTokenSource();
-
-        Task operation = app.CheckForUpdatesAsync("1.0.0", cancellationTokenSource.Token);
+        Task operation = service.GetPackages(cancellationTokenSource.Token);
 
         await AssertTransportCancellation(operation, handler, cancellationTokenSource);
     }
@@ -374,20 +305,6 @@ public sealed class PublicApiCancellationTests
             Owned = false,
         };
         return new Package(owner, packageResponse, app);
-    }
-
-    private static Profile CreateProfile(BeutlApiApplication app)
-    {
-        ProfileResponse response = new()
-        {
-            Id = "profile-id",
-            Name = "profile-name",
-            DisplayName = "Profile",
-            Bio = null,
-            IconId = null,
-            IconUrl = null,
-        };
-        return new Profile(response, app);
     }
 
     private static Release CreateRelease(BeutlApiApplication app)

--- a/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
+++ b/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
@@ -54,6 +54,11 @@
     <Compile Include="..\..\src\Beutl\Helpers\CancellationTokenSourceHelper.cs" Link="Helpers\Linked\CancellationTokenSourceHelper.cs" />
     <Compile Include="..\..\src\Beutl\Helpers\HistoryMutationPlaybackGuard.cs" Link="Helpers\Linked\HistoryMutationPlaybackGuard.cs" />
     <Compile Include="..\..\src\Beutl\Models\BufferedPlayerWaitGate.cs" Link="Models\Linked\BufferedPlayerWaitGate.cs" />
+    <Compile Include="..\..\src\Beutl\Services\AI\CaptionDraftStore.cs" Link="Services\AI\Linked\CaptionDraftStore.cs" />
+    <Compile Include="..\..\src\Beutl\Services\AI\AiRequestKey.cs" Link="Services\AI\Linked\AiRequestKey.cs" />
+    <Compile Include="..\..\src\Beutl\Services\AI\FileAiRequestRecoveryStore.cs" Link="Services\AI\Linked\FileAiRequestRecoveryStore.cs" />
+    <Compile Include="..\..\src\Beutl\Services\AI\AiUploadBytes.cs" Link="Services\AI\Linked\AiUploadBytes.cs" />
+    <Compile Include="..\..\src\Beutl\Services\AI\AiOutstandingRequests.cs" Link="Services\AI\Linked\AiOutstandingRequests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Beutl.UnitTests/Editor/ElementDescriptionTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ElementDescriptionTests.cs
@@ -1,54 +1,77 @@
 ﻿using Beutl.Editor.Models;
 using Beutl.Engine;
 using Beutl.Graphics;
+using Beutl.ProjectSystem;
 
 namespace Beutl.UnitTests.Editor;
 
-public class ElementDescriptionTests
+[TestFixture]
+public sealed class ElementDescriptionTests
 {
     [Test]
-    public void Default_HasExpectedDefaults()
+    public void Constructor_RequiresExactlyOneDiscriminatedSource()
     {
-        var desc = new ElementDescription(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), 3);
-        Assert.That(desc.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
-        Assert.That(desc.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
-        Assert.That(desc.Layer, Is.EqualTo(3));
-        Assert.That(desc.Name, Is.EqualTo(string.Empty));
-        // Cast to object so NUnit compares the delegate reference instead of invoking it.
-        Assert.That((object?)desc.EngineObjectFactory, Is.Null);
-        Assert.That(desc.FileName, Is.Null);
-        Assert.That(desc.Position, Is.EqualTo(default(Point)));
+        var source = new ElementSource.File("/tmp/x.mp4");
+        var description = new ElementDescription(
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(2),
+            3,
+            source);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(description.Source, Is.SameAs(source));
+            Assert.That(description.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(description.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(description.Layer, Is.EqualTo(3));
+            Assert.That(description.Name, Is.EqualTo(string.Empty));
+            Assert.That(description.Position, Is.Null);
+            Assert.That(
+                typeof(ElementDescription).GetProperties().Select(property => property.Name),
+                Does.Not.Contain("FileName")
+                    .And.Not.Contain("EngineObjectFactory")
+                    .And.Not.Contain("ElementFactory"));
+        }
+
+        Assert.That(
+            () => new ElementDescription(TimeSpan.Zero, TimeSpan.Zero, 0, null!),
+            Throws.ArgumentNullException);
     }
 
     [Test]
-    public void With_AllProperties()
+    public void LengthOverride_IsExplicitlyNullableForEverySourceHandler()
     {
-        Func<EngineObject> factory = () => new SourceBackdrop();
-        var desc = new ElementDescription(
-            TimeSpan.FromSeconds(0),
+        var templateSource = new ElementSource.ElementTemplate(() => new());
+
+        var preserved = new ElementDescription(TimeSpan.Zero, null, 0, templateSource);
+        var zeroLengthOverride = new ElementDescription(TimeSpan.Zero, TimeSpan.Zero, 0, templateSource);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(preserved.Length, Is.Null);
+            Assert.That(zeroLengthOverride.Length, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(
+                new ElementDescription(
+                    TimeSpan.Zero,
+                    null,
+                    0,
+                    new CustomSource()).Length,
+                Is.Null);
+        }
+    }
+
+    [Test]
+    public void EngineObjectSource_ProducesConfiguredObject()
+    {
+        var description = new ElementDescription(
+            TimeSpan.Zero,
             TimeSpan.FromSeconds(5),
-            Layer: 2,
-            Name: "title",
-            EngineObjectFactory: factory,
-            FileName: "/tmp/x.mp4",
-            Position: new Point(10, 20));
+            0,
+            new ElementSource.EngineObject(
+                () => new SourceBackdrop { Clear = { CurrentValue = true } }));
 
-        Assert.That(desc.Name, Is.EqualTo("title"));
-        // Cast to object so NUnit compares the delegate reference instead of invoking it.
-        Assert.That((object?)desc.EngineObjectFactory, Is.SameAs(factory));
-        Assert.That(desc.FileName, Is.EqualTo("/tmp/x.mp4"));
-        Assert.That(desc.Position, Is.EqualTo(new Point(10, 20)));
-    }
-
-    [Test]
-    public void EngineObjectFactory_ProducesConfiguredObject()
-    {
-        // Mirrors the "Add Adjustment Layer" caller: the factory both constructs and configures.
-        var desc = new ElementDescription(
-            TimeSpan.Zero, TimeSpan.FromSeconds(5), 0,
-            EngineObjectFactory: () => new SourceBackdrop { Clear = { CurrentValue = true } });
-
-        EngineObject produced = desc.EngineObjectFactory!();
+        var source = (ElementSource.EngineObject)description.Source;
+        EngineObject produced = source.Factory();
 
         Assert.That(produced, Is.TypeOf<SourceBackdrop>());
         Assert.That(((SourceBackdrop)produced).Clear.CurrentValue, Is.True);
@@ -57,39 +80,51 @@ public class ElementDescriptionTests
     [Test]
     public void ResolveName_ReturnsExplicitName_WhenSet()
     {
-        var desc = new ElementDescription(TimeSpan.Zero, TimeSpan.FromSeconds(1), 0, Name: "Adjustment Layer");
+        var description = CreateDescription("Adjustment Layer");
 
-        // The explicit name wins even though the fallback type has a different localized name.
-        Assert.That(desc.ResolveName(typeof(SourceBackdrop)), Is.EqualTo("Adjustment Layer"));
+        Assert.That(description.ResolveName(typeof(SourceBackdrop)), Is.EqualTo("Adjustment Layer"));
     }
 
     [Test]
     public void ResolveName_FallsBackToLocalizedTypeName_WhenNameEmpty()
     {
-        var desc = new ElementDescription(TimeSpan.Zero, TimeSpan.FromSeconds(1), 0);
+        ElementDescription description = CreateDescription(string.Empty);
 
         Assert.That(
-            desc.ResolveName(typeof(SourceBackdrop)),
+            description.ResolveName(typeof(SourceBackdrop)),
             Is.EqualTo(TypeDisplayHelpers.GetLocalizedName(typeof(SourceBackdrop))));
     }
 
     [Test]
     public void ResolveName_TreatsWhitespaceNameAsExplicit()
     {
-        // Pins IsNullOrEmpty (not IsNullOrWhiteSpace) semantics: a whitespace name is kept verbatim.
-        var desc = new ElementDescription(TimeSpan.Zero, TimeSpan.FromSeconds(1), 0, Name: " ");
+        ElementDescription description = CreateDescription(" ");
 
-        Assert.That(desc.ResolveName(typeof(SourceBackdrop)), Is.EqualTo(" "));
+        Assert.That(description.ResolveName(typeof(SourceBackdrop)), Is.EqualTo(" "));
     }
 
     [Test]
-    public void Equality_BasedOnAllFields()
+    public void Equality_IsBasedOnAllRequestFields()
     {
-        var a = new ElementDescription(TimeSpan.Zero, TimeSpan.FromSeconds(1), 0, "x");
-        var b = new ElementDescription(TimeSpan.Zero, TimeSpan.FromSeconds(1), 0, "x");
-        Assert.That(a, Is.EqualTo(b));
+        var source = new ElementSource.EngineObject(() => new SourceBackdrop());
+        var first = new ElementDescription(TimeSpan.Zero, TimeSpan.FromSeconds(1), 0, source, "x");
+        var equivalent = new ElementDescription(TimeSpan.Zero, TimeSpan.FromSeconds(1), 0, source, "x");
+        var different = new ElementDescription(TimeSpan.Zero, TimeSpan.FromSeconds(1), 0, source, "y");
 
-        var c = new ElementDescription(TimeSpan.Zero, TimeSpan.FromSeconds(1), 0, "y");
-        Assert.That(a, Is.Not.EqualTo(c));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(first, Is.EqualTo(equivalent));
+            Assert.That(first, Is.Not.EqualTo(different));
+        }
     }
+
+    private static ElementDescription CreateDescription(string name) =>
+        new(
+            TimeSpan.Zero,
+            TimeSpan.FromSeconds(1),
+            0,
+            new ElementSource.EngineObject(() => new SourceBackdrop()),
+            name);
+
+    private sealed record CustomSource : ElementSource;
 }

--- a/tests/Beutl.UnitTests/Editor/ObjectTemplatePreviewRendererTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ObjectTemplatePreviewRendererTests.cs
@@ -69,6 +69,36 @@ public class ObjectTemplatePreviewRendererTests
         Assert.That(png, Is.Not.Null);
     }
 
+    [Test]
+    public async Task RenderElementsPngAsync_AllowsHigherDensityOutputForCaptionPreviews()
+    {
+        var element = new Element { Start = TimeSpan.Zero, Length = TimeSpan.FromSeconds(1) };
+        element.Objects.Add(CreateRedRect());
+
+        byte[]? png = await ObjectTemplatePreviewRenderer.RenderElementsPngAsync(
+            [element],
+            new PixelSize(1920, 1080),
+            new PixelSize(1024, 576));
+
+        Assert.That(png, Is.Not.Null);
+        using SKBitmap decoded = SKBitmap.Decode(png);
+        Assert.That(decoded.Width, Is.GreaterThan(ObjectTemplatePreviewRenderer.PreviewWidth));
+        Assert.That(decoded.Height, Is.GreaterThan(ObjectTemplatePreviewRenderer.PreviewHeight));
+    }
+
+    [Test]
+    public void RenderElementsPngAsync_RejectsUnboundedOutputSize()
+    {
+        var element = new Element { Start = TimeSpan.Zero, Length = TimeSpan.FromSeconds(1) };
+
+        Assert.That(
+            async () => await ObjectTemplatePreviewRenderer.RenderElementsPngAsync(
+                [element],
+                new PixelSize(1920, 1080),
+                new PixelSize(4096, 4096)),
+            Throws.TypeOf<ArgumentOutOfRangeException>());
+    }
+
     // The saved object is not itself drawable, so the preview must be the drawable that owns it
     // rather than the generic sample shape.
     [Test]

--- a/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionCodecExtensibilityTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionCodecExtensibilityTests.cs
@@ -1,0 +1,453 @@
+﻿using System.Text;
+using Beutl.Editor.Services.Captions;
+
+namespace Beutl.UnitTests.Editor.Services.Captions;
+
+[TestFixture]
+public class CaptionCodecExtensibilityTests
+{
+    private static readonly CaptionFormatId s_pipeFormat = new("example.pipe");
+
+    [Test]
+    public async Task Registry_CustomSlotsResolveAndNotifyAStableMetadataList()
+    {
+        await using var registry = new CaptionCodecRegistry();
+        var codec = new PipeCaptionCodec();
+        var metadata = registry.Codecs;
+        int changes = 0;
+        metadata.CollectionChanged += (_, _) => changes++;
+
+        await using ICaptionCodecDescriptorRegistration descriptor = registry.Register(
+            new CaptionCodecDescriptorRegistration(
+                new CaptionCodecDescriptor(s_pipeFormat, [".pipe"])));
+        await using ICaptionDecoderRegistration decoder = registry.Register(
+            new CaptionDecoderRegistration(s_pipeFormat, codec));
+        await using ICaptionEncoderRegistration encoder = registry.Register(
+            new CaptionEncoderRegistration(s_pipeFormat, codec));
+
+        CaptionCodecInfo registered = registry.GetRequired(s_pipeFormat);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(registry.Codecs, Is.SameAs(metadata));
+            Assert.That(changes, Is.EqualTo(3));
+            Assert.That(registered.CanDecode, Is.True);
+            Assert.That(registered.CanEncode, Is.True);
+            Assert.That(registered.FileExtensions, Is.EqualTo(new[] { ".pipe" }));
+            Assert.That(
+                registry.TryGetByFileName("captions.PIPE", out CaptionCodecInfo? byFileName),
+                Is.True);
+            Assert.That(byFileName!.Format, Is.EqualTo(s_pipeFormat));
+        }
+    }
+
+    [Test]
+    public async Task FileNameLookupPrefersTheLongestRegisteredCompoundSuffix()
+    {
+        var jsonFormat = new CaptionFormatId("json");
+        var compoundFormat = new CaptionFormatId("captions-json");
+        await using var registry = new CaptionCodecRegistry(
+        [
+            new CaptionCodecDescriptorRegistration(
+                new CaptionCodecDescriptor(jsonFormat, [".json"])),
+            new CaptionCodecDescriptorRegistration(
+                new CaptionCodecDescriptor(compoundFormat, [".captions.json"])),
+        ], [], []);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(registry.TryGetByFileName("movie.CAPTIONS.JSON", out CaptionCodecInfo? compound), Is.True);
+            Assert.That(compound!.Format, Is.EqualTo(compoundFormat));
+            Assert.That(registry.TryGetByFileName("movie.json", out CaptionCodecInfo? json), Is.True);
+            Assert.That(json!.Format, Is.EqualTo(jsonFormat));
+        });
+    }
+
+    [Test]
+    public async Task Serializer_CustomCapabilitiesCanCreateSuccessAndFailureResults()
+    {
+        var codec = new PipeCaptionCodec();
+        await using var registry = new CaptionCodecRegistry(
+            [new CaptionCodecDescriptorRegistration(
+                new CaptionCodecDescriptor(s_pipeFormat, [".pipe"]))],
+            [new CaptionDecoderRegistration(s_pipeFormat, codec)],
+            [new CaptionEncoderRegistration(s_pipeFormat, codec)]);
+        var serializer = new CaptionDocumentSerializer(registry);
+
+        CaptionImportResult success = serializer.Import(
+            Encoding.UTF8.GetBytes("custom text"),
+            s_pipeFormat);
+        byte[] exported = serializer.Export(success.Document!, s_pipeFormat);
+        CaptionImportResult failure = serializer.Import(
+            Encoding.UTF8.GetBytes("!invalid"),
+            s_pipeFormat);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(success.IsSuccess, Is.True);
+            Assert.That(success.Document![0].Text, Is.EqualTo("custom text"));
+            Assert.That(Encoding.UTF8.GetString(exported), Is.EqualTo("custom text"));
+            Assert.That(failure.IsSuccess, Is.False);
+            Assert.That(failure.Diagnostics, Has.One.Matches<CaptionDiagnostic>(error =>
+                error.Kind == CaptionDiagnosticKinds.InvalidStructure
+                && error.Message == "Custom codec rejected the content."));
+        }
+    }
+
+    [Test]
+    public async Task DescriptorlessCapabilitySupportsExactLookupButIsNotPublished()
+    {
+        var codec = new PipeCaptionCodec();
+        await using var registry = new CaptionCodecRegistry(
+            [],
+            [new CaptionDecoderRegistration(s_pipeFormat, codec)],
+            []);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(registry.Codecs, Is.Empty);
+            Assert.That(registry.TryGet(s_pipeFormat, out _), Is.False);
+            Assert.That(registry.Decode(s_pipeFormat, "text").IsSuccess, Is.True);
+            Assert.Throws<NotSupportedException>(() =>
+                registry.Encode(new CaptionFormatId("example.pipe"), new CaptionDocument()));
+        }
+    }
+
+    [Test]
+    public async Task DescriptorOnlyFormatIsPublishedWithoutExecutableDirections()
+    {
+        await using var registry = new CaptionCodecRegistry(
+            [new CaptionCodecDescriptorRegistration(
+                new CaptionCodecDescriptor(s_pipeFormat, [".pipe"]))],
+            [],
+            []);
+
+        CaptionCodecInfo info = registry.Codecs.Single();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(info.CanDecode, Is.False);
+            Assert.That(info.CanEncode, Is.False);
+            Assert.Throws<NotSupportedException>(() => registry.Decode(s_pipeFormat, "text"));
+            Assert.Throws<NotSupportedException>(() =>
+                registry.Encode(s_pipeFormat, new CaptionDocument()));
+        }
+    }
+
+    [Test]
+    public async Task DecoderAndEncoderReplaceAndRestoreIndependently()
+    {
+        var baseCodec = new TaggedCodec("base");
+        var decoderReplacement = new TaggedCodec("decoder");
+        var encoderReplacement = new TaggedCodec("encoder");
+        await using var registry = new CaptionCodecRegistry(
+            [new CaptionCodecDescriptorRegistration(
+                new CaptionCodecDescriptor(s_pipeFormat, [".pipe"], order: -20))],
+            [new CaptionDecoderRegistration(s_pipeFormat, baseCodec)],
+            [new CaptionEncoderRegistration(s_pipeFormat, baseCodec)]);
+        ICaptionDecoderRegistration decoder = registry.Register(
+            new CaptionDecoderRegistration(
+                s_pipeFormat,
+                decoderReplacement,
+                CaptionCodecRegistrationMode.Replace));
+        ICaptionEncoderRegistration encoder = registry.Register(
+            new CaptionEncoderRegistration(
+                s_pipeFormat,
+                encoderReplacement,
+                CaptionCodecRegistrationMode.Replace));
+        var document = new CaptionDocument(
+        [
+            new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "text"),
+        ]);
+        try
+        {
+            CaptionCodecInfo info = registry.GetRequired(s_pipeFormat);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(info.FileExtensions, Is.EqualTo(new[] { ".pipe" }));
+                Assert.That(info.Order, Is.EqualTo(-20));
+                Assert.That(registry.Decode(s_pipeFormat, "text").Document![0].Text,
+                    Is.EqualTo("decoder:text"));
+                Assert.That(registry.Encode(s_pipeFormat, document), Is.EqualTo("encoder:text"));
+            }
+
+            await decoder.DisposeAsync();
+            Assert.That(registry.Decode(s_pipeFormat, "text").Document![0].Text,
+                Is.EqualTo("base:text"));
+            Assert.That(registry.Encode(s_pipeFormat, document), Is.EqualTo("encoder:text"));
+
+            await encoder.DisposeAsync();
+            Assert.That(registry.Encode(s_pipeFormat, document), Is.EqualTo("base:text"));
+        }
+        finally
+        {
+            await decoder.DisposeAsync();
+            await encoder.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task DescriptorRemovalLeavesExactCapabilitiesAvailable()
+    {
+        var codec = new PipeCaptionCodec();
+        await using var registry = new CaptionCodecRegistry();
+        ICaptionCodecDescriptorRegistration descriptor = registry.Register(
+            new CaptionCodecDescriptorRegistration(
+                new CaptionCodecDescriptor(s_pipeFormat, [".pipe"])));
+        await using ICaptionDecoderRegistration decoder = registry.Register(
+            new CaptionDecoderRegistration(s_pipeFormat, codec));
+        await using ICaptionEncoderRegistration encoder = registry.Register(
+            new CaptionEncoderRegistration(s_pipeFormat, codec));
+
+        await descriptor.DisposeAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(registry.Codecs, Is.Empty);
+            Assert.That(registry.TryGetByFileExtension(".pipe", out _), Is.False);
+            Assert.That(registry.Decode(s_pipeFormat, "text").IsSuccess, Is.True);
+            Assert.That(registry.Encode(
+                s_pipeFormat,
+                new CaptionDocument([
+                    new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "text"),
+                ])), Is.EqualTo("text"));
+        }
+    }
+
+    [Test]
+    public async Task RegistrationModesAreValidatedPerSlot()
+    {
+        var codec = new PipeCaptionCodec();
+        await using var registry = new CaptionCodecRegistry();
+        await using ICaptionCodecDescriptorRegistration descriptor = registry.Register(
+            new CaptionCodecDescriptorRegistration(
+                new CaptionCodecDescriptor(s_pipeFormat, [".pipe"])));
+        await using ICaptionDecoderRegistration decoder = registry.Register(
+            new CaptionDecoderRegistration(s_pipeFormat, codec));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.Throws<ArgumentException>(() => registry.Register(
+                new CaptionCodecDescriptorRegistration(
+                    new CaptionCodecDescriptor(s_pipeFormat, [".other"]))));
+            Assert.Throws<ArgumentException>(() => registry.Register(
+                new CaptionDecoderRegistration(s_pipeFormat, codec)));
+            Assert.Throws<ArgumentException>(() => registry.Register(
+                new CaptionEncoderRegistration(
+                    s_pipeFormat,
+                    codec,
+                    CaptionCodecRegistrationMode.Replace)));
+        }
+    }
+
+    [Test]
+    public async Task DescriptorOrderAndExtensionCollisionsAreDeterministic()
+    {
+        var other = new CaptionFormatId("example.other");
+        await using var registry = new CaptionCodecRegistry(
+            [
+                new CaptionCodecDescriptorRegistration(
+                    new CaptionCodecDescriptor(s_pipeFormat, [".pipe"], order: 20)),
+                new CaptionCodecDescriptorRegistration(
+                    new CaptionCodecDescriptor(other, [".other"], order: 0)),
+            ],
+            [],
+            []);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(registry.Codecs.Select(codec => codec.Format),
+                Is.EqualTo(new[] { other, s_pipeFormat }));
+            Assert.Throws<ArgumentException>(() => registry.Register(
+                new CaptionCodecDescriptorRegistration(
+                    new CaptionCodecDescriptor(
+                        new CaptionFormatId("duplicate"),
+                        ["PIPE"]))));
+        }
+    }
+
+    [Test]
+    public async Task DecoderRetirementDoesNotWaitForAnActiveEncoderLease()
+    {
+        var decoder = new PipeCaptionCodec();
+        var encoder = new BlockingEncoder();
+        await using var registry = new CaptionCodecRegistry();
+        ICaptionDecoderRegistration decoderRegistration = registry.Register(
+            new CaptionDecoderRegistration(s_pipeFormat, decoder));
+        await using ICaptionEncoderRegistration encoderRegistration = registry.Register(
+            new CaptionEncoderRegistration(s_pipeFormat, encoder));
+        Task<string> encoding = Task.Run(() => registry.Encode(
+            s_pipeFormat,
+            new CaptionDocument([
+                new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "text"),
+            ])));
+        Assert.That(encoder.Started.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+        try
+        {
+            await decoderRegistration.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(2));
+        }
+        finally
+        {
+            encoder.Release.Set();
+        }
+
+        Assert.That(await encoding.WaitAsync(TimeSpan.FromSeconds(5)), Is.EqualTo("text"));
+    }
+
+    [Test]
+    public async Task EqualDecoderReplacementEntriesKeepReferenceIdentityForOwnerDrains()
+    {
+        var baseCodec = new PipeCaptionCodec();
+        var replacementCodec = new ResettableBlockingDecoder();
+        await using var registry = new CaptionCodecRegistry(
+            [],
+            [new CaptionDecoderRegistration(s_pipeFormat, baseCodec)],
+            []);
+        var replacementRegistration = new CaptionDecoderRegistration(
+            s_pipeFormat,
+            replacementCodec,
+            CaptionCodecRegistrationMode.Replace);
+        ICaptionDecoderRegistration first = registry.Register(replacementRegistration);
+        ICaptionDecoderRegistration second = registry.Register(replacementRegistration);
+        try
+        {
+            await AssertRetirementWaitsForDecode(second, replacementCodec);
+            replacementCodec.Reset();
+            await AssertRetirementWaitsForDecode(first, replacementCodec);
+        }
+        finally
+        {
+            replacementCodec.Release.Set();
+            await second.DisposeAsync();
+            await first.DisposeAsync();
+        }
+
+        async Task AssertRetirementWaitsForDecode(
+            ICaptionDecoderRegistration registration,
+            ResettableBlockingDecoder blocking)
+        {
+            Task<CaptionImportResult> decode = Task.Run(() =>
+                registry.Decode(s_pipeFormat, "text"));
+            Assert.That(blocking.Started.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            Task retirement = registration.DisposeAsync().AsTask();
+            await Task.Yield();
+            Assert.That(retirement.IsCompleted, Is.False);
+            blocking.Release.Set();
+            await Task.WhenAll(decode, retirement).WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [Test]
+    public async Task RegistryDisposeWaitsForLeaseFromStateRetiredByDescriptorChange()
+    {
+        var decoder = new ResettableBlockingDecoder();
+        var registry = new CaptionCodecRegistry(
+            [new CaptionCodecDescriptorRegistration(
+                new CaptionCodecDescriptor(s_pipeFormat, [".old"]))],
+            [new CaptionDecoderRegistration(s_pipeFormat, decoder)],
+            []);
+        Task<CaptionImportResult> decode = Task.Run(() => registry.Decode(s_pipeFormat, "text"));
+        Assert.That(decoder.Started.Wait(TimeSpan.FromSeconds(5)), Is.True);
+        await using ICaptionCodecDescriptorRegistration replacement = registry.Register(
+            new CaptionCodecDescriptorRegistration(
+                new CaptionCodecDescriptor(s_pipeFormat, [".new"]),
+                CaptionCodecRegistrationMode.Replace));
+        Task disposal = registry.DisposeAsync().AsTask();
+        await Task.Yield();
+        Assert.That(disposal.IsCompleted, Is.False);
+
+        decoder.Release.Set();
+        await Task.WhenAll(decode, disposal).WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task MetadataObserverFailureDoesNotRollBackRegistryCommit()
+    {
+        await using var registry = new CaptionCodecRegistry();
+        registry.Codecs.CollectionChanged += (_, _) =>
+            throw new InvalidOperationException("Observer failure");
+
+        Assert.DoesNotThrow(() => registry.Register(
+            new CaptionCodecDescriptorRegistration(
+                new CaptionCodecDescriptor(s_pipeFormat, [".pipe"]))));
+        Assert.That(registry.GetRequired(s_pipeFormat).FileExtensions,
+            Is.EqualTo(new[] { ".pipe" }));
+    }
+
+    [Test]
+    public void DiagnosticKind_AllowsThirdPartyIdentifiers()
+    {
+        var customKind = new CaptionDiagnosticKind("example.pipe.invalid-token");
+        var error = new CaptionDiagnostic(customKind, 4, "Invalid token.");
+
+        Assert.That(error.Kind, Is.EqualTo(customKind));
+    }
+
+    private class PipeCaptionCodec : ICaptionDecoder, ICaptionEncoder
+    {
+        public virtual CaptionImportResult Decode(string content)
+        {
+            if (content.StartsWith('!'))
+            {
+                return CaptionImportResult.Failure(new CaptionDiagnostic(
+                    CaptionDiagnosticKinds.InvalidStructure,
+                    1,
+                    "Custom codec rejected the content."));
+            }
+
+            return CaptionImportResult.Imported(new CaptionDocument(
+            [
+                new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), content),
+            ]));
+        }
+
+        public virtual string Encode(CaptionDocument document) => document[0].Text;
+    }
+
+    private sealed class TaggedCodec(string tag) : PipeCaptionCodec
+    {
+        public override CaptionImportResult Decode(string content)
+            => base.Decode($"{tag}:{content}");
+
+        public override string Encode(CaptionDocument document)
+            => $"{tag}:{base.Encode(document)}";
+    }
+
+    private sealed class BlockingEncoder : ICaptionEncoder
+    {
+        public ManualResetEventSlim Started { get; } = new();
+
+        public ManualResetEventSlim Release { get; } = new();
+
+        public string Encode(CaptionDocument document)
+        {
+            Started.Set();
+            if (!Release.Wait(TimeSpan.FromSeconds(10)))
+                throw new TimeoutException("The blocking encoder was not released.");
+            return document[0].Text;
+        }
+    }
+
+    private sealed class ResettableBlockingDecoder : ICaptionDecoder
+    {
+        public ManualResetEventSlim Started { get; } = new();
+
+        public ManualResetEventSlim Release { get; } = new();
+
+        public void Reset()
+        {
+            Started.Reset();
+            Release.Reset();
+        }
+
+        public CaptionImportResult Decode(string content)
+        {
+            Started.Set();
+            if (!Release.Wait(TimeSpan.FromSeconds(10)))
+                throw new TimeoutException("The blocking decoder was not released.");
+            return CaptionImportResult.Imported(new CaptionDocument(
+            [
+                new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), content),
+            ]));
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionDocumentSerializerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionDocumentSerializerTests.cs
@@ -358,6 +358,43 @@ public class CaptionDocumentSerializerTests
         }
     }
 
+    [TestCase("<lang fr>Bonjour</lang> hello", "fr")]
+    [TestCase("hello <lang fr>Bonjour</lang>", null)]
+    public void ImportWebVtt_PartialLanguageSpanProducesAnExplicitDiagnostic(
+        string payload,
+        string? expectedLanguage)
+    {
+        CaptionImportResult result = Import(
+            $"WEBVTT\n\n00:00.000 --> 00:01.000\n{payload}\n",
+            CaptionFormats.WebVtt);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Document![0].Language, Is.EqualTo(expectedLanguage));
+            Assert.That(result.Diagnostics, Has.One.Matches<CaptionDiagnostic>(diagnostic =>
+                diagnostic.Kind == CaptionDiagnosticKinds.UnsupportedMarkup
+                && diagnostic.LineNumber == 4));
+        }
+    }
+
+    [Test]
+    public void ImportWebVtt_CueSettingsProduceAnExplicitDiagnostic()
+    {
+        CaptionImportResult result = Import(
+            "WEBVTT\n\n00:00.000 --> 00:01.000 line:0 position:50% align:center\ntext\n",
+            CaptionFormats.WebVtt);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Document![0].Text, Is.EqualTo("text"));
+            Assert.That(result.Diagnostics, Has.One.Matches<CaptionDiagnostic>(diagnostic =>
+                diagnostic.Kind == CaptionDiagnosticKinds.UnsupportedMarkup
+                && diagnostic.LineNumber == 3));
+        }
+    }
+
     [TestCase("<b>bold</b>", "bold")]
     [TestCase("<ruby>漢<rt>かん</rt></ruby>", "漢かん")]
     [TestCase("before <00:00:00.500>after", "before after")]
@@ -406,7 +443,7 @@ public class CaptionDocumentSerializerTests
                 result.Diagnostics.Where(diagnostic =>
                     diagnostic.Kind == CaptionDiagnosticKinds.UnsupportedMarkup)
                     .Select(diagnostic => diagnostic.LineNumber),
-                Is.EqualTo(new int?[] { 3, 6 }));
+                Is.EqualTo(new int?[] { 3, 6, 10 }));
         }
     }
 

--- a/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionDocumentSerializerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionDocumentSerializerTests.cs
@@ -1,0 +1,700 @@
+﻿using System.Text;
+using Beutl.Editor.Services.Captions;
+
+namespace Beutl.UnitTests.Editor.Services.Captions;
+
+[TestFixture]
+public class CaptionDocumentSerializerTests
+{
+    private readonly CaptionDocumentSerializer _serializer =
+        CaptionCatalog.CreateDefault("Default").Serializer;
+
+    [Test]
+    public void Import_InvalidUtf8_ReturnsFailureWithoutThrowing()
+    {
+        byte[] invalidUtf8 = [0xC3, 0x28];
+
+        CaptionImportResult result = _serializer.Import(invalidUtf8, CaptionFormats.Srt);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.Document, Is.Null);
+            Assert.That(result.Diagnostics, Has.One.Matches<CaptionDiagnostic>(error =>
+                error.Kind == CaptionDiagnosticKinds.InvalidUtf8 && error.LineNumber is null));
+        });
+    }
+
+    [Test]
+    public void ImportSrt_BomUnicodeMultilineAndArrowText_ArePreserved()
+    {
+        const string source = "\uFEFF1\r\n00:00:01,250 --> 00:00:03,500\r\nこんにちは & <world>\r\ntext --> text\r\n\r\n";
+
+        CaptionImportResult result = Import(source, CaptionFormats.Srt);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Document!.Cues, Has.Count.EqualTo(1));
+            Assert.That(result.Document[0], Is.EqualTo(new CaptionCue(
+                TimeSpan.FromMilliseconds(1250),
+                TimeSpan.FromMilliseconds(3500),
+                "こんにちは & <world>\ntext --> text")));
+        });
+    }
+
+    [Test]
+    public void ImportSrt_WhitespaceOnlyBlankLinesSeparateCuesAndMalformedBlocks()
+    {
+        const string source = " \t\n"
+                              + "1\n00:00:00,000 --> 00:00:01,000\nfirst\n\t \n"
+                              + "not a cue\nignored\n \t\n"
+                              + "2\n00:00:01,000 --> 00:00:02,000\nsecond\n";
+
+        CaptionImportResult result = Import(source, CaptionFormats.Srt);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Document!.Cues.Select(cue => cue.Text),
+                Is.EqualTo(new[] { "first", "second" }));
+            Assert.That(result.Diagnostics, Has.One.Matches<CaptionDiagnostic>(diagnostic =>
+                diagnostic.Kind == CaptionDiagnosticKinds.InvalidStructure));
+        });
+    }
+
+    [Test]
+    public void SrtRoundTrip_UsesUtf8WithoutBomAndSupportsLargeHours()
+    {
+        TimeSpan start = TimeSpan.FromHours(100) + TimeSpan.FromMilliseconds(1);
+        TimeSpan end = start + TimeSpan.FromMilliseconds(999);
+        var document = new CaptionDocument(
+        [
+            new CaptionCue(start, end, "Escaping stays literal: <b>&</b>\n日本語"),
+        ]);
+
+        byte[] exported = _serializer.Export(document, CaptionFormats.Srt);
+        CaptionImportResult imported = _serializer.Import(exported, CaptionFormats.Srt);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exported.Take(3), Is.Not.EqualTo(new byte[] { 0xEF, 0xBB, 0xBF }));
+            Assert.That(Encoding.UTF8.GetString(exported), Does.Contain("100:00:00,001"));
+            Assert.That(imported.IsSuccess, Is.True);
+            Assert.That(imported.Document!.Cues, Is.EqualTo(document.Cues));
+        });
+    }
+
+    [Test]
+    public void ExportSrt_SubMillisecondCue_ExpandsToRepresentableBoundary()
+    {
+        var document = new CaptionDocument(
+        [
+            new CaptionCue(TimeSpan.FromTicks(1), TimeSpan.FromTicks(2), "short"),
+        ]);
+
+        byte[] exported = _serializer.Export(document, CaptionFormats.Srt);
+        CaptionImportResult imported = _serializer.Import(exported, CaptionFormats.Srt);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(imported.IsSuccess, Is.True);
+            Assert.That(imported.Document![0].Start, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(imported.Document[0].End, Is.EqualTo(TimeSpan.FromMilliseconds(1)));
+        });
+    }
+
+    [TestCase("00:60:00,000 --> 00:60:01,000")]
+    [TestCase("00:00:00.000 --> 00:00:01.000")]
+    [TestCase("00:00:01,000 --> 00:00:01,000")]
+    [TestCase("99999999999999999999:00:00,000 --> 99999999999999999999:00:01,000")]
+    public void ImportSrt_MalformedTiming_RejectsWholeDocument(string timing)
+    {
+        CaptionImportResult result = Import($"1\n{timing}\ntext\n", CaptionFormats.Srt);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.Document, Is.Null);
+            Assert.That(result.Diagnostics, Has.Some.Matches<CaptionDiagnostic>(error =>
+                error.Kind == CaptionDiagnosticKinds.InvalidTiming));
+        });
+    }
+
+    [Test]
+    public void ImportSrt_MixedValidity_PreservesValidCuesWithDiagnostics()
+    {
+        const string source = """
+            1
+            00:00:00,000 --> 00:00:01,000
+            first
+
+            2
+            invalid --> timing
+            skipped
+
+            3
+            00:00:02,000 --> 00:00:03,000
+            third
+            """;
+
+        CaptionImportResult result = Import(source, CaptionFormats.Srt);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Document!.Cues.Select(cue => cue.Text), Is.EqualTo(new[] { "first", "third" }));
+            Assert.That(result.Diagnostics, Has.One.Matches<CaptionDiagnostic>(diagnostic =>
+                diagnostic.Kind == CaptionDiagnosticKinds.InvalidTiming));
+        }
+    }
+
+    [Test]
+    public void ExportSrt_BlankLineInsideCue_ThrowsWithCueIndex()
+    {
+        var document = new CaptionDocument(
+        [
+            new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "first\n\nsecond"),
+        ]);
+
+        CaptionExportException? exception = Assert.Throws<CaptionExportException>(() =>
+            _serializer.Export(document, CaptionFormats.Srt));
+
+        Assert.That(exception!.CueIndex, Is.Zero);
+    }
+
+    [Test]
+    public void ExportSrt_WhitespaceOnlyLineInsideCue_ThrowsWithCueIndex()
+    {
+        var document = new CaptionDocument(
+        [
+            new CaptionCue(
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(1),
+                "first\n \t\nsecond"),
+        ]);
+
+        CaptionExportException? exception = Assert.Throws<CaptionExportException>(() =>
+            _serializer.Export(document, CaptionFormats.Srt));
+
+        Assert.That(exception!.CueIndex, Is.Zero);
+    }
+
+    [Test]
+    public void ExportSrt_UnsupportedStructuredFields_ThrowWithCueIndex()
+    {
+        CaptionDocument[] documents =
+        [
+            new([new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "text", speaker: "Alice")]),
+            new([new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "text", language: "en")]),
+            new([new CaptionCue(
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(1),
+                "text",
+                metadata: Metadata(CaptionMetadataKeys.AssStyle, "Default"))]),
+        ];
+
+        foreach (CaptionDocument document in documents)
+        {
+            CaptionExportException? exception = Assert.Throws<CaptionExportException>(() =>
+                _serializer.Export(document, CaptionFormats.Srt));
+            Assert.That(exception!.CueIndex, Is.Zero);
+        }
+    }
+
+    [Test]
+    public void ImportWebVtt_IdentifiersSettingsMetadataEntitiesAndFormatting_AreHandled()
+    {
+        const string source = """
+            WEBVTT Sample
+
+            NOTE ignored
+            note body
+
+            STYLE
+            ::cue { color: lime; }
+
+            cue-1
+            01:02.003 --> 00:01:04.005 align:start
+            <v Tom &amp; Jerry><lang en-US><c.warning.high>Go &lt;now&gt; <b>bold</b></c></lang></v>
+
+            """;
+
+        CaptionImportResult result = Import(source, CaptionFormats.WebVtt);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Document![0], Is.EqualTo(new CaptionCue(
+                TimeSpan.FromMinutes(1) + TimeSpan.FromMilliseconds(2003),
+                TimeSpan.FromMinutes(1) + TimeSpan.FromMilliseconds(4005),
+                "Go <now> bold",
+                "Tom & Jerry",
+                "en-US",
+                Metadata(CaptionMetadataKeys.WebVttClasses, "warning.high"))));
+        });
+    }
+
+    [Test]
+    public void WebVttRoundTrip_EscapesTextAndPreservesMetadata()
+    {
+        var document = new CaptionDocument(
+        [
+            new CaptionCue(
+                TimeSpan.FromMilliseconds(1),
+                TimeSpan.FromSeconds(2),
+                "<hello> & 'quoted'\n日本語",
+                "A > B & C",
+                "ja-JP",
+                Metadata(CaptionMetadataKeys.WebVttClasses, "warning.high")),
+        ]);
+
+        byte[] exported = _serializer.Export(document, CaptionFormats.WebVtt);
+        string text = Encoding.UTF8.GetString(exported);
+        CaptionImportResult imported = _serializer.Import(exported, CaptionFormats.WebVtt);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(text, Does.Contain("&lt;hello&gt; &amp;"));
+            Assert.That(text, Does.Contain("<v A &gt; B &amp; C>"));
+            Assert.That(imported.IsSuccess, Is.True);
+            Assert.That(imported.Document!.Cues, Is.EqualTo(document.Cues));
+        });
+    }
+
+    [Test]
+    public void ImportWebVtt_MissingHeaderOrMalformedTiming_ReturnsFailure()
+    {
+        CaptionImportResult missingHeader = Import("00:00.000 --> 00:01.000\ntext\n", CaptionFormats.WebVtt);
+        CaptionImportResult badTiming = Import(
+            "WEBVTT\n\n00:00:00.000 --> 00:00:00.000\ntext\n",
+            CaptionFormats.WebVtt);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(missingHeader.Diagnostics, Has.One.Matches<CaptionDiagnostic>(error =>
+                error.Kind == CaptionDiagnosticKinds.InvalidHeader));
+            Assert.That(badTiming.Diagnostics, Has.One.Matches<CaptionDiagnostic>(error =>
+                error.Kind == CaptionDiagnosticKinds.InvalidTiming));
+            Assert.That(missingHeader.Document, Is.Null);
+            Assert.That(badTiming.Document, Is.Null);
+        });
+    }
+
+    [Test]
+    public void ImportWebVtt_MixedValidity_PreservesValidCuesWithDiagnostics()
+    {
+        const string source = """
+            WEBVTT
+
+            00:00.000 --> 00:01.000
+            first
+
+            invalid --> timing
+            skipped
+
+            00:02.000 --> 00:03.000
+            third
+            """;
+
+        CaptionImportResult result = Import(source, CaptionFormats.WebVtt);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Document!.Cues.Select(cue => cue.Text), Is.EqualTo(new[] { "first", "third" }));
+            Assert.That(result.Diagnostics, Has.One.Matches<CaptionDiagnostic>(diagnostic =>
+                diagnostic.Kind == CaptionDiagnosticKinds.InvalidTiming));
+        }
+    }
+
+    [Test]
+    public void ImportWebVtt_CanonicalizesVoiceAnnotationWhitespace()
+    {
+        CaptionImportResult result = Import(
+            "WEBVTT\n\n00:00.000 --> 00:01.000\n<v\tAlice  Bob\t>text</v>\n",
+            CaptionFormats.WebVtt);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Document![0].Speaker, Is.EqualTo("Alice Bob"));
+            Assert.That(result.Document[0].Text, Is.EqualTo("text"));
+        }
+    }
+
+    [Test]
+    public void ImportWebVtt_MultipleVoiceSpansProduceAnExplicitDiagnostic()
+    {
+        CaptionImportResult result = Import(
+            "WEBVTT\n\n00:00.000 --> 00:01.000\n<v Alice>Hello</v> <v Bob>Bye</v>\n",
+            CaptionFormats.WebVtt);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Document![0].Speaker, Is.EqualTo("Alice"));
+            Assert.That(result.Document[0].Text, Is.EqualTo("Hello Bye"));
+            Assert.That(result.Diagnostics, Has.One.Matches<CaptionDiagnostic>(diagnostic =>
+                diagnostic.Kind == CaptionDiagnosticKinds.UnsupportedMarkup
+                && diagnostic.LineNumber == 4));
+        }
+    }
+
+    [Test]
+    public void ImportWebVtt_NonLeadingVoiceSpanProducesAnExplicitDiagnostic()
+    {
+        CaptionImportResult result = Import(
+            "WEBVTT\n\n00:00.000 --> 00:01.000\nHello <v Alice>world</v>\n",
+            CaptionFormats.WebVtt);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Document![0].Speaker, Is.Null);
+            Assert.That(result.Document[0].Text, Is.EqualTo("Hello world"));
+            Assert.That(result.Diagnostics, Has.One.Matches<CaptionDiagnostic>(diagnostic =>
+                diagnostic.Kind == CaptionDiagnosticKinds.UnsupportedMarkup
+                && diagnostic.LineNumber == 4));
+        }
+    }
+
+    [TestCase(" Alice")]
+    [TestCase("Alice ")]
+    [TestCase("Alice\tBob")]
+    [TestCase("Alice  Bob")]
+    [TestCase(" \t ")]
+    public void ExportWebVtt_NoncanonicalSpeakerWhitespace_ThrowsWithCueIndex(string speaker)
+    {
+        var document = new CaptionDocument(
+        [
+            new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "text", speaker),
+        ]);
+
+        CaptionExportException? exception = Assert.Throws<CaptionExportException>(() =>
+            _serializer.Export(document, CaptionFormats.WebVtt));
+
+        Assert.That(exception!.CueIndex, Is.Zero);
+    }
+
+    [Test]
+    public void ExportWebVtt_InvalidLanguageOrClass_ThrowsSafely()
+    {
+        var invalidLanguage = new CaptionDocument(
+        [
+            new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "text", language: "en_US"),
+        ]);
+        var invalidClass = new CaptionDocument(
+        [
+            new CaptionCue(
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(1),
+                "text",
+                metadata: Metadata(CaptionMetadataKeys.WebVttClasses, "bad class")),
+        ]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<CaptionExportException>(() =>
+                _serializer.Export(invalidLanguage, CaptionFormats.WebVtt));
+            Assert.Throws<CaptionExportException>(() =>
+                _serializer.Export(invalidClass, CaptionFormats.WebVtt));
+        });
+    }
+
+    [Test]
+    public void ImportAss_DialogueMetadataCommasEscapesAndOverrides_AreHandled()
+    {
+        const string source = """
+            [Script Info]
+            ScriptType: v4.00+
+
+            [Events]
+            Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+            Dialogue: 0,0:00:01.23,0:00:03.45,Narration,Alice,0,0,0,beutl-language=ja-JP,{\i1}Hello, world\Nnext\hline{\i0}
+            """;
+
+        CaptionImportResult result = Import(source, CaptionFormats.Ass);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Document![0], Is.EqualTo(new CaptionCue(
+                TimeSpan.FromMilliseconds(1230),
+                TimeSpan.FromMilliseconds(3450),
+                "Hello, world\nnext\u00A0line",
+                "Alice",
+                "ja-JP",
+                Metadata(CaptionMetadataKeys.AssStyle, "Narration"))));
+        });
+    }
+
+    [Test]
+    public void ImportSsa_ActorAndLegacyFormatting_ArePreservedAsPlainCueData()
+    {
+        const string source = """
+            [Events]
+            Format: Marked, Start, End, Style, Actor, MarginL, MarginR, MarginV, Effect, Text
+            Dialogue: Marked=0,0:00:00.00,0:00:01.00,Default,Bob,0,0,0,,<b>Hello</b>
+            """;
+
+        CaptionImportResult result = Import(source, CaptionFormats.Ass);
+
+        Assert.That(result.Document![0], Is.EqualTo(new CaptionCue(
+            TimeSpan.Zero,
+            TimeSpan.FromSeconds(1),
+            "Hello",
+            "Bob",
+            null,
+            Metadata(CaptionMetadataKeys.AssStyle, "Default"))));
+    }
+
+    [Test]
+    public void AssRoundTrip_PreservesStyleSpeakerLanguageCommaBackslashAndTrailingSpaces()
+    {
+        var document = new CaptionDocument(
+        [
+            new CaptionCue(
+                TimeSpan.FromMilliseconds(10),
+                TimeSpan.FromMilliseconds(2010),
+                "Hello, world\nC:\\New  ",
+                "Alice",
+                "pt-BR",
+                Metadata(CaptionMetadataKeys.AssStyle, "Narration")),
+        ]);
+
+        byte[] exported = _serializer.Export(document, CaptionFormats.Ass);
+        string text = Encoding.UTF8.GetString(exported);
+        CaptionImportResult imported = _serializer.Import(exported, CaptionFormats.Ass);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(text, Does.Contain("Style: Narration,"));
+            Assert.That(text, Does.Contain("Hello, world\\NC:\\\\New  "));
+            Assert.That(imported.IsSuccess, Is.True);
+            Assert.That(imported.Document!.Cues, Is.EqualTo(document.Cues));
+        });
+    }
+
+    [Test]
+    public void AssRoundTrip_DistinguishesAbsentStyleFromExplicitDefaultStyle()
+    {
+        var document = new CaptionDocument(
+        [
+            new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "plain"),
+            new CaptionCue(
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                "localized",
+                language: "ja-JP"),
+            new CaptionCue(
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(3),
+                "explicit",
+                metadata: Metadata(CaptionMetadataKeys.AssStyle, "Default")),
+        ]);
+
+        byte[] exported = _serializer.Export(document, CaptionFormats.Ass);
+        string text = Encoding.UTF8.GetString(exported);
+        CaptionDocument imported = _serializer.Import(exported, CaptionFormats.Ass).Document!;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                text,
+                Does.Contain("beutl-language=ja-JP;beutl-style=implicit"));
+            Assert.That(imported[0].Metadata.ContainsKey(CaptionMetadataKeys.AssStyle), Is.False);
+            Assert.That(imported[0].Language, Is.Null);
+            Assert.That(
+                imported[1].Metadata.ContainsKey(CaptionMetadataKeys.AssStyle),
+                Is.False);
+            Assert.That(imported[1].Language, Is.EqualTo("ja-JP"));
+            Assert.That(
+                imported[2].Metadata.GetValueOrDefault(CaptionMetadataKeys.AssStyle),
+                Is.EqualTo("Default"));
+            Assert.DoesNotThrow(() => _serializer.Export(
+                new CaptionDocument([imported[0]]),
+                CaptionFormats.Srt));
+        }
+    }
+
+    [Test]
+    public void BuiltInCodecs_UseIndependentWebVttClassAndAssStyleMetadata()
+    {
+        CaptionMetadata metadata = CaptionMetadata.Empty
+            .Set(CaptionMetadataKeys.WebVttClasses, "web-class")
+            .Set(CaptionMetadataKeys.AssStyle, "AssStyle");
+        var document = new CaptionDocument(
+        [
+            new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "text", metadata: metadata),
+        ]);
+
+        string webVtt = Encoding.UTF8.GetString(_serializer.Export(document, CaptionFormats.WebVtt));
+        string ass = Encoding.UTF8.GetString(_serializer.Export(document, CaptionFormats.Ass));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(webVtt, Does.Contain("<c.web-class>"));
+            Assert.That(webVtt, Does.Not.Contain("AssStyle"));
+            Assert.That(ass, Does.Contain("Style: AssStyle,"));
+            Assert.That(ass, Does.Not.Contain("web-class"));
+        });
+    }
+
+    [Test]
+    public void ExportAss_SubCentisecondCue_ExpandsToRepresentableBoundary()
+    {
+        var document = new CaptionDocument(
+        [
+            new CaptionCue(TimeSpan.FromTicks(1), TimeSpan.FromTicks(2), "short"),
+        ]);
+
+        CaptionImportResult imported = _serializer.Import(
+            _serializer.Export(document, CaptionFormats.Ass),
+            CaptionFormats.Ass);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(imported.Document![0].Start, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(imported.Document[0].End, Is.EqualTo(TimeSpan.FromMilliseconds(10)));
+        });
+    }
+
+    [TestCase("0:60:00.00", "0:60:01.00")]
+    [TestCase("0:00:00.000", "0:00:01.00")]
+    [TestCase("0:00:01.00", "0:00:01.00")]
+    [TestCase("99999999999999999999:00:00.00", "99999999999999999999:00:01.00")]
+    public void ImportAss_MalformedTiming_RejectsWholeDocument(string start, string end)
+    {
+        string source = $"[Events]\nFormat: Start, End, Text\nDialogue: {start},{end},text\n";
+
+        CaptionImportResult result = Import(source, CaptionFormats.Ass);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.Document, Is.Null);
+            Assert.That(result.Diagnostics, Has.Some.Matches<CaptionDiagnostic>(error =>
+                error.Kind == CaptionDiagnosticKinds.InvalidTiming));
+        });
+    }
+
+    [Test]
+    public void ImportAss_MixedValidity_PreservesValidCuesWithDiagnostics()
+    {
+        const string source = """
+            [Events]
+            Format: Start, End, Text
+            Dialogue: 0:00:00.00,0:00:01.00,first
+            Dialogue: invalid,0:00:02.00,skipped
+            Dialogue: 0:00:02.00,0:00:03.00,third
+            """;
+
+        CaptionImportResult result = Import(source, CaptionFormats.Ass);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Document!.Cues.Select(cue => cue.Text), Is.EqualTo(new[] { "first", "third" }));
+            Assert.That(result.Diagnostics, Has.One.Matches<CaptionDiagnostic>(diagnostic =>
+                diagnostic.Kind == CaptionDiagnosticKinds.InvalidTiming));
+        }
+    }
+
+    [Test]
+    public void ImportAss_MissingEventsOrUnsupportedFormat_ReturnsFailure()
+    {
+        CaptionImportResult missingEvents = Import(
+            "[Script Info]\nScriptType: v4.00+\n",
+            CaptionFormats.Ass);
+        CaptionImportResult unsupportedFormat = Import(
+            "[Events]\nFormat: Start, Text, End\n",
+            CaptionFormats.Ass);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(missingEvents.Diagnostics, Has.One.Matches<CaptionDiagnostic>(error =>
+                error.Kind == CaptionDiagnosticKinds.InvalidHeader));
+            Assert.That(unsupportedFormat.Diagnostics, Has.One.Matches<CaptionDiagnostic>(error =>
+                error.Kind == CaptionDiagnosticKinds.InvalidStructure));
+        });
+    }
+
+    [Test]
+    public void ExportAss_UnrepresentableOverrideOrFieldDelimiter_ThrowsWithCueIndex()
+    {
+        var braces = new CaptionDocument(
+        [
+            new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "literal {brace}"),
+        ]);
+        var speakerComma = new CaptionDocument(
+        [
+            new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "text", "Doe, Jane"),
+        ]);
+        var legacyFormatting = new CaptionDocument(
+        [
+            new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "literal < B >bold</b>"),
+        ]);
+
+        CaptionExportException? bracesError = Assert.Throws<CaptionExportException>(() =>
+            _serializer.Export(braces, CaptionFormats.Ass));
+        CaptionExportException? speakerError = Assert.Throws<CaptionExportException>(() =>
+            _serializer.Export(speakerComma, CaptionFormats.Ass));
+        CaptionExportException? legacyFormattingError = Assert.Throws<CaptionExportException>(() =>
+            _serializer.Export(legacyFormatting, CaptionFormats.Ass));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(bracesError!.CueIndex, Is.Zero);
+            Assert.That(speakerError!.CueIndex, Is.Zero);
+            Assert.That(legacyFormattingError!.CueIndex, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void ExportAss_LossySpeakerOrStyleWhitespace_ThrowsWithCueIndex()
+    {
+        var speakerWhitespace = new CaptionDocument(
+        [
+            new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "text", " Alice"),
+        ]);
+        var styleWhitespace = new CaptionDocument(
+        [
+            new CaptionCue(
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(1),
+                "text",
+                metadata: Metadata(CaptionMetadataKeys.AssStyle, "Narration ")),
+        ]);
+
+        CaptionExportException? speakerError = Assert.Throws<CaptionExportException>(() =>
+            _serializer.Export(speakerWhitespace, CaptionFormats.Ass));
+        CaptionExportException? styleError = Assert.Throws<CaptionExportException>(() =>
+            _serializer.Export(styleWhitespace, CaptionFormats.Ass));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(speakerError!.CueIndex, Is.Zero);
+            Assert.That(styleError!.CueIndex, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void Export_InvalidCueTiming_ThrowsWithCueIndex()
+    {
+        var document = new CaptionDocument(
+        [
+            new CaptionCue(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), "text"),
+        ]);
+
+        CaptionExportException? exception = Assert.Throws<CaptionExportException>(() =>
+            _serializer.Export(document, CaptionFormats.WebVtt));
+
+        Assert.That(exception!.CueIndex, Is.Zero);
+    }
+
+    private CaptionImportResult Import(string value, CaptionFormatId format)
+        => _serializer.Import(new UTF8Encoding(false, true).GetBytes(value), format);
+
+    private static CaptionMetadata Metadata(string key, string value)
+        => CaptionMetadata.Empty.Set(key, value);
+}

--- a/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionDocumentSerializerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionDocumentSerializerTests.cs
@@ -425,7 +425,30 @@ public class CaptionDocumentSerializerTests
                 "Alice",
                 "ja-JP",
                 Metadata(CaptionMetadataKeys.AssStyle, "Narration"))));
+            Assert.That(result.Diagnostics, Has.One.Matches<CaptionDiagnostic>(diagnostic =>
+                diagnostic.Kind == CaptionDiagnosticKinds.UnsupportedMarkup
+                && diagnostic.LineNumber == 6));
         });
+    }
+
+    [TestCase(@"{\an8}Top", "Top")]
+    [TestCase(@"{\k20}lyric", "lyric")]
+    public void ImportAss_OverrideBlocksProduceAnExplicitDiagnostic(
+        string markedUpText,
+        string expectedText)
+    {
+        string source = $"[Events]\nFormat: Start, End, Text\nDialogue: 0:00:00.00,0:00:01.00,{markedUpText}\n";
+
+        CaptionImportResult result = Import(source, CaptionFormats.Ass);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Document![0].Text, Is.EqualTo(expectedText));
+            Assert.That(result.Diagnostics, Has.One.Matches<CaptionDiagnostic>(diagnostic =>
+                diagnostic.Kind == CaptionDiagnosticKinds.UnsupportedMarkup
+                && diagnostic.LineNumber == 3));
+        }
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionDocumentSerializerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionDocumentSerializerTests.cs
@@ -410,6 +410,21 @@ public class CaptionDocumentSerializerTests
         }
     }
 
+    [TestCase("STYLE\n::cue { color: lime; }")]
+    [TestCase("REGION\nid:top\nwidth:40%")]
+    public void ImportWebVtt_BlockOnlyDocumentRemainsAValidEmptyImport(string block)
+    {
+        CaptionImportResult result = Import($"WEBVTT\n\n{block}\n", CaptionFormats.WebVtt);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Document!.Cues, Is.Empty);
+            Assert.That(result.Diagnostics, Has.One.Matches<CaptionDiagnostic>(diagnostic =>
+                diagnostic.Kind == CaptionDiagnosticKinds.UnsupportedMarkup));
+        }
+    }
+
     [TestCase(" Alice")]
     [TestCase("Alice ")]
     [TestCase("Alice\tBob")]

--- a/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionDocumentSerializerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionDocumentSerializerTests.cs
@@ -379,6 +379,37 @@ public class CaptionDocumentSerializerTests
         }
     }
 
+    [Test]
+    public void ImportWebVtt_DiscardedStyleAndRegionBlocksProduceExplicitDiagnostics()
+    {
+        const string source = """
+            WEBVTT
+
+            STYLE
+            ::cue { color: lime; }
+
+            REGION
+            id:top
+            width:40%
+
+            00:00.000 --> 00:01.000 region:top
+            text
+            """;
+
+        CaptionImportResult result = Import(source, CaptionFormats.WebVtt);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Document![0].Text, Is.EqualTo("text"));
+            Assert.That(
+                result.Diagnostics.Where(diagnostic =>
+                    diagnostic.Kind == CaptionDiagnosticKinds.UnsupportedMarkup)
+                    .Select(diagnostic => diagnostic.LineNumber),
+                Is.EqualTo(new int?[] { 3, 6 }));
+        }
+    }
+
     [TestCase(" Alice")]
     [TestCase("Alice ")]
     [TestCase("Alice\tBob")]
@@ -473,6 +504,74 @@ public class CaptionDocumentSerializerTests
     }
 
     [Test]
+    public void ImportAss_DiscardedCustomStyleDefinitionProducesAnExplicitDiagnostic()
+    {
+        const string source = """
+            [V4+ Styles]
+            Format: Name, Fontname, Fontsize
+            Style: Narration,Comic Sans MS,72
+
+            [Events]
+            Format: Start, End, Style, Text
+            Dialogue: 0:00:00.00,0:00:01.00,Narration,text
+            """;
+
+        CaptionImportResult result = Import(source, CaptionFormats.Ass);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(
+                result.Document![0].Metadata.GetValueOrDefault(CaptionMetadataKeys.AssStyle),
+                Is.EqualTo("Narration"));
+            Assert.That(result.Diagnostics, Has.One.Matches<CaptionDiagnostic>(diagnostic =>
+                diagnostic.Kind == CaptionDiagnosticKinds.UnsupportedMarkup
+                && diagnostic.LineNumber == 3));
+        }
+    }
+
+    [Test]
+    public void ImportAss_UnreferencedGeneratedStyleProducesAnExplicitDiagnostic()
+    {
+        string generated = new AssCaptionCodec().Encode(new CaptionDocument(
+        [
+            new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "text"),
+        ]));
+        string defaultStyle = generated.Split("\r\n", StringSplitOptions.None)
+            .Single(line => line.StartsWith("Style: Default,", StringComparison.Ordinal));
+        string withUnusedStyle = generated.Replace(
+            defaultStyle,
+            defaultStyle + "\r\n" + defaultStyle.Replace(
+                "Style: Default,",
+                "Style: Unused,",
+                StringComparison.Ordinal),
+            StringComparison.Ordinal);
+
+        CaptionImportResult result = new AssCaptionCodec().Decode(withUnusedStyle);
+
+        Assert.That(result.Diagnostics, Has.One.Matches<CaptionDiagnostic>(diagnostic =>
+            diagnostic.Kind == CaptionDiagnosticKinds.UnsupportedMarkup));
+    }
+
+    [Test]
+    public void ImportAss_GeneratedStyleUnderReorderedFormatProducesAnExplicitDiagnostic()
+    {
+        string generated = new AssCaptionCodec().Encode(new CaptionDocument(
+        [
+            new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "text"),
+        ]));
+        string reordered = generated.Replace(
+            "Format: Name, Fontname, Fontsize,",
+            "Format: Fontname, Name, Fontsize,",
+            StringComparison.Ordinal);
+
+        CaptionImportResult result = new AssCaptionCodec().Decode(reordered);
+
+        Assert.That(result.Diagnostics, Has.One.Matches<CaptionDiagnostic>(diagnostic =>
+            diagnostic.Kind == CaptionDiagnosticKinds.UnsupportedMarkup));
+    }
+
+    [Test]
     public void ImportSsa_ActorAndLegacyFormatting_ArePreservedAsPlainCueData()
     {
         const string source = """
@@ -515,6 +614,7 @@ public class CaptionDocumentSerializerTests
             Assert.That(text, Does.Contain("Style: Narration,"));
             Assert.That(text, Does.Contain("Hello, world\\NC:\\\\New  "));
             Assert.That(imported.IsSuccess, Is.True);
+            Assert.That(imported.Diagnostics, Is.Empty);
             Assert.That(imported.Document!.Cues, Is.EqualTo(document.Cues));
         });
     }

--- a/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionDocumentSerializerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionDocumentSerializerTests.cs
@@ -358,6 +358,27 @@ public class CaptionDocumentSerializerTests
         }
     }
 
+    [TestCase("<b>bold</b>", "bold")]
+    [TestCase("<ruby>漢<rt>かん</rt></ruby>", "漢かん")]
+    [TestCase("before <00:00:00.500>after", "before after")]
+    public void ImportWebVtt_StrippedInlineMarkupProducesAnExplicitDiagnostic(
+        string payload,
+        string expectedText)
+    {
+        CaptionImportResult result = Import(
+            $"WEBVTT\n\n00:00.000 --> 00:01.000\n{payload}\n",
+            CaptionFormats.WebVtt);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Document![0].Text, Is.EqualTo(expectedText));
+            Assert.That(result.Diagnostics, Has.One.Matches<CaptionDiagnostic>(diagnostic =>
+                diagnostic.Kind == CaptionDiagnosticKinds.UnsupportedMarkup
+                && diagnostic.LineNumber == 4));
+        }
+    }
+
     [TestCase(" Alice")]
     [TestCase("Alice ")]
     [TestCase("Alice\tBob")]

--- a/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionDocumentSerializerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionDocumentSerializerTests.cs
@@ -379,6 +379,42 @@ public class CaptionDocumentSerializerTests
     }
 
     [Test]
+    public void ImportWebVtt_ClassBearingLanguageSpanPreservesLanguageAndDiagnosesClass()
+    {
+        CaptionImportResult result = Import(
+            "WEBVTT\n\n00:00.000 --> 00:01.000\n<lang.foreign fr>Bonjour</lang>\n",
+            CaptionFormats.WebVtt);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Document![0].Text, Is.EqualTo("Bonjour"));
+            Assert.That(result.Document[0].Language, Is.EqualTo("fr"));
+            Assert.That(result.Diagnostics, Has.One.Matches<CaptionDiagnostic>(diagnostic =>
+                diagnostic.Kind == CaptionDiagnosticKinds.UnsupportedMarkup
+                && diagnostic.LineNumber == 4));
+        }
+    }
+
+    [Test]
+    public void ImportWebVtt_ClassBearingVoiceSpanPreservesSpeakerAndDiagnosesClass()
+    {
+        CaptionImportResult result = Import(
+            "WEBVTT\n\n00:00.000 --> 00:01.000\n<v.role Alice>Hello</v>\n",
+            CaptionFormats.WebVtt);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Document![0].Text, Is.EqualTo("Hello"));
+            Assert.That(result.Document[0].Speaker, Is.EqualTo("Alice"));
+            Assert.That(result.Diagnostics, Has.One.Matches<CaptionDiagnostic>(diagnostic =>
+                diagnostic.Kind == CaptionDiagnosticKinds.UnsupportedMarkup
+                && diagnostic.LineNumber == 4));
+        }
+    }
+
+    [Test]
     public void ImportWebVtt_CueSettingsProduceAnExplicitDiagnostic()
     {
         CaptionImportResult result = Import(

--- a/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionDocumentTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionDocumentTests.cs
@@ -1,0 +1,198 @@
+﻿using Beutl.Editor.Services.Captions;
+
+namespace Beutl.UnitTests.Editor.Services.Captions;
+
+[TestFixture]
+public class CaptionDocumentTests
+{
+    [Test]
+    public void CollectionEdits_UpdateDocumentWithoutExposingMutableList()
+    {
+        var first = new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "first");
+        var second = new CaptionCue(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), "second");
+        var replacement = new CaptionCue(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), "replacement");
+        var document = new CaptionDocument([first]);
+
+        document.Add(second);
+        document.Insert(1, replacement);
+        document.Replace(0, second);
+        CaptionCue removed = document.RemoveAt(1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(document.Cues, Is.Not.InstanceOf<List<CaptionCue>>());
+            Assert.That(document.Cues, Is.EqualTo(new[] { second, second }));
+            Assert.That(removed, Is.SameAs(replacement));
+        });
+    }
+
+    [Test]
+    public void SplitCue_RetainsMetadataAndSplitsTimeAndText()
+    {
+        var cue = new CaptionCue(
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(5),
+            "Hello world",
+            "Alice",
+            "en-US",
+            Metadata((CaptionMetadataKeys.AssStyle, "Narration"), ("example.source-id", "cue-1")));
+        var document = new CaptionDocument([cue]);
+
+        (CaptionCue first, CaptionCue second) = document.SplitCue(
+            0,
+            TimeSpan.FromSeconds(3),
+            6);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(document.Count, Is.EqualTo(2));
+            Assert.That(first, Is.EqualTo(new CaptionCue(
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(3),
+                "Hello ",
+                "Alice",
+                "en-US",
+                Metadata((CaptionMetadataKeys.AssStyle, "Narration"), ("example.source-id", "cue-1")))));
+            Assert.That(second, Is.EqualTo(new CaptionCue(
+                TimeSpan.FromSeconds(3),
+                TimeSpan.FromSeconds(5),
+                "world",
+                "Alice",
+                "en-US",
+                Metadata((CaptionMetadataKeys.AssStyle, "Narration"), ("example.source-id", "cue-1")))));
+        });
+    }
+
+    [Test]
+    public void SplitCue_InsideUnicodeTextElement_ThrowsWithoutMutation()
+    {
+        var cue = new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(2), "A😀B");
+        var document = new CaptionDocument([cue]);
+
+        Assert.Throws<ArgumentException>(() =>
+            document.SplitCue(0, TimeSpan.FromSeconds(1), 2));
+
+        Assert.That(document.Cues, Is.EqualTo(new[] { cue }));
+    }
+
+    [TestCase(0)]
+    [TestCase(2)]
+    public void SplitCue_AtCueBoundary_ThrowsWithoutMutation(int seconds)
+    {
+        var cue = new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(2), "text");
+        var document = new CaptionDocument([cue]);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            document.SplitCue(0, TimeSpan.FromSeconds(seconds), 2));
+
+        Assert.That(document.Cues, Is.EqualTo(new[] { cue }));
+    }
+
+    [Test]
+    public void MergeWithNext_SharedMetadataIsRetained()
+    {
+        var document = new CaptionDocument(
+        [
+            new CaptionCue(
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                "one",
+                "Alice",
+                "en",
+                Metadata((CaptionMetadataKeys.AssStyle, "Default"), ("first-only", "value"))),
+            new CaptionCue(
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(4),
+                "two",
+                "Alice",
+                "en",
+                Metadata((CaptionMetadataKeys.AssStyle, "Default"), ("second-only", "value"))),
+        ]);
+
+        CaptionCue merged = document.MergeWithNext(0, " / ");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(document.Count, Is.EqualTo(1));
+            Assert.That(merged, Is.EqualTo(new CaptionCue(
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(4),
+                "one / two",
+                "Alice",
+                "en",
+                Metadata((CaptionMetadataKeys.AssStyle, "Default")))));
+        });
+    }
+
+    [Test]
+    public void MergeWithNext_DifferingMetadataIsClearedAndRangeContainsBothCues()
+    {
+        var document = new CaptionDocument(
+        [
+            new CaptionCue(
+                TimeSpan.FromSeconds(5),
+                TimeSpan.FromSeconds(8),
+                "one",
+                "Alice",
+                "en",
+                Metadata((CaptionMetadataKeys.AssStyle, "A"), ("shared-key", "first"))),
+            new CaptionCue(
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(6),
+                "two",
+                "Bob",
+                "ja",
+                Metadata((CaptionMetadataKeys.AssStyle, "B"), ("shared-key", "second"))),
+        ]);
+
+        CaptionCue merged = document.MergeWithNext(0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(merged.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(merged.End, Is.EqualTo(TimeSpan.FromSeconds(8)));
+            Assert.That(merged.Text, Is.EqualTo("one\ntwo"));
+            Assert.That(merged.Speaker, Is.Null);
+            Assert.That(merged.Language, Is.Null);
+            Assert.That(merged.Metadata, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void Metadata_CopiesInputAndSetReturnsASeparateStructurallyEqualValue()
+    {
+        var source = new Dictionary<string, string>
+        {
+            ["example.id"] = "42",
+        };
+        var metadata = new CaptionMetadata(source);
+
+        source["example.id"] = "changed";
+        CaptionMetadata updated = metadata.Set(CaptionMetadataKeys.WebVttClasses, "warning");
+        CaptionMetadata equivalent = Metadata(
+            ("example.id", "42"),
+            (CaptionMetadataKeys.WebVttClasses, "warning"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(metadata["example.id"], Is.EqualTo("42"));
+            Assert.That(metadata.ContainsKey(CaptionMetadataKeys.WebVttClasses), Is.False);
+            Assert.That(updated, Is.EqualTo(equivalent));
+            Assert.That(updated.GetHashCode(), Is.EqualTo(equivalent.GetHashCode()));
+        });
+    }
+
+    [Test]
+    public void MergeWithNext_OnLastCue_ThrowsWithoutMutation()
+    {
+        var cue = new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "only");
+        var document = new CaptionDocument([cue]);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => document.MergeWithNext(0));
+
+        Assert.That(document.Cues, Is.EqualTo(new[] { cue }));
+    }
+
+    private static CaptionMetadata Metadata(params (string Key, string Value)[] entries)
+        => new(entries.Select(entry => KeyValuePair.Create(entry.Key, entry.Value)));
+}

--- a/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionTemplateRegistryTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionTemplateRegistryTests.cs
@@ -1,0 +1,1287 @@
+﻿namespace Beutl.UnitTests.Editor.Services.Captions;
+
+using System.Collections.Specialized;
+using System.Runtime.CompilerServices;
+using Beutl.Api.Services;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Editor.Services.Captions;
+using Beutl.Extensibility;
+using Beutl.Graphics;
+
+[TestFixture]
+public sealed class CaptionTemplateRegistryTests
+{
+    private static readonly CaptionTemplateProviderId s_provider = new("beutl.tests");
+
+    [Test]
+    public async Task Register_RejectsCaseInsensitiveIdentifierCollision()
+    {
+        await using CaptionTemplateRegistry registry = CreateRegistry(
+            CreateText("Vendor.Template", "First"));
+
+        Assert.That(() => registry.Register(
+                CreateText("vendor.template", "Second").DescriptorRegistration),
+            Throws.ArgumentException.With.Message.Contains("already has a descriptor"));
+    }
+
+    [Test]
+    public async Task Register_RequiresExplicitReplacementOfExistingTemplate()
+    {
+        CaptionTemplateRegistrationSet original = CaptionTemplateDefaults.CreateDefaultText("Default");
+        CaptionTemplateRegistrationSet replacement = CaptionTemplateDefaults.CreateText(
+            CaptionTemplateIds.DefaultText,
+            s_provider,
+            "Replacement");
+        await using CaptionTemplateRegistry registry = CreateRegistry(original);
+
+        await using ICaptionTemplateDescriptorRegistration replacementRegistration = registry.Register(
+            new CaptionTemplateDescriptorRegistration(
+                replacement.DescriptorRegistration.Descriptor,
+                CaptionTemplateRegistrationMode.Replace));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(
+                registry.GetRequired(CaptionTemplateIds.DefaultText).Name,
+                Is.EqualTo("Replacement"));
+            Assert.That(
+                () => registry.Register(new CaptionTemplateDescriptorRegistration(
+                    CreateText("beutl.tests.missing", "Missing").DescriptorRegistration.Descriptor,
+                    CaptionTemplateRegistrationMode.Replace)),
+                Throws.ArgumentException.With.Message.Contains("no descriptor"));
+        }
+    }
+
+    [Test]
+    public async Task DescriptorFactoryAndPlacementReplaceAndRestoreIndependently()
+    {
+        CaptionTemplateRegistrationSet original = CreateText(
+            "beutl.tests.independent-template",
+            "Original");
+        CaptionTemplateId id = original.DescriptorRegistration.Descriptor.Id;
+        var replacementFactory = new TaggedFactory("Replacement factory");
+        var replacementPlacement = new FixedPlacementPolicy(new Point(9, 10), layer: 42);
+        await using CaptionTemplateRegistry registry = CreateRegistry(original);
+        ICaptionTemplateDescriptorRegistration descriptor = registry.Register(
+            new CaptionTemplateDescriptorRegistration(
+                new CaptionTemplateDescriptor(id, s_provider, "Replacement"),
+                CaptionTemplateRegistrationMode.Replace));
+        ICaptionElementFactoryRegistration factory = registry.Register(
+            new CaptionElementFactoryRegistration(
+                id,
+                replacementFactory,
+                CaptionTemplateRegistrationMode.Replace));
+        ICaptionPlacementPolicyRegistration placement = registry.Register(
+            new CaptionPlacementPolicyRegistration(
+                id,
+                replacementPlacement,
+                CaptionTemplateRegistrationMode.Replace));
+        var cue = new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "text");
+        var context = new CaptionElementContext(3, "Caption", new Point(1, 2));
+        try
+        {
+            Assert.That(registry.GetRequired(id).Name, Is.EqualTo("Replacement"));
+            ElementDescription replaced = CreateOne(registry, id, cue, context);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(replaced.Name, Is.EqualTo("Replacement factory"));
+                Assert.That(replaced.Position, Is.EqualTo(new Point(9, 10)));
+                Assert.That(replaced.Layer, Is.EqualTo(42));
+            }
+
+            await descriptor.DisposeAsync();
+            Assert.That(registry.GetRequired(id).Name, Is.EqualTo("Original"));
+            Assert.That(CreateOne(registry, id, cue, context).Name,
+                Is.EqualTo("Replacement factory"));
+
+            await factory.DisposeAsync();
+            ElementDescription originalFactory = CreateOne(registry, id, cue, context);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(originalFactory.Name, Is.EqualTo("Caption"));
+                Assert.That(originalFactory.Position, Is.EqualTo(new Point(9, 10)));
+                Assert.That(originalFactory.Layer, Is.EqualTo(42));
+            }
+
+            await placement.DisposeAsync();
+            ElementDescription restored = CreateOne(registry, id, cue, context);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(restored.Layer, Is.EqualTo(3));
+                Assert.That(restored.Position, Is.EqualTo(new Point(1, 2)));
+            }
+        }
+        finally
+        {
+            await descriptor.DisposeAsync();
+            await factory.DisposeAsync();
+            await placement.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task PartialTemplateIsPublishedOnlyAfterEverySlotExists()
+    {
+        CaptionTemplateRegistrationSet template = CreateText(
+            "beutl.tests.partial-template",
+            "Partial");
+        await using var registry = new CaptionTemplateRegistry();
+        await using ICaptionTemplateDescriptorRegistration descriptor =
+            registry.Register(template.DescriptorRegistration);
+        Assert.That(registry.Templates, Is.Empty);
+        await using ICaptionElementFactoryRegistration factory =
+            registry.Register(template.ElementFactoryRegistration);
+        Assert.That(registry.Templates, Is.Empty);
+        ICaptionPlacementPolicyRegistration placement = registry.Register(template.PlacementPolicyRegistration);
+
+        Assert.That(registry.Templates.Select(item => item.Name), Is.EqualTo(["Partial"]));
+
+        await placement.DisposeAsync();
+        Assert.That(registry.Templates, Is.Empty);
+    }
+
+    [Test]
+    public async Task DisposingDescriptorBaseKeepsItsActiveReplacementUntilThatHandleEnds()
+    {
+        var id = new CaptionTemplateId("beutl.tests.base-disposal");
+        CaptionTemplateRegistrationSet template = CreateTemplate(
+            id,
+            "Base",
+            new TaggedFactory("Factory"),
+            PreserveCaptionPlacementPolicy.Instance);
+        await using var registry = new CaptionTemplateRegistry();
+        ICaptionTemplateDescriptorRegistration baseRegistration = registry.Register(
+            template.DescriptorRegistration);
+        await using ICaptionElementFactoryRegistration factory = registry.Register(
+            template.ElementFactoryRegistration);
+        await using ICaptionPlacementPolicyRegistration placement = registry.Register(
+            template.PlacementPolicyRegistration);
+        ICaptionTemplateDescriptorRegistration replacement = registry.Register(
+            new CaptionTemplateDescriptorRegistration(
+                new CaptionTemplateDescriptor(id, s_provider, "Replacement"),
+                CaptionTemplateRegistrationMode.Replace));
+        try
+        {
+            await baseRegistration.DisposeAsync();
+            Assert.That(registry.GetRequired(id).Name, Is.EqualTo("Replacement"));
+
+            await replacement.DisposeAsync();
+            Assert.That(registry.TryGet(id, out _), Is.False);
+        }
+        finally
+        {
+            await baseRegistration.DisposeAsync();
+            await replacement.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task ReplacedFactoryRegistrationWaitsForItsRetiredTemplateLease()
+    {
+        CaptionTemplateRegistrationSet template = CreateText(
+            "beutl.tests.direct-owner-drain",
+            "Direct owner drain");
+        CaptionTemplateId id = template.DescriptorRegistration.Descriptor.Id;
+        await using var registry = new CaptionTemplateRegistry();
+        await using ICaptionTemplateDescriptorRegistration descriptor = registry.Register(
+            template.DescriptorRegistration);
+        ICaptionElementFactoryRegistration factory = registry.Register(template.ElementFactoryRegistration);
+        await using ICaptionPlacementPolicyRegistration placement = registry.Register(
+            template.PlacementPolicyRegistration);
+        using CaptionTemplateLease oldLease = registry.Acquire(id);
+        await using ICaptionElementFactoryRegistration replacement = registry.Register(
+            new CaptionElementFactoryRegistration(
+                id,
+                new TaggedFactory("Replacement"),
+                CaptionTemplateRegistrationMode.Replace));
+
+        Task disposal = factory.DisposeAsync().AsTask();
+        await Task.Yield();
+        Assert.That(disposal.IsCompleted, Is.False);
+
+        oldLease.Dispose();
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task EqualReplacementEntriesKeepReferenceIdentityForOwnerDrains()
+    {
+        CaptionTemplateRegistrationSet template = CreateText(
+            "beutl.tests.equal-registration-owners",
+            "Equal registration owners");
+        CaptionTemplateId id = template.DescriptorRegistration.Descriptor.Id;
+        await using var registry = new CaptionTemplateRegistry();
+        await using ICaptionTemplateDescriptorRegistration descriptor = registry.Register(
+            template.DescriptorRegistration);
+        await using ICaptionElementFactoryRegistration factory = registry.Register(
+            template.ElementFactoryRegistration);
+        await using ICaptionPlacementPolicyRegistration placement = registry.Register(
+            template.PlacementPolicyRegistration);
+        var replacementRegistration = new CaptionElementFactoryRegistration(
+            id,
+            new TaggedFactory("Replacement"),
+            CaptionTemplateRegistrationMode.Replace);
+        ICaptionElementFactoryRegistration firstReplacement = registry.Register(
+            replacementRegistration);
+        ICaptionElementFactoryRegistration secondReplacement = registry.Register(
+            replacementRegistration);
+        try
+        {
+            using (CaptionTemplateLease topLease = registry.Acquire(id))
+            {
+                Task topDisposal = secondReplacement.DisposeAsync().AsTask();
+                await Task.Yield();
+                Assert.That(topDisposal.IsCompleted, Is.False);
+                topLease.Dispose();
+                await topDisposal.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+
+            using CaptionTemplateLease fallbackLease = registry.Acquire(id);
+            Task fallbackDisposal = firstReplacement.DisposeAsync().AsTask();
+            await Task.Yield();
+            Assert.That(fallbackDisposal.IsCompleted, Is.False);
+            fallbackLease.Dispose();
+            await fallbackDisposal.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            await secondReplacement.DisposeAsync();
+            await firstReplacement.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task RegistryDisposeWaitsForLeaseFromStateRetiredByReplacement()
+    {
+        CaptionTemplateRegistrationSet template = CreateText(
+            "beutl.tests.registry-retired-state-drain",
+            "Registry retired-state drain");
+        CaptionTemplateId id = template.DescriptorRegistration.Descriptor.Id;
+        var registry = new CaptionTemplateRegistry();
+        await using ICaptionTemplateDescriptorRegistration descriptor = registry.Register(
+            template.DescriptorRegistration);
+        await using ICaptionElementFactoryRegistration factory = registry.Register(
+            template.ElementFactoryRegistration);
+        await using ICaptionPlacementPolicyRegistration placement = registry.Register(
+            template.PlacementPolicyRegistration);
+        using CaptionTemplateLease oldLease = registry.Acquire(id);
+        await using ICaptionElementFactoryRegistration replacement = registry.Register(
+            new CaptionElementFactoryRegistration(
+                id,
+                new TaggedFactory("Replacement"),
+                CaptionTemplateRegistrationMode.Replace));
+
+        Task disposal = registry.DisposeAsync().AsTask();
+        await Task.Yield();
+        Assert.That(disposal.IsCompleted, Is.False);
+
+        oldLease.Dispose();
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task DataOnlyPlacementCannotReplaceTheFactoryCreatedSource()
+    {
+        var source = new ElementSource.EngineObject(() => new Beutl.Graphics.Shapes.TextBlock());
+        var factory = new FixedSourceFactory(source);
+        var template = CreateTemplate(
+            new CaptionTemplateId("beutl.tests.source-preservation"),
+            "Source preservation",
+            factory,
+            new FixedPlacementPolicy(new Point(12, 34), layer: 9));
+        await using CaptionTemplateRegistry registry = CreateRegistry(template);
+
+        ElementDescription description = CreateOne(
+            registry,
+            template.DescriptorRegistration.Descriptor.Id,
+            new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "text"),
+            new CaptionElementContext(0, "Caption"));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(description.Source, Is.SameAs(source));
+            Assert.That(description.Position, Is.EqualTo(new Point(12, 34)));
+            Assert.That(description.Layer, Is.EqualTo(9));
+            Assert.That(
+                typeof(CaptionElementPlacement).GetProperties()
+                    .Select(property => property.PropertyType),
+                Does.Not.Contain(typeof(ElementSource)));
+        }
+    }
+
+    [Test]
+    public async Task Templates_AreOrderedByExplicitOrderThenStableIdentifier()
+    {
+        await using CaptionTemplateRegistry registry = CreateRegistry(
+            CreateText("beutl.tests.zulu", "Zulu", order: 10),
+            CreateText("beutl.tests.beta", "Beta"),
+            CreateText("beutl.tests.alpha", "Alpha"));
+
+        Assert.That(
+            registry.Templates.Select(template => template.Name),
+            Is.EqualTo(new[] { "Alpha", "Beta", "Zulu" }));
+    }
+
+    [Test]
+    public async Task Register_MetadataObserverFailureDoesNotInterruptRegistryReplacement()
+    {
+        await using var registry = new CaptionTemplateRegistry();
+        CaptionTemplateRegistrationSet template = CreateText("beutl.tests.safe", "Safe");
+        await using ICaptionElementFactoryRegistration factory = registry.Register(
+            template.ElementFactoryRegistration);
+        await using ICaptionPlacementPolicyRegistration placement = registry.Register(
+            template.PlacementPolicyRegistration);
+        registry.Templates.CollectionChanged += (_, _) =>
+            throw new InvalidOperationException("Observer failure");
+
+        Assert.DoesNotThrow(() => registry.Register(template.DescriptorRegistration));
+        Assert.That(registry.GetRequired(new CaptionTemplateId("beutl.tests.safe")).Name, Is.EqualTo("Safe"));
+    }
+
+    [Test]
+    public async Task Catalog_ComposesCodecAndTemplateExtensionsForNonUiConsumers()
+    {
+        var format = new CaptionFormatId("beutl.tests.caption");
+        CaptionTemplateRegistrationSet template = CreateText(
+            "beutl.tests.catalog-template",
+            "Catalog template");
+        var codec = new TestCodec();
+
+        var extensions = new ExtensionProvider();
+        await using CaptionCatalog catalog = CaptionCatalog.Compose(
+            "Default",
+            [],
+            extensions);
+        extensions.AddExtensions(1,
+        [
+            .. CreateCodecExtensions(format, codec),
+            .. CreateTemplateExtensions(template),
+        ]);
+        try
+        {
+            CaptionImportResult imported = catalog.Serializer.Import(
+                "From extension"u8,
+                format);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(imported.IsSuccess, Is.True);
+                Assert.That(imported.Document!.Cues.Single().Text, Is.EqualTo("From extension"));
+                Assert.That(
+                    catalog.Templates.GetRequired(template.DescriptorRegistration.Descriptor.Id).Name,
+                    Is.EqualTo(template.DescriptorRegistration.Descriptor.Name));
+            }
+        }
+        finally
+        {
+            extensions.RemoveExtensions(1);
+        }
+    }
+
+    [Test]
+    public async Task Catalog_CodecMetadataListStaysStableAndNotifiesOnExtensionChanges()
+    {
+        var format = new CaptionFormatId("beutl.tests.observable-codec");
+        var extensions = new ExtensionProvider();
+        await using CaptionCatalog catalog = CaptionCatalog.Compose("Default", [], extensions);
+        var metadata = catalog.Codecs.Codecs;
+        int changes = 0;
+        metadata.CollectionChanged += (_, _) => changes++;
+
+        extensions.AddExtensions(2,
+        [
+            new RegistrationCodecDescriptorExtension([
+                new CaptionCodecDescriptorRegistration(
+                    new CaptionCodecDescriptor(format, [".observable-caption"])),
+            ]),
+        ]);
+        Assert.That(catalog.Codecs.Codecs, Is.SameAs(metadata));
+        Assert.That(catalog.Codecs.TryGet(format, out _), Is.True);
+
+        await extensions.RemoveExtensions(2).DrainAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(catalog.Codecs.Codecs, Is.SameAs(metadata));
+            Assert.That(catalog.Codecs.TryGet(format, out _), Is.False);
+            Assert.That(changes, Is.EqualTo(2));
+        }
+    }
+
+    [Test]
+    public async Task Catalog_DoesNotPublishACodecFromARolledBackExtensionBatch()
+    {
+        var format = new CaptionFormatId("beutl.tests.rolled-back-codec");
+        var extensions = new ExtensionProvider();
+        await using CaptionCatalog catalog = CaptionCatalog.Compose("Default", [], extensions);
+        int metadataChanges = 0;
+        catalog.Codecs.Codecs.CollectionChanged += (_, _) => metadataChanges++;
+        var observerEntered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseObserver = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        NotifyCollectionChangedEventHandler failingObserver = (_, args) =>
+        {
+            if (args.Action != NotifyCollectionChangedAction.Add)
+                return;
+            observerEntered.TrySetResult();
+            releaseObserver.Task.GetAwaiter().GetResult();
+            throw new InvalidOperationException("Injected extension observer failure.");
+        };
+        extensions.AllExtensions.CollectionChanged += failingObserver;
+        Task<Exception?> addition = Task.Run(() =>
+        {
+            try
+            {
+                extensions.AddExtensions(3,
+                [
+                    new RegistrationCodecDescriptorExtension([
+                        new CaptionCodecDescriptorRegistration(
+                            new CaptionCodecDescriptor(format, [".rolled-back-caption"])),
+                    ]),
+                ]);
+                return null;
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
+        });
+
+        try
+        {
+            await observerEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(catalog.Codecs.TryGet(format, out _), Is.False);
+            releaseObserver.TrySetResult();
+            Exception? failure = await addition.WaitAsync(TimeSpan.FromSeconds(5));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(failure, Is.TypeOf<ExtensionRegistrationNotificationException>());
+                Assert.That(catalog.Codecs.TryGet(format, out _), Is.False);
+                Assert.That(metadataChanges, Is.Zero);
+            }
+        }
+        finally
+        {
+            releaseObserver.TrySetResult();
+            extensions.AllExtensions.CollectionChanged -= failingObserver;
+            await addition.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [Test]
+    public async Task Catalog_ComposesCodecReplacementEnumeratedBeforeItsBase()
+    {
+        var format = new CaptionFormatId("beutl.tests.dependent-caption");
+        var replacementCodec = new PrefixDecoder("replacement");
+        var baseCodec = new PrefixDecoder("base");
+        var replacement = new RegistrationDecoderExtension(
+        [
+            new CaptionDecoderRegistration(
+                format,
+                replacementCodec,
+                CaptionCodecRegistrationMode.Replace),
+        ]);
+        var @base = new RegistrationDecoderExtension(
+        [
+            new CaptionDecoderRegistration(format, baseCodec),
+        ]);
+        var descriptor = new RegistrationCodecDescriptorExtension(
+        [
+            new CaptionCodecDescriptorRegistration(
+                new CaptionCodecDescriptor(format, [".dependent-caption"])),
+        ]);
+        var failures = new List<CaptionCatalogExtensionFailure>();
+        var extensions = new ExtensionProvider();
+        await using CaptionCatalog catalog = CaptionCatalog.Compose(
+            "Default",
+            [],
+            extensions,
+            failures.Add);
+
+        extensions.AddExtensions(5, [replacement]);
+        Assert.That(failures, Has.Count.EqualTo(1));
+        failures.Clear();
+        extensions.AddExtensions(6, [@base, descriptor]);
+
+        CaptionCodecInfo info = catalog.Codecs.GetRequired(format);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(info.CanDecode, Is.True);
+            Assert.That(info.CanEncode, Is.False);
+            Assert.That(
+                catalog.Serializer.Import("text"u8, format).Document![0].Text,
+                Is.EqualTo("replacement:text"));
+            Assert.That(replacement.RegistrationsReadCount, Is.EqualTo(2));
+            Assert.That(@base.RegistrationsReadCount, Is.EqualTo(1));
+            Assert.That(failures, Is.Empty);
+        }
+
+        await extensions.RemoveExtensions(5).DrainAsync();
+        Assert.That(
+            catalog.Serializer.Import("text"u8, format).Document![0].Text,
+            Is.EqualTo("base:text"));
+        await extensions.RemoveExtensions(6).DrainAsync();
+    }
+
+    [Test]
+    public async Task Catalog_ComposesIndependentCodecSlotsFromSeparateExtensions()
+    {
+        var format = new CaptionFormatId("beutl.tests.independent-slots");
+        var codec = new TestCodec();
+        var descriptor = new RegistrationCodecDescriptorExtension(
+        [
+            new CaptionCodecDescriptorRegistration(
+                new CaptionCodecDescriptor(format, [".independent-slots"])),
+        ]);
+        var decoder = new RegistrationDecoderExtension(
+        [
+            new CaptionDecoderRegistration(format, codec),
+        ]);
+        var encoder = new RegistrationEncoderExtension(
+        [
+            new CaptionEncoderRegistration(format, codec),
+        ]);
+        var failures = new List<CaptionCatalogExtensionFailure>();
+        var extensions = new ExtensionProvider();
+        await using CaptionCatalog catalog = CaptionCatalog.Compose(
+            "Default",
+            [],
+            extensions,
+            failures.Add);
+
+        extensions.AddExtensions(6, [encoder, descriptor, decoder]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(catalog.Codecs.GetRequired(format).CanDecode, Is.True);
+            Assert.That(catalog.Codecs.GetRequired(format).CanEncode, Is.True);
+            Assert.That(failures, Is.Empty);
+        }
+    }
+
+    [Test]
+    public async Task Catalog_DecoderOnlyReplacementPreservesBuiltInDescriptorAndEncoder()
+    {
+        var extensions = new ExtensionProvider();
+        await using CaptionCatalog catalog = CaptionCatalog.Compose("Default", [], extensions);
+        var replacement = new RegistrationDecoderExtension(
+        [
+            new CaptionDecoderRegistration(
+                CaptionFormats.Srt,
+                new PrefixDecoder("replacement"),
+                CaptionCodecRegistrationMode.Replace),
+        ]);
+
+        extensions.AddExtensions(7, [replacement]);
+
+        CaptionCodecInfo info = catalog.Codecs.GetRequired(CaptionFormats.Srt);
+        byte[] exported = catalog.Serializer.Export(
+            new CaptionDocument([
+                new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "text"),
+            ]),
+            CaptionFormats.Srt);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(info.FileExtensions, Is.EqualTo(new[] { ".srt" }));
+            Assert.That(info.CanDecode, Is.True);
+            Assert.That(info.CanEncode, Is.True);
+            Assert.That(
+                catalog.Serializer.Import("text"u8, CaptionFormats.Srt).Document![0].Text,
+                Is.EqualTo("replacement:text"));
+            Assert.That(exported, Is.Not.Empty);
+        }
+
+        await extensions.RemoveExtensions(7).DrainAsync();
+        CaptionImportResult restored = catalog.Serializer.Import(
+            "1\n00:00:00,000 --> 00:00:01,000\nrestored\n"u8,
+            CaptionFormats.Srt);
+        Assert.That(restored.Document![0].Text, Is.EqualTo("restored"));
+    }
+
+    [Test]
+    public async Task Catalog_ReevaluatesHealthyCodecAfterInvalidProvisionalAddIsRejected()
+    {
+        var format = new CaptionFormatId("beutl.tests.provisional-codec");
+        var missing = new CaptionFormatId("beutl.tests.missing-codec");
+        var invalid = new RegistrationCodecDescriptorExtension(
+        [
+            new CaptionCodecDescriptorRegistration(
+                new CaptionCodecDescriptor(format, [".invalid"])),
+            new CaptionCodecDescriptorRegistration(
+                new CaptionCodecDescriptor(missing, [".missing"]),
+                CaptionCodecRegistrationMode.Replace),
+        ]);
+        var healthy = new RegistrationCodecDescriptorExtension(
+        [
+            new CaptionCodecDescriptorRegistration(
+                new CaptionCodecDescriptor(format, [".healthy"])),
+        ]);
+        var failures = new List<CaptionCatalogExtensionFailure>();
+        var extensions = new ExtensionProvider();
+        await using CaptionCatalog catalog = CaptionCatalog.Compose(
+            "Default",
+            [],
+            extensions,
+            failures.Add);
+
+        extensions.AddExtensions(7, [invalid, healthy]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(catalog.Codecs.GetRequired(format).FileExtensions,
+                Is.EqualTo(new[] { ".healthy" }));
+            Assert.That(failures, Has.Count.EqualTo(1));
+            Assert.That(failures[0].Kind,
+                Is.EqualTo(CaptionCatalogContributionKind.CodecDescriptor));
+        }
+    }
+
+    [Test]
+    public async Task Catalog_ReevaluatesHealthyTemplateAfterInvalidProvisionalAddIsRejected()
+    {
+        CaptionTemplateRegistrationSet invalidTemplate = CreateText(
+            "beutl.tests.provisional-template",
+            "Invalid provisional");
+        CaptionTemplateRegistrationSet healthyTemplate = CreateText(
+            "beutl.tests.provisional-template",
+            "Healthy");
+        CaptionTemplateRegistrationSet missingTemplate = CreateText(
+            "beutl.tests.missing-template",
+            "Missing");
+        var invalid = new TestTemplateDescriptorExtension(
+        [
+            invalidTemplate.DescriptorRegistration,
+            new CaptionTemplateDescriptorRegistration(
+                missingTemplate.DescriptorRegistration.Descriptor,
+                CaptionTemplateRegistrationMode.Replace),
+        ]);
+        var healthy = new TestTemplateDescriptorExtension([healthyTemplate.DescriptorRegistration]);
+        var failures = new List<CaptionCatalogExtensionFailure>();
+        var extensions = new ExtensionProvider();
+        await using CaptionCatalog catalog = CaptionCatalog.Compose(
+            "Default",
+            [],
+            extensions,
+            failures.Add);
+
+        extensions.AddExtensions(8,
+        [
+            invalid,
+            healthy,
+            new TestElementFactoryExtension([healthyTemplate.ElementFactoryRegistration]),
+            new TestPlacementExtension([healthyTemplate.PlacementPolicyRegistration]),
+        ]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(catalog.Templates.GetRequired(healthyTemplate.DescriptorRegistration.Descriptor.Id).Name,
+                Is.EqualTo("Healthy"));
+            Assert.That(failures, Has.Count.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public async Task Catalog_DiscardsAnInvalidExtensionAtomically()
+    {
+        CaptionTemplateRegistrationSet valid = CreateText(
+            "beutl.tests.valid-before-collision",
+            "Valid before collision");
+        CaptionTemplateRegistrationSet duplicateDefault = CaptionTemplateDefaults.CreateText(
+            CaptionTemplateIds.DefaultText,
+            s_provider,
+            "Unexpected replacement");
+        var extension = new TestTemplateDescriptorExtension(
+        [
+            valid.DescriptorRegistration,
+            duplicateDefault.DescriptorRegistration,
+        ]);
+        var failures = new List<CaptionCatalogExtensionFailure>();
+
+        var extensions = new ExtensionProvider();
+        await using CaptionCatalog catalog = CaptionCatalog.Compose(
+            "Default",
+            [],
+            extensions,
+            failures.Add);
+        extensions.AddExtensions(1,
+        [
+            extension,
+            new TestElementFactoryExtension([valid.ElementFactoryRegistration]),
+            new TestPlacementExtension([valid.PlacementPolicyRegistration]),
+        ]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(failures, Has.Count.EqualTo(1));
+            Assert.That(
+                failures[0].Kind,
+                Is.EqualTo(CaptionCatalogContributionKind.TemplateDescriptor));
+            Assert.That(catalog.Templates.TryGet(valid.DescriptorRegistration.Descriptor.Id, out _), Is.False);
+            Assert.That(
+                catalog.Templates.GetRequired(CaptionTemplateIds.DefaultText).Name,
+                Is.EqualTo("Default"));
+        }
+
+        extensions.RemoveExtensions(1);
+    }
+
+    [Test]
+    public async Task Catalog_FailureReporterCannotInterruptRegistryChanges()
+    {
+        var extensions = new ExtensionProvider();
+        await using CaptionCatalog catalog = CaptionCatalog.Compose(
+            "Default",
+            [],
+            extensions,
+            _ => throw new InvalidOperationException("Reporter failure"));
+        var invalid = new TestTemplateDescriptorExtension([null!]);
+
+        Assert.DoesNotThrow(() => extensions.AddExtensions(1, [invalid]));
+        Assert.DoesNotThrow(() => extensions.RemoveExtensions(1));
+        Assert.That(catalog.Templates.Templates, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Catalog_RefreshObjectTemplatesUpdatesTheSharedMetadataView()
+    {
+        var extensions = new ExtensionProvider();
+        await using CaptionCatalog catalog = CaptionCatalog.Compose("Default", [], extensions);
+        ObjectTemplateItem item = ObjectTemplateItem.CreateFromInstance(
+            new Beutl.Graphics.Shapes.TextBlock(),
+            "Saved caption");
+
+        catalog.RefreshObjectTemplates([item]);
+        Assert.That(
+            catalog.Templates.Templates.Select(template => template.Name),
+            Does.Contain("Saved caption"));
+
+        catalog.RefreshObjectTemplates([]);
+        Assert.That(
+            catalog.Templates.Templates.Select(template => template.Name),
+            Does.Not.Contain("Saved caption"));
+    }
+
+    [Test]
+    public async Task Catalog_ObjectTemplatesRemainAlphabeticalAcrossComposeAndRefresh()
+    {
+        var extensions = new ExtensionProvider();
+        ObjectTemplateItem zulu = ObjectTemplateItem.CreateFromInstance(
+            new Beutl.Graphics.Shapes.TextBlock(),
+            "Zulu");
+        ObjectTemplateItem alpha = ObjectTemplateItem.CreateFromInstance(
+            new Beutl.Graphics.Shapes.TextBlock(),
+            "Alpha");
+        await using CaptionCatalog catalog = CaptionCatalog.Compose(
+            "Default",
+            [zulu, alpha],
+            extensions);
+
+        Assert.That(
+            catalog.Templates.Templates.Select(template => template.Name),
+            Is.EqualTo(new[] { "Default", "Alpha", "Zulu" }));
+
+        ObjectTemplateItem beta = ObjectTemplateItem.CreateFromInstance(
+            new Beutl.Graphics.Shapes.TextBlock(),
+            "Beta");
+        catalog.RefreshObjectTemplates([zulu, beta, alpha]);
+
+        Assert.That(
+            catalog.Templates.Templates.Select(template => template.Name),
+            Is.EqualTo(new[] { "Default", "Alpha", "Beta", "Zulu" }));
+    }
+
+    [Test]
+    public async Task Catalog_RemovingCodecExtensionDoesNotWaitForUnrelatedTemplateLease()
+    {
+        var extensions = new ExtensionProvider();
+        await using CaptionCatalog catalog = CaptionCatalog.Compose("Default", [], extensions);
+        Extension[] codecExtensions = CreateCodecExtensions(
+            new CaptionFormatId("beutl.tests.independent-codec"),
+            new TestCodec());
+        CaptionTemplateRegistrationSet template = CreateText(
+            "beutl.tests.independent-template",
+            "Independent template");
+        extensions.AddExtensions(1, codecExtensions);
+        extensions.AddExtensions(2, CreateTemplateExtensions(template));
+        using ICaptionTemplateLease lease = catalog.Templates.Acquire(
+            template.DescriptorRegistration.Descriptor.Id);
+
+        ExtensionRemoval removal = extensions.RemoveExtensions(1);
+        await removal.DrainAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(catalog.Codecs.TryGet(new CaptionFormatId("beutl.tests.independent-codec"), out _), Is.False);
+    }
+
+    [Test, NonParallelizable]
+    public async Task Catalog_RemovingCodecExtensionDoesNotWaitForAnotherPackageCodecLease()
+    {
+        var extensions = new ExtensionProvider();
+        await using CaptionCatalog catalog = CaptionCatalog.Compose("Default", [], extensions);
+        var removedFormat = new CaptionFormatId("beutl.tests.removed-codec");
+        var activeFormat = new CaptionFormatId("beutl.tests.active-codec");
+        WeakReference removedExtension = RegisterCollectibleCodecExtension(
+            extensions,
+            1,
+            removedFormat);
+        var blocking = new BlockingCodecExtension(activeFormat);
+        extensions.AddExtensions(2, [blocking]);
+
+        Task<CaptionImportResult> decode = Task.Run(() =>
+            catalog.Serializer.Import("caption"u8, activeFormat));
+        Assert.That(blocking.WaitForDecode(TimeSpan.FromSeconds(5)), Is.True);
+        try
+        {
+            RemoveExtensionsAndDrain(extensions, 1);
+            await Task.Yield();
+            Assert.That(Collect(removedExtension), Is.False);
+        }
+        finally
+        {
+            blocking.ReleaseDecode();
+        }
+
+        Assert.That((await decode).IsSuccess, Is.True);
+    }
+
+    [Test, NonParallelizable]
+    public async Task Catalog_RemovingDecoderExtensionDoesNotWaitForEncoderLease()
+    {
+        var extensions = new ExtensionProvider();
+        await using CaptionCatalog catalog = CaptionCatalog.Compose("Default", [], extensions);
+        var format = new CaptionFormatId("beutl.tests.independent-codec-directions");
+        WeakReference removedDecoder = RegisterCollectibleDecoderExtension(
+            extensions,
+            1,
+            format);
+        var encoder = new BlockingEncoderExtension(format);
+        extensions.AddExtensions(2, [encoder]);
+        Task<string> encode = Task.Run(() => catalog.Codecs.Encode(
+            format,
+            new CaptionDocument([
+                new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "caption"),
+            ])));
+        Assert.That(encoder.WaitForEncode(TimeSpan.FromSeconds(5)), Is.True);
+
+        try
+        {
+            RemoveExtensionsAndDrain(extensions, 1);
+            await Task.Yield();
+            Assert.That(Collect(removedDecoder), Is.False);
+        }
+        finally
+        {
+            encoder.ReleaseEncode();
+        }
+
+        Assert.That(await encode.WaitAsync(TimeSpan.FromSeconds(5)), Is.EqualTo("caption"));
+    }
+
+    [Test, NonParallelizable]
+    public async Task Catalog_RemovedTemplatePolicyCanCollectWhileAnotherPackageLeaseIsActive()
+    {
+        var extensions = new ExtensionProvider();
+        await using CaptionCatalog catalog = CaptionCatalog.Compose("Default", [], extensions);
+        var removedId = new CaptionTemplateId("beutl.tests.collectible-policy");
+        WeakReference removedPolicy = RegisterCollectibleTemplateExtensions(
+            extensions,
+            3,
+            removedId);
+        CaptionTemplateRegistrationSet activeTemplate = CreateText(
+            "beutl.tests.active-template",
+            "Active template");
+        extensions.AddExtensions(4, CreateTemplateExtensions(activeTemplate));
+        using ICaptionTemplateLease activeLease = catalog.Templates.Acquire(
+            activeTemplate.DescriptorRegistration.Descriptor.Id);
+
+        RemoveExtensionsAndDrain(extensions, 3);
+        await Task.Yield();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(catalog.Templates.TryGet(removedId, out _), Is.False);
+            Assert.That(Collect(removedPolicy), Is.False);
+        }
+    }
+
+    [Test]
+    public async Task Catalog_RemovingDecoderOwnerWaitsForItsActiveLease()
+    {
+        var extensions = new ExtensionProvider();
+        await using CaptionCatalog catalog = CaptionCatalog.Compose("Default", [], extensions);
+        var format = new CaptionFormatId("beutl.tests.merged-codec");
+        var decoder = new BlockingCodecExtension(format);
+        extensions.AddExtensions(1, [decoder]);
+        extensions.AddExtensions(2, [new EncoderOnlyCodecExtension(format)]);
+
+        Task<CaptionImportResult> decode = Task.Run(() =>
+            catalog.Serializer.Import("caption"u8, format));
+        Assert.That(decoder.WaitForDecode(TimeSpan.FromSeconds(5)), Is.True);
+        ExtensionRemoval removal = extensions.RemoveExtensions(1);
+        Task drain = removal.DrainAsync().AsTask();
+        try
+        {
+            await Task.Delay(50);
+            Assert.That(drain.IsCompleted, Is.False);
+        }
+        finally
+        {
+            decoder.ReleaseDecode();
+        }
+
+        await drain.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That((await decode).IsSuccess, Is.True);
+    }
+
+    [Test]
+    public async Task Catalog_RepeatedDisposeAsyncReturnsTheSameIncompleteDrain()
+    {
+        var extensions = new ExtensionProvider();
+        CaptionTemplateRegistrationSet template = CreateText(
+            "beutl.tests.dispose-template",
+            "Dispose template");
+        var catalog = CaptionCatalog.Compose("Default", [], extensions);
+        extensions.AddExtensions(1, CreateTemplateExtensions(template));
+        using ICaptionTemplateLease lease = catalog.Templates.Acquire(
+            template.DescriptorRegistration.Descriptor.Id);
+
+        Task first = catalog.DisposeAsync().AsTask();
+        Task second = catalog.DisposeAsync().AsTask();
+        await Task.Yield();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(first.IsCompleted, Is.False);
+            Assert.That(second.IsCompleted, Is.False);
+        }
+
+        lease.Dispose();
+        await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    private static CaptionTemplateRegistrationSet CreateText(
+        string id,
+        string name,
+        int order = 0)
+        => CaptionTemplateDefaults.CreateText(
+            new CaptionTemplateId(id),
+            s_provider,
+            name,
+            order);
+
+    private static CaptionTemplateRegistrationSet CreateTemplate(
+        CaptionTemplateId id,
+        string name,
+        ICaptionElementFactory factory,
+        ICaptionPlacementPolicy placement)
+    {
+        var descriptor = new CaptionTemplateDescriptor(id, s_provider, name);
+        return new CaptionTemplateRegistrationSet(
+            new CaptionTemplateDescriptorRegistration(descriptor),
+            new CaptionElementFactoryRegistration(id, factory),
+            new CaptionPlacementPolicyRegistration(id, placement));
+    }
+
+    private static ElementDescription CreateOne(
+        CaptionTemplateRegistry registry,
+        CaptionTemplateId id,
+        CaptionCue cue,
+        CaptionElementContext context)
+    {
+        using CaptionTemplateLease lease = registry.Acquire(id);
+        return lease.CreateElements(cue, context).Single();
+    }
+
+    private static CaptionTemplateRegistry CreateRegistry(
+        params CaptionTemplateRegistrationSet[] templates)
+        => new(
+            templates.Select(item => item.DescriptorRegistration),
+            templates.Select(item => item.ElementFactoryRegistration),
+            templates.Select(item => item.PlacementPolicyRegistration));
+
+    private static Extension[] CreateTemplateExtensions(CaptionTemplateRegistrationSet template)
+        =>
+        [
+            new TestTemplateDescriptorExtension([template.DescriptorRegistration]),
+            new TestElementFactoryExtension([template.ElementFactoryRegistration]),
+            new TestPlacementExtension([template.PlacementPolicyRegistration]),
+        ];
+
+    private static Extension[] CreateCodecExtensions(
+        CaptionFormatId format,
+        TestCodec codec)
+        =>
+        [
+            new RegistrationCodecDescriptorExtension([
+                new CaptionCodecDescriptorRegistration(
+                    new CaptionCodecDescriptor(format, [".test-caption"])),
+            ]),
+            new RegistrationDecoderExtension([
+                new CaptionDecoderRegistration(format, codec),
+            ]),
+            new RegistrationEncoderExtension([
+                new CaptionEncoderRegistration(format, codec),
+            ]),
+        ];
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference RegisterCollectibleCodecExtension(
+        ExtensionProvider extensions,
+        int packageId,
+        CaptionFormatId format)
+    {
+        var extension = new RegistrationCodecDescriptorExtension(
+        [
+            new CaptionCodecDescriptorRegistration(
+                new CaptionCodecDescriptor(format, [".collectible-caption"])),
+        ]);
+        extensions.AddExtensions(packageId, [extension]);
+        return new WeakReference(extension);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference RegisterCollectibleDecoderExtension(
+        ExtensionProvider extensions,
+        int packageId,
+        CaptionFormatId format)
+    {
+        var decoder = new TestCodec();
+        extensions.AddExtensions(packageId,
+        [
+            new RegistrationDecoderExtension([
+                new CaptionDecoderRegistration(format, decoder),
+            ]),
+        ]);
+        return new WeakReference(decoder);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference RegisterCollectibleTemplateExtensions(
+        ExtensionProvider extensions,
+        int packageId,
+        CaptionTemplateId id)
+    {
+        var policy = new FixedPlacementPolicy(new Point(1, 2), layer: 3);
+        CaptionTemplateRegistrationSet template = CreateTemplate(
+            id,
+            "Collectible template",
+            new TaggedFactory("Collectible factory"),
+            policy);
+        extensions.AddExtensions(packageId, CreateTemplateExtensions(template));
+        return new WeakReference(policy);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void RemoveExtensionsAndDrain(
+        ExtensionProvider extensions,
+        int packageId)
+    {
+        ExtensionRemoval removal = extensions.RemoveExtensions(packageId);
+        removal.DrainAsync().AsTask().GetAwaiter().GetResult();
+    }
+
+    private static bool Collect(WeakReference reference)
+    {
+        for (int index = 0; reference.IsAlive && index < 10; index++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
+        return reference.IsAlive;
+    }
+
+    private sealed class TaggedFactory(string name) : ICaptionElementFactory
+    {
+        public IReadOnlyList<ElementDescription> CreateElements(
+            CaptionCue cue,
+            CaptionElementContext context)
+            => [context.CreateDescription(cue, () => new Beutl.Graphics.Shapes.TextBlock(), name: name)];
+    }
+
+    private sealed class FixedSourceFactory(ElementSource source) : ICaptionElementFactory
+    {
+        public IReadOnlyList<ElementDescription> CreateElements(
+            CaptionCue cue,
+            CaptionElementContext context)
+            => [new ElementDescription(cue.Start, cue.End - cue.Start, context.Layer, source)];
+    }
+
+    private sealed class FixedPlacementPolicy(Point position, int layer) : ICaptionPlacementPolicy
+    {
+        public CaptionElementPlacement Place(
+            CaptionCue cue,
+            CaptionElementContext context,
+            CaptionElementPlacement placement,
+            int elementIndex)
+            => placement with { Position = position, Layer = layer };
+    }
+
+    private sealed class RegistrationCodecDescriptorExtension(
+        IReadOnlyCollection<CaptionCodecDescriptorRegistration> registrations)
+        : CaptionCodecDescriptorExtension
+    {
+        public int RegistrationsReadCount { get; private set; }
+
+        public override IReadOnlyCollection<CaptionCodecDescriptorRegistration> Registrations
+        {
+            get
+            {
+                RegistrationsReadCount++;
+                return registrations;
+            }
+        }
+    }
+
+    private sealed class RegistrationDecoderExtension(
+        IReadOnlyCollection<CaptionDecoderRegistration> registrations)
+        : CaptionDecoderExtension
+    {
+        public int RegistrationsReadCount { get; private set; }
+
+        public override IReadOnlyCollection<CaptionDecoderRegistration> Registrations
+        {
+            get
+            {
+                RegistrationsReadCount++;
+                return registrations;
+            }
+        }
+    }
+
+    private sealed class RegistrationEncoderExtension(
+        IReadOnlyCollection<CaptionEncoderRegistration> registrations)
+        : CaptionEncoderExtension
+    {
+        public override IReadOnlyCollection<CaptionEncoderRegistration> Registrations
+            => registrations;
+    }
+
+    private sealed class TestTemplateDescriptorExtension(
+        IReadOnlyCollection<CaptionTemplateDescriptorRegistration> registrations)
+        : CaptionTemplateDescriptorExtension
+    {
+        public override IReadOnlyCollection<CaptionTemplateDescriptorRegistration> Registrations
+            => registrations;
+    }
+
+    private sealed class TestElementFactoryExtension(
+        IReadOnlyCollection<CaptionElementFactoryRegistration> registrations)
+        : CaptionElementFactoryExtension
+    {
+        public override IReadOnlyCollection<CaptionElementFactoryRegistration> Registrations
+            => registrations;
+    }
+
+    private sealed class TestPlacementExtension(
+        IReadOnlyCollection<CaptionPlacementPolicyRegistration> registrations)
+        : CaptionPlacementPolicyExtension
+    {
+        public override IReadOnlyCollection<CaptionPlacementPolicyRegistration> Registrations
+            => registrations;
+    }
+
+    private sealed class TestCodec : ICaptionDecoder, ICaptionEncoder
+    {
+        public CaptionImportResult Decode(string content)
+            => CaptionImportResult.Imported(new CaptionDocument(
+            [
+                new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), content),
+            ]));
+
+        public string Encode(CaptionDocument document)
+            => string.Join('\n', document.Cues.Select(cue => cue.Text));
+    }
+
+    private sealed class PrefixDecoder(string prefix) : ICaptionDecoder
+    {
+        public CaptionImportResult Decode(string content)
+            => CaptionImportResult.Imported(new CaptionDocument(
+            [
+                new CaptionCue(
+                    TimeSpan.Zero,
+                    TimeSpan.FromSeconds(1),
+                    $"{prefix}:{content}"),
+            ]));
+    }
+
+    private sealed class BlockingCodecExtension : CaptionDecoderExtension, ICaptionDecoder
+    {
+        private readonly ManualResetEventSlim _decodeStarted = new();
+        private readonly ManualResetEventSlim _releaseDecode = new();
+        private readonly IReadOnlyCollection<CaptionDecoderRegistration> _registrations;
+
+        public BlockingCodecExtension(CaptionFormatId format)
+        {
+            _registrations =
+            [
+                new CaptionDecoderRegistration(format, this),
+            ];
+        }
+
+        public override IReadOnlyCollection<CaptionDecoderRegistration> Registrations
+            => _registrations;
+
+        public bool WaitForDecode(TimeSpan timeout) => _decodeStarted.Wait(timeout);
+
+        public void ReleaseDecode() => _releaseDecode.Set();
+
+        public CaptionImportResult Decode(string content)
+        {
+            _decodeStarted.Set();
+            if (!_releaseDecode.Wait(TimeSpan.FromSeconds(10)))
+                throw new TimeoutException("The blocking codec was not released.");
+            return CaptionImportResult.Imported(new CaptionDocument(
+            [
+                new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), content),
+            ]));
+        }
+    }
+
+    private sealed class EncoderOnlyCodecExtension : CaptionEncoderExtension, ICaptionEncoder
+    {
+        private readonly IReadOnlyCollection<CaptionEncoderRegistration> _registrations;
+
+        public EncoderOnlyCodecExtension(CaptionFormatId format)
+        {
+            _registrations =
+            [
+                new CaptionEncoderRegistration(format, this),
+            ];
+        }
+
+        public override IReadOnlyCollection<CaptionEncoderRegistration> Registrations
+            => _registrations;
+
+        public string Encode(CaptionDocument document)
+            => string.Join('\n', document.Cues.Select(cue => cue.Text));
+    }
+
+    private sealed class BlockingEncoderExtension : CaptionEncoderExtension, ICaptionEncoder
+    {
+        private readonly ManualResetEventSlim _encodeStarted = new();
+        private readonly ManualResetEventSlim _releaseEncode = new();
+        private readonly IReadOnlyCollection<CaptionEncoderRegistration> _registrations;
+
+        public BlockingEncoderExtension(CaptionFormatId format)
+        {
+            _registrations = [new CaptionEncoderRegistration(format, this)];
+        }
+
+        public override IReadOnlyCollection<CaptionEncoderRegistration> Registrations
+            => _registrations;
+
+        public bool WaitForEncode(TimeSpan timeout) => _encodeStarted.Wait(timeout);
+
+        public void ReleaseEncode() => _releaseEncode.Set();
+
+        public string Encode(CaptionDocument document)
+        {
+            _encodeStarted.Set();
+            if (!_releaseEncode.Wait(TimeSpan.FromSeconds(10)))
+                throw new TimeoutException("The blocking encoder was not released.");
+            return string.Join('\n', document.Cues.Select(cue => cue.Text));
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionTemplateTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionTemplateTests.cs
@@ -1,0 +1,304 @@
+﻿using Beutl.Animation;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Editor.Services.Captions;
+using Beutl.Engine.Expressions;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Shapes;
+using Beutl.Graphics.Transformation;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Editor.Services.Captions;
+
+[TestFixture]
+public class CaptionTemplateTests
+{
+    private static readonly CaptionTemplateProviderId s_testProvider = new("beutl.tests");
+
+    [Test]
+    public async Task DefaultCatalogDisposesItsOwnedRegistries()
+    {
+        CaptionCatalog catalog = CaptionCatalog.CreateDefault("Default");
+        Assert.That(catalog.Codecs.Codecs, Is.Not.Empty);
+        Assert.That(catalog.Templates.Templates, Is.Not.Empty);
+
+        await catalog.DisposeAsync();
+        await catalog.DisposeAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(catalog.Codecs.Codecs, Is.Empty);
+            Assert.That(catalog.Templates.Templates, Is.Empty);
+            Assert.That(catalog.Codecs.TryGet(CaptionFormats.Srt, out _), Is.False);
+            Assert.That(catalog.Templates.TryGet(CaptionTemplateIds.DefaultText, out _), Is.False);
+        });
+    }
+
+    [Test]
+    public void DefaultFactory_UsesTheRenderingEngineDefaultFont()
+    {
+        CaptionTemplateRegistrationSet template = CaptionTemplateDefaults.CreateDefaultText("Default");
+        var cue = new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "Hello");
+        var context = new CaptionElementContext(0, "Caption");
+
+        TextBlock text = CreateTextBlock(CreateElements(template, cue, context).Single());
+
+        Assert.That(text.FontFamily.CurrentValue, Is.EqualTo(FontFamily.Default));
+    }
+
+    [Test]
+    public void DefaultTemplate_CreatesTextDescriptionAndAppliesContextPlacement()
+    {
+        var fontFamily = new FontFamily("Noto Sans JP");
+        CaptionTemplateRegistrationSet template = CaptionTemplateDefaults.CreateDefaultText(
+            "Default",
+            new DefaultTextCaptionElementFactory(fontFamily));
+        var cue = new CaptionCue(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1.2), "Hello");
+        var context = new CaptionElementContext(
+            layer: 3,
+            elementName: "Caption",
+            defaultPosition: new Point(0, 240));
+
+        ElementDescription description = CreateElements(template, cue, context).Single();
+        TextBlock text = CreateTextBlock(description);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(template.DescriptorRegistration.Descriptor.Name, Is.EqualTo("Default"));
+            Assert.That(description.Start, Is.EqualTo(cue.Start));
+            Assert.That(description.Length, Is.EqualTo(TimeSpan.FromSeconds(0.5)));
+            Assert.That(description.Layer, Is.EqualTo(3));
+            Assert.That(description.Name, Is.EqualTo("Caption"));
+            Assert.That(description.Position, Is.EqualTo(new Point(0, 240)));
+            Assert.That(text.Text.CurrentValue, Is.EqualTo("Hello"));
+            Assert.That(text.Size.CurrentValue, Is.EqualTo(48));
+            Assert.That(text.FontFamily.CurrentValue?.Name, Is.EqualTo("Noto Sans JP"));
+            Assert.That(text.AlignmentX.CurrentValue, Is.EqualTo(AlignmentX.Center));
+            Assert.That(text.AlignmentY.CurrentValue, Is.EqualTo(AlignmentY.Center));
+        }
+    }
+
+    [Test]
+    public void TextBlockAdapter_PreservesStyleAndAuthoredPlacementWhileReplacingText()
+    {
+        var source = new TextBlock
+        {
+            Text = { CurrentValue = "Placeholder" },
+            Size = { CurrentValue = 72 },
+            FontWeight = { CurrentValue = FontWeight.Bold },
+            Pen =
+            {
+                CurrentValue = new Pen
+                {
+                    Brush = { CurrentValue = Brushes.Black },
+                    Thickness = { CurrentValue = 4 },
+                }
+            },
+            Transform = { CurrentValue = new TranslateTransform(120, 300) },
+            FilterEffect = { CurrentValue = new Blur { Sigma = { CurrentValue = new Size(2, 3) } } },
+        };
+        source.Opacity.Animation = new KeyFrameAnimation<float>();
+        source.Text.Expression = Expression.Create<string?>("\"Expression text\"");
+        ObjectTemplateItem item = ObjectTemplateItem.CreateFromInstance(source, "Outlined caption");
+        CaptionTemplateRegistrationSet template = TextBlockCaptionTemplateAdapter.TryCreate(item)!;
+        var context = new CaptionElementContext(4, "Caption", new Point(0, 200));
+
+        ElementDescription firstDescription = CreateElements(template,
+            new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "First"),
+            context).Single();
+        ElementDescription secondDescription = CreateElements(template,
+            new CaptionCue(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), "Second"),
+            context).Single();
+        TextBlock first = CreateTextBlock(firstDescription);
+        TextBlock second = CreateTextBlock(secondDescription);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(template.DescriptorRegistration.Descriptor.Name, Is.EqualTo("Outlined caption"));
+            Assert.That(firstDescription.Position, Is.Null);
+            Assert.That(first.Text.CurrentValue, Is.EqualTo("First"));
+            Assert.That(second.Text.CurrentValue, Is.EqualTo("Second"));
+            Assert.That(first.Text.Expression, Is.Null);
+            Assert.That(first.Size.CurrentValue, Is.EqualTo(72));
+            Assert.That(first.FontWeight.CurrentValue, Is.EqualTo(FontWeight.Bold));
+            Assert.That(first.Pen.CurrentValue?.Thickness.CurrentValue, Is.EqualTo(4));
+            Assert.That(first.Transform.CurrentValue, Is.TypeOf<TranslateTransform>());
+            Assert.That(((TranslateTransform)first.Transform.CurrentValue!).X.CurrentValue, Is.EqualTo(120));
+            Assert.That(((TranslateTransform)first.Transform.CurrentValue!).Y.CurrentValue, Is.EqualTo(300));
+            Assert.That(first.FilterEffect.CurrentValue, Is.TypeOf<Blur>());
+            Assert.That(((Blur)first.FilterEffect.CurrentValue!).Sigma.CurrentValue, Is.EqualTo(new Size(2, 3)));
+            Assert.That(first.Opacity.Animation, Is.Not.Null);
+            Assert.That(first.Id, Is.Not.EqualTo(source.Id));
+            Assert.That(second.Id, Is.Not.EqualTo(first.Id));
+        }
+    }
+
+    [Test]
+    public void TextBlockAdapter_NonTextTemplateIsNotAdapted()
+    {
+        ObjectTemplateItem item = ObjectTemplateItem.CreateFromInstance(new EllipseShape(), "Ellipse");
+
+        CaptionTemplateRegistrationSet? result = TextBlockCaptionTemplateAdapter.TryCreate(item);
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void CustomFactory_ReceivesCueAndCanReturnMultipleElementRequests()
+    {
+        var factory = new MultiElementFactory();
+        CaptionTemplateRegistrationSet template = CreateTemplate(
+            new CaptionTemplateId("beutl.tests.bilingual"),
+            s_testProvider,
+            "Bilingual",
+            factory,
+            DefaultCaptionPlacementPolicy.Instance);
+        var cue = new CaptionCue(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4), "Hello");
+        var context = new CaptionElementContext(6, "Caption", new Point(0, 180));
+
+        IReadOnlyList<ElementDescription> descriptions = CreateElements(template, cue, context);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(factory.ReceivedCue, Is.SameAs(cue));
+            Assert.That(descriptions, Has.Count.EqualTo(2));
+            Assert.That(descriptions.Select(item => item.Layer), Is.EqualTo(new[] { 6, 7 }));
+            Assert.That(descriptions[0].Position, Is.EqualTo(new Point(20, 30)));
+            Assert.That(descriptions[1].Position, Is.EqualTo(context.DefaultPosition));
+            Assert.That(
+                descriptions.Select(item => CreateTextBlock(item).Text.CurrentValue),
+                Is.EqualTo(new[] { "Hello", "Hello translation" }));
+        });
+    }
+
+    [Test]
+    public void DefaultPlacement_PreservesAnExplicitOrigin()
+    {
+        CaptionTemplateRegistrationSet template = CreateTemplate(
+            new CaptionTemplateId("beutl.tests.origin"),
+            s_testProvider,
+            "Origin",
+            new ExplicitOriginFactory(),
+            DefaultCaptionPlacementPolicy.Instance);
+        var context = new CaptionElementContext(0, "Caption", new Point(100, 200));
+
+        ElementDescription description = CreateElements(template,
+            new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "Text"),
+            context).Single();
+
+        Assert.That(description.Position, Is.EqualTo(new Point(0, 0)));
+    }
+
+    [Test]
+    public void CreateElements_RejectsNullFactoryAndPlacementResults()
+    {
+        var cue = new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "Text");
+        var context = new CaptionElementContext(0, "Caption");
+        CaptionTemplateRegistrationSet nullFactoryTemplate = CreateTemplate(
+            new CaptionTemplateId("beutl.tests.null-factory"),
+            s_testProvider,
+            "Null factory item",
+            new NullItemFactory(),
+            PreserveCaptionPlacementPolicy.Instance);
+        CaptionTemplateRegistrationSet nullPlacementTemplate = CreateTemplate(
+            new CaptionTemplateId("beutl.tests.null-placement"),
+            s_testProvider,
+            "Null placement item",
+            DefaultTextCaptionElementFactory.Instance,
+            new NullPlacementPolicy());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => CreateElements(nullFactoryTemplate, cue, context),
+                Throws.InvalidOperationException.With.Message.Contains("null element description"));
+            Assert.That(
+                () => CreateElements(nullPlacementTemplate, cue, context),
+                Throws.InvalidOperationException.With.Message.Contains("placement returned null"));
+        });
+    }
+
+    private static CaptionTemplateRegistrationSet CreateTemplate(
+        CaptionTemplateId id,
+        CaptionTemplateProviderId providerId,
+        string name,
+        ICaptionElementFactory factory,
+        ICaptionPlacementPolicy placement,
+        int order = 0)
+    {
+        var descriptor = new CaptionTemplateDescriptor(id, providerId, name, order);
+        return new CaptionTemplateRegistrationSet(
+            new CaptionTemplateDescriptorRegistration(descriptor),
+            new CaptionElementFactoryRegistration(id, factory),
+            new CaptionPlacementPolicyRegistration(id, placement));
+    }
+
+    private static IReadOnlyList<ElementDescription> CreateElements(
+        CaptionTemplateRegistrationSet template,
+        CaptionCue cue,
+        CaptionElementContext context)
+        => new CaptionTemplateComposition(
+                template.DescriptorRegistration.Descriptor,
+                template.ElementFactoryRegistration.Factory,
+                template.PlacementPolicyRegistration.Policy)
+            .CreateElements(cue, context);
+
+    private static TextBlock CreateTextBlock(ElementDescription description) =>
+        (TextBlock)((ElementSource.EngineObject)description.Source).Factory();
+
+    private sealed class MultiElementFactory : ICaptionElementFactory
+    {
+        public CaptionCue? ReceivedCue { get; private set; }
+
+        public IReadOnlyList<ElementDescription> CreateElements(
+            CaptionCue cue,
+            CaptionElementContext context)
+        {
+            ReceivedCue = cue;
+            return
+            [
+                context.CreateDescription(
+                    cue,
+                    () => new TextBlock { Text = { CurrentValue = cue.Text } },
+                    position: new Point(20, 30)),
+                context.CreateDescription(
+                    cue,
+                    () => new TextBlock { Text = { CurrentValue = cue.Text + " translation" } },
+                    layerOffset: 1),
+            ];
+        }
+    }
+
+    private sealed class ExplicitOriginFactory : ICaptionElementFactory
+    {
+        public IReadOnlyList<ElementDescription> CreateElements(
+            CaptionCue cue,
+            CaptionElementContext context)
+            =>
+            [
+                context.CreateDescription(
+                    cue,
+                    () => new TextBlock(),
+                    position: new Point(0, 0)),
+            ];
+    }
+
+    private sealed class NullItemFactory : ICaptionElementFactory
+    {
+        public IReadOnlyList<ElementDescription> CreateElements(
+            CaptionCue cue,
+            CaptionElementContext context)
+            => [null!];
+    }
+
+    private sealed class NullPlacementPolicy : ICaptionPlacementPolicy
+    {
+        public CaptionElementPlacement Place(
+            CaptionCue cue,
+            CaptionElementContext context,
+            CaptionElementPlacement placement,
+            int elementIndex)
+            => null!;
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionTextWrapperTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionTextWrapperTests.cs
@@ -1,0 +1,62 @@
+﻿using Beutl.Editor.Services.Captions;
+
+namespace Beutl.UnitTests.Editor.Services.Captions;
+
+[TestFixture]
+public class CaptionTextWrapperTests
+{
+    [Test]
+    public void Wrap_PrefersWordBoundary()
+    {
+        var constraints = new CaptionTextConstraints(maximumLineLength: 11, maximumLineCount: 2);
+
+        string result = CaptionTextWrapper.Wrap("Hello world again", constraints);
+
+        Assert.That(result, Is.EqualTo("Hello world\nagain"));
+    }
+
+    [Test]
+    public void Wrap_LongUnbrokenText_HardWrapsWithoutTruncation()
+    {
+        var constraints = new CaptionTextConstraints(maximumLineLength: 3, maximumLineCount: 2);
+
+        string result = CaptionTextWrapper.Wrap("日本語字幕", constraints);
+
+        Assert.That(result, Is.EqualTo("日本語\n字幕"));
+    }
+
+    [Test]
+    public void Wrap_DoesNotSplitSurrogatePairs()
+    {
+        var constraints = new CaptionTextConstraints(maximumLineLength: 3, maximumLineCount: 2);
+
+        string result = CaptionTextWrapper.Wrap("A😀B😀C", constraints);
+
+        Assert.That(result, Is.EqualTo("A😀B\n😀C"));
+    }
+
+    [Test]
+    public void Wrap_NormalizesExplicitLineEndingsAndPreservesBlankLine()
+    {
+        var constraints = new CaptionTextConstraints(maximumLineLength: 20, maximumLineCount: 3);
+
+        string result = CaptionTextWrapper.Wrap("first\r\n\rsecond", constraints);
+
+        Assert.That(result, Is.EqualTo("first\n\nsecond"));
+    }
+
+    [Test]
+    public void TryWrap_ReportsMaximumLineCountWithoutDroppingContent()
+    {
+        var constraints = new CaptionTextConstraints(maximumLineLength: 4, maximumLineCount: 2);
+
+        bool fits = CaptionTextWrapper.TryWrap("one two three", constraints, out string wrapped);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fits, Is.False);
+            Assert.That(wrapped, Is.EqualTo("one\ntwo\nthre\ne"));
+            Assert.That(wrapped.Replace("\n", string.Empty, StringComparison.Ordinal), Is.EqualTo("onetwothree"));
+        });
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionValidationTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/Captions/CaptionValidationTests.cs
@@ -1,0 +1,104 @@
+﻿using Beutl.Editor.Services.Captions;
+
+namespace Beutl.UnitTests.Editor.Services.Captions;
+
+[TestFixture]
+public class CaptionValidationTests
+{
+    [Test]
+    public void Validate_OrderedAdjacentCues_HasNoIssues()
+    {
+        var document = new CaptionDocument(
+        [
+            new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(1), "first"),
+            new CaptionCue(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), "second"),
+        ]);
+
+        IReadOnlyList<CaptionValidationIssue> issues = CaptionDocumentValidator.Validate(document);
+
+        Assert.That(issues, Is.Empty);
+    }
+
+    [Test]
+    public void Validate_InvalidTimingAndOrder_ReportsEachProblem()
+    {
+        var document = new CaptionDocument(
+        [
+            new CaptionCue(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(4), "bad duration"),
+            new CaptionCue(TimeSpan.FromSeconds(-1), TimeSpan.FromSeconds(1), "negative and unordered"),
+        ]);
+
+        IReadOnlyList<CaptionValidationIssue> issues = CaptionDocumentValidator.Validate(document);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(issues, Has.Some.Matches<CaptionValidationIssue>(issue =>
+                issue.Kind == CaptionValidationIssueKind.EndNotAfterStart && issue.CueIndex == 0));
+            Assert.That(issues, Has.Some.Matches<CaptionValidationIssue>(issue =>
+                issue.Kind == CaptionValidationIssueKind.NegativeStart && issue.CueIndex == 1));
+            Assert.That(issues, Has.Some.Matches<CaptionValidationIssue>(issue =>
+                issue.Kind == CaptionValidationIssueKind.OutOfOrder
+                && issue.CueIndex == 1
+                && issue.RelatedCueIndex == 0));
+        });
+    }
+
+    [Test]
+    public void Validate_NestedOverlapInUnorderedDocument_ReportsOverlapAndOrder()
+    {
+        var document = new CaptionDocument(
+        [
+            new CaptionCue(TimeSpan.Zero, TimeSpan.FromSeconds(10), "long"),
+            new CaptionCue(TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(30), "later"),
+            new CaptionCue(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(6), "nested"),
+        ]);
+
+        IReadOnlyList<CaptionValidationIssue> issues = CaptionDocumentValidator.Validate(document);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(issues, Has.Some.Matches<CaptionValidationIssue>(issue =>
+                issue.Kind == CaptionValidationIssueKind.Overlap
+                && issue.CueIndex == 2
+                && issue.RelatedCueIndex == 0));
+            Assert.That(issues, Has.Some.Matches<CaptionValidationIssue>(issue =>
+                issue.Kind == CaptionValidationIssueKind.OutOfOrder && issue.CueIndex == 2));
+        });
+    }
+
+    [Test]
+    public void Validate_TextConstraints_CountsGraphemeClustersAndNormalizedLines()
+    {
+        var document = new CaptionDocument(
+        [
+            new CaptionCue(
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(1),
+                "a\u0301bcde\r\nok\rthird"),
+        ]);
+        var constraints = new CaptionTextConstraints(maximumLineLength: 4, maximumLineCount: 2);
+
+        IReadOnlyList<CaptionValidationIssue> issues = CaptionDocumentValidator.Validate(document, constraints);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(issues, Has.One.Matches<CaptionValidationIssue>(issue =>
+                issue.Kind == CaptionValidationIssueKind.TooManyLines
+                && issue.ActualValue == 3
+                && issue.Limit == 2));
+            Assert.That(issues, Has.One.Matches<CaptionValidationIssue>(issue =>
+                issue.Kind == CaptionValidationIssueKind.LineTooLong
+                && issue.LineIndex == 0
+                && issue.ActualValue == 5
+                && issue.Limit == 4));
+        });
+    }
+
+    [TestCase(0, 2)]
+    [TestCase(10, 0)]
+    public void TextConstraints_NonPositiveLimit_Throws(int maximumLineLength, int maximumLineCount)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            _ = new CaptionTextConstraints(maximumLineLength, maximumLineCount));
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/Services/ElementClipboardServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementClipboardServiceTests.cs
@@ -1,4 +1,5 @@
 ﻿using Beutl.Editor;
+using Beutl.Editor.Models;
 using Beutl.Editor.Services;
 using Beutl.Media;
 using Beutl.ProjectSystem;
@@ -25,11 +26,17 @@ public class ElementClipboardServiceTests
         _history = _harness.History;
         _clipboard = new InMemoryClipboardGateway();
         _duplicateService = new ElementDuplicateService(_history);
-        _service = new ElementClipboardService(
+        _service = CreateService();
+    }
+
+    private ElementClipboardService CreateService(IElementAdder? elementAdder = null)
+    {
+        return new ElementClipboardService(
             _history,
             _clipboard,
             _duplicateService,
-            imageAccentColorFactory: () => Colors.Magenta);
+            imageAccentColorFactory: () => Colors.Magenta,
+            elementAdder);
     }
 
     [TearDown]
@@ -192,6 +199,69 @@ public class ElementClipboardServiceTests
     }
 
     [Test]
+    public async Task PasteAsync_FilesFormat_WhenElementAdderRefuses_ReturnsEmpty()
+    {
+        var elementAdder = new StubElementAdder([]);
+        ElementClipboardService service = CreateService(elementAdder);
+        _clipboard.SetFiles(["first.png", "second.png"]);
+
+        ElementPasteOutcome outcome = await service.PasteAsync(
+            _scene,
+            TimeSpan.FromSeconds(12),
+            4);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(outcome.Pasted, Is.False);
+            Assert.That(outcome.AddFailure, Is.TypeOf<ElementMaterializationFailure>());
+            Assert.That(elementAdder.CallCount, Is.EqualTo(1));
+            Assert.That(elementAdder.Descriptions, Has.Count.EqualTo(2));
+            Assert.That(elementAdder.Descriptions, Has.All.Matches<ElementDescription>(description =>
+                description.Start == TimeSpan.FromSeconds(12)
+                && description.Length == TimeSpan.FromSeconds(5)
+                && description.Layer == 4
+                && description.Source is ElementSource.File));
+        });
+    }
+
+    [Test]
+    public async Task PasteAsync_FilesFormat_WhenElementAdderSucceeds_ReturnsCreatedElements()
+    {
+        Element[] created =
+        [
+            new Element
+            {
+                Start = TimeSpan.FromSeconds(12),
+                Length = TimeSpan.FromSeconds(5),
+                ZIndex = 4,
+            },
+            new Element
+            {
+                Start = TimeSpan.FromSeconds(12),
+                Length = TimeSpan.FromSeconds(7),
+                ZIndex = 5,
+            },
+        ];
+        var elementAdder = new StubElementAdder(created);
+        ElementClipboardService service = CreateService(elementAdder);
+        _clipboard.SetFiles(["video.mp4"]);
+
+        ElementPasteOutcome outcome = await service.PasteAsync(
+            _scene,
+            TimeSpan.FromSeconds(12),
+            4);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(outcome.Pasted, Is.True);
+            Assert.That(outcome.NewElements, Is.EqualTo(created));
+            Assert.That(outcome.ScrollTo, Is.EqualTo(created[^1].Range));
+            Assert.That(outcome.ScrollToZIndex, Is.EqualTo(created[^1].ZIndex));
+            Assert.That(elementAdder.CallCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
     public async Task PasteAsync_SingleElementFormat_AddsClonedElement()
     {
         Element original = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
@@ -311,5 +381,37 @@ public class ElementClipboardServiceTests
             Assert.That(formats, Contains.Item(BeutlClipboardFormats.Element));
             Assert.That(formats, Contains.Item(BeutlClipboardFormats.Text));
         });
+    }
+
+    private sealed class StubElementAdder(IReadOnlyList<Element> result) : IElementAdder
+    {
+        public IElementSourceHandlerRegistry SourceHandlers { get; } = new ElementSourceHandlerRegistry();
+
+        public int CallCount { get; private set; }
+
+        public IReadOnlyList<ElementDescription> Descriptions { get; private set; } = [];
+
+        public ValueTask<ElementAddResult> AddAsync(
+            IReadOnlyList<ElementDescription> descriptions,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            CallCount++;
+            Descriptions = descriptions;
+            if (result.Count == 0)
+            {
+                return ValueTask.FromResult(ElementAddResult.Failed(
+                    new ElementMaterializationFailure("The test element could not be materialized.")));
+            }
+
+            ElementAddItemResult[] items = result
+                .Select((element, index) =>
+                {
+                    ElementDescription description = descriptions[Math.Min(index, descriptions.Count - 1)];
+                    return new ElementAddItemResult(description, element, []);
+                })
+                .ToArray();
+            return ValueTask.FromResult(ElementAddResult.Succeeded(items));
+        }
     }
 }

--- a/tests/Beutl.UnitTests/Editor/Services/ElementSourceHandlerRegistryTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementSourceHandlerRegistryTests.cs
@@ -1,0 +1,675 @@
+﻿using System.Collections;
+using System.Collections.Immutable;
+using Beutl.Api.Services;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.ProjectSystem;
+
+namespace Beutl.UnitTests.Editor.Services;
+
+[TestFixture]
+public sealed class ElementSourceHandlerRegistryTests
+{
+    [Test]
+    public void MaterializationSnapshotsOuterAndInnerGroupsWithTheHostComparer()
+    {
+        var primary = new Element();
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+        var supplied = new HashSet<Guid>(new DelegatingGuidComparer()) { first, second };
+        var inner = new SingleUseReadOnlySet<Guid>(supplied);
+        var outer = new SingleUseEnumerable<IReadOnlySet<Guid>>([inner]);
+        var materialization = new ElementMaterialization(
+            primary,
+            groups: outer);
+
+        supplied.Clear();
+        supplied.Add(Guid.NewGuid());
+
+        var snapshot = (ImmutableHashSet<Guid>)materialization.Groups.Single();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(snapshot, Is.EquivalentTo(new[] { first, second }));
+            Assert.That(snapshot.KeyComparer, Is.SameAs(EqualityComparer<Guid>.Default));
+            Assert.Throws<ArgumentException>(() => new ElementMaterialization(
+                primary,
+                groups: [null!]));
+        }
+    }
+
+    [Test]
+    public async Task Register_OrdersHandlersAndRequiresExplicitReplacement()
+    {
+        await using var registry = new ElementSourceHandlerRegistry();
+        var original = new TestHandler(typeof(FirstSource));
+        var other = new TestHandler(typeof(SecondSource));
+        await using IElementSourceHandlerRegistration originalRegistration = registry.Register(
+            new ElementSourceHandlerRegistration(original, order: 20));
+        await using IElementSourceHandlerRegistration otherRegistration = registry.Register(
+            new ElementSourceHandlerRegistration(other, order: -10));
+
+        Assert.That(
+            registry.Handlers.Select(handler => handler.SourceTypeName),
+            Is.EqualTo(new[]
+            {
+                typeof(SecondSource).AssemblyQualifiedName,
+                typeof(FirstSource).AssemblyQualifiedName,
+            }));
+        Assert.Throws<ArgumentException>(() => registry.Register(
+            new ElementSourceHandlerRegistration(new TestHandler(typeof(FirstSource)))));
+
+        var replacement = new TestHandler(typeof(FirstSource));
+        IElementSourceHandlerRegistration replacementRegistration = registry.Register(
+            new ElementSourceHandlerRegistration(
+                replacement,
+                ElementSourceHandlerRegistrationMode.Replace,
+                order: 0));
+
+        Assert.That(registry.TryAcquire(typeof(FirstSource), out IElementSourceHandlerLease? lease), Is.True);
+        using (lease)
+        {
+            Assert.That(lease!.Handler, Is.SameAs(replacement));
+        }
+        Assert.That(
+            registry.Handlers.Select(handler => handler.Order),
+            Is.EqualTo(new[] { -10, 0 }));
+
+        await replacementRegistration.DisposeAsync();
+        Assert.That(registry.TryAcquire(typeof(FirstSource), out lease), Is.True);
+        using (lease)
+        {
+            Assert.That(lease!.Handler, Is.SameAs(original));
+        }
+    }
+
+    [Test]
+    public async Task Handlers_IsStableAndNotifiesOncePerVisibleDirectMutation()
+    {
+        await using var registry = new ElementSourceHandlerRegistry();
+        var handlers = registry.Handlers;
+        var snapshots = new List<int[]>();
+        handlers.CollectionChanged += (_, _) =>
+            snapshots.Add(handlers.Select(handler => handler.Order).ToArray());
+
+        IElementSourceHandlerRegistration original = registry.Register(
+            new ElementSourceHandlerRegistration(
+                new TestHandler(typeof(FirstSource)),
+                order: 20));
+        IElementSourceHandlerRegistration replacement = registry.Register(
+            new ElementSourceHandlerRegistration(
+                new TestHandler(typeof(FirstSource)),
+                ElementSourceHandlerRegistrationMode.Replace,
+                order: -10));
+        await replacement.DisposeAsync();
+        await original.DisposeAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(registry.Handlers, Is.SameAs(handlers));
+            Assert.That(snapshots, Is.EqualTo(new[]
+            {
+                new[] { 20 },
+                new[] { -10 },
+                new[] { 20 },
+                Array.Empty<int>(),
+            }));
+            Assert.That(handlers, Is.Empty);
+        }
+    }
+
+    [Test]
+    public async Task Handlers_DoesNotNotifyWhenOnlyTheImplementationChanges()
+    {
+        await using var registry = new ElementSourceHandlerRegistry();
+        int metadataChanges = 0;
+        registry.Handlers.CollectionChanged += (_, _) => metadataChanges++;
+        var original = new TestHandler(typeof(FirstSource));
+        var replacement = new TestHandler(typeof(FirstSource));
+        IElementSourceHandlerRegistration originalRegistration = registry.Register(
+            new ElementSourceHandlerRegistration(original));
+        IElementSourceHandlerRegistration replacementRegistration = registry.Register(
+            new ElementSourceHandlerRegistration(
+                replacement,
+                ElementSourceHandlerRegistrationMode.Replace));
+
+        Assert.That(registry.TryAcquire(
+            typeof(FirstSource),
+            out IElementSourceHandlerLease? replacementLease), Is.True);
+        using (replacementLease)
+        {
+            Assert.That(replacementLease!.Handler, Is.SameAs(replacement));
+        }
+        await replacementRegistration.DisposeAsync();
+        Assert.That(registry.TryAcquire(
+            typeof(FirstSource),
+            out IElementSourceHandlerLease? originalLease), Is.True);
+        using (originalLease)
+        {
+            Assert.That(originalLease!.Handler, Is.SameAs(original));
+        }
+
+        Assert.That(metadataChanges, Is.EqualTo(1));
+        await originalRegistration.DisposeAsync();
+        Assert.That(metadataChanges, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task HandlerMetadataObserverFailureDoesNotRollBackRegistryMutation()
+    {
+        await using var registry = new ElementSourceHandlerRegistry();
+        registry.Handlers.CollectionChanged += (_, _) =>
+            throw new InvalidOperationException("observer failure");
+        IElementSourceHandlerRegistration? registration = null;
+
+        Assert.DoesNotThrow(() => registration = registry.Register(
+            new ElementSourceHandlerRegistration(new TestHandler(typeof(FirstSource)))));
+        Assert.That(registry.TryAcquire(
+            typeof(FirstSource),
+            out IElementSourceHandlerLease? lease), Is.True);
+        lease!.Dispose();
+        Assert.DoesNotThrowAsync(async () => await registration!.DisposeAsync());
+        Assert.That(registry.Handlers, Is.Empty);
+    }
+
+    [Test]
+    public async Task Register_ReplaceRequiresAnExistingHandler()
+    {
+        await using var registry = new ElementSourceHandlerRegistry();
+
+        Assert.Throws<ArgumentException>(() => registry.Register(
+            new ElementSourceHandlerRegistration(
+                new TestHandler(typeof(FirstSource)),
+                ElementSourceHandlerRegistrationMode.Replace)));
+    }
+
+    [Test]
+    public async Task RegistrationDispose_RetiresBeforeWaitingAndDrainsActiveLeases()
+    {
+        await using var registry = new ElementSourceHandlerRegistry();
+        var fallback = new TestHandler(typeof(FirstSource));
+        var replacement = new TestHandler(typeof(FirstSource));
+        await using IElementSourceHandlerRegistration fallbackRegistration = registry.Register(
+            new ElementSourceHandlerRegistration(fallback, order: 10));
+        IElementSourceHandlerRegistration replacementRegistration = registry.Register(
+            new ElementSourceHandlerRegistration(
+                replacement,
+                ElementSourceHandlerRegistrationMode.Replace,
+                order: -10));
+        Assert.That(
+            registry.TryAcquire(typeof(FirstSource), out IElementSourceHandlerLease? activeLease),
+            Is.True);
+        IElementSourceHandlerLease lease = activeLease!;
+        int metadataChanges = 0;
+        registry.Handlers.CollectionChanged += (_, _) => metadataChanges++;
+
+        Task disposeTask = replacementRegistration.DisposeAsync().AsTask();
+        try
+        {
+            await WaitUntilAsync(IsFallbackActive, TimeSpan.FromSeconds(5));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(disposeTask.IsCompleted, Is.False);
+                Assert.That(lease.Handler, Is.SameAs(replacement));
+                Assert.That(registry.Handlers.Single().Order, Is.EqualTo(10));
+                Assert.That(metadataChanges, Is.EqualTo(1));
+            }
+        }
+        finally
+        {
+            lease.Dispose();
+            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        Assert.Throws<ObjectDisposedException>(() => _ = lease.Handler);
+
+        bool IsFallbackActive()
+        {
+            if (!registry.TryAcquire(typeof(FirstSource), out IElementSourceHandlerLease? candidate))
+                return false;
+
+            using (candidate)
+            {
+                return ReferenceEquals(candidate!.Handler, fallback);
+            }
+        }
+    }
+
+    [Test]
+    public async Task RegistryDisposalJoinsAConcurrentDirectRegistrationRetirement()
+    {
+        var registry = new ElementSourceHandlerRegistry();
+        IElementSourceHandlerRegistration registration = registry.Register(
+            new ElementSourceHandlerRegistration(new TestHandler(typeof(FirstSource))));
+        Assert.That(
+            registry.TryAcquire(typeof(FirstSource), out IElementSourceHandlerLease? lease),
+            Is.True);
+
+        Task registrationDisposal = registration.DisposeAsync().AsTask();
+        Assert.That(registrationDisposal.IsCompleted, Is.False);
+        Task registryDisposal = registry.DisposeAsync().AsTask();
+        Assert.That(registryDisposal.IsCompleted, Is.False);
+
+        lease!.Dispose();
+        await Task.WhenAll(registrationDisposal, registryDisposal)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ReentrantRegistryDisposalFromMetadataObserverStillWaitsForActiveLease()
+    {
+        await using var registry = new ElementSourceHandlerRegistry();
+        IElementSourceHandlerRegistration registration = registry.Register(
+            new ElementSourceHandlerRegistration(new TestHandler(typeof(FirstSource))));
+        Assert.That(registry.TryAcquire(
+            typeof(FirstSource),
+            out IElementSourceHandlerLease? lease), Is.True);
+        Task? reentrantDisposal = null;
+        registry.Handlers.CollectionChanged += (_, _) =>
+            reentrantDisposal ??= registry.DisposeAsync().AsTask();
+
+        Task registrationDisposal = registration.DisposeAsync().AsTask();
+        try
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(registrationDisposal.IsCompleted, Is.False);
+                Assert.That(reentrantDisposal, Is.Not.Null);
+                Assert.That(reentrantDisposal!.IsCompleted, Is.False);
+            }
+        }
+        finally
+        {
+            lease!.Dispose();
+        }
+
+        await Task.WhenAll(registrationDisposal, reentrantDisposal!)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ExtensionRegistrations_AreComposedAndRetiredWhenPackageIsRemoved()
+    {
+        var provider = new ExtensionProvider();
+        await using var registry = new ElementSourceHandlerRegistry([], provider);
+        var handlers = registry.Handlers;
+        int metadataChanges = 0;
+        handlers.CollectionChanged += (_, _) => metadataChanges++;
+        var handler = new TestHandler(typeof(FirstSource));
+        var extension = new TestExtension(
+        [
+            new ElementSourceHandlerRegistration(handler),
+        ]);
+
+        provider.AddExtensions(1, [extension]);
+
+        Assert.That(registry.TryAcquire(typeof(FirstSource), out IElementSourceHandlerLease? lease), Is.True);
+        using (lease)
+        {
+            Assert.That(lease!.Handler, Is.SameAs(handler));
+        }
+
+        await provider.RemoveExtensions(1).DrainAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(registry.TryAcquire(typeof(FirstSource), out lease), Is.False);
+            Assert.That(registry.Handlers, Is.SameAs(handlers));
+            Assert.That(handlers, Is.Empty);
+            Assert.That(metadataChanges, Is.EqualTo(2));
+        }
+    }
+
+    [Test]
+    public async Task ExtensionRemovalRetiresMetadataBeforeActiveLeaseDrainCompletes()
+    {
+        var provider = new ExtensionProvider();
+        await using var registry = new ElementSourceHandlerRegistry([], provider);
+        var handler = new TestHandler(typeof(FirstSource));
+        provider.AddExtensions(12,
+        [
+            new TestExtension(
+            [
+                new ElementSourceHandlerRegistration(handler),
+            ]),
+        ]);
+        Assert.That(registry.TryAcquire(
+            typeof(FirstSource),
+            out IElementSourceHandlerLease? lease), Is.True);
+
+        ExtensionRemoval removal = provider.RemoveExtensions(12);
+        Task drain = removal.DrainAsync().AsTask();
+        try
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(registry.Handlers, Is.Empty);
+                Assert.That(registry.TryAcquire(typeof(FirstSource), out _), Is.False);
+                Assert.That(drain.IsCompleted, Is.False);
+                Assert.That(lease!.Handler, Is.SameAs(handler));
+            }
+        }
+        finally
+        {
+            lease!.Dispose();
+        }
+
+        await drain.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task FailedProviderAdditionDoesNotPublishHandlerMetadata()
+    {
+        var provider = new ExtensionProvider();
+        await using var registry = new ElementSourceHandlerRegistry([], provider);
+        int metadataChanges = 0;
+        registry.Handlers.CollectionChanged += (_, _) => metadataChanges++;
+        provider.AllExtensions.CollectionChanged += (_, args) =>
+        {
+            if (args.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Add)
+                throw new InvalidOperationException("composition failure");
+        };
+        var extension = new TestExtension(
+        [
+            new ElementSourceHandlerRegistration(new TestHandler(typeof(FirstSource))),
+        ]);
+
+        var failure = Assert.Throws<ExtensionRegistrationNotificationException>(() =>
+            provider.AddExtensions(11, [extension]));
+        await failure!.Removal.DrainAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(registry.Handlers, Is.Empty);
+            Assert.That(metadataChanges, Is.Zero);
+            Assert.That(registry.TryAcquire(typeof(FirstSource), out _), Is.False);
+        }
+    }
+
+    [Test]
+    public async Task ExtensionRegistrations_ComposeReplacementEnumeratedBeforeItsBase()
+    {
+        var provider = new ExtensionProvider();
+        var failures = new List<ElementSourceHandlerExtensionFailure>();
+        await using var registry = new ElementSourceHandlerRegistry([], provider, failures.Add);
+        int metadataChanges = 0;
+        registry.Handlers.CollectionChanged += (_, _) => metadataChanges++;
+        var baseHandler = new TestHandler(typeof(FirstSource));
+        var replacementHandler = new TestHandler(typeof(FirstSource));
+        var replacement = new TestExtension(
+        [
+            new ElementSourceHandlerRegistration(
+                replacementHandler,
+                ElementSourceHandlerRegistrationMode.Replace),
+        ]);
+        var baseExtension = new TestExtension(
+        [
+            new ElementSourceHandlerRegistration(baseHandler),
+        ]);
+
+        provider.AddExtensions(3, [replacement, baseExtension]);
+
+        Assert.That(registry.TryAcquire(
+            typeof(FirstSource),
+            out IElementSourceHandlerLease? lease), Is.True);
+        using (lease)
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(lease!.Handler, Is.SameAs(replacementHandler));
+            Assert.That(replacement.RegistrationsReadCount, Is.EqualTo(1));
+            Assert.That(baseExtension.RegistrationsReadCount, Is.EqualTo(1));
+            Assert.That(failures, Is.Empty);
+            Assert.That(metadataChanges, Is.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public async Task InvalidExtensionRegistration_RollsBackPartialContributions()
+    {
+        var provider = new ExtensionProvider();
+        var failures = new List<ElementSourceHandlerExtensionFailure>();
+        var hostHandler = new TestHandler(typeof(FirstSource));
+        await using var registry = new ElementSourceHandlerRegistry(
+        [
+            new ElementSourceHandlerRegistration(hostHandler),
+        ],
+        provider,
+        failures.Add);
+        int metadataChanges = 0;
+        registry.Handlers.CollectionChanged += (_, _) => metadataChanges++;
+        var extension = new TestExtension(
+        [
+            new ElementSourceHandlerRegistration(new TestHandler(typeof(SecondSource))),
+            new ElementSourceHandlerRegistration(new TestHandler(typeof(FirstSource))),
+        ]);
+
+        provider.AddExtensions(2, [extension]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(failures, Has.Count.EqualTo(1));
+            Assert.That(registry.TryAcquire(typeof(SecondSource), out _), Is.False);
+            Assert.That(registry.TryAcquire(typeof(FirstSource), out IElementSourceHandlerLease? lease), Is.True);
+            using (lease)
+            {
+                Assert.That(lease!.Handler, Is.SameAs(hostHandler));
+            }
+            Assert.That(registry.Handlers.Select(handler => handler.SourceTypeName),
+                Is.EqualTo(new[] { typeof(FirstSource).AssemblyQualifiedName }));
+            Assert.That(metadataChanges, Is.Zero);
+        }
+    }
+
+    [Test]
+    public async Task InvalidProvisionalRegistration_DoesNotShadowAValidExtension()
+    {
+        var provider = new ExtensionProvider();
+        var failures = new List<ElementSourceHandlerExtensionFailure>();
+        await using var registry = new ElementSourceHandlerRegistry([], provider, failures.Add);
+        var invalidHandler = new TestHandler(typeof(FirstSource));
+        var validHandler = new TestHandler(typeof(FirstSource));
+        var invalidExtension = new TestExtension(
+        [
+            new ElementSourceHandlerRegistration(invalidHandler),
+            new ElementSourceHandlerRegistration(
+                new TestHandler(typeof(SecondSource)),
+                ElementSourceHandlerRegistrationMode.Replace),
+        ]);
+        var validExtension = new TestExtension(
+        [
+            new ElementSourceHandlerRegistration(validHandler),
+        ]);
+        var metadataSnapshots = new List<string[]>();
+        registry.Handlers.CollectionChanged += (_, _) => metadataSnapshots.Add(
+            registry.Handlers.Select(handler => handler.SourceTypeName).ToArray());
+
+        provider.AddExtensions(5, [invalidExtension, validExtension]);
+
+        Assert.That(registry.TryAcquire(typeof(FirstSource), out IElementSourceHandlerLease? lease), Is.True);
+        using (lease)
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(lease!.Handler, Is.SameAs(validHandler));
+            Assert.That(registry.TryAcquire(typeof(SecondSource), out _), Is.False);
+            Assert.That(failures, Has.Count.EqualTo(1));
+            Assert.That(metadataSnapshots, Has.Count.EqualTo(1));
+            Assert.That(metadataSnapshots.Single(),
+                Is.EqualTo(new[] { typeof(FirstSource).AssemblyQualifiedName }));
+        }
+    }
+
+    [Test]
+    public async Task InvalidExtensionNeverPublishesItsPartialRegistration()
+    {
+        var provider = new ExtensionProvider();
+        var failures = new List<ElementSourceHandlerExtensionFailure>();
+        await using var registry = new ElementSourceHandlerRegistry([], provider, failures.Add);
+        using var invalidGetterEntered = new ManualResetEventSlim();
+        using var releaseInvalidGetter = new ManualResetEventSlim();
+        var extension = new TestExtension(
+        [
+            new ElementSourceHandlerRegistration(new TestHandler(typeof(FirstSource))),
+            new ElementSourceHandlerRegistration(new BlockingInvalidHandler(
+                invalidGetterEntered,
+                releaseInvalidGetter)),
+        ]);
+
+        Task addition = Task.Run(() => provider.AddExtensions(4, [extension]));
+        Assert.That(invalidGetterEntered.Wait(TimeSpan.FromSeconds(5)), Is.True);
+        Task<bool> acquisition = Task.Run(() =>
+        {
+            bool acquired = registry.TryAcquire(
+                typeof(FirstSource),
+                out IElementSourceHandlerLease? lease);
+            lease?.Dispose();
+            return acquired;
+        });
+        Assert.That(
+            await acquisition.WaitAsync(TimeSpan.FromSeconds(2)),
+            Is.False,
+            "Plugin getters must run before the registry gate is acquired.");
+
+        releaseInvalidGetter.Set();
+        await addition.WaitAsync(TimeSpan.FromSeconds(5));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(acquisition.Result, Is.False);
+            Assert.That(failures, Has.Count.EqualTo(1));
+        }
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        const int DelayMilliseconds = 10;
+        int attempts = (int)Math.Ceiling(timeout.TotalMilliseconds / DelayMilliseconds);
+        for (int index = 0; index < attempts; index++)
+        {
+            if (condition())
+                return;
+
+            await Task.Delay(DelayMilliseconds);
+        }
+
+        Assert.Fail("The expected registry state was not reached before the timeout.");
+    }
+
+    private sealed record FirstSource : ElementSource;
+
+    private sealed record SecondSource : ElementSource;
+
+    private sealed class DelegatingGuidComparer : IEqualityComparer<Guid>
+    {
+        public bool Equals(Guid x, Guid y) => x.Equals(y);
+
+        public int GetHashCode(Guid obj) => obj.GetHashCode();
+    }
+
+    private sealed class SingleUseEnumerable<T>(IEnumerable<T> values) : IEnumerable<T>
+    {
+        private int _enumerations;
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            if (Interlocked.Increment(ref _enumerations) != 1)
+                throw new InvalidOperationException("The outer collection was enumerated twice.");
+            return values.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class SingleUseReadOnlySet<T>(IReadOnlySet<T> values) : IReadOnlySet<T>
+    {
+        private int _enumerations;
+
+        public int Count => values.Count;
+
+        public bool Contains(T item) => values.Contains(item);
+
+        public bool IsProperSubsetOf(IEnumerable<T> other) => values.IsProperSubsetOf(other);
+
+        public bool IsProperSupersetOf(IEnumerable<T> other) => values.IsProperSupersetOf(other);
+
+        public bool IsSubsetOf(IEnumerable<T> other) => values.IsSubsetOf(other);
+
+        public bool IsSupersetOf(IEnumerable<T> other) => values.IsSupersetOf(other);
+
+        public bool Overlaps(IEnumerable<T> other) => values.Overlaps(other);
+
+        public bool SetEquals(IEnumerable<T> other) => values.SetEquals(other);
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            if (Interlocked.Increment(ref _enumerations) != 1)
+                throw new InvalidOperationException("The inner set was enumerated twice.");
+            return values.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class TestHandler(Type sourceType) : IElementSourceHandler
+    {
+        public Type SourceType { get; } = sourceType;
+
+        public ValueTask<ElementSourcePreflightResult> PreflightAsync(
+            ElementSourcePreflightContext context,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public ValueTask<ElementSourceMaterializationResult> MaterializeAsync(
+            ElementSourceMaterializationContext context,
+            IElementSourcePreflight preflight,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class BlockingInvalidHandler(
+        ManualResetEventSlim entered,
+        ManualResetEventSlim release) : IElementSourceHandler
+    {
+        public Type SourceType
+        {
+            get
+            {
+                entered.Set();
+                if (!release.Wait(TimeSpan.FromSeconds(5)))
+                    throw new TimeoutException("The invalid handler getter was not released.");
+                return typeof(string);
+            }
+        }
+
+        public ValueTask<ElementSourcePreflightResult> PreflightAsync(
+            ElementSourcePreflightContext context,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public ValueTask<ElementSourceMaterializationResult> MaterializeAsync(
+            ElementSourceMaterializationContext context,
+            IElementSourcePreflight preflight,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class TestExtension : ElementSourceHandlerExtension
+    {
+        private readonly IReadOnlyCollection<ElementSourceHandlerRegistration> _registrations;
+
+        public TestExtension(IReadOnlyCollection<ElementSourceHandlerRegistration> registrations)
+        {
+            _registrations = registrations;
+        }
+
+        public int RegistrationsReadCount { get; private set; }
+
+        public override IReadOnlyCollection<ElementSourceHandlerRegistration> Registrations
+        {
+            get
+            {
+                RegistrationsReadCount++;
+                return _registrations;
+            }
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/PackageTools/AsyncOperationLifetimeTests.cs
+++ b/tests/Beutl.UnitTests/PackageTools/AsyncOperationLifetimeTests.cs
@@ -12,13 +12,13 @@ public sealed class AsyncOperationLifetimeTests
         var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var allowOperationToFinish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var requestsCanceled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        bool resourcesDisposed = false;
+        bool requestsCanceled = false;
+        int resourceDisposeCount = 0;
         var lifetime = new AsyncOperationLifetime(
-            () => requestsCanceled.TrySetResult(),
+            () => requestsCanceled = true,
             () =>
             {
-                resourcesDisposed = true;
+                resourceDisposeCount++;
                 return ValueTask.CompletedTask;
             });
         Task operation = lifetime.RunAsync(async cancellationToken =>
@@ -42,14 +42,14 @@ public sealed class AsyncOperationLifetimeTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(requestsCanceled.Task.IsCompleted, Is.True);
-            Assert.That(resourcesDisposed, Is.False);
+            Assert.That(requestsCanceled, Is.True);
+            Assert.That(resourceDisposeCount, Is.Zero);
             Assert.That(dispose.IsCompleted, Is.False);
         });
 
         allowOperationToFinish.TrySetResult();
         await Task.WhenAll(operation, dispose).WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.That(resourcesDisposed, Is.True);
+        Assert.That(resourceDisposeCount, Is.EqualTo(1));
     }
 
     [Test]
@@ -78,11 +78,127 @@ public sealed class AsyncOperationLifetimeTests
     }
 
     [Test]
-    public async Task DisposeAsync_StillDrainsAndDisposesWhenCancellationThrows()
+    public async Task DisposeAsync_PublishesOneTaskBeforeCancellationCanReenter()
     {
         var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var allowOperationToFinish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task? reentrantDisposal = null;
+        int resourceDisposeCount = 0;
+        AsyncOperationLifetime? lifetime = null;
+        lifetime = new AsyncOperationLifetime(
+            static () => { },
+            () =>
+            {
+                Interlocked.Increment(ref resourceDisposeCount);
+                return ValueTask.CompletedTask;
+            });
+        Task operation = lifetime.RunAsync(async cancellationToken =>
+        {
+            using CancellationTokenRegistration registration = cancellationToken.Register(() =>
+                reentrantDisposal = lifetime.DisposeAsync().AsTask());
+            operationStarted.TrySetResult();
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
+        });
+        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Task disposal = lifetime.DisposeAsync().AsTask();
+        await Task.WhenAll(operation, disposal).WaitAsync(TimeSpan.FromSeconds(5));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(reentrantDisposal, Is.SameAs(disposal));
+            Assert.That(resourceDisposeCount, Is.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public async Task DisposeAsync_SynchronousReentrantWaitCompletesAtTheSharedDeadline()
+    {
+        var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var callbackReturned = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int resourceDisposeCount = 0;
+        AsyncOperationLifetime? lifetime = null;
+        lifetime = new AsyncOperationLifetime(
+            static () => { },
+            () =>
+            {
+                resourceDisposeCount++;
+                return ValueTask.CompletedTask;
+            },
+            TimeSpan.FromMilliseconds(100));
+        Task operation = lifetime.RunAsync(async cancellationToken =>
+        {
+            using CancellationTokenRegistration registration = cancellationToken.Register(() =>
+            {
+                lifetime.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                callbackReturned.TrySetResult();
+            });
+            operationStarted.TrySetResult();
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
+        });
+        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var stopwatch = Stopwatch.StartNew();
+        await lifetime.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        stopwatch.Stop();
+        await callbackReturned.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await operation.WaitAsync(TimeSpan.FromSeconds(5));
+        await WaitUntilAsync(() => resourceDisposeCount == 1, TimeSpan.FromSeconds(5));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(2)));
+            Assert.That(resourceDisposeCount, Is.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public async Task DisposeAsync_CancellationCallbackFailureCannotSkipOtherCancellationOrCleanup()
+    {
+        var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        bool pendingRequestsCanceled = false;
+        int resourceDisposeCount = 0;
+        var lifetime = new AsyncOperationLifetime(
+            () => pendingRequestsCanceled = true,
+            () =>
+            {
+                resourceDisposeCount++;
+                return ValueTask.CompletedTask;
+            });
+        Task operation = lifetime.RunAsync(async cancellationToken =>
+        {
+            using CancellationTokenRegistration registration = cancellationToken.Register(static () =>
+                throw new InvalidOperationException("callback failed"));
+            operationStarted.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        });
+        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.CatchAsync<Exception>(async () =>
+            await lifetime.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.CatchAsync<OperationCanceledException>(async () => await operation);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(pendingRequestsCanceled, Is.True);
+            Assert.That(resourceDisposeCount, Is.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public async Task DisposeAsync_CancelPendingFailureCannotSkipResourceCleanup()
+    {
         bool resourcesDisposed = false;
         var lifetime = new AsyncOperationLifetime(
             static () => throw new InvalidOperationException("cancel failed"),
@@ -91,143 +207,56 @@ public sealed class AsyncOperationLifetimeTests
                 resourcesDisposed = true;
                 return ValueTask.CompletedTask;
             });
-        Task operation = lifetime.RunAsync(async cancellationToken =>
-        {
-            operationStarted.TrySetResult();
-            try
-            {
-                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                cancellationObserved.TrySetResult();
-            }
 
-            await allowOperationToFinish.Task;
-        });
-        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-
-        Task dispose = lifetime.DisposeAsync().AsTask();
-        await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        allowOperationToFinish.TrySetResult();
-
-        await operation.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.Multiple(() =>
-        {
-            Assert.That(
-                async () => await dispose.WaitAsync(TimeSpan.FromSeconds(5)),
-                Throws.TypeOf<InvalidOperationException>());
-            Assert.That(resourcesDisposed, Is.True);
-        });
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await lifetime.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.That(resourcesDisposed, Is.True);
     }
 
     [Test]
-    public async Task RunAsync_InvokesCompletionWhenCallerCancelsButLifetimeIsNotStopping()
+    public async Task DisposeAsync_DeadlineDefersResourcesUntilAStubbornOperationReleasesThem()
     {
         var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var allowOperationToFinish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        int completionCount = 0;
-        var lifetime = new AsyncOperationLifetime(
-            static () => { },
-            static () => ValueTask.CompletedTask);
-        using var callerCancellation = new CancellationTokenSource();
-
-        Task operation = lifetime.RunAsync(
-            async cancellationToken =>
-            {
-                operationStarted.TrySetResult();
-                try
-                {
-                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
-                }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                {
-                    cancellationObserved.TrySetResult();
-                }
-
-                await allowOperationToFinish.Task;
-            },
-            () => Interlocked.Increment(ref completionCount),
-            callerCancellation.Token);
-        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-
-        callerCancellation.Cancel();
-        await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        allowOperationToFinish.TrySetResult();
-        await operation.WaitAsync(TimeSpan.FromSeconds(5));
-
-        Assert.That(completionCount, Is.EqualTo(1));
-    }
-
-    [Test]
-    public async Task DisposeAsync_RunsCancelPendingRequests_WhenTokenCallbackThrows()
-    {
-        var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var allowOperationToFinish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        bool requestsCanceled = false;
-        var lifetime = new AsyncOperationLifetime(
-            () => requestsCanceled = true,
-            static () => ValueTask.CompletedTask);
-
-        Task operation = lifetime.RunAsync(async cancellationToken =>
-        {
-            operationStarted.TrySetResult();
-            using var registration = cancellationToken.Register(static () =>
-                throw new InvalidOperationException("callback failed"));
-            try
-            {
-                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-            }
-
-            await allowOperationToFinish.Task;
-        });
-        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-
-        Task dispose = lifetime.DisposeAsync().AsTask();
-        allowOperationToFinish.TrySetResult();
-
-        await operation.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.CatchAsync<Exception>(async () =>
-            await dispose.WaitAsync(TimeSpan.FromSeconds(5)));
-        Assert.That(requestsCanceled, Is.True,
-            "CancelPendingRequests must run even when a token callback throws");
-    }
-
-    [Test]
-    public async Task DisposeAsync_StopsWaitingAtTheDrainDeadline_WhenAnOperationNeverCompletes()
-    {
-        var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        bool resourcesDisposed = false;
+        var releaseOperation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int resourceDisposeCount = 0;
         var lifetime = new AsyncOperationLifetime(
             static () => { },
             () =>
             {
-                resourcesDisposed = true;
+                resourceDisposeCount++;
                 return ValueTask.CompletedTask;
             },
-            drainDeadlineMilliseconds: 500);
-        Task operation = lifetime.RunAsync(async cancellationToken =>
+            TimeSpan.FromMilliseconds(100));
+        Task operation = lifetime.RunAsync(async _ =>
         {
             operationStarted.TrySetResult();
-            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            await releaseOperation.Task;
         });
         await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         var stopwatch = Stopwatch.StartNew();
-        await lifetime.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        await lifetime.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
         stopwatch.Stop();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
-            Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(5)),
-                "disposal must stop waiting at the drain deadline even when an operation never completes");
-            Assert.That(resourcesDisposed, Is.True,
-                "resources must still be disposed after the drain deadline expires");
-        });
+            Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(2)));
+            Assert.That(resourceDisposeCount, Is.Zero,
+                "Resources must remain alive while the admitted operation can still use them.");
+        }
+
+        releaseOperation.TrySetResult();
+        await operation.WaitAsync(TimeSpan.FromSeconds(5));
+        await WaitUntilAsync(() => resourceDisposeCount == 1, TimeSpan.FromSeconds(5));
+        Assert.That(resourceDisposeCount, Is.EqualTo(1));
     }
 
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        using var cancellation = new CancellationTokenSource(timeout);
+        while (!condition())
+        {
+            await Task.Delay(10, cancellation.Token);
+        }
+    }
 }

--- a/tests/Beutl.UnitTests/Services/AI/AiOutstandingRequestsTests.cs
+++ b/tests/Beutl.UnitTests/Services/AI/AiOutstandingRequestsTests.cs
@@ -1,0 +1,76 @@
+﻿using Beutl.Services.AI;
+
+namespace Beutl.UnitTests.Services.AI;
+
+public class AiOutstandingRequestsTests
+{
+    [Test]
+    public void TryFind_ReadsTheRequestThatWasSentLast()
+    {
+        // 同じ task の依頼が 2 つ未回収で残ることがある——1 枚目を X で、2 枚目を
+        // Y で送って、どちらも答えが返らないまま戻ってきたとき。戻り先の一覧が
+        // どちらのモデルに落ち着くかが呼び出しごとに変わると、画面が見せるものが
+        // 定まらない。最後に送ったものが、画面が最後に見せていたもの。
+        var requests = new AiOutstandingRequests();
+        requests.Remember(new AiRequestName("upscale-first", IsRepeat: false), ["upscale", "model-x"]);
+        requests.Remember(new AiRequestName("upscale-second", IsRepeat: false), ["upscale", "model-y"]);
+
+        Assert.That(
+            requests.TryFind(request => request[0] == "upscale", out string?[] found),
+            Is.True);
+        Assert.That(found[1], Is.EqualTo("model-y"));
+    }
+
+    [Test]
+    public void TryFind_FallsBackToWhatIsLeftOnceTheNewestIsSettled()
+    {
+        var requests = new AiOutstandingRequests();
+        var first = new AiRequestName("upscale-first", IsRepeat: false);
+        var second = new AiRequestName("upscale-second", IsRepeat: false);
+        requests.Remember(first, ["upscale", "model-x"]);
+        requests.Remember(second, ["upscale", "model-y"]);
+
+        requests.Forget(second);
+
+        Assert.That(
+            requests.TryFind(request => request[0] == "upscale", out string?[] found),
+            Is.True);
+        Assert.That(found[1], Is.EqualTo("model-x"));
+
+        requests.Forget(first);
+        Assert.Multiple(() =>
+        {
+            Assert.That(requests.TryFind(request => request[0] == "upscale", out _), Is.False);
+            Assert.That(requests.Any(request => request[0] == "upscale"), Is.False);
+            Assert.That(requests.All(), Is.Empty);
+        });
+    }
+
+    [Test]
+    public void Remember_SendingTheSameNameAgainLeavesOneRequestUnderIt()
+    {
+        // 同じ名前で送り直しても、抱えているのは 1 つの依頼。二重に数えると、
+        // 決着させても片方が残り、その task はいつまでも未回収に見える。
+        var requests = new AiOutstandingRequests();
+        var name = new AiRequestName("upscale-first", IsRepeat: false);
+        requests.Remember(name, ["upscale", "model-x"]);
+        requests.Remember(name with { IsRepeat = true }, ["upscale", "model-x"]);
+
+        Assert.That(requests.All().Count(), Is.EqualTo(1));
+
+        requests.Forget(name);
+        Assert.That(requests.All(), Is.Empty);
+    }
+
+    [Test]
+    public void Remember_KeepsNothingForARequestThatWasNeverNamed()
+    {
+        // 名前の付かなかった依頼は、サーバーが何も作っていない。抱えると、その
+        // task がいつまでも未回収に見え、一覧が取りに行けなくなる。
+        var requests = new AiOutstandingRequests();
+
+        requests.Remember(new AiRequestName(string.Empty, IsRepeat: false), ["upscale", "model-x"]);
+
+        Assert.That(requests.All(), Is.Empty);
+    }
+}

--- a/tests/Beutl.UnitTests/Services/AI/AiRequestKeyTests.cs
+++ b/tests/Beutl.UnitTests/Services/AI/AiRequestKeyTests.cs
@@ -1,0 +1,1164 @@
+﻿using Beutl.Api.Services;
+using Beutl.Services.AI;
+
+namespace Beutl.UnitTests.Services.AI;
+
+[TestFixture]
+public sealed class AiRequestKeyTests
+{
+    [Test]
+    public void CanWithdraw_AuthenticationRequiresKnownAbsentFirstAttempt()
+    {
+        var first = new AiRequestName("first", IsRepeat: false);
+        var repeat = new AiRequestName("repeat", IsRepeat: true);
+        var knownAbsent = new AuthenticationRequiredException();
+        var unknown = new AuthenticationRequiredException(
+            currentAttemptReservationIsKnownAbsent: false);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(AiRequestOutcome.CanWithdraw(first, knownAbsent), Is.True);
+            Assert.That(AiRequestOutcome.CanWithdraw(first, unknown), Is.False);
+            Assert.That(AiRequestOutcome.CanWithdraw(repeat, knownAbsent), Is.False);
+            Assert.That(
+                AiRequestOutcome.CanWithdraw(first, new AiFileTooLargeException()),
+                Is.True);
+            Assert.That(
+                AiRequestOutcome.CanWithdraw(repeat, new AiFileTooLargeException()),
+                Is.False);
+            Assert.That(
+                AiRequestOutcome.CanWithdraw(repeat, new AiPlanRequiredException()),
+                Is.True);
+        }
+    }
+
+    [Test]
+    public void NameFor_TellsTheSameRequestFromADifferentOne()
+    {
+        var key = new AiRequestKey();
+
+        AiRequestName first = key.NameFor("a prompt", "16:9");
+        AiRequestName again = key.NameFor("a prompt", "16:9");
+        AiRequestName other = key.NameFor("a prompt", "9:16");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.IsRepeat, Is.False);
+            Assert.That(again.Key, Is.EqualTo(first.Key));
+            Assert.That(again.IsRepeat, Is.True);
+            Assert.That(other.Key, Is.Not.EqualTo(first.Key));
+        });
+    }
+
+    [Test]
+    public void Withdraw_ClosesANameTheServerNeverMadeAJobUnder()
+    {
+        // 名前はリクエストを出す前に配られる。契約や残高やモデルの可否で断られた
+        // ときは、サーバーは名前を先に引いて「何も無い」と分かったうえで断って
+        // いる——job は作られていない。その名前を抱えたままだと、実行はそれを
+        // 名乗ったモデルに縛られ、作られてもいない job への道が開いたままになる。
+        var key = new AiRequestKey();
+        AiRequestName issued = key.NameFor("a prompt");
+        Assert.That(key.HasOutstandingName.Value, Is.True);
+
+        key.Withdraw(issued);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(key.HasOutstandingName.Value, Is.False);
+            // 取り下げたので、次は初めての依頼として扱われる——残高の確認が
+            // もう一度前に立つ。
+            Assert.That(key.NameFor("a prompt").IsRepeat, Is.False);
+        });
+    }
+
+    [Test]
+    public void Withdraw_LetsTheSameRequestGoOutUnderTheSameNameAgain()
+    {
+        // 予約されなかったのだから、その名前はまだ何も指していない。同じ依頼は
+        // 同じ名前で出してよい——別の名前にすると、次に届いたときに新しい依頼
+        // として課金される。
+        var key = new AiRequestKey();
+        AiRequestName issued = key.NameFor("a prompt");
+
+        key.Withdraw(issued);
+
+        Assert.That(key.NameFor("a prompt").Key, Is.EqualTo(issued.Key));
+    }
+
+    [Test]
+    public void DispatchedExactOwnerCanWithdrawAfterAuthoritativeNoReservation()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            var store = new FileAiRequestRecoveryStore(directory);
+            var key = new AiRequestKey(
+                recoveryContext: RecoveryContext(store, () => "account"),
+                operation: "video.generate");
+            AiRequestName issued = key.NameFor("a prompt");
+            AiRequestRecoveryLease claim = key.TryClaim(issued)!;
+            key.MarkClaimDispatched(claim);
+            AiPendingAttempt pending = store.PendingFor("account", "video.generate").Single();
+
+            Assert.That(store.TryWithdraw(
+                pending.AccountId,
+                pending.Operation,
+                pending.Fingerprint,
+                pending.Key), Is.False,
+                "A caller without the dispatch owner cannot clear a paid-job fence.");
+            // The ordinary withdrawal API is deliberately fail-closed once
+            // dispatch has been persisted; only the owner-authorized path used
+            // for an authoritative no-reservation response may clear it.
+            key.Withdraw(issued);
+            Assert.That(store.Find(
+                pending.AccountId,
+                pending.Operation,
+                pending.Fingerprint), Is.Not.Null);
+
+            key.WithdrawAfterNoReservation(issued);
+            Assert.Multiple(() =>
+            {
+                Assert.That(store.Find(
+                    pending.AccountId,
+                    pending.Operation,
+                    pending.Fingerprint), Is.Null);
+                Assert.That(claim.IsReleased, Is.True);
+            });
+
+            AiRequestName retry = key.NameFor("a prompt");
+            Assert.Multiple(() =>
+            {
+                Assert.That(retry.Key, Is.EqualTo(issued.Key));
+                Assert.That(retry.IsRepeat, Is.False);
+            });
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void OwnerAuthorizedWithdrawalRequiresTheLiveDispatchLease()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            var store = new FileAiRequestRecoveryStore(directory);
+            var key = new AiRequestKey(
+                recoveryContext: RecoveryContext(store, () => "account"),
+                operation: "video.generate");
+            AiRequestName issued = key.NameFor("a prompt");
+            AiRequestRecoveryLease claim = key.TryClaim(issued)!;
+            key.MarkClaimDispatched(claim);
+            AiPendingAttempt pending = store.PendingFor("account", "video.generate").Single();
+
+            // Process loss releases the in-memory handle, but not the durable
+            // dispatched fence. A later call without the live owner must stay
+            // fail-closed until the provider outcome is known.
+            claim.Dispose();
+            key.WithdrawAfterNoReservation(issued);
+
+            Assert.That(store.Find(
+                pending.AccountId,
+                pending.Operation,
+                pending.Fingerprint), Is.Not.Null);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void Retire_SettlesOneRequestAndLeavesTheOthersOutstanding()
+    {
+        // A が課金されたまま応答を落とし、入力を変えた B が成功する。B の決着で
+        // A の名前まで捨てると、A に戻ったとき新しい名前になり、支払い済みの
+        // ものをもう一度買うことになる。
+        var key = new AiRequestKey();
+        AiRequestName a = key.NameFor("prompt a");
+        AiRequestName b = key.NameFor("prompt b");
+
+        key.Retire(b);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(key.HasOutstandingName.Value, Is.True);
+            Assert.That(key.NameFor("prompt a").Key, Is.EqualTo(a.Key));
+            Assert.That(key.NameFor("prompt a").IsRepeat, Is.True);
+            // 決着した依頼をもう一度出すなら、それは新しい依頼。
+            Assert.That(key.NameFor("prompt b").Key, Is.Not.EqualTo(b.Key));
+        });
+    }
+
+    [Test]
+    public void Withdraw_LeavesTheOtherNamesOfTheRunAlone()
+    {
+        var key = new AiRequestKey();
+        AiRequestName first = key.NameFor(0, "a chunk");
+        AiRequestName second = key.NameFor(1, "a chunk");
+
+        key.Withdraw(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(key.HasOutstandingName.Value, Is.True);
+            Assert.That(key.NameFor(0, "a chunk").Key, Is.EqualTo(first.Key));
+            Assert.That(key.NameFor(0, "a chunk").IsRepeat, Is.True);
+        });
+    }
+
+    [Test]
+    public void FileStamp_NamesAFileTheWayTheServerDoes()
+    {
+        // サーバーは、届いた名前と中身でその依頼を見分ける。場所や更新時刻で
+        // 見分けると、移しただけ・触っただけの絵が別の依頼になり、同じ仕事を
+        // 二度買うことになる。
+        string directory = Path.Combine(
+            Path.GetTempPath(),
+            "Beutl.UnitTests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            string here = Path.Combine(directory, "picture.png");
+            string moved = Path.Combine(directory, "moved");
+            Directory.CreateDirectory(moved);
+            string there = Path.Combine(moved, "picture.png");
+            File.WriteAllBytes(here, [1, 2, 3]);
+            string before = AiRequestKey.FileStamp(here);
+
+            File.SetLastWriteTimeUtc(here, DateTime.UnixEpoch);
+            Assert.That(AiRequestKey.FileStamp(here), Is.EqualTo(before),
+                "Touching a file does not make it another request.");
+
+            File.Copy(here, there);
+            Assert.That(AiRequestKey.FileStamp(there), Is.EqualTo(before),
+                "Nor does moving it.");
+
+            File.WriteAllBytes(here, [3, 2, 1]);
+            Assert.That(AiRequestKey.FileStamp(here), Is.Not.EqualTo(before),
+                "Changing what is in it does.");
+
+            string renamed = Path.Combine(directory, "another.png");
+            File.WriteAllBytes(renamed, [1, 2, 3]);
+            Assert.That(AiRequestKey.FileStamp(renamed), Is.Not.EqualTo(before),
+                "So does the name it arrives under.");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void Retire_StartsTheNextRequestUnderAFreshName()
+    {
+        var key = new AiRequestKey();
+        AiRequestName settled = key.NameFor("a prompt");
+
+        key.Retire();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(key.HasOutstandingName.Value, Is.False);
+            Assert.That(key.NameFor("a prompt").Key, Is.Not.EqualTo(settled.Key));
+        });
+    }
+
+    [Test]
+    public void ResumedRun_AsksForItsFirstPieceAsARepeat()
+    {
+        // 控えから拾い直した実行は、名前は持っていても「どれを送ったか」は
+        // 持っていない。最初に配り直す名前は、前のセッションで支払われた job を
+        // 指しているかもしれないので、一度だけ再送として扱う。
+        var resumed = new AiRequestKey("seed-of-the-run", namePending: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(resumed.HasOutstandingName.Value, Is.True);
+            Assert.That(resumed.NameFor(0, "a chunk").IsRepeat, Is.True);
+            Assert.That(resumed.NameFor(1, "a chunk").IsRepeat, Is.False);
+        });
+    }
+
+    [Test]
+    public void ResumedRun_WithNothingInFlight_StartsAsANewRequest()
+    {
+        // seed が残っているだけでは、支払われたということにはならない——予約
+        // されなかった依頼や、返金されて捨てられた依頼の seed も控えに残る。
+        // それを再送として扱うと、誰も払っていない依頼が「支払い済みの回収」に
+        // 化けて、残高の確認をすり抜ける。
+        var resumed = new AiRequestKey("seed-of-the-run", namePending: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(resumed.HasOutstandingName.Value, Is.False);
+            Assert.That(resumed.NameFor(0, "a chunk").IsRepeat, Is.False);
+        });
+    }
+
+    [Test]
+    public void Seed_SurvivesIntoTheNamesOfAResumedRun()
+    {
+        var key = new AiRequestKey();
+        AiRequestName original = key.NameFor(2, "a chunk");
+
+        var resumed = new AiRequestKey(key.Seed);
+
+        Assert.That(resumed.NameFor(2, "a chunk").Key, Is.EqualTo(original.Key));
+    }
+
+    [TestCase("image.generate", null)]
+    [TestCase("video.generate", null)]
+    [TestCase("image.edit", "upscale")]
+    public void DurableNameSurvivesARecreatedRequestKey(
+        string operation,
+        string? editTask)
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            var firstStore = new FileAiRequestRecoveryStore(directory);
+            var first = new AiRequestKey(
+                recoveryContext: RecoveryContext(firstStore, () => "account"),
+                operation: operation);
+            string?[] parts = editTask is null ? ["prompt"] : [editTask, "prompt"];
+            AiRequestName issued = first.NameFor(parts);
+
+            var restarted = new AiRequestKey(
+                recoveryContext: RecoveryContext(
+                    new FileAiRequestRecoveryStore(directory),
+                    () => "account"),
+                operation: operation);
+            AiRequestName recovered = restarted.NameFor(parts);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(recovered.Key, Is.EqualTo(issued.Key));
+                Assert.That(recovered.IsRepeat, Is.True);
+                if (editTask is not null)
+                {
+                    Assert.That(
+                        File.ReadAllText(Path.Combine(directory, "ai-request-recovery.json")),
+                        Does.Contain($"image.edit.{editTask}"));
+                }
+            });
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void RetireRemovesTheIssuingAccountAfterAnAccountSwitch()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string? account = "account-a";
+            var store = new FileAiRequestRecoveryStore(directory);
+            var key = new AiRequestKey(
+                recoveryContext: RecoveryContext(store, () => account),
+                operation: "image.generate");
+            AiRequestName issued = key.NameFor("prompt");
+            account = "account-b";
+            AiRequestName issuedForB = key.NameFor("prompt");
+            Assert.That(issuedForB.Key, Is.Not.EqualTo(issued.Key));
+
+            key.Retire(issued);
+
+            var accountA = new AiRequestKey(
+                recoveryContext: RecoveryContext(
+                    new FileAiRequestRecoveryStore(directory),
+                    () => "account-a"),
+                operation: "image.generate");
+            var accountB = new AiRequestKey(
+                recoveryContext: RecoveryContext(
+                    new FileAiRequestRecoveryStore(directory),
+                    () => "account-b"),
+                operation: "image.generate");
+            Assert.Multiple(() =>
+            {
+                Assert.That(accountA.NameFor("prompt").Key, Is.Not.EqualTo(issued.Key));
+                Assert.That(accountB.NameFor("prompt").Key, Is.EqualTo(issuedForB.Key));
+            });
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void AccountSwitchBeforeSendFailsWithoutDeletingTheIssuedRecovery()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string? account = "account-a";
+            var store = new FileAiRequestRecoveryStore(directory);
+            var key = new AiRequestKey(
+                recoveryContext: RecoveryContext(store, () => account),
+                operation: "image.generate");
+            AiRequestName issued = key.NameFor("prompt");
+            account = "account-b";
+
+            Assert.Throws<AuthenticationRequiredException>(() =>
+                key.EnterAuthenticatedScope(issued));
+
+            var accountA = new AiRequestKey(
+                recoveryContext: RecoveryContext(
+                    new FileAiRequestRecoveryStore(directory),
+                    () => "account-a"),
+                operation: "image.generate");
+            Assert.That(accountA.NameFor("prompt").Key, Is.EqualTo(issued.Key));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void StoreFailureDoesNotPublishAnInMemoryOutstandingName()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            var store = new FileAiRequestRecoveryStore(directory);
+            var key = new AiRequestKey(
+                recoveryContext: RecoveryContext(store, () => "account"),
+                operation: "image.generate");
+            string lockPath = Path.Combine(directory, "ai-request-recovery.json.lock");
+            using (var lease = new FileStream(
+                       lockPath,
+                       FileMode.OpenOrCreate,
+                       FileAccess.ReadWrite,
+                       FileShare.None))
+            {
+                Assert.Throws<InvalidDataException>(() => key.NameFor("prompt"));
+                Assert.That(key.HasOutstandingName.Value, Is.False);
+            }
+
+            AiRequestName issued = key.NameFor("prompt");
+            Assert.Multiple(() =>
+            {
+                Assert.That(issued.IsRepeat, Is.False);
+                Assert.That(key.HasOutstandingName.Value, Is.True);
+            });
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void RetireLeavesOtherDurableRequestNamesRecoverable()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            var store = new FileAiRequestRecoveryStore(directory);
+            var key = new AiRequestKey(
+                recoveryContext: RecoveryContext(store, () => "account"),
+                operation: "image.generate");
+            AiRequestName first = key.NameFor("first");
+            AiRequestName second = key.NameFor("second");
+            key.Retire(second);
+
+            var restarted = new AiRequestKey(
+                recoveryContext: RecoveryContext(
+                    new FileAiRequestRecoveryStore(directory),
+                    () => "account"),
+                operation: "image.generate");
+            Assert.Multiple(() =>
+            {
+                Assert.That(restarted.NameFor("first").Key, Is.EqualTo(first.Key));
+                Assert.That(restarted.NameFor("first").IsRepeat, Is.True);
+                Assert.That(restarted.NameFor("second").Key, Is.Not.EqualTo(second.Key));
+            });
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void RestartedKeySettlingOneDurableRequestKeepsGateAndOtherModel()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            var first = new AiRequestKey(
+                recoveryContext: RecoveryContext(new FileAiRequestRecoveryStore(directory), () => "account"),
+                operation: "image.generate");
+            string?[] firstParts = ["p1", "", "", "", "model-a"];
+            string?[] secondParts = ["p2", "", "", "", "model-b"];
+            AiRequestName firstName = first.NameFor(firstParts);
+            _ = first.NameFor(secondParts);
+
+            var restarted = new AiRequestKey(
+                recoveryContext: RecoveryContext(new FileAiRequestRecoveryStore(directory), () => "account"),
+                operation: "image.generate");
+            AiRequestName materialized = restarted.NameFor(firstParts);
+            restarted.Retire(materialized);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(restarted.HasOutstandingName.Value, Is.True);
+                Assert.That(restarted.PersistedModels(AiOperations.ImageGeneration),
+                    Does.Contain(new AiModelId("model-b")));
+                Assert.That(materialized.Key, Is.EqualTo(firstName.Key));
+            });
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void RetireAllRemovesEveryDurableIdentityBeforeResettingMemory()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            var key = new AiRequestKey(
+                recoveryContext: RecoveryContext(
+                    new FileAiRequestRecoveryStore(directory),
+                    () => "account"),
+                operation: "image.generate");
+            AiRequestName first = key.NameFor("first");
+            AiRequestName second = key.NameFor("second");
+
+            key.Retire();
+
+            var restarted = new AiRequestKey(
+                recoveryContext: RecoveryContext(
+                    new FileAiRequestRecoveryStore(directory),
+                    () => "account"),
+                operation: "image.generate");
+            Assert.Multiple(() =>
+            {
+                Assert.That(restarted.NameFor("first").Key, Is.Not.EqualTo(first.Key));
+                Assert.That(restarted.NameFor("second").Key, Is.Not.EqualTo(second.Key));
+            });
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void DurableRecoveryOpensCommandGateButOnlyExactFingerprintIsRepeat()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            var first = new AiRequestKey(
+                recoveryContext: RecoveryContext(
+                    new FileAiRequestRecoveryStore(directory),
+                    () => "account"),
+                operation: "image.generate");
+            AiRequestName paid = first.NameFor("paid prompt");
+
+            var restarted = new AiRequestKey(
+                recoveryContext: RecoveryContext(
+                    new FileAiRequestRecoveryStore(directory),
+                    () => "account"),
+                operation: "image.generate");
+            bool gateWasOpen = restarted.HasOutstandingName.Value;
+            AiRequestName unrelated = restarted.NameFor("another prompt");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(gateWasOpen, Is.True);
+                Assert.That(unrelated.IsRepeat, Is.False);
+                Assert.That(unrelated.Key, Is.Not.EqualTo(paid.Key));
+            });
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void DispatchedRecoveryCanResumeWithTheSameLocalOwner()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            var firstStore = new FileAiRequestRecoveryStore(directory);
+            var first = new AiRequestKey(
+                recoveryContext: RecoveryContext(firstStore, () => "account"),
+                operation: "video.generate");
+            AiRequestName issued = first.NameFor("prompt");
+            AiRequestRecoveryLease original = first.TryClaim(issued)!;
+            first.MarkClaimDispatched(original);
+            string owner = original.OwnerToken;
+            original.Dispose();
+            AiPendingAttempt pending = first.PendingAttempts(AiOperations.VideoGeneration).Single();
+
+            var competingStore = new FileAiRequestRecoveryStore(directory);
+            AiRequestRecoveryLease? competing = competingStore.Claim(
+                pending.AccountId, pending.Operation, pending.Fingerprint, issued.Key);
+            Assert.That(competing, Is.Null);
+            Assert.That(competingStore.Abandon(pending), Is.False);
+
+            AiRequestName retry = first.NameFor("prompt");
+            AiRequestRecoveryLease? resumed = first.TryClaim(retry);
+            Assert.That(resumed, Is.Not.Null);
+            Assert.That(resumed!.OwnerToken, Is.EqualTo(owner));
+
+            first.Retire(retry);
+            Assert.That(competingStore.Find(
+                pending.AccountId,
+                pending.Operation,
+                pending.Fingerprint), Is.Null);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void ExpiredDispatchedFenceRejectsAbandonAndCompetingClaimButExactOwnerCanSettle()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            var firstStore = new FileAiRequestRecoveryStore(directory, () => now);
+            var key = new AiRequestKey(
+                recoveryContext: RecoveryContext(firstStore, () => "account"),
+                operation: "video.generate");
+            AiRequestName issued = key.NameFor("prompt");
+            AiRequestRecoveryLease owner = key.TryClaim(issued)!;
+            key.MarkClaimDispatched(owner);
+            AiPendingAttempt pending = firstStore.PendingFor("account", "video.generate").Single();
+            owner.Dispose();
+
+            now = now.AddMinutes(16);
+            var restartedStore = new FileAiRequestRecoveryStore(directory, () => now);
+            Assert.Throws<InvalidDataException>(() => restartedStore.Claim(
+                pending.AccountId,
+                pending.Operation,
+                pending.Fingerprint,
+                pending.Key + "-wrong"));
+            AiRequestRecoveryLease adopted = restartedStore.Claim(
+                pending.AccountId,
+                pending.Operation,
+                pending.Fingerprint,
+                pending.Key)!;
+            Assert.That(adopted, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(adopted.IsDispatched, Is.True);
+                Assert.That(adopted.OwnerToken, Is.Not.EqualTo(owner.OwnerToken));
+                Assert.That(adopted.Generation, Is.EqualTo(owner.Generation));
+                Assert.That(restartedStore.Abandon(pending), Is.False);
+                Assert.That(owner.Renew(), Is.False);
+                Assert.That(restartedStore.TrySettle(
+                    pending.AccountId,
+                    pending.Operation,
+                    pending.Fingerprint,
+                    pending.Key,
+                    owner.OwnerToken,
+                    owner.Generation), Is.False);
+                Assert.That(restartedStore.TrySettle(
+                    pending.AccountId,
+                    pending.Operation,
+                    pending.Fingerprint,
+                    pending.Key,
+                    adopted.OwnerToken,
+                    adopted.Generation + 1), Is.False);
+                Assert.That(restartedStore.TrySettle(
+                    pending.AccountId,
+                    pending.Operation,
+                    pending.Fingerprint,
+                    pending.Key,
+                    adopted.OwnerToken,
+                    adopted.Generation), Is.True);
+            });
+            Assert.That(restartedStore.Find(
+                pending.AccountId,
+                pending.Operation,
+                pending.Fingerprint), Is.Null);
+            adopted.Dispose();
+            owner.Dispose();
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void ReacquireFailureRollsBackStateSoDisposeTerminates()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            var store = new FileAiRequestRecoveryStore(directory);
+            var key = new AiRequestKey(
+                recoveryContext: RecoveryContext(store, () => "account"),
+                operation: "image.generate");
+            AiRequestName issued = key.NameFor("prompt");
+            AiRequestRecoveryLease claim = key.TryClaim(issued)!;
+            key.MarkClaimDispatched(claim);
+            claim.Dispose();
+
+            File.WriteAllText(Path.Combine(directory, "ai-request-recovery-claims.json"), "not-json");
+            Assert.Throws<InvalidDataException>(() => claim.Reacquire());
+
+            Task dispose = Task.Run(claim.Dispose);
+            Assert.That(dispose.Wait(TimeSpan.FromSeconds(2)), Is.True,
+                "Dispose must not spin after a failed reacquire.");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void DisposeWaitsUntilReacquirePublishesItsRenewalTimer()
+    {
+        string directory = CreateTemporaryDirectory();
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        try
+        {
+            var store = new FileAiRequestRecoveryStore(directory);
+            var key = new AiRequestKey(
+                recoveryContext: RecoveryContext(store, () => "account"),
+                operation: "image.generate");
+            AiRequestName issued = key.NameFor("prompt");
+            AiRequestRecoveryLease claim = key.TryClaim(issued)!;
+            key.MarkClaimDispatched(claim);
+            claim.Dispose();
+            claim.BeforeReacquirePublish = () =>
+            {
+                entered.Set();
+                release.Wait();
+            };
+
+            Task<bool> reacquire = Task.Run(claim.Reacquire);
+            Assert.That(entered.Wait(TimeSpan.FromSeconds(2)), Is.True);
+            Task dispose = Task.Run(claim.Dispose);
+            Assert.That(dispose.Wait(TimeSpan.FromMilliseconds(50)), Is.False,
+                "Dispose must wait while timer and dispatched state are being published.");
+
+            release.Set();
+            Assert.That(reacquire.Wait(TimeSpan.FromSeconds(2)), Is.True);
+            Assert.That(reacquire.Result, Is.True);
+            Assert.That(dispose.Wait(TimeSpan.FromSeconds(2)), Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(claim.IsReleased, Is.True);
+                Assert.That(claim.Renew(), Is.False);
+            });
+        }
+        finally
+        {
+            release.Set();
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void ReacquireLockFailureRollsBackStateSoDisposeTerminates()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            var store = new FileAiRequestRecoveryStore(directory);
+            var key = new AiRequestKey(
+                recoveryContext: RecoveryContext(store, () => "account"),
+                operation: "image.generate");
+            AiRequestName issued = key.NameFor("prompt");
+            AiRequestRecoveryLease claim = key.TryClaim(issued)!;
+            key.MarkClaimDispatched(claim);
+            claim.Dispose();
+
+            string lockPath = Path.Combine(directory, "ai-request-recovery.json.lock");
+            using var heldLock = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+            Assert.Throws<InvalidDataException>(() => claim.Reacquire());
+
+            Task dispose = Task.Run(claim.Dispose);
+            Assert.That(dispose.Wait(TimeSpan.FromSeconds(2)), Is.True,
+                "Dispose must not spin after a failed lock acquisition.");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void BulkSettlementCannotRemoveDispatchedRows()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            var store = new FileAiRequestRecoveryStore(directory);
+            var key = new AiRequestKey(
+                recoveryContext: RecoveryContext(store, () => "account"),
+                operation: "video.generate");
+            AiRequestName first = key.NameFor("first");
+            _ = key.NameFor("second");
+            AiRequestRecoveryLease claim = key.TryClaim(first)!;
+            key.MarkClaimDispatched(claim);
+            AiPendingAttempt[] pending = store.PendingFor("account", "video.generate").ToArray();
+
+            Assert.Throws<InvalidDataException>(() => store.SettleMany(
+                "account",
+                "video.generate",
+                pending));
+            Assert.That(store.PendingFor("account", "video.generate"), Has.Count.EqualTo(2));
+            Assert.Throws<InvalidDataException>(() => key.Abandon(pending.Single(item => item.Key == first.Key)));
+            Assert.That(store.Find("account", "video.generate", pending.Single(item => item.Key == first.Key).Fingerprint), Is.Not.Null);
+            claim.Dispose();
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void ExplicitAbandonAdvancesGenerationAndLeavesOtherAccountUntouched()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string? account = "account-a";
+            var store = new FileAiRequestRecoveryStore(directory);
+            var keyA = new AiRequestKey(
+                recoveryContext: RecoveryContext(store, () => account),
+                operation: "image.generate");
+            AiRequestName abandoned = keyA.NameFor("same");
+            account = "account-b";
+            var keyB = new AiRequestKey(
+                recoveryContext: RecoveryContext(store, () => account),
+                operation: "image.generate");
+            AiRequestName other = keyB.NameFor("same");
+
+            account = "account-a";
+            AiPendingAttempt pendingA = store.PendingFor("account-a", "image.generate").Single();
+            keyA.Abandon(pendingA);
+            AiRequestName next = keyA.NameFor("same");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(next.Key, Is.Not.EqualTo(abandoned.Key));
+                Assert.That(next.IsRepeat, Is.False);
+                Assert.That(store.Find("account-b", "image.generate", pendingA.Fingerprint)?.Key,
+                    Is.EqualTo(other.Key));
+            });
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void AbandonTreatsAConcurrentSettlementAsIdempotentSuccess()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            var store = new FileAiRequestRecoveryStore(directory);
+            var otherProcess = new FileAiRequestRecoveryStore(directory);
+            var key = new AiRequestKey(
+                seed: "stable-seed",
+                recoveryContext: RecoveryContext(store, () => "account"),
+                operation: "image.generate");
+            AiRequestName issued = key.NameFor("same");
+            AiPendingAttempt pending = store.PendingFor("account", "image.generate").Single();
+            key.BeforeAbandonPersistedRemoval = () =>
+            {
+                Assert.That(otherProcess.TrySettle(
+                    pending.AccountId,
+                    pending.Operation,
+                    pending.Fingerprint,
+                    pending.Key), Is.True);
+            };
+
+            Assert.DoesNotThrow(() => key.Abandon(pending));
+            AiRequestName next = key.NameFor("same");
+            Assert.Multiple(() =>
+            {
+                Assert.That(key.HasOutstandingName.Value, Is.True);
+                Assert.That(next.Key, Is.Not.EqualTo(issued.Key));
+                Assert.That(next.IsRepeat, Is.False);
+            });
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void StaleRetireAndWithdrawCannotDeleteNewGeneration()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string? account = "account";
+            var store = new FileAiRequestRecoveryStore(directory);
+            var first = new AiRequestKey(
+                recoveryContext: RecoveryContext(store, () => account),
+                operation: "image.generate");
+            AiRequestName oldName = first.NameFor("same");
+            var stale = new AiRequestKey(
+                recoveryContext: RecoveryContext(store, () => account),
+                operation: "image.generate");
+            _ = stale.NameFor("same");
+            AiPendingAttempt oldAttempt = store.PendingFor("account", "image.generate").Single();
+            first.Abandon(oldAttempt);
+            AiRequestName currentName = first.NameFor("same");
+
+            AiRequestName materializedOld = new(oldName.Key, true);
+            stale.Retire(materializedOld);
+            stale.Withdraw(materializedOld);
+
+            Assert.That(store.Find("account", "image.generate", oldAttempt.Fingerprint)?.Key,
+                Is.EqualTo(currentName.Key));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void RetireReportsCasFailureAndKeepsOutstandingName()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            var store = new FileAiRequestRecoveryStore(directory);
+            var other = new FileAiRequestRecoveryStore(directory);
+            var key = new AiRequestKey(
+                recoveryContext: RecoveryContext(store, () => "account"),
+                operation: "image.generate");
+            AiRequestName issued = key.NameFor("same");
+            AiPendingAttempt pending = store.PendingFor("account", "image.generate").Single();
+
+            Assert.That(other.TrySettle(
+                pending.AccountId,
+                pending.Operation,
+                pending.Fingerprint,
+                pending.Key), Is.True);
+            other.WriteOrGet(pending with { Key = "new-owner-key" });
+
+            Assert.That(key.Retire(issued), Is.False);
+            Assert.Multiple(() =>
+            {
+                Assert.That(key.HasOutstandingName.Value, Is.True);
+                Assert.That(store.Find("account", "image.generate", pending.Fingerprint)?.Key,
+                    Is.EqualTo("new-owner-key"));
+            });
+
+            AiRequestName current = key.NameFor("same");
+            Assert.That(current.Key, Is.EqualTo("new-owner-key"));
+            Assert.That(key.Retire(current), Is.True);
+            Assert.That(key.HasOutstandingName.Value, Is.False);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void WithdrawAfterNoReservationReportsCasFailureAndKeepsOutstandingName()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            var store = new FileAiRequestRecoveryStore(directory);
+            var other = new FileAiRequestRecoveryStore(directory);
+            var key = new AiRequestKey(
+                recoveryContext: RecoveryContext(store, () => "account"),
+                operation: "video.generate");
+            AiRequestName issued = key.NameFor("same");
+            AiPendingAttempt pending = store.PendingFor("account", "video.generate").Single();
+
+            Assert.That(other.TryWithdraw(
+                pending.AccountId,
+                pending.Operation,
+                pending.Fingerprint,
+                pending.Key), Is.True);
+            other.WriteOrGet(pending with { Key = "new-owner-key" });
+
+            Assert.That(key.WithdrawAfterNoReservation(issued), Is.False);
+            Assert.Multiple(() =>
+            {
+                Assert.That(key.HasOutstandingName.Value, Is.True);
+                Assert.That(store.Find("account", "video.generate", pending.Fingerprint)?.Key,
+                    Is.EqualTo("new-owner-key"));
+            });
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void BulkRetireReportsCasFailureWithoutClearingOtherOutstandingNames()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            var store = new FileAiRequestRecoveryStore(directory);
+            var other = new FileAiRequestRecoveryStore(directory);
+            var key = new AiRequestKey(
+                recoveryContext: RecoveryContext(store, () => "account"),
+                operation: "image.generate");
+            _ = key.NameFor("first");
+            _ = key.NameFor("second");
+            AiPendingAttempt[] pending = store.PendingFor("account", "image.generate").ToArray();
+            AiPendingAttempt replaced = pending[0];
+            Assert.That(other.TrySettle(
+                replaced.AccountId,
+                replaced.Operation,
+                replaced.Fingerprint,
+                replaced.Key), Is.True);
+            other.WriteOrGet(replaced with { Key = "new-owner-key" });
+
+            Assert.That(key.Retire(), Is.False);
+            Assert.That(key.HasOutstandingName.Value, Is.True);
+            Assert.That(store.PendingFor("account", "image.generate"), Has.Count.EqualTo(2));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void BulkRetireDoesNotDiscardUnmaterializedDurableRecovery()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            var store = new FileAiRequestRecoveryStore(directory);
+            store.WriteOrGet(new AiPendingAttempt(
+                "account", "image.generate", "same", "persisted-key", null,
+                new AiRequestFormSnapshot(Prompt: "same")));
+            var key = new AiRequestKey(
+                seed: "stable-seed",
+                recoveryContext: RecoveryContext(store, () => "account"),
+                operation: "image.generate");
+
+            Assert.That(key.Retire(), Is.False);
+            Assert.That(store.Find("account", "image.generate", "same"), Is.Not.Null);
+            Assert.That(key.HasOutstandingName.Value, Is.True);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void BulkRetireDoesNotSettleMaterializedSubsetOfDurableRun()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            var store = new FileAiRequestRecoveryStore(directory);
+            var key = new AiRequestKey(
+                recoveryContext: RecoveryContext(store, () => "account"),
+                operation: "image.generate");
+            _ = key.NameFor("materialized");
+            store.WriteOrGet(new AiPendingAttempt(
+                "account", "image.generate", "not-materialized", "other-key", null,
+                new AiRequestFormSnapshot(Prompt: "other")));
+            AiPendingAttempt[] before = store.PendingFor("account", "image.generate").ToArray();
+
+            Assert.That(key.Retire(), Is.False);
+            Assert.Multiple(() =>
+            {
+                Assert.That(key.HasOutstandingName.Value, Is.True);
+                Assert.That(
+                    store.PendingFor("account", "image.generate")
+                        .Select(static item => (item.AccountId, item.Operation, item.Fingerprint, item.Key)),
+                    Is.EquivalentTo(before.Select(static item =>
+                        (item.AccountId, item.Operation, item.Fingerprint, item.Key))));
+            });
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void AbandonGenerationSurvivesAProcessRestartWithTheSameSeed()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            var first = new AiRequestKey(
+                seed: "stable-seed",
+                recoveryContext: RecoveryContext(
+                    new FileAiRequestRecoveryStore(directory),
+                    () => "account"),
+                operation: "image.generate");
+            AiRequestName oldName = first.NameFor("same");
+            AiPendingAttempt pending = first.PendingAttempts(AiOperations.ImageGeneration).Single();
+            first.Abandon(pending);
+
+            var restarted = new AiRequestKey(
+                seed: "stable-seed",
+                recoveryContext: RecoveryContext(
+                    new FileAiRequestRecoveryStore(directory),
+                    () => "account"),
+                operation: "image.generate");
+            AiRequestName next = restarted.NameFor("same");
+            Assert.Multiple(() =>
+            {
+                Assert.That(next.Key, Is.Not.EqualTo(oldName.Key));
+                Assert.That(next.IsRepeat, Is.False);
+            });
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static string CreateTemporaryDirectory()
+    {
+        string directory = Path.Combine(
+            Path.GetTempPath(),
+            "Beutl.UnitTests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static AiRequestRecoveryContext RecoveryContext(
+        FileAiRequestRecoveryStore store,
+        Func<string?> accountProvider)
+        => new(
+            store,
+            () => accountProvider() is { } account
+                ? new AiAuthenticatedRequestIdentity(account, User: null)
+                : null);
+}

--- a/tests/Beutl.UnitTests/Services/AI/AiUploadBytesTests.cs
+++ b/tests/Beutl.UnitTests/Services/AI/AiUploadBytesTests.cs
@@ -1,0 +1,73 @@
+﻿using Beutl.Api.Services;
+using Beutl.Services.AI;
+
+namespace Beutl.UnitTests.Services.AI;
+
+public class AiUploadBytesTests
+{
+    private string _directory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), $"beutl-ai-upload-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_directory);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_directory))
+            Directory.Delete(_directory, recursive: true);
+    }
+
+    [Test]
+    public async Task ReadWithinAsync_ReturnsWhatTheFileHoldsWhenItFitsAsync()
+    {
+        string path = await WriteAsync("fits.bin", 4096);
+
+        byte[] bytes = await AiUploadBytes.ReadWithinAsync(path, 4096, default);
+
+        Assert.That(bytes, Is.EqualTo(await File.ReadAllBytesAsync(path)));
+    }
+
+    [Test]
+    public async Task ReadWithinAsync_RefusesAFileLargerThanWhatTheRequestIsAllowedAsync()
+    {
+        // 名前を付けるために読むが、送れる量は先に分かっている。それを超えて
+        // 読んでも使い道はなく、選んだあとに膨らんだ 1 つのファイルで残りの
+        // メモリを使い切る。
+        string path = await WriteAsync("too-large.bin", 8192);
+
+        Assert.ThrowsAsync<AiFileTooLargeException>(
+            async () => await AiUploadBytes.ReadWithinAsync(path, 4096, default));
+    }
+
+    [Test]
+    public async Task ReadWithinAsync_StopsAtTheLimitEvenWhenTheFileGrowsWhileItIsReadAsync()
+    {
+        // 書かれている最中のファイルは、長さを見たあとに伸びる。長さだけを
+        // 信じると、上限をいくらでも超えて読み続けることになる。
+        string path = Path.Combine(_directory, "growing.bin");
+        await File.WriteAllBytesAsync(path, new byte[1024]);
+
+        await using (FileStream growing = new(path, FileMode.Open, FileAccess.Write, FileShare.ReadWrite))
+        {
+            growing.Seek(0, SeekOrigin.End);
+            await growing.WriteAsync(new byte[256 * 1024]);
+            await growing.FlushAsync();
+
+            Assert.ThrowsAsync<AiFileTooLargeException>(
+                async () => await AiUploadBytes.ReadWithinAsync(path, 2048, default));
+        }
+    }
+
+    private async Task<string> WriteAsync(string name, int length)
+    {
+        string path = Path.Combine(_directory, name);
+        byte[] bytes = new byte[length];
+        Random.Shared.NextBytes(bytes);
+        await File.WriteAllBytesAsync(path, bytes);
+        return path;
+    }
+}

--- a/tests/Beutl.UnitTests/Services/AI/CaptionDraftStoreTests.cs
+++ b/tests/Beutl.UnitTests/Services/AI/CaptionDraftStoreTests.cs
@@ -1,0 +1,708 @@
+﻿using System.Globalization;
+using Beutl.Api.Services;
+using Beutl.Services.AI;
+
+namespace Beutl.UnitTests.Services.AI;
+
+[TestFixture]
+public sealed class CaptionDraftStoreTests
+{
+    private string _directory = null!;
+    private string _storageDirectory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _directory = Path.Combine(
+            Path.GetTempPath(),
+            "Beutl.UnitTests",
+            nameof(CaptionDraftStoreTests),
+            Guid.NewGuid().ToString("N"));
+        _storageDirectory = Path.Combine(_directory, "drafts");
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_directory))
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void Save_RoundTripsEveryRetainedPaidRecovery()
+    {
+        var store = new FileCaptionDraftStore(_storageDirectory);
+        CaptionDraftScope scope = CreateScope();
+        var retained = new CaptionDraftEntry(
+            "job-a",
+            CreateResumableSourceDraft());
+        var current = new CaptionDraftEntry(
+            "job-b",
+            CreateResumableSourceDraft(),
+            [retained]);
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? session), Is.True);
+
+        using (session)
+        {
+            session!.Save(current);
+            CaptionDraftEntry restored = session.Read().Entry!;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(restored.JobId, Is.EqualTo("job-b"));
+                Assert.That(restored.Recoveries, Has.Length.EqualTo(1));
+                Assert.That(restored.Recoveries[0].JobId, Is.EqualTo("job-a"));
+                Assert.That(
+                    restored.Recoveries[0].Draft.SourceTranscriptionResume!.RequestKeySeed,
+                    Is.EqualTo(retained.Draft.SourceTranscriptionResume!.RequestKeySeed));
+            }
+        }
+    }
+
+    [Test]
+    public void Save_RejectsMoreRecoveriesBeforeReplacingTheDurableEntry()
+    {
+        var store = new FileCaptionDraftStore(_storageDirectory);
+        CaptionDraftScope scope = CreateScope();
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? session), Is.True);
+
+        using (session)
+        {
+            var original = new CaptionDraftEntry("job-original", CreateResumableSourceDraft());
+            session!.Save(original);
+            CaptionDraftEntry[] tooMany = Enumerable.Range(0, 64)
+                .Select(index => new CaptionDraftEntry(
+                    $"job-{index}",
+                    CreateResumableSourceDraft()))
+                .ToArray();
+
+            Assert.Throws<ArgumentException>(() => session.Save(new CaptionDraftEntry(
+                "job-new",
+                CreateResumableSourceDraft(),
+                tooMany)));
+            Assert.That(session.Read().Entry!.JobId, Is.EqualTo("job-original"));
+        }
+    }
+
+    [Test]
+    public void SaveLoadDelete_RoundTripsRecoverableProgress()
+    {
+        var store = new FileCaptionDraftStore(_storageDirectory);
+        CaptionDraftScope scope = CreateScope();
+        CaptionDraft original = CreateDraft();
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? session), Is.True);
+        using (session)
+        {
+            session!.Save(new CaptionDraftEntry("job-42", original));
+            CaptionDraftEntry? restored = session.Read().Entry;
+
+            Assert.That(restored, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(restored!.JobId, Is.EqualTo("job-42"));
+                Assert.That(restored.Draft.Version, Is.EqualTo(FileCaptionDraftStore.CurrentVersion));
+                Assert.That(restored.Draft.Cues.Single().Text, Is.EqualTo("paid result"));
+                Assert.That(restored.Draft.SceneTranscriptionResume?.CompletedChunkCount, Is.EqualTo(1));
+                Assert.That(restored.Draft.Segments?.Single().Text, Is.EqualTo("paid result"));
+            });
+
+            session.Delete();
+            Assert.That(session.Read().Entry, Is.Null);
+        }
+    }
+
+    [Test]
+    public void Load_DeletesMalformedOrOversizedDrafts()
+    {
+        Directory.CreateDirectory(_storageDirectory);
+        var store = new FileCaptionDraftStore(_storageDirectory);
+        CaptionDraftScope scope = CreateScope();
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? session), Is.True);
+        using (session)
+        {
+            string storagePath = store.GetStoragePath(scope);
+            File.WriteAllText(storagePath, "{not-json");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(session!.Read().Entry, Is.Null);
+                Assert.That(File.Exists(storagePath), Is.False);
+            });
+
+            File.WriteAllBytes(
+                storagePath,
+                new byte[FileCaptionDraftStore.MaximumStorageBytes + 1]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(session!.Read().Entry, Is.Null);
+                Assert.That(File.Exists(storagePath), Is.False);
+            });
+        }
+    }
+
+    [Test]
+    public void Scopes_IsolateUsersProjectsAndScenes()
+    {
+        var store = new FileCaptionDraftStore(_storageDirectory);
+        CaptionDraftScope firstScope = CreateScope();
+        CaptionDraftScope[] otherScopes =
+        [
+            new("other-user", firstScope.ProjectId, firstScope.SceneId),
+            new(firstScope.UserId, Guid.NewGuid(), firstScope.SceneId),
+            new(firstScope.UserId, firstScope.ProjectId, Guid.NewGuid()),
+        ];
+        Assert.That(store.TryOpen(firstScope, out ICaptionDraftSession? first), Is.True);
+        using (first)
+        {
+            first!.Save(new CaptionDraftEntry("job-1", CreateDraft()));
+            foreach (CaptionDraftScope scope in otherScopes)
+            {
+                Assert.That(store.TryOpen(scope, out ICaptionDraftSession? other), Is.True);
+                using (other)
+                {
+                    Assert.That(other!.Read().Entry, Is.Null, scope.ToString());
+                }
+            }
+        }
+    }
+
+    [Test]
+    public void SameScope_HasOneOwnerAndAnotherTabCannotOverwriteOrDeleteItsDraft()
+    {
+        var store = new FileCaptionDraftStore(_storageDirectory);
+        CaptionDraftScope scope = CreateScope();
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? owner), Is.True);
+        owner!.Save(new CaptionDraftEntry("job-1", CreateDraft()));
+
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? competing), Is.False);
+        Assert.That(competing, Is.Null);
+        Assert.That(owner.Read().Entry, Is.Not.Null);
+
+        owner.Dispose();
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? successor), Is.True);
+        using (successor)
+        {
+            Assert.That(successor!.Read().Entry?.Draft.Cues.Single().Text, Is.EqualTo("paid result"));
+        }
+    }
+
+    [Test]
+    public void JobOwnedDraft_ReopensThroughBaseScopeAfterStoreRecreation()
+    {
+        CaptionDraftScope scope = CreateScope();
+        var firstStore = new FileCaptionDraftStore(_storageDirectory);
+        Assert.That(firstStore.TryOpen(scope, out ICaptionDraftSession? firstSession), Is.True);
+        using (firstSession)
+        {
+            firstSession!.Save(new CaptionDraftEntry("paid-job-123", CreateDraft()));
+        }
+
+        var recreatedStore = new FileCaptionDraftStore(_storageDirectory);
+        Assert.That(recreatedStore.TryOpen(scope, out ICaptionDraftSession? restoredSession), Is.True);
+        using (restoredSession)
+        {
+            CaptionDraftEntry? restored = restoredSession!.Read().Entry;
+            Assert.Multiple(() =>
+            {
+                Assert.That(restored?.JobId, Is.EqualTo("paid-job-123"));
+                Assert.That(restored?.Draft.Cues.Single().Text, Is.EqualTo("paid result"));
+                Assert.That(Directory.GetFiles(_storageDirectory, "*.json"), Has.Length.EqualTo(1));
+            });
+        }
+    }
+
+    private static CaptionDraftScope CreateScope()
+        => new("user-1", Guid.NewGuid(), Guid.NewGuid());
+
+    [Test]
+    public void Save_KeepsARunThatHasOnlyNamedItsFirstPiece()
+    {
+        // 最初のひと切れは、課金されたまま失われる可能性がいちばん高い。それが
+        // 返ってくるまで何も書き残さないと、その名前はセッションと一緒に消え、
+        // 次の実行は同じ切れ端を別の名前で買い直すことになる。
+        var store = new FileCaptionDraftStore(_storageDirectory);
+        CaptionDraftScope scope = CreateScope();
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? session), Is.True);
+        using (session)
+        {
+            session!.Save(new CaptionDraftEntry(null, CreateUnstartedDraft()));
+            CaptionDraftEntry? restored = session.Read().Entry;
+
+            Assert.That(restored, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(restored!.Draft.CompletedSteps, Is.Zero);
+                Assert.That(
+                    restored.Draft.SourceTranscriptionResume?.RequestKeySeed,
+                    Is.EqualTo("seed-of-the-run"));
+                Assert.That(
+                    restored.Draft.SourceTranscriptionResume?.RequestKeyModel,
+                    Is.EqualTo("openai/whisper-1"));
+            });
+        }
+    }
+
+    [Test]
+    public void Load_KeepsWhatAnEarlierVersionPaidForAndDropsOnlyItsNames()
+    {
+        // 版 1 の控えには、seed を書いたあとモデルを書く前の時期のものが混じって
+        // いる。seed だけがある状態は「モデルを指定しなかった実行」と見分けが
+        // つかず、取り違えると支払い済みの切れ端に別の名前を付けて買い直す。
+        // 曖昧なのは名前だけなので、支払い済みの結果まで捨てる理由は無い。
+        var store = new FileCaptionDraftStore(_storageDirectory);
+        CaptionDraftScope scope = CreateScope();
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? session), Is.True);
+        using (session)
+        {
+            session!.Save(new CaptionDraftEntry("job-1", CreateResumableSourceDraft()));
+        }
+
+        string path = store.GetStoragePath(scope);
+        string stored = File.ReadAllText(path);
+        File.WriteAllText(
+            path,
+            stored.Replace(
+                $"\"version\":{FileCaptionDraftStore.CurrentVersion}",
+                "\"version\":1"));
+
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? reopened), Is.True);
+        using (reopened)
+        {
+            CaptionDraftEntry? restored = reopened!.Read().Entry;
+
+            Assert.That(restored, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(restored!.Draft.Cues.Single().Text, Is.EqualTo("paid result"));
+                Assert.That(restored.Draft.CompletedSteps, Is.EqualTo(1));
+                Assert.That(
+                    restored.Draft.SourceTranscriptionResume?.RequestKeySeed,
+                    Is.Empty,
+                    "The names of a version 1 draft cannot be told apart, so they go.");
+                Assert.That(
+                    restored.Draft.SourceTranscriptionResume?.RequestKeyModel,
+                    Is.Empty);
+                Assert.That(
+                    restored.Draft.SourceTranscriptionResume?.RequestKeyNamePending,
+                    Is.False);
+            });
+        }
+    }
+
+    [Test]
+    public void Load_ReadsAVersion2DraftAsStillHoldingItsName()
+    {
+        // 版 2 には「名前を抱えたまま終わったか」が無い。読み落として false に
+        // すると、まだ返ってきていない最初の切れ端を持つ実行が拾い直せず、
+        // 買い直しになる。版 2 は切れ端が返るたびに名前を決着させていなかった
+        // ので、seed があるなら抱えていたということ。
+        var store = new FileCaptionDraftStore(_storageDirectory);
+        CaptionDraftScope scope = CreateScope();
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? session), Is.True);
+        using (session)
+        {
+            session!.Save(new CaptionDraftEntry("job-1", CreateResumableSourceDraft()));
+        }
+
+        string path = store.GetStoragePath(scope);
+        string stored = File.ReadAllText(path);
+        // 版 2 が書いた控えそのもの——版が 2 で、その項目がまだ無い。
+        string asVersion2 = stored
+            .Replace(
+                $"\"version\":{FileCaptionDraftStore.CurrentVersion}",
+                "\"version\":2")
+            .Replace(",\"requestKeyNamePending\":true", string.Empty);
+        Assert.That(asVersion2, Does.Not.Contain("requestKeyNamePending"));
+        File.WriteAllText(path, asVersion2);
+
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? reopened), Is.True);
+        using (reopened)
+        {
+            CaptionDraftEntry? restored = reopened!.Read().Entry;
+
+            Assert.That(restored, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    restored!.Draft.SourceTranscriptionResume?.RequestKeySeed,
+                    Is.EqualTo("seed-of-the-run"),
+                    "What it paid for is still named.");
+                Assert.That(
+                    restored.Draft.SourceTranscriptionResume?.RequestKeyNamePending,
+                    Is.True);
+            });
+        }
+    }
+
+    [Test]
+    public void Read_SaysUnreadableForADraftANewerVersionWroteInsteadOfDeletingIt()
+    {
+        // 新しい版で書かれた控えを、古い版に戻して開いたとき。読めないだけで
+        // 壊れてはいないので、消してはいけない——消すと、新しい版に戻っても
+        // そこに書いてあった支払い済みの名前は返ってこない。
+        var store = new FileCaptionDraftStore(_storageDirectory);
+        CaptionDraftScope scope = CreateScope();
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? session), Is.True);
+        using (session)
+        {
+            session!.Save(new CaptionDraftEntry("job-1", CreateResumableSourceDraft()));
+        }
+
+        string path = store.GetStoragePath(scope);
+        string stored = File.ReadAllText(path);
+        string asFutureVersion = stored.Replace(
+            string.Create(CultureInfo.InvariantCulture, $"\"version\":{FileCaptionDraftStore.CurrentVersion}"),
+            string.Create(CultureInfo.InvariantCulture, $"\"version\":{FileCaptionDraftStore.CurrentVersion + 1}"));
+        Assert.That(asFutureVersion, Is.Not.EqualTo(stored));
+        File.WriteAllText(path, asFutureVersion);
+
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? reopened), Is.True);
+        using (reopened)
+        {
+            CaptionDraftReadResult read = reopened!.Read();
+            Assert.Multiple(() =>
+            {
+                Assert.That(read.Outcome, Is.EqualTo(CaptionDraftReadOutcome.Unreadable));
+                Assert.That(read.Entry, Is.Null);
+            });
+        }
+
+        Assert.That(
+            File.Exists(path),
+            Is.True,
+            "A draft a newer version wrote is still there for that version to read.");
+    }
+
+    [Test]
+    public void TryOpen_RefusesAScopeAnotherProcessIsHolding()
+    {
+        // 同じ人の同じ場面を、もう 1 つの Beutl が開いていることがある。どちらも
+        // 書けてしまうと、片方が書いた支払い済みの名前をもう片方が上書きし、次の
+        // 起動でそれを買い直す。別の store インスタンスは別のプロセスの代わり。
+        var first = new FileCaptionDraftStore(_storageDirectory);
+        var second = new FileCaptionDraftStore(_storageDirectory);
+        CaptionDraftScope scope = CreateScope();
+        string lockPath = first.GetStoragePath(scope) + ".lock";
+
+        Assert.That(first.TryOpen(scope, out ICaptionDraftSession? held), Is.True);
+        using (held)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(File.Exists(lockPath), Is.True,
+                    "The lock must keep a stable name while another process resolves it.");
+                Assert.That(second.TryOpen(scope, out ICaptionDraftSession? blocked), Is.False);
+                Assert.That(blocked, Is.Null);
+            });
+        }
+
+        // The empty named file is reused so there is no close/delete/reopen race between processes.
+        Assert.That(File.Exists(lockPath), Is.True);
+        Assert.That(second.TryOpen(scope, out ICaptionDraftSession? afterRelease), Is.True);
+        afterRelease!.Dispose();
+    }
+
+    [Test]
+    public void Load_TakesAVersion2DraftAtItsWordWhenItSaysSo()
+    {
+        // 版 2 のうち、その項目を書くようになったあとのもの。書いてある false は
+        // 「決着済み」という意味なので、抱えているものとして復活させてはいけない。
+        var store = new FileCaptionDraftStore(_storageDirectory);
+        CaptionDraftScope scope = CreateScope();
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? session), Is.True);
+        using (session)
+        {
+            session!.Save(new CaptionDraftEntry("job-1", CreateResumableSourceDraft()));
+        }
+
+        string path = store.GetStoragePath(scope);
+        File.WriteAllText(
+            path,
+            File.ReadAllText(path)
+                .Replace(
+                    $"\"version\":{FileCaptionDraftStore.CurrentVersion}",
+                    "\"version\":2")
+                .Replace("\"requestKeyNamePending\":true", "\"requestKeyNamePending\":false"));
+
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? reopened), Is.True);
+        using (reopened)
+        {
+            CaptionDraftEntry? restored = reopened!.Read().Entry;
+
+            Assert.That(restored, Is.Not.Null);
+            Assert.That(
+                restored!.Draft.SourceTranscriptionResume?.RequestKeyNamePending,
+                Is.False,
+                "A draft that says the run settled is not a paid recovery.");
+        }
+    }
+
+    [Test]
+    public void Read_SaysUnreadableRatherThanDeletingWhatItCannotOpen()
+    {
+        // 読めなかったのと、無いのとは違う。取り違えて消すか上書きすると、
+        // そこに書いてあった支払い済みの名前ごと失われる。
+        var store = new FileCaptionDraftStore(_storageDirectory);
+        CaptionDraftScope scope = CreateScope();
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? session), Is.True);
+        using (session)
+        {
+            session!.Save(new CaptionDraftEntry("job-1", CreateResumableSourceDraft()));
+        }
+
+        string path = store.GetStoragePath(scope);
+        using (FileStream held = new(path, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            Assert.That(store.TryOpen(scope, out ICaptionDraftSession? blocked), Is.True);
+            using (blocked)
+            {
+                CaptionDraftReadResult read = blocked!.Read();
+                Assert.That(read.Outcome, Is.EqualTo(CaptionDraftReadOutcome.Unreadable));
+            }
+        }
+
+        Assert.That(File.Exists(path), Is.True, "What could not be read is still there.");
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? reopened), Is.True);
+        using (reopened)
+        {
+            Assert.That(reopened!.Read().Entry, Is.Not.Null);
+        }
+    }
+
+    private static CaptionDraft CreateResumableSourceDraft()
+    {
+        var cue = new StoredCaptionCue(
+            TimeSpan.Zero.Ticks,
+            TimeSpan.FromSeconds(1).Ticks,
+            "paid result",
+            null,
+            "en",
+            new Dictionary<string, string>(StringComparer.Ordinal));
+        var segment = new AiTranscriptionSegment { Start = 0, End = 1, Text = "paid result" };
+        return new CaptionDraft(
+            FileCaptionDraftStore.CurrentVersion,
+            [cue],
+            "en",
+            [segment],
+            CaptionDraftKind.Transcription,
+            1,
+            3,
+            null,
+            null,
+            new CaptionSourceTranscriptionResume(
+                Path.Combine(Path.GetTempPath(), "clip.wav"),
+                Guid.NewGuid(),
+                1024,
+                DateTime.UnixEpoch.Ticks,
+                "en",
+                16_000,
+                48_000,
+                16_000,
+                3,
+                [segment],
+                "en",
+                1,
+                "seed-of-the-run",
+                "openai/whisper-1",
+                true));
+    }
+
+    private static CaptionDraft CreateUnstartedDraft()
+    {
+        return new CaptionDraft(
+            FileCaptionDraftStore.CurrentVersion,
+            [],
+            "en",
+            [],
+            CaptionDraftKind.Transcription,
+            0,
+            3,
+            null,
+            null,
+            new CaptionSourceTranscriptionResume(
+                Path.Combine(Path.GetTempPath(), "clip.wav"),
+                Guid.NewGuid(),
+                1024,
+                DateTime.UnixEpoch.Ticks,
+                "en",
+                16_000,
+                48_000,
+                16_000,
+                3,
+                [],
+                null,
+                0,
+                "seed-of-the-run",
+                "openai/whisper-1"));
+    }
+
+    private static CaptionDraft CreateDraft()
+    {
+        var cue = new StoredCaptionCue(
+            TimeSpan.Zero.Ticks,
+            TimeSpan.FromSeconds(1).Ticks,
+            "paid result",
+            null,
+            "en",
+            new Dictionary<string, string>(StringComparer.Ordinal));
+        var segment = new AiTranscriptionSegment
+        {
+            Start = 0,
+            End = 1,
+            Text = "paid result",
+        };
+        return new CaptionDraft(
+            FileCaptionDraftStore.CurrentVersion,
+            [cue],
+            "en",
+            [segment],
+            CaptionDraftKind.Transcription,
+            1,
+            2,
+            null,
+            new CaptionSceneTranscriptionResume(
+                Guid.NewGuid(),
+                null,
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(1),
+                2,
+                [segment],
+                "en",
+                1));
+    }
+
+    [Test]
+    public void TranslationResume_RoundTripsTheNameItsBatchesWereSentUnder()
+    {
+        var store = new FileCaptionDraftStore(_storageDirectory);
+        CaptionDraftScope scope = CreateScope();
+        var draft = new CaptionDraft(
+            FileCaptionDraftStore.CurrentVersion,
+            [new StoredCaptionCue(0, TimeSpan.FromSeconds(1).Ticks, "Hello", null, "en", [])],
+            "ja",
+            null,
+            CaptionDraftKind.Translation,
+            1,
+            2,
+            new CaptionTranslationResume(
+                [new StoredCaptionCue(0, TimeSpan.FromSeconds(1).Ticks, "Hello", null, "en", [])],
+                "en",
+                "en",
+                "ja",
+                new Dictionary<string, string>(StringComparer.Ordinal) { ["line-1"] = "こんにちは" },
+                1,
+                "8c1d7e2a5b904f36a1e0c4d8f7b62039",
+                "openai/gpt-5",
+                false,
+                150,
+                12_000,
+                96 * 1024),
+            null);
+
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? session), Is.True);
+        using (session)
+        {
+            session!.Save(new CaptionDraftEntry("job-translation", draft));
+        }
+
+        Assert.That(store.TryOpen(scope, out session), Is.True);
+        using (session)
+        {
+            CaptionDraftEntry? restored = session!.Read().Entry;
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(restored, Is.Not.Null);
+                Assert.That(restored!.Draft.TranslationResume, Is.Not.Null);
+                Assert.That(restored.Draft.TranslationResume!.CompletedBatchCount, Is.EqualTo(1));
+                // The name the unfinished batches will be asked for under. Without
+                // it a run resumed in a later session would buy a batch the first
+                // session may already have paid for.
+                Assert.That(
+                    restored.Draft.TranslationResume.RequestKeySeed,
+                    Is.EqualTo("8c1d7e2a5b904f36a1e0c4d8f7b62039"));
+                // 名前はモデルまで含めて作られる。どのモデルで走っていたかを
+                // 覚えていないと、再開時に別のモデルが選ばれ、未完了のバッチが
+                // 別の名前で送られて二重に課金される。
+                Assert.That(
+                    restored.Draft.TranslationResume.RequestKeyModel,
+                    Is.EqualTo("openai/gpt-5"));
+                Assert.That(restored.Draft.TranslationResume.MaxSegments, Is.EqualTo(150));
+                Assert.That(restored.Draft.TranslationResume.MaxCharacters, Is.EqualTo(12_000));
+                Assert.That(restored.Draft.TranslationResume.MaxRequestBytes,
+                    Is.EqualTo(96 * 1024));
+            }
+        }
+    }
+
+    [Test]
+    public void SourceTranscriptionResume_RoundTripsIncompleteProgress()
+    {
+        var store = new FileCaptionDraftStore(_storageDirectory);
+        CaptionDraftScope scope = CreateScope();
+        var segment = new AiTranscriptionSegment
+        {
+            Start = 0,
+            End = 1,
+            Text = "decoded source",
+        };
+        var draft = new CaptionDraft(
+            FileCaptionDraftStore.CurrentVersion,
+            [new StoredCaptionCue(0, TimeSpan.FromSeconds(1).Ticks, segment.Text, null, "en", [])],
+            "en",
+            [segment],
+            CaptionDraftKind.Transcription,
+            1,
+            2,
+            null,
+            null,
+            new CaptionSourceTranscriptionResume(
+                Path.GetFullPath("source.flac"),
+                Guid.Empty,
+                1_024,
+                DateTime.UtcNow.Ticks,
+                "en",
+                48_000,
+                57_600_000,
+                28_800_000,
+                2,
+                [segment],
+                "en",
+                1,
+                "1f4c2b0d9e6a4f118b7c3d5e6f708192",
+                "openai/whisper-1"));
+
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? session), Is.True);
+        using (session)
+        {
+            session!.Save(new CaptionDraftEntry("job-source", draft));
+        }
+
+        Assert.That(store.TryOpen(scope, out session), Is.True);
+        using (session)
+        {
+            CaptionDraftEntry? restored = session!.Read().Entry;
+            Assert.Multiple(() =>
+            {
+                Assert.That(restored, Is.Not.Null);
+                Assert.That(restored!.Draft.SourceTranscriptionResume, Is.Not.Null);
+                Assert.That(
+                    restored.Draft.SourceTranscriptionResume!.CompletedChunkCount,
+                    Is.EqualTo(1));
+                Assert.That(restored.Draft.SourceTranscriptionResume.Segments[0].Text,
+                    Is.EqualTo("decoded source"));
+                // The name the finished chunks were sent under. Without it a run
+                // resumed in a later session would ask for chunks it has already
+                // paid for as though they were new.
+                Assert.That(
+                    restored.Draft.SourceTranscriptionResume.RequestKeySeed,
+                    Is.EqualTo("1f4c2b0d9e6a4f118b7c3d5e6f708192"));
+                Assert.That(
+                    restored.Draft.SourceTranscriptionResume.RequestKeyModel,
+                    Is.EqualTo("openai/whisper-1"));
+            });
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Services/AI/CaptionDraftStoreTests.cs
+++ b/tests/Beutl.UnitTests/Services/AI/CaptionDraftStoreTests.cs
@@ -62,6 +62,51 @@ public sealed class CaptionDraftStoreTests
     }
 
     [Test]
+    public void Load_MigratesEveryRetainedRecoveryBeforeValidation()
+    {
+        var store = new FileCaptionDraftStore(_storageDirectory);
+        CaptionDraftScope scope = CreateScope();
+        var retained = new CaptionDraftEntry("job-a", CreateResumableSourceDraft());
+        var current = new CaptionDraftEntry(
+            "job-b",
+            CreateResumableSourceDraft(),
+            [retained]);
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? session), Is.True);
+        using (session)
+        {
+            session!.Save(current);
+        }
+        string path = store.GetStoragePath(scope);
+        File.WriteAllText(
+            path,
+            File.ReadAllText(path).Replace(
+                $"\"version\":{FileCaptionDraftStore.CurrentVersion}",
+                "\"version\":4",
+                StringComparison.Ordinal));
+
+        Assert.That(store.TryOpen(scope, out ICaptionDraftSession? reopened), Is.True);
+        using (reopened)
+        {
+            CaptionDraftEntry? restored = reopened!.Read().Entry;
+
+            Assert.That(restored, Is.Not.Null);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(restored!.Draft.Version, Is.EqualTo(FileCaptionDraftStore.CurrentVersion));
+                Assert.That(restored.Recoveries, Has.Length.EqualTo(1));
+                Assert.That(
+                    restored.Recoveries[0].Draft.Version,
+                    Is.EqualTo(FileCaptionDraftStore.CurrentVersion));
+                Assert.That(restored.Recoveries[0].JobId, Is.EqualTo("job-a"));
+                Assert.That(
+                    restored.Recoveries[0].Draft.SourceTranscriptionResume!.RequestKeySeed,
+                    Is.EqualTo("seed-of-the-run"));
+                Assert.That(File.Exists(path), Is.True);
+            }
+        }
+    }
+
+    [Test]
     public void Save_RejectsMoreRecoveriesBeforeReplacingTheDurableEntry()
     {
         var store = new FileCaptionDraftStore(_storageDirectory);

--- a/tests/Beutl.UnitTests/Services/AI/CaptionDraftStoreTests.cs
+++ b/tests/Beutl.UnitTests/Services/AI/CaptionDraftStoreTests.cs
@@ -672,7 +672,8 @@ public sealed class CaptionDraftStoreTests
                 "en",
                 1,
                 "1f4c2b0d9e6a4f118b7c3d5e6f708192",
-                "openai/whisper-1"));
+                "openai/whisper-1",
+                SourceStartSamples: 96_000));
 
         Assert.That(store.TryOpen(scope, out ICaptionDraftSession? session), Is.True);
         using (session)
@@ -702,6 +703,9 @@ public sealed class CaptionDraftStoreTests
                 Assert.That(
                     restored.Draft.SourceTranscriptionResume.RequestKeyModel,
                     Is.EqualTo("openai/whisper-1"));
+                Assert.That(
+                    restored.Draft.SourceTranscriptionResume.SourceStartSamples,
+                    Is.EqualTo(96_000));
             });
         }
     }

--- a/tests/Beutl.UnitTests/Services/AI/FileAiRequestRecoveryStoreTests.cs
+++ b/tests/Beutl.UnitTests/Services/AI/FileAiRequestRecoveryStoreTests.cs
@@ -1,0 +1,654 @@
+﻿using Beutl.Services.AI;
+
+namespace Beutl.UnitTests.Services.AI;
+
+[TestFixture]
+public sealed class FileAiRequestRecoveryStoreTests
+{
+    private string _directory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), "Beutl.UnitTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_directory);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_directory))
+            Directory.Delete(_directory, recursive: true);
+    }
+
+    [Test]
+    public void RestartAndTwoInstancesMergeWithoutClobbering()
+    {
+        var first = new FileAiRequestRecoveryStore(_directory);
+        var a = Record("account", "image.generate", "fingerprint-a", "key-a");
+        var b = Record("account", "video.generate", "fingerprint-b", "key-b");
+        Assert.That(first.WriteOrGet(a).Key, Is.EqualTo("key-a"));
+        var second = new FileAiRequestRecoveryStore(_directory);
+        Assert.That(second.WriteOrGet(b).Key, Is.EqualTo("key-b"));
+
+        var restarted = new FileAiRequestRecoveryStore(_directory);
+        Assert.Multiple(() =>
+        {
+            Assert.That(restarted.Find(a.AccountId, a.Operation, a.Fingerprint)?.Key, Is.EqualTo("key-a"));
+            Assert.That(restarted.Find(b.AccountId, b.Operation, b.Fingerprint)?.Key, Is.EqualTo("key-b"));
+        });
+    }
+
+    [Test]
+    public void ConcurrentIdentityKeepsTheFirstDurableKey()
+    {
+        var first = new FileAiRequestRecoveryStore(_directory);
+        var second = new FileAiRequestRecoveryStore(_directory);
+        var original = Record("account", "image.generate", "same", "first-key");
+        var competing = original with { Key = "second-key" };
+
+        Assert.That(first.WriteOrGet(original).Key, Is.EqualTo("first-key"));
+        Assert.That(second.WriteOrGet(competing).Key, Is.EqualTo("first-key"));
+        Assert.That(second.Find(original.AccountId, original.Operation, original.Fingerprint)?.Key, Is.EqualTo("first-key"));
+    }
+
+    [Test]
+    public void AccountOperationAndFingerprintAreIndependent()
+    {
+        var store = new FileAiRequestRecoveryStore(_directory);
+        AiPendingAttempt[] records =
+        [
+            Record("a", "image.generate", "same", "key-a"),
+            Record("b", "image.generate", "same", "key-b"),
+            Record("a", "video.generate", "same", "key-video"),
+            Record("a", "image.generate", "other", "key-other"),
+        ];
+        foreach (AiPendingAttempt record in records)
+            store.WriteOrGet(record);
+
+        Assert.That(records.Select(record =>
+            store.Find(record.AccountId, record.Operation, record.Fingerprint)?.Key),
+            Is.EqualTo(records.Select(record => record.Key)));
+    }
+
+    [Test]
+    public void RemoveDeletesOnlyTheExactIdentity()
+    {
+        var store = new FileAiRequestRecoveryStore(_directory);
+        var first = Record("account", "image.generate", "first", "key-first");
+        var second = Record("account", "image.generate", "second", "key-second");
+        store.WriteOrGet(first);
+        store.WriteOrGet(second);
+
+        Assert.That(
+            store.TrySettle(first.AccountId, first.Operation, first.Fingerprint, first.Key),
+            Is.True);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(store.Find(first.AccountId, first.Operation, first.Fingerprint), Is.Null);
+            Assert.That(store.Find(second.AccountId, second.Operation, second.Fingerprint)?.Key, Is.EqualTo(second.Key));
+        });
+    }
+
+    [TestCase("{")]
+    [TestCase("{\"version\":2,\"records\":[]}")]
+    [TestCase("{\"version\":1,\"records\":[],\"unexpected\":true}")]
+    public void CorruptFutureAndUnknownShapeFailClosed(string contents)
+    {
+        File.WriteAllText(Path.Combine(_directory, "ai-request-recovery.json"), contents);
+        var store = new FileAiRequestRecoveryStore(_directory);
+
+        Assert.Throws<InvalidDataException>(() => store.Find("account", "image.generate", "fingerprint"));
+    }
+
+    [Test]
+    public void NullContentHashFailsClosedWithoutNullReferenceException()
+    {
+        File.WriteAllText(Path.Combine(_directory, "ai-request-recovery.json"), """
+            {"version":1,"records":[{"AccountId":"account","Operation":"image.edit.upscale","Fingerprint":"fingerprint","Key":"key","Model":null,"Form":null,"Sources":[{"Role":"image","Path":"/tmp/source.png","Name":"source.png","ContentHash":null,"Length":1,"DurableFile":null,"ElementId":null}]}]}
+            """);
+        var store = new FileAiRequestRecoveryStore(_directory);
+
+        Exception? exception = Assert.Throws<InvalidDataException>(
+            () => store.Find("account", "image.edit.upscale", "fingerprint"));
+        Assert.That(exception, Is.Not.TypeOf<NullReferenceException>());
+    }
+
+    [Test]
+    public void OversizeInvalidAndLockContentionFailClosed()
+    {
+        string path = Path.Combine(_directory, "ai-request-recovery.json");
+        File.WriteAllBytes(path, new byte[1024 * 1024 + 1]);
+        var oversized = new FileAiRequestRecoveryStore(_directory);
+        Assert.Throws<InvalidDataException>(() => oversized.Find("account", "image.generate", "fingerprint"));
+
+        File.Delete(path);
+        var store = new FileAiRequestRecoveryStore(_directory);
+        Assert.Throws<InvalidDataException>(() => store.WriteOrGet(
+            Record("account", "image.generate", "fingerprint", "bad\nkey")));
+        using var lease = new FileStream(
+            path + ".lock",
+            FileMode.OpenOrCreate,
+            FileAccess.ReadWrite,
+            FileShare.None);
+        Assert.Throws<InvalidDataException>(() => store.Find("account", "image.generate", "fingerprint"));
+    }
+
+    [Test]
+    public void FullStoreRejectsNewRecordWithoutEvictingUnresolvedRecords()
+    {
+        var store = new FileAiRequestRecoveryStore(_directory);
+        var first = Record("account", "image.generate", "fingerprint-000", "key-000");
+        store.WriteOrGet(first);
+        for (int index = 1; index < 256; index++)
+        {
+            store.WriteOrGet(Record(
+                "account",
+                "image.generate",
+                $"fingerprint-{index:000}",
+                $"key-{index:000}"));
+        }
+
+        Assert.Throws<InvalidDataException>(() => store.WriteOrGet(
+            Record("account", "image.generate", "overflow", "overflow-key")));
+        var restarted = new FileAiRequestRecoveryStore(_directory);
+        Assert.That(restarted.Find(first.AccountId, first.Operation, first.Fingerprint)?.Key, Is.EqualTo(first.Key));
+    }
+
+    [Test]
+    public void StoreFilesArePrivateOnUnix()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("Unix modes are not available on Windows.");
+            return;
+        }
+        var store = new FileAiRequestRecoveryStore(_directory);
+        store.WriteOrGet(Record("account", "image.generate", "fingerprint", "key"));
+
+#pragma warning disable CA1416 // Guarded above; these APIs are unavailable only on Windows.
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                File.GetUnixFileMode(_directory),
+                Is.EqualTo(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute));
+            Assert.That(
+                File.GetUnixFileMode(Path.Combine(_directory, "ai-request-recovery.json")),
+                Is.EqualTo(UnixFileMode.UserRead | UnixFileMode.UserWrite));
+        });
+#pragma warning restore CA1416
+    }
+
+    [Test]
+    public void FormSnapshotAndExternalSourceRoundTripAndFailClosedOnChange()
+    {
+        var store = new FileAiRequestRecoveryStore(_directory);
+        string sourcePath = Path.Combine(_directory, "source.png");
+        byte[] bytes = [1, 2, 3, 4];
+        File.WriteAllBytes(sourcePath, bytes);
+        var source = FileAiRequestRecoveryStore.CreateExternalSource(
+            "image", sourcePath, "source.png", bytes);
+        var attempt = new AiPendingAttempt(
+            "account",
+            "image.edit.upscale",
+            "fp",
+            "key",
+            "model",
+            new AiRequestFormSnapshot(
+                Prompt: "line 1\nline 2\twith tab",
+                Task: "upscale",
+                AspectRatio: "1:1",
+                Seed: 42),
+            [source]);
+        store.WriteOrGet(attempt);
+        AiPendingAttempt? restarted = new FileAiRequestRecoveryStore(_directory)
+            .Find("account", "image.edit.upscale", "fp");
+        Assert.That(restarted, Is.Not.Null);
+        Assert.That(restarted!.Form!.Prompt, Is.EqualTo("line 1\nline 2\twith tab"));
+        Assert.That(store.TryResolveSource(restarted.EffectiveSources[0], out string? resolved), Is.True);
+        Assert.That(resolved, Is.EqualTo(sourcePath));
+
+        File.WriteAllBytes(sourcePath, [9, 8, 7]);
+        Assert.That(store.TryResolveSource(restarted.EffectiveSources[0], out _), Is.False);
+    }
+
+    [Test]
+    public void DurableSourceIsCleanedOnAbandonButRetainedWhileReferenced()
+    {
+        var store = new FileAiRequestRecoveryStore(_directory);
+        AiRequestRecoverySource source = store.CreateDurableSource("frame", "frame.png", [1, 2, 3]);
+        string sourcePath = Path.Combine(store.SourceDirectory, source.DurableFile!);
+        Assert.That(File.Exists(sourcePath), Is.True);
+        var first = new AiPendingAttempt("account", "video.generate", "first", "key-first", null, new AiRequestFormSnapshot(), [source]);
+        var second = first with { Fingerprint = "second", Key = "key-second" };
+        store.WriteOrGet(first);
+        store.WriteOrGet(second);
+        store.Abandon(first);
+        Assert.That(File.Exists(sourcePath), Is.True);
+        store.Abandon(second);
+        Assert.That(File.Exists(sourcePath), Is.False);
+    }
+
+    [Test]
+    public void ExplicitNullModelIsRetainedWithMultipleRows()
+    {
+        var store = new FileAiRequestRecoveryStore(_directory);
+        store.WriteOrGet(new AiPendingAttempt("account", "image.generate", "a", "key-a", null, new AiRequestFormSnapshot()));
+        store.WriteOrGet(new AiPendingAttempt("account", "image.generate", "b", "key-b", "model-b", new AiRequestFormSnapshot()));
+        Assert.That(store.HasModelless("account", "image.generate"), Is.True);
+        Assert.That(store.ModelsFor("account", "image.generate"), Is.EqualTo(new[] { "model-b" }));
+    }
+
+    [Test]
+    public void CanonicalSnapshotsForAllFormsSurviveRestart()
+    {
+        var store = new FileAiRequestRecoveryStore(_directory);
+        AiRequestFormSnapshot[] forms =
+        [
+            new(Prompt: "image\nwith tab\t", AspectRatio: "3:2", Background: "transparent", Seed: 12),
+            new(Prompt: "edit", Task: "upscale", SourceName: "source.png", SourceElementId: "element-a"),
+            new(Prompt: "video", DurationSeconds: 8, Resolution: "1080p", AspectRatio: "16:9", GenerateAudio: false, Seed: 3),
+        ];
+        string[] operations = ["image.generate", "image.edit.upscale", "video.generate"];
+        for (int index = 0; index < forms.Length; index++)
+        {
+            store.WriteOrGet(new AiPendingAttempt(
+                "account",
+                operations[index],
+                $"fingerprint-{index}",
+                $"key-{index}",
+                index == 1 ? "edit-model" : null,
+                forms[index]));
+        }
+
+        var restarted = new FileAiRequestRecoveryStore(_directory);
+        AiPendingAttempt[] attempts = [
+            restarted.PendingFor("account", operations[0]).Single(),
+            restarted.PendingFor("account", operations[1]).Single(),
+            restarted.PendingFor("account", operations[2]).Single(),
+        ];
+        Assert.Multiple(() =>
+        {
+            Assert.That(attempts[0].Form, Is.EqualTo(forms[0]));
+            Assert.That(attempts[1].Form, Is.EqualTo(forms[1]));
+            Assert.That(attempts[2].Form, Is.EqualTo(forms[2]));
+            Assert.That(File.ReadAllText(restarted.StoragePath), Does.Not.Contain("010203"));
+        });
+    }
+
+    [Test]
+    public void RestartOrphanSweepDeletesOnlyOldUnreferencedCopies()
+    {
+        var first = new FileAiRequestRecoveryStore(_directory);
+        AiRequestRecoverySource orphan = first.CreateDurableSource("frame", "frame.png", [4, 5, 6]);
+        string orphanPath = Path.Combine(first.SourceDirectory, orphan.DurableFile!);
+        File.SetLastWriteTimeUtc(orphanPath, DateTime.UtcNow.AddHours(-2));
+        File.SetLastWriteTimeUtc(orphanPath + ".pending", DateTime.UtcNow.AddHours(-2));
+        var retainedSource = first.CreateDurableSource("frame", "retained.png", [7, 8, 9]);
+        string retainedPath = Path.Combine(first.SourceDirectory, retainedSource.DurableFile!);
+        first.WriteOrGet(new AiPendingAttempt(
+            "account",
+            "video.generate",
+            "retained",
+            "retained-key",
+            null,
+            new AiRequestFormSnapshot(DurationSeconds: 4),
+            [retainedSource]));
+        File.SetLastWriteTimeUtc(retainedPath, DateTime.UtcNow.AddHours(-2));
+
+        first.Dispose();
+        _ = new FileAiRequestRecoveryStore(_directory);
+        Assert.Multiple(() =>
+        {
+            Assert.That(File.Exists(orphanPath), Is.False);
+            Assert.That(File.Exists(retainedPath), Is.True);
+        });
+    }
+
+    [Test]
+    public void RestartSweepDeletesOldSourceAndStoreTempsWithoutTouchingPublishedSource()
+    {
+        var store = new FileAiRequestRecoveryStore(_directory);
+        AiRequestRecoverySource source = store.CreateDurableSource("frame", "kept.png", [1, 2, 3]);
+        store.WriteOrGet(new AiPendingAttempt(
+            "account", "video.generate", "kept", "kept-key", null,
+            new AiRequestFormSnapshot(DurationSeconds: 4), [source]));
+        string staleSourceTemp = Path.Combine(store.SourceDirectory, "orphan.src.abc.tmp");
+        File.WriteAllText(staleSourceTemp, "partial");
+        File.SetLastWriteTimeUtc(staleSourceTemp, DateTime.UtcNow.AddHours(-2));
+        string staleStoreTemp = Path.Combine(_directory, "ai-request-recovery.json.abc.tmp");
+        File.WriteAllText(staleStoreTemp, "partial");
+        File.SetLastWriteTimeUtc(staleStoreTemp, DateTime.UtcNow.AddHours(-2));
+
+        _ = new FileAiRequestRecoveryStore(_directory);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(File.Exists(staleSourceTemp), Is.False);
+            Assert.That(File.Exists(staleStoreTemp), Is.False);
+            Assert.That(File.Exists(Path.Combine(store.SourceDirectory, source.DurableFile!)), Is.True);
+        });
+    }
+
+    [Test]
+    public void RestartOrphanSweepDeletesOldMarkerWithoutPublishedSource()
+    {
+        var store = new FileAiRequestRecoveryStore(_directory);
+        string marker = Path.Combine(store.SourceDirectory, "crashed.src.pending");
+        File.WriteAllText(marker, "crashed-before-publish");
+        File.SetLastWriteTimeUtc(marker, DateTime.UtcNow.AddHours(-2));
+
+        _ = new FileAiRequestRecoveryStore(_directory);
+
+        Assert.That(File.Exists(marker), Is.False);
+    }
+
+    [Test]
+    public void StaleExactRemovalCannotDeleteNewKey()
+    {
+        var store = new FileAiRequestRecoveryStore(_directory);
+        var current = new AiPendingAttempt(
+            "account",
+            "video.generate",
+            "same",
+            "key-new",
+            "model",
+            new AiRequestFormSnapshot(DurationSeconds: 4));
+        store.WriteOrGet(current);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(store.TrySettle("account", "video.generate", "same", "key-old"), Is.False);
+            Assert.That(store.TryWithdraw("account", "video.generate", "same", "key-old"), Is.False);
+            Assert.That(store.Find("account", "video.generate", "same")?.Key, Is.EqualTo("key-new"));
+        });
+    }
+
+    [Test]
+    public void ClaimCompetesAcrossStoreInstancesAndSettleInvalidatesIt()
+    {
+        var firstStore = new FileAiRequestRecoveryStore(_directory);
+        var secondStore = new FileAiRequestRecoveryStore(_directory);
+        var attempt = new AiPendingAttempt(
+            "account",
+            "image.generate",
+            "claim-fingerprint",
+            "claim-key",
+            null,
+            new AiRequestFormSnapshot(Prompt: "claim"));
+        firstStore.WriteOrGet(attempt);
+        using AiRequestRecoveryLease first = firstStore.Claim(
+            attempt.AccountId,
+            attempt.Operation,
+            attempt.Fingerprint,
+            attempt.Key)!;
+        first.MarkDispatched();
+        AiRequestRecoveryLease? second = secondStore.Claim(
+            attempt.AccountId,
+            attempt.Operation,
+            attempt.Fingerprint,
+            attempt.Key);
+        Assert.That(second, Is.Null);
+        Assert.That(firstStore.TrySettle(
+            attempt.AccountId,
+            attempt.Operation,
+            attempt.Fingerprint,
+            attempt.Key,
+            first.OwnerToken,
+            first.Generation), Is.True);
+        first.Dispose();
+        Assert.That(secondStore.Abandon(attempt), Is.False);
+    }
+
+    [Test]
+    public void ClaimRejectsLiveOwnerAfterRemovingAllStaleClaims()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        var store = new FileAiRequestRecoveryStore(_directory, () => now);
+        var attempt = new AiPendingAttempt(
+            "account", "image.generate", "multi-claim", "current-key", null,
+            new AiRequestFormSnapshot(Prompt: "multi"));
+        store.WriteOrGet(attempt);
+        string claimsPath = Path.Combine(_directory, "ai-request-recovery-claims.json");
+        string expiry = now.AddMinutes(15).ToString("O");
+        File.WriteAllText(claimsPath, $$"""
+            {"version":1,"claims":[
+              {"AccountId":"account","Operation":"image.generate","Fingerprint":"multi-claim","Key":"stale-key","Generation":99,"OwnerToken":"stale-owner","ExpiresAt":"{{expiry}}","Dispatched":false},
+              {"AccountId":"account","Operation":"image.generate","Fingerprint":"multi-claim","Key":"current-key","Generation":0,"OwnerToken":"live-owner","ExpiresAt":"{{expiry}}","Dispatched":true}
+            ]}
+            """);
+
+        Assert.That(store.Claim(attempt.AccountId, attempt.Operation, attempt.Fingerprint, attempt.Key), Is.Null);
+        now = now.AddMinutes(16);
+        Assert.That(store.Claim(attempt.AccountId, attempt.Operation, attempt.Fingerprint, attempt.Key), Is.Not.Null);
+    }
+
+    [Test]
+    public void PredispatchClaimCanBeReleasedAndAbandoned()
+    {
+        var store = new FileAiRequestRecoveryStore(_directory);
+        var attempt = new AiPendingAttempt(
+            "account",
+            "video.generate",
+            "predispatch",
+            "predispatch-key",
+            null,
+            new AiRequestFormSnapshot(Prompt: "video"));
+        store.WriteOrGet(attempt);
+        using (store.Claim(attempt.AccountId, attempt.Operation, attempt.Fingerprint, attempt.Key)!) { }
+        Assert.That(store.Abandon(attempt), Is.True);
+    }
+
+    [Test]
+    public void DispatchedClaimRenewalExtendsFenceAndExpiredFenceCanBeAdopted()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        var store = new FileAiRequestRecoveryStore(_directory, () => now);
+        var attempt = new AiPendingAttempt(
+            "account", "image.generate", "renewal", "renewal-key", null,
+            new AiRequestFormSnapshot(Prompt: "renewal"));
+        store.WriteOrGet(attempt);
+        using AiRequestRecoveryLease claim = store.Claim(
+            attempt.AccountId, attempt.Operation, attempt.Fingerprint, attempt.Key)!;
+        Assert.That(claim.MarkDispatched(), Is.True);
+
+        now = now.AddMinutes(10);
+        Assert.That(claim.Renew(), Is.True);
+        Assert.That(store.Abandon(attempt), Is.False);
+
+        now = now.AddMinutes(16);
+        using AiRequestRecoveryLease adopted = store.Claim(
+            attempt.AccountId, attempt.Operation, attempt.Fingerprint, attempt.Key)!;
+        Assert.Multiple(() =>
+        {
+            Assert.That(adopted.IsDispatched, Is.True);
+            Assert.That(adopted.Generation, Is.EqualTo(claim.Generation));
+            Assert.That(adopted.OwnerToken, Is.Not.EqualTo(claim.OwnerToken));
+            Assert.That(claim.Renew(), Is.False);
+            Assert.That(store.Abandon(attempt), Is.False);
+        });
+    }
+
+    [Test]
+    public void RenewedDispatchedClaimWinsPastOriginalTtlAgainstAnotherStore()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        var firstStore = new FileAiRequestRecoveryStore(_directory, () => now);
+        var secondStore = new FileAiRequestRecoveryStore(_directory, () => now);
+        var attempt = new AiPendingAttempt(
+            "account", "image.generate", "renewed-race", "renewed-key", null,
+            new AiRequestFormSnapshot(Prompt: "renewed"));
+        firstStore.WriteOrGet(attempt);
+        using AiRequestRecoveryLease owner = firstStore.Claim(
+            attempt.AccountId, attempt.Operation, attempt.Fingerprint, attempt.Key)!;
+        Assert.That(owner.MarkDispatched(), Is.True);
+
+        now = now.AddMinutes(14);
+        Assert.That(owner.Renew(), Is.True);
+        now = now.AddMinutes(2); // Past the original 15-minute claim lifetime.
+        Assert.That(secondStore.Claim(
+            attempt.AccountId, attempt.Operation, attempt.Fingerprint, attempt.Key),
+            Is.Null);
+        Assert.That(secondStore.Abandon(attempt), Is.False);
+
+        now = now.AddMinutes(14);
+        Assert.That(secondStore.Claim(
+            attempt.AccountId, attempt.Operation, attempt.Fingerprint, attempt.Key),
+            Is.Not.Null);
+    }
+
+    [Test]
+    public void ExpiredDispatchedFenceAdoptionFencesTheStaleOwner()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        var first = new FileAiRequestRecoveryStore(_directory, () => now);
+        var attempt = new AiPendingAttempt(
+            "account", "image.generate", "stale-renewal", "stale-key", null,
+            new AiRequestFormSnapshot(Prompt: "stale"));
+        first.WriteOrGet(attempt);
+        using AiRequestRecoveryLease claim = first.Claim(
+            attempt.AccountId, attempt.Operation, attempt.Fingerprint, attempt.Key)!;
+        Assert.That(claim.MarkDispatched(), Is.True);
+        now = now.AddMinutes(16);
+        using AiRequestRecoveryLease adopted = first.Claim(
+            attempt.AccountId, attempt.Operation, attempt.Fingerprint, attempt.Key)!;
+        Assert.That(adopted.IsDispatched, Is.True);
+        Assert.That(adopted.OwnerToken, Is.Not.EqualTo(claim.OwnerToken));
+        Assert.That(claim.Renew(), Is.False);
+        Assert.That(first.Abandon(attempt), Is.False);
+    }
+
+    [Test]
+    public void DispatchFencePersistenceFailureFailsClosed()
+    {
+        var store = new FileAiRequestRecoveryStore(_directory);
+        var attempt = new AiPendingAttempt(
+            "account", "image.generate", "dispatch-failure", "dispatch-key", null,
+            new AiRequestFormSnapshot(Prompt: "dispatch"));
+        store.WriteOrGet(attempt);
+        using AiRequestRecoveryLease claim = store.Claim(
+            attempt.AccountId, attempt.Operation, attempt.Fingerprint, attempt.Key)!;
+        File.Delete(Path.Combine(_directory, "ai-request-recovery-claims.json"));
+        Assert.That(claim.MarkDispatched(), Is.False);
+        Assert.That(claim.IsDispatched, Is.False);
+    }
+
+    [Test]
+    public void DispatchedClaimRemainsFenceAfterDisposeAndExpiry()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        var store = new FileAiRequestRecoveryStore(_directory, () => now);
+        var attempt = new AiPendingAttempt("account", "image.generate", "dispose-fence", "dispose-key", null, new AiRequestFormSnapshot(Prompt: "fence"));
+        store.WriteOrGet(attempt);
+        AiRequestRecoveryLease claim = store.Claim(attempt.AccountId, attempt.Operation, attempt.Fingerprint, attempt.Key)!;
+        Assert.That(claim.MarkDispatched(), Is.True);
+        claim.Dispose();
+        Assert.That(store.Abandon(attempt), Is.False);
+        now = now.AddMinutes(16);
+        using AiRequestRecoveryLease adopted = store.Claim(
+            attempt.AccountId, attempt.Operation, attempt.Fingerprint, attempt.Key)!;
+        Assert.Multiple(() =>
+        {
+            Assert.That(adopted.IsDispatched, Is.True);
+            Assert.That(adopted.Generation, Is.EqualTo(0));
+            Assert.That(adopted.OwnerToken, Is.Not.EqualTo(claim.OwnerToken));
+            Assert.That(store.Abandon(attempt), Is.False);
+        });
+    }
+
+    [Test]
+    public void ReleasedClaimCannotBeDispatched()
+    {
+        var store = new FileAiRequestRecoveryStore(_directory);
+        var attempt = new AiPendingAttempt(
+            "account", "image.generate", "released-dispatch", "released-key", null,
+            new AiRequestFormSnapshot(Prompt: "released"));
+        store.WriteOrGet(attempt);
+        AiRequestRecoveryLease claim = store.Claim(
+            attempt.AccountId, attempt.Operation, attempt.Fingerprint, attempt.Key)!;
+        claim.Dispose();
+
+        Assert.That(claim.MarkDispatched(), Is.False);
+        Assert.That(store.Abandon(attempt), Is.True);
+    }
+
+    [Test]
+    public void ConcurrentDispatchCallsPublishOneFence()
+    {
+        var store = new FileAiRequestRecoveryStore(_directory);
+        for (int round = 0; round < 50; round++)
+        {
+            var attempt = new AiPendingAttempt(
+                "account", "image.generate", $"concurrent-dispatch-{round}", $"concurrent-key-{round}", null,
+                new AiRequestFormSnapshot(Prompt: "concurrent"));
+            store.WriteOrGet(attempt);
+            using AiRequestRecoveryLease claim = store.Claim(
+                attempt.AccountId, attempt.Operation, attempt.Fingerprint, attempt.Key)!;
+            using var beforeCas = new Barrier(2);
+            claim.BeforeDispatchCompareExchange = () =>
+            {
+                if (!beforeCas.SignalAndWait(TimeSpan.FromSeconds(5)))
+                    throw new TimeoutException("Concurrent callers did not reach the dispatch CAS together.");
+            };
+
+            bool[] results = new bool[16];
+            Task first = Task.Factory.StartNew(
+                () => results[0] = claim.MarkDispatched(),
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
+            Task second = Task.Factory.StartNew(
+                () => results[1] = claim.MarkDispatched(),
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
+            Assert.That(Task.WaitAll([first, second], TimeSpan.FromSeconds(5)), Is.True);
+            Parallel.For(2, results.Length, index => results[index] = claim.MarkDispatched());
+
+            Assert.That(results, Has.All.True, $"round {round}");
+            Assert.That(claim.IsDispatched, Is.True, $"round {round}");
+            Assert.That(store.Abandon(attempt), Is.False, $"round {round}");
+        }
+    }
+
+    [Test]
+    public void GenerationTombstonesPruneSettledIdentities()
+    {
+        var store = new FileAiRequestRecoveryStore(_directory);
+        for (int index = 0; index < 1_100; index++)
+        {
+            var attempt = new AiPendingAttempt(
+                "account",
+                "image.generate",
+                $"generation-{index}",
+                $"generation-key-{index}",
+                null,
+                new AiRequestFormSnapshot(Prompt: index.ToString()));
+            store.WriteOrGet(attempt);
+            Assert.That(store.TrySettle(
+                attempt.AccountId,
+                attempt.Operation,
+                attempt.Fingerprint,
+                attempt.Key), Is.True);
+        }
+
+        var active = new AiPendingAttempt(
+            "account",
+            "image.generate",
+            "active-generation",
+            "active-generation-key",
+            null,
+            new AiRequestFormSnapshot(Prompt: "active"));
+        store.WriteOrGet(active);
+        Assert.That(store.Find(active.AccountId, active.Operation, active.Fingerprint)?.Key,
+            Is.EqualTo(active.Key));
+    }
+
+    private static AiPendingAttempt Record(
+        string account,
+        string operation,
+        string fingerprint,
+        string key)
+        => new(account, operation, fingerprint, key, Model: null);
+}


### PR DESCRIPTION
## Description

- Add server-backed paid AI image generation, image editing, video generation, caption generation/translation, and job recovery workflows.
- Present the workflows in non-modal AI workspaces with model-aware validation, usage estimates, prompt history, and durable account-scoped recovery.
- Add lease-backed extension points for AI job capabilities, element-source handlers, caption codecs, and caption templates.
- Keep generated media, caption metadata, retries, uploads, and shutdown cleanup bounded and durable.

The branch was rewritten onto `origin/main` as one focused commit. Unrelated changes were removed into independent PRs:

- #2322 — DirectoryWatcher disposal race.
- #2323 — AgentHost endpoint lifecycle.
- #2324 — generic editor, tool, and project lifecycle ownership.

## Affected areas

- `Beutl.Api`: paid AI transport, models, job monitoring, retry, upload, entitlement, and extension registry contracts.
- `Beutl.Editor`: asynchronous element sources, AI result application, caption codecs/templates, and serialization.
- `Beutl`: AI workspace UI, account presentation, recovery, import/export, and application shutdown.
- Extension SDK, package lifecycle handling, localization resources, and focused tests.

## Breaking changes

- `Beutl.Api` adds paid AI contracts and revises AI model, request, retry, upload, availability, and job capability APIs.
- `IExtensionProvider` uses descriptor/lease discovery and exposes `ExtensionsChanged`; executable extension instances must be retained only through leases.
- `IElementAdder` uses `AddAsync`; `ElementDescription` uses `ElementSource` and permits handler-defined duration.
- AI result, source-handler, caption codec, and caption template contributions are registered as independent lease-backed capability slots.
- Extension projects using these contracts must reference `Beutl.Api` and `Beutl.Editor` and migrate their registrations.

## Test plan

- GitHub build, full CPU tests, Vulkan validation tests, format check, and coverage upload passed at `5d114303a`.
- `dotnet build Beutl.slnx -c Debug --no-restore --nologo` — passed locally with 15 existing warnings and 0 errors.
- Focused regression passes include 102 unit tests for AI jobs/models/captions, 15 AI importer tests, 8 element-entry headless tests, 5 video-import headless tests, and 220 public API contract tests.
- The package-tools cancellation race passed its two-test fixture and 20 consecutive focused repetitions.
- GPL/MIT diff scan and `git diff --check` passed.
- Changed-file `dotnet format --verify-no-changes` passed; the full-solution check reports only the existing MediaFoundation CA1416 diagnostics locally.
- Final branch audit: one commit and 288 files. The extracted generic lifecycle API work, DirectoryWatcher race fix, AgentHost endpoint lifecycle fix, and CI workflow edits are not present.

## Fixed issues

None.