### PR TITLE
ci: integrate Codecov coverage reporting

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   build:
     permissions:
-      pull-requests: write
+      contents: read
+      id-token: write
 
     runs-on: ubuntu-latest
 
@@ -162,27 +163,13 @@ jobs:
         # instead of listing each package once per test assembly.
         run: reportgenerator -reports:"tests/**/coverage.cobertura.xml" -targetdir:coveragereport -reporttypes:"Cobertura;Html"
 
-      - name: Code Coverage Report
-        uses: irongut/CodeCoverageSummary@v1.3.0
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          filename: coveragereport/Cobertura.xml
-          badge: true
-          fail_below_min: true
-          format: markdown
-          hide_branch_rate: false
-          hide_complexity: false
-          indicators: true
-          output: both
-          thresholds: '0 80'
-#          thresholds: '60 80'
-
-      - name: Add Coverage PR Comment
-        uses: marocchino/sticky-pull-request-comment@v3
-        if: github.event_name == 'pull_request'
-        continue-on-error: true
-        with:
-          recreate: true
-          path: code-coverage-results.md
+          files: ./coveragereport/Cobertura.xml
+          disable_search: true
+          fail_ci_if_error: true
+          use_oidc: true
 
       - name: Save
         uses: actions/upload-artifact@v7

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -10,7 +10,6 @@ jobs:
   build:
     permissions:
       contents: read
-      id-token: write
 
     runs-on: ubuntu-latest
 
@@ -163,6 +162,32 @@ jobs:
         # instead of listing each package once per test assembly.
         run: reportgenerator -reports:"tests/**/coverage.cobertura.xml" -targetdir:coveragereport -reporttypes:"Cobertura;Html"
 
+      - name: Save
+        uses: actions/upload-artifact@v7
+        with:
+          name: Coverage
+          path: coveragereport
+
+  upload-coverage:
+    needs: build
+    permissions:
+      contents: read
+      id-token: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Download coverage report
+        uses: actions/download-artifact@v8
+        with:
+          name: Coverage
+          path: coveragereport
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
@@ -170,9 +195,3 @@ jobs:
           disable_search: true
           fail_ci_if_error: true
           use_oidc: true
-
-      - name: Save
-        uses: actions/upload-artifact@v7
-        with:
-          name: Coverage
-          path: coveragereport

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+comment:
+  layout: "header, diff, files, footer"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true
+  hide_project_coverage: false


### PR DESCRIPTION
## Description

- Upload the merged Cobertura report to Codecov from the existing .NET workflow.
- Authenticate same-repository runs with GitHub OIDC and retain tokenless uploads for public fork pull requests.
- Pin `codecov/codecov-action` v7.0.0 to its commit SHA.
- Replace the hand-written coverage summary comment with Codecov-managed pull request comments.
- Configure comments to include project, diff, and affected-file coverage, including the initial pull request before a base report exists.

## Affected areas

- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [x] Build / CI / docs only

## Breaking changes

None.

## Test plan

- `actionlint .github/workflows/dotnet.yml`
- Validate `codecov.yml` with Codecov's configuration validator
- `dotnet format Beutl.slnx --verify-no-changes --no-restore`
- `bash .claude/scripts/check-gpl-mit-boundary-diff.sh --files .github/workflows/dotnet.yml codecov.yml`
- `dotnet build Beutl.slnx -c Debug --nologo`
- `git diff --check`

## Fixed issues / References

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated build checks to publish test coverage through a separate Codecov reporting step.
  * Coverage reports are preserved and transferred between build and reporting stages.
  * Coverage uploads continue to fail the workflow when reporting encounters an error.
  * Configured pull-request coverage comments to show summary, changed files, and footer details.
  * Coverage comments can be posted without requiring coverage changes or a base commit, while requiring a head commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->