### PR TITLE
test(rendering): scope renderer pull API census

### DIFF
--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
@@ -381,6 +381,81 @@ public sealed class RenderPipelineMigrationCensusTests
     }
 
     [Test]
+    public void ProcessorPullApiCensus_Resolves_global_alias_block_and_shadowing_rules()
+    {
+        const string globalPath = "src/Compatibility/GlobalExtensions.cs";
+        const string aliasPath = "src/Compatibility/AliasExtensions.cs";
+        const string blockPath = "src/Compatibility/ExtensionBlock.cs";
+        SourceCorpus corpus = SourceCorpus.Create(
+            ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
+                """
+                namespace Beutl.Graphics.Rendering;
+                public sealed class RenderNodeProcessor { }
+                """),
+            ("src/Compatibility/GlobalUsings.cs",
+                "global using Beutl.Graphics.Rendering;"),
+            (globalPath,
+                """
+                namespace Compatibility;
+                public static class GlobalExtensions
+                {
+                    public static void Pull(this RenderNodeProcessor processor) { }
+                }
+                """),
+            (aliasPath,
+                """
+                using Rendering = Beutl.Graphics.Rendering;
+                namespace Compatibility;
+                public static class AliasExtensions
+                {
+                    public static void Pull(this Rendering.RenderNodeProcessor processor) { }
+                }
+                """),
+            (blockPath,
+                """
+                using Beutl.Graphics.Rendering;
+                namespace Compatibility;
+                public static class BlockExtensions
+                {
+                    extension(RenderNodeProcessor processor)
+                    {
+                        public void Pull() { }
+                    }
+                }
+                """),
+            ("src/Other/AliasShadow.cs",
+                """
+                using RenderNodeProcessor = Other.RenderNodeProcessor;
+                using Beutl.Graphics.Rendering;
+                namespace Other;
+                public sealed class RenderNodeProcessor { }
+                public static class AliasShadowExtensions
+                {
+                    public static void Pull(this RenderNodeProcessor processor) { }
+                }
+                """),
+            ("src/Other/LocalShadow.cs",
+                """
+                using Beutl.Graphics.Rendering;
+                namespace LocalShadow;
+                public sealed class RenderNodeProcessor { }
+                public static class LocalShadowExtensions
+                {
+                    public static void Pull(this RenderNodeProcessor processor) { }
+                }
+                """));
+
+        SourceFinding[] findings = corpus.FindMembersDeclaredByType(
+                "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                ["Pull"])
+            .ToArray();
+
+        Assert.That(
+            findings.Select(finding => finding.RelativePath),
+            Is.EquivalentTo(new[] { globalPath, aliasPath, blockPath }));
+    }
+
+    [Test]
     public void ListRasterizationCompatibility_IsRemoved()
     {
         string[] compatibilityNames =
@@ -462,6 +537,7 @@ public sealed class RenderPipelineMigrationCensusTests
     public void ContextScaleHelpers_AreMovedWithoutForwardingMembers()
     {
         string contextType = BuildName("Render", "Node", "Context");
+        string qualifiedContextType = $"Beutl.Graphics.Rendering.{contextType}";
         string[] helperNames =
         [
             BuildName("Max", "Buffer", "Dimension"),
@@ -470,7 +546,7 @@ public sealed class RenderPipelineMigrationCensusTests
             BuildName("Clamp", "Working", "Scale", "To", "Buffer", "Budget"),
         ];
         IEnumerable<SourceFinding> findings = s_corpus.Value.FindQualifiedReferences(contextType, helperNames)
-            .Concat(s_corpus.Value.FindMembersDeclaredByType(contextType, helperNames));
+            .Concat(s_corpus.Value.FindMembersDeclaredByType(qualifiedContextType, helperNames));
 
         AssertNoFindings("Scale helpers must be owned only by RenderScaleUtilities.", findings);
     }
@@ -595,10 +671,21 @@ public sealed class RenderPipelineMigrationCensusTests
 
     private sealed class SourceCorpus
     {
+        private readonly UsingDirectiveSyntax[] _globalUsings;
+        private readonly HashSet<string> _declaredTypes;
+
         private SourceCorpus(string repositoryRoot, IReadOnlyList<SourceDocument> documents)
         {
             RepositoryRoot = repositoryRoot;
             Documents = documents;
+            _globalUsings = documents
+                .SelectMany(document => document.Root.Usings)
+                .Where(item => item.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword))
+                .ToArray();
+            _declaredTypes = documents
+                .SelectMany(document => document.Root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+                .Select(GetQualifiedTypeName)
+                .ToHashSet(StringComparer.Ordinal);
         }
 
         public string RepositoryRoot { get; }
@@ -631,7 +718,9 @@ public sealed class RenderPipelineMigrationCensusTests
                     SourceText text = SourceText.From(File.ReadAllText(path));
                     var tree = CSharpSyntaxTree.ParseText(
                         text,
-                        CSharpParseOptions.Default.WithDocumentationMode(DocumentationMode.Parse),
+                        CSharpParseOptions.Default
+                            .WithLanguageVersion(LanguageVersion.Preview)
+                            .WithDocumentationMode(DocumentationMode.Parse),
                         relativePath);
                     documents.Add(new SourceDocument(
                         relativePath,
@@ -653,7 +742,9 @@ public sealed class RenderPipelineMigrationCensusTests
                     SourceText text = SourceText.From(source.Source);
                     var tree = CSharpSyntaxTree.ParseText(
                         text,
-                        CSharpParseOptions.Default.WithDocumentationMode(DocumentationMode.Parse),
+                        CSharpParseOptions.Default
+                            .WithLanguageVersion(LanguageVersion.Preview)
+                            .WithDocumentationMode(DocumentationMode.Parse),
                         source.RelativePath);
                     return new SourceDocument(source.RelativePath, text, tree.GetCompilationUnitRoot());
                 })
@@ -834,11 +925,24 @@ public sealed class RenderPipelineMigrationCensusTests
                              .Where(method => memberNameSet.Contains(method.Identifier.ValueText)))
                 {
                     ParameterSyntax? receiver = method.ParameterList.Parameters.FirstOrDefault();
+                    bool extensionBlockReceiver = false;
                     if (receiver is null
-                        || !receiver.Modifiers.Any(SyntaxKind.ThisKeyword)
+                        && method.Ancestors().FirstOrDefault(node =>
+                            node.IsKind(SyntaxKind.ExtensionBlockDeclaration)) is { } extensionBlock)
+                    {
+                        receiver = extensionBlock.ChildNodes()
+                            .OfType<ParameterListSyntax>()
+                            .SelectMany(list => list.Parameters)
+                            .FirstOrDefault();
+                        extensionBlockReceiver = receiver is not null;
+                    }
+
+                    if (receiver is null
+                        || !extensionBlockReceiver
+                        && !receiver.Modifiers.Any(SyntaxKind.ThisKeyword)
                         || !CouldReferToType(
                             receiver.Type,
-                            document.Root,
+                            document,
                             namespaceName,
                             typeName,
                             qualifiedTypeName))
@@ -866,9 +970,9 @@ public sealed class RenderPipelineMigrationCensusTests
             return string.Join('.', namespaces.Concat(containingTypes).Append(type.Identifier.ValueText));
         }
 
-        private static bool CouldReferToType(
+        private bool CouldReferToType(
             TypeSyntax? type,
-            CompilationUnitSyntax root,
+            SourceDocument document,
             string namespaceName,
             string typeName,
             string qualifiedTypeName)
@@ -884,14 +988,22 @@ public sealed class RenderPipelineMigrationCensusTests
                 return true;
             }
 
-            IEnumerable<UsingDirectiveSyntax> usings = root.Usings.Concat(
+            UsingDirectiveSyntax[] usings = document.Root.Usings.Concat(
                 type.Ancestors().OfType<BaseNamespaceDeclarationSyntax>().SelectMany(item => item.Usings));
+            usings = usings.Concat(_globalUsings).ToArray();
+            int nameSeparator = writtenType.IndexOf('.');
+            string aliasName = nameSeparator < 0 ? writtenType : writtenType[..nameSeparator];
             UsingDirectiveSyntax? alias = usings.FirstOrDefault(item =>
-                item.Alias?.Name.Identifier.ValueText == writtenType);
-            if (alias?.Name?.ToString().Replace("global::", string.Empty, StringComparison.Ordinal)
-                == qualifiedTypeName)
+                item.Alias?.Name.Identifier.ValueText == aliasName);
+            if (alias is not null)
             {
-                return true;
+                string aliasTarget = alias.Name?.ToString()
+                    .Replace("global::", string.Empty, StringComparison.Ordinal)
+                    ?? string.Empty;
+                string resolvedAlias = nameSeparator < 0
+                    ? aliasTarget
+                    : aliasTarget + writtenType[nameSeparator..];
+                return resolvedAlias == qualifiedTypeName;
             }
 
             if (writtenType != typeName)
@@ -903,8 +1015,31 @@ public sealed class RenderPipelineMigrationCensusTests
                 .OfType<BaseNamespaceDeclarationSyntax>()
                 .Reverse()
                 .Select(item => item.Name.ToString()));
+            for (string scope = declaredNamespace;;)
+            {
+                string declaredType = string.IsNullOrEmpty(scope)
+                    ? typeName
+                    : scope + "." + typeName;
+                if (_declaredTypes.Contains(declaredType))
+                {
+                    return declaredType == qualifiedTypeName;
+                }
+
+                int separator = scope.LastIndexOf('.');
+                if (separator < 0)
+                {
+                    break;
+                }
+
+                scope = scope[..separator];
+            }
+
             return declaredNamespace == namespaceName
-                   || usings.Any(item => item.Alias is null && item.Name?.ToString() == namespaceName);
+                   || usings.Any(item => item.Alias is null
+                       && item.Name?.ToString().Replace(
+                           "global::",
+                           string.Empty,
+                           StringComparison.Ordinal) == namespaceName);
         }
 
         private IEnumerable<SourceFinding> FindText(Regex pattern, string detail)

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
@@ -733,6 +733,68 @@ public sealed class RenderPipelineMigrationCensusTests
     }
 
     [Test]
+    public void ProcessorPullApiCensus_Filters_private_bases_and_resolves_generic_aliases()
+    {
+        const string genericBasePath = "src/Compatibility/ProcessorBase.cs";
+        SourceCorpus corpus = SourceCorpus.Create(
+            (genericBasePath,
+                """
+                namespace Compatibility;
+                public class ProcessorBase<T>
+                {
+                    public void Pull() { }
+                    private void PullToRoot() { }
+                }
+                """),
+            ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
+                """
+                using B = Compatibility.ProcessorBase<int>;
+                namespace Beutl.Graphics.Rendering;
+                public sealed class RenderNodeProcessor : B { }
+                """));
+
+        SourceFinding[] findings = corpus.FindMembersDeclaredByType(
+                "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                ["Pull", "PullToRoot"])
+            .ToArray();
+
+        Assert.That(findings.Select(finding => finding.RelativePath),
+            Is.EqualTo(new[] { genericBasePath }));
+    }
+
+    [Test]
+    public void ProcessorPullApiCensus_Preserves_global_qualification_over_aliases()
+    {
+        SourceCorpus corpus = SourceCorpus.Create(
+            ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
+                """
+                namespace Beutl.Graphics.Rendering;
+                public sealed class RenderNodeProcessor { }
+                """),
+            ("src/Other/GlobalProcessor.cs",
+                """
+                namespace Rendering;
+                public sealed class RenderNodeProcessor { }
+                """),
+            ("src/Compatibility/GlobalQualifiedExtensions.cs",
+                """
+                using Rendering = Beutl.Graphics.Rendering;
+                namespace Compatibility;
+                public static class GlobalQualifiedExtensions
+                {
+                    public static void Pull(
+                        this global::Rendering.RenderNodeProcessor processor) { }
+                }
+                """));
+
+        Assert.That(
+            corpus.FindMembersDeclaredByType(
+                "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                ["Pull"]),
+            Is.Empty);
+    }
+
+    [Test]
     public void ProcessorPullApiCensus_Scopes_global_usings_to_their_compilation()
     {
         const string visiblePath = "src/A/VisibleExtensions.cs";
@@ -1351,6 +1413,11 @@ public sealed class RenderPipelineMigrationCensusTests
                     {
                         foreach (MemberDeclarationSyntax member in visibleType.Syntax.Members)
                         {
+                            if (!IsExternallyAccessible(member, visibleType.Syntax))
+                            {
+                                continue;
+                            }
+
                             foreach (SyntaxToken identifier in GetDeclaredIdentifiers(member)
                                          .Where(token => memberNameSet.Contains(token.ValueText)))
                             {
@@ -1387,6 +1454,15 @@ public sealed class RenderPipelineMigrationCensusTests
                 foreach (MemberDeclarationSyntax member in document.Root.DescendantNodes()
                              .OfType<MemberDeclarationSyntax>())
                 {
+                    TypeDeclarationSyntax? containingType = member.Ancestors()
+                        .OfType<TypeDeclarationSyntax>()
+                        .FirstOrDefault();
+                    if (containingType is null
+                        || !IsExternallyAccessible(member, containingType))
+                    {
+                        continue;
+                    }
+
                     SyntaxToken[] identifiers = GetDeclaredIdentifiers(member)
                         .Where(token => memberNameSet.Contains(token.ValueText))
                         .ToArray();
@@ -1848,6 +1924,11 @@ public sealed class RenderPipelineMigrationCensusTests
                 return true;
             }
 
+            if (IsGloballyQualified(type))
+            {
+                return false;
+            }
+
             UsingDirectiveSyntax[] usings = type.Ancestors()
                 .OfType<BaseNamespaceDeclarationSyntax>()
                 .SelectMany(item => item.Usings)
@@ -1875,7 +1956,7 @@ public sealed class RenderPipelineMigrationCensusTests
             {
                 string aliasTarget = alias.Name is null
                     ? string.Empty
-                    : GetWrittenName(alias.Name);
+                    : GetWrittenTypeIdentity(alias.Name);
                 string suffix = nameSeparator < 0 ? string.Empty : writtenType[nameSeparator..];
                 return GetImportCandidates(alias, aliasTarget)
                     .Any(candidate => candidate + suffix == qualifiedTypeName);
@@ -1977,6 +2058,13 @@ public sealed class RenderPipelineMigrationCensusTests
             };
         }
 
+        private static bool IsGloballyQualified(TypeSyntax type)
+        {
+            return type.DescendantNodesAndSelf()
+                .OfType<AliasQualifiedNameSyntax>()
+                .Any(alias => alias.Alias.Identifier.ValueText == "global");
+        }
+
         private static string GetWrittenName(NameSyntax name)
         {
             return name.ToString().Replace("global::", string.Empty, StringComparison.Ordinal);
@@ -2051,6 +2139,22 @@ public sealed class RenderPipelineMigrationCensusTests
                     eventField.Declaration.Variables.Select(variable => variable.Identifier),
                 _ => [],
             };
+        }
+
+        private static bool IsExternallyAccessible(
+            MemberDeclarationSyntax member,
+            TypeDeclarationSyntax containingType)
+        {
+            SyntaxTokenList modifiers = member switch
+            {
+                BaseMethodDeclarationSyntax method => method.Modifiers,
+                BasePropertyDeclarationSyntax property => property.Modifiers,
+                BaseFieldDeclarationSyntax field => field.Modifiers,
+                _ => default,
+            };
+            return modifiers.Any(SyntaxKind.PublicKeyword)
+                   || containingType is InterfaceDeclarationSyntax
+                   && !modifiers.Any(SyntaxKind.PrivateKeyword);
         }
 
         private static string NormalizePath(string path)

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
@@ -953,6 +953,124 @@ public sealed class RenderPipelineMigrationCensusTests
     }
 
     [Test]
+    public void ProcessorPullApiCensus_Does_not_inherit_interface_default_members()
+    {
+        SourceCorpus corpus = SourceCorpus.Create(
+            ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
+                """
+                namespace Beutl.Graphics.Rendering;
+                public interface IProcessor
+                {
+                    public void Pull() { }
+                }
+                public sealed class RenderNodeProcessor : IProcessor { }
+                """));
+
+        Assert.That(
+            corpus.FindMembersDeclaredByType(
+                "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                ["Pull"]),
+            Is.Empty);
+    }
+
+    [Test]
+    public void ProcessorPullApiCensus_Resolves_engine_extern_alias_receivers()
+    {
+        const string extensionPath = "src/Compatibility/ExternAliasExtensions.cs";
+        SourceCorpus corpus = SourceCorpus.Create(
+            ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
+                """
+                namespace Beutl.Graphics.Rendering;
+                public sealed class RenderNodeProcessor { }
+                """),
+            (extensionPath,
+                """
+                extern alias Engine;
+                namespace Compatibility;
+                public static class ExternAliasExtensions
+                {
+                    public static void Pull(
+                        this Engine::Beutl.Graphics.Rendering.RenderNodeProcessor processor) { }
+                }
+                """));
+
+        Assert.That(
+            corpus.FindMembersDeclaredByType(
+                    "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                    ["Pull"])
+                .Select(finding => finding.RelativePath),
+            Is.EqualTo(new[] { extensionPath }));
+    }
+
+    [Test]
+    public void ProcessorPullApiCensus_Uses_active_variant_receiver_hierarchy()
+    {
+        const string extensionPath = "src/Compatibility/WindowsBaseExtensions.cs";
+        SourceCorpus corpus = SourceCorpus.Create(
+            ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
+                """
+                namespace Beutl.Graphics.Rendering;
+                public interface IProcessorBase { }
+                public sealed class RenderNodeProcessor
+                #if WINDOWS
+                    : IProcessorBase
+                #endif
+                { }
+                """),
+            (extensionPath,
+                """
+                using Beutl.Graphics.Rendering;
+                namespace Compatibility;
+                public static class WindowsBaseExtensions
+                {
+                #if WINDOWS
+                    public static void Pull(this IProcessorBase processor) { }
+                #endif
+                }
+                """));
+
+        Assert.That(
+            corpus.FindMembersDeclaredByType(
+                    "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                    ["Pull"])
+                .Select(finding => finding.RelativePath),
+            Is.EqualTo(new[] { extensionPath }));
+    }
+
+    [Test]
+    public void ProcessorPullApiCensus_Follows_indirect_referenced_base_receivers()
+    {
+        const string extensionPath = "src/Compatibility/IndirectBaseExtensions.cs";
+        SourceCorpus corpus = SourceCorpus.Create(
+            ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
+                """
+                using System;
+                namespace Beutl.Graphics.Rendering;
+                public class ProcessorBase : IDisposable
+                {
+                    public void Dispose() { }
+                }
+                public sealed class RenderNodeProcessor : ProcessorBase { }
+                """),
+            (extensionPath,
+                """
+                using System;
+                namespace Compatibility;
+                public static class IndirectBaseExtensions
+                {
+                    public static void Pull(this IDisposable processor) { }
+                }
+                """));
+
+        Assert.That(
+            corpus.FindMembersDeclaredByType(
+                    "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                    ["Pull"])
+                .Select(finding => finding.RelativePath),
+            Is.EqualTo(new[] { extensionPath }));
+    }
+
+    [Test]
     public void ProcessorPullApiCensus_Scopes_global_usings_to_their_compilation()
     {
         const string visiblePath = "src/A/VisibleExtensions.cs";
@@ -1569,6 +1687,12 @@ public sealed class RenderPipelineMigrationCensusTests
                 {
                     foreach (DeclaredType visibleType in EnumerateTypeHierarchy(declared))
                     {
+                        if (!ReferenceEquals(visibleType.Syntax, declared.Syntax)
+                            && visibleType.Syntax is InterfaceDeclarationSyntax)
+                        {
+                            continue;
+                        }
+
                         foreach (MemberDeclarationSyntax member in visibleType.Syntax.Members)
                         {
                             if (!IsExternallyAccessible(member, visibleType.Syntax))
@@ -1686,7 +1810,14 @@ public sealed class RenderPipelineMigrationCensusTests
             IReadOnlySet<string> productionCompilationIds)
         {
             var result = new List<SourceDocument>();
-            foreach (IGrouping<string, SourceDocument> compilation in documents
+            IEnumerable<SourceDocument> memberDocuments = documents;
+            if (repositoryRoot != "synthetic")
+            {
+                memberDocuments = memberDocuments.Concat(
+                    GetLinkedSourceDocuments(repositoryRoot, documents));
+            }
+
+            foreach (IGrouping<string, SourceDocument> compilation in memberDocuments
                          .Where(document =>
                              document.RelativePath.StartsWith("src/", StringComparison.Ordinal)
                              && productionCompilationIds.Contains(document.CompilationId))
@@ -1717,6 +1848,88 @@ public sealed class RenderPipelineMigrationCensusTests
             }
 
             return [.. result];
+        }
+
+        private static IEnumerable<SourceDocument> GetLinkedSourceDocuments(
+            string repositoryRoot,
+            IReadOnlyList<SourceDocument> documents)
+        {
+            var byPath = documents
+                .GroupBy(document => document.RelativePath, StringComparer.Ordinal)
+                .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+            string sourceRoot = Path.Combine(repositoryRoot, "src");
+            foreach (string projectPath in Directory.EnumerateFiles(
+                         sourceRoot,
+                         "*.csproj",
+                         SearchOption.AllDirectories))
+            {
+                string compilationId = NormalizePath(Path.GetRelativePath(
+                    repositoryRoot,
+                    projectPath));
+                XDocument project;
+                try
+                {
+                    project = XDocument.Load(projectPath);
+                }
+                catch (Exception ex) when (ex is IOException
+                                           or UnauthorizedAccessException
+                                           or System.Xml.XmlException)
+                {
+                    continue;
+                }
+
+                foreach (string include in project.Descendants()
+                             .Where(element => element.Name.LocalName == "Compile")
+                             .Select(element => (string?)element.Attribute("Include"))
+                             .OfType<string>()
+                             .Where(include =>
+                                 !include.Contains('*', StringComparison.Ordinal)
+                                 && !include.Contains("$(", StringComparison.Ordinal)))
+                {
+                    string fullPath;
+                    try
+                    {
+                        fullPath = Path.GetFullPath(
+                            include.Replace('\\', Path.DirectorySeparatorChar),
+                            Path.GetDirectoryName(projectPath)!);
+                    }
+                    catch (Exception ex) when (ex is ArgumentException or NotSupportedException)
+                    {
+                        continue;
+                    }
+
+                    if (!File.Exists(fullPath))
+                    {
+                        continue;
+                    }
+
+                    string relativePath = NormalizePath(Path.GetRelativePath(
+                        repositoryRoot,
+                        fullPath));
+                    if (!relativePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
+                        || documents.Any(document =>
+                            document.RelativePath == relativePath
+                            && document.CompilationId == compilationId))
+                    {
+                        continue;
+                    }
+
+                    SourceText text = byPath.TryGetValue(relativePath, out SourceDocument? existing)
+                        ? existing.Text
+                        : SourceText.From(File.ReadAllText(fullPath));
+                    var tree = CSharpSyntaxTree.ParseText(
+                        text,
+                        CSharpParseOptions.Default
+                            .WithLanguageVersion(LanguageVersion.Preview)
+                            .WithDocumentationMode(DocumentationMode.Parse),
+                        relativePath);
+                    yield return new SourceDocument(
+                        relativePath,
+                        text,
+                        tree.GetCompilationUnitRoot(),
+                        compilationId);
+                }
+            }
         }
 
         private static IReadOnlyList<string[]> GetCompilationSymbolSets(
@@ -2032,18 +2245,21 @@ public sealed class RenderPipelineMigrationCensusTests
                 return true;
             }
 
-            foreach (DeclaredType target in _declaredTypes.Where(item =>
+            foreach (DeclaredType target in _memberDeclaredTypes.Value.Where(item =>
                          !item.IsFileLocal
                          && item.Document.RelativePath.StartsWith("src/", StringComparison.Ordinal)
                          && _productionCompilationIds.Contains(item.Document.CompilationId)
+                         && item.Document.VariantId == document.VariantId
                          && item.QualifiedName == qualifiedTypeName))
             {
-                if (CanReceiveReferencedBase(receiverType, target))
+                DeclaredType[] hierarchy = EnumerateTypeHierarchy(target).ToArray();
+                if (hierarchy.Any(candidate =>
+                        CanReceiveReferencedBase(receiverType, candidate)))
                 {
                     return true;
                 }
 
-                foreach (DeclaredType baseType in EnumerateTypeHierarchy(target).Skip(1))
+                foreach (DeclaredType baseType in hierarchy.Skip(1))
                 {
                     if (CouldReferToType(
                             receiverType,
@@ -2105,6 +2321,19 @@ public sealed class RenderPipelineMigrationCensusTests
             if (writtenType == qualifiedTypeName)
             {
                 return true;
+            }
+
+            AliasQualifiedNameSyntax? aliasQualified = type.DescendantNodesAndSelf()
+                .OfType<AliasQualifiedNameSyntax>()
+                .FirstOrDefault();
+            if (aliasQualified is not null
+                && aliasQualified.Alias.Identifier.ValueText != "global")
+            {
+                string aliasName = aliasQualified.Alias.Identifier.ValueText;
+                string prefix = aliasName + ".";
+                return writtenType.StartsWith(prefix, StringComparison.Ordinal)
+                       && writtenType[prefix.Length..] == qualifiedTypeName
+                       && ExternAliasTargetsEngine(aliasName, document);
             }
 
             if (IsGloballyQualified(type))
@@ -2233,6 +2462,65 @@ public sealed class RenderPipelineMigrationCensusTests
                 {
                     return resolved == qualifiedTarget;
                 }
+            }
+
+            return false;
+        }
+
+        private bool ExternAliasTargetsEngine(
+            string aliasName,
+            SourceDocument document)
+        {
+            bool declared = document.Root.DescendantNodes()
+                .OfType<ExternAliasDirectiveSyntax>()
+                .Any(directive => directive.Identifier.ValueText == aliasName);
+            if (!declared)
+            {
+                return false;
+            }
+
+            if (RepositoryRoot == "synthetic")
+            {
+                return aliasName == "Engine";
+            }
+
+            string projectPath = Path.Combine(
+                RepositoryRoot,
+                document.CompilationId.Replace('/', Path.DirectorySeparatorChar));
+            try
+            {
+                XDocument project = XDocument.Load(projectPath);
+                foreach (XElement reference in project.Descendants()
+                             .Where(element => element.Name.LocalName == "ProjectReference"))
+                {
+                    string? include = (string?)reference.Attribute("Include");
+                    string? aliases = reference.Elements()
+                        .FirstOrDefault(element => element.Name.LocalName == "Aliases")?
+                        .Value;
+                    if (include is null
+                        || aliases is null
+                        || !aliases.Split(
+                                [';', ',', ' '],
+                                StringSplitOptions.RemoveEmptyEntries)
+                            .Contains(aliasName, StringComparer.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    string referencedProject = NormalizePath(Path.GetRelativePath(
+                        RepositoryRoot,
+                        Path.GetFullPath(
+                            include.Replace('\\', Path.DirectorySeparatorChar),
+                            Path.GetDirectoryName(projectPath)!)));
+                    return referencedProject == "src/Beutl.Engine/Beutl.Engine.csproj";
+                }
+            }
+            catch (Exception ex) when (ex is IOException
+                                       or UnauthorizedAccessException
+                                       or ArgumentException
+                                       or NotSupportedException
+                                       or System.Xml.XmlException)
+            {
             }
 
             return false;

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
@@ -509,6 +509,107 @@ public sealed class RenderPipelineMigrationCensusTests
     }
 
     [Test]
+    public void ProcessorPullApiCensus_Resolves_target_symbols_and_receiver_conversions()
+    {
+        string[] expectedPaths =
+        [
+            "src/Compatibility/ConditionalExtensions.cs",
+            "src/Compatibility/InnerAliasExtensions.cs",
+            "src/Compatibility/GenericBlockExtensions.cs",
+            "src/Compatibility/PropertyExtensions.cs",
+            "src/Beutl.Compatibility/RelativeQualifiedExtensions.cs",
+            "src/Compatibility/BaseReceiverExtensions.cs",
+        ];
+        SourceCorpus corpus = SourceCorpus.Create(
+            ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
+                """
+                namespace Beutl.Graphics.Rendering;
+                public class ProcessorBase { }
+                public sealed class RenderNodeProcessor : ProcessorBase { }
+                """),
+            ("src/Other/RenderNodeProcessor.cs",
+                """
+                namespace Other;
+                public sealed class RenderNodeProcessor { }
+                """),
+            (expectedPaths[0],
+                """
+                namespace Compatibility;
+                public static class ConditionalExtensions
+                {
+                #if WINDOWS
+                    public static void Pull(
+                        this Beutl.Graphics.Rendering.RenderNodeProcessor processor) { }
+                #endif
+                }
+                """),
+            (expectedPaths[1],
+                """
+                using P = Other.RenderNodeProcessor;
+                namespace Compatibility
+                {
+                    using P = Beutl.Graphics.Rendering.RenderNodeProcessor;
+                    public static class InnerAliasExtensions
+                    {
+                        public static void Pull(this P processor) { }
+                    }
+                }
+                """),
+            (expectedPaths[2],
+                """
+                using Beutl.Graphics.Rendering;
+                namespace Compatibility;
+                public static class GenericBlockExtensions
+                {
+                    extension<T>(T processor) where T : RenderNodeProcessor
+                    {
+                        public void Pull() { }
+                    }
+                }
+                """),
+            (expectedPaths[3],
+                """
+                using System;
+                using Beutl.Graphics.Rendering;
+                namespace Compatibility;
+                public static class PropertyExtensions
+                {
+                    extension(RenderNodeProcessor processor)
+                    {
+                        public Action Pull => () => { };
+                    }
+                }
+                """),
+            (expectedPaths[4],
+                """
+                namespace Beutl.Compatibility;
+                public static class RelativeQualifiedExtensions
+                {
+                    public static void Pull(
+                        this Graphics.Rendering.RenderNodeProcessor processor) { }
+                }
+                """),
+            (expectedPaths[5],
+                """
+                using Beutl.Graphics.Rendering;
+                namespace Compatibility;
+                public static class BaseReceiverExtensions
+                {
+                    public static void Pull(this ProcessorBase processor) { }
+                }
+                """));
+
+        SourceFinding[] findings = corpus.FindMembersDeclaredByType(
+                "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                ["Pull"])
+            .ToArray();
+
+        Assert.That(
+            findings.Select(finding => finding.RelativePath),
+            Is.EquivalentTo(expectedPaths));
+    }
+
+    [Test]
     public void ProcessorPullApiCensus_Includes_inherited_members()
     {
         const string basePath = "src/Beutl.Engine/Graphics/Rendering/ProcessorBase.cs";
@@ -789,11 +890,14 @@ public sealed class RenderPipelineMigrationCensusTests
     {
         private readonly IReadOnlyDictionary<string, UsingDirectiveSyntax[]> _globalUsings;
         private readonly DeclaredType[] _declaredTypes;
+        private readonly Lazy<SourceDocument[]> _memberCensusDocuments;
 
         private SourceCorpus(string repositoryRoot, IReadOnlyList<SourceDocument> documents)
         {
             RepositoryRoot = repositoryRoot;
             Documents = documents;
+            _memberCensusDocuments = new Lazy<SourceDocument[]>(() =>
+                CreateMemberCensusDocuments(documents));
             _globalUsings = documents
                 .GroupBy(document => document.CompilationId, StringComparer.Ordinal)
                 .ToDictionary(
@@ -1104,12 +1208,18 @@ public sealed class RenderPipelineMigrationCensusTests
             string typeName = separator >= 0 ? qualifiedTypeName[(separator + 1)..] : qualifiedTypeName;
             var memberNameSet = new HashSet<string>(memberNames, StringComparer.Ordinal);
             var reportedMembers = new HashSet<(string Path, int Position)>();
-            foreach (SourceDocument document in Documents)
+            foreach (SourceDocument document in EnumerateMemberCensusDocuments())
             {
-                foreach (DeclaredType declared in _declaredTypes.Where(item =>
-                             ReferenceEquals(item.Document, document)
-                             && !item.IsFileLocal
-                             && item.QualifiedName == qualifiedTypeName))
+                foreach (DeclaredType declared in document.Root.DescendantNodes()
+                             .OfType<TypeDeclarationSyntax>()
+                             .Select(type => new DeclaredType(
+                                 document,
+                                 type,
+                                 GetQualifiedTypeName(type),
+                                 type.Modifiers.Any(SyntaxKind.FileKeyword)))
+                             .Where(item =>
+                                 !item.IsFileLocal
+                                 && item.QualifiedName == qualifiedTypeName))
                 {
                     foreach (DeclaredType visibleType in EnumerateTypeHierarchy(declared))
                     {
@@ -1128,11 +1238,18 @@ public sealed class RenderPipelineMigrationCensusTests
                     }
                 }
 
-                foreach (MethodDeclarationSyntax method in document.Root.DescendantNodes()
-                             .OfType<MethodDeclarationSyntax>()
-                             .Where(method => memberNameSet.Contains(method.Identifier.ValueText)))
+                foreach (MemberDeclarationSyntax member in document.Root.DescendantNodes()
+                             .OfType<MemberDeclarationSyntax>())
                 {
-                    SyntaxNode? extensionBlock = method.Ancestors().FirstOrDefault(node =>
+                    SyntaxToken[] identifiers = GetDeclaredIdentifiers(member)
+                        .Where(token => memberNameSet.Contains(token.ValueText))
+                        .ToArray();
+                    if (identifiers.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    SyntaxNode? extensionBlock = member.Ancestors().FirstOrDefault(node =>
                         node.IsKind(SyntaxKind.ExtensionBlockDeclaration));
                     bool extensionBlockReceiver = extensionBlock is not null;
                     ParameterSyntax? receiver;
@@ -1143,15 +1260,19 @@ public sealed class RenderPipelineMigrationCensusTests
                             .SelectMany(list => list.Parameters)
                             .FirstOrDefault();
                     }
-                    else
+                    else if (member is MethodDeclarationSyntax method)
                     {
                         receiver = method.ParameterList.Parameters.FirstOrDefault();
+                    }
+                    else
+                    {
+                        continue;
                     }
 
                     if (receiver is null
                         || !extensionBlockReceiver
                         && !receiver.Modifiers.Any(SyntaxKind.ThisKeyword)
-                        || !CouldReferToType(
+                        || !CanReceiveType(
                             receiver.Type,
                             document,
                             namespaceName,
@@ -1161,11 +1282,50 @@ public sealed class RenderPipelineMigrationCensusTests
                         continue;
                     }
 
-                    yield return document.ToFinding(
-                        method.Identifier,
-                        $"extension member '{method.Identifier.ValueText}' for '{qualifiedTypeName}'");
+                    foreach (SyntaxToken identifier in identifiers)
+                    {
+                        if (reportedMembers.Add((document.RelativePath, identifier.SpanStart)))
+                        {
+                            yield return document.ToFinding(
+                                identifier,
+                                $"extension member '{identifier.ValueText}' for '{qualifiedTypeName}'");
+                        }
+                    }
                 }
             }
+        }
+
+        private IEnumerable<SourceDocument> EnumerateMemberCensusDocuments()
+        {
+            return _memberCensusDocuments.Value;
+        }
+
+        private static SourceDocument[] CreateMemberCensusDocuments(
+            IReadOnlyList<SourceDocument> documents)
+        {
+            string[][] symbolSets =
+            [
+                ["NET", "NET10_0", "NETCOREAPP"],
+                ["NET", "NET10_0", "NET10_0_WINDOWS", "NETCOREAPP", "WINDOWS"],
+            ];
+            var result = new List<SourceDocument>(documents.Count * (symbolSets.Length + 1));
+            foreach (SourceDocument document in documents)
+            {
+                result.Add(document);
+                foreach (string[] symbols in symbolSets)
+                {
+                    var tree = CSharpSyntaxTree.ParseText(
+                        document.Text,
+                        CSharpParseOptions.Default
+                            .WithLanguageVersion(LanguageVersion.Preview)
+                            .WithDocumentationMode(DocumentationMode.Parse)
+                            .WithPreprocessorSymbols(symbols),
+                        document.RelativePath);
+                    result.Add(document with { Root = tree.GetCompilationUnitRoot() });
+                }
+            }
+
+            return [.. result];
         }
 
         private static string GetQualifiedTypeName(TypeDeclarationSyntax type)
@@ -1224,6 +1384,44 @@ public sealed class RenderPipelineMigrationCensusTests
             }
         }
 
+        private bool CanReceiveType(
+            TypeSyntax? receiverType,
+            SourceDocument document,
+            string namespaceName,
+            string typeName,
+            string qualifiedTypeName)
+        {
+            if (CouldReferToType(
+                    receiverType,
+                    document,
+                    namespaceName,
+                    typeName,
+                    qualifiedTypeName))
+            {
+                return true;
+            }
+
+            foreach (DeclaredType target in _declaredTypes.Where(item =>
+                         !item.IsFileLocal
+                         && item.QualifiedName == qualifiedTypeName))
+            {
+                foreach (DeclaredType baseType in EnumerateTypeHierarchy(target).Skip(1))
+                {
+                    if (CouldReferToType(
+                            receiverType,
+                            document,
+                            GetNamespaceName(baseType.Syntax),
+                            GetTypeIdentityName(baseType.Syntax),
+                            baseType.QualifiedName))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
         private bool CouldReferToType(
             TypeSyntax? type,
             SourceDocument document,
@@ -1241,11 +1439,17 @@ public sealed class RenderPipelineMigrationCensusTests
                 type = nullable.ElementType;
             }
 
-            if (type is IdentifierNameSyntax typeParameter
-                && type.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault() is { } method)
+            if (type is IdentifierNameSyntax typeParameter)
             {
-                TypeParameterConstraintClauseSyntax? clause = method.ConstraintClauses.FirstOrDefault(
-                    item => item.Name.Identifier.ValueText == typeParameter.Identifier.ValueText);
+                TypeParameterConstraintClauseSyntax? clause = type.Ancestors()
+                    .OfType<MethodDeclarationSyntax>()
+                    .SelectMany(method => method.ConstraintClauses)
+                    .Concat(type.Ancestors()
+                        .FirstOrDefault(node => node.IsKind(SyntaxKind.ExtensionBlockDeclaration))?
+                        .ChildNodes()
+                        .OfType<TypeParameterConstraintClauseSyntax>() ?? [])
+                    .FirstOrDefault(item =>
+                        item.Name.Identifier.ValueText == typeParameter.Identifier.ValueText);
                 if (clause is not null)
                 {
                     return clause.Constraints
@@ -1265,8 +1469,11 @@ public sealed class RenderPipelineMigrationCensusTests
                 return true;
             }
 
-            UsingDirectiveSyntax[] usings = document.Root.Usings.Concat(
-                    type.Ancestors().OfType<BaseNamespaceDeclarationSyntax>().SelectMany(item => item.Usings))
+            UsingDirectiveSyntax[] usings = type.Ancestors()
+                .OfType<BaseNamespaceDeclarationSyntax>()
+                .SelectMany(item => item.Usings)
+                .Concat(document.Root.Usings.Where(item =>
+                    !item.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword)))
                 .ToArray();
             if (_globalUsings.TryGetValue(
                     document.CompilationId,
@@ -1289,12 +1496,39 @@ public sealed class RenderPipelineMigrationCensusTests
                     .Any(candidate => candidate + suffix == qualifiedTypeName);
             }
 
+            string declaredNamespace = GetNamespaceName(type);
+            if (writtenType.Contains('.', StringComparison.Ordinal))
+            {
+                for (string scope = declaredNamespace; ;)
+                {
+                    string candidate = string.IsNullOrEmpty(scope)
+                        ? writtenType
+                        : scope + "." + writtenType;
+                    DeclaredType? visible = _declaredTypes.FirstOrDefault(item =>
+                        IsVisibleIn(item, document)
+                        && item.QualifiedName == candidate);
+                    if (visible is not null || candidate == qualifiedTypeName)
+                    {
+                        return candidate == qualifiedTypeName;
+                    }
+
+                    int separator = scope.LastIndexOf('.');
+                    if (separator < 0)
+                    {
+                        break;
+                    }
+
+                    scope = scope[..separator];
+                }
+
+                return false;
+            }
+
             if (writtenType != typeName)
             {
                 return false;
             }
 
-            string declaredNamespace = GetNamespaceName(type);
             for (string scope = declaredNamespace; ;)
             {
                 string declaredType = string.IsNullOrEmpty(scope)

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
@@ -386,6 +386,9 @@ public sealed class RenderPipelineMigrationCensusTests
         const string globalPath = "src/Compatibility/GlobalExtensions.cs";
         const string aliasPath = "src/Compatibility/AliasExtensions.cs";
         const string blockPath = "src/Compatibility/ExtensionBlock.cs";
+        const string constrainedPath = "src/Compatibility/ConstrainedExtensions.cs";
+        const string relativeImportPath = "src/Beutl.Compatibility/RelativeExtensions.cs";
+        const string fileLocalPeerPath = "src/FileLocal/PeerExtensions.cs";
         SourceCorpus corpus = SourceCorpus.Create(
             ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
                 """
@@ -419,8 +422,50 @@ public sealed class RenderPipelineMigrationCensusTests
                 {
                     extension(RenderNodeProcessor? processor)
                     {
-                        public void Pull() { }
+                        public void Pull(RenderNode node) { }
                     }
+                }
+                """),
+            (constrainedPath,
+                """
+                using Beutl.Graphics.Rendering;
+                namespace Compatibility;
+                public static class ConstrainedExtensions
+                {
+                    public static void Pull<T>(this T processor) where T : RenderNodeProcessor { }
+                }
+                """),
+            (relativeImportPath,
+                """
+                namespace Beutl.Compatibility
+                {
+                    using Graphics.Rendering;
+                    public static class RelativeExtensions
+                    {
+                        public static void Pull(this RenderNodeProcessor processor) { }
+                    }
+                }
+                """),
+            ("src/FileLocal/Shadow.cs",
+                """
+                namespace FileLocal;
+                file sealed class RenderNodeProcessor { }
+                """),
+            (fileLocalPeerPath,
+                """
+                using Beutl.Graphics.Rendering;
+                namespace FileLocal;
+                public static class PeerExtensions
+                {
+                    public static void Pull(this RenderNodeProcessor processor) { }
+                }
+                """),
+            ("src/Beutl.Engine/Graphics/Rendering/GenericProcessor.cs",
+                """
+                namespace Beutl.Graphics.Rendering;
+                public sealed class RenderNodeProcessor<T>
+                {
+                    public void Pull() { }
                 }
                 """),
             ("src/Other/AliasShadow.cs",
@@ -452,7 +497,78 @@ public sealed class RenderPipelineMigrationCensusTests
 
         Assert.That(
             findings.Select(finding => finding.RelativePath),
-            Is.EquivalentTo(new[] { globalPath, aliasPath, blockPath }));
+            Is.EquivalentTo(new[]
+            {
+                globalPath,
+                aliasPath,
+                blockPath,
+                constrainedPath,
+                relativeImportPath,
+                fileLocalPeerPath,
+            }));
+    }
+
+    [Test]
+    public void ProcessorPullApiCensus_Includes_inherited_members()
+    {
+        const string basePath = "src/Beutl.Engine/Graphics/Rendering/ProcessorBase.cs";
+        SourceCorpus corpus = SourceCorpus.Create(
+            (basePath,
+                """
+                namespace Beutl.Graphics.Rendering;
+                public class ProcessorBase
+                {
+                    public void Pull() { }
+                }
+                """),
+            ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
+                """
+                namespace Beutl.Graphics.Rendering;
+                public sealed class RenderNodeProcessor : ProcessorBase { }
+                """));
+
+        SourceFinding[] findings = corpus.FindMembersDeclaredByType(
+                "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                ["Pull"])
+            .ToArray();
+
+        Assert.That(findings.Select(finding => finding.RelativePath), Is.EqualTo(new[] { basePath }));
+    }
+
+    [Test]
+    public void ProcessorPullApiCensus_Scopes_global_usings_to_their_compilation()
+    {
+        const string visiblePath = "src/A/VisibleExtensions.cs";
+        SourceCorpus corpus = SourceCorpus.CreatePartitioned(
+            ("A", "src/A/GlobalUsings.cs", "global using Beutl.Graphics.Rendering;"),
+            ("A", visiblePath,
+                """
+                namespace A;
+                public static class VisibleExtensions
+                {
+                    public static void Pull(this RenderNodeProcessor processor) { }
+                }
+                """),
+            ("B", "src/B/InvisibleExtensions.cs",
+                """
+                namespace B;
+                public static class InvisibleExtensions
+                {
+                    public static void Pull(this RenderNodeProcessor processor) { }
+                }
+                """),
+            ("Engine", "src/Engine/RenderNodeProcessor.cs",
+                """
+                namespace Beutl.Graphics.Rendering;
+                public sealed class RenderNodeProcessor { }
+                """));
+
+        SourceFinding[] findings = corpus.FindMembersDeclaredByType(
+                "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                ["Pull"])
+            .ToArray();
+
+        Assert.That(findings.Select(finding => finding.RelativePath), Is.EqualTo(new[] { visiblePath }));
     }
 
     [Test]
@@ -671,21 +787,30 @@ public sealed class RenderPipelineMigrationCensusTests
 
     private sealed class SourceCorpus
     {
-        private readonly UsingDirectiveSyntax[] _globalUsings;
-        private readonly HashSet<string> _declaredTypes;
+        private readonly IReadOnlyDictionary<string, UsingDirectiveSyntax[]> _globalUsings;
+        private readonly DeclaredType[] _declaredTypes;
 
         private SourceCorpus(string repositoryRoot, IReadOnlyList<SourceDocument> documents)
         {
             RepositoryRoot = repositoryRoot;
             Documents = documents;
             _globalUsings = documents
-                .SelectMany(document => document.Root.Usings)
-                .Where(item => item.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword))
-                .ToArray();
+                .GroupBy(document => document.CompilationId, StringComparer.Ordinal)
+                .ToDictionary(
+                    group => group.Key,
+                    group => group.SelectMany(document => document.Root.Usings)
+                        .Where(item => item.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword))
+                        .ToArray(),
+                    StringComparer.Ordinal);
             _declaredTypes = documents
-                .SelectMany(document => document.Root.DescendantNodes().OfType<TypeDeclarationSyntax>())
-                .Select(GetQualifiedTypeName)
-                .ToHashSet(StringComparer.Ordinal);
+                .SelectMany(document => document.Root.DescendantNodes()
+                    .OfType<TypeDeclarationSyntax>()
+                    .Select(type => new DeclaredType(
+                        document,
+                        type,
+                        GetQualifiedTypeName(type),
+                        type.Modifiers.Any(SyntaxKind.FileKeyword))))
+                .ToArray();
         }
 
         public string RepositoryRoot { get; }
@@ -706,6 +831,7 @@ public sealed class RenderPipelineMigrationCensusTests
 
             string repositoryRoot = directory.FullName;
             var documents = new List<SourceDocument>();
+            var compilationIds = new Dictionary<string, string>(StringComparer.Ordinal);
             foreach (string sourceRootName in new[] { "src", "tests" })
             {
                 string sourceRoot = Path.Combine(repositoryRoot, sourceRootName);
@@ -725,7 +851,8 @@ public sealed class RenderPipelineMigrationCensusTests
                     documents.Add(new SourceDocument(
                         relativePath,
                         text,
-                        tree.GetCompilationUnitRoot()));
+                        tree.GetCompilationUnitRoot(),
+                        GetCompilationId(repositoryRoot, path, compilationIds)));
                 }
             }
 
@@ -746,11 +873,84 @@ public sealed class RenderPipelineMigrationCensusTests
                             .WithLanguageVersion(LanguageVersion.Preview)
                             .WithDocumentationMode(DocumentationMode.Parse),
                         source.RelativePath);
-                    return new SourceDocument(source.RelativePath, text, tree.GetCompilationUnitRoot());
+                    return new SourceDocument(
+                        source.RelativePath,
+                        text,
+                        tree.GetCompilationUnitRoot(),
+                        "synthetic");
                 })
                 .OrderBy(document => document.RelativePath, StringComparer.Ordinal)
                 .ToArray();
             return new SourceCorpus("synthetic", documents);
+        }
+
+        public static SourceCorpus CreatePartitioned(
+            params (string CompilationId, string RelativePath, string Source)[] sources)
+        {
+            SourceDocument[] documents = sources
+                .Select(source =>
+                {
+                    SourceText text = SourceText.From(source.Source);
+                    var tree = CSharpSyntaxTree.ParseText(
+                        text,
+                        CSharpParseOptions.Default
+                            .WithLanguageVersion(LanguageVersion.Preview)
+                            .WithDocumentationMode(DocumentationMode.Parse),
+                        source.RelativePath);
+                    return new SourceDocument(
+                        source.RelativePath,
+                        text,
+                        tree.GetCompilationUnitRoot(),
+                        source.CompilationId);
+                })
+                .OrderBy(document => document.RelativePath, StringComparer.Ordinal)
+                .ToArray();
+            return new SourceCorpus("synthetic", documents);
+        }
+
+        private static string GetCompilationId(
+            string repositoryRoot,
+            string path,
+            Dictionary<string, string> cache)
+        {
+            DirectoryInfo? directory = new FileInfo(path).Directory;
+            var visited = new List<string>();
+            while (directory is not null
+                   && directory.FullName.StartsWith(repositoryRoot, StringComparison.Ordinal))
+            {
+                if (cache.TryGetValue(directory.FullName, out string? cached))
+                {
+                    foreach (string visitedDirectory in visited)
+                    {
+                        cache[visitedDirectory] = cached;
+                    }
+
+                    return cached;
+                }
+
+                visited.Add(directory.FullName);
+                string? project = Directory.EnumerateFiles(
+                        directory.FullName,
+                        "*.csproj",
+                        SearchOption.TopDirectoryOnly)
+                    .OrderBy(candidate => candidate, StringComparer.Ordinal)
+                    .FirstOrDefault();
+                if (project is not null)
+                {
+                    string compilationId = NormalizePath(
+                        Path.GetRelativePath(repositoryRoot, project));
+                    foreach (string visitedDirectory in visited)
+                    {
+                        cache[visitedDirectory] = compilationId;
+                    }
+
+                    return compilationId;
+                }
+
+                directory = directory.Parent;
+            }
+
+            return NormalizePath(Path.GetRelativePath(repositoryRoot, path));
         }
 
         public IReadOnlyList<SourceMethod> FindRenderNodeProcessOverrides()
@@ -903,19 +1103,27 @@ public sealed class RenderPipelineMigrationCensusTests
             string namespaceName = separator >= 0 ? qualifiedTypeName[..separator] : string.Empty;
             string typeName = separator >= 0 ? qualifiedTypeName[(separator + 1)..] : qualifiedTypeName;
             var memberNameSet = new HashSet<string>(memberNames, StringComparer.Ordinal);
+            var reportedMembers = new HashSet<(string Path, int Position)>();
             foreach (SourceDocument document in Documents)
             {
-                foreach (TypeDeclarationSyntax type in document.Root.DescendantNodes()
-                             .OfType<TypeDeclarationSyntax>()
-                             .Where(type => GetQualifiedTypeName(type) == qualifiedTypeName))
+                foreach (DeclaredType declared in _declaredTypes.Where(item =>
+                             ReferenceEquals(item.Document, document)
+                             && !item.IsFileLocal
+                             && item.QualifiedName == qualifiedTypeName))
                 {
-                    foreach (MemberDeclarationSyntax member in type.Members)
+                    foreach (DeclaredType visibleType in EnumerateTypeHierarchy(declared))
                     {
-                        foreach (SyntaxToken identifier in GetDeclaredIdentifiers(member)
-                                     .Where(token => memberNameSet.Contains(token.ValueText)))
+                        foreach (MemberDeclarationSyntax member in visibleType.Syntax.Members)
                         {
-                            yield return document.ToFinding(identifier,
-                                $"forwarding member '{identifier.ValueText}' on '{typeName}'");
+                            foreach (SyntaxToken identifier in GetDeclaredIdentifiers(member)
+                                         .Where(token => memberNameSet.Contains(token.ValueText)))
+                            {
+                                if (reportedMembers.Add((visibleType.Document.RelativePath, identifier.SpanStart)))
+                                {
+                                    yield return visibleType.Document.ToFinding(identifier,
+                                        $"forwarding member '{identifier.ValueText}' on '{typeName}'");
+                                }
+                            }
                         }
                     }
                 }
@@ -924,17 +1132,20 @@ public sealed class RenderPipelineMigrationCensusTests
                              .OfType<MethodDeclarationSyntax>()
                              .Where(method => memberNameSet.Contains(method.Identifier.ValueText)))
                 {
-                    ParameterSyntax? receiver = method.ParameterList.Parameters.FirstOrDefault();
-                    bool extensionBlockReceiver = false;
-                    if (receiver is null
-                        && method.Ancestors().FirstOrDefault(node =>
-                            node.IsKind(SyntaxKind.ExtensionBlockDeclaration)) is { } extensionBlock)
+                    SyntaxNode? extensionBlock = method.Ancestors().FirstOrDefault(node =>
+                        node.IsKind(SyntaxKind.ExtensionBlockDeclaration));
+                    bool extensionBlockReceiver = extensionBlock is not null;
+                    ParameterSyntax? receiver;
+                    if (extensionBlock is not null)
                     {
                         receiver = extensionBlock.ChildNodes()
                             .OfType<ParameterListSyntax>()
                             .SelectMany(list => list.Parameters)
                             .FirstOrDefault();
-                        extensionBlockReceiver = receiver is not null;
+                    }
+                    else
+                    {
+                        receiver = method.ParameterList.Parameters.FirstOrDefault();
                     }
 
                     if (receiver is null
@@ -966,8 +1177,51 @@ public sealed class RenderPipelineMigrationCensusTests
             IEnumerable<string> containingTypes = type.Ancestors()
                 .OfType<TypeDeclarationSyntax>()
                 .Reverse()
-                .Select(item => item.Identifier.ValueText);
-            return string.Join('.', namespaces.Concat(containingTypes).Append(type.Identifier.ValueText));
+                .Select(GetTypeIdentityName);
+            return string.Join('.', namespaces.Concat(containingTypes).Append(GetTypeIdentityName(type)));
+        }
+
+        private static string GetTypeIdentityName(TypeDeclarationSyntax type)
+        {
+            int arity = type.TypeParameterList?.Parameters.Count ?? 0;
+            return arity == 0
+                ? type.Identifier.ValueText
+                : $"{type.Identifier.ValueText}`{arity}";
+        }
+
+        private IEnumerable<DeclaredType> EnumerateTypeHierarchy(DeclaredType root)
+        {
+            var pending = new Stack<DeclaredType>();
+            var visited = new HashSet<(string Path, int Position)>();
+            pending.Push(root);
+            while (pending.TryPop(out DeclaredType? current))
+            {
+                if (!visited.Add((current.Document.RelativePath, current.Syntax.SpanStart)))
+                {
+                    continue;
+                }
+
+                yield return current;
+                if (current.Syntax.BaseList is null)
+                {
+                    continue;
+                }
+
+                foreach (BaseTypeSyntax baseType in current.Syntax.BaseList.Types)
+                {
+                    foreach (DeclaredType candidate in _declaredTypes.Where(candidate =>
+                                 IsVisibleIn(candidate, current.Document)
+                                 && CouldReferToType(
+                                     baseType.Type,
+                                     current.Document,
+                                     GetNamespaceName(candidate.Syntax),
+                                     GetTypeIdentityName(candidate.Syntax),
+                                     candidate.QualifiedName)))
+                    {
+                        pending.Push(candidate);
+                    }
+                }
+            }
         }
 
         private bool CouldReferToType(
@@ -987,7 +1241,25 @@ public sealed class RenderPipelineMigrationCensusTests
                 type = nullable.ElementType;
             }
 
-            string writtenType = type.ToString().Replace("global::", string.Empty, StringComparison.Ordinal);
+            if (type is IdentifierNameSyntax typeParameter
+                && type.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault() is { } method)
+            {
+                TypeParameterConstraintClauseSyntax? clause = method.ConstraintClauses.FirstOrDefault(
+                    item => item.Name.Identifier.ValueText == typeParameter.Identifier.ValueText);
+                if (clause is not null)
+                {
+                    return clause.Constraints
+                        .OfType<TypeConstraintSyntax>()
+                        .Any(constraint => CouldReferToType(
+                            constraint.Type,
+                            document,
+                            namespaceName,
+                            typeName,
+                            qualifiedTypeName));
+                }
+            }
+
+            string writtenType = GetWrittenTypeIdentity(type);
             if (writtenType == qualifiedTypeName)
             {
                 return true;
@@ -996,20 +1268,25 @@ public sealed class RenderPipelineMigrationCensusTests
             UsingDirectiveSyntax[] usings = document.Root.Usings.Concat(
                     type.Ancestors().OfType<BaseNamespaceDeclarationSyntax>().SelectMany(item => item.Usings))
                 .ToArray();
-            usings = usings.Concat(_globalUsings).ToArray();
+            if (_globalUsings.TryGetValue(
+                    document.CompilationId,
+                    out UsingDirectiveSyntax[]? globalUsings))
+            {
+                usings = usings.Concat(globalUsings).ToArray();
+            }
+
             int nameSeparator = writtenType.IndexOf('.');
             string aliasName = nameSeparator < 0 ? writtenType : writtenType[..nameSeparator];
             UsingDirectiveSyntax? alias = usings.FirstOrDefault(item =>
                 item.Alias?.Name.Identifier.ValueText == aliasName);
             if (alias is not null)
             {
-                string aliasTarget = alias.Name?.ToString()
-                    .Replace("global::", string.Empty, StringComparison.Ordinal)
-                    ?? string.Empty;
-                string resolvedAlias = nameSeparator < 0
-                    ? aliasTarget
-                    : aliasTarget + writtenType[nameSeparator..];
-                return resolvedAlias == qualifiedTypeName;
+                string aliasTarget = alias.Name is null
+                    ? string.Empty
+                    : GetWrittenName(alias.Name);
+                string suffix = nameSeparator < 0 ? string.Empty : writtenType[nameSeparator..];
+                return GetImportCandidates(alias, aliasTarget)
+                    .Any(candidate => candidate + suffix == qualifiedTypeName);
             }
 
             if (writtenType != typeName)
@@ -1017,16 +1294,15 @@ public sealed class RenderPipelineMigrationCensusTests
                 return false;
             }
 
-            string declaredNamespace = string.Join('.', type.Ancestors()
-                .OfType<BaseNamespaceDeclarationSyntax>()
-                .Reverse()
-                .Select(item => item.Name.ToString()));
+            string declaredNamespace = GetNamespaceName(type);
             for (string scope = declaredNamespace; ;)
             {
                 string declaredType = string.IsNullOrEmpty(scope)
                     ? typeName
                     : scope + "." + typeName;
-                if (_declaredTypes.Contains(declaredType))
+                if (_declaredTypes.Any(item =>
+                        IsVisibleIn(item, document)
+                        && item.QualifiedName == declaredType))
                 {
                     return declaredType == qualifiedTypeName;
                 }
@@ -1042,10 +1318,67 @@ public sealed class RenderPipelineMigrationCensusTests
 
             return declaredNamespace == namespaceName
                    || usings.Any(item => item.Alias is null
-                       && item.Name?.ToString().Replace(
-                           "global::",
-                           string.Empty,
-                           StringComparison.Ordinal) == namespaceName);
+                       && item.Name is not null
+                       && GetImportCandidates(item, GetWrittenName(item.Name))
+                           .Contains(namespaceName, StringComparer.Ordinal));
+        }
+
+        private static string GetWrittenTypeIdentity(TypeSyntax type)
+        {
+            return type switch
+            {
+                IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
+                GenericNameSyntax generic =>
+                    $"{generic.Identifier.ValueText}`{generic.TypeArgumentList.Arguments.Count}",
+                QualifiedNameSyntax qualified =>
+                    $"{GetWrittenTypeIdentity(qualified.Left)}.{GetWrittenTypeIdentity(qualified.Right)}",
+                AliasQualifiedNameSyntax alias =>
+                    alias.Alias.Identifier.ValueText == "global"
+                        ? GetWrittenTypeIdentity(alias.Name)
+                        : $"{alias.Alias.Identifier.ValueText}.{GetWrittenTypeIdentity(alias.Name)}",
+                _ => type.ToString().Replace("global::", string.Empty, StringComparison.Ordinal),
+            };
+        }
+
+        private static string GetWrittenName(NameSyntax name)
+        {
+            return name.ToString().Replace("global::", string.Empty, StringComparison.Ordinal);
+        }
+
+        private static IEnumerable<string> GetImportCandidates(
+            UsingDirectiveSyntax directive,
+            string importedName)
+        {
+            if (directive.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword))
+            {
+                yield return importedName;
+                yield break;
+            }
+
+            string scope = GetNamespaceName(directive);
+            while (!string.IsNullOrEmpty(scope))
+            {
+                yield return scope + "." + importedName;
+                int separator = scope.LastIndexOf('.');
+                scope = separator < 0 ? string.Empty : scope[..separator];
+            }
+
+            yield return importedName;
+        }
+
+        private static string GetNamespaceName(SyntaxNode node)
+        {
+            return string.Join('.', node.Ancestors()
+                .OfType<BaseNamespaceDeclarationSyntax>()
+                .Reverse()
+                .Select(item => item.Name.ToString()));
+        }
+
+        private static bool IsVisibleIn(DeclaredType declared, SourceDocument document)
+        {
+            return declared.Document.CompilationId == document.CompilationId
+                   && (!declared.IsFileLocal
+                       || declared.Document.RelativePath == document.RelativePath);
         }
 
         private IEnumerable<SourceFinding> FindText(Regex pattern, string detail)
@@ -1092,7 +1425,8 @@ public sealed class RenderPipelineMigrationCensusTests
     private sealed record SourceDocument(
         string RelativePath,
         SourceText Text,
-        CompilationUnitSyntax Root)
+        CompilationUnitSyntax Root,
+        string CompilationId)
     {
         public SourceFinding ToFinding(SyntaxNode node, string detail)
         {
@@ -1124,6 +1458,12 @@ public sealed class RenderPipelineMigrationCensusTests
             return Document.ToFinding(Method, detail);
         }
     }
+
+    private sealed record DeclaredType(
+        SourceDocument Document,
+        TypeDeclarationSyntax Syntax,
+        string QualifiedName,
+        bool IsFileLocal);
 
     private sealed record SourceFinding(
         string RelativePath,

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
@@ -1071,6 +1071,127 @@ public sealed class RenderPipelineMigrationCensusTests
     }
 
     [Test]
+    public void ProcessorPullApiCensus_Applies_hierarchy_to_generic_receiver_constraints()
+    {
+        const string extensionPath = "src/Compatibility/ConstrainedBaseExtensions.cs";
+        SourceCorpus corpus = SourceCorpus.Create(
+            ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
+                """
+                namespace Beutl.Graphics.Rendering;
+                public class ProcessorBase { }
+                public sealed class RenderNodeProcessor : ProcessorBase { }
+                """),
+            (extensionPath,
+                """
+                using Beutl.Graphics.Rendering;
+                namespace Compatibility;
+                public static class ConstrainedBaseExtensions
+                {
+                    public static void Pull<T>(this T processor) where T : ProcessorBase { }
+                }
+                """));
+
+        Assert.That(
+            corpus.FindMembersDeclaredByType(
+                    "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                    ["Pull"])
+                .Select(finding => finding.RelativePath),
+            Is.EqualTo(new[] { extensionPath }));
+    }
+
+    [Test]
+    public void ProcessorPullApiCensus_Distinguishes_referenced_base_identities()
+    {
+        SourceCorpus corpus = SourceCorpus.Create(
+            ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
+                """
+                namespace Other
+                {
+                    public interface IProcessor { }
+                }
+                namespace Beutl.Graphics.Rendering
+                {
+                    public sealed class RenderNodeProcessor : Other.IProcessor { }
+                }
+                """),
+            ("src/Compatibility/CompatibilityProcessor.cs",
+                """
+                namespace Compatibility
+                {
+                    public interface IProcessor { }
+                    public static class CompatibilityExtensions
+                    {
+                        public static void Pull(this IProcessor processor) { }
+                    }
+                }
+                """));
+
+        Assert.That(
+            corpus.FindMembersDeclaredByType(
+                "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                ["Pull"]),
+            Is.Empty);
+    }
+
+    [Test]
+    public void ProcessorPullApiCensus_Stops_aliases_at_nearest_existing_type()
+    {
+        SourceCorpus corpus = SourceCorpus.Create(
+            ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
+                """
+                namespace Beutl.Graphics.Rendering;
+                public sealed class RenderNodeProcessor { }
+                """),
+            ("src/Compatibility/ShadowedAliasExtensions.cs",
+                """
+                namespace Compatibility.Beutl.Graphics.Rendering;
+                public sealed class RenderNodeProcessor { }
+
+                namespace Compatibility
+                {
+                    using P = Beutl.Graphics.Rendering.RenderNodeProcessor;
+                    public static class ShadowedAliasExtensions
+                    {
+                        public static void Pull(this P processor) { }
+                    }
+                }
+                """));
+
+        Assert.That(
+            corpus.FindMembersDeclaredByType(
+                "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                ["Pull"]),
+            Is.Empty);
+    }
+
+    [Test]
+    public void ProcessorPullApiCensus_Includes_protected_members()
+    {
+        const string basePath = "src/Beutl.Engine/Graphics/Rendering/ProcessorBase.cs";
+        SourceCorpus corpus = SourceCorpus.Create(
+            (basePath,
+                """
+                namespace Beutl.Graphics.Rendering;
+                public class ProcessorBase
+                {
+                    protected void Pull() { }
+                }
+                """),
+            ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
+                """
+                namespace Beutl.Graphics.Rendering;
+                public class RenderNodeProcessor : ProcessorBase { }
+                """));
+
+        Assert.That(
+            corpus.FindMembersDeclaredByType(
+                    "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                    ["Pull"])
+                .Select(finding => finding.RelativePath),
+            Is.EqualTo(new[] { basePath }));
+    }
+
+    [Test]
     public void ProcessorPullApiCensus_Scopes_global_usings_to_their_compilation()
     {
         const string visiblePath = "src/A/VisibleExtensions.cs";
@@ -2235,6 +2356,20 @@ public sealed class RenderPipelineMigrationCensusTests
             string typeName,
             string qualifiedTypeName)
         {
+            if (receiverType is IdentifierNameSyntax typeParameter)
+            {
+                TypeSyntax[] constraints = GetTypeParameterConstraints(typeParameter).ToArray();
+                if (constraints.Length > 0)
+                {
+                    return constraints.Any(constraint => CanReceiveType(
+                        constraint,
+                        document,
+                        namespaceName,
+                        typeName,
+                        qualifiedTypeName));
+                }
+            }
+
             if (CouldReferToType(
                     receiverType,
                     document,
@@ -2254,7 +2389,7 @@ public sealed class RenderPipelineMigrationCensusTests
             {
                 DeclaredType[] hierarchy = EnumerateTypeHierarchy(target).ToArray();
                 if (hierarchy.Any(candidate =>
-                        CanReceiveReferencedBase(receiverType, candidate)))
+                        CanReceiveReferencedBase(receiverType, document, candidate)))
                 {
                     return true;
                 }
@@ -2295,26 +2430,13 @@ public sealed class RenderPipelineMigrationCensusTests
 
             if (type is IdentifierNameSyntax typeParameter)
             {
-                TypeParameterConstraintClauseSyntax? clause = type.Ancestors()
-                    .OfType<MethodDeclarationSyntax>()
-                    .SelectMany(method => method.ConstraintClauses)
-                    .Concat(type.Ancestors()
-                        .FirstOrDefault(node => node.IsKind(SyntaxKind.ExtensionBlockDeclaration))?
-                        .ChildNodes()
-                        .OfType<TypeParameterConstraintClauseSyntax>() ?? [])
-                    .FirstOrDefault(item =>
-                        item.Name.Identifier.ValueText == typeParameter.Identifier.ValueText);
-                if (clause is not null)
-                {
-                    return clause.Constraints
-                        .OfType<TypeConstraintSyntax>()
-                        .Any(constraint => CouldReferToType(
-                            constraint.Type,
-                            document,
-                            namespaceName,
-                            typeName,
-                            qualifiedTypeName));
-                }
+                return GetTypeParameterConstraints(typeParameter)
+                    .Any(constraint => CouldReferToType(
+                        constraint,
+                        document,
+                        namespaceName,
+                        typeName,
+                        qualifiedTypeName));
             }
 
             string writtenType = GetWrittenTypeIdentity(type);
@@ -2370,8 +2492,12 @@ public sealed class RenderPipelineMigrationCensusTests
                     ? string.Empty
                     : GetWrittenTypeIdentity(alias.Name);
                 string suffix = nameSeparator < 0 ? string.Empty : writtenType[nameSeparator..];
-                return GetImportCandidates(alias, aliasTarget)
-                    .Any(candidate => candidate + suffix == qualifiedTypeName);
+                return AliasResolvesTo(
+                    alias,
+                    aliasTarget,
+                    suffix,
+                    qualifiedTypeName,
+                    document);
             }
 
             string declaredNamespace = GetNamespaceName(type);
@@ -2535,8 +2661,9 @@ public sealed class RenderPipelineMigrationCensusTests
                 item.QualifiedName.StartsWith(prefix, StringComparison.Ordinal));
         }
 
-        private static bool CanReceiveReferencedBase(
+        private bool CanReceiveReferencedBase(
             TypeSyntax? receiverType,
+            SourceDocument receiverDocument,
             DeclaredType target)
         {
             if (receiverType is null)
@@ -2544,19 +2671,103 @@ public sealed class RenderPipelineMigrationCensusTests
                 return false;
             }
 
-            string receiverIdentity = GetWrittenTypeIdentity(receiverType);
-            if (receiverIdentity is "object" or "System.Object")
+            HashSet<string> receiverIdentities = GetTypeReferenceCandidates(
+                receiverType,
+                receiverDocument);
+            if (receiverIdentities.Contains("object")
+                || receiverIdentities.Contains("System.Object"))
             {
                 return true;
             }
 
-            string receiverName = receiverIdentity[(receiverIdentity.LastIndexOf('.') + 1)..];
             return target.Syntax.BaseList?.Types.Any(baseType =>
+                GetTypeReferenceCandidates(baseType.Type, target.Document)
+                    .Overlaps(receiverIdentities)) == true;
+        }
+
+        private static IEnumerable<TypeSyntax> GetTypeParameterConstraints(
+            IdentifierNameSyntax typeParameter)
+        {
+            return typeParameter.Ancestors()
+                .OfType<MethodDeclarationSyntax>()
+                .SelectMany(method => method.ConstraintClauses)
+                .Concat(typeParameter.Ancestors()
+                    .FirstOrDefault(node => node.IsKind(SyntaxKind.ExtensionBlockDeclaration))?
+                    .ChildNodes()
+                    .OfType<TypeParameterConstraintClauseSyntax>() ?? [])
+                .Where(item =>
+                    item.Name.Identifier.ValueText == typeParameter.Identifier.ValueText)
+                .SelectMany(item => item.Constraints.OfType<TypeConstraintSyntax>())
+                .Select(constraint => constraint.Type);
+        }
+
+        private bool AliasResolvesTo(
+            UsingDirectiveSyntax alias,
+            string aliasTarget,
+            string suffix,
+            string qualifiedTarget,
+            SourceDocument document)
+        {
+            foreach (string candidate in GetImportCandidates(alias, aliasTarget))
             {
-                string baseIdentity = GetWrittenTypeIdentity(baseType.Type);
-                string baseName = baseIdentity[(baseIdentity.LastIndexOf('.') + 1)..];
-                return baseName == receiverName;
-            }) == true;
+                string resolved = candidate + suffix;
+                if (GetMemberDeclaredTypes(document).Any(item =>
+                        item.QualifiedName == resolved)
+                    || resolved == qualifiedTarget)
+                {
+                    return resolved == qualifiedTarget;
+                }
+            }
+
+            return false;
+        }
+
+        private HashSet<string> GetTypeReferenceCandidates(
+            TypeSyntax type,
+            SourceDocument document)
+        {
+            if (type is NullableTypeSyntax nullable)
+            {
+                type = nullable.ElementType;
+            }
+
+            string written = GetWrittenTypeIdentity(type);
+            var result = new HashSet<string>(StringComparer.Ordinal) { written };
+            if (IsGloballyQualified(type))
+            {
+                return result;
+            }
+
+            string declaredNamespace = GetNamespaceName(type);
+            for (string scope = declaredNamespace; ;)
+            {
+                result.Add(string.IsNullOrEmpty(scope) ? written : scope + "." + written);
+                int separator = scope.LastIndexOf('.');
+                if (separator < 0)
+                {
+                    break;
+                }
+
+                scope = scope[..separator];
+            }
+
+            UsingDirectiveSyntax[] usings = type.Ancestors()
+                .OfType<BaseNamespaceDeclarationSyntax>()
+                .SelectMany(item => item.Usings)
+                .Concat(document.Root.Usings)
+                .Where(item => item.Alias is null && item.Name is not null)
+                .ToArray();
+            foreach (UsingDirectiveSyntax import in usings)
+            {
+                foreach (string importedNamespace in GetImportCandidates(
+                             import,
+                             GetWrittenName(import.Name!)))
+                {
+                    result.Add(importedNamespace + "." + written);
+                }
+            }
+
+            return result;
         }
 
         private IEnumerable<DeclaredType> GetMemberDeclaredTypes(SourceDocument document)
@@ -2684,6 +2895,8 @@ public sealed class RenderPipelineMigrationCensusTests
                 _ => default,
             };
             return modifiers.Any(SyntaxKind.PublicKeyword)
+                   || modifiers.Any(SyntaxKind.ProtectedKeyword)
+                   && !modifiers.Any(SyntaxKind.PrivateKeyword)
                    || containingType is InterfaceDeclarationSyntax
                    && !modifiers.Any(SyntaxKind.PrivateKeyword);
         }

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
 using Beutl.UnitTests.Engine.Graphics.Rendering.Baseline;
@@ -264,6 +266,43 @@ public sealed class RenderPipelineMigrationCensusTests
 
         AssertNoFindings("Processor pull APIs must be absent.",
             s_corpus.Value.FindMembersDeclaredByType(processorType, pullNames));
+    }
+
+    [Test]
+    public void ProcessorPullRuntimeSurface_IncludesGeneratedEngineMembers()
+    {
+        const string processorTypeName = "Beutl.Graphics.Rendering.RenderNodeProcessor";
+        string[] pullNames = ["Pull", "PullToRoot"];
+        Assembly engine = typeof(Beutl.Graphics.Rendering.RenderNode).Assembly;
+        Type? processor = engine.GetType(processorTypeName);
+        if (processor is null)
+        {
+            Assert.Pass();
+            return;
+        }
+
+        MemberInfo[] directMembers = processor.GetMembers(
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
+            .Where(member => pullNames.Contains(member.Name, StringComparer.Ordinal))
+            .ToArray();
+        MethodInfo[] extensionMembers = engine.GetTypes()
+            .SelectMany(type => type.GetMethods(
+                BindingFlags.Public | BindingFlags.Static))
+            .Where(method =>
+                pullNames.Contains(method.Name, StringComparer.Ordinal)
+                && method.IsDefined(typeof(ExtensionAttribute), inherit: false)
+                && method.GetParameters() is [{ ParameterType: var receiver }, ..]
+                && (receiver.IsAssignableFrom(processor)
+                    || receiver.IsGenericParameter
+                    && receiver.GetGenericParameterConstraints()
+                        .Any(constraint => constraint.IsAssignableFrom(processor))))
+            .ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(directMembers, Is.Empty);
+            Assert.That(extensionMembers, Is.Empty);
+        });
     }
 
     [Test]
@@ -792,6 +831,125 @@ public sealed class RenderPipelineMigrationCensusTests
                 "Beutl.Graphics.Rendering.RenderNodeProcessor",
                 ["Pull"]),
             Is.Empty);
+    }
+
+    [Test]
+    public void ProcessorPullApiCensus_Uses_nearest_imported_namespace()
+    {
+        SourceCorpus corpus = SourceCorpus.Create(
+            ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
+                """
+                namespace Beutl.Graphics.Rendering;
+                public sealed class RenderNodeProcessor { }
+                """),
+            ("src/Compatibility/LocalProcessor.cs",
+                """
+                namespace Beutl.Compatibility.Graphics.Rendering;
+                public sealed class RenderNodeProcessor { }
+                """),
+            ("src/Compatibility/LocalExtensions.cs",
+                """
+                namespace Beutl.Compatibility
+                {
+                    using Graphics.Rendering;
+                    public static class LocalExtensions
+                    {
+                        public static void Pull(this RenderNodeProcessor processor) { }
+                    }
+                }
+                """));
+
+        Assert.That(
+            corpus.FindMembersDeclaredByType(
+                "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                ["Pull"]),
+            Is.Empty);
+    }
+
+    [Test]
+    public void ProcessorPullApiCensus_Includes_referenced_receiver_bases()
+    {
+        const string extensionPath = "src/Compatibility/FrameworkBaseExtensions.cs";
+        SourceCorpus corpus = SourceCorpus.Create(
+            ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
+                """
+                using System;
+                namespace Beutl.Graphics.Rendering;
+                public sealed class RenderNodeProcessor : IDisposable
+                {
+                    public void Dispose() { }
+                }
+                """),
+            (extensionPath,
+                """
+                using System;
+                namespace Compatibility;
+                public static class FrameworkBaseExtensions
+                {
+                    public static void Pull(this IDisposable processor) { }
+                    public static void PullToRoot(this object processor) { }
+                }
+                """));
+
+        Assert.That(
+            corpus.FindMembersDeclaredByType(
+                    "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                    ["Pull", "PullToRoot"])
+                .Select(finding => finding.RelativePath),
+            Is.EqualTo(new[] { extensionPath, extensionPath }));
+    }
+
+    [Test]
+    public void ProcessorPullApiCensus_Combines_reachable_nested_directive_symbols()
+    {
+        const string extensionPath = "src/Compatibility/NestedConditionalExtensions.cs";
+        SourceCorpus corpus = SourceCorpus.Create(
+            ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
+                """
+                namespace Beutl.Graphics.Rendering;
+                public sealed class RenderNodeProcessor { }
+                """),
+            (extensionPath,
+                """
+                namespace Compatibility;
+                public static class NestedConditionalExtensions
+                {
+                #if WINDOWS
+                #elif FEATURE
+                #if DEBUG
+                    public static void Pull(
+                        this Beutl.Graphics.Rendering.RenderNodeProcessor processor) { }
+                #endif
+                #endif
+                }
+                """));
+
+        Assert.That(
+            corpus.FindMembersDeclaredByType(
+                    "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                    ["Pull"])
+                .Select(finding => finding.RelativePath),
+            Is.EqualTo(new[] { extensionPath }));
+    }
+
+    [Test]
+    public void ProcessorPullApiCensus_Normalizes_escaped_namespace_identifiers()
+    {
+        SourceCorpus corpus = SourceCorpus.Create(
+            ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
+                """
+                namespace @Beutl.Graphics.Rendering;
+                public sealed class RenderNodeProcessor
+                {
+                    public void Pull() { }
+                }
+                """));
+
+        Assert.That(
+            corpus.FindMembersDeclaredByType(
+                "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                ["Pull"]),
+            Has.Count.EqualTo(1));
     }
 
     [Test]
@@ -1627,14 +1785,27 @@ public sealed class RenderPipelineMigrationCensusTests
             AddSymbolVariant(variants, baseSymbols.Concat(projectSymbols));
             AddSymbolVariant(
                 variants,
+                baseSymbols.Concat(projectSymbols).Concat(["DEBUG", "TRACE"]));
+            AddSymbolVariant(
+                variants,
                 baseSymbols.Concat(windowsSymbols).Concat(projectSymbols));
             AddSymbolVariant(variants, baseSymbols.Concat(directiveSymbols));
             AddSymbolVariant(
                 variants,
                 baseSymbols.Concat(windowsSymbols).Concat(directiveSymbols));
+            IEnumerable<string> nonWindowsDirectiveSymbols = directiveSymbols.Except(
+                windowsSymbols,
+                StringComparer.Ordinal);
+            AddSymbolVariant(variants, baseSymbols.Concat(nonWindowsDirectiveSymbols));
+            AddSymbolVariant(
+                variants,
+                baseSymbols.Concat(nonWindowsDirectiveSymbols).Concat(["DEBUG", "TRACE"]));
             foreach (string[] positiveSymbols in directivePositiveSets)
             {
                 AddSymbolVariant(variants, baseSymbols.Concat(positiveSymbols));
+                AddSymbolVariant(
+                    variants,
+                    baseSymbols.Concat(positiveSymbols).Concat(["DEBUG", "TRACE"]));
                 AddSymbolVariant(
                     variants,
                     baseSymbols.Concat(windowsSymbols).Concat(positiveSymbols));
@@ -1731,6 +1902,13 @@ public sealed class RenderPipelineMigrationCensusTests
                     "src/Beutl.Engine/Beutl.Engine.csproj",
                     StringComparison.Ordinal))
                 .ToHashSet(StringComparer.Ordinal);
+            if (result.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    "The renderer census could not locate "
+                    + "'src/Beutl.Engine/Beutl.Engine.csproj'.");
+            }
+
             bool changed;
             do
             {
@@ -1785,7 +1963,7 @@ public sealed class RenderPipelineMigrationCensusTests
             IEnumerable<string> namespaces = type.Ancestors()
                 .OfType<BaseNamespaceDeclarationSyntax>()
                 .Reverse()
-                .Select(item => item.Name.ToString());
+                .Select(item => GetWrittenTypeIdentity(item.Name));
             IEnumerable<string> containingTypes = type.Ancestors()
                 .OfType<TypeDeclarationSyntax>()
                 .Reverse()
@@ -1860,6 +2038,11 @@ public sealed class RenderPipelineMigrationCensusTests
                          && _productionCompilationIds.Contains(item.Document.CompilationId)
                          && item.QualifiedName == qualifiedTypeName))
             {
+                if (CanReceiveReferencedBase(receiverType, target))
+                {
+                    return true;
+                }
+
                 foreach (DeclaredType baseType in EnumerateTypeHierarchy(target).Skip(1))
                 {
                     if (CouldReferToType(
@@ -1989,10 +2172,11 @@ public sealed class RenderPipelineMigrationCensusTests
 
                 return usings
                     .Where(item => item.Alias is null && item.Name is not null)
-                    .SelectMany(item => GetImportCandidates(
+                    .Any(item => ImportResolvesTo(
                         item,
-                        GetWrittenName(item.Name!)))
-                    .Any(import => import + "." + writtenType == qualifiedTypeName);
+                        writtenType,
+                        qualifiedTypeName,
+                        document));
             }
 
             if (writtenType != typeName)
@@ -2024,8 +2208,67 @@ public sealed class RenderPipelineMigrationCensusTests
             return declaredNamespace == namespaceName
                    || usings.Any(item => item.Alias is null
                        && item.Name is not null
-                       && GetImportCandidates(item, GetWrittenName(item.Name))
-                           .Contains(namespaceName, StringComparer.Ordinal));
+                       && ImportResolvesTo(
+                           item,
+                           string.Empty,
+                           namespaceName,
+                           document));
+        }
+
+        private bool ImportResolvesTo(
+            UsingDirectiveSyntax directive,
+            string suffix,
+            string qualifiedTarget,
+            SourceDocument document)
+        {
+            foreach (string candidate in GetImportCandidates(
+                         directive,
+                         GetWrittenName(directive.Name!)))
+            {
+                string resolved = string.IsNullOrEmpty(suffix)
+                    ? candidate
+                    : candidate + "." + suffix;
+                if (NamespaceExistsInCompilation(candidate, document)
+                    || resolved == qualifiedTarget)
+                {
+                    return resolved == qualifiedTarget;
+                }
+            }
+
+            return false;
+        }
+
+        private bool NamespaceExistsInCompilation(
+            string namespaceName,
+            SourceDocument document)
+        {
+            string prefix = namespaceName + ".";
+            return GetMemberDeclaredTypes(document).Any(item =>
+                item.QualifiedName.StartsWith(prefix, StringComparison.Ordinal));
+        }
+
+        private static bool CanReceiveReferencedBase(
+            TypeSyntax? receiverType,
+            DeclaredType target)
+        {
+            if (receiverType is null)
+            {
+                return false;
+            }
+
+            string receiverIdentity = GetWrittenTypeIdentity(receiverType);
+            if (receiverIdentity is "object" or "System.Object")
+            {
+                return true;
+            }
+
+            string receiverName = receiverIdentity[(receiverIdentity.LastIndexOf('.') + 1)..];
+            return target.Syntax.BaseList?.Types.Any(baseType =>
+            {
+                string baseIdentity = GetWrittenTypeIdentity(baseType.Type);
+                string baseName = baseIdentity[(baseIdentity.LastIndexOf('.') + 1)..];
+                return baseName == receiverName;
+            }) == true;
         }
 
         private IEnumerable<DeclaredType> GetMemberDeclaredTypes(SourceDocument document)
@@ -2067,7 +2310,7 @@ public sealed class RenderPipelineMigrationCensusTests
 
         private static string GetWrittenName(NameSyntax name)
         {
-            return name.ToString().Replace("global::", string.Empty, StringComparison.Ordinal);
+            return GetWrittenTypeIdentity(name);
         }
 
         private static IEnumerable<string> GetImportCandidates(
@@ -2096,7 +2339,7 @@ public sealed class RenderPipelineMigrationCensusTests
             return string.Join('.', node.Ancestors()
                 .OfType<BaseNamespaceDeclarationSyntax>()
                 .Reverse()
-                .Select(item => item.Name.ToString()));
+                .Select(item => GetWrittenTypeIdentity(item.Name)));
         }
 
         private static bool IsVisibleIn(DeclaredType declared, SourceDocument document)

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
@@ -994,7 +994,8 @@ public sealed class RenderPipelineMigrationCensusTests
             }
 
             UsingDirectiveSyntax[] usings = document.Root.Usings.Concat(
-                type.Ancestors().OfType<BaseNamespaceDeclarationSyntax>().SelectMany(item => item.Usings));
+                    type.Ancestors().OfType<BaseNamespaceDeclarationSyntax>().SelectMany(item => item.Usings))
+                .ToArray();
             usings = usings.Concat(_globalUsings).ToArray();
             int nameSeparator = writtenType.IndexOf('.');
             string aliasName = nameSeparator < 0 ? writtenType : writtenType[..nameSeparator];
@@ -1020,7 +1021,7 @@ public sealed class RenderPipelineMigrationCensusTests
                 .OfType<BaseNamespaceDeclarationSyntax>()
                 .Reverse()
                 .Select(item => item.Name.ToString()));
-            for (string scope = declaredNamespace;;)
+            for (string scope = declaredNamespace; ;)
             {
                 string declaredType = string.IsNullOrEmpty(scope)
                     ? typeName

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using System.Xml.Linq;
 
 using Beutl.UnitTests.Engine.Graphics.Rendering.Baseline;
 
@@ -519,6 +520,10 @@ public sealed class RenderPipelineMigrationCensusTests
             "src/Compatibility/PropertyExtensions.cs",
             "src/Beutl.Compatibility/RelativeQualifiedExtensions.cs",
             "src/Compatibility/BaseReceiverExtensions.cs",
+            "src/Compatibility/DebugExtensions.cs",
+            "src/Compatibility/BuiltInExtensions.cs",
+            "src/Compatibility/ImportedQualifiedExtensions.cs",
+            "src/Conditional/ConditionalGlobalExtensions.cs",
         ];
         SourceCorpus corpus = SourceCorpus.Create(
             ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
@@ -597,6 +602,53 @@ public sealed class RenderPipelineMigrationCensusTests
                 {
                     public static void Pull(this ProcessorBase processor) { }
                 }
+                """),
+            (expectedPaths[6],
+                """
+                namespace Compatibility;
+                public static class DebugExtensions
+                {
+                #if DEBUG
+                    public static void Pull(
+                        this Beutl.Graphics.Rendering.RenderNodeProcessor processor) { }
+                #endif
+                }
+                """),
+            (expectedPaths[7],
+                """
+                namespace Compatibility;
+                public static class BuiltInExtensions
+                {
+                #if FFMPEG_BUILD_IN
+                    public static void Pull(
+                        this Beutl.Graphics.Rendering.RenderNodeProcessor processor) { }
+                #endif
+                }
+                """),
+            (expectedPaths[8],
+                """
+                using Beutl.Graphics;
+                namespace Compatibility;
+                public static class ImportedQualifiedExtensions
+                {
+                    public static void Pull(this Rendering.RenderNodeProcessor processor) { }
+                }
+                """),
+            ("src/Conditional/GlobalUsings.cs",
+                """
+                #if WINDOWS
+                global using Beutl.Graphics.Rendering;
+                #endif
+                """),
+            (expectedPaths[9],
+                """
+                namespace Conditional;
+                public static class ConditionalGlobalExtensions
+                {
+                #if WINDOWS
+                    public static void Pull(this RenderNodeProcessor processor) { }
+                #endif
+                }
                 """));
 
         SourceFinding[] findings = corpus.FindMembersDeclaredByType(
@@ -607,6 +659,50 @@ public sealed class RenderPipelineMigrationCensusTests
         Assert.That(
             findings.Select(finding => finding.RelativePath),
             Is.EquivalentTo(expectedPaths));
+    }
+
+    [Test]
+    public void ProcessorPullApiCensus_Reports_positional_record_members()
+    {
+        SourceCorpus corpus = SourceCorpus.Create(
+            ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
+                """
+                using System;
+                namespace Beutl.Graphics.Rendering;
+                public sealed record RenderNodeProcessor(Action Pull);
+                """));
+
+        SourceFinding[] findings = corpus.FindMembersDeclaredByType(
+                "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                ["Pull"])
+            .ToArray();
+
+        Assert.That(findings, Has.Length.EqualTo(1));
+    }
+
+    [Test]
+    public void ProcessorPullApiCensus_Excludes_test_compilations()
+    {
+        SourceCorpus corpus = SourceCorpus.Create(
+            ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
+                """
+                namespace Beutl.Graphics.Rendering;
+                public sealed class RenderNodeProcessor { }
+                """),
+            ("tests/Compatibility/RenderNodeProcessor.cs",
+                """
+                namespace Beutl.Graphics.Rendering;
+                public sealed class RenderNodeProcessor
+                {
+                    public void Pull() { }
+                }
+                """));
+
+        Assert.That(
+            corpus.FindMembersDeclaredByType(
+                "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                ["Pull"]),
+            Is.Empty);
     }
 
     [Test]
@@ -890,14 +986,44 @@ public sealed class RenderPipelineMigrationCensusTests
     {
         private readonly IReadOnlyDictionary<string, UsingDirectiveSyntax[]> _globalUsings;
         private readonly DeclaredType[] _declaredTypes;
+        private readonly HashSet<string> _productionCompilationIds;
         private readonly Lazy<SourceDocument[]> _memberCensusDocuments;
+        private readonly Lazy<IReadOnlyDictionary<(string CompilationId, string VariantId), UsingDirectiveSyntax[]>>
+            _memberGlobalUsings;
+        private readonly Lazy<DeclaredType[]> _memberDeclaredTypes;
 
         private SourceCorpus(string repositoryRoot, IReadOnlyList<SourceDocument> documents)
         {
             RepositoryRoot = repositoryRoot;
             Documents = documents;
+            _productionCompilationIds = GetProductionCompilationIds(repositoryRoot, documents);
             _memberCensusDocuments = new Lazy<SourceDocument[]>(() =>
-                CreateMemberCensusDocuments(documents));
+                CreateMemberCensusDocuments(
+                    repositoryRoot,
+                    documents,
+                    _productionCompilationIds));
+            _memberGlobalUsings = new Lazy<IReadOnlyDictionary<
+                (string CompilationId, string VariantId),
+                UsingDirectiveSyntax[]>>(() =>
+                    _memberCensusDocuments.Value
+                        .GroupBy(document =>
+                            (document.CompilationId, document.VariantId))
+                        .ToDictionary(
+                            group => group.Key,
+                            group => group.SelectMany(document => document.Root.Usings)
+                                .Where(item => item.GlobalKeyword.IsKind(
+                                    SyntaxKind.GlobalKeyword))
+                                .ToArray()));
+            _memberDeclaredTypes = new Lazy<DeclaredType[]>(() =>
+                _memberCensusDocuments.Value
+                    .SelectMany(document => document.Root.DescendantNodes()
+                        .OfType<TypeDeclarationSyntax>()
+                        .Select(type => new DeclaredType(
+                            document,
+                            type,
+                            GetQualifiedTypeName(type),
+                            type.Modifiers.Any(SyntaxKind.FileKeyword))))
+                    .ToArray());
             _globalUsings = documents
                 .GroupBy(document => document.CompilationId, StringComparer.Ordinal)
                 .ToDictionary(
@@ -1235,6 +1361,26 @@ public sealed class RenderPipelineMigrationCensusTests
                                 }
                             }
                         }
+
+                        if (visibleType.Syntax is RecordDeclarationSyntax
+                            {
+                                ParameterList: { } parameterList,
+                            })
+                        {
+                            foreach (SyntaxToken identifier in parameterList.Parameters
+                                         .Select(parameter => parameter.Identifier)
+                                         .Where(token => memberNameSet.Contains(token.ValueText)))
+                            {
+                                if (reportedMembers.Add((
+                                        visibleType.Document.RelativePath,
+                                        identifier.SpanStart)))
+                                {
+                                    yield return visibleType.Document.ToFinding(
+                                        identifier,
+                                        $"positional member '{identifier.ValueText}' on '{typeName}'");
+                                }
+                            }
+                        }
                     }
                 }
 
@@ -1301,31 +1447,261 @@ public sealed class RenderPipelineMigrationCensusTests
         }
 
         private static SourceDocument[] CreateMemberCensusDocuments(
-            IReadOnlyList<SourceDocument> documents)
+            string repositoryRoot,
+            IReadOnlyList<SourceDocument> documents,
+            IReadOnlySet<string> productionCompilationIds)
         {
-            string[][] symbolSets =
-            [
-                ["NET", "NET10_0", "NETCOREAPP"],
-                ["NET", "NET10_0", "NET10_0_WINDOWS", "NETCOREAPP", "WINDOWS"],
-            ];
-            var result = new List<SourceDocument>(documents.Count * (symbolSets.Length + 1));
-            foreach (SourceDocument document in documents)
+            var result = new List<SourceDocument>();
+            foreach (IGrouping<string, SourceDocument> compilation in documents
+                         .Where(document =>
+                             document.RelativePath.StartsWith("src/", StringComparison.Ordinal)
+                             && productionCompilationIds.Contains(document.CompilationId))
+                         .GroupBy(document => document.CompilationId, StringComparer.Ordinal))
             {
-                result.Add(document);
-                foreach (string[] symbols in symbolSets)
+                IReadOnlyList<string[]> symbolSets = GetCompilationSymbolSets(
+                    repositoryRoot,
+                    compilation.Key,
+                    compilation);
+                foreach (SourceDocument document in compilation)
                 {
-                    var tree = CSharpSyntaxTree.ParseText(
-                        document.Text,
-                        CSharpParseOptions.Default
-                            .WithLanguageVersion(LanguageVersion.Preview)
-                            .WithDocumentationMode(DocumentationMode.Parse)
-                            .WithPreprocessorSymbols(symbols),
-                        document.RelativePath);
-                    result.Add(document with { Root = tree.GetCompilationUnitRoot() });
+                    foreach (string[] symbols in symbolSets)
+                    {
+                        var tree = CSharpSyntaxTree.ParseText(
+                            document.Text,
+                            CSharpParseOptions.Default
+                                .WithLanguageVersion(LanguageVersion.Preview)
+                                .WithDocumentationMode(DocumentationMode.Parse)
+                                .WithPreprocessorSymbols(symbols),
+                            document.RelativePath);
+                        result.Add(document with
+                        {
+                            Root = tree.GetCompilationUnitRoot(),
+                            VariantId = string.Join(';', symbols),
+                        });
+                    }
                 }
             }
 
             return [.. result];
+        }
+
+        private static IReadOnlyList<string[]> GetCompilationSymbolSets(
+            string repositoryRoot,
+            string compilationId,
+            IEnumerable<SourceDocument> documents)
+        {
+            string[] baseSymbols =
+            [
+                "NET",
+                "NET10_0",
+                "NET10_0_OR_GREATER",
+                "NET9_0_OR_GREATER",
+                "NET8_0_OR_GREATER",
+                "NETCOREAPP",
+            ];
+            string[] windowsSymbols = ["NET10_0_WINDOWS", "WINDOWS"];
+            var directiveSymbols = new HashSet<string>(StringComparer.Ordinal);
+            var directivePositiveSets = new List<string[]>();
+            var conditionalPattern = new Regex(
+                @"(?m)^\s*#(?:if|elif)\s+(?<expression>[^\r\n]+)",
+                RegexOptions.CultureInvariant);
+            var identifierPattern = new Regex(
+                @"\b[A-Za-z_][A-Za-z0-9_]*\b",
+                RegexOptions.CultureInvariant);
+            foreach (SourceDocument document in documents)
+            {
+                foreach (Match match in conditionalPattern.Matches(document.Text.ToString()))
+                {
+                    string expression = match.Groups["expression"].Value;
+                    string withoutNegatedSymbols = Regex.Replace(
+                        expression,
+                        @"!\s*[A-Za-z_][A-Za-z0-9_]*",
+                        string.Empty,
+                        RegexOptions.CultureInvariant);
+                    string[] positiveSymbols = identifierPattern.Matches(withoutNegatedSymbols)
+                        .Select(item => item.Value)
+                        .Where(IsPreprocessorSymbol)
+                        .Distinct(StringComparer.Ordinal)
+                        .ToArray();
+                    if (positiveSymbols.Length > 0)
+                    {
+                        directivePositiveSets.Add(positiveSymbols);
+                    }
+
+                    foreach (string symbol in identifierPattern.Matches(expression)
+                                 .Select(item => item.Value)
+                                 .Where(IsPreprocessorSymbol))
+                    {
+                        directiveSymbols.Add(symbol);
+                    }
+                }
+            }
+
+            HashSet<string> projectSymbols = GetProjectDefinedSymbols(
+                repositoryRoot,
+                compilationId);
+            var variants = new Dictionary<string, string[]>(StringComparer.Ordinal);
+            AddSymbolVariant(variants, []);
+            AddSymbolVariant(variants, baseSymbols);
+            AddSymbolVariant(variants, baseSymbols.Concat(["DEBUG", "TRACE"]));
+            AddSymbolVariant(variants, baseSymbols.Concat(windowsSymbols));
+            AddSymbolVariant(
+                variants,
+                baseSymbols.Concat(windowsSymbols).Concat(["DEBUG", "TRACE"]));
+            AddSymbolVariant(variants, baseSymbols.Concat(projectSymbols));
+            AddSymbolVariant(
+                variants,
+                baseSymbols.Concat(windowsSymbols).Concat(projectSymbols));
+            AddSymbolVariant(variants, baseSymbols.Concat(directiveSymbols));
+            AddSymbolVariant(
+                variants,
+                baseSymbols.Concat(windowsSymbols).Concat(directiveSymbols));
+            foreach (string[] positiveSymbols in directivePositiveSets)
+            {
+                AddSymbolVariant(variants, baseSymbols.Concat(positiveSymbols));
+                AddSymbolVariant(
+                    variants,
+                    baseSymbols.Concat(windowsSymbols).Concat(positiveSymbols));
+            }
+
+            return variants.Values.ToArray();
+        }
+
+        private static bool IsPreprocessorSymbol(string value)
+        {
+            return value is not ("true" or "false" or "defined");
+        }
+
+        private static void AddSymbolVariant(
+            IDictionary<string, string[]> variants,
+            IEnumerable<string> symbols)
+        {
+            string[] normalized = symbols
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(symbol => symbol, StringComparer.Ordinal)
+                .ToArray();
+            variants.TryAdd(string.Join(';', normalized), normalized);
+        }
+
+        private static HashSet<string> GetProjectDefinedSymbols(
+            string repositoryRoot,
+            string compilationId)
+        {
+            var result = new HashSet<string>(StringComparer.Ordinal);
+            string projectPath = Path.Combine(
+                repositoryRoot,
+                compilationId.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(projectPath))
+            {
+                return result;
+            }
+
+            try
+            {
+                XDocument project = XDocument.Load(projectPath);
+                foreach (XElement constants in project.Descendants()
+                             .Where(element => element.Name.LocalName == "DefineConstants"))
+                {
+                    foreach (string symbol in constants.Value.Split(
+                                 [';', ',', ' '],
+                                 StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        if (symbol.All(character =>
+                                char.IsLetterOrDigit(character) || character == '_')
+                            && symbol != "DefineConstants")
+                        {
+                            result.Add(symbol);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is IOException
+                                       or UnauthorizedAccessException
+                                       or System.Xml.XmlException)
+            {
+            }
+
+            return result;
+        }
+
+        private static HashSet<string> GetProductionCompilationIds(
+            string repositoryRoot,
+            IReadOnlyList<SourceDocument> documents)
+        {
+            if (repositoryRoot == "synthetic")
+            {
+                return documents
+                    .Where(document => document.RelativePath.StartsWith(
+                        "src/",
+                        StringComparison.Ordinal))
+                    .Select(document => document.CompilationId)
+                    .ToHashSet(StringComparer.Ordinal);
+            }
+
+            string[] projects = documents
+                .Select(document => document.CompilationId)
+                .Where(compilationId =>
+                    compilationId.StartsWith("src/", StringComparison.Ordinal)
+                    && compilationId.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+            var references = projects.ToDictionary(
+                project => project,
+                project => GetProjectReferences(repositoryRoot, project),
+                StringComparer.Ordinal);
+            var result = projects
+                .Where(project => string.Equals(
+                    project,
+                    "src/Beutl.Engine/Beutl.Engine.csproj",
+                    StringComparison.Ordinal))
+                .ToHashSet(StringComparer.Ordinal);
+            bool changed;
+            do
+            {
+                changed = false;
+                foreach (string project in projects)
+                {
+                    if (!result.Contains(project)
+                        && references[project].Any(result.Contains))
+                    {
+                        result.Add(project);
+                        changed = true;
+                    }
+                }
+            } while (changed);
+
+            return result;
+        }
+
+        private static string[] GetProjectReferences(
+            string repositoryRoot,
+            string compilationId)
+        {
+            string projectPath = Path.Combine(
+                repositoryRoot,
+                compilationId.Replace('/', Path.DirectorySeparatorChar));
+            try
+            {
+                XDocument project = XDocument.Load(projectPath);
+                return project.Descendants()
+                    .Where(element => element.Name.LocalName == "ProjectReference")
+                    .Select(element => (string?)element.Attribute("Include"))
+                    .OfType<string>()
+                    .Select(reference => NormalizePath(Path.GetRelativePath(
+                        repositoryRoot,
+                        Path.GetFullPath(
+                            reference.Replace('\\', Path.DirectorySeparatorChar),
+                            Path.GetDirectoryName(projectPath)!))))
+                    .ToArray();
+            }
+            catch (Exception ex) when (ex is IOException
+                                       or UnauthorizedAccessException
+                                       or ArgumentException
+                                       or NotSupportedException
+                                       or System.Xml.XmlException)
+            {
+                return [];
+            }
         }
 
         private static string GetQualifiedTypeName(TypeDeclarationSyntax type)
@@ -1369,7 +1745,8 @@ public sealed class RenderPipelineMigrationCensusTests
 
                 foreach (BaseTypeSyntax baseType in current.Syntax.BaseList.Types)
                 {
-                    foreach (DeclaredType candidate in _declaredTypes.Where(candidate =>
+                    foreach (DeclaredType candidate in GetMemberDeclaredTypes(
+                                 current.Document).Where(candidate =>
                                  IsVisibleIn(candidate, current.Document)
                                  && CouldReferToType(
                                      baseType.Type,
@@ -1403,6 +1780,8 @@ public sealed class RenderPipelineMigrationCensusTests
 
             foreach (DeclaredType target in _declaredTypes.Where(item =>
                          !item.IsFileLocal
+                         && item.Document.RelativePath.StartsWith("src/", StringComparison.Ordinal)
+                         && _productionCompilationIds.Contains(item.Document.CompilationId)
                          && item.QualifiedName == qualifiedTypeName))
             {
                 foreach (DeclaredType baseType in EnumerateTypeHierarchy(target).Skip(1))
@@ -1475,9 +1854,15 @@ public sealed class RenderPipelineMigrationCensusTests
                 .Concat(document.Root.Usings.Where(item =>
                     !item.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword)))
                 .ToArray();
-            if (_globalUsings.TryGetValue(
-                    document.CompilationId,
-                    out UsingDirectiveSyntax[]? globalUsings))
+            UsingDirectiveSyntax[]? globalUsings = null;
+            if (!_memberGlobalUsings.Value.TryGetValue(
+                    (document.CompilationId, document.VariantId),
+                    out globalUsings))
+            {
+                _globalUsings.TryGetValue(document.CompilationId, out globalUsings);
+            }
+
+            if (globalUsings is not null)
             {
                 usings = usings.Concat(globalUsings).ToArray();
             }
@@ -1504,7 +1889,7 @@ public sealed class RenderPipelineMigrationCensusTests
                     string candidate = string.IsNullOrEmpty(scope)
                         ? writtenType
                         : scope + "." + writtenType;
-                    DeclaredType? visible = _declaredTypes.FirstOrDefault(item =>
+                    DeclaredType? visible = GetMemberDeclaredTypes(document).FirstOrDefault(item =>
                         IsVisibleIn(item, document)
                         && item.QualifiedName == candidate);
                     if (visible is not null || candidate == qualifiedTypeName)
@@ -1521,7 +1906,12 @@ public sealed class RenderPipelineMigrationCensusTests
                     scope = scope[..separator];
                 }
 
-                return false;
+                return usings
+                    .Where(item => item.Alias is null && item.Name is not null)
+                    .SelectMany(item => GetImportCandidates(
+                        item,
+                        GetWrittenName(item.Name!)))
+                    .Any(import => import + "." + writtenType == qualifiedTypeName);
             }
 
             if (writtenType != typeName)
@@ -1534,7 +1924,7 @@ public sealed class RenderPipelineMigrationCensusTests
                 string declaredType = string.IsNullOrEmpty(scope)
                     ? typeName
                     : scope + "." + typeName;
-                if (_declaredTypes.Any(item =>
+                if (GetMemberDeclaredTypes(document).Any(item =>
                         IsVisibleIn(item, document)
                         && item.QualifiedName == declaredType))
                 {
@@ -1555,6 +1945,19 @@ public sealed class RenderPipelineMigrationCensusTests
                        && item.Name is not null
                        && GetImportCandidates(item, GetWrittenName(item.Name))
                            .Contains(namespaceName, StringComparer.Ordinal));
+        }
+
+        private IEnumerable<DeclaredType> GetMemberDeclaredTypes(SourceDocument document)
+        {
+            IEnumerable<DeclaredType> candidates = document.VariantId == "default"
+                ? _declaredTypes
+                : _memberDeclaredTypes.Value;
+            return candidates.Where(item =>
+                item.Document.CompilationId == document.CompilationId
+                && (document.VariantId == "default"
+                    || item.Document.VariantId == document.VariantId)
+                && item.Document.RelativePath.StartsWith("src/", StringComparison.Ordinal)
+                && _productionCompilationIds.Contains(item.Document.CompilationId));
         }
 
         private static string GetWrittenTypeIdentity(TypeSyntax type)
@@ -1662,6 +2065,8 @@ public sealed class RenderPipelineMigrationCensusTests
         CompilationUnitSyntax Root,
         string CompilationId)
     {
+        public string VariantId { get; init; } = "default";
+
         public SourceFinding ToFinding(SyntaxNode node, string detail)
         {
             return ToFinding(node.SpanStart, detail);

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
@@ -254,6 +254,7 @@ public sealed class RenderPipelineMigrationCensusTests
     [Test]
     public void ProcessorPullApis_AreRemoved()
     {
+        string processorType = $"Beutl.Graphics.Rendering.{BuildName("Render", "Node", "Processor")}";
         string[] pullNames =
         [
             BuildName("Pu", "ll"),
@@ -261,7 +262,122 @@ public sealed class RenderPipelineMigrationCensusTests
         ];
 
         AssertNoFindings("Processor pull APIs must be absent.",
-            pullNames.SelectMany(s_corpus.Value.FindWord));
+            s_corpus.Value.FindMembersDeclaredByType(processorType, pullNames));
+    }
+
+    [Test]
+    public void ProcessorPullApiCensus_OnlyReportsMembersDeclaredByRenderNodeProcessor()
+    {
+        const string processorPath = "src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs";
+        SourceCorpus corpus = SourceCorpus.Create(
+            (processorPath,
+                """
+                namespace Beutl.Graphics.Rendering;
+
+                public sealed class RenderNodeProcessor
+                {
+                    public void Pull() { }
+
+                    public void PullToRoot() { }
+                }
+                """),
+            ("src/Other/RenderNodeProcessor.cs",
+                """
+                namespace Other;
+
+                public sealed class RenderNodeProcessor
+                {
+                    public void Pull() { }
+                }
+                """),
+            ("src/Beutl.Editor.Components/VersionControlTab/ViewModels/VersionControlPrimaryAction.cs",
+                """
+                namespace Beutl.Editor.Components.VersionControlTab.ViewModels;
+
+                public enum VersionControlPrimaryActionKind
+                {
+                    Pull,
+                }
+
+                public sealed class VersionControlTabViewModel
+                {
+                    public void Pull() { }
+                }
+                """));
+
+        SourceFinding[] findings = corpus.FindMembersDeclaredByType(
+                "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                ["Pull", "PullToRoot"])
+            .ToArray();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(findings, Has.Length.EqualTo(2));
+            Assert.That(findings.Select(finding => finding.RelativePath),
+                Is.All.EqualTo(processorPath));
+            Assert.That(findings.Select(finding => finding.Snippet),
+                Is.EquivalentTo(new[] { "public void Pull() { }", "public void PullToRoot() { }" }));
+        }
+    }
+
+    [Test]
+    public void ProcessorPullApiCensus_ReportsApplicableExtensionMethods()
+    {
+        const string extensionPath = "src/Compatibility/RenderNodeProcessorExtensions.cs";
+        SourceCorpus corpus = SourceCorpus.Create(
+            ("src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs",
+                """
+                namespace Beutl.Graphics.Rendering;
+
+                public sealed class RenderNodeProcessor
+                {
+                }
+                """),
+            (extensionPath,
+                """
+                using Beutl.Graphics.Rendering;
+
+                namespace Compatibility;
+
+                public static class RenderNodeProcessorExtensions
+                {
+                    public static void Pull(this RenderNodeProcessor processor) { }
+
+                    public static void PullToRoot(
+                        this global::Beutl.Graphics.Rendering.RenderNodeProcessor processor) { }
+                }
+                """),
+            ("src/Other/OtherExtensions.cs",
+                """
+                namespace Other;
+
+                public sealed class RenderNodeProcessor
+                {
+                }
+
+                public static class OtherExtensions
+                {
+                    public static void Pull(this RenderNodeProcessor processor) { }
+                }
+                """));
+
+        SourceFinding[] findings = corpus.FindMembersDeclaredByType(
+                "Beutl.Graphics.Rendering.RenderNodeProcessor",
+                ["Pull", "PullToRoot"])
+            .ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(findings, Has.Length.EqualTo(2));
+            Assert.That(findings.Select(finding => finding.RelativePath),
+                Is.All.EqualTo(extensionPath));
+            Assert.That(findings.Select(finding => finding.Snippet),
+                Is.EquivalentTo(new[]
+                {
+                    "public static void Pull(this RenderNodeProcessor processor) { }",
+                    "public static void PullToRoot(",
+                }));
+        });
     }
 
     [Test]
@@ -529,6 +645,23 @@ public sealed class RenderPipelineMigrationCensusTests
             return new SourceCorpus(repositoryRoot, documents);
         }
 
+        public static SourceCorpus Create(params (string RelativePath, string Source)[] sources)
+        {
+            SourceDocument[] documents = sources
+                .Select(source =>
+                {
+                    SourceText text = SourceText.From(source.Source);
+                    var tree = CSharpSyntaxTree.ParseText(
+                        text,
+                        CSharpParseOptions.Default.WithDocumentationMode(DocumentationMode.Parse),
+                        source.RelativePath);
+                    return new SourceDocument(source.RelativePath, text, tree.GetCompilationUnitRoot());
+                })
+                .OrderBy(document => document.RelativePath, StringComparer.Ordinal)
+                .ToArray();
+            return new SourceCorpus("synthetic", documents);
+        }
+
         public IReadOnlyList<SourceMethod> FindRenderNodeProcessOverrides()
         {
             return Documents.SelectMany(document => document.Root.DescendantNodes()
@@ -672,15 +805,18 @@ public sealed class RenderPipelineMigrationCensusTests
         }
 
         public IEnumerable<SourceFinding> FindMembersDeclaredByType(
-            string typeName,
+            string qualifiedTypeName,
             IReadOnlyCollection<string> memberNames)
         {
+            int separator = qualifiedTypeName.LastIndexOf('.');
+            string namespaceName = separator >= 0 ? qualifiedTypeName[..separator] : string.Empty;
+            string typeName = separator >= 0 ? qualifiedTypeName[(separator + 1)..] : qualifiedTypeName;
             var memberNameSet = new HashSet<string>(memberNames, StringComparer.Ordinal);
             foreach (SourceDocument document in Documents)
             {
                 foreach (TypeDeclarationSyntax type in document.Root.DescendantNodes()
                              .OfType<TypeDeclarationSyntax>()
-                             .Where(type => type.Identifier.ValueText == typeName))
+                             .Where(type => GetQualifiedTypeName(type) == qualifiedTypeName))
                 {
                     foreach (MemberDeclarationSyntax member in type.Members)
                     {
@@ -692,7 +828,83 @@ public sealed class RenderPipelineMigrationCensusTests
                         }
                     }
                 }
+
+                foreach (MethodDeclarationSyntax method in document.Root.DescendantNodes()
+                             .OfType<MethodDeclarationSyntax>()
+                             .Where(method => memberNameSet.Contains(method.Identifier.ValueText)))
+                {
+                    ParameterSyntax? receiver = method.ParameterList.Parameters.FirstOrDefault();
+                    if (receiver is null
+                        || !receiver.Modifiers.Any(SyntaxKind.ThisKeyword)
+                        || !CouldReferToType(
+                            receiver.Type,
+                            document.Root,
+                            namespaceName,
+                            typeName,
+                            qualifiedTypeName))
+                    {
+                        continue;
+                    }
+
+                    yield return document.ToFinding(
+                        method.Identifier,
+                        $"extension member '{method.Identifier.ValueText}' for '{qualifiedTypeName}'");
+                }
             }
+        }
+
+        private static string GetQualifiedTypeName(TypeDeclarationSyntax type)
+        {
+            IEnumerable<string> namespaces = type.Ancestors()
+                .OfType<BaseNamespaceDeclarationSyntax>()
+                .Reverse()
+                .Select(item => item.Name.ToString());
+            IEnumerable<string> containingTypes = type.Ancestors()
+                .OfType<TypeDeclarationSyntax>()
+                .Reverse()
+                .Select(item => item.Identifier.ValueText);
+            return string.Join('.', namespaces.Concat(containingTypes).Append(type.Identifier.ValueText));
+        }
+
+        private static bool CouldReferToType(
+            TypeSyntax? type,
+            CompilationUnitSyntax root,
+            string namespaceName,
+            string typeName,
+            string qualifiedTypeName)
+        {
+            if (type is null)
+            {
+                return false;
+            }
+
+            string writtenType = type.ToString().Replace("global::", string.Empty, StringComparison.Ordinal);
+            if (writtenType == qualifiedTypeName)
+            {
+                return true;
+            }
+
+            IEnumerable<UsingDirectiveSyntax> usings = root.Usings.Concat(
+                type.Ancestors().OfType<BaseNamespaceDeclarationSyntax>().SelectMany(item => item.Usings));
+            UsingDirectiveSyntax? alias = usings.FirstOrDefault(item =>
+                item.Alias?.Name.Identifier.ValueText == writtenType);
+            if (alias?.Name?.ToString().Replace("global::", string.Empty, StringComparison.Ordinal)
+                == qualifiedTypeName)
+            {
+                return true;
+            }
+
+            if (writtenType != typeName)
+            {
+                return false;
+            }
+
+            string declaredNamespace = string.Join('.', type.Ancestors()
+                .OfType<BaseNamespaceDeclarationSyntax>()
+                .Reverse()
+                .Select(item => item.Name.ToString()));
+            return declaredNamespace == namespaceName
+                   || usings.Any(item => item.Alias is null && item.Name?.ToString() == namespaceName);
         }
 
         private IEnumerable<SourceFinding> FindText(Regex pattern, string detail)

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
@@ -417,7 +417,7 @@ public sealed class RenderPipelineMigrationCensusTests
                 namespace Compatibility;
                 public static class BlockExtensions
                 {
-                    extension(RenderNodeProcessor processor)
+                    extension(RenderNodeProcessor? processor)
                     {
                         public void Pull() { }
                     }
@@ -980,6 +980,11 @@ public sealed class RenderPipelineMigrationCensusTests
             if (type is null)
             {
                 return false;
+            }
+
+            if (type is NullableTypeSyntax nullable)
+            {
+                type = nullable.ElementType;
             }
 
             string writtenType = type.ToString().Replace("global::", string.Empty, StringComparison.Ordinal);


### PR DESCRIPTION
## Description

- Make the render-pipeline migration census inspect production renderer assemblies explicitly.
- Keep test assemblies and incidental build outputs from broadening the API census.
- This is an independent PR based directly on main and has no dependency on PR #2164 or another extracted PR.

## Affected areas

- [x] Beutl.Engine (rendering / scene / track)
- [ ] Beutl.ProjectSystem (project / document persistence)
- [ ] UI (Beutl.Editor, Beutl.Editor.Components, Beutl.Controls)
- [ ] Beutl.Extensibility (plugin abstractions)
- [ ] Beutl.NodeGraph (node editor)
- [ ] Beutl.FFmpegIpc / Beutl.FFmpegWorker (media IPC boundary)
- [ ] Beutl.Api (server API client)
- [ ] Build / CI / docs only

## Breaking changes

None.

## Test plan

- dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --filter FullyQualifiedName~RenderPipelineMigrationCensusTests
- Result: 12 passed.
- git diff --check
- GPL/MIT boundary hook

## Fixed issues / References

- Extracted from the unrelated review expansion of #2164.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded render pipeline API census coverage to distinguish types with identical names in different namespaces.
  * Added validation for extension methods and properties, including extension blocks, aliases, global imports, nullable receivers, inherited members, generic constraints, and shadowing scenarios.
  * Added coverage for target and receiver type conversions, conditional compilation, positional record members, and per-compilation import scoping.
  * Added synthetic source-document support, preview-language parsing, and validation that test-only compilations are excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->