### PR TITLE
refactor(core)!: use canonical filesystem path identity

### DIFF
--- a/src/Beutl.Core/FilePathComparison.cs
+++ b/src/Beutl.Core/FilePathComparison.cs
@@ -340,7 +340,8 @@ public static class FilePathComparison
         if (OperatingSystem.IsWindows()
             && TryGetWindowsLongPath(candidate) is { } longPath)
         {
-            return longPath;
+            candidate = longPath;
+            component = Path.GetFileName(longPath);
         }
 
         try

--- a/src/Beutl.Core/FilePathComparison.cs
+++ b/src/Beutl.Core/FilePathComparison.cs
@@ -76,11 +76,6 @@ public static class FilePathComparison
             return true;
         }
 
-        if (!CouldHaveEquivalentFilesystemSpelling(leftName, rightName))
-        {
-            return true;
-        }
-
         string leftPath = Path.Combine(parentPath, leftName);
         string rightPath = Path.Combine(parentPath, rightName);
         bool leftExists = Path.Exists(leftPath);
@@ -88,6 +83,26 @@ public static class FilePathComparison
         if (!leftExists || !rightExists)
         {
             return leftExists != rightExists;
+        }
+
+        if (!CouldHaveEquivalentFilesystemSpelling(leftName, rightName))
+        {
+            try
+            {
+                bool leftIsLink = GetFileSystemInfo(leftPath).LinkTarget is not null;
+                bool rightIsLink = GetFileSystemInfo(rightPath).LinkTarget is not null;
+                if (!leftIsLink && !rightIsLink)
+                {
+                    return true;
+                }
+            }
+            catch (Exception ex) when (ex is IOException
+                                       or UnauthorizedAccessException
+                                       or ArgumentException
+                                       or NotSupportedException)
+            {
+                return false;
+            }
         }
 
         try
@@ -277,9 +292,7 @@ public static class FilePathComparison
 
     private static string? TryGetLinkTarget(string path)
     {
-        FileSystemInfo info = Directory.Exists(path)
-            ? new DirectoryInfo(path)
-            : new FileInfo(path);
+        FileSystemInfo info = GetFileSystemInfo(path);
         try
         {
             return info.LinkTarget;
@@ -294,6 +307,13 @@ public static class FilePathComparison
                 $"Could not inspect symbolic-link metadata for '{path}'.",
                 ex);
         }
+    }
+
+    private static FileSystemInfo GetFileSystemInfo(string path)
+    {
+        return Directory.Exists(path)
+            ? new DirectoryInfo(path)
+            : new FileInfo(path);
     }
 
     private static bool CouldHaveEquivalentFilesystemSpelling(string left, string right)

--- a/src/Beutl.Core/FilePathComparison.cs
+++ b/src/Beutl.Core/FilePathComparison.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Beutl;
 
@@ -336,6 +337,12 @@ public static class FilePathComparison
             return candidate;
         }
 
+        if (OperatingSystem.IsWindows()
+            && TryGetWindowsLongPath(candidate) is { } longPath)
+        {
+            return longPath;
+        }
+
         try
         {
             return SelectCanonicalExistingEntry(
@@ -422,6 +429,21 @@ public static class FilePathComparison
             ambiguous = true;
         }
     }
+
+    private static string? TryGetWindowsLongPath(string path)
+    {
+        var buffer = new StringBuilder(32768);
+        uint length = GetLongPathName(path, buffer, (uint)buffer.Capacity);
+        return length is > 0 and < 32768
+            ? Path.GetFullPath(buffer.ToString())
+            : null;
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern uint GetLongPathName(
+        string shortPath,
+        StringBuilder longPath,
+        uint bufferLength);
 
     internal sealed class ResolutionContext
     {

--- a/src/Beutl.Core/FilePathComparison.cs
+++ b/src/Beutl.Core/FilePathComparison.cs
@@ -20,10 +20,11 @@ public static class FilePathComparison
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(left);
         ArgumentException.ThrowIfNullOrWhiteSpace(right);
+        ResolutionContext context = CreateResolutionContext();
 
         return string.Equals(
-            ResolveCanonicalPath(left),
-            ResolveCanonicalPath(right),
+            context.ResolveCanonicalPath(left),
+            context.ResolveCanonicalPath(right),
             StringComparison.Ordinal);
     }
 
@@ -33,8 +34,11 @@ public static class FilePathComparison
         ArgumentException.ThrowIfNullOrWhiteSpace(root);
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
 
-        string canonicalRoot = Path.TrimEndingDirectorySeparator(ResolveCanonicalPath(root));
-        string canonicalPath = Path.TrimEndingDirectorySeparator(ResolveCanonicalPath(path));
+        ResolutionContext context = CreateResolutionContext();
+        string canonicalRoot = Path.TrimEndingDirectorySeparator(
+            context.ResolveCanonicalPath(root));
+        string canonicalPath = Path.TrimEndingDirectorySeparator(
+            context.ResolveCanonicalPath(path));
         if (string.Equals(canonicalRoot, canonicalPath, StringComparison.Ordinal))
         {
             return true;
@@ -106,6 +110,16 @@ public static class FilePathComparison
     /// <remarks>Any nonexistent suffix is retained exactly as supplied.</remarks>
     public static string ResolveCanonicalPath(string path)
     {
+        return CreateResolutionContext().ResolveCanonicalPath(path);
+    }
+
+    internal static ResolutionContext CreateResolutionContext()
+    {
+        return new ResolutionContext();
+    }
+
+    private static string ResolveCanonicalPath(string path, ResolutionContext context)
+    {
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
 
         (string root, IEnumerable<string> unresolvedComponents) =
@@ -132,7 +146,11 @@ public static class FilePathComparison
             }
 
             string candidate = Path.GetFullPath(Path.Combine(resolved, component));
-            candidate = NormalizeExistingEntrySpelling(resolved, component, candidate);
+            candidate = NormalizeExistingEntrySpelling(
+                resolved,
+                component,
+                candidate,
+                context);
             string? target = TryGetLinkTarget(candidate);
             if (target is null)
             {
@@ -290,7 +308,8 @@ public static class FilePathComparison
     private static string NormalizeExistingEntrySpelling(
         string parent,
         string component,
-        string candidate)
+        string candidate,
+        ResolutionContext context)
     {
         if (!Path.Exists(candidate))
         {
@@ -302,7 +321,7 @@ public static class FilePathComparison
             return SelectCanonicalExistingEntry(
                 component,
                 candidate,
-                Directory.EnumerateFileSystemEntries(parent));
+                context.GetEntries(parent));
         }
         catch (Exception ex)
             when (ex is IOException
@@ -381,6 +400,28 @@ public static class FilePathComparison
         else if (!string.Equals(match, entry, StringComparison.Ordinal))
         {
             ambiguous = true;
+        }
+    }
+
+    internal sealed class ResolutionContext
+    {
+        private readonly Dictionary<string, string[]> _directoryEntries =
+            new(StringComparer.Ordinal);
+
+        public string ResolveCanonicalPath(string path)
+        {
+            return FilePathComparison.ResolveCanonicalPath(path, this);
+        }
+
+        internal IReadOnlyList<string> GetEntries(string directory)
+        {
+            if (!_directoryEntries.TryGetValue(directory, out string[]? entries))
+            {
+                entries = Directory.GetFileSystemEntries(directory);
+                _directoryEntries.Add(directory, entries);
+            }
+
+            return entries;
         }
     }
 

--- a/src/Beutl.Core/FilePathComparison.cs
+++ b/src/Beutl.Core/FilePathComparison.cs
@@ -19,8 +19,8 @@ public static class FilePathComparison
     /// <summary>Determines whether two paths have the same canonical spelling.</summary>
     public static bool AreSameCanonicalPath(string left, string right)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(left);
-        ArgumentException.ThrowIfNullOrWhiteSpace(right);
+        ValidatePath(left, nameof(left));
+        ValidatePath(right, nameof(right));
         ResolutionContext context = CreateResolutionContext();
 
         return string.Equals(
@@ -32,8 +32,8 @@ public static class FilePathComparison
     /// <summary>Determines whether a path is the root itself or one of its descendants.</summary>
     public static bool IsSameOrDescendant(string root, string path)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(root);
-        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ValidatePath(root, nameof(root));
+        ValidatePath(path, nameof(path));
 
         ResolutionContext context = CreateResolutionContext();
         string canonicalRoot = Path.TrimEndingDirectorySeparator(
@@ -66,7 +66,7 @@ public static class FilePathComparison
         string rightName,
         out bool areSame)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(parentPath);
+        ValidatePath(parentPath, nameof(parentPath));
         ValidateChildName(leftName, nameof(leftName));
         ValidateChildName(rightName, nameof(rightName));
 
@@ -84,26 +84,6 @@ public static class FilePathComparison
         if (!leftExists || !rightExists)
         {
             return leftExists != rightExists;
-        }
-
-        if (!CouldHaveEquivalentFilesystemSpelling(leftName, rightName))
-        {
-            try
-            {
-                bool leftIsLink = GetFileSystemInfo(leftPath).LinkTarget is not null;
-                bool rightIsLink = GetFileSystemInfo(rightPath).LinkTarget is not null;
-                if (!leftIsLink && !rightIsLink)
-                {
-                    return true;
-                }
-            }
-            catch (Exception ex) when (ex is IOException
-                                       or UnauthorizedAccessException
-                                       or ArgumentException
-                                       or NotSupportedException)
-            {
-                return false;
-            }
         }
 
         try
@@ -136,7 +116,7 @@ public static class FilePathComparison
 
     private static string ResolveCanonicalPath(string path, ResolutionContext context)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ValidatePath(path, nameof(path));
 
         (string root, IEnumerable<string> unresolvedComponents) =
             GetUnresolvedAbsolutePath(path);
@@ -260,7 +240,7 @@ public static class FilePathComparison
 
     private static void ValidateChildName(string name, string paramName)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(name, paramName);
+        ValidatePath(name, paramName);
         if (name is "." or ".."
             || Path.IsPathRooted(name)
             || name.AsSpan().IndexOfAny(
@@ -271,6 +251,16 @@ public static class FilePathComparison
             throw new ArgumentException(
                 "A child name must contain exactly one path component.",
                 paramName);
+        }
+    }
+
+    private static void ValidatePath(string path, string paramName)
+    {
+        ArgumentNullException.ThrowIfNull(path, paramName);
+        if (path.Length == 0
+            || OperatingSystem.IsWindows() && string.IsNullOrWhiteSpace(path))
+        {
+            throw new ArgumentException("The path must not be empty.", paramName);
         }
     }
 
@@ -315,15 +305,6 @@ public static class FilePathComparison
         return Directory.Exists(path)
             ? new DirectoryInfo(path)
             : new FileInfo(path);
-    }
-
-    private static bool CouldHaveEquivalentFilesystemSpelling(string left, string right)
-    {
-        return string.Equals(left, right, StringComparison.OrdinalIgnoreCase)
-               || string.Equals(
-                   left.Normalize(NormalizationForm.FormC),
-                   right.Normalize(NormalizationForm.FormC),
-                   StringComparison.OrdinalIgnoreCase);
     }
 
     private static string NormalizeExistingEntrySpelling(

--- a/src/Beutl.Core/FilePathComparison.cs
+++ b/src/Beutl.Core/FilePathComparison.cs
@@ -1,23 +1,387 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Text;
 
 namespace Beutl;
 
-/// <summary>
-/// How to compare two file paths for identity on the current platform.
-/// </summary>
+/// <summary>Compares file paths after resolving their existing filesystem identity.</summary>
 /// <remarks>
-/// Windows and macOS resolve paths case-insensitively; Linux does not, where <c>Item.json</c> and
-/// <c>item.json</c> are two different files. Comparing case-insensitively everywhere makes distinct
-/// files collide, so anything keying a cache or a containment test on a path uses this.
+/// Existing components are rewritten to their on-disk spelling and symbolic links are followed.
+/// Dot segments are applied after resolving any preceding symbolic link. Nonexistent suffixes
+/// retain their lexical spelling. Results describe a point-in-time lookup and do not lock the
+/// inspected entries against concurrent replacement. If several non-exact case/normalization
+/// candidates are visible, the supplied spelling is retained rather than guessing which distinct
+/// entry the filesystem resolved.
 /// </remarks>
 public static class FilePathComparison
 {
-    public static StringComparison Comparison { get; } =
-        RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
-            ? StringComparison.Ordinal
-            : StringComparison.OrdinalIgnoreCase;
+    private const int MaxSymbolicLinkHops = 64;
 
-    public static bool Equals(string? left, string? right) => string.Equals(left, right, Comparison);
+    /// <summary>Determines whether two paths have the same canonical spelling.</summary>
+    public static bool AreSameCanonicalPath(string left, string right)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(left);
+        ArgumentException.ThrowIfNullOrWhiteSpace(right);
 
-    public static bool StartsWith(string path, string prefix) => path.StartsWith(prefix, Comparison);
+        return string.Equals(
+            ResolveCanonicalPath(left),
+            ResolveCanonicalPath(right),
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>Determines whether a path is the root itself or one of its descendants.</summary>
+    public static bool IsSameOrDescendant(string root, string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(root);
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        string canonicalRoot = Path.TrimEndingDirectorySeparator(ResolveCanonicalPath(root));
+        string canonicalPath = Path.TrimEndingDirectorySeparator(ResolveCanonicalPath(path));
+        if (string.Equals(canonicalRoot, canonicalPath, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        string prefix = canonicalRoot.EndsWith(Path.DirectorySeparatorChar)
+            ? canonicalRoot
+            : canonicalRoot + Path.DirectorySeparatorChar;
+        return canonicalPath.StartsWith(prefix, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Tries to determine whether two single-component child paths identify the same canonical path.
+    /// </summary>
+    /// <remarks>
+    /// The method returns <see langword="false"/> when case- or normalization-variant children are
+    /// both absent or when their filesystem metadata cannot be inspected. A successful result is
+    /// only a snapshot; callers that mutate either path still need an operation-specific ownership
+    /// mechanism.
+    /// </remarks>
+    public static bool TryAreSameChildPath(
+        string parentPath,
+        string leftName,
+        string rightName,
+        out bool areSame)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(parentPath);
+        ValidateChildName(leftName, nameof(leftName));
+        ValidateChildName(rightName, nameof(rightName));
+
+        areSame = false;
+        if (string.Equals(leftName, rightName, StringComparison.Ordinal))
+        {
+            areSame = true;
+            return true;
+        }
+
+        if (!CouldHaveEquivalentFilesystemSpelling(leftName, rightName))
+        {
+            return true;
+        }
+
+        string leftPath = Path.Combine(parentPath, leftName);
+        string rightPath = Path.Combine(parentPath, rightName);
+        bool leftExists = Path.Exists(leftPath);
+        bool rightExists = Path.Exists(rightPath);
+        if (!leftExists || !rightExists)
+        {
+            return leftExists != rightExists;
+        }
+
+        try
+        {
+            areSame = AreSameCanonicalPath(leftPath, rightPath);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException
+                                   or UnauthorizedAccessException
+                                   or ArgumentException
+                                   or NotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Resolves symbolic links and the on-disk spelling of each existing path component.
+    /// </summary>
+    /// <remarks>Any nonexistent suffix is retained exactly as supplied.</remarks>
+    public static string ResolveCanonicalPath(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        (string root, IEnumerable<string> unresolvedComponents) =
+            GetUnresolvedAbsolutePath(path);
+        var components = new Queue<string>(unresolvedComponents);
+        var visitedStates = new HashSet<string>(StringComparer.Ordinal)
+        {
+            CreateResolutionState(root, components),
+        };
+        string resolved = root;
+        int linkHops = 0;
+
+        while (components.TryDequeue(out string? component))
+        {
+            if (component == ".")
+            {
+                continue;
+            }
+
+            if (component == "..")
+            {
+                resolved = Path.GetDirectoryName(resolved) ?? resolved;
+                continue;
+            }
+
+            string candidate = Path.GetFullPath(Path.Combine(resolved, component));
+            candidate = NormalizeExistingEntrySpelling(resolved, component, candidate);
+            string? target = TryGetLinkTarget(candidate);
+            if (target is null)
+            {
+                resolved = candidate;
+                continue;
+            }
+
+            linkHops++;
+            if (linkHops > MaxSymbolicLinkHops)
+            {
+                throw new IOException(
+                    $"The path '{path}' exceeds the symbolic-link resolution limit.");
+            }
+
+            string targetRoot = NormalizeRoot(Path.GetPathRoot(target) ?? string.Empty);
+            if (Path.IsPathFullyQualified(target))
+            {
+                resolved = targetRoot;
+            }
+            else if (Path.IsPathRooted(target))
+            {
+                if (!OperatingSystem.IsWindows()
+                    || targetRoot.Length != 1
+                    || targetRoot[0] is not ('\\' or '/'))
+                {
+                    throw new IOException(
+                        $"The symbolic link '{candidate}' has an unsupported rooted target.");
+                }
+
+                resolved = NormalizeRoot(
+                    Path.GetPathRoot(resolved)
+                    ?? throw new IOException(
+                        $"The path '{path}' has no drive root."));
+            }
+
+            IEnumerable<string> targetComponents = SplitComponents(target, targetRoot);
+            components = new Queue<string>(targetComponents.Concat(components));
+            string state = CreateResolutionState(resolved, components);
+            if (!visitedStates.Add(state))
+            {
+                throw new IOException(
+                    $"A symbolic-link cycle was found while resolving '{path}'.");
+            }
+        }
+
+        return Path.TrimEndingDirectorySeparator(Path.GetFullPath(resolved));
+    }
+
+    private static (string Root, IEnumerable<string> Components) GetUnresolvedAbsolutePath(
+        string path)
+    {
+        string? suppliedRoot = Path.GetPathRoot(path);
+        if (Path.IsPathFullyQualified(path))
+        {
+            string root = suppliedRoot
+                          ?? throw new IOException($"The path '{path}' has no root.");
+            return (NormalizeRoot(root), SplitComponents(path, root));
+        }
+
+        string basePath;
+        string suffix;
+        if (OperatingSystem.IsWindows()
+            && suppliedRoot is { Length: 2 }
+            && suppliedRoot[1] == Path.VolumeSeparatorChar)
+        {
+            basePath = Path.GetFullPath(suppliedRoot + ".");
+            suffix = path[suppliedRoot.Length..];
+        }
+        else if (Path.IsPathRooted(path))
+        {
+            string fullPath = Path.GetFullPath(path);
+            string root = Path.GetPathRoot(fullPath)
+                          ?? throw new IOException($"The path '{path}' has no root.");
+            return (
+                NormalizeRoot(root),
+                SplitComponents(path, suppliedRoot ?? string.Empty));
+        }
+        else
+        {
+            basePath = Path.GetFullPath(Environment.CurrentDirectory);
+            suffix = path;
+        }
+
+        string baseRoot = Path.GetPathRoot(basePath)
+                          ?? throw new IOException($"The path '{path}' has no root.");
+        return (
+            NormalizeRoot(baseRoot),
+            SplitComponents(basePath, baseRoot)
+                .Concat(SplitComponents(suffix, string.Empty)));
+    }
+
+    private static void ValidateChildName(string name, string paramName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name, paramName);
+        if (name is "." or ".."
+            || Path.IsPathRooted(name)
+            || name.AsSpan().IndexOfAny(
+                Path.DirectorySeparatorChar,
+                Path.AltDirectorySeparatorChar) >= 0
+            || OperatingSystem.IsWindows() && name.Contains(Path.VolumeSeparatorChar))
+        {
+            throw new ArgumentException(
+                "A child name must contain exactly one path component.",
+                paramName);
+        }
+    }
+
+    private static string NormalizeRoot(string root)
+    {
+        return OperatingSystem.IsWindows() ? root.ToUpperInvariant() : root;
+    }
+
+    private static IEnumerable<string> SplitComponents(string path, string root)
+    {
+        return path[root.Length..].Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    private static string CreateResolutionState(string resolved, IEnumerable<string> components)
+    {
+        return string.Join('\0', new[] { resolved }.Concat(components));
+    }
+
+    private static string? TryGetLinkTarget(string path)
+    {
+        FileSystemInfo info = Directory.Exists(path)
+            ? new DirectoryInfo(path)
+            : new FileInfo(path);
+        try
+        {
+            return info.LinkTarget;
+        }
+        catch (Exception ex)
+            when (ex is IOException
+                  or UnauthorizedAccessException
+                  or NotSupportedException
+                  or ArgumentException)
+        {
+            throw new IOException(
+                $"Could not inspect symbolic-link metadata for '{path}'.",
+                ex);
+        }
+    }
+
+    private static bool CouldHaveEquivalentFilesystemSpelling(string left, string right)
+    {
+        return string.Equals(left, right, StringComparison.OrdinalIgnoreCase)
+               || string.Equals(
+                   left.Normalize(NormalizationForm.FormC),
+                   right.Normalize(NormalizationForm.FormC),
+                   StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizeExistingEntrySpelling(
+        string parent,
+        string component,
+        string candidate)
+    {
+        if (!Path.Exists(candidate))
+        {
+            return candidate;
+        }
+
+        try
+        {
+            return SelectCanonicalExistingEntry(
+                component,
+                candidate,
+                Directory.EnumerateFileSystemEntries(parent));
+        }
+        catch (Exception ex)
+            when (ex is IOException
+                  or UnauthorizedAccessException
+                  or NotSupportedException)
+        {
+            throw new IOException(
+                $"Could not normalize the on-disk spelling of '{candidate}'.",
+                ex);
+        }
+    }
+
+    internal static string SelectCanonicalExistingEntry(
+        string component,
+        string candidate,
+        IEnumerable<string> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+
+        string normalizedComponent = component.Normalize(NormalizationForm.FormC);
+        string? equivalentMatch = null;
+        bool equivalentMatchAmbiguous = false;
+
+        foreach (string entry in entries)
+        {
+            string entryName = Path.GetFileName(entry);
+            if (string.Equals(entryName, component, StringComparison.Ordinal))
+            {
+                return entry;
+            }
+
+            if (string.Equals(entryName, component, StringComparison.OrdinalIgnoreCase))
+            {
+                TrackUniqueMatch(
+                    entry,
+                    ref equivalentMatch,
+                    ref equivalentMatchAmbiguous);
+                continue;
+            }
+
+            string normalizedEntryName = entryName.Normalize(NormalizationForm.FormC);
+            if (string.Equals(
+                    normalizedEntryName,
+                    normalizedComponent,
+                    StringComparison.Ordinal))
+            {
+                TrackUniqueMatch(
+                    entry,
+                    ref equivalentMatch,
+                    ref equivalentMatchAmbiguous);
+            }
+            else if (string.Equals(
+                         normalizedEntryName,
+                         normalizedComponent,
+                         StringComparison.OrdinalIgnoreCase))
+            {
+                TrackUniqueMatch(
+                    entry,
+                    ref equivalentMatch,
+                    ref equivalentMatchAmbiguous);
+            }
+        }
+
+        return equivalentMatchAmbiguous ? candidate : equivalentMatch ?? candidate;
+    }
+
+    private static void TrackUniqueMatch(
+        string entry,
+        ref string? match,
+        ref bool ambiguous)
+    {
+        if (match is null)
+        {
+            match = entry;
+        }
+        else if (!string.Equals(match, entry, StringComparison.Ordinal))
+        {
+            ambiguous = true;
+        }
+    }
+
 }

--- a/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
@@ -326,6 +326,11 @@ internal sealed class DirectoryWatcherService : IDisposable
 
     private bool IsTemplateOrMaterialPath(string path)
     {
+        if (IsConfiguredSpecialDirectory(path))
+        {
+            return true;
+        }
+
         string? directory = Directory.Exists(path) ? path : Path.GetDirectoryName(path);
         if (string.IsNullOrEmpty(directory))
         {
@@ -384,6 +389,31 @@ internal sealed class DirectoryWatcherService : IDisposable
         return _templateOrMaterialDirectories.GetOrAdd(canonicalDirectory, static candidate =>
             PathScope.IsUnderDirectory(candidate, BeutlEnvironment.GetTemplatesDirectoryPath())
             || PathScope.IsUnderDirectory(candidate, BeutlEnvironment.GetMaterialsDirectoryPath()));
+    }
+
+    private static bool IsConfiguredSpecialDirectory(string path)
+    {
+        try
+        {
+            string fullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+            return string.Equals(
+                       fullPath,
+                       Path.TrimEndingDirectorySeparator(Path.GetFullPath(
+                           BeutlEnvironment.GetTemplatesDirectoryPath())),
+                       StringComparison.Ordinal)
+                   || string.Equals(
+                       fullPath,
+                       Path.TrimEndingDirectorySeparator(Path.GetFullPath(
+                           BeutlEnvironment.GetMaterialsDirectoryPath())),
+                       StringComparison.Ordinal);
+        }
+        catch (Exception ex) when (ex is IOException
+                                   or UnauthorizedAccessException
+                                   or ArgumentException
+                                   or NotSupportedException)
+        {
+            return false;
+        }
     }
 
     private static string CreateLinkFingerprint(string directory)

--- a/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
@@ -400,9 +400,17 @@ internal sealed class DirectoryWatcherService : IDisposable
         {
             current = Path.Combine(current, segment);
             var info = new DirectoryInfo(current);
+            string? linkTarget = info.LinkTarget;
             fingerprint.Append(segment)
                 .Append('=')
-                .Append(info.LinkTarget)
+                .Append(linkTarget);
+            if (linkTarget is not null)
+            {
+                fingerprint.Append("->")
+                    .Append(info.ResolveLinkTarget(returnFinalTarget: true)?.FullName);
+            }
+
+            fingerprint
                 .Append('\0');
         }
 

--- a/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Threading;
+﻿using System.Collections.Concurrent;
+using Avalonia.Threading;
 using Beutl.Editor.Services;
 using Beutl.Logging;
 using Microsoft.Extensions.Logging;
@@ -10,74 +11,190 @@ internal sealed class DirectoryWatcherService : IDisposable
 {
     private static readonly TimeSpan s_debounceInterval = TimeSpan.FromMilliseconds(300);
     private readonly ILogger _logger = Log.CreateLogger<DirectoryWatcherService>();
+    private readonly object _stateSync = new();
+    private readonly TimeSpan _debounceInterval;
+    private readonly Action<Action> _postDelivery;
+    private readonly Action<FileSystemWatcher> _startWatcher;
+    private readonly ConcurrentDictionary<string, bool> _templateOrMaterialDirectories =
+        new(StringComparer.Ordinal);
     // Limit consecutive rearm attempts because persistent failures recur immediately.
     private const int MaxErrorRearms = 3;
 
     private FileSystemWatcher? _watcher;
+    private string? _watchedCanonicalPath;
+    private string? _watchedRequestedPath;
     private CancellationTokenSource? _debounceCts;
     private int _errorRearmCount;
-    private string? _failingPath;
+    private string? _failingCanonicalPath;
+    private bool _disposed;
+    private long _stateGeneration;
+
+    public DirectoryWatcherService()
+        : this(
+            s_debounceInterval,
+            callback => Dispatcher.UIThread.Post(callback, DispatcherPriority.Background))
+    {
+    }
+
+    internal DirectoryWatcherService(
+        TimeSpan debounceInterval,
+        Action<Action> postDelivery,
+        Action<FileSystemWatcher>? startWatcher = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(debounceInterval, TimeSpan.Zero);
+        ArgumentNullException.ThrowIfNull(postDelivery);
+
+        _debounceInterval = debounceInterval;
+        _postDelivery = postDelivery;
+        _startWatcher = startWatcher
+                        ?? (static watcher => watcher.EnableRaisingEvents = true);
+    }
 
     // ファイルシステムに変更があったときに発火する。UIスレッドで呼び出される。
     public event Action? Changed;
 
-    internal bool IsWatching => _watcher is not null;
+    internal bool IsWatching
+    {
+        get
+        {
+            lock (_stateSync)
+            {
+                return _watcher is not null;
+            }
+        }
+    }
 
     // 指定パスの監視を開始する。前回の監視は自動的に停止される。
     public void Watch(string? path) => Watch(path, isErrorRearm: false);
 
     private void Watch(string? path, bool isErrorRearm)
     {
-        // Only changing folders clears a failure budget.
-        if (!isErrorRearm && !string.Equals(_failingPath, path, StringComparison.Ordinal))
+        FileSystemWatcher? currentWatcher;
+        string? watchedCanonicalPath;
+        lock (_stateSync)
         {
-            _errorRearmCount = 0;
-            _failingPath = null;
+            if (_disposed)
+                return;
+
+            currentWatcher = _watcher;
+            watchedCanonicalPath = _watchedCanonicalPath;
+        }
+
+        bool pathResolved = TryResolveWatchPath(path, out string? canonicalPath);
+
+        // Only changing folders clears a failure budget.
+        if (!isErrorRearm)
+        {
+            lock (_stateSync)
+            {
+                if (!pathResolved
+                    || !string.Equals(
+                        _failingCanonicalPath,
+                        canonicalPath,
+                        StringComparison.Ordinal))
+                {
+                    _errorRearmCount = 0;
+                    _failingCanonicalPath = null;
+                }
+            }
         }
 
         // Recursive watchers consume one inotify descriptor per subdirectory.
-        if (_watcher is not null && string.Equals(_watcher.Path, path, StringComparison.Ordinal))
+        if (currentWatcher is not null
+            && pathResolved
+            && canonicalPath is not null
+            && Directory.Exists(canonicalPath)
+            && string.Equals(
+                watchedCanonicalPath,
+                canonicalPath,
+                StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        CancellationTokenSource? previousDebounce;
+        FileSystemWatcher? previousWatcher;
+        long watchGeneration;
+        lock (_stateSync)
+        {
+            if (_disposed)
+                return;
+
+            watchGeneration = ++_stateGeneration;
+            previousDebounce = _debounceCts;
+            _debounceCts = null;
+            previousWatcher = _watcher;
+            _watcher = null;
+            _watchedCanonicalPath = null;
+            _watchedRequestedPath = null;
+        }
+
+        CancelAndDispose(previousDebounce);
+        previousWatcher?.Dispose();
+        _templateOrMaterialDirectories.Clear();
+
+        if (!pathResolved || canonicalPath is null || !Directory.Exists(canonicalPath))
             return;
 
-        _debounceCts?.Cancel();
-        _debounceCts?.Dispose();
-        _debounceCts = null;
-
-        _watcher?.Dispose();
-        _watcher = null;
-
-        if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
-            return;
-
+        FileSystemWatcher? nextWatcher = null;
         try
         {
-            _watcher = new FileSystemWatcher(path)
+            nextWatcher = new FileSystemWatcher(canonicalPath)
             {
                 NotifyFilter = NotifyFilters.FileName | NotifyFilters.DirectoryName | NotifyFilters.LastWrite,
                 IncludeSubdirectories = true,
-                EnableRaisingEvents = true
             };
 
-            _watcher.Created += OnFileSystemEvent;
-            _watcher.Deleted += OnFileSystemEvent;
-            _watcher.Renamed += OnFileSystemEvent;
-            _watcher.Changed += OnFileSystemEvent;
-            _watcher.Error += OnWatcherError;
+            nextWatcher.Created += OnFileSystemEvent;
+            nextWatcher.Deleted += OnFileSystemEvent;
+            nextWatcher.Renamed += OnFileSystemEvent;
+            nextWatcher.Changed += OnFileSystemEvent;
+            nextWatcher.Error += OnWatcherError;
+
+            lock (_stateSync)
+            {
+                if (_disposed || _stateGeneration != watchGeneration)
+                    return;
+
+                _watcher = nextWatcher;
+                _watchedCanonicalPath = canonicalPath;
+                _watchedRequestedPath = Path.GetFullPath(path!);
+                try
+                {
+                    _startWatcher(nextWatcher);
+                }
+                catch
+                {
+                    _watcher = null;
+                    _watchedCanonicalPath = null;
+                    _watchedRequestedPath = null;
+                    throw;
+                }
+
+                nextWatcher = null;
+            }
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to create FileSystemWatcher for {Path}", path);
+            _logger.LogWarning(ex, "Failed to create FileSystemWatcher for {Path}", canonicalPath);
+        }
+        finally
+        {
+            nextWatcher?.Dispose();
         }
     }
 
     // Rebuild after Error; otherwise the current folder stays unwatched.
     private void OnWatcherError(object sender, ErrorEventArgs e)
     {
+        if (!IsCurrentWatcher(sender))
+            return;
+
         _logger.LogWarning(e.GetException(), "FileSystemWatcher stopped; rebuilding it");
 
         Dispatcher.UIThread.Post(() =>
         {
-            if (_watcher is not { } watcher || !ReferenceEquals(watcher, sender))
+            if (!IsCurrentWatcher(sender))
                 return;
 
             if (TryRearmAfterError())
@@ -90,100 +207,337 @@ internal sealed class DirectoryWatcherService : IDisposable
 
     internal bool TryRearmAfterError()
     {
-        string? path = _watcher?.Path;
-        _watcher?.Dispose();
-        _watcher = null;
-
-        if (path is null || _errorRearmCount >= MaxErrorRearms)
+        string? requestedPath;
+        string? canonicalPath;
+        FileSystemWatcher? watcher;
+        CancellationTokenSource? debounce;
+        lock (_stateSync)
         {
-            if (path is not null)
-            {
-                _logger.LogWarning(
-                    "FileSystemWatcher for {Path} failed {Count} times in a row; leaving it off until the folder changes",
-                    path,
-                    _errorRearmCount);
-            }
+            if (_disposed)
+                return false;
 
+            watcher = _watcher;
+            requestedPath = _watchedRequestedPath ?? watcher?.Path;
+            canonicalPath = _watchedCanonicalPath ?? watcher?.Path;
+            _watcher = null;
+            _watchedCanonicalPath = null;
+            _watchedRequestedPath = null;
+            debounce = _debounceCts;
+            _debounceCts = null;
+            _stateGeneration++;
+        }
+
+        CancelAndDispose(debounce);
+        watcher?.Dispose();
+        _templateOrMaterialDirectories.Clear();
+
+        if (requestedPath is null || canonicalPath is null)
+        {
             return false;
         }
 
-        _failingPath = path;
+        lock (_stateSync)
+        {
+            _failingCanonicalPath ??= canonicalPath;
+        }
 
         // Watch swallows a construction failure, and with no watcher no further Error can arrive to
         // spend what is left of the budget.
-        while (_errorRearmCount < MaxErrorRearms)
+        while (true)
         {
-            _errorRearmCount++;
-            Watch(path, isErrorRearm: true);
-            if (_watcher is not null)
+            lock (_stateSync)
+            {
+                if (_disposed || _errorRearmCount >= MaxErrorRearms)
+                {
+                    break;
+                }
+
+                _errorRearmCount++;
+            }
+
+            Watch(requestedPath, isErrorRearm: true);
+            if (IsWatching)
                 return true;
         }
 
         _logger.LogWarning(
             "FileSystemWatcher for {Path} could not be rebuilt in {Count} attempts; leaving it off until the folder changes",
-            path,
-            _errorRearmCount);
+            requestedPath,
+            GetErrorRearmCount());
         return false;
     }
 
-    // プロジェクト、シーン、要素のファイルは頻繁に変更されるため除外
-    private bool ShouldExcludePath(string path)
+    private int GetErrorRearmCount()
     {
-        // templatesディレクトリは例外
-        if (PathScope.IsUnderDirectory(path, BeutlEnvironment.GetTemplatesDirectoryPath()))
+        lock (_stateSync)
+        {
+            return _errorRearmCount;
+        }
+    }
+
+    private bool IsCurrentWatcher(object sender)
+    {
+        lock (_stateSync)
+        {
+            return !_disposed && ReferenceEquals(_watcher, sender);
+        }
+    }
+
+    // プロジェクト、シーン、要素のファイルは頻繁に変更されるため除外
+    internal bool ShouldExcludePath(string path)
+    {
+        // Templates and materials live below BEUTL_HOME/.beutl by default, so their explicit
+        // exception must win over the reserved-metadata rule. Cache by containing directory: a
+        // watcher burst commonly reports hundreds of sibling files, and canonical resolution only
+        // needs to run once for that directory identity.
+        if (IsTemplateOrMaterialPath(path))
         {
             return false;
         }
 
-        // materialsディレクトリも例外
-        if (PathScope.IsUnderDirectory(path, BeutlEnvironment.GetMaterialsDirectoryPath()))
+        if (HasReservedMetadataSegment(path))
         {
-            return false;
+            return true;
         }
 
         return path.EndsWith(".bep", StringComparison.OrdinalIgnoreCase) ||
                path.EndsWith(".scene", StringComparison.OrdinalIgnoreCase) ||
-               path.EndsWith(".belm", StringComparison.OrdinalIgnoreCase) ||
-               path.Contains(".beutl");
+               path.EndsWith(".belm", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private bool IsTemplateOrMaterialPath(string path)
+    {
+        string? directory = Directory.Exists(path) ? path : Path.GetDirectoryName(path);
+        if (string.IsNullOrEmpty(directory))
+        {
+            return false;
+        }
+
+        if (_templateOrMaterialDirectories.Count >= 512)
+        {
+            _templateOrMaterialDirectories.Clear();
+        }
+
+        return _templateOrMaterialDirectories.GetOrAdd(directory, static candidate =>
+            PathScope.IsUnderDirectory(candidate, BeutlEnvironment.GetTemplatesDirectoryPath())
+            || PathScope.IsUnderDirectory(candidate, BeutlEnvironment.GetMaterialsDirectoryPath()));
+    }
+
+    private static bool HasReservedMetadataSegment(string path)
+    {
+        string fullPath = Path.GetFullPath(path);
+        string root = Path.GetPathRoot(fullPath)
+                      ?? throw new ArgumentException("The path has no filesystem root.", nameof(path));
+        string parent = root;
+        foreach (string segment in fullPath[root.Length..].Split(
+                     [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+                     StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (AreSameChildPath(parent, segment, ".git")
+                || AreSameChildPath(parent, segment, ".beutl"))
+            {
+                return true;
+            }
+
+            parent = Path.Combine(parent, segment);
+        }
+
+        return false;
+    }
+
+    private static bool AreSameChildPath(string parent, string leftName, string rightName)
+    {
+        return FilePathComparison.TryAreSameChildPath(
+                   parent,
+                   leftName,
+                   rightName,
+                   out bool areSame)
+               && areSame;
+    }
+
+    private bool TryResolveWatchPath(string? path, out string? canonicalPath)
+    {
+        canonicalPath = null;
+        if (string.IsNullOrEmpty(path))
+        {
+            return true;
+        }
+
+        try
+        {
+            canonicalPath = FilePathComparison.ResolveCanonicalPath(path);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException
+                                   or UnauthorizedAccessException
+                                   or ArgumentException
+                                   or NotSupportedException)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to resolve watched directory path {Path}",
+                path);
+            return false;
+        }
     }
 
     private void OnFileSystemEvent(object sender, FileSystemEventArgs e)
     {
-        if (ShouldExcludePath(e.FullPath))
-            return;
-
-        _debounceCts?.Cancel();
-        _debounceCts?.Dispose();
-        _debounceCts = new CancellationTokenSource();
-        var token = _debounceCts.Token;
-
-        Task.Delay(s_debounceInterval, token).ContinueWith(_ =>
+        if (IsCurrentWatcher(sender))
         {
-            if (!token.IsCancellationRequested)
+            NotifyPathChanged(e.FullPath, sender);
+        }
+    }
+
+    internal void NotifyPathChanged(string path) => NotifyPathChanged(path, sourceWatcher: null);
+
+    private void NotifyPathChanged(string path, object? sourceWatcher)
+    {
+        try
+        {
+            if (ShouldExcludePath(path))
+                return;
+        }
+        catch (Exception ex) when (ex is IOException
+                                   or UnauthorizedAccessException
+                                   or ArgumentException
+                                   or NotSupportedException)
+        {
+            _logger.LogWarning(ex, "Failed to classify filesystem event path {Path}", path);
+            return;
+        }
+
+        var nextDebounce = new CancellationTokenSource();
+        CancellationToken token = nextDebounce.Token;
+        CancellationTokenSource? previousDebounce;
+        long deliveryGeneration;
+        lock (_stateSync)
+        {
+            if (_disposed
+                || sourceWatcher is not null && !ReferenceEquals(_watcher, sourceWatcher))
             {
-                Dispatcher.UIThread.Post(
-                    () =>
-                    {
-                        MarkDelivered();
-                        Changed?.Invoke();
-                    },
-                    DispatcherPriority.Background);
+                nextDebounce.Dispose();
+                return;
             }
-        }, token, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
+
+            deliveryGeneration = ++_stateGeneration;
+            previousDebounce = _debounceCts;
+            _debounceCts = nextDebounce;
+            _ = PostDeliveryAfterDelayAsync(nextDebounce, token, deliveryGeneration);
+        }
+
+        CancelAndDispose(previousDebounce);
+    }
+
+    private async Task PostDeliveryAfterDelayAsync(
+        CancellationTokenSource debounce,
+        CancellationToken token,
+        long deliveryGeneration)
+    {
+        try
+        {
+            await Task.Delay(_debounceInterval, token).ConfigureAwait(false);
+            _postDelivery(() => TryDeliver(debounce, deliveryGeneration));
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            ClearFailedDelivery(debounce, deliveryGeneration);
+            _logger.LogWarning(ex, "Failed to deliver a file browser change notification");
+        }
+    }
+
+    private void ClearFailedDelivery(
+        CancellationTokenSource debounce,
+        long deliveryGeneration)
+    {
+        bool ownsDebounce;
+        lock (_stateSync)
+        {
+            ownsDebounce = deliveryGeneration == _stateGeneration
+                           && ReferenceEquals(_debounceCts, debounce);
+            if (ownsDebounce)
+            {
+                _debounceCts = null;
+            }
+        }
+
+        if (ownsDebounce)
+        {
+            debounce.Dispose();
+        }
+    }
+
+    private void TryDeliver(CancellationTokenSource debounce, long deliveryGeneration)
+    {
+        Action? changed;
+        lock (_stateSync)
+        {
+            if (_disposed
+                || deliveryGeneration != _stateGeneration
+                || !ReferenceEquals(_debounceCts, debounce))
+            {
+                return;
+            }
+
+            _debounceCts = null;
+            _errorRearmCount = 0;
+            _failingCanonicalPath = null;
+            changed = Changed;
+        }
+
+        debounce.Dispose();
+        changed?.Invoke();
     }
 
     // A delivered event resets the rearm budget.
     internal void MarkDelivered()
     {
-        _errorRearmCount = 0;
-        _failingPath = null;
+        lock (_stateSync)
+        {
+            _errorRearmCount = 0;
+            _failingCanonicalPath = null;
+        }
     }
 
     public void Dispose()
     {
-        _debounceCts?.Cancel();
-        _debounceCts?.Dispose();
-        _watcher?.Dispose();
-        _watcher = null;
+        CancellationTokenSource? debounce;
+        FileSystemWatcher? watcher;
+        lock (_stateSync)
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            _stateGeneration++;
+            debounce = _debounceCts;
+            _debounceCts = null;
+            watcher = _watcher;
+            _watcher = null;
+            _watchedCanonicalPath = null;
+            _watchedRequestedPath = null;
+        }
+
+        CancelAndDispose(debounce);
+        watcher?.Dispose();
+        _templateOrMaterialDirectories.Clear();
+    }
+
+    private static void CancelAndDispose(CancellationTokenSource? cancellation)
+    {
+        if (cancellation is null)
+            return;
+
+        try
+        {
+            cancellation.Cancel();
+        }
+        finally
+        {
+            cancellation.Dispose();
+        }
     }
 }

--- a/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
@@ -313,12 +313,25 @@ internal sealed class DirectoryWatcherService : IDisposable
             return false;
         }
 
+        string canonicalDirectory;
+        try
+        {
+            canonicalDirectory = FilePathComparison.ResolveCanonicalPath(directory);
+        }
+        catch (Exception ex) when (ex is IOException
+                                   or UnauthorizedAccessException
+                                   or ArgumentException
+                                   or NotSupportedException)
+        {
+            return false;
+        }
+
         if (_templateOrMaterialDirectories.Count >= 512)
         {
             _templateOrMaterialDirectories.Clear();
         }
 
-        return _templateOrMaterialDirectories.GetOrAdd(directory, static candidate =>
+        return _templateOrMaterialDirectories.GetOrAdd(canonicalDirectory, static candidate =>
             PathScope.IsUnderDirectory(candidate, BeutlEnvironment.GetTemplatesDirectoryPath())
             || PathScope.IsUnderDirectory(candidate, BeutlEnvironment.GetMaterialsDirectoryPath()));
     }

--- a/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
@@ -109,7 +109,19 @@ internal sealed class DirectoryWatcherService : IDisposable
                 canonicalPath,
                 StringComparison.Ordinal))
         {
-            return;
+            lock (_stateSync)
+            {
+                if (!_disposed
+                    && ReferenceEquals(_watcher, currentWatcher)
+                    && string.Equals(
+                        _watchedCanonicalPath,
+                        canonicalPath,
+                        StringComparison.Ordinal))
+                {
+                    _watchedRequestedPath = Path.GetFullPath(path!);
+                    return;
+                }
+            }
         }
 
         CancellationTokenSource? previousDebounce;

--- a/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
@@ -12,14 +12,19 @@ internal sealed class DirectoryWatcherService : IDisposable
 {
     private sealed record DirectoryIdentity(string LinkFingerprint, string CanonicalPath);
 
+    private readonly record struct SpecialDirectoryMembershipKey(
+        string TemplatesDirectory,
+        string MaterialsDirectory,
+        string CandidateDirectory);
+
     private static readonly TimeSpan s_debounceInterval = TimeSpan.FromMilliseconds(300);
     private readonly ILogger _logger = Log.CreateLogger<DirectoryWatcherService>();
     private readonly object _stateSync = new();
     private readonly TimeSpan _debounceInterval;
     private readonly Action<Action> _postDelivery;
     private readonly Action<FileSystemWatcher> _startWatcher;
-    private readonly ConcurrentDictionary<string, bool> _templateOrMaterialDirectories =
-        new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<SpecialDirectoryMembershipKey, bool>
+        _templateOrMaterialDirectories = new();
     private readonly ConcurrentDictionary<string, DirectoryIdentity> _directoryIdentities =
         new(StringComparer.Ordinal);
     // Limit consecutive rearm attempts because persistent failures recur immediately.
@@ -305,11 +310,25 @@ internal sealed class DirectoryWatcherService : IDisposable
     // プロジェクト、シーン、要素のファイルは頻繁に変更されるため除外
     internal bool ShouldExcludePath(string path)
     {
+        return ShouldExcludePath(
+            path,
+            BeutlEnvironment.GetTemplatesDirectoryPath(),
+            BeutlEnvironment.GetMaterialsDirectoryPath());
+    }
+
+    internal bool ShouldExcludePath(
+        string path,
+        string templatesDirectoryPath,
+        string materialsDirectoryPath)
+    {
         // Templates and materials live below BEUTL_HOME/.beutl by default, so their explicit
         // exception must win over the reserved-metadata rule. Cache by containing directory: a
         // watcher burst commonly reports hundreds of sibling files, and canonical resolution only
         // needs to run once for that directory identity.
-        if (IsTemplateOrMaterialPath(path))
+        if (IsTemplateOrMaterialPath(
+                path,
+                templatesDirectoryPath,
+                materialsDirectoryPath))
         {
             return false;
         }
@@ -324,9 +343,15 @@ internal sealed class DirectoryWatcherService : IDisposable
                path.EndsWith(".belm", StringComparison.OrdinalIgnoreCase);
     }
 
-    private bool IsTemplateOrMaterialPath(string path)
+    private bool IsTemplateOrMaterialPath(
+        string path,
+        string templatesDirectoryPath,
+        string materialsDirectoryPath)
     {
-        if (IsConfiguredSpecialDirectory(path))
+        if (IsConfiguredSpecialDirectory(
+                path,
+                templatesDirectoryPath,
+                materialsDirectoryPath))
         {
             return true;
         }
@@ -353,6 +378,8 @@ internal sealed class DirectoryWatcherService : IDisposable
         }
 
         string canonicalDirectory;
+        string canonicalTemplatesDirectory;
+        string canonicalMaterialsDirectory;
         if (_directoryIdentities.TryGetValue(fullDirectory, out DirectoryIdentity? identity)
             && string.Equals(
                 identity.LinkFingerprint,
@@ -380,18 +407,44 @@ internal sealed class DirectoryWatcherService : IDisposable
                 canonicalDirectory);
         }
 
+        try
+        {
+            canonicalTemplatesDirectory = FilePathComparison.ResolveCanonicalPath(
+                templatesDirectoryPath);
+            canonicalMaterialsDirectory = FilePathComparison.ResolveCanonicalPath(
+                materialsDirectoryPath);
+        }
+        catch (Exception ex) when (ex is IOException
+                                   or UnauthorizedAccessException
+                                   or ArgumentException
+                                   or NotSupportedException)
+        {
+            return false;
+        }
+
         if (_templateOrMaterialDirectories.Count >= 512)
         {
             _templateOrMaterialDirectories.Clear();
             _directoryIdentities.Clear();
         }
 
-        return _templateOrMaterialDirectories.GetOrAdd(canonicalDirectory, static candidate =>
-            PathScope.IsUnderDirectory(candidate, BeutlEnvironment.GetTemplatesDirectoryPath())
-            || PathScope.IsUnderDirectory(candidate, BeutlEnvironment.GetMaterialsDirectoryPath()));
+        return _templateOrMaterialDirectories.GetOrAdd(
+            new SpecialDirectoryMembershipKey(
+                canonicalTemplatesDirectory,
+                canonicalMaterialsDirectory,
+                canonicalDirectory),
+            static key => FilePathComparison.IsSameOrDescendant(
+                              key.TemplatesDirectory,
+                              key.CandidateDirectory)
+                          || FilePathComparison.IsSameOrDescendant(
+                              key.MaterialsDirectory,
+                              key.CandidateDirectory));
     }
 
-    private static bool IsConfiguredSpecialDirectory(string path)
+    private static bool IsConfiguredSpecialDirectory(
+        string path,
+        string templatesDirectoryPath,
+        string materialsDirectoryPath)
     {
         try
         {
@@ -399,12 +452,12 @@ internal sealed class DirectoryWatcherService : IDisposable
             return string.Equals(
                        fullPath,
                        Path.TrimEndingDirectorySeparator(Path.GetFullPath(
-                           BeutlEnvironment.GetTemplatesDirectoryPath())),
+                           templatesDirectoryPath)),
                        StringComparison.Ordinal)
                    || string.Equals(
                        fullPath,
                        Path.TrimEndingDirectorySeparator(Path.GetFullPath(
-                           BeutlEnvironment.GetMaterialsDirectoryPath())),
+                           materialsDirectoryPath)),
                        StringComparison.Ordinal);
         }
         catch (Exception ex) when (ex is IOException

--- a/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Text;
 using Avalonia.Threading;
 using Beutl.Editor.Services;
 using Beutl.Logging;
@@ -9,6 +10,8 @@ namespace Beutl.Editor.Components.FileBrowserTab.Services;
 // ディレクトリ変更を監視し、デバウンス付きで変更通知を発行する。
 internal sealed class DirectoryWatcherService : IDisposable
 {
+    private sealed record DirectoryIdentity(string LinkFingerprint, string CanonicalPath);
+
     private static readonly TimeSpan s_debounceInterval = TimeSpan.FromMilliseconds(300);
     private readonly ILogger _logger = Log.CreateLogger<DirectoryWatcherService>();
     private readonly object _stateSync = new();
@@ -16,6 +19,8 @@ internal sealed class DirectoryWatcherService : IDisposable
     private readonly Action<Action> _postDelivery;
     private readonly Action<FileSystemWatcher> _startWatcher;
     private readonly ConcurrentDictionary<string, bool> _templateOrMaterialDirectories =
+        new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, DirectoryIdentity> _directoryIdentities =
         new(StringComparer.Ordinal);
     // Limit consecutive rearm attempts because persistent failures recur immediately.
     private const int MaxErrorRearms = 3;
@@ -144,6 +149,7 @@ internal sealed class DirectoryWatcherService : IDisposable
         CancelAndDispose(previousDebounce);
         previousWatcher?.Dispose();
         _templateOrMaterialDirectories.Clear();
+        _directoryIdentities.Clear();
 
         if (!pathResolved || canonicalPath is null || !Directory.Exists(canonicalPath))
             return;
@@ -242,6 +248,7 @@ internal sealed class DirectoryWatcherService : IDisposable
         CancelAndDispose(debounce);
         watcher?.Dispose();
         _templateOrMaterialDirectories.Clear();
+        _directoryIdentities.Clear();
 
         if (requestedPath is null || canonicalPath is null)
         {
@@ -325,10 +332,12 @@ internal sealed class DirectoryWatcherService : IDisposable
             return false;
         }
 
-        string canonicalDirectory;
+        string fullDirectory;
+        string linkFingerprint;
         try
         {
-            canonicalDirectory = FilePathComparison.ResolveCanonicalPath(directory);
+            fullDirectory = Path.GetFullPath(directory);
+            linkFingerprint = CreateLinkFingerprint(fullDirectory);
         }
         catch (Exception ex) when (ex is IOException
                                    or UnauthorizedAccessException
@@ -338,14 +347,66 @@ internal sealed class DirectoryWatcherService : IDisposable
             return false;
         }
 
+        string canonicalDirectory;
+        if (_directoryIdentities.TryGetValue(fullDirectory, out DirectoryIdentity? identity)
+            && string.Equals(
+                identity.LinkFingerprint,
+                linkFingerprint,
+                StringComparison.Ordinal))
+        {
+            canonicalDirectory = identity.CanonicalPath;
+        }
+        else
+        {
+            try
+            {
+                canonicalDirectory = FilePathComparison.ResolveCanonicalPath(fullDirectory);
+            }
+            catch (Exception ex) when (ex is IOException
+                                       or UnauthorizedAccessException
+                                       or ArgumentException
+                                       or NotSupportedException)
+            {
+                return false;
+            }
+
+            _directoryIdentities[fullDirectory] = new DirectoryIdentity(
+                linkFingerprint,
+                canonicalDirectory);
+        }
+
         if (_templateOrMaterialDirectories.Count >= 512)
         {
             _templateOrMaterialDirectories.Clear();
+            _directoryIdentities.Clear();
         }
 
         return _templateOrMaterialDirectories.GetOrAdd(canonicalDirectory, static candidate =>
             PathScope.IsUnderDirectory(candidate, BeutlEnvironment.GetTemplatesDirectoryPath())
             || PathScope.IsUnderDirectory(candidate, BeutlEnvironment.GetMaterialsDirectoryPath()));
+    }
+
+    private static string CreateLinkFingerprint(string directory)
+    {
+        string root = Path.GetPathRoot(directory)
+                      ?? throw new ArgumentException(
+                          "The directory has no filesystem root.",
+                          nameof(directory));
+        string current = root;
+        var fingerprint = new StringBuilder();
+        foreach (string segment in directory[root.Length..].Split(
+                     [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+                     StringSplitOptions.RemoveEmptyEntries))
+        {
+            current = Path.Combine(current, segment);
+            var info = new DirectoryInfo(current);
+            fingerprint.Append(segment)
+                .Append('=')
+                .Append(info.LinkTarget)
+                .Append('\0');
+        }
+
+        return fingerprint.ToString();
     }
 
     private static bool HasReservedMetadataSegment(string path)
@@ -549,6 +610,7 @@ internal sealed class DirectoryWatcherService : IDisposable
         CancelAndDispose(debounce);
         watcher?.Dispose();
         _templateOrMaterialDirectories.Clear();
+        _directoryIdentities.Clear();
     }
 
     private static void CancelAndDispose(CancellationTokenSource? cancellation)

--- a/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
@@ -25,6 +25,8 @@ internal sealed class DirectoryWatcherService : IDisposable
     private readonly Action<FileSystemWatcher> _startWatcher;
     private readonly ConcurrentDictionary<SpecialDirectoryMembershipKey, bool>
         _templateOrMaterialDirectories = new();
+    private readonly ConcurrentDictionary<string, string> _configuredSpecialDirectoryIdentities =
+        new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, DirectoryIdentity> _directoryIdentities =
         new(StringComparer.Ordinal);
     // Limit consecutive rearm attempts because persistent failures recur immediately.
@@ -253,6 +255,7 @@ internal sealed class DirectoryWatcherService : IDisposable
         CancelAndDispose(debounce);
         watcher?.Dispose();
         _templateOrMaterialDirectories.Clear();
+        _configuredSpecialDirectoryIdentities.Clear();
         _directoryIdentities.Clear();
 
         if (requestedPath is null || canonicalPath is null)
@@ -409,9 +412,9 @@ internal sealed class DirectoryWatcherService : IDisposable
 
         try
         {
-            canonicalTemplatesDirectory = FilePathComparison.ResolveCanonicalPath(
+            canonicalTemplatesDirectory = ResolveConfiguredDirectoryIdentity(
                 templatesDirectoryPath);
-            canonicalMaterialsDirectory = FilePathComparison.ResolveCanonicalPath(
+            canonicalMaterialsDirectory = ResolveConfiguredDirectoryIdentity(
                 materialsDirectoryPath);
         }
         catch (Exception ex) when (ex is IOException
@@ -441,7 +444,7 @@ internal sealed class DirectoryWatcherService : IDisposable
                               key.CandidateDirectory));
     }
 
-    private static bool IsConfiguredSpecialDirectory(
+    private bool IsConfiguredSpecialDirectory(
         string path,
         string templatesDirectoryPath,
         string materialsDirectoryPath)
@@ -449,15 +452,26 @@ internal sealed class DirectoryWatcherService : IDisposable
         try
         {
             string fullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+            string canonicalPath = FilePathComparison.ResolveCanonicalPath(fullPath);
+            string fullTemplatesDirectory = Path.TrimEndingDirectorySeparator(Path.GetFullPath(
+                templatesDirectoryPath));
+            string fullMaterialsDirectory = Path.TrimEndingDirectorySeparator(Path.GetFullPath(
+                materialsDirectoryPath));
             return string.Equals(
                        fullPath,
-                       Path.TrimEndingDirectorySeparator(Path.GetFullPath(
-                           templatesDirectoryPath)),
+                       fullTemplatesDirectory,
+                       StringComparison.Ordinal)
+                   || string.Equals(
+                       canonicalPath,
+                       ResolveConfiguredDirectoryIdentity(templatesDirectoryPath),
                        StringComparison.Ordinal)
                    || string.Equals(
                        fullPath,
-                       Path.TrimEndingDirectorySeparator(Path.GetFullPath(
-                           materialsDirectoryPath)),
+                       fullMaterialsDirectory,
+                       StringComparison.Ordinal)
+                   || string.Equals(
+                       canonicalPath,
+                       ResolveConfiguredDirectoryIdentity(materialsDirectoryPath),
                        StringComparison.Ordinal);
         }
         catch (Exception ex) when (ex is IOException
@@ -467,6 +481,23 @@ internal sealed class DirectoryWatcherService : IDisposable
         {
             return false;
         }
+    }
+
+    private string ResolveConfiguredDirectoryIdentity(string directory)
+    {
+        string fullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(directory));
+        if (Directory.Exists(fullPath))
+        {
+            string canonicalPath = FilePathComparison.ResolveCanonicalPath(fullPath);
+            _configuredSpecialDirectoryIdentities[fullPath] = canonicalPath;
+            return canonicalPath;
+        }
+
+        return _configuredSpecialDirectoryIdentities.TryGetValue(
+            fullPath,
+            out string? previousIdentity)
+            ? previousIdentity
+            : FilePathComparison.ResolveCanonicalPath(fullPath);
     }
 
     private static string CreateLinkFingerprint(string directory)

--- a/src/Beutl.Editor.Components/FileBrowserTab/Services/FileThumbnailService.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Services/FileThumbnailService.cs
@@ -93,8 +93,8 @@ public sealed class FileThumbnailService : IDisposable
     private static readonly Lazy<FileThumbnailService> s_instance = new(() => new FileThumbnailService());
     private readonly ConcurrentDictionary<string, CachedThumbnail> _cache = new();
     private readonly ConcurrentDictionary<string, (MediaFileInfo Info, long LastAccessTicks)> _mediaInfoCache = new();
-    private readonly ConcurrentDictionary<string, bool> _templateDirectoryMembership =
-        new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<TemplateDirectoryMembershipKey, bool>
+        _templateDirectoryMembership = new();
     private readonly SemaphoreSlim _semaphore = new(4); // 同時生成数を制限
     private readonly ILogger _logger = Log.CreateLogger<FileThumbnailService>();
     private readonly Timer _pruneTimer;
@@ -304,21 +304,32 @@ public sealed class FileThumbnailService : IDisposable
     /// </remarks>
     public bool IsObjectTemplateFile(string filePath)
     {
+        return IsObjectTemplateFile(
+            filePath,
+            BeutlEnvironment.GetTemplatesDirectoryPath());
+    }
+
+    internal bool IsObjectTemplateFile(string filePath, string templatesDirectoryPath)
+    {
         if (!string.Equals(Path.GetExtension(filePath), ".json", StringComparison.OrdinalIgnoreCase))
         {
             return false;
         }
 
-        string? directory = Path.GetDirectoryName(filePath);
-        if (string.IsNullOrEmpty(directory))
-        {
-            return false;
-        }
-
         string canonicalDirectory;
+        string canonicalTemplatesDirectory;
         try
         {
+            string fullPath = Path.GetFullPath(filePath);
+            string? directory = Path.GetDirectoryName(fullPath);
+            if (string.IsNullOrEmpty(directory))
+            {
+                return false;
+            }
+
             canonicalDirectory = FilePathComparison.ResolveCanonicalPath(directory);
+            canonicalTemplatesDirectory = FilePathComparison.ResolveCanonicalPath(
+                templatesDirectoryPath);
         }
         catch (Exception ex) when (ex is IOException
                                    or UnauthorizedAccessException
@@ -333,9 +344,18 @@ public sealed class FileThumbnailService : IDisposable
             _templateDirectoryMembership.Clear();
         }
 
-        return _templateDirectoryMembership.GetOrAdd(canonicalDirectory, static candidate =>
-            PathScope.IsUnderDirectory(candidate, BeutlEnvironment.GetTemplatesDirectoryPath()));
+        return _templateDirectoryMembership.GetOrAdd(
+            new TemplateDirectoryMembershipKey(
+                canonicalTemplatesDirectory,
+                canonicalDirectory),
+            static key => FilePathComparison.IsSameOrDescendant(
+                key.TemplatesDirectory,
+                key.CandidateDirectory));
     }
+
+    private readonly record struct TemplateDirectoryMembershipKey(
+        string TemplatesDirectory,
+        string CandidateDirectory);
 
     private async Task<Bitmap?> GenerateImageThumbnailAsync(string filePath, CancellationToken cancellationToken)
     {

--- a/src/Beutl.Editor.Components/FileBrowserTab/Services/FileThumbnailService.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Services/FileThumbnailService.cs
@@ -315,12 +315,25 @@ public sealed class FileThumbnailService : IDisposable
             return false;
         }
 
+        string canonicalDirectory;
+        try
+        {
+            canonicalDirectory = FilePathComparison.ResolveCanonicalPath(directory);
+        }
+        catch (Exception ex) when (ex is IOException
+                                   or UnauthorizedAccessException
+                                   or ArgumentException
+                                   or NotSupportedException)
+        {
+            return false;
+        }
+
         if (_templateDirectoryMembership.Count >= 512)
         {
             _templateDirectoryMembership.Clear();
         }
 
-        return _templateDirectoryMembership.GetOrAdd(directory, static candidate =>
+        return _templateDirectoryMembership.GetOrAdd(canonicalDirectory, static candidate =>
             PathScope.IsUnderDirectory(candidate, BeutlEnvironment.GetTemplatesDirectoryPath()));
     }
 

--- a/src/Beutl.Editor.Components/FileBrowserTab/Services/FileThumbnailService.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Services/FileThumbnailService.cs
@@ -93,6 +93,8 @@ public sealed class FileThumbnailService : IDisposable
     private static readonly Lazy<FileThumbnailService> s_instance = new(() => new FileThumbnailService());
     private readonly ConcurrentDictionary<string, CachedThumbnail> _cache = new();
     private readonly ConcurrentDictionary<string, (MediaFileInfo Info, long LastAccessTicks)> _mediaInfoCache = new();
+    private readonly ConcurrentDictionary<string, bool> _templateDirectoryMembership =
+        new(StringComparer.Ordinal);
     private readonly SemaphoreSlim _semaphore = new(4); // 同時生成数を制限
     private readonly ILogger _logger = Log.CreateLogger<FileThumbnailService>();
     private readonly Timer _pruneTimer;
@@ -106,6 +108,8 @@ public sealed class FileThumbnailService : IDisposable
     public static FileThumbnailService Instance => s_instance.Value;
 
     public int ThumbnailSize { get; set; } = 64;
+
+    internal int TemplateDirectoryMembershipCount => _templateDirectoryMembership.Count;
 
     public async Task<Bitmap?> GetThumbnailAsync(string filePath, CancellationToken cancellationToken = default)
     {
@@ -300,8 +304,24 @@ public sealed class FileThumbnailService : IDisposable
     /// </remarks>
     public bool IsObjectTemplateFile(string filePath)
     {
-        return string.Equals(Path.GetExtension(filePath), ".json", StringComparison.OrdinalIgnoreCase)
-               && PathScope.IsUnderDirectory(filePath, BeutlEnvironment.GetTemplatesDirectoryPath());
+        if (!string.Equals(Path.GetExtension(filePath), ".json", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        string? directory = Path.GetDirectoryName(filePath);
+        if (string.IsNullOrEmpty(directory))
+        {
+            return false;
+        }
+
+        if (_templateDirectoryMembership.Count >= 512)
+        {
+            _templateDirectoryMembership.Clear();
+        }
+
+        return _templateDirectoryMembership.GetOrAdd(directory, static candidate =>
+            PathScope.IsUnderDirectory(candidate, BeutlEnvironment.GetTemplatesDirectoryPath()));
     }
 
     private async Task<Bitmap?> GenerateImageThumbnailAsync(string filePath, CancellationToken cancellationToken)
@@ -487,6 +507,7 @@ public sealed class FileThumbnailService : IDisposable
     {
         _cache.Clear();
         _mediaInfoCache.Clear();
+        _templateDirectoryMembership.Clear();
     }
 
     public void Dispose()

--- a/src/Beutl.Editor.Components/FileBrowserTab/Services/PathScope.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Services/PathScope.cs
@@ -4,12 +4,16 @@ internal static class PathScope
 {
     public static bool IsUnderDirectory(string path, string directory)
     {
-        string normalizedDir = Path.GetFullPath(directory)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-            + Path.DirectorySeparatorChar;
-        string normalizedPath = Path.GetFullPath(path);
-
-        return FilePathComparison.StartsWith(normalizedPath, normalizedDir)
-            || FilePathComparison.Equals(normalizedPath + Path.DirectorySeparatorChar, normalizedDir);
+        try
+        {
+            return FilePathComparison.IsSameOrDescendant(directory, path);
+        }
+        catch (Exception ex) when (ex is IOException
+                                   or UnauthorizedAccessException
+                                   or ArgumentException
+                                   or NotSupportedException)
+        {
+            return false;
+        }
     }
 }

--- a/src/Beutl.Editor/Services/ObjectTemplateItem.cs
+++ b/src/Beutl.Editor/Services/ObjectTemplateItem.cs
@@ -31,6 +31,8 @@ public sealed class ObjectTemplateItem(
 
     public DateTime LastWriteTimeUtc { get; internal set; }
 
+    internal string? CanonicalFilePath { get; set; }
+
     // Base64 of 1 MiB, four times what ObjectTemplatePreviewRenderer will ever write — headroom for
     // a package authored elsewhere, without letting one file dictate the allocation.
     private const int MaxEncodedPreviewLength = 1_398_104;

--- a/src/Beutl.Editor/Services/ObjectTemplateService.cs
+++ b/src/Beutl.Editor/Services/ObjectTemplateService.cs
@@ -93,6 +93,7 @@ public sealed class ObjectTemplateService
         string filePath = Path.Combine(_directoryPath, name + ".json");
         if (File.Exists(filePath)) return true;
 
+        // Display names remain case-insensitively unique independently of path identity.
         foreach (ObjectTemplateItem item in _items)
         {
             if (string.Equals(item.Name.Value, name, StringComparison.OrdinalIgnoreCase))
@@ -291,11 +292,36 @@ public sealed class ObjectTemplateService
     {
         foreach (ObjectTemplateItem item in _items)
         {
-            if (FilePathComparison.Equals(item.FilePath, filePath))
+            if (item.FilePath is { } itemFilePath
+                && TryAreSameCanonicalPath(itemFilePath, filePath))
                 return item;
         }
 
         return null;
+    }
+
+    private static bool TryAreSameCanonicalPath(string left, string right)
+    {
+        return TryResolveCanonicalPath(left, out string canonicalLeft)
+               && TryResolveCanonicalPath(right, out string canonicalRight)
+               && string.Equals(canonicalLeft, canonicalRight, StringComparison.Ordinal);
+    }
+
+    private static bool TryResolveCanonicalPath(string path, out string canonicalPath)
+    {
+        canonicalPath = string.Empty;
+        try
+        {
+            canonicalPath = FilePathComparison.ResolveCanonicalPath(path);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException
+                                   or UnauthorizedAccessException
+                                   or ArgumentException
+                                   or NotSupportedException)
+        {
+            return false;
+        }
     }
 
     private void OnFileSystemEvent(object sender, FileSystemEventArgs e)
@@ -320,15 +346,20 @@ public sealed class ObjectTemplateService
         }
     }
 
-    private void RefreshFromFileSystem()
+    internal void RefreshFromFileSystem()
     {
         try
         {
             if (!Directory.Exists(_directoryPath)) return;
 
-            var diskFiles = new HashSet<string>(
-                Directory.EnumerateFiles(_directoryPath, "*.json", SearchOption.AllDirectories),
-                StringComparer.OrdinalIgnoreCase);
+            string[] diskFiles = Directory
+                .EnumerateFiles(_directoryPath, "*.json", SearchOption.AllDirectories)
+                .ToArray();
+            var diskPaths = new CanonicalPathSet();
+            foreach (string diskFile in diskFiles)
+            {
+                diskPaths.Add(diskFile);
+            }
 
             lock (_lock)
             {
@@ -336,7 +367,7 @@ public sealed class ObjectTemplateService
                 for (int i = _items.Count - 1; i >= 0; i--)
                 {
                     ObjectTemplateItem item = _items[i];
-                    if (item.FilePath == null || !diskFiles.Contains(item.FilePath))
+                    if (item.FilePath == null || !diskPaths.Contains(item.FilePath))
                     {
                         _items.RemoveAt(i);
                         _logger.LogInformation("Removed template (file gone): {FilePath}", item.FilePath);
@@ -344,7 +375,7 @@ public sealed class ObjectTemplateService
                 }
 
                 // 外部変更を検知したら再読み込み、既読パスを収集
-                var loadedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var loadedPaths = new CanonicalPathSet();
                 for (int i = 0; i < _items.Count; i++)
                 {
                     ObjectTemplateItem item = _items[i];
@@ -373,6 +404,7 @@ public sealed class ObjectTemplateService
                     if (newItem != null)
                     {
                         _items.Add(newItem);
+                        loadedPaths.Add(filePath);
                         _logger.LogInformation("Added template (new file): {FilePath}", filePath);
                     }
                 }
@@ -381,6 +413,47 @@ public sealed class ObjectTemplateService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to refresh templates from filesystem.");
+        }
+    }
+
+    private sealed class CanonicalPathSet
+    {
+        private readonly HashSet<string> _canonicalPaths = new(StringComparer.Ordinal);
+        private readonly HashSet<string> _exactPaths = new(StringComparer.Ordinal);
+
+        public void Add(string path)
+        {
+            _exactPaths.Add(path);
+            if (IsLiveFile(path)
+                && TryResolveCanonicalPath(path, out string canonicalPath))
+            {
+                _canonicalPaths.Add(canonicalPath);
+            }
+        }
+
+        private static bool IsLiveFile(string path)
+        {
+            try
+            {
+                var info = new FileInfo(path);
+                return info.LinkTarget is null
+                    ? info.Exists
+                    : info.ResolveLinkTarget(returnFinalTarget: true)?.Exists == true;
+            }
+            catch (Exception ex) when (ex is IOException
+                                       or UnauthorizedAccessException
+                                       or ArgumentException
+                                       or NotSupportedException)
+            {
+                return false;
+            }
+        }
+
+        public bool Contains(string path)
+        {
+            return _exactPaths.Contains(path)
+                   || TryResolveCanonicalPath(path, out string canonicalPath)
+                   && _canonicalPaths.Contains(canonicalPath);
         }
     }
 }

--- a/src/Beutl.Editor/Services/ObjectTemplateService.cs
+++ b/src/Beutl.Editor/Services/ObjectTemplateService.cs
@@ -450,6 +450,15 @@ public sealed class ObjectTemplateService
                         }
                     }
 
+                    if (loadedPaths.ContainsKnown(item.FilePath, currentCanonicalPath))
+                    {
+                        _items.RemoveAt(i--);
+                        _logger.LogInformation(
+                            "Removed duplicate template identity: {FilePath}",
+                            item.FilePath);
+                        continue;
+                    }
+
                     loadedPaths.AddKnown(item.FilePath, currentCanonicalPath);
 
                     DateTime diskTime = GetLastWriteTimeOrDefault(item.FilePath);
@@ -588,7 +597,7 @@ public sealed class ObjectTemplateService
         {
             if (_exactPaths.TryGetValue(path, out canonicalPath))
             {
-                return true;
+                return canonicalPath is not null;
             }
 
             if (TryResolve(path, out string resolvedPath)

--- a/src/Beutl.Editor/Services/ObjectTemplateService.cs
+++ b/src/Beutl.Editor/Services/ObjectTemplateService.cs
@@ -266,7 +266,7 @@ public sealed class ObjectTemplateService
                     .ToArray();
                 CanonicalPathSet diskPaths = CanonicalPathSet.FromEnumeratedFiles(diskFiles);
                 var loadedPaths = new CanonicalPathSet();
-                foreach (string filePath in diskFiles)
+                foreach (string filePath in diskPaths.GetPreferredPaths(diskFiles))
                 {
                     diskPaths.TryGetExact(filePath, out string? canonicalPath);
                     if (loadedPaths.ContainsKnown(filePath, canonicalPath)) continue;
@@ -403,6 +403,7 @@ public sealed class ObjectTemplateService
                 .EnumerateFiles(_directoryPath, "*.json", SearchOption.AllDirectories)
                 .ToArray();
             CanonicalPathSet diskPaths = CanonicalPathSet.FromEnumeratedFiles(diskFiles);
+            IEnumerable<string> preferredDiskFiles = diskPaths.GetPreferredPaths(diskFiles);
 
             lock (_lock)
             {
@@ -428,6 +429,27 @@ public sealed class ObjectTemplateService
                     if (item.FilePath == null) continue;
 
                     diskPaths.TryMatch(item.FilePath, out string? currentCanonicalPath);
+                    if (currentCanonicalPath is not null
+                        && diskPaths.TryGetPreferredPath(
+                            currentCanonicalPath,
+                            out string? preferredPath)
+                        && preferredPath is not null
+                        && !string.Equals(
+                            item.FilePath,
+                            preferredPath,
+                            StringComparison.Ordinal))
+                    {
+                        ObjectTemplateItem? preferred = LoadFromFile(preferredPath);
+                        if (preferred is not null)
+                        {
+                            _items[i] = item = preferred;
+                            currentCanonicalPath = preferred.CanonicalFilePath;
+                            _logger.LogInformation(
+                                "Reloaded template from preferred path: {FilePath}",
+                                preferredPath);
+                        }
+                    }
+
                     loadedPaths.AddKnown(item.FilePath, currentCanonicalPath);
 
                     DateTime diskTime = GetLastWriteTimeOrDefault(item.FilePath);
@@ -448,7 +470,7 @@ public sealed class ObjectTemplateService
                 }
 
                 // 新しいファイルを読み込んで追加
-                foreach (string filePath in diskFiles)
+                foreach (string filePath in preferredDiskFiles)
                 {
                     diskPaths.TryGetExact(filePath, out string? canonicalPath);
                     if (loadedPaths.ContainsKnown(filePath, canonicalPath)) continue;
@@ -473,6 +495,7 @@ public sealed class ObjectTemplateService
     {
         private readonly HashSet<string> _canonicalPaths = new(StringComparer.Ordinal);
         private readonly Dictionary<string, string?> _exactPaths = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, string> _preferredPaths = new(StringComparer.Ordinal);
         private readonly FilePathComparison.ResolutionContext _resolutionContext;
 
         public CanonicalPathSet()
@@ -524,7 +547,36 @@ public sealed class ObjectTemplateService
             if (canonicalPath is not null)
             {
                 _canonicalPaths.Add(canonicalPath);
+                if (!_preferredPaths.TryGetValue(canonicalPath, out string? current)
+                    || IsPreferredPath(path, current, canonicalPath))
+                {
+                    _preferredPaths[canonicalPath] = path;
+                }
             }
+        }
+
+        public IEnumerable<string> GetPreferredPaths(IEnumerable<string> paths)
+        {
+            foreach (string path in paths)
+            {
+                if (!_exactPaths.TryGetValue(path, out string? canonicalPath)
+                    || canonicalPath is null)
+                {
+                    yield return path;
+                    continue;
+                }
+
+                if (_preferredPaths.TryGetValue(canonicalPath, out string? preferredPath)
+                    && string.Equals(path, preferredPath, StringComparison.Ordinal))
+                {
+                    yield return path;
+                }
+            }
+        }
+
+        public bool TryGetPreferredPath(string canonicalPath, out string? preferredPath)
+        {
+            return _preferredPaths.TryGetValue(canonicalPath, out preferredPath);
         }
 
         public bool TryGetExact(string path, out string? canonicalPath)
@@ -571,6 +623,24 @@ public sealed class ObjectTemplateService
             {
                 return false;
             }
+        }
+
+        private static bool IsPreferredPath(
+            string candidate,
+            string current,
+            string canonicalPath)
+        {
+            bool candidateIsCanonical = string.Equals(
+                Path.GetFullPath(candidate),
+                canonicalPath,
+                StringComparison.Ordinal);
+            bool currentIsCanonical = string.Equals(
+                Path.GetFullPath(current),
+                canonicalPath,
+                StringComparison.Ordinal);
+            return candidateIsCanonical != currentIsCanonical
+                ? candidateIsCanonical
+                : string.CompareOrdinal(candidate, current) < 0;
         }
     }
 }

--- a/src/Beutl.Editor/Services/ObjectTemplateService.cs
+++ b/src/Beutl.Editor/Services/ObjectTemplateService.cs
@@ -137,8 +137,16 @@ public sealed class ObjectTemplateService
             ObjectTemplateItem? cached = FindByFilePathLocked(filePath);
             if (cached != null)
             {
+                string? canonicalPath = TryResolveCanonicalPath(filePath, out string resolvedPath)
+                    ? resolvedPath
+                    : null;
                 DateTime diskTime = GetLastWriteTimeOrDefault(filePath);
-                if (diskTime != default && diskTime <= cached.LastWriteTimeUtc)
+                if (string.Equals(
+                        canonicalPath,
+                        cached.CanonicalFilePath,
+                        StringComparison.Ordinal)
+                    && diskTime != default
+                    && diskTime <= cached.LastWriteTimeUtc)
                 {
                     return cached;
                 }
@@ -179,6 +187,11 @@ public sealed class ObjectTemplateService
             if (item != null)
             {
                 item.LastWriteTimeUtc = lastWriteTime;
+                item.CanonicalFilePath = TryResolveCanonicalPath(
+                    filePath,
+                    out string canonicalPath)
+                    ? canonicalPath
+                    : null;
             }
 
             return item;
@@ -218,6 +231,11 @@ public sealed class ObjectTemplateService
 
             item.FilePath = filePath;
             item.LastWriteTimeUtc = File.GetLastWriteTimeUtc(filePath);
+            item.CanonicalFilePath = TryResolveCanonicalPath(
+                filePath,
+                out string canonicalPath)
+                ? canonicalPath
+                : null;
             _logger.LogInformation("Saved ObjectTemplateItem to file: {FilePath}", filePath);
             return true;
         }
@@ -355,11 +373,7 @@ public sealed class ObjectTemplateService
             string[] diskFiles = Directory
                 .EnumerateFiles(_directoryPath, "*.json", SearchOption.AllDirectories)
                 .ToArray();
-            var diskPaths = new CanonicalPathSet();
-            foreach (string diskFile in diskFiles)
-            {
-                diskPaths.Add(diskFile);
-            }
+            CanonicalPathSet diskPaths = CanonicalPathSet.FromEnumeratedFiles(diskFiles);
 
             lock (_lock)
             {
@@ -367,11 +381,14 @@ public sealed class ObjectTemplateService
                 for (int i = _items.Count - 1; i >= 0; i--)
                 {
                     ObjectTemplateItem item = _items[i];
-                    if (item.FilePath == null || !diskPaths.Contains(item.FilePath))
+                    if (item.FilePath == null
+                        || !diskPaths.TryMatch(item.FilePath, out _))
                     {
                         _items.RemoveAt(i);
                         _logger.LogInformation("Removed template (file gone): {FilePath}", item.FilePath);
+                        continue;
                     }
+
                 }
 
                 // 外部変更を検知したら再読み込み、既読パスを収集
@@ -381,10 +398,16 @@ public sealed class ObjectTemplateService
                     ObjectTemplateItem item = _items[i];
                     if (item.FilePath == null) continue;
 
-                    loadedPaths.Add(item.FilePath);
+                    diskPaths.TryMatch(item.FilePath, out string? currentCanonicalPath);
+                    loadedPaths.AddKnown(item.FilePath, currentCanonicalPath);
 
                     DateTime diskTime = GetLastWriteTimeOrDefault(item.FilePath);
-                    if (diskTime == default || diskTime <= item.LastWriteTimeUtc)
+                    bool targetChanged = !string.Equals(
+                        currentCanonicalPath,
+                        item.CanonicalFilePath,
+                        StringComparison.Ordinal);
+                    if (!targetChanged
+                        && (diskTime == default || diskTime <= item.LastWriteTimeUtc))
                         continue;
 
                     ObjectTemplateItem? reloaded = LoadFromFile(item.FilePath);
@@ -398,13 +421,14 @@ public sealed class ObjectTemplateService
                 // 新しいファイルを読み込んで追加
                 foreach (string filePath in diskFiles)
                 {
-                    if (loadedPaths.Contains(filePath)) continue;
+                    diskPaths.TryGetExact(filePath, out string? canonicalPath);
+                    if (loadedPaths.ContainsKnown(filePath, canonicalPath)) continue;
 
                     ObjectTemplateItem? newItem = LoadFromFile(filePath);
                     if (newItem != null)
                     {
                         _items.Add(newItem);
-                        loadedPaths.Add(filePath);
+                        loadedPaths.AddKnown(filePath, canonicalPath);
                         _logger.LogInformation("Added template (new file): {FilePath}", filePath);
                     }
                 }
@@ -419,26 +443,78 @@ public sealed class ObjectTemplateService
     private sealed class CanonicalPathSet
     {
         private readonly HashSet<string> _canonicalPaths = new(StringComparer.Ordinal);
-        private readonly HashSet<string> _exactPaths = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, string?> _exactPaths = new(StringComparer.Ordinal);
+        private readonly FilePathComparison.ResolutionContext _resolutionContext;
 
-        public void Add(string path)
+        public CanonicalPathSet()
+            : this(FilePathComparison.CreateResolutionContext())
         {
-            _exactPaths.Add(path);
-            if (IsLiveFile(path)
-                && TryResolveCanonicalPath(path, out string canonicalPath))
+        }
+
+        private CanonicalPathSet(FilePathComparison.ResolutionContext resolutionContext)
+        {
+            _resolutionContext = resolutionContext;
+        }
+
+        public static CanonicalPathSet FromEnumeratedFiles(IEnumerable<string> paths)
+        {
+            var result = new CanonicalPathSet(FilePathComparison.CreateResolutionContext());
+            foreach (string path in paths)
+            {
+                string? canonicalPath = result.TryResolve(path, out string resolvedPath)
+                    ? resolvedPath
+                    : null;
+                result.AddKnown(path, canonicalPath);
+            }
+
+            return result;
+        }
+
+        public void AddKnown(string path, string? canonicalPath)
+        {
+            _exactPaths[path] = canonicalPath;
+            if (canonicalPath is not null)
             {
                 _canonicalPaths.Add(canonicalPath);
             }
         }
 
-        private static bool IsLiveFile(string path)
+        public bool TryGetExact(string path, out string? canonicalPath)
         {
+            return _exactPaths.TryGetValue(path, out canonicalPath);
+        }
+
+        public bool TryMatch(string path, out string? canonicalPath)
+        {
+            if (_exactPaths.TryGetValue(path, out canonicalPath))
+            {
+                return true;
+            }
+
+            if (TryResolve(path, out string resolvedPath)
+                && _canonicalPaths.Contains(resolvedPath))
+            {
+                canonicalPath = resolvedPath;
+                return true;
+            }
+
+            canonicalPath = null;
+            return false;
+        }
+
+        public bool ContainsKnown(string path, string? canonicalPath)
+        {
+            return _exactPaths.ContainsKey(path)
+                   || canonicalPath is not null && _canonicalPaths.Contains(canonicalPath);
+        }
+
+        private bool TryResolve(string path, out string canonicalPath)
+        {
+            canonicalPath = string.Empty;
             try
             {
-                var info = new FileInfo(path);
-                return info.LinkTarget is null
-                    ? info.Exists
-                    : info.ResolveLinkTarget(returnFinalTarget: true)?.Exists == true;
+                canonicalPath = _resolutionContext.ResolveCanonicalPath(path);
+                return true;
             }
             catch (Exception ex) when (ex is IOException
                                        or UnauthorizedAccessException
@@ -447,13 +523,6 @@ public sealed class ObjectTemplateService
             {
                 return false;
             }
-        }
-
-        public bool Contains(string path)
-        {
-            return _exactPaths.Contains(path)
-                   || TryResolveCanonicalPath(path, out string canonicalPath)
-                   && _canonicalPaths.Contains(canonicalPath);
         }
     }
 }

--- a/src/Beutl.Editor/Services/ObjectTemplateService.cs
+++ b/src/Beutl.Editor/Services/ObjectTemplateService.cs
@@ -461,13 +461,32 @@ public sealed class ObjectTemplateService
             var result = new CanonicalPathSet(FilePathComparison.CreateResolutionContext());
             foreach (string path in paths)
             {
-                string? canonicalPath = result.TryResolve(path, out string resolvedPath)
+                string? canonicalPath = IsLiveFile(path)
+                    && result.TryResolve(path, out string resolvedPath)
                     ? resolvedPath
                     : null;
                 result.AddKnown(path, canonicalPath);
             }
 
             return result;
+        }
+
+        private static bool IsLiveFile(string path)
+        {
+            try
+            {
+                var info = new FileInfo(path);
+                return info.LinkTarget is null
+                    ? info.Exists
+                    : info.ResolveLinkTarget(returnFinalTarget: true)?.Exists == true;
+            }
+            catch (Exception ex) when (ex is IOException
+                                       or UnauthorizedAccessException
+                                       or ArgumentException
+                                       or NotSupportedException)
+            {
+                return false;
+            }
         }
 
         public void AddKnown(string path, string? canonicalPath)

--- a/src/Beutl.Editor/Services/ObjectTemplateService.cs
+++ b/src/Beutl.Editor/Services/ObjectTemplateService.cs
@@ -308,21 +308,29 @@ public sealed class ObjectTemplateService
 
     private ObjectTemplateItem? FindByFilePathLocked(string filePath)
     {
+        string fullPath = Path.GetFullPath(filePath);
+        string? canonicalPath = TryResolveCanonicalPath(fullPath, out string resolvedPath)
+            ? resolvedPath
+            : null;
         foreach (ObjectTemplateItem item in _items)
         {
-            if (item.FilePath is { } itemFilePath
-                && TryAreSameCanonicalPath(itemFilePath, filePath))
+            if (item.FilePath is not { } itemFilePath)
+            {
+                continue;
+            }
+
+            if (string.Equals(Path.GetFullPath(itemFilePath), fullPath, StringComparison.Ordinal)
+                || canonicalPath is not null
+                && string.Equals(
+                    item.CanonicalFilePath,
+                    canonicalPath,
+                    StringComparison.Ordinal))
+            {
                 return item;
+            }
         }
 
         return null;
-    }
-
-    private static bool TryAreSameCanonicalPath(string left, string right)
-    {
-        return TryResolveCanonicalPath(left, out string canonicalLeft)
-               && TryResolveCanonicalPath(right, out string canonicalRight)
-               && string.Equals(canonicalLeft, canonicalRight, StringComparison.Ordinal);
     }
 
     private static bool TryResolveCanonicalPath(string path, out string canonicalPath)

--- a/src/Beutl.Editor/Services/ObjectTemplateService.cs
+++ b/src/Beutl.Editor/Services/ObjectTemplateService.cs
@@ -259,14 +259,23 @@ public sealed class ObjectTemplateService
             lock (_lock)
             {
                 _items.Clear();
-
-                foreach (string filePath in Directory.EnumerateFiles(
-                             _directoryPath, "*.json", SearchOption.AllDirectories))
+                string[] diskFiles = Directory.EnumerateFiles(
+                        _directoryPath,
+                        "*.json",
+                        SearchOption.AllDirectories)
+                    .ToArray();
+                CanonicalPathSet diskPaths = CanonicalPathSet.FromEnumeratedFiles(diskFiles);
+                var loadedPaths = new CanonicalPathSet();
+                foreach (string filePath in diskFiles)
                 {
+                    diskPaths.TryGetExact(filePath, out string? canonicalPath);
+                    if (loadedPaths.ContainsKnown(filePath, canonicalPath)) continue;
+
                     var item = LoadFromFile(filePath);
                     if (item != null)
                     {
                         _items.Add(item);
+                        loadedPaths.AddKnown(filePath, canonicalPath);
                     }
                 }
 
@@ -308,7 +317,19 @@ public sealed class ObjectTemplateService
 
     private ObjectTemplateItem? FindByFilePathLocked(string filePath)
     {
-        string fullPath = Path.GetFullPath(filePath);
+        string fullPath;
+        try
+        {
+            fullPath = Path.GetFullPath(filePath);
+        }
+        catch (Exception ex) when (ex is IOException
+                                   or UnauthorizedAccessException
+                                   or ArgumentException
+                                   or NotSupportedException)
+        {
+            return null;
+        }
+
         string? canonicalPath = TryResolveCanonicalPath(fullPath, out string resolvedPath)
             ? resolvedPath
             : null;

--- a/tests/Beutl.UnitTests/Core/FilePathComparisonTests.cs
+++ b/tests/Beutl.UnitTests/Core/FilePathComparisonTests.cs
@@ -4,6 +4,40 @@
 public class FilePathComparisonTests
 {
     [Test]
+    public void Canonical_identity_accepts_whitespace_only_posix_components()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("Windows does not preserve whitespace-only path components.");
+        }
+
+        string temporaryRoot = CreateTemporaryDirectory();
+        string whitespacePath = Path.Combine(temporaryRoot, " ");
+        Directory.CreateDirectory(whitespacePath);
+        try
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    FilePathComparison.ResolveCanonicalPath(whitespacePath),
+                    Is.EqualTo(whitespacePath));
+                Assert.That(
+                    FilePathComparison.TryAreSameChildPath(
+                        temporaryRoot,
+                        " ",
+                        " ",
+                        out bool areSame),
+                    Is.True);
+                Assert.That(areSame, Is.True);
+            });
+        }
+        finally
+        {
+            Directory.Delete(temporaryRoot, recursive: true);
+        }
+    }
+
+    [Test]
     public void Canonical_identity_follows_the_actual_volume_casing_rules()
     {
         string temporaryRoot = CreateTemporaryDirectory();

--- a/tests/Beutl.UnitTests/Core/FilePathComparisonTests.cs
+++ b/tests/Beutl.UnitTests/Core/FilePathComparisonTests.cs
@@ -273,6 +273,40 @@ public class FilePathComparisonTests
     }
 
     [Test]
+    public void Child_path_comparison_resolves_differently_named_symbolic_links()
+    {
+        string temporaryRoot = CreateTemporaryDirectory();
+        string target = Path.Combine(temporaryRoot, ".git");
+        string alias = Path.Combine(temporaryRoot, "metadata");
+        Directory.CreateDirectory(target);
+        try
+        {
+            try
+            {
+                Directory.CreateSymbolicLink(alias, target);
+            }
+            catch (Exception ex)
+                when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+            {
+                Assert.Ignore($"Symbolic links are unavailable here: {ex.Message}");
+            }
+
+            Assert.That(
+                FilePathComparison.TryAreSameChildPath(
+                    temporaryRoot,
+                    "metadata",
+                    ".git",
+                    out bool areSame),
+                Is.True);
+            Assert.That(areSame, Is.True);
+        }
+        finally
+        {
+            Directory.Delete(temporaryRoot, recursive: true);
+        }
+    }
+
+    [Test]
     public void Canonical_identity_applies_parent_segments_after_resolving_symbolic_links()
     {
         string temporaryRoot = CreateTemporaryDirectory();

--- a/tests/Beutl.UnitTests/Core/FilePathComparisonTests.cs
+++ b/tests/Beutl.UnitTests/Core/FilePathComparisonTests.cs
@@ -1,34 +1,348 @@
-﻿using System.Runtime.InteropServices;
-
-namespace Beutl.UnitTests.Core;
+﻿namespace Beutl.UnitTests.Core;
 
 [TestFixture]
 public class FilePathComparisonTests
 {
-    // Two paths differing only in case are the same file on Windows and macOS and two different
-    // files on Linux, so a cache keyed on a path must not fold them together there.
     [Test]
-    public void Equals_FollowsThePlatformsCaseRules()
+    public void Canonical_identity_follows_the_actual_volume_casing_rules()
     {
-        bool expected = !RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+        string temporaryRoot = CreateTemporaryDirectory();
+        string storedPath = Path.Combine(temporaryRoot, "Templates");
+        string alternatePath = Path.Combine(temporaryRoot, "templates");
+        Directory.CreateDirectory(storedPath);
+        try
+        {
+            bool volumeResolvesAlternateCasing = Directory.Exists(alternatePath);
+
+            Assert.That(
+                FilePathComparison.AreSameCanonicalPath(storedPath, alternatePath),
+                Is.EqualTo(volumeResolvesAlternateCasing));
+
+            if (!volumeResolvesAlternateCasing)
+            {
+                Directory.CreateDirectory(alternatePath);
+                Assert.That(
+                    FilePathComparison.AreSameCanonicalPath(storedPath, alternatePath),
+                    Is.False);
+            }
+        }
+        finally
+        {
+            Directory.Delete(temporaryRoot, recursive: true);
+        }
+    }
+
+    [Test]
+    public void Canonical_identity_follows_the_actual_volume_unicode_normalization_rules()
+    {
+        string temporaryRoot = CreateTemporaryDirectory();
+        string composedPath = Path.Combine(temporaryRoot, "caf\u00e9");
+        string decomposedPath = Path.Combine(temporaryRoot, "cafe\u0301");
+        Directory.CreateDirectory(composedPath);
+        try
+        {
+            bool volumeResolvesAlternateNormalization = Directory.Exists(decomposedPath);
+
+            Assert.That(
+                FilePathComparison.AreSameCanonicalPath(composedPath, decomposedPath),
+                Is.EqualTo(volumeResolvesAlternateNormalization));
+
+            if (!volumeResolvesAlternateNormalization)
+            {
+                Directory.CreateDirectory(decomposedPath);
+                Assert.That(
+                    FilePathComparison.AreSameCanonicalPath(composedPath, decomposedPath),
+                    Is.False);
+            }
+        }
+        finally
+        {
+            Directory.Delete(temporaryRoot, recursive: true);
+        }
+    }
+
+    [Test]
+    public void Canonical_entry_selection_accepts_one_equivalent_spelling_and_prefers_exact()
+    {
+        string parent = Path.Combine(Path.GetTempPath(), "synthetic-parent");
+        string candidate = Path.Combine(parent, "\u00c9");
+        string rawIgnoreCase = Path.Combine(parent, "\u00e9");
+        string normalizedOrdinal = Path.Combine(parent, "E\u0301");
+        string normalizedIgnoreCase = Path.Combine(parent, "e\u0301");
 
         Assert.Multiple(() =>
         {
-            Assert.That(FilePathComparison.Equals("/tmp/pkg/Item.json", "/tmp/pkg/item.json"), Is.EqualTo(expected));
-            Assert.That(FilePathComparison.StartsWith("/tmp/Templates/a.json", "/tmp/templates/"), Is.EqualTo(expected));
+            Assert.That(
+                FilePathComparison.SelectCanonicalExistingEntry(
+                    "\u00c9",
+                    candidate,
+                    [normalizedIgnoreCase]),
+                Is.EqualTo(normalizedIgnoreCase));
+            Assert.That(
+                FilePathComparison.SelectCanonicalExistingEntry(
+                    "\u00c9",
+                    candidate,
+                    [normalizedOrdinal]),
+                Is.EqualTo(normalizedOrdinal));
+            Assert.That(
+                FilePathComparison.SelectCanonicalExistingEntry(
+                    "\u00c9",
+                    candidate,
+                    [rawIgnoreCase]),
+                Is.EqualTo(rawIgnoreCase));
+            Assert.That(
+                FilePathComparison.SelectCanonicalExistingEntry(
+                    "\u00c9",
+                    candidate,
+                    [rawIgnoreCase, candidate]),
+                Is.EqualTo(candidate));
         });
     }
 
     [Test]
-    public void Equals_IsExactRegardlessOfPlatform()
+    public void Canonical_entry_selection_fails_closed_across_equivalence_categories()
     {
-        Assert.Multiple(() =>
+        string parent = Path.Combine(Path.GetTempPath(), "synthetic-parent");
+        string candidate = Path.Combine(parent, "\u00c9");
+
+        string selected = FilePathComparison.SelectCanonicalExistingEntry(
+            "\u00c9",
+            candidate,
+            [
+                Path.Combine(parent, "\u00e9"),
+                Path.Combine(parent, "E\u0301"),
+            ]);
+
+        Assert.That(selected, Is.EqualTo(candidate));
+    }
+
+    [Test]
+    public void Canonical_entry_selection_fails_closed_when_the_best_rank_is_ambiguous()
+    {
+        string parent = Path.Combine(Path.GetTempPath(), "synthetic-parent");
+        string candidate = Path.Combine(parent, "CAF\u00c9");
+
+        string selected = FilePathComparison.SelectCanonicalExistingEntry(
+            "CAF\u00c9",
+            candidate,
+            [
+                Path.Combine(parent, "caf\u00e9"),
+                Path.Combine(parent, "Caf\u00e9"),
+                Path.Combine(parent, "CAFE\u0301"),
+            ]);
+
+        Assert.That(selected, Is.EqualTo(candidate));
+    }
+
+    [Test]
+    public void Containment_includes_the_root_and_rejects_a_sibling()
+    {
+        string temporaryRoot = CreateTemporaryDirectory();
+        string child = Path.Combine(temporaryRoot, "nested", "item.json");
+        string sibling = temporaryRoot + "-sibling";
+        Directory.CreateDirectory(Path.GetDirectoryName(child)!);
+        Directory.CreateDirectory(sibling);
+        File.WriteAllText(child, "content");
+        try
         {
-            Assert.That(FilePathComparison.Equals("/tmp/pkg/item.json", "/tmp/pkg/item.json"), Is.True);
-            Assert.That(FilePathComparison.Equals("/tmp/pkg/item.json", "/tmp/pkg/other.json"), Is.False);
-            Assert.That(FilePathComparison.Equals(null, null), Is.True);
-            Assert.That(FilePathComparison.StartsWith("/tmp/templates/a.json", "/tmp/templates/"), Is.True);
-            Assert.That(FilePathComparison.StartsWith("/tmp/other/a.json", "/tmp/templates/"), Is.False);
-        });
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    FilePathComparison.IsSameOrDescendant(temporaryRoot, temporaryRoot),
+                    Is.True);
+                Assert.That(
+                    FilePathComparison.IsSameOrDescendant(temporaryRoot, child),
+                    Is.True);
+                Assert.That(
+                    FilePathComparison.IsSameOrDescendant(temporaryRoot, sibling),
+                    Is.False);
+            });
+        }
+        finally
+        {
+            Directory.Delete(temporaryRoot, recursive: true);
+            Directory.Delete(sibling, recursive: true);
+        }
+    }
+
+    [Test]
+    public void Child_path_comparison_reports_the_actual_volume_result()
+    {
+        string temporaryRoot = CreateTemporaryDirectory();
+        const string storedName = "Metadata";
+        const string alternateName = "mETADATA";
+        Directory.CreateDirectory(Path.Combine(temporaryRoot, storedName));
+        try
+        {
+            bool volumeResolvesAlternateCasing =
+                Directory.Exists(Path.Combine(temporaryRoot, alternateName));
+
+            Assert.That(
+                FilePathComparison.TryAreSameChildPath(
+                    temporaryRoot,
+                    storedName,
+                    alternateName,
+                    out bool areSame),
+                Is.True);
+            Assert.That(areSame, Is.EqualTo(volumeResolvesAlternateCasing));
+        }
+        finally
+        {
+            Directory.Delete(temporaryRoot, recursive: true);
+        }
+    }
+
+    [Test]
+    public void Child_path_comparison_reports_the_actual_volume_unicode_normalization_result()
+    {
+        string temporaryRoot = CreateTemporaryDirectory();
+        const string composedName = "caf\u00e9";
+        const string decomposedName = "cafe\u0301";
+        Directory.CreateDirectory(Path.Combine(temporaryRoot, composedName));
+        try
+        {
+            bool volumeResolvesAlternateNormalization =
+                Directory.Exists(Path.Combine(temporaryRoot, decomposedName));
+
+            Assert.That(
+                FilePathComparison.TryAreSameChildPath(
+                    temporaryRoot,
+                    composedName,
+                    decomposedName,
+                    out bool areSame),
+                Is.True);
+            Assert.That(areSame, Is.EqualTo(volumeResolvesAlternateNormalization));
+
+            if (!volumeResolvesAlternateNormalization)
+            {
+                Directory.CreateDirectory(Path.Combine(temporaryRoot, decomposedName));
+                Assert.That(
+                    FilePathComparison.TryAreSameChildPath(
+                        temporaryRoot,
+                        composedName,
+                        decomposedName,
+                        out areSame),
+                    Is.True);
+                Assert.That(areSame, Is.False);
+            }
+        }
+        finally
+        {
+            Directory.Delete(temporaryRoot, recursive: true);
+        }
+    }
+
+    [TestCase(".")]
+    [TestCase("..")]
+    [TestCase("nested/item")]
+    public void Child_path_comparison_rejects_non_child_names(string invalidName)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            FilePathComparison.TryAreSameChildPath(
+                Path.GetTempPath(),
+                invalidName,
+                "item",
+                out _));
+    }
+
+    [Test]
+    public void Canonical_identity_resolves_symbolic_link_aliases()
+    {
+        string temporaryRoot = CreateTemporaryDirectory();
+        string target = Path.Combine(temporaryRoot, "target");
+        string alias = Path.Combine(temporaryRoot, "alias");
+        Directory.CreateDirectory(target);
+        try
+        {
+            try
+            {
+                Directory.CreateSymbolicLink(alias, target);
+            }
+            catch (Exception ex)
+                when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+            {
+                Assert.Ignore($"Symbolic links are unavailable here: {ex.Message}");
+            }
+
+            Assert.That(FilePathComparison.AreSameCanonicalPath(target, alias), Is.True);
+        }
+        finally
+        {
+            Directory.Delete(temporaryRoot, recursive: true);
+        }
+    }
+
+    [Test]
+    public void Canonical_identity_applies_parent_segments_after_resolving_symbolic_links()
+    {
+        string temporaryRoot = CreateTemporaryDirectory();
+        string lexicalParent = Path.Combine(temporaryRoot, "lexical");
+        string targetParent = Path.Combine(temporaryRoot, "outside");
+        string targetLeaf = Path.Combine(temporaryRoot, "outside", "leaf");
+        string alias = Path.Combine(lexicalParent, "alias");
+        Directory.CreateDirectory(lexicalParent);
+        Directory.CreateDirectory(targetLeaf);
+        try
+        {
+            try
+            {
+                Directory.CreateSymbolicLink(alias, targetLeaf);
+            }
+            catch (Exception ex)
+                when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+            {
+                Assert.Ignore($"Symbolic links are unavailable here: {ex.Message}");
+            }
+
+            Assert.That(
+                FilePathComparison.AreSameCanonicalPath(
+                    Path.Combine(alias, ".."),
+                    Path.Combine(targetLeaf, "..")),
+                Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    FilePathComparison.IsSameOrDescendant(
+                        targetParent,
+                        Path.Combine(alias, "..")),
+                    Is.True);
+                Assert.That(
+                    FilePathComparison.IsSameOrDescendant(
+                        lexicalParent,
+                        Path.Combine(alias, "..")),
+                    Is.False);
+            });
+        }
+        finally
+        {
+            Directory.Delete(temporaryRoot, recursive: true);
+        }
+    }
+
+    [Test]
+    public void Windows_drive_root_casing_is_canonicalized()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("Drive-letter casing is Windows-specific.");
+        }
+
+        string path = Path.GetFullPath(Path.GetTempPath());
+        string root = Path.GetPathRoot(path)!;
+        string alternateRoot = char.IsUpper(root[0])
+            ? char.ToLowerInvariant(root[0]) + root[1..]
+            : char.ToUpperInvariant(root[0]) + root[1..];
+        string alternatePath = alternateRoot + path[root.Length..];
+
+        Assert.That(FilePathComparison.AreSameCanonicalPath(path, alternatePath), Is.True);
+    }
+
+    private static string CreateTemporaryDirectory()
+    {
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"beutl-path-comparison-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
     }
 }

--- a/tests/Beutl.UnitTests/Editor/DirectoryWatcherServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/DirectoryWatcherServiceTests.cs
@@ -157,4 +157,156 @@ public class DirectoryWatcherServiceTests
 
         Assert.That(service.IsWatching, Is.False);
     }
+
+    [Test]
+    public void Failed_watcher_start_does_not_publish_a_disposed_instance()
+    {
+        using var service = new DirectoryWatcherService(
+            TimeSpan.Zero,
+            _ => { },
+            _ => throw new IOException("Injected watcher start failure."));
+
+        service.Watch(_scratch);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.IsWatching, Is.False);
+            Assert.That(service.TryRearmAfterError(), Is.False);
+        });
+    }
+
+    [Test]
+    public void Retargeted_symbolic_link_rebuilds_the_watcher_for_the_new_identity()
+    {
+        string firstTarget = Path.Combine(_scratch, "first-target");
+        string secondTarget = Path.Combine(_scratch, "second-target");
+        string alias = Path.Combine(_scratch, "alias");
+        Directory.CreateDirectory(firstTarget);
+        Directory.CreateDirectory(secondTarget);
+        try
+        {
+            Directory.CreateSymbolicLink(alias, firstTarget);
+        }
+        catch (Exception ex) when (ex is IOException
+                                   or UnauthorizedAccessException
+                                   or PlatformNotSupportedException)
+        {
+            Assert.Ignore($"Symbolic links are unavailable: {ex.Message}");
+        }
+
+        var startedPaths = new List<string>();
+        using var service = new DirectoryWatcherService(
+            TimeSpan.Zero,
+            _ => { },
+            watcher =>
+            {
+                startedPaths.Add(watcher.Path);
+                watcher.EnableRaisingEvents = true;
+            });
+
+        service.Watch(alias);
+        Directory.Delete(alias);
+        Directory.CreateSymbolicLink(alias, secondTarget);
+        service.Watch(alias);
+
+        Assert.That(
+            startedPaths,
+            Is.EqualTo(new[]
+            {
+                FilePathComparison.ResolveCanonicalPath(firstTarget),
+                FilePathComparison.ResolveCanonicalPath(secondTarget),
+            }));
+    }
+
+    [Test]
+    public void Error_rearm_resolves_the_original_symbolic_link_again()
+    {
+        string firstTarget = Path.Combine(_scratch, "first-error-target");
+        string secondTarget = Path.Combine(_scratch, "second-error-target");
+        string alias = Path.Combine(_scratch, "error-alias");
+        Directory.CreateDirectory(firstTarget);
+        Directory.CreateDirectory(secondTarget);
+        try
+        {
+            Directory.CreateSymbolicLink(alias, firstTarget);
+        }
+        catch (Exception ex) when (ex is IOException
+                                   or UnauthorizedAccessException
+                                   or PlatformNotSupportedException)
+        {
+            Assert.Ignore($"Symbolic links are unavailable: {ex.Message}");
+        }
+
+        var startedPaths = new List<string>();
+        using var service = new DirectoryWatcherService(
+            TimeSpan.Zero,
+            _ => { },
+            watcher => startedPaths.Add(watcher.Path));
+        service.Watch(alias);
+        Directory.Delete(alias);
+        Directory.CreateSymbolicLink(alias, secondTarget);
+
+        bool rearmed = service.TryRearmAfterError();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rearmed, Is.True);
+            Assert.That(startedPaths, Has.Count.EqualTo(2));
+            Assert.That(startedPaths[1],
+                Is.EqualTo(FilePathComparison.ResolveCanonicalPath(secondTarget)));
+        });
+    }
+
+    [Test]
+    public void Concurrent_rearms_cannot_exceed_the_retry_budget()
+    {
+        int starts = 0;
+        using var service = new DirectoryWatcherService(
+            TimeSpan.Zero,
+            _ => { },
+            _ => Interlocked.Increment(ref starts));
+        service.Watch(_scratch);
+        var failures = new System.Collections.Concurrent.ConcurrentQueue<Exception>();
+
+        Parallel.For(0, 128, _ =>
+        {
+            try
+            {
+                service.TryRearmAfterError();
+            }
+            catch (Exception ex)
+            {
+                failures.Enqueue(ex);
+            }
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failures, Is.Empty);
+            Assert.That(Volatile.Read(ref starts), Is.LessThanOrEqualTo(4));
+        });
+    }
+
+    [Test]
+    public void Navigating_to_a_symbolic_link_cycle_does_not_escape_path_comparison()
+    {
+        string cycle = Path.Combine(_scratch, "cycle");
+        try
+        {
+            Directory.CreateSymbolicLink(cycle, cycle);
+        }
+        catch (Exception ex) when (ex is IOException
+                                   or UnauthorizedAccessException
+                                   or PlatformNotSupportedException)
+        {
+            Assert.Ignore($"Symbolic links are unavailable: {ex.Message}");
+        }
+
+        using var service = new DirectoryWatcherService();
+        service.Watch(_scratch);
+        Assert.That(service.IsWatching, Is.True);
+
+        Assert.DoesNotThrow(() => service.Watch(cycle));
+        Assert.That(service.IsWatching, Is.False);
+    }
 }

--- a/tests/Beutl.UnitTests/Editor/FileBrowser/DirectoryWatcherServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/FileBrowser/DirectoryWatcherServiceTests.cs
@@ -231,6 +231,45 @@ public class DirectoryWatcherServiceTests
         }
     }
 
+    [Test]
+    public void Retargeted_directory_alias_recomputes_template_and_watcher_membership()
+    {
+        string templatesRoot = BeutlEnvironment.GetTemplatesDirectoryPath();
+        string templateTarget = Path.Combine(templatesRoot, $"retarget-{Guid.NewGuid():N}");
+        string outsideTarget = Path.Combine(_projectRoot, "outside");
+        string alias = Path.Combine(_projectRoot, "alias");
+        Directory.CreateDirectory(templateTarget);
+        Directory.CreateDirectory(outsideTarget);
+        CreateDirectorySymlinkOrIgnore(alias, templateTarget);
+        FileThumbnailService thumbnails = FileThumbnailService.Instance;
+        thumbnails.ClearCache();
+        using var watcher = new DirectoryWatcherService();
+
+        try
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(watcher.ShouldExcludePath(Path.Combine(alias, "item.bep")), Is.False);
+                Assert.That(thumbnails.IsObjectTemplateFile(Path.Combine(alias, "item.json")), Is.True);
+            });
+
+            Directory.Delete(alias);
+            CreateDirectorySymlinkOrIgnore(alias, outsideTarget);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(watcher.ShouldExcludePath(Path.Combine(alias, "item.bep")), Is.True);
+                Assert.That(thumbnails.IsObjectTemplateFile(Path.Combine(alias, "item.json")), Is.False);
+            });
+        }
+        finally
+        {
+            thumbnails.ClearCache();
+            if (Directory.Exists(alias)) Directory.Delete(alias);
+            Directory.Delete(templateTarget, recursive: true);
+        }
+    }
+
     private string CreateFile(string relativePath)
     {
         string path = Path.Combine(
@@ -239,6 +278,20 @@ public class DirectoryWatcherServiceTests
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         File.WriteAllText(path, "content");
         return path;
+    }
+
+    private static void CreateDirectorySymlinkOrIgnore(string alias, string target)
+    {
+        try
+        {
+            Directory.CreateSymbolicLink(alias, target);
+        }
+        catch (Exception ex) when (ex is IOException
+                                   or UnauthorizedAccessException
+                                   or PlatformNotSupportedException)
+        {
+            Assert.Ignore($"Directory symbolic links are unavailable: {ex.Message}");
+        }
     }
 
     private static Action TakePostedAction(

--- a/tests/Beutl.UnitTests/Editor/FileBrowser/DirectoryWatcherServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/FileBrowser/DirectoryWatcherServiceTests.cs
@@ -209,6 +209,28 @@ public class DirectoryWatcherServiceTests
         Assert.That(service.ShouldExcludePath(path), Is.False);
     }
 
+    [TestCase(true)]
+    [TestCase(false)]
+    [NonParallelizable]
+    public void Deleted_template_and_material_roots_remain_explicit_filter_exceptions(
+        bool template)
+    {
+        string directory = template
+            ? BeutlEnvironment.GetTemplatesDirectoryPath()
+            : BeutlEnvironment.GetMaterialsDirectoryPath();
+        Directory.CreateDirectory(directory);
+        Directory.Delete(directory, recursive: true);
+        try
+        {
+            using var service = new DirectoryWatcherService();
+            Assert.That(service.ShouldExcludePath(directory), Is.False);
+        }
+        finally
+        {
+            Directory.CreateDirectory(directory);
+        }
+    }
+
     [Test]
     public void Template_thumbnail_scope_is_cached_per_containing_directory()
     {
@@ -228,6 +250,59 @@ public class DirectoryWatcherServiceTests
         finally
         {
             service.ClearCache();
+        }
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void Template_thumbnail_scope_resolves_a_bare_relative_file_path()
+    {
+        string previousDirectory = Environment.CurrentDirectory;
+        FileThumbnailService service = FileThumbnailService.Instance;
+        service.ClearCache();
+        try
+        {
+            Environment.CurrentDirectory = _projectRoot;
+            Assert.That(
+                service.IsObjectTemplateFile("template.json", _projectRoot),
+                Is.True);
+        }
+        finally
+        {
+            Environment.CurrentDirectory = previousDirectory;
+            service.ClearCache();
+        }
+    }
+
+    [Test]
+    public void Template_root_retarget_invalidates_cached_directory_membership()
+    {
+        string firstTarget = Path.Combine(_projectRoot, "template-root-first");
+        string secondTarget = Path.Combine(_projectRoot, "template-root-second");
+        string templateAlias = Path.Combine(_projectRoot, "template-root-alias");
+        Directory.CreateDirectory(firstTarget);
+        Directory.CreateDirectory(secondTarget);
+        FileThumbnailService service = FileThumbnailService.Instance;
+        service.ClearCache();
+        try
+        {
+            CreateDirectorySymlinkOrIgnore(templateAlias, firstTarget);
+            string candidate = Path.Combine(secondTarget, "template.json");
+            Assert.That(
+                service.IsObjectTemplateFile(candidate, templateAlias),
+                Is.False);
+
+            Directory.Delete(templateAlias);
+            CreateDirectorySymlinkOrIgnore(templateAlias, secondTarget);
+
+            Assert.That(
+                service.IsObjectTemplateFile(candidate, templateAlias),
+                Is.True);
+        }
+        finally
+        {
+            service.ClearCache();
+            if (Directory.Exists(templateAlias)) Directory.Delete(templateAlias);
         }
     }
 
@@ -306,12 +381,12 @@ public class DirectoryWatcherServiceTests
         string alias = Path.Combine(_projectRoot, "nested-alias");
         Directory.CreateDirectory(templateTarget);
         Directory.CreateDirectory(outsideTarget);
-        CreateDirectorySymlinkOrIgnore(intermediate, templateTarget);
-        CreateDirectorySymlinkOrIgnore(alias, intermediate);
-        using var service = new DirectoryWatcherService();
 
         try
         {
+            CreateDirectorySymlinkOrIgnore(intermediate, templateTarget);
+            CreateDirectorySymlinkOrIgnore(alias, intermediate);
+            using var service = new DirectoryWatcherService();
             Assert.That(service.ShouldExcludePath(Path.Combine(alias, "item.bep")), Is.False);
 
             Directory.Delete(intermediate);
@@ -323,7 +398,7 @@ public class DirectoryWatcherServiceTests
         {
             if (Directory.Exists(alias)) Directory.Delete(alias);
             if (Directory.Exists(intermediate)) Directory.Delete(intermediate);
-            Directory.Delete(templateTarget, recursive: true);
+            if (Directory.Exists(templateTarget)) Directory.Delete(templateTarget, recursive: true);
         }
     }
 

--- a/tests/Beutl.UnitTests/Editor/FileBrowser/DirectoryWatcherServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/FileBrowser/DirectoryWatcherServiceTests.cs
@@ -296,6 +296,37 @@ public class DirectoryWatcherServiceTests
         Assert.That(startedPaths.Last(), Is.EqualTo(FilePathComparison.ResolveCanonicalPath(secondTarget)));
     }
 
+    [Test]
+    public void Nested_directory_link_retarget_invalidates_the_cached_identity()
+    {
+        string templatesRoot = BeutlEnvironment.GetTemplatesDirectoryPath();
+        string templateTarget = Path.Combine(templatesRoot, $"nested-{Guid.NewGuid():N}");
+        string outsideTarget = Path.Combine(_projectRoot, "nested-outside");
+        string intermediate = Path.Combine(_projectRoot, "intermediate");
+        string alias = Path.Combine(_projectRoot, "nested-alias");
+        Directory.CreateDirectory(templateTarget);
+        Directory.CreateDirectory(outsideTarget);
+        CreateDirectorySymlinkOrIgnore(intermediate, templateTarget);
+        CreateDirectorySymlinkOrIgnore(alias, intermediate);
+        using var service = new DirectoryWatcherService();
+
+        try
+        {
+            Assert.That(service.ShouldExcludePath(Path.Combine(alias, "item.bep")), Is.False);
+
+            Directory.Delete(intermediate);
+            CreateDirectorySymlinkOrIgnore(intermediate, outsideTarget);
+
+            Assert.That(service.ShouldExcludePath(Path.Combine(alias, "item.bep")), Is.True);
+        }
+        finally
+        {
+            if (Directory.Exists(alias)) Directory.Delete(alias);
+            if (Directory.Exists(intermediate)) Directory.Delete(intermediate);
+            Directory.Delete(templateTarget, recursive: true);
+        }
+    }
+
     private string CreateFile(string relativePath)
     {
         string path = Path.Combine(

--- a/tests/Beutl.UnitTests/Editor/FileBrowser/DirectoryWatcherServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/FileBrowser/DirectoryWatcherServiceTests.cs
@@ -1,0 +1,254 @@
+﻿using Beutl.Editor;
+using Beutl.Editor.Components.FileBrowserTab.Services;
+
+namespace Beutl.UnitTests.Editor.FileBrowser;
+
+[TestFixture]
+public class DirectoryWatcherServiceTests
+{
+    private string _projectRoot = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _projectRoot = Path.Combine(
+            Path.GetTempPath(),
+            $"directory-watcher-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_projectRoot);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Directory.Delete(_projectRoot, recursive: true);
+    }
+
+    [TestCase(".git", true)]
+    [TestCase(".git/index", true)]
+    [TestCase("assets/.git/objects/ab/cdef", true)]
+    [TestCase(".gitkeep", false)]
+    [TestCase("assets/.gitkeep", false)]
+    [TestCase(".github/workflows/ci.yml", false)]
+    [TestCase("assets/.git-cache/file.bin", false)]
+    [TestCase(".beutl", true)]
+    [TestCase(".beutl/view-state.json", true)]
+    [TestCase("assets/.beutl/autosave.json", true)]
+    [TestCase(".beutl-cache/file.bin", false)]
+    [TestCase("assets/project.beutl-cache/file.bin", false)]
+    public void Path_filter_excludes_only_exact_reserved_metadata_segments(
+        string relativePath,
+        bool expected)
+    {
+        string path = Path.Combine(
+            _projectRoot,
+            relativePath.Replace('/', Path.DirectorySeparatorChar));
+        using var service = new DirectoryWatcherService();
+
+        Assert.That(service.ShouldExcludePath(path), Is.EqualTo(expected));
+    }
+
+    [TestCase(".GIT", ".git")]
+    [TestCase("assets/.GIT/objects/ab/cdef", ".git")]
+    [TestCase(".BEUTL", ".beutl")]
+    [TestCase("assets/.BEUTL/view-state.json", ".beutl")]
+    public void Alternate_case_reserved_segments_follow_the_actual_volume_case_semantics(
+        string relativePath,
+        string reservedName)
+    {
+        string parent = relativePath.StartsWith("assets/", StringComparison.Ordinal)
+            ? Path.Combine(_projectRoot, "assets")
+            : _projectRoot;
+        Directory.CreateDirectory(Path.Combine(parent, reservedName));
+        string path = Path.Combine(
+            _projectRoot,
+            relativePath.Replace('/', Path.DirectorySeparatorChar));
+        using var service = new DirectoryWatcherService();
+        Assert.That(
+            FilePathComparison.TryAreSameChildPath(
+                parent,
+                relativePath.Contains(".GIT", StringComparison.Ordinal) ? ".GIT" : ".BEUTL",
+                reservedName,
+                out bool areSame),
+            Is.True);
+
+        Assert.That(
+            service.ShouldExcludePath(path),
+            Is.EqualTo(areSame));
+    }
+
+    [Test]
+    public void Concurrent_path_notifications_do_not_race_debounce_disposal()
+    {
+        string path = Path.Combine(_projectRoot, "assets", "clip.png");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "content");
+        var service = new DirectoryWatcherService();
+        var failures = new System.Collections.Concurrent.ConcurrentQueue<Exception>();
+
+        Parallel.For(0, 512, _ =>
+        {
+            try
+            {
+                service.NotifyPathChanged(path);
+            }
+            catch (Exception ex)
+            {
+                failures.Enqueue(ex);
+            }
+        });
+        service.Dispose();
+        Parallel.For(0, 32, _ =>
+        {
+            try
+            {
+                service.NotifyPathChanged(path);
+            }
+            catch (Exception ex)
+            {
+                failures.Enqueue(ex);
+            }
+        });
+
+        Assert.That(failures, Is.Empty);
+    }
+
+    [Test]
+    public void Newer_notification_invalidates_an_already_queued_delivery()
+    {
+        string path = CreateFile("assets/clip.png");
+        var posted = new System.Collections.Concurrent.ConcurrentQueue<Action>();
+        using var service = new DirectoryWatcherService(TimeSpan.Zero, posted.Enqueue);
+        int deliveries = 0;
+        service.Changed += () => deliveries++;
+
+        service.NotifyPathChanged(path);
+        Action staleDelivery = TakePostedAction(posted);
+        service.NotifyPathChanged(path);
+        Action currentDelivery = TakePostedAction(posted);
+
+        staleDelivery();
+        Assert.That(deliveries, Is.Zero);
+
+        currentDelivery();
+        Assert.That(deliveries, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Changing_the_watched_path_invalidates_an_already_queued_delivery()
+    {
+        string path = CreateFile("assets/clip.png");
+        string nextDirectory = Path.Combine(_projectRoot, "next");
+        Directory.CreateDirectory(nextDirectory);
+        var posted = new System.Collections.Concurrent.ConcurrentQueue<Action>();
+        using var service = new DirectoryWatcherService(TimeSpan.Zero, posted.Enqueue);
+        int deliveries = 0;
+        service.Changed += () => deliveries++;
+
+        service.NotifyPathChanged(path);
+        Action staleDelivery = TakePostedAction(posted);
+        service.Watch(nextDirectory);
+
+        staleDelivery();
+
+        Assert.That(deliveries, Is.Zero);
+    }
+
+    [Test]
+    public void Dispose_invalidates_an_already_queued_delivery()
+    {
+        string path = CreateFile("assets/clip.png");
+        var posted = new System.Collections.Concurrent.ConcurrentQueue<Action>();
+        using var service = new DirectoryWatcherService(TimeSpan.Zero, posted.Enqueue);
+        int deliveries = 0;
+        service.Changed += () => deliveries++;
+
+        service.NotifyPathChanged(path);
+        Action staleDelivery = TakePostedAction(posted);
+        service.Dispose();
+
+        staleDelivery();
+
+        Assert.That(deliveries, Is.Zero);
+    }
+
+    [Test]
+    public void Watch_accepts_empty_and_null_paths_when_stopping()
+    {
+        using var service = new DirectoryWatcherService();
+        service.Watch(_projectRoot);
+        Assert.That(service.IsWatching, Is.True);
+
+        Assert.DoesNotThrow(() => service.Watch(string.Empty));
+        Assert.That(service.IsWatching, Is.False);
+        Assert.DoesNotThrow(() => service.Watch(null));
+        Assert.That(service.IsWatching, Is.False);
+    }
+
+    [Test]
+    public void Path_scope_fails_closed_when_canonical_inspection_is_invalid()
+    {
+        bool result = true;
+
+        Assert.DoesNotThrow(() =>
+            result = PathScope.IsUnderDirectory("\0", _projectRoot));
+        Assert.That(result, Is.False);
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Built_in_template_and_material_paths_override_the_reserved_metadata_filter(
+        bool template)
+    {
+        string directory = template
+            ? BeutlEnvironment.GetTemplatesDirectoryPath()
+            : BeutlEnvironment.GetMaterialsDirectoryPath();
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "watched.bep");
+        using var service = new DirectoryWatcherService();
+
+        Assert.That(service.ShouldExcludePath(path), Is.False);
+    }
+
+    [Test]
+    public void Template_thumbnail_scope_is_cached_per_containing_directory()
+    {
+        string directory = BeutlEnvironment.GetTemplatesDirectoryPath();
+        Directory.CreateDirectory(directory);
+        FileThumbnailService service = FileThumbnailService.Instance;
+        service.ClearCache();
+        try
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(service.IsObjectTemplateFile(Path.Combine(directory, "one.json")), Is.True);
+                Assert.That(service.IsObjectTemplateFile(Path.Combine(directory, "two.json")), Is.True);
+                Assert.That(service.TemplateDirectoryMembershipCount, Is.EqualTo(1));
+            });
+        }
+        finally
+        {
+            service.ClearCache();
+        }
+    }
+
+    private string CreateFile(string relativePath)
+    {
+        string path = Path.Combine(
+            _projectRoot,
+            relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "content");
+        return path;
+    }
+
+    private static Action TakePostedAction(
+        System.Collections.Concurrent.ConcurrentQueue<Action> posted)
+    {
+        Assert.That(
+            SpinWait.SpinUntil(() => !posted.IsEmpty, TimeSpan.FromSeconds(5)),
+            Is.True,
+            "A debounce delivery was not posted.");
+        Assert.That(posted.TryDequeue(out Action? callback), Is.True);
+        return callback!;
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/FileBrowser/DirectoryWatcherServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/FileBrowser/DirectoryWatcherServiceTests.cs
@@ -339,6 +339,37 @@ public class DirectoryWatcherServiceTests
     }
 
     [Test]
+    public void Deleted_special_root_keeps_its_last_live_filesystem_identity()
+    {
+        string target = Path.Combine(_projectRoot, "configured-template-target");
+        string templateAlias = Path.Combine(_projectRoot, "configured-template-alias");
+        string materialsRoot = Path.Combine(_projectRoot, "configured-materials-root");
+        Directory.CreateDirectory(target);
+        Directory.CreateDirectory(materialsRoot);
+        try
+        {
+            CreateDirectorySymlinkOrIgnore(templateAlias, target);
+            using var service = new DirectoryWatcherService();
+            Assert.That(
+                service.ShouldExcludePath(
+                    Path.Combine(templateAlias, "template.bep"),
+                    templateAlias,
+                    materialsRoot),
+                Is.False);
+
+            Directory.Delete(templateAlias);
+
+            Assert.That(
+                service.ShouldExcludePath(target, templateAlias, materialsRoot),
+                Is.False);
+        }
+        finally
+        {
+            if (Directory.Exists(templateAlias)) Directory.Delete(templateAlias);
+        }
+    }
+
+    [Test]
     public void Retargeted_directory_alias_recomputes_template_and_watcher_membership()
     {
         string templatesRoot = BeutlEnvironment.GetTemplatesDirectoryPath();

--- a/tests/Beutl.UnitTests/Editor/FileBrowser/DirectoryWatcherServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/FileBrowser/DirectoryWatcherServiceTests.cs
@@ -270,6 +270,32 @@ public class DirectoryWatcherServiceTests
         }
     }
 
+    [Test]
+    public void Same_target_navigation_refreshes_the_alias_used_for_error_rearm()
+    {
+        string firstTarget = Path.Combine(_projectRoot, "first-target");
+        string secondTarget = Path.Combine(_projectRoot, "second-target");
+        string firstAlias = Path.Combine(_projectRoot, "first-alias");
+        string secondAlias = Path.Combine(_projectRoot, "second-alias");
+        Directory.CreateDirectory(firstTarget);
+        Directory.CreateDirectory(secondTarget);
+        CreateDirectorySymlinkOrIgnore(firstAlias, firstTarget);
+        CreateDirectorySymlinkOrIgnore(secondAlias, firstTarget);
+        var startedPaths = new List<string>();
+        using var service = new DirectoryWatcherService(
+            TimeSpan.Zero,
+            static action => action(),
+            watcher => startedPaths.Add(watcher.Path));
+
+        service.Watch(firstAlias);
+        service.Watch(secondAlias);
+        Directory.Delete(secondAlias);
+        CreateDirectorySymlinkOrIgnore(secondAlias, secondTarget);
+
+        Assert.That(service.TryRearmAfterError(), Is.True);
+        Assert.That(startedPaths.Last(), Is.EqualTo(FilePathComparison.ResolveCanonicalPath(secondTarget)));
+    }
+
     private string CreateFile(string relativePath)
     {
         string path = Path.Combine(

--- a/tests/Beutl.UnitTests/Editor/FileBrowser/DirectoryWatcherServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/FileBrowser/DirectoryWatcherServiceTests.cs
@@ -307,6 +307,38 @@ public class DirectoryWatcherServiceTests
     }
 
     [Test]
+    public void Watcher_template_root_retarget_invalidates_cached_directory_membership()
+    {
+        string firstTarget = Path.Combine(_projectRoot, "watcher-template-root-first");
+        string secondTarget = Path.Combine(_projectRoot, "watcher-template-root-second");
+        string templateAlias = Path.Combine(_projectRoot, "watcher-template-root-alias");
+        string materialsRoot = Path.Combine(_projectRoot, "watcher-materials-root");
+        Directory.CreateDirectory(firstTarget);
+        Directory.CreateDirectory(secondTarget);
+        Directory.CreateDirectory(materialsRoot);
+        try
+        {
+            CreateDirectorySymlinkOrIgnore(templateAlias, firstTarget);
+            string candidate = Path.Combine(secondTarget, "template.bep");
+            using var service = new DirectoryWatcherService();
+            Assert.That(
+                service.ShouldExcludePath(candidate, templateAlias, materialsRoot),
+                Is.True);
+
+            Directory.Delete(templateAlias);
+            CreateDirectorySymlinkOrIgnore(templateAlias, secondTarget);
+
+            Assert.That(
+                service.ShouldExcludePath(candidate, templateAlias, materialsRoot),
+                Is.False);
+        }
+        finally
+        {
+            if (Directory.Exists(templateAlias)) Directory.Delete(templateAlias);
+        }
+    }
+
+    [Test]
     public void Retargeted_directory_alias_recomputes_template_and_watcher_membership()
     {
         string templatesRoot = BeutlEnvironment.GetTemplatesDirectoryPath();

--- a/tests/Beutl.UnitTests/Editor/ObjectTemplateServicePreviewTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ObjectTemplateServicePreviewTests.cs
@@ -42,4 +42,140 @@ public class ObjectTemplateServicePreviewTests
         Assert.That(item!.Preview, Is.Null);
         Assert.That(File.Exists(item.FilePath), Is.True);
     }
+
+    [Test]
+    public async Task TryLoadFromFile_ReturnsNullForMalformedPathWhenItemsAreCached()
+    {
+        ObjectTemplateItem? item = await ObjectTemplateService.Instance
+            .AddFromInstanceAsync(
+                new Audio.Effects.AudioEffectGroup(),
+                $"malformed-path-{Guid.NewGuid():N}");
+        Assert.That(item, Is.Not.Null);
+
+        ObjectTemplateItem? result = ObjectTemplateService.Instance.TryLoadFromFile("\0");
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public async Task GetUniqueName_keeps_display_names_case_insensitively_unique()
+    {
+        ObjectTemplateService service = ObjectTemplateService.Instance;
+        string name = $"DisplayName-{Guid.NewGuid():N}";
+        ObjectTemplateItem? item = await service.AddFromInstanceAsync(
+            new Audio.Effects.AudioEffectGroup(),
+            name);
+        Assert.That(item, Is.Not.Null);
+
+        string alternateCase = name.ToLowerInvariant();
+
+        Assert.That(service.GetUniqueName(alternateCase), Is.EqualTo($"{alternateCase} (2)"));
+    }
+
+    [Test]
+    public async Task RefreshFromFileSystem_tracks_case_distinct_files_independently()
+    {
+        ObjectTemplateService service = ObjectTemplateService.Instance;
+        string name = $"CaseSensitive-{Guid.NewGuid():N}";
+        ObjectTemplateItem? item = await service.AddFromInstanceAsync(
+            new Audio.Effects.AudioEffectGroup(),
+            name);
+        Assert.That(item, Is.Not.Null);
+
+        string originalPath = item!.FilePath!;
+        string alternatePath = Path.Combine(
+            Path.GetDirectoryName(originalPath)!,
+            Path.GetFileName(originalPath).ToLowerInvariant());
+        try
+        {
+            if (File.Exists(alternatePath))
+            {
+                Assert.Ignore("The templates volume does not distinguish case-only file names.");
+            }
+
+            File.Copy(originalPath, alternatePath);
+            service.RefreshFromFileSystem();
+
+            string?[] loadedPaths = service.FindByBaseType(item.BaseType)
+                .Select(x => x.FilePath)
+                .ToArray();
+            Assert.Multiple(() =>
+            {
+                Assert.That(loadedPaths, Does.Contain(originalPath));
+                Assert.That(loadedPaths, Does.Contain(alternatePath));
+            });
+
+            File.Delete(originalPath);
+            service.RefreshFromFileSystem();
+
+            loadedPaths = service.FindByBaseType(item.BaseType)
+                .Select(x => x.FilePath)
+                .ToArray();
+            Assert.Multiple(() =>
+            {
+                Assert.That(loadedPaths, Does.Not.Contain(originalPath));
+                Assert.That(loadedPaths, Does.Contain(alternatePath));
+            });
+
+            File.Copy(alternatePath, originalPath);
+            service.RefreshFromFileSystem();
+            File.Delete(alternatePath);
+            service.RefreshFromFileSystem();
+
+            loadedPaths = service.FindByBaseType(item.BaseType)
+                .Select(x => x.FilePath)
+                .ToArray();
+            Assert.Multiple(() =>
+            {
+                Assert.That(loadedPaths, Does.Contain(originalPath));
+                Assert.That(loadedPaths, Does.Not.Contain(alternatePath));
+            });
+        }
+        finally
+        {
+            File.Delete(originalPath);
+            File.Delete(alternatePath);
+            service.RestoreItems();
+        }
+    }
+
+    [Test]
+    public async Task RefreshFromFileSystem_removes_a_template_hidden_by_a_dangling_link()
+    {
+        ObjectTemplateService service = ObjectTemplateService.Instance;
+        ObjectTemplateItem? item = await service.AddFromInstanceAsync(
+            new Audio.Effects.AudioEffectGroup(),
+            $"Dangling-{Guid.NewGuid():N}");
+        Assert.That(item, Is.Not.Null);
+        string originalPath = item!.FilePath!;
+        string aliasPath = Path.Combine(
+            Path.GetDirectoryName(originalPath)!,
+            $"dangling-{Guid.NewGuid():N}.json");
+        try
+        {
+            try
+            {
+                File.CreateSymbolicLink(aliasPath, originalPath);
+            }
+            catch (Exception ex) when (ex is IOException
+                                       or UnauthorizedAccessException
+                                       or PlatformNotSupportedException)
+            {
+                Assert.Ignore($"Symbolic links are unavailable: {ex.Message}");
+            }
+
+            File.Delete(originalPath);
+            service.RefreshFromFileSystem();
+
+            Assert.That(
+                service.FindByBaseType(item.BaseType).Select(template => template.FilePath),
+                Does.Not.Contain(originalPath));
+        }
+        finally
+        {
+            File.Delete(aliasPath);
+            File.Delete(originalPath);
+            service.RestoreItems();
+        }
+    }
 }

--- a/tests/Beutl.UnitTests/Editor/ObjectTemplateServicePreviewTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ObjectTemplateServicePreviewTests.cs
@@ -178,4 +178,61 @@ public class ObjectTemplateServicePreviewTests
             service.RestoreItems();
         }
     }
+
+    [Test]
+    public void RefreshFromFileSystem_reloads_a_retargeted_alias_even_when_target_is_older()
+    {
+        ObjectTemplateService service = ObjectTemplateService.Instance;
+        string templates = BeutlEnvironment.GetTemplatesDirectoryPath();
+        string tempRoot = Path.Combine(
+            Path.GetTempPath(),
+            $"template-retarget-{Guid.NewGuid():N}");
+        string firstTarget = Path.Combine(tempRoot, "first.json");
+        string secondTarget = Path.Combine(tempRoot, "second.json");
+        string alias = Path.Combine(templates, $"retarget-{Guid.NewGuid():N}.json");
+        Directory.CreateDirectory(tempRoot);
+        Directory.CreateDirectory(templates);
+        ObjectTemplateItem first = ObjectTemplateItem.CreateFromInstance(
+            new Audio.Effects.AudioEffectGroup(),
+            "first");
+        ObjectTemplateItem second = ObjectTemplateItem.CreateFromInstance(
+            new Audio.Effects.AudioEffectGroup(),
+            "second");
+        File.WriteAllText(firstTarget, ObjectTemplateItem.ToJson(first).ToJsonString());
+        File.WriteAllText(secondTarget, ObjectTemplateItem.ToJson(second).ToJsonString());
+        File.SetLastWriteTimeUtc(firstTarget, DateTime.UtcNow);
+        File.SetLastWriteTimeUtc(secondTarget, DateTime.UtcNow.AddMinutes(-10));
+        try
+        {
+            try
+            {
+                File.CreateSymbolicLink(alias, firstTarget);
+            }
+            catch (Exception ex) when (ex is IOException
+                                       or UnauthorizedAccessException
+                                       or PlatformNotSupportedException)
+            {
+                Assert.Ignore($"File symbolic links are unavailable: {ex.Message}");
+            }
+
+            service.RestoreItems();
+            ObjectTemplateItem loadedFirst = service.FindByBaseType(first.BaseType)
+                .Single(item => string.Equals(item.FilePath, alias, StringComparison.Ordinal));
+            Assert.That(loadedFirst.Id, Is.EqualTo(first.Id));
+
+            File.Delete(alias);
+            File.CreateSymbolicLink(alias, secondTarget);
+            service.RefreshFromFileSystem();
+
+            ObjectTemplateItem loadedSecond = service.FindByBaseType(first.BaseType)
+                .Single(item => string.Equals(item.FilePath, alias, StringComparison.Ordinal));
+            Assert.That(loadedSecond.Id, Is.EqualTo(second.Id));
+        }
+        finally
+        {
+            File.Delete(alias);
+            Directory.Delete(tempRoot, recursive: true);
+            service.RestoreItems();
+        }
+    }
 }

--- a/tests/Beutl.UnitTests/Editor/ObjectTemplateServicePreviewTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ObjectTemplateServicePreviewTests.cs
@@ -263,9 +263,11 @@ public class ObjectTemplateServicePreviewTests
 
             service.RestoreItems();
 
-            int matching = service.FindByBaseType(item.BaseType).Count(template =>
-                template.FilePath == originalPath || template.FilePath == aliasPath);
-            Assert.That(matching, Is.EqualTo(1));
+            string?[] matchingPaths = service.FindByBaseType(item.BaseType)
+                .Select(template => template.FilePath)
+                .Where(path => path == originalPath || path == aliasPath)
+                .ToArray();
+            Assert.That(matchingPaths, Is.EqualTo(new[] { originalPath }));
         }
         finally
         {

--- a/tests/Beutl.UnitTests/Editor/ObjectTemplateServicePreviewTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ObjectTemplateServicePreviewTests.cs
@@ -235,4 +235,43 @@ public class ObjectTemplateServicePreviewTests
             service.RestoreItems();
         }
     }
+
+    [Test]
+    public async Task RestoreItems_deduplicates_a_template_and_its_symbolic_link_alias()
+    {
+        ObjectTemplateService service = ObjectTemplateService.Instance;
+        ObjectTemplateItem? item = await service.AddFromInstanceAsync(
+            new Audio.Effects.AudioEffectGroup(),
+            $"deduplicate-{Guid.NewGuid():N}");
+        Assert.That(item, Is.Not.Null);
+        string originalPath = item!.FilePath!;
+        string aliasPath = Path.Combine(
+            Path.GetDirectoryName(originalPath)!,
+            $"alias-{Guid.NewGuid():N}.json");
+        try
+        {
+            try
+            {
+                File.CreateSymbolicLink(aliasPath, originalPath);
+            }
+            catch (Exception ex) when (ex is IOException
+                                       or UnauthorizedAccessException
+                                       or PlatformNotSupportedException)
+            {
+                Assert.Ignore($"File symbolic links are unavailable: {ex.Message}");
+            }
+
+            service.RestoreItems();
+
+            int matching = service.FindByBaseType(item.BaseType).Count(template =>
+                template.FilePath == originalPath || template.FilePath == aliasPath);
+            Assert.That(matching, Is.EqualTo(1));
+        }
+        finally
+        {
+            File.Delete(aliasPath);
+            File.Delete(originalPath);
+            service.RestoreItems();
+        }
+    }
 }

--- a/tests/Beutl.UnitTests/Editor/ObjectTemplateServicePreviewTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ObjectTemplateServicePreviewTests.cs
@@ -276,4 +276,98 @@ public class ObjectTemplateServicePreviewTests
             service.RestoreItems();
         }
     }
+
+    [Test]
+    public void RefreshFromFileSystem_removes_an_alias_whose_target_was_deleted()
+    {
+        ObjectTemplateService service = ObjectTemplateService.Instance;
+        string targetRoot = Path.Combine(
+            Path.GetTempPath(),
+            $"template-dangling-target-{Guid.NewGuid():N}");
+        string targetPath = Path.Combine(targetRoot, "target.json");
+        string aliasPath = Path.Combine(
+            BeutlEnvironment.GetTemplatesDirectoryPath(),
+            $"dangling-alias-{Guid.NewGuid():N}.json");
+        Directory.CreateDirectory(targetRoot);
+        Directory.CreateDirectory(Path.GetDirectoryName(aliasPath)!);
+        ObjectTemplateItem template = ObjectTemplateItem.CreateFromInstance(
+            new Audio.Effects.AudioEffectGroup(),
+            "dangling-alias");
+        File.WriteAllText(targetPath, ObjectTemplateItem.ToJson(template).ToJsonString());
+        try
+        {
+            try
+            {
+                File.CreateSymbolicLink(aliasPath, targetPath);
+            }
+            catch (Exception ex) when (ex is IOException
+                                       or UnauthorizedAccessException
+                                       or PlatformNotSupportedException)
+            {
+                Assert.Ignore($"File symbolic links are unavailable: {ex.Message}");
+            }
+
+            service.RestoreItems();
+            Assert.That(
+                service.FindByBaseType(template.BaseType).Select(item => item.FilePath),
+                Does.Contain(aliasPath));
+
+            File.Delete(targetPath);
+            service.RefreshFromFileSystem();
+
+            Assert.That(
+                service.FindByBaseType(template.BaseType).Select(item => item.FilePath),
+                Does.Not.Contain(aliasPath));
+        }
+        finally
+        {
+            File.Delete(aliasPath);
+            if (Directory.Exists(targetRoot)) Directory.Delete(targetRoot, recursive: true);
+            service.RestoreItems();
+        }
+    }
+
+    [Test]
+    public async Task RefreshFromFileSystem_deduplicates_paths_that_converge_on_one_identity()
+    {
+        ObjectTemplateService service = ObjectTemplateService.Instance;
+        ObjectTemplateItem? first = await service.AddFromInstanceAsync(
+            new Audio.Effects.AudioEffectGroup(),
+            $"converging-first-{Guid.NewGuid():N}");
+        ObjectTemplateItem? second = await service.AddFromInstanceAsync(
+            new Audio.Effects.AudioEffectGroup(),
+            $"converging-second-{Guid.NewGuid():N}");
+        Assert.That(first, Is.Not.Null);
+        Assert.That(second, Is.Not.Null);
+        string firstPath = first!.FilePath!;
+        string secondPath = second!.FilePath!;
+        try
+        {
+            File.Delete(secondPath);
+            try
+            {
+                File.CreateSymbolicLink(secondPath, firstPath);
+            }
+            catch (Exception ex) when (ex is IOException
+                                       or UnauthorizedAccessException
+                                       or PlatformNotSupportedException)
+            {
+                Assert.Ignore($"File symbolic links are unavailable: {ex.Message}");
+            }
+
+            service.RefreshFromFileSystem();
+
+            string?[] matchingPaths = service.FindByBaseType(first.BaseType)
+                .Select(item => item.FilePath)
+                .Where(path => path == firstPath || path == secondPath)
+                .ToArray();
+            Assert.That(matchingPaths, Is.EqualTo(new[] { firstPath }));
+        }
+        finally
+        {
+            File.Delete(secondPath);
+            File.Delete(firstPath);
+            service.RestoreItems();
+        }
+    }
 }


### PR DESCRIPTION
## Description

- Replace platform-wide lexical path casing assumptions with filesystem-backed canonical identity in `Beutl.Core`.
- Resolve on-disk case and Unicode spelling, symbolic links, and dot segments in filesystem order while failing closed on ambiguous non-exact entries.
- Migrate File Browser containment, watcher filtering, and template-file reconciliation without introducing a Version Control dependency.
- Keep watcher source and debounce generations coherent across navigation, disposal, startup failure, and retargeted symbolic links.

This PR is based directly on `main` and does not include `src/Beutl.Editor/VersionControl` files or Git/session/lease types from #2164.

## Affected areas

- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

`Beutl.Core` is also affected; the template has no separate checkbox for it.

## Breaking changes

`Beutl.Core.FilePathComparison` removes the public lexical `Comparison`, `Equals(string?, string?)`, and `StartsWith(string, string)` members.

- Use `AreSameCanonicalPath` for path identity.
- Use `IsSameOrDescendant` for containment.
- Use `TryAreSameChildPath` for a single child component.
- Use `ResolveCanonicalPath` when a canonical path string is required.

The replacements inspect the filesystem, follow symbolic links, normalize existing on-disk case and Unicode spelling, can surface inspection failures, and are not lexical drop-in replacements.

## Test plan

- `dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --settings coverlet.runsettings --filter "FullyQualifiedName~FilePathComparisonTests|FullyQualifiedName~DirectoryWatcherServiceTests|FullyQualifiedName~ObjectTemplateServicePreviewTests"` — 49 passed, 2 environment-specific skips (Windows drive casing and case-sensitive-volume reconciliation on the default case-insensitive macOS volume).
- `dotnet test tests/Beutl.PublicApiContractTests/Beutl.PublicApiContractTests.csproj -f net10.0 --no-build` — 209 passed.
- `dotnet build Beutl.slnx -c Debug --nologo` — 0 warnings, 0 errors.
- `dotnet format Beutl.slnx --verify-no-changes --no-restore --include <all eight changed files>` — passed.
- `bash .claude/scripts/check-gpl-mit-boundary-diff.sh --files <all eight changed files>` — passed.
- Independent `beutl-design-reviewer` re-review — Go, with no remaining medium-or-higher finding.

A solution-wide format probe also identified the unchanged `src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs` baseline as format-dirty; its blob is identical to `origin/main`, while every file in this PR passes scoped format verification.

## Fixed issues / References

- Extracted independently useful filesystem hardening from #2164 without depending on that PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file and folder matching across symbolic links, path casing, Unicode variations, and relative path segments.
  - Prevented directory watching from escaping path boundaries or following symbolic-link cycles.
  - Improved watcher recovery, debounced updates, and handling of failed or disposed watchers.
  - Reserved metadata folders are now excluded accurately without affecting similarly named folders.
  - File templates now avoid duplicates across symbolic-link aliases while tracking case-distinct files independently.
  - Improved template and thumbnail detection when directories or symbolic links change.
  - Improved thumbnail handling by caching template-directory checks for faster repeated access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->