### PR TITLE
refactor(project-system)!: propagate persisted-content migration requirements

### DIFF
--- a/src/Beutl.Core/Beutl.Core.csproj
+++ b/src/Beutl.Core/Beutl.Core.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="System.Reactive" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="NuGet.Versioning" />
   </ItemGroup>
 
 </Project>

--- a/src/Beutl.Core/CoreObject.cs
+++ b/src/Beutl.Core/CoreObject.cs
@@ -27,8 +27,6 @@ public interface ICoreObject : INotifyPropertyChanged, INotifyDataErrorInfo, ICo
 
 public abstract class CoreObject : ICoreObject
 {
-    private static readonly AsyncLocal<MigrationCollector?> s_migrationCollector = new();
-
     public static readonly CoreProperty<Guid> IdProperty;
 
     public static readonly CoreProperty<string> NameProperty;
@@ -90,7 +88,7 @@ public abstract class CoreObject : ICoreObject
             _wasTypeDiscriminatorAddedDuringRestore = value;
             if (value)
             {
-                ReportPersistedContentMigration(Project.DefaultMinAppVersion);
+                MergePersistedContentMigration(Project.DefaultMinAppVersion);
             }
         }
     }
@@ -98,88 +96,12 @@ public abstract class CoreObject : ICoreObject
     internal string? RequiredMinAppVersionAfterMigration
         => _requiredMinAppVersionAfterMigration;
 
-    /// <summary>
-    /// Reports that deserialization migrated persisted content and records the minimum Beutl
-    /// version required to read the migrated form.
-    /// </summary>
-    /// <param name="minAppVersion">A valid NuGet version string required by the migrated form.</param>
-    /// <remarks>
-    /// Derived serializable types should call this only when they actually rewrite legacy content.
-    /// Multiple reports are combined and the highest version is propagated to the containing
-    /// project when the object hierarchy is attached or serialized.
-    /// </remarks>
-    protected void ReportPersistedContentMigration(string minAppVersion)
+    internal void MergePersistedContentMigration(string minAppVersion)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(minAppVersion);
         _requiredMinAppVersionAfterMigration = Project.GetMaximumMigrationVersion(
             _requiredMinAppVersionAfterMigration,
             minAppVersion);
-        s_migrationCollector.Value?.Report(minAppVersion);
-    }
-
-    internal static IDisposable BeginPersistedContentMigrationCollection(CoreObject? root)
-    {
-        if (s_migrationCollector.Value is not null)
-        {
-            return EmptyDisposable.Instance;
-        }
-
-        var collector = new MigrationCollector();
-        s_migrationCollector.Value = collector;
-        return new MigrationCollectionScope(root, collector);
-    }
-
-    private void MergePersistedContentMigration(string minAppVersion)
-    {
-        _requiredMinAppVersionAfterMigration = Project.GetMaximumMigrationVersion(
-            _requiredMinAppVersionAfterMigration,
-            minAppVersion);
-    }
-
-    private sealed class MigrationCollector
-    {
-        public string? RequiredMinAppVersion { get; private set; }
-
-        public void Report(string minAppVersion)
-        {
-            RequiredMinAppVersion = Project.GetMaximumMigrationVersion(
-                RequiredMinAppVersion,
-                minAppVersion);
-        }
-    }
-
-    private sealed class MigrationCollectionScope(
-        CoreObject? root,
-        MigrationCollector collector) : IDisposable
-    {
-        private int _disposed;
-
-        public void Dispose()
-        {
-            if (Interlocked.Exchange(ref _disposed, 1) != 0)
-            {
-                return;
-            }
-
-            s_migrationCollector.Value = null;
-            if (collector.RequiredMinAppVersion is { } requiredVersion)
-            {
-                root?.MergePersistedContentMigration(requiredVersion);
-                if (root is Project project)
-                {
-                    project.MarkAsMigrated(requiredVersion);
-                }
-            }
-        }
-    }
-
-    private sealed class EmptyDisposable : IDisposable
-    {
-        public static EmptyDisposable Instance { get; } = new();
-
-        public void Dispose()
-        {
-        }
     }
 
     private Dictionary<int, IEntry> Values => _values ??= [];

--- a/src/Beutl.Core/CoreObject.cs
+++ b/src/Beutl.Core/CoreObject.cs
@@ -33,6 +33,8 @@ public abstract class CoreObject : ICoreObject
     private Dictionary<int, IEntry>? _values;
     private Dictionary<int, string>? _errors;
     private CoreProperty? _forcedReplacementProperty;
+    private string? _requiredMinAppVersionAfterMigration;
+    private bool _wasTypeDiscriminatorAddedDuringRestore;
 
     internal interface IEntry
     {
@@ -78,6 +80,39 @@ public abstract class CoreObject : ICoreObject
     // Non-null while this object stands in for a file the serializer must not regenerate:
     // StoreToUri skips the source location and copies the raw text verbatim to any new one.
     internal SuppressedStorageSource? SuppressedStorageSource { get; set; }
+    internal bool WasTypeDiscriminatorAddedDuringRestore
+    {
+        get => _wasTypeDiscriminatorAddedDuringRestore;
+        set
+        {
+            _wasTypeDiscriminatorAddedDuringRestore = value;
+            if (value)
+            {
+                ReportPersistedContentMigration(Project.DefaultMinAppVersion);
+            }
+        }
+    }
+
+    internal string? RequiredMinAppVersionAfterMigration
+        => _requiredMinAppVersionAfterMigration;
+
+    /// <summary>
+    /// Reports that deserialization migrated persisted content and records the minimum Beutl
+    /// version required to read the migrated form.
+    /// </summary>
+    /// <param name="minAppVersion">A valid NuGet version string required by the migrated form.</param>
+    /// <remarks>
+    /// Derived serializable types should call this only when they actually rewrite legacy content.
+    /// Multiple reports are combined and the highest version is propagated to the containing
+    /// project when the object hierarchy is attached or serialized.
+    /// </remarks>
+    protected void ReportPersistedContentMigration(string minAppVersion)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(minAppVersion);
+        _requiredMinAppVersionAfterMigration = Project.GetMaximumMigrationVersion(
+            _requiredMinAppVersionAfterMigration,
+            minAppVersion);
+    }
 
     private Dictionary<int, IEntry> Values => _values ??= [];
 

--- a/src/Beutl.Core/CoreObject.cs
+++ b/src/Beutl.Core/CoreObject.cs
@@ -27,6 +27,8 @@ public interface ICoreObject : INotifyPropertyChanged, INotifyDataErrorInfo, ICo
 
 public abstract class CoreObject : ICoreObject
 {
+    private static readonly AsyncLocal<MigrationCollector?> s_migrationCollector = new();
+
     public static readonly CoreProperty<Guid> IdProperty;
 
     public static readonly CoreProperty<string> NameProperty;
@@ -112,6 +114,72 @@ public abstract class CoreObject : ICoreObject
         _requiredMinAppVersionAfterMigration = Project.GetMaximumMigrationVersion(
             _requiredMinAppVersionAfterMigration,
             minAppVersion);
+        s_migrationCollector.Value?.Report(minAppVersion);
+    }
+
+    internal static IDisposable BeginPersistedContentMigrationCollection(CoreObject? root)
+    {
+        if (s_migrationCollector.Value is not null)
+        {
+            return EmptyDisposable.Instance;
+        }
+
+        var collector = new MigrationCollector();
+        s_migrationCollector.Value = collector;
+        return new MigrationCollectionScope(root, collector);
+    }
+
+    private void MergePersistedContentMigration(string minAppVersion)
+    {
+        _requiredMinAppVersionAfterMigration = Project.GetMaximumMigrationVersion(
+            _requiredMinAppVersionAfterMigration,
+            minAppVersion);
+    }
+
+    private sealed class MigrationCollector
+    {
+        public string? RequiredMinAppVersion { get; private set; }
+
+        public void Report(string minAppVersion)
+        {
+            RequiredMinAppVersion = Project.GetMaximumMigrationVersion(
+                RequiredMinAppVersion,
+                minAppVersion);
+        }
+    }
+
+    private sealed class MigrationCollectionScope(
+        CoreObject? root,
+        MigrationCollector collector) : IDisposable
+    {
+        private int _disposed;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            s_migrationCollector.Value = null;
+            if (collector.RequiredMinAppVersion is { } requiredVersion)
+            {
+                root?.MergePersistedContentMigration(requiredVersion);
+                if (root is Project project)
+                {
+                    project.MarkAsMigrated(requiredVersion);
+                }
+            }
+        }
+    }
+
+    private sealed class EmptyDisposable : IDisposable
+    {
+        public static EmptyDisposable Instance { get; } = new();
+
+        public void Dispose()
+        {
+        }
     }
 
     private Dictionary<int, IEntry> Values => _values ??= [];

--- a/src/Beutl.Core/CoreObject.cs
+++ b/src/Beutl.Core/CoreObject.cs
@@ -33,7 +33,6 @@ public abstract class CoreObject : ICoreObject
     private Dictionary<int, IEntry>? _values;
     private Dictionary<int, string>? _errors;
     private CoreProperty? _forcedReplacementProperty;
-    private readonly object _migrationSync = new();
     private string? _requiredMinAppVersionAfterMigration;
     private bool _wasTypeDiscriminatorAddedDuringRestore;
 
@@ -95,24 +94,26 @@ public abstract class CoreObject : ICoreObject
     }
 
     internal string? RequiredMinAppVersionAfterMigration
-    {
-        get
-        {
-            lock (_migrationSync)
-            {
-                return _requiredMinAppVersionAfterMigration;
-            }
-        }
-    }
+        => Volatile.Read(ref _requiredMinAppVersionAfterMigration);
 
     internal void MergePersistedContentMigration(string minAppVersion)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(minAppVersion);
-        lock (_migrationSync)
+        while (true)
         {
-            _requiredMinAppVersionAfterMigration = Project.GetMaximumMigrationVersion(
-                _requiredMinAppVersionAfterMigration,
+            string? current = Volatile.Read(ref _requiredMinAppVersionAfterMigration);
+            string? required = Project.GetMaximumMigrationVersion(
+                current,
                 minAppVersion);
+            if (ReferenceEquals(
+                    Interlocked.CompareExchange(
+                        ref _requiredMinAppVersionAfterMigration,
+                        required,
+                        current),
+                    current))
+            {
+                return;
+            }
         }
     }
 

--- a/src/Beutl.Core/CoreObject.cs
+++ b/src/Beutl.Core/CoreObject.cs
@@ -33,6 +33,7 @@ public abstract class CoreObject : ICoreObject
     private Dictionary<int, IEntry>? _values;
     private Dictionary<int, string>? _errors;
     private CoreProperty? _forcedReplacementProperty;
+    private readonly object _migrationSync = new();
     private string? _requiredMinAppVersionAfterMigration;
     private bool _wasTypeDiscriminatorAddedDuringRestore;
 
@@ -94,14 +95,25 @@ public abstract class CoreObject : ICoreObject
     }
 
     internal string? RequiredMinAppVersionAfterMigration
-        => _requiredMinAppVersionAfterMigration;
+    {
+        get
+        {
+            lock (_migrationSync)
+            {
+                return _requiredMinAppVersionAfterMigration;
+            }
+        }
+    }
 
     internal void MergePersistedContentMigration(string minAppVersion)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(minAppVersion);
-        _requiredMinAppVersionAfterMigration = Project.GetMaximumMigrationVersion(
-            _requiredMinAppVersionAfterMigration,
-            minAppVersion);
+        lock (_migrationSync)
+        {
+            _requiredMinAppVersionAfterMigration = Project.GetMaximumMigrationVersion(
+                _requiredMinAppVersionAfterMigration,
+                minAppVersion);
+        }
     }
 
     private Dictionary<int, IEntry> Values => _values ??= [];

--- a/src/Beutl.Core/Project.cs
+++ b/src/Beutl.Core/Project.cs
@@ -120,6 +120,15 @@ public sealed class Project : Hierarchical
 
     private void PropagateItemMigration(ProjectItem item)
     {
+        string? requiredVersion = GetRequiredMigrationVersion(item);
+        if (requiredVersion is not null)
+        {
+            MarkAsMigrated(requiredVersion);
+        }
+    }
+
+    internal static string? GetRequiredMigrationVersion(ProjectItem item)
+    {
         string? requiredVersion = null;
         var pending = new Stack<CoreObject>();
         pending.Push(item);
@@ -140,10 +149,7 @@ public sealed class Project : Hierarchical
             }
         }
 
-        if (requiredVersion is not null)
-        {
-            MarkAsMigrated(requiredVersion);
-        }
+        return requiredVersion;
     }
 
     internal static string? GetMaximumMigrationVersion(string? left, string? right)

--- a/src/Beutl.Core/Project.cs
+++ b/src/Beutl.Core/Project.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using Beutl.Collections;
 using Beutl.Serialization;
+using NuGet.Versioning;
 
 namespace Beutl;
 
@@ -44,6 +45,7 @@ public sealed class Project : Hierarchical
     {
         MinAppVersion = DefaultMinAppVersion;
         _items = new HierarchicalList<ProjectItem>(this);
+        _items.Attached += PropagateItemMigration;
     }
 
     public string AppVersion { get; private set; } = BeutlApplication.Version;
@@ -94,8 +96,89 @@ public sealed class Project : Hierarchical
         activity?.SetTag("itemsCount", Items.Count);
     }
 
+    // Call only after a migration has rewritten persisted content. Project-item migrations,
+    // including extension-provided item types, are aggregated during deserialization; a plain
+    // load/save keeps the version from disk.
+    internal void MarkAsMigrated(string requiredMinAppVersion = DefaultMinAppVersion)
+    {
+        AppVersion = BeutlApplication.Version;
+        MinAppVersion = GetMaximumVersion(MinAppVersion, requiredMinAppVersion);
+    }
+
+    private void PropagateItemMigration(ProjectItem item)
+    {
+        string? requiredVersion = null;
+        var pending = new Stack<CoreObject>();
+        pending.Push(item);
+        while (pending.TryPop(out CoreObject? current))
+        {
+            requiredVersion = GetMaximumMigrationVersion(
+                requiredVersion,
+                current.RequiredMinAppVersionAfterMigration);
+            if (current is IHierarchical hierarchical)
+            {
+                foreach (IHierarchical child in hierarchical.HierarchicalChildren)
+                {
+                    if (child is CoreObject coreObject)
+                    {
+                        pending.Push(coreObject);
+                    }
+                }
+            }
+        }
+
+        if (requiredVersion is not null)
+        {
+            MarkAsMigrated(requiredVersion);
+        }
+    }
+
+    internal static string? GetMaximumMigrationVersion(string? left, string? right)
+    {
+        NuGetVersion? leftVersion = null;
+        if (left is not null && !NuGetVersion.TryParse(left, out leftVersion))
+        {
+            throw new InvalidOperationException($"Invalid migration minimum version '{left}'.");
+        }
+
+        NuGetVersion? rightVersion = null;
+        if (right is not null && !NuGetVersion.TryParse(right, out rightVersion))
+        {
+            throw new InvalidOperationException($"Invalid migration minimum version '{right}'.");
+        }
+
+        if (leftVersion is null)
+        {
+            return right;
+        }
+
+        if (rightVersion is null)
+        {
+            return left;
+        }
+
+        return VersionComparer.VersionRelease.Compare(leftVersion, rightVersion) < 0
+            ? right
+            : left;
+    }
+
+    private static string GetMaximumVersion(string persistedVersion, string requiredVersion)
+    {
+        // An unknown persisted constraint is retained so migration cannot weaken it.
+        return NuGetVersion.TryParse(persistedVersion, out NuGetVersion? persisted)
+               && NuGetVersion.TryParse(requiredVersion, out NuGetVersion? required)
+               && VersionComparer.VersionRelease.Compare(persisted, required) < 0
+            ? requiredVersion
+            : persistedVersion;
+    }
+
     public override void Serialize(ICoreSerializationContext context)
     {
+        foreach (ProjectItem item in Items)
+        {
+            PropagateItemMigration(item);
+        }
+
         using Activity? activity = BeutlApplication.ActivitySource.StartActivity("Project.Serialize");
         activity?.SetTag("appVersion", AppVersion);
         activity?.SetTag("minAppVersion", MinAppVersion);

--- a/src/Beutl.Core/Project.cs
+++ b/src/Beutl.Core/Project.cs
@@ -105,6 +105,12 @@ public sealed class Project : Hierarchical
         MinAppVersion = GetMaximumVersion(MinAppVersion, requiredMinAppVersion);
     }
 
+    internal void RestoreVersionMetadata(string appVersion, string minAppVersion)
+    {
+        AppVersion = appVersion;
+        MinAppVersion = minAppVersion;
+    }
+
     private void PropagateItemMigration(ProjectItem item)
     {
         string? requiredVersion = null;

--- a/src/Beutl.Core/Project.cs
+++ b/src/Beutl.Core/Project.cs
@@ -18,6 +18,7 @@ public sealed class Project : Hierarchical
     public static readonly CoreProperty<string> AppVersionProperty;
     public static readonly CoreProperty<string> MinAppVersionProperty;
     private readonly HierarchicalList<ProjectItem> _items;
+    private readonly object _versionMetadataSync = new();
 
     public const string DefaultMinAppVersion = "2.0.0-preview.1";
 
@@ -101,14 +102,20 @@ public sealed class Project : Hierarchical
     // load/save keeps the version from disk.
     internal void MarkAsMigrated(string requiredMinAppVersion = DefaultMinAppVersion)
     {
-        AppVersion = BeutlApplication.Version;
-        MinAppVersion = GetMaximumVersion(MinAppVersion, requiredMinAppVersion);
+        lock (_versionMetadataSync)
+        {
+            AppVersion = BeutlApplication.Version;
+            MinAppVersion = GetMaximumVersion(MinAppVersion, requiredMinAppVersion);
+        }
     }
 
     internal void RestoreVersionMetadata(string appVersion, string minAppVersion)
     {
-        AppVersion = appVersion;
-        MinAppVersion = minAppVersion;
+        lock (_versionMetadataSync)
+        {
+            AppVersion = appVersion;
+            MinAppVersion = minAppVersion;
+        }
     }
 
     private void PropagateItemMigration(ProjectItem item)
@@ -185,15 +192,23 @@ public sealed class Project : Hierarchical
             PropagateItemMigration(item);
         }
 
+        string appVersion;
+        string minAppVersion;
+        lock (_versionMetadataSync)
+        {
+            appVersion = AppVersion;
+            minAppVersion = MinAppVersion;
+        }
+
         using Activity? activity = BeutlApplication.ActivitySource.StartActivity("Project.Serialize");
-        activity?.SetTag("appVersion", AppVersion);
-        activity?.SetTag("minAppVersion", MinAppVersion);
+        activity?.SetTag("appVersion", appVersion);
+        activity?.SetTag("minAppVersion", minAppVersion);
         activity?.SetTag("itemsCount", Items.Count);
 
         base.Serialize(context);
 
-        context.SetValue("appVersion", AppVersion);
-        context.SetValue("minAppVersion", MinAppVersion);
+        context.SetValue("appVersion", appVersion);
+        context.SetValue("minAppVersion", minAppVersion);
 
         context.SetValue("items", Items);
 

--- a/src/Beutl.Core/ProjectItem.cs
+++ b/src/Beutl.Core/ProjectItem.cs
@@ -1,5 +1,3 @@
 ﻿namespace Beutl;
 
-public abstract class ProjectItem : Hierarchical
-{
-}
+public abstract class ProjectItem : Hierarchical;

--- a/src/Beutl.Core/Serialization/CoreSerializer.cs
+++ b/src/Beutl.Core/Serialization/CoreSerializer.cs
@@ -228,11 +228,15 @@ public static class CoreSerializer
             if (obj is CoreObject coreObj)
             {
                 coreObj.Uri = uri;
-                coreObj.WasTypeDiscriminatorAddedDuringRestore = addedTypeDiscriminator;
             }
 
             var options = new CoreSerializerOptions { BaseUri = uri, Mode = CoreSerializationMode.Read };
             PopulateFromJsonObject(obj, type, jsonObject, options);
+            if (obj is CoreObject restoredCoreObject)
+            {
+                restoredCoreObject.WasTypeDiscriminatorAddedDuringRestore =
+                    addedTypeDiscriminator;
+            }
 
             if (obj is IFallback fallbackObj)
             {
@@ -264,16 +268,19 @@ public static class CoreSerializer
 
         var node = JsonNode.Parse(stream);
         if (node is not JsonObject jsonObject) throw new JsonException();
+        bool addedTypeDiscriminator = AddLegacyTypeDiscriminator(jsonObject, type);
         if (obj is CoreObject coreObj)
         {
             coreObj.Uri = uri;
-            coreObj.WasTypeDiscriminatorAddedDuringRestore = AddLegacyTypeDiscriminator(
-                jsonObject,
-                type);
         }
 
         var options = new CoreSerializerOptions { BaseUri = uri, Mode = CoreSerializationMode.Read };
         PopulateFromJsonObject(obj, type, jsonObject, options);
+        if (obj is CoreObject populatedCoreObject)
+        {
+            populatedCoreObject.WasTypeDiscriminatorAddedDuringRestore =
+                addedTypeDiscriminator;
+        }
     }
 
     private static bool AddLegacyTypeDiscriminator(JsonObject json, Type type)

--- a/src/Beutl.Core/Serialization/CoreSerializer.cs
+++ b/src/Beutl.Core/Serialization/CoreSerializer.cs
@@ -146,6 +146,8 @@ public static class CoreSerializer
         ReflectUri(json, obj, parentContext, ref options);
 
         var context = new JsonSerializationContext(type, parentContext, json, options);
+        using IDisposable migrationScope = CoreObject.BeginPersistedContentMigrationCollection(
+            obj as CoreObject);
         using (ThreadLocalSerializationContext.Enter(context))
         {
             obj.Deserialize(context);
@@ -170,23 +172,7 @@ public static class CoreSerializer
         // 互換性処理
         // 1.x で作成されたファイルでは一部のオブジェクトに $type が付与されないため、
         // 期待される型に基づいてディスクリミネータを補完する。
-        bool addedTypeDiscriminator = false;
-        // Presence is checked on the property key alone: a present-but-unparsable or non-string
-        // discriminator must fail as an unknown type, not silently deserialize as the legacy
-        // default and overwrite the original data on the next save.
-        if (!jsonObject.ContainsKey("$type") && !jsonObject.ContainsKey("@type"))
-        {
-            if (type == typeof(ProjectItem))
-            {
-                node["$type"] = LegacyTypeNames.SceneDiscriminator;
-                addedTypeDiscriminator = true;
-            }
-            else if (type.FullName == LegacyTypeNames.ElementFullName)
-            {
-                node["$type"] = LegacyTypeNames.ElementDiscriminator;
-                addedTypeDiscriminator = true;
-            }
-        }
+        bool addedTypeDiscriminator = AddLegacyTypeDiscriminator(jsonObject, type);
 
         bool hasDiscriminator = jsonObject.ContainsKey("$type") || jsonObject.ContainsKey("@type");
         Type? actualType = hasDiscriminator
@@ -280,10 +266,36 @@ public static class CoreSerializer
         if (obj is CoreObject coreObj)
         {
             coreObj.Uri = uri;
+            coreObj.WasTypeDiscriminatorAddedDuringRestore = AddLegacyTypeDiscriminator(
+                jsonObject,
+                type);
         }
 
         var options = new CoreSerializerOptions { BaseUri = uri, Mode = CoreSerializationMode.Read };
         PopulateFromJsonObject(obj, type, jsonObject, options);
+    }
+
+    private static bool AddLegacyTypeDiscriminator(JsonObject json, Type type)
+    {
+        // Preserve present but invalid discriminators for unknown-type recovery.
+        if (json.ContainsKey("$type") || json.ContainsKey("@type"))
+        {
+            return false;
+        }
+
+        if (type == typeof(ProjectItem))
+        {
+            json["$type"] = LegacyTypeNames.SceneDiscriminator;
+            return true;
+        }
+
+        if (type.FullName == LegacyTypeNames.ElementFullName)
+        {
+            json["$type"] = LegacyTypeNames.ElementDiscriminator;
+            return true;
+        }
+
+        return false;
     }
 
     public static void StoreToUri<T>(T obj, Uri uri, CoreSerializationMode? mode = null)

--- a/src/Beutl.Core/Serialization/CoreSerializer.cs
+++ b/src/Beutl.Core/Serialization/CoreSerializer.cs
@@ -84,6 +84,7 @@ public static class CoreSerializer
             ReflectUri(json, obj, parentContext, ref options);
 
             var context = new JsonSerializationContext(actualType, parentContext, json, options);
+            context.EnablePersistedContentMigrationReporting();
             using (ThreadLocalSerializationContext.Enter(context))
             {
                 obj.Deserialize(context);
@@ -127,6 +128,7 @@ public static class CoreSerializer
     {
         var ownerJson = new JsonObject { ["Value"] = json.DeepClone() };
         var context = new JsonSerializationContext(type, ThreadLocalSerializationContext.Current, ownerJson, options);
+        context.EnablePersistedContentMigrationReporting();
         using (ThreadLocalSerializationContext.Enter(context))
         {
             return context.GetValue("Value", type);
@@ -146,8 +148,7 @@ public static class CoreSerializer
         ReflectUri(json, obj, parentContext, ref options);
 
         var context = new JsonSerializationContext(type, parentContext, json, options);
-        using IDisposable migrationScope = CoreObject.BeginPersistedContentMigrationCollection(
-            obj as CoreObject);
+        context.EnablePersistedContentMigrationReporting();
         using (ThreadLocalSerializationContext.Enter(context))
         {
             obj.Deserialize(context);

--- a/src/Beutl.Core/Serialization/CoreSerializer.cs
+++ b/src/Beutl.Core/Serialization/CoreSerializer.cs
@@ -144,6 +144,13 @@ public static class CoreSerializer
     public static void PopulateFromJsonObject(ICoreSerializable obj, Type type, JsonObject json,
         CoreSerializerOptions? options = null)
     {
+        bool addedTypeDiscriminator = AddLegacyTypeDiscriminator(json, obj.GetType());
+        PopulateFromJsonObjectCore(obj, type, json, options, addedTypeDiscriminator);
+    }
+
+    private static void PopulateFromJsonObjectCore(ICoreSerializable obj, Type type, JsonObject json,
+        CoreSerializerOptions? options, bool addedTypeDiscriminator)
+    {
         var parentContext = ThreadLocalSerializationContext.Current;
         ReflectUri(json, obj, parentContext, ref options);
 
@@ -152,7 +159,15 @@ public static class CoreSerializer
         using (ThreadLocalSerializationContext.Enter(context))
         {
             obj.Deserialize(context);
+            if (addedTypeDiscriminator)
+            {
+                context.ReportPersistedContentMigration(Project.DefaultMinAppVersion);
+            }
             context.AfterDeserialized(obj);
+        }
+        if (addedTypeDiscriminator && obj is CoreObject coreObject)
+        {
+            coreObject.WasTypeDiscriminatorAddedDuringRestore = true;
         }
     }
 
@@ -231,7 +246,7 @@ public static class CoreSerializer
             }
 
             var options = new CoreSerializerOptions { BaseUri = uri, Mode = CoreSerializationMode.Read };
-            PopulateFromJsonObject(obj, type, jsonObject, options);
+            PopulateFromJsonObjectCore(obj, type, jsonObject, options, addedTypeDiscriminator);
             if (obj is CoreObject restoredCoreObject)
             {
                 restoredCoreObject.WasTypeDiscriminatorAddedDuringRestore =
@@ -268,14 +283,14 @@ public static class CoreSerializer
 
         var node = JsonNode.Parse(stream);
         if (node is not JsonObject jsonObject) throw new JsonException();
-        bool addedTypeDiscriminator = AddLegacyTypeDiscriminator(jsonObject, type);
+        bool addedTypeDiscriminator = AddLegacyTypeDiscriminator(jsonObject, obj.GetType());
         if (obj is CoreObject coreObj)
         {
             coreObj.Uri = uri;
         }
 
         var options = new CoreSerializerOptions { BaseUri = uri, Mode = CoreSerializationMode.Read };
-        PopulateFromJsonObject(obj, type, jsonObject, options);
+        PopulateFromJsonObjectCore(obj, type, jsonObject, options, addedTypeDiscriminator);
         if (obj is CoreObject populatedCoreObject)
         {
             populatedCoreObject.WasTypeDiscriminatorAddedDuringRestore =
@@ -291,7 +306,7 @@ public static class CoreSerializer
             return false;
         }
 
-        if (type == typeof(ProjectItem))
+        if (type == typeof(ProjectItem) || type.FullName == "Beutl.ProjectSystem.Scene")
         {
             json["$type"] = LegacyTypeNames.SceneDiscriminator;
             return true;

--- a/src/Beutl.Core/Serialization/CoreSerializer.cs
+++ b/src/Beutl.Core/Serialization/CoreSerializer.cs
@@ -170,6 +170,7 @@ public static class CoreSerializer
         // 互換性処理
         // 1.x で作成されたファイルでは一部のオブジェクトに $type が付与されないため、
         // 期待される型に基づいてディスクリミネータを補完する。
+        bool addedTypeDiscriminator = false;
         // Presence is checked on the property key alone: a present-but-unparsable or non-string
         // discriminator must fail as an unknown type, not silently deserialize as the legacy
         // default and overwrite the original data on the next save.
@@ -178,10 +179,12 @@ public static class CoreSerializer
             if (type == typeof(ProjectItem))
             {
                 node["$type"] = LegacyTypeNames.SceneDiscriminator;
+                addedTypeDiscriminator = true;
             }
             else if (type.FullName == LegacyTypeNames.ElementFullName)
             {
                 node["$type"] = LegacyTypeNames.ElementDiscriminator;
+                addedTypeDiscriminator = true;
             }
         }
 
@@ -238,6 +241,7 @@ public static class CoreSerializer
             if (obj is CoreObject coreObj)
             {
                 coreObj.Uri = uri;
+                coreObj.WasTypeDiscriminatorAddedDuringRestore = addedTypeDiscriminator;
             }
 
             var options = new CoreSerializerOptions { BaseUri = uri, Mode = CoreSerializationMode.Read };

--- a/src/Beutl.Core/Serialization/ICoreSerializationContext.cs
+++ b/src/Beutl.Core/Serialization/ICoreSerializationContext.cs
@@ -8,6 +8,18 @@ public interface ICoreSerializationContext
 
     Type OwnerType { get; }
 
+    /// <summary>
+    /// Reports that deserialization migrated persisted content and records the minimum Beutl
+    /// version required to read the migrated form.
+    /// </summary>
+    /// <param name="minAppVersion">A valid NuGet version string required by the migrated form.</param>
+    /// <remarks>
+    /// Call this from <see cref="ICoreSerializable.Deserialize"/> only when legacy persisted data
+    /// was actually rewritten. Reports from nested serializable values are combined and propagated
+    /// to their containing project.
+    /// </remarks>
+    void ReportPersistedContentMigration(string minAppVersion);
+
     void SetValue<T>(string name, T? value);
 
     T? GetValue<T>(string name);

--- a/src/Beutl.Core/Serialization/JsonSerializationContext.Deserialize.cs
+++ b/src/Beutl.Core/Serialization/JsonSerializationContext.Deserialize.cs
@@ -106,6 +106,7 @@ public partial class JsonSerializationContext
                 parent: parent,
                 json: obj,
                 options: options);
+            context.EnablePersistedContentMigrationReporting();
 
             using (ThreadLocalSerializationContext.Enter(context))
             {

--- a/src/Beutl.Core/Serialization/JsonSerializationContext.cs
+++ b/src/Beutl.Core/Serialization/JsonSerializationContext.cs
@@ -35,8 +35,7 @@ public partial class JsonSerializationContext(
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(minAppVersion);
         if (!_acceptsPersistedContentMigrationReports
-            && (!Mode.HasFlag(CoreSerializationMode.Read)
-                || Mode.HasFlag(CoreSerializationMode.Write)))
+            && !Mode.HasFlag(CoreSerializationMode.Read))
         {
             throw new InvalidOperationException(
                 "Persisted-content migrations can only be reported while deserializing.");

--- a/src/Beutl.Core/Serialization/JsonSerializationContext.cs
+++ b/src/Beutl.Core/Serialization/JsonSerializationContext.cs
@@ -15,8 +15,11 @@ public partial class JsonSerializationContext(
     private List<(Guid, Action<ICoreSerializable>)>? _resolvers;
     private Dictionary<Guid, ICoreSerializable>? _objects;
     private readonly JsonObject _json = json ?? [];
+    private readonly object _migrationSync = new();
+    private ICoreSerializable? _deserializedObject;
     private string? _requiredMinAppVersionAfterMigration;
     private bool _acceptsPersistedContentMigrationReports;
+    private bool _afterDeserializedCompleted;
 
     public ICoreSerializationContext? Parent { get; } = parent;
 
@@ -31,15 +34,32 @@ public partial class JsonSerializationContext(
     public void ReportPersistedContentMigration(string minAppVersion)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(minAppVersion);
-        if (!_acceptsPersistedContentMigrationReports)
+        if (!_acceptsPersistedContentMigrationReports
+            && (!Mode.HasFlag(CoreSerializationMode.Read)
+                || Mode.HasFlag(CoreSerializationMode.Write)))
         {
             throw new InvalidOperationException(
                 "Persisted-content migrations can only be reported while deserializing.");
         }
 
-        _requiredMinAppVersionAfterMigration = Project.GetMaximumMigrationVersion(
-            _requiredMinAppVersionAfterMigration,
-            minAppVersion);
+        ICoreSerializable? deserializedObject = null;
+        string? requiredVersion = null;
+        lock (_migrationSync)
+        {
+            _requiredMinAppVersionAfterMigration = Project.GetMaximumMigrationVersion(
+                _requiredMinAppVersionAfterMigration,
+                minAppVersion);
+            if (_afterDeserializedCompleted)
+            {
+                deserializedObject = _deserializedObject;
+                requiredVersion = _requiredMinAppVersionAfterMigration;
+            }
+        }
+
+        if (deserializedObject is not null && requiredVersion is not null)
+        {
+            PropagatePersistedContentMigration(deserializedObject, requiredVersion);
+        }
     }
 
     internal void EnablePersistedContentMigrationReporting()
@@ -92,18 +112,9 @@ public partial class JsonSerializationContext(
 
     public void AfterDeserialized(ICoreSerializable obj)
     {
-        if (_requiredMinAppVersionAfterMigration is { } requiredVersion)
+        lock (_migrationSync)
         {
-            if (obj is CoreObject migratedObject)
-            {
-                migratedObject.MergePersistedContentMigration(requiredVersion);
-                if (migratedObject is Project project)
-                {
-                    project.MarkAsMigrated(requiredVersion);
-                }
-            }
-
-            Parent?.ReportPersistedContentMigration(requiredVersion);
+            _deserializedObject = obj;
         }
 
         if (_resolvers?.Count > 0)
@@ -120,34 +131,62 @@ public partial class JsonSerializationContext(
             if (IsRoot)
             {
                 // Resolve references
-                if (_rootResolvers == null || _objects == null)
-                    return;
-
-                for (int i = _rootResolvers.Count - 1; i >= 0; i--)
+                if (_rootResolvers is not null && _objects is not null)
                 {
-                    var item = _rootResolvers[i];
-                    var (self, id, callback) = item;
-                    if (_objects.TryGetValue(id, out var resolved))
+                    for (int i = _rootResolvers.Count - 1; i >= 0; i--)
                     {
-                        callback(resolved);
-                        _rootResolvers.RemoveAt(i);
-                    }
-                    else if (coreObject is IHierarchical hierarchical)
-                    {
-                        var resolver = new ReferenceResolver(hierarchical, id);
-                        resolver.Resolve().ContinueWith(t =>
+                        var item = _rootResolvers[i];
+                        var (self, id, callback) = item;
+                        if (_objects.TryGetValue(id, out var resolved))
                         {
-                            callback(t.Result);
-                            _rootResolvers?.Remove(item);
-                        });
-                    }
-                    else
-                    {
-                        // Error
+                            callback(resolved);
+                            _rootResolvers.RemoveAt(i);
+                        }
+                        else if (coreObject is IHierarchical hierarchical)
+                        {
+                            var resolver = new ReferenceResolver(hierarchical, id);
+                            resolver.Resolve().ContinueWith(t =>
+                            {
+                                callback(t.Result);
+                                _rootResolvers?.Remove(item);
+                            });
+                        }
+                        else
+                        {
+                            // Error
+                        }
                     }
                 }
             }
         }
+
+        string? requiredVersion;
+        lock (_migrationSync)
+        {
+            _afterDeserializedCompleted = true;
+            requiredVersion = _requiredMinAppVersionAfterMigration;
+        }
+
+        if (requiredVersion is not null)
+        {
+            PropagatePersistedContentMigration(obj, requiredVersion);
+        }
+    }
+
+    private void PropagatePersistedContentMigration(
+        ICoreSerializable obj,
+        string requiredVersion)
+    {
+        if (obj is CoreObject migratedObject)
+        {
+            migratedObject.MergePersistedContentMigration(requiredVersion);
+            if (migratedObject is Project project)
+            {
+                project.MarkAsMigrated(requiredVersion);
+            }
+        }
+
+        Parent?.ReportPersistedContentMigration(requiredVersion);
     }
 
     private void SetObjectAndId(CoreObject coreObject)

--- a/src/Beutl.Core/Serialization/JsonSerializationContext.cs
+++ b/src/Beutl.Core/Serialization/JsonSerializationContext.cs
@@ -15,6 +15,8 @@ public partial class JsonSerializationContext(
     private List<(Guid, Action<ICoreSerializable>)>? _resolvers;
     private Dictionary<Guid, ICoreSerializable>? _objects;
     private readonly JsonObject _json = json ?? [];
+    private string? _requiredMinAppVersionAfterMigration;
+    private bool _acceptsPersistedContentMigrationReports;
 
     public ICoreSerializationContext? Parent { get; } = parent;
 
@@ -25,6 +27,25 @@ public partial class JsonSerializationContext(
     public Uri? BaseUri => options?.BaseUri ?? Parent?.BaseUri;
 
     public Type OwnerType { get; } = ownerType;
+
+    public void ReportPersistedContentMigration(string minAppVersion)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(minAppVersion);
+        if (!_acceptsPersistedContentMigrationReports)
+        {
+            throw new InvalidOperationException(
+                "Persisted-content migrations can only be reported while deserializing.");
+        }
+
+        _requiredMinAppVersionAfterMigration = Project.GetMaximumMigrationVersion(
+            _requiredMinAppVersionAfterMigration,
+            minAppVersion);
+    }
+
+    internal void EnablePersistedContentMigrationReporting()
+    {
+        _acceptsPersistedContentMigrationReports = true;
+    }
 
     [MemberNotNullWhen(false, nameof(Parent))]
     public bool IsRoot => Parent == null;
@@ -59,6 +80,7 @@ public partial class JsonSerializationContext(
                 ownerType: obj.GetType(),
                 parent: this,
                 json: jobj);
+            context.EnablePersistedContentMigrationReporting();
 
             using (ThreadLocalSerializationContext.Enter(context))
             {
@@ -70,6 +92,20 @@ public partial class JsonSerializationContext(
 
     public void AfterDeserialized(ICoreSerializable obj)
     {
+        if (_requiredMinAppVersionAfterMigration is { } requiredVersion)
+        {
+            if (obj is CoreObject migratedObject)
+            {
+                migratedObject.MergePersistedContentMigration(requiredVersion);
+                if (migratedObject is Project project)
+                {
+                    project.MarkAsMigrated(requiredVersion);
+                }
+            }
+
+            Parent?.ReportPersistedContentMigration(requiredVersion);
+        }
+
         if (_resolvers?.Count > 0)
         {
             Root._rootResolvers ??= [];

--- a/src/Beutl.Editor/VersionControl/VersionControlSerializationGraph.cs
+++ b/src/Beutl.Editor/VersionControl/VersionControlSerializationGraph.cs
@@ -1769,8 +1769,9 @@ internal static class VersionControlSerializationGraph
 
         public void ReportPersistedContentMigration(string minAppVersion)
         {
-            throw new InvalidOperationException(
-                "Persisted-content migrations cannot be reported during serialization graph inspection.");
+            // Round-trip inspection deserializes temporary values to discover their resources.
+            // A valid migration report belongs to that temporary graph and must not mutate or
+            // reject the live project being inspected.
         }
 
         public JsonObject GetJsonObject()

--- a/src/Beutl.Editor/VersionControl/VersionControlSerializationGraph.cs
+++ b/src/Beutl.Editor/VersionControl/VersionControlSerializationGraph.cs
@@ -1767,6 +1767,12 @@ internal static class VersionControlSerializationGraph
 
         public Type OwnerType => owner.GetType();
 
+        public void ReportPersistedContentMigration(string minAppVersion)
+        {
+            throw new InvalidOperationException(
+                "Persisted-content migrations cannot be reported during serialization graph inspection.");
+        }
+
         public JsonObject GetJsonObject()
         {
             throw new InvalidDataException(

--- a/src/Beutl.ProjectSystem/ProjectSystem/Element.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Element.cs
@@ -69,6 +69,8 @@ public class Element : Hierarchical, INotifyEdited
 
     public event EventHandler? Edited;
 
+    internal bool WasMigratedFromOperation { get; private set; }
+
     // 0以上
     [Display(Name = nameof(Strings.StartTime), ResourceType = typeof(Strings))]
     public TimeSpan Start
@@ -189,10 +191,11 @@ public class Element : Hierarchical, INotifyEdited
         }
         else if (context is IJsonSerializationContext jsonContext)
         {
-            EngineObject[] migrated = ElementMigration.MigrateFromOperation(jsonContext);
-            if (migrated.Length > 0)
+            if (ElementMigration.TryMigrateFromOperation(jsonContext, out EngineObject[] migrated))
             {
                 Objects.Replace(migrated);
+                WasMigratedFromOperation = true;
+                ReportPersistedContentMigration(Project.DefaultMinAppVersion);
             }
         }
     }

--- a/src/Beutl.ProjectSystem/ProjectSystem/Element.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Element.cs
@@ -195,7 +195,7 @@ public class Element : Hierarchical, INotifyEdited
             {
                 Objects.Replace(migrated);
                 WasMigratedFromOperation = true;
-                ReportPersistedContentMigration(Project.DefaultMinAppVersion);
+                context.ReportPersistedContentMigration(Project.DefaultMinAppVersion);
             }
         }
     }

--- a/src/Beutl.ProjectSystem/ProjectSystem/ElementMigration.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/ElementMigration.cs
@@ -39,13 +39,21 @@ internal static class ElementMigration
         new KeyValuePair<string, Type>("[Beutl.Operators].Source:PointLight3DOperator", typeof(PointLight3D)),
         new KeyValuePair<string, Type>("[Beutl.Operators].Source:SpotLight3DOperator", typeof(SpotLight3D)));
 
-    internal static EngineObject[] MigrateFromOperation(IJsonSerializationContext jsonContext)
+    internal static bool TryMigrateFromOperation(
+        IJsonSerializationContext jsonContext,
+        out EngineObject[] migrated)
     {
         if (jsonContext.GetNode("Operation") is not JsonObject operation)
-            return [];
+        {
+            migrated = [];
+            return false;
+        }
 
         if (operation["Children"] is not JsonArray children)
-            return [];
+        {
+            migrated = [];
+            return false;
+        }
 
         var results = new List<EngineObject>();
         foreach (JsonNode? child in children)
@@ -57,7 +65,8 @@ internal static class ElementMigration
             results.Add(engineObject);
         }
 
-        return results.ToArray();
+        migrated = results.ToArray();
+        return true;
     }
 
     private static EngineObject ExtractEngineObjectFromOperator(JsonObject operatorObj,

--- a/src/Beutl.ProjectSystem/Services/ProjectPersistence.cs
+++ b/src/Beutl.ProjectSystem/Services/ProjectPersistence.cs
@@ -55,8 +55,22 @@ internal static class ProjectPersistence
             return;
         }
 
+        string appVersion = project.AppVersion;
+        string minAppVersion = project.MinAppVersion;
         project.Items.Add(item);
-        PersistOrRollback(persist, () => project.Items.Remove(item));
+        PersistOrRollback(
+            persist,
+            () =>
+            {
+                try
+                {
+                    project.Items.Remove(item);
+                }
+                finally
+                {
+                    project.RestoreVersionMetadata(appVersion, minAppVersion);
+                }
+            });
     }
 
     /// <summary>

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -1216,6 +1216,13 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
             }
 
             relocation.Commit();
+            if (scene.RequiredMinAppVersionAfterMigration is not null
+                && scene.HierarchicalParent is Project project
+                && project.Uri is not null)
+            {
+                CoreSerializer.StoreToUri(project, project.Uri);
+            }
+
             viewModel.SaveState(isExplicitUserSave: true);
             viewModel._logger.LogInformation("Scene ({SceneId}) saved successfully.", scene.Id);
 

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -1220,7 +1220,10 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
                 && scene.HierarchicalParent is Project project
                 && project.Uri is not null)
             {
-                CoreSerializer.StoreToUri(project, project.Uri);
+                CoreSerializer.StoreToUri(
+                    project,
+                    project.Uri,
+                    CoreSerializationMode.Write);
             }
 
             viewModel.SaveState(isExplicitUserSave: true);

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -1216,7 +1216,7 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
             }
 
             relocation.Commit();
-            if (scene.RequiredMinAppVersionAfterMigration is not null
+            if (Project.GetRequiredMigrationVersion(scene) is not null
                 && scene.HierarchicalParent is Project project
                 && project.Uri is not null)
             {

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -1203,6 +1203,15 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
                 UnsavedSceneStorage.PrepareSave(scene, sceneUri);
             try
             {
+                // Persist the compatibility gate before replacing any migrated sidecar.
+                // A failed project write must leave the original scene and elements intact.
+                if (Project.GetRequiredMigrationVersion(scene) is not null
+                    && scene.HierarchicalParent is Project project
+                    && project.Uri is not null)
+                {
+                    CoreSerializer.StoreToUri(project, project.Uri, CoreSerializationMode.Write);
+                }
+
                 relocation.Apply();
                 Parallel.ForEach(scene.Children, item => CoreSerializer.StoreToUri(item, item.Uri!));
                 // The scene is the commit record for every child/resource URI. Persist it only
@@ -1216,15 +1225,6 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
             }
 
             relocation.Commit();
-            if (Project.GetRequiredMigrationVersion(scene) is not null
-                && scene.HierarchicalParent is Project project
-                && project.Uri is not null)
-            {
-                CoreSerializer.StoreToUri(
-                    project,
-                    project.Uri,
-                    CoreSerializationMode.Write);
-            }
 
             viewModel.SaveState(isExplicitUserSave: true);
             viewModel._logger.LogInformation("Scene ({SceneId}) saved successfully.", scene.Id);

--- a/tests/Beutl.E2ETests/Scenarios/ProjectPersistenceTests.cs
+++ b/tests/Beutl.E2ETests/Scenarios/ProjectPersistenceTests.cs
@@ -179,7 +179,7 @@ public class ProjectPersistenceTests
         public override void Deserialize(ICoreSerializationContext context)
         {
             base.Deserialize(context);
-            ReportPersistedContentMigration(Project.DefaultMinAppVersion);
+            context.ReportPersistedContentMigration(Project.DefaultMinAppVersion);
         }
     }
 }

--- a/tests/Beutl.E2ETests/Scenarios/ProjectPersistenceTests.cs
+++ b/tests/Beutl.E2ETests/Scenarios/ProjectPersistenceTests.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.Graphics.Shapes;
+﻿using System.Text.Json.Nodes;
+using Beutl.Graphics.Shapes;
 using Beutl.Media;
 using Beutl.ProjectSystem;
 using Beutl.Serialization;
@@ -140,5 +141,45 @@ public class ProjectPersistenceTests
             Assert.That(secondScene.Children, Has.Count.EqualTo(1));
             Assert.That(secondScene.Children[0].Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
         });
+    }
+
+    [TestCase("1.0.0", Project.DefaultMinAppVersion)]
+    [TestCase("2.0.0-alpha.1", Project.DefaultMinAppVersion)]
+    [TestCase("2.0.0-preview.2", "2.0.0-preview.2")]
+    [TestCase("2.0.0", "2.0.0")]
+    [TestCase("2.1.0", "2.1.0")]
+    [TestCase("10.0.0", "10.0.0")]
+    [TestCase("unknown-version", "unknown-version")]
+    [TestCase("1.0.0+", "1.0.0+")]
+    [TestCase("1.0.0-alpha..1", "1.0.0-alpha..1")]
+    public void External_project_item_migration_does_not_weaken_minimum_app_version(
+        string persistedMinAppVersion,
+        string expectedMinAppVersion)
+    {
+        var project = new Project();
+        project.Items.Add(new ExternalMigratingProjectItem());
+        JsonObject json = CoreSerializer.SerializeToJsonObject(project);
+        json["appVersion"] = "1.0.0";
+        json["minAppVersion"] = persistedMinAppVersion;
+
+        var restored = (Project)CoreSerializer.DeserializeFromJsonObject(json, typeof(Project));
+        JsonObject migrated = CoreSerializer.SerializeToJsonObject(restored);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(restored.Items.Single(), Is.TypeOf<ExternalMigratingProjectItem>());
+            Assert.That(restored.AppVersion, Is.EqualTo(BeutlApplication.Version));
+            Assert.That(restored.MinAppVersion, Is.EqualTo(expectedMinAppVersion));
+            Assert.That((string?)migrated["minAppVersion"], Is.EqualTo(expectedMinAppVersion));
+        });
+    }
+
+    public sealed class ExternalMigratingProjectItem : ProjectItem
+    {
+        public override void Deserialize(ICoreSerializationContext context)
+        {
+            base.Deserialize(context);
+            ReportPersistedContentMigration(Project.DefaultMinAppVersion);
+        }
     }
 }

--- a/tests/Beutl.HeadlessUITests/ContextCommandDispatchTests.cs
+++ b/tests/Beutl.HeadlessUITests/ContextCommandDispatchTests.cs
@@ -132,11 +132,12 @@ public class ContextCommandDispatchTests
             HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-            adder.AddElement(new ElementDescription(
+            await adder.AddAsync([new ElementDescription(
                 Start: TimeSpan.Zero,
                 Length: TimeSpan.FromSeconds(1),
                 Layer: 0,
-                EngineObjectFactory: () => new RectShape()));
+                Source: new ElementSource.EngineObject(() => new RectShape()))],
+                CancellationToken.None);
             HeadlessTestHelpers.Settle();
             TimelineTabViewModel timeline = editor.FindToolTab<TimelineTabViewModel>()!;
             ElementViewModel target = timeline.Elements.Single();
@@ -182,11 +183,12 @@ public class ContextCommandDispatchTests
             HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-            adder.AddElement(new ElementDescription(
+            await adder.AddAsync([new ElementDescription(
                 Start: TimeSpan.Zero,
                 Length: TimeSpan.FromSeconds(1),
                 Layer: 0,
-                EngineObjectFactory: () => new RectShape()));
+                Source: new ElementSource.EngineObject(() => new RectShape()))],
+                CancellationToken.None);
             HeadlessTestHelpers.Settle();
             TimelineTabViewModel timeline = editor.FindToolTab<TimelineTabViewModel>()!;
             ElementViewModel target = timeline.Elements.Single();

--- a/tests/Beutl.HeadlessUITests/SaveRoundTripTests.cs
+++ b/tests/Beutl.HeadlessUITests/SaveRoundTripTests.cs
@@ -114,16 +114,28 @@ public class SaveRoundTripTests
         Project project = (await TestShell.Project.CreateProject(
             640, 480, 30, 44100, "migrated-save", NewWorkspace("migrated-save")))!;
         string projectFile = project.Uri!.LocalPath;
-        string sceneFile = project.Items.OfType<Scene>().Single().Uri!.LocalPath;
+        Scene sourceScene = project.Items.OfType<Scene>().Single();
+        TestShell.Editor.ActivateTabItem(sourceScene);
+        HeadlessTestHelpers.Settle();
+        var sourceEditor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+        var adder = (IElementAdder)sourceEditor.GetService(typeof(IElementAdder))!;
+        adder.AddElement(new ElementDescription(
+            Start: TimeSpan.Zero,
+            Length: TimeSpan.FromSeconds(1),
+            Layer: 0,
+            EngineObjectFactory: () => new RectShape()));
+        HeadlessTestHelpers.Settle();
+        Assert.That(await sourceEditor.Commands!.OnSave(), Is.True);
+        string elementFile = sourceScene.Children.Single().Uri!.LocalPath;
         await ResetProjectAsync();
 
         JsonObject projectJson = JsonNode.Parse(File.ReadAllText(projectFile))!.AsObject();
         projectJson["appVersion"] = "1.0.0";
         projectJson["minAppVersion"] = "1.0.0";
         projectJson.JsonSave(projectFile);
-        JsonObject sceneJson = JsonNode.Parse(File.ReadAllText(sceneFile))!.AsObject();
-        sceneJson.Remove("$type");
-        sceneJson.JsonSave(sceneFile);
+        JsonObject elementJson = JsonNode.Parse(File.ReadAllText(elementFile))!.AsObject();
+        elementJson.Remove("$type");
+        elementJson.JsonSave(elementFile);
 
         await TestShell.Project.OpenProject(projectFile);
         Scene migratedScene = TestShell.Project.CurrentProject.Value!.Items

--- a/tests/Beutl.HeadlessUITests/SaveRoundTripTests.cs
+++ b/tests/Beutl.HeadlessUITests/SaveRoundTripTests.cs
@@ -1,8 +1,10 @@
-﻿using Avalonia.Headless.NUnit;
+﻿using System.Text.Json.Nodes;
+using Avalonia.Headless.NUnit;
 using Beutl.Editor.Models;
 using Beutl.Editor.Services;
 using Beutl.Graphics.Shapes;
 using Beutl.ProjectSystem;
+using Beutl.Serialization;
 using Beutl.Services;
 using Beutl.Testing.Headless;
 using Beutl.ViewModels;
@@ -102,5 +104,44 @@ public class SaveRoundTripTests
         Assert.That(saved, Is.True);
         Assert.That(File.Exists(element.Uri!.LocalPath), Is.True);
         Assert.That(new FileInfo(element.Uri!.LocalPath).Length, Is.GreaterThan(0));
+    }
+
+    [AvaloniaTest]
+    public async Task Saving_a_migrated_scene_persists_project_version_metadata()
+    {
+        await ResetProjectAsync();
+
+        Project project = (await TestShell.Project.CreateProject(
+            640, 480, 30, 44100, "migrated-save", NewWorkspace("migrated-save")))!;
+        string projectFile = project.Uri!.LocalPath;
+        string sceneFile = project.Items.OfType<Scene>().Single().Uri!.LocalPath;
+        await ResetProjectAsync();
+
+        JsonObject projectJson = JsonNode.Parse(File.ReadAllText(projectFile))!.AsObject();
+        projectJson["appVersion"] = "1.0.0";
+        projectJson["minAppVersion"] = "1.0.0";
+        projectJson.JsonSave(projectFile);
+        JsonObject sceneJson = JsonNode.Parse(File.ReadAllText(sceneFile))!.AsObject();
+        sceneJson.Remove("$type");
+        sceneJson.JsonSave(sceneFile);
+
+        await TestShell.Project.OpenProject(projectFile);
+        Scene migratedScene = TestShell.Project.CurrentProject.Value!.Items
+            .OfType<Scene>()
+            .Single();
+        TestShell.Editor.ActivateTabItem(migratedScene);
+        HeadlessTestHelpers.Settle();
+        var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+
+        Assert.That(await editor.Commands!.OnSave(), Is.True);
+        JsonObject savedProject = JsonNode.Parse(File.ReadAllText(projectFile))!.AsObject();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That((string?)savedProject["appVersion"], Is.EqualTo(BeutlApplication.Version));
+            Assert.That(
+                (string?)savedProject["minAppVersion"],
+                Is.EqualTo(Project.DefaultMinAppVersion));
+        });
     }
 }

--- a/tests/Beutl.HeadlessUITests/SaveRoundTripTests.cs
+++ b/tests/Beutl.HeadlessUITests/SaveRoundTripTests.cs
@@ -107,7 +107,9 @@ public class SaveRoundTripTests
     }
 
     [AvaloniaTest]
-    public async Task Saving_a_migrated_scene_persists_project_version_metadata()
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task Saving_a_migrated_scene_persists_project_version_metadata(bool failProjectWrite)
     {
         await ResetProjectAsync();
 
@@ -119,11 +121,12 @@ public class SaveRoundTripTests
         HeadlessTestHelpers.Settle();
         var sourceEditor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
         var adder = (IElementAdder)sourceEditor.GetService(typeof(IElementAdder))!;
-        adder.AddElement(new ElementDescription(
+        await adder.AddAsync([new ElementDescription(
             Start: TimeSpan.Zero,
             Length: TimeSpan.FromSeconds(1),
             Layer: 0,
-            EngineObjectFactory: () => new RectShape()));
+            Source: new ElementSource.EngineObject(() => new RectShape()))],
+            CancellationToken.None);
         HeadlessTestHelpers.Settle();
         Assert.That(await sourceEditor.Commands!.OnSave(), Is.True);
         string elementFile = sourceScene.Children.Single().Uri!.LocalPath;
@@ -162,6 +165,39 @@ public class SaveRoundTripTests
         TestShell.Editor.ActivateTabItem(migratedScene);
         HeadlessTestHelpers.Settle();
         var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+
+        if (failProjectWrite)
+        {
+            Project currentProject = TestShell.Project.CurrentProject.Value!;
+            Uri originalUri = currentProject.Uri!;
+            byte[] projectBefore = File.ReadAllBytes(projectFile);
+            byte[] sceneBefore = File.ReadAllBytes(migratedScene.Uri!.LocalPath);
+            byte[] elementBefore = File.ReadAllBytes(elementFile);
+            // An existing file cannot serve as the destination's parent directory.
+            currentProject.Uri = new Uri(Path.Combine(projectFile, "blocked.bep"));
+            Exception? failure = null;
+            try
+            {
+                await editor.Commands!.OnSave();
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+            finally
+            {
+                currentProject.Uri = originalUri;
+            }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(failure, Is.Not.Null);
+                Assert.That(File.ReadAllBytes(projectFile), Is.EqualTo(projectBefore));
+                Assert.That(File.ReadAllBytes(migratedScene.Uri.LocalPath), Is.EqualTo(sceneBefore));
+                Assert.That(File.ReadAllBytes(elementFile), Is.EqualTo(elementBefore));
+            });
+            return;
+        }
 
         Assert.That(await editor.Commands!.OnSave(), Is.True);
         JsonObject savedProject = JsonNode.Parse(File.ReadAllText(projectFile))!.AsObject();

--- a/tests/Beutl.HeadlessUITests/SaveRoundTripTests.cs
+++ b/tests/Beutl.HeadlessUITests/SaveRoundTripTests.cs
@@ -107,9 +107,10 @@ public class SaveRoundTripTests
     }
 
     [AvaloniaTest]
-    [TestCase(false)]
-    [TestCase(true)]
-    public async Task Saving_a_migrated_scene_persists_project_version_metadata(bool failProjectWrite)
+    [TestCase(0)]
+    [TestCase(1)]
+    [TestCase(2)]
+    public async Task Saving_a_migrated_scene_persists_project_version_metadata(int failureStage)
     {
         await ResetProjectAsync();
 
@@ -166,15 +167,19 @@ public class SaveRoundTripTests
         HeadlessTestHelpers.Settle();
         var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
 
-        if (failProjectWrite)
+        if (failureStage != 0)
         {
             Project currentProject = TestShell.Project.CurrentProject.Value!;
             Uri originalUri = currentProject.Uri!;
+            Uri originalSceneUri = migratedScene.Uri!;
             byte[] projectBefore = File.ReadAllBytes(projectFile);
             byte[] sceneBefore = File.ReadAllBytes(migratedScene.Uri!.LocalPath);
             byte[] elementBefore = File.ReadAllBytes(elementFile);
             // An existing file cannot serve as the destination's parent directory.
-            currentProject.Uri = new Uri(Path.Combine(projectFile, "blocked.bep"));
+            if (failureStage == 1)
+                currentProject.Uri = new Uri(Path.Combine(projectFile, "blocked.bep"));
+            else
+                migratedScene.Uri = new Uri(Path.Combine(projectFile, "blocked.scene"));
             Exception? failure = null;
             try
             {
@@ -187,14 +192,27 @@ public class SaveRoundTripTests
             finally
             {
                 currentProject.Uri = originalUri;
+                migratedScene.Uri = originalSceneUri;
             }
 
             Assert.Multiple(() =>
             {
                 Assert.That(failure, Is.Not.Null);
-                Assert.That(File.ReadAllBytes(projectFile), Is.EqualTo(projectBefore));
                 Assert.That(File.ReadAllBytes(migratedScene.Uri.LocalPath), Is.EqualTo(sceneBefore));
-                Assert.That(File.ReadAllBytes(elementFile), Is.EqualTo(elementBefore));
+                if (failureStage == 1)
+                {
+                    Assert.That(File.ReadAllBytes(projectFile), Is.EqualTo(projectBefore));
+                    Assert.That(File.ReadAllBytes(elementFile), Is.EqualTo(elementBefore));
+                }
+                else
+                {
+                    // The element write succeeded before the scene failed. Lowering the
+                    // project gate here would expose migrated bytes to older applications.
+                    JsonObject persistedProject = JsonNode.Parse(File.ReadAllText(projectFile))!.AsObject();
+                    Assert.That((string?)persistedProject["minAppVersion"],
+                        Is.EqualTo(Project.DefaultMinAppVersion));
+                    Assert.That(JsonNode.Parse(File.ReadAllText(elementFile))!["$type"], Is.Not.Null);
+                }
             });
             return;
         }

--- a/tests/Beutl.HeadlessUITests/SaveRoundTripTests.cs
+++ b/tests/Beutl.HeadlessUITests/SaveRoundTripTests.cs
@@ -127,6 +127,20 @@ public class SaveRoundTripTests
         HeadlessTestHelpers.Settle();
         Assert.That(await sourceEditor.Commands!.OnSave(), Is.True);
         string elementFile = sourceScene.Children.Single().Uri!.LocalPath;
+        var unrelatedScene = new Scene
+        {
+            Name = "unrelated-original",
+            Uri = new Uri(Path.Combine(
+                Path.GetDirectoryName(projectFile)!,
+                "unrelated.scene")),
+        };
+        Guid unrelatedSceneId = unrelatedScene.Id;
+        project.Items.Add(unrelatedScene);
+        CoreSerializer.StoreToUri(unrelatedScene, unrelatedScene.Uri);
+        CoreSerializer.StoreToUri(
+            project,
+            project.Uri,
+            CoreSerializationMode.Write);
         await ResetProjectAsync();
 
         JsonObject projectJson = JsonNode.Parse(File.ReadAllText(projectFile))!.AsObject();
@@ -140,13 +154,18 @@ public class SaveRoundTripTests
         await TestShell.Project.OpenProject(projectFile);
         Scene migratedScene = TestShell.Project.CurrentProject.Value!.Items
             .OfType<Scene>()
-            .Single();
+            .Single(scene => scene.Id == sourceScene.Id);
+        Scene unrelated = TestShell.Project.CurrentProject.Value.Items
+            .OfType<Scene>()
+            .Single(scene => scene.Id == unrelatedSceneId);
+        unrelated.Name = "unrelated-unsaved";
         TestShell.Editor.ActivateTabItem(migratedScene);
         HeadlessTestHelpers.Settle();
         var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
 
         Assert.That(await editor.Commands!.OnSave(), Is.True);
         JsonObject savedProject = JsonNode.Parse(File.ReadAllText(projectFile))!.AsObject();
+        Scene persistedUnrelated = CoreSerializer.RestoreFromUri<Scene>(unrelated.Uri!);
 
         Assert.Multiple(() =>
         {
@@ -154,6 +173,7 @@ public class SaveRoundTripTests
             Assert.That(
                 (string?)savedProject["minAppVersion"],
                 Is.EqualTo(Project.DefaultMinAppVersion));
+            Assert.That(persistedUnrelated.Name, Is.EqualTo("unrelated-original"));
         });
     }
 }

--- a/tests/Beutl.PublicApiContractTests/Beutl.PublicApiContractTests.csproj
+++ b/tests/Beutl.PublicApiContractTests/Beutl.PublicApiContractTests.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\..\src\Beutl.Api\Beutl.Api.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Editor\Beutl.Editor.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Extensibility\Beutl.Extensibility.csproj" />
+    <ProjectReference Include="..\..\src\Beutl.ProjectSystem\Beutl.ProjectSystem.csproj" />
     <!-- Match the analyzer reference used by out-of-tree plugins. -->
     <ProjectReference Include="..\..\src\Beutl.Engine.SourceGenerators\Beutl.Engine.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/tests/Beutl.PublicApiContractTests/PersistedContentMigrationContractTests.cs
+++ b/tests/Beutl.PublicApiContractTests/PersistedContentMigrationContractTests.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.ProjectSystem;
+﻿using System.Text.Json.Nodes;
+using Beutl.ProjectSystem;
 using Beutl.Serialization;
 
 namespace Beutl.PublicApiContractTests;
@@ -7,42 +8,55 @@ namespace Beutl.PublicApiContractTests;
 public sealed class PersistedContentMigrationContractTests : PublicApiContractTestBase
 {
     [Test]
-    public void Plugin_project_items_and_elements_can_report_required_migration_versions()
+    public void Plugin_serializable_types_can_report_required_migration_versions()
     {
         AssertDoesNotHaveFriendAccess(typeof(Project).Assembly);
         AssertDoesNotHaveFriendAccess(typeof(Element).Assembly);
         string root = Path.Combine(
             Path.GetTempPath(),
             $"migration-contract-{Guid.NewGuid():N}");
-        var project = new Project { Uri = new Uri(Path.Combine(root, "project.bep")) };
-        var scene = new MigratingSceneItem
+        var source = new MigratingSceneItem
         {
             Uri = new Uri(Path.Combine(root, "scene.scene")),
+            Child = new MigratingLeaf(),
         };
-        project.Items.Add(scene);
-        scene.AddChild(new MigratingElement
-        {
-            Uri = new Uri(Path.Combine(root, "element.belm")),
-        });
-
-        CoreSerializer.SerializeToJsonObject(project);
+        JsonObject json = CoreSerializer.SerializeToJsonObject(source);
+        var restored = (MigratingSceneItem)CoreSerializer.DeserializeFromJsonObject(
+            json,
+            typeof(ProjectItem));
+        var project = new Project { Uri = new Uri(Path.Combine(root, "project.bep")) };
+        project.Items.Add(restored);
 
         Assert.That(project.MinAppVersion, Is.EqualTo("8.0.0"));
     }
 
     private sealed class MigratingSceneItem : Scene
     {
-        public MigratingSceneItem()
+        public MigratingLeaf? Child { get; set; }
+
+        public override void Serialize(ICoreSerializationContext context)
         {
-            ReportPersistedContentMigration("7.0.0");
+            base.Serialize(context);
+            context.SetValue(nameof(Child), Child);
+        }
+
+        public override void Deserialize(ICoreSerializationContext context)
+        {
+            base.Deserialize(context);
+            context.ReportPersistedContentMigration("7.0.0");
+            Child = context.GetValue<MigratingLeaf>(nameof(Child));
         }
     }
 
-    private sealed class MigratingElement : Element
+    private sealed class MigratingLeaf : ICoreSerializable
     {
-        public MigratingElement()
+        public void Serialize(ICoreSerializationContext context)
         {
-            ReportPersistedContentMigration("8.0.0");
+        }
+
+        public void Deserialize(ICoreSerializationContext context)
+        {
+            context.ReportPersistedContentMigration("8.0.0");
         }
     }
 }

--- a/tests/Beutl.PublicApiContractTests/PersistedContentMigrationContractTests.cs
+++ b/tests/Beutl.PublicApiContractTests/PersistedContentMigrationContractTests.cs
@@ -26,9 +26,7 @@ public sealed class PersistedContentMigrationContractTests : PublicApiContractTe
             typeof(ProjectItem));
         var project = new Project { Uri = new Uri(Path.Combine(root, "project.bep")) };
         project.Items.Add(restored);
-        var manualContext = new JsonSerializationContext(
-            typeof(MigratingLeaf),
-            options: new CoreSerializerOptions { Mode = CoreSerializationMode.Read });
+        var manualContext = new JsonSerializationContext(typeof(MigratingLeaf));
 
         Assert.Multiple(() =>
         {

--- a/tests/Beutl.PublicApiContractTests/PersistedContentMigrationContractTests.cs
+++ b/tests/Beutl.PublicApiContractTests/PersistedContentMigrationContractTests.cs
@@ -1,4 +1,4 @@
-using Beutl.ProjectSystem;
+﻿using Beutl.ProjectSystem;
 using Beutl.Serialization;
 
 namespace Beutl.PublicApiContractTests;
@@ -11,10 +11,19 @@ public sealed class PersistedContentMigrationContractTests : PublicApiContractTe
     {
         AssertDoesNotHaveFriendAccess(typeof(Project).Assembly);
         AssertDoesNotHaveFriendAccess(typeof(Element).Assembly);
-        var project = new Project();
-        var scene = new MigratingSceneItem();
+        string root = Path.Combine(
+            Path.GetTempPath(),
+            $"migration-contract-{Guid.NewGuid():N}");
+        var project = new Project { Uri = new Uri(Path.Combine(root, "project.bep")) };
+        var scene = new MigratingSceneItem
+        {
+            Uri = new Uri(Path.Combine(root, "scene.scene")),
+        };
         project.Items.Add(scene);
-        scene.AddChild(new MigratingElement());
+        scene.AddChild(new MigratingElement
+        {
+            Uri = new Uri(Path.Combine(root, "element.belm")),
+        });
 
         CoreSerializer.SerializeToJsonObject(project);
 

--- a/tests/Beutl.PublicApiContractTests/PersistedContentMigrationContractTests.cs
+++ b/tests/Beutl.PublicApiContractTests/PersistedContentMigrationContractTests.cs
@@ -26,8 +26,15 @@ public sealed class PersistedContentMigrationContractTests : PublicApiContractTe
             typeof(ProjectItem));
         var project = new Project { Uri = new Uri(Path.Combine(root, "project.bep")) };
         project.Items.Add(restored);
+        var manualContext = new JsonSerializationContext(
+            typeof(MigratingLeaf),
+            options: new CoreSerializerOptions { Mode = CoreSerializationMode.Read });
 
-        Assert.That(project.MinAppVersion, Is.EqualTo("8.0.0"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(project.MinAppVersion, Is.EqualTo("8.0.0"));
+            Assert.DoesNotThrow(() => new MigratingLeaf().Deserialize(manualContext));
+        });
     }
 
     private sealed class MigratingSceneItem : Scene

--- a/tests/Beutl.PublicApiContractTests/PersistedContentMigrationContractTests.cs
+++ b/tests/Beutl.PublicApiContractTests/PersistedContentMigrationContractTests.cs
@@ -1,0 +1,39 @@
+using Beutl.ProjectSystem;
+using Beutl.Serialization;
+
+namespace Beutl.PublicApiContractTests;
+
+[TestFixture]
+public sealed class PersistedContentMigrationContractTests : PublicApiContractTestBase
+{
+    [Test]
+    public void Plugin_project_items_and_elements_can_report_required_migration_versions()
+    {
+        AssertDoesNotHaveFriendAccess(typeof(Project).Assembly);
+        AssertDoesNotHaveFriendAccess(typeof(Element).Assembly);
+        var project = new Project();
+        var scene = new MigratingSceneItem();
+        project.Items.Add(scene);
+        scene.AddChild(new MigratingElement());
+
+        CoreSerializer.SerializeToJsonObject(project);
+
+        Assert.That(project.MinAppVersion, Is.EqualTo("8.0.0"));
+    }
+
+    private sealed class MigratingSceneItem : Scene
+    {
+        public MigratingSceneItem()
+        {
+            ReportPersistedContentMigration("7.0.0");
+        }
+    }
+
+    private sealed class MigratingElement : Element
+    {
+        public MigratingElement()
+        {
+            ReportPersistedContentMigration("8.0.0");
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Core/ProjectMutateAndPersistTests.cs
+++ b/tests/Beutl.UnitTests/Core/ProjectMutateAndPersistTests.cs
@@ -11,9 +11,10 @@ public class ProjectMutateAndPersistTests
 
     private sealed class MigratingProjectItem : ProjectItem
     {
-        public MigratingProjectItem()
+        public override void Deserialize(ICoreSerializationContext context)
         {
-            ReportPersistedContentMigration("9.0.0");
+            base.Deserialize(context);
+            context.ReportPersistedContentMigration("9.0.0");
         }
     }
 
@@ -52,7 +53,9 @@ public class ProjectMutateAndPersistTests
         var project = new Project();
         string appVersion = project.AppVersion;
         string minAppVersion = project.MinAppVersion;
-        var item = new MigratingProjectItem();
+        var item = (MigratingProjectItem)CoreSerializer.DeserializeFromJsonObject(
+            CoreSerializer.SerializeToJsonObject(new MigratingProjectItem()),
+            typeof(MigratingProjectItem));
 
         Assert.Throws<InvalidOperationException>(() =>
             ProjectPersistence.AddItemAndPersist(

--- a/tests/Beutl.UnitTests/Core/ProjectMutateAndPersistTests.cs
+++ b/tests/Beutl.UnitTests/Core/ProjectMutateAndPersistTests.cs
@@ -9,6 +9,14 @@ public class ProjectMutateAndPersistTests
     {
     }
 
+    private sealed class MigratingProjectItem : ProjectItem
+    {
+        public MigratingProjectItem()
+        {
+            ReportPersistedContentMigration("9.0.0");
+        }
+    }
+
     [Test]
     public void AddItemAndPersist_NewItemPersistSucceeds_ItemAdded()
     {
@@ -36,6 +44,28 @@ public class ProjectMutateAndPersistTests
         Assert.That(project.Items, Does.Not.Contain(item));
         // Rolling back must also detach the parent.
         Assert.That(item.HierarchicalParent, Is.Null);
+    }
+
+    [Test]
+    public void AddItemAndPersist_MigratedItemPersistThrows_VersionMetadataRolledBack()
+    {
+        var project = new Project();
+        string appVersion = project.AppVersion;
+        string minAppVersion = project.MinAppVersion;
+        var item = new MigratingProjectItem();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            ProjectPersistence.AddItemAndPersist(
+                project,
+                item,
+                () => throw new InvalidOperationException("disk full")));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project.Items, Does.Not.Contain(item));
+            Assert.That(project.AppVersion, Is.EqualTo(appVersion));
+            Assert.That(project.MinAppVersion, Is.EqualTo(minAppVersion));
+        });
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/ProjectSystem/NoMigrationRegressionTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/NoMigrationRegressionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using System.Text.Json.Nodes;
+using Beutl.Editor;
 using Beutl.Graphics;
 using Beutl.Graphics.Effects;
 using Beutl.Graphics.Shapes;
@@ -254,6 +255,43 @@ public class NoMigrationRegressionTests
     }
 
     [Test]
+    public void Failed_legacy_population_does_not_mark_the_retained_object_as_migrated()
+    {
+        string path = Path.Combine(_tempDirectory, "legacy-failure.scene");
+        JsonObject json = CoreSerializer.SerializeToJsonObject(
+            new ThrowingLegacyProjectItem());
+        json.Remove("$type");
+        json.JsonSave(path);
+        var retained = new ThrowingLegacyProjectItem();
+        var project = new Project();
+        project.RestoreVersionMetadata("3.1.4", "1.0.0");
+        project.Items.Add(retained);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            CoreSerializer.PopulateFromUri(
+                retained,
+                typeof(ProjectItem),
+                new Uri(path)));
+        JsonObject serialized = CoreSerializer.SerializeToJsonObject(project);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project.AppVersion, Is.EqualTo("3.1.4"));
+            Assert.That(project.MinAppVersion, Is.EqualTo("1.0.0"));
+            Assert.That((string?)serialized["appVersion"], Is.EqualTo("3.1.4"));
+            Assert.That((string?)serialized["minAppVersion"], Is.EqualTo("1.0.0"));
+        });
+    }
+
+    [Test]
+    public void Serialization_graph_accepts_temporary_migration_reports()
+    {
+        Assert.DoesNotThrow(() =>
+            VersionControlSerializationGraph.DiscoverSerializationGraph(
+                new MigrationNodeContainer()));
+    }
+
+    [Test]
     public void PopulateFromUri_reports_a_legacy_discriminator_migration()
     {
         string scenePath = Path.Combine(_tempDirectory, "legacy.scene");
@@ -492,6 +530,31 @@ public class NoMigrationRegressionTests
             base.Deserialize(context);
             context.ReportPersistedContentMigration("9.0.0");
             throw new InvalidOperationException("migration failed");
+        }
+    }
+
+    private sealed class ThrowingLegacyProjectItem : ProjectItem
+    {
+        public override void Deserialize(ICoreSerializationContext context)
+        {
+            base.Deserialize(context);
+            throw new InvalidOperationException("legacy population failed");
+        }
+    }
+
+    private sealed class MigrationNodeContainer : ProjectItem
+    {
+        public override void Serialize(ICoreSerializationContext context)
+        {
+            base.Serialize(context);
+            var jsonContext = (IJsonSerializationContext)context;
+            JsonObject child = CoreSerializer.SerializeToJsonObject(
+                new MigratingLeaf("7.0.0"));
+            jsonContext.SetNode(
+                "MigrationAwareChild",
+                typeof(MigratingLeaf),
+                typeof(MigratingLeaf),
+                child);
         }
     }
 

--- a/tests/Beutl.UnitTests/ProjectSystem/NoMigrationRegressionTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/NoMigrationRegressionTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Nodes;
 using Beutl.Graphics;
 using Beutl.Graphics.Effects;
 using Beutl.Graphics.Shapes;
+using Beutl.ProjectSystem;
 using Beutl.Serialization;
 
 namespace Beutl.UnitTests.ProjectSystem;
@@ -80,7 +81,7 @@ public class NoMigrationRegressionTests
             source,
             new CoreSerializerOptions { BaseUri = source.Uri });
         json["appVersion"] = "3.1.4";
-        json["minAppVersion"] = "2.0.0-preview.1";
+        json["minAppVersion"] = Project.DefaultMinAppVersion;
         json.JsonSave(path);
         byte[] before = File.ReadAllBytes(path);
 
@@ -115,5 +116,190 @@ public class NoMigrationRegressionTests
             Assert.That(text, Does.Not.Contain("\r\n"));
             Assert.That(bytes, Has.None.EqualTo((byte)'\r'));
         });
+    }
+
+    [Test]
+    public void Project_marked_as_migrated_advances_app_version()
+    {
+        string path = Path.Combine(_tempDirectory, "project.bep");
+        var source = new Project
+        {
+            Uri = new Uri(path),
+        };
+        JsonObject json = CoreSerializer.SerializeToJsonObject(
+            source,
+            new CoreSerializerOptions { BaseUri = source.Uri });
+        json["appVersion"] = "3.1.4";
+        json.JsonSave(path);
+        Project restored = CoreSerializer.RestoreFromUri<Project>(new Uri(path));
+
+        restored.MarkAsMigrated();
+        JsonObject migrated = CoreSerializer.SerializeToJsonObject(restored);
+
+        Assert.That((string?)migrated["appVersion"], Is.EqualTo(BeutlApplication.Version));
+    }
+
+    [Test]
+    public void Project_aggregates_migration_versions_from_items_attached_after_loading()
+    {
+        string path = Path.Combine(_tempDirectory, "project.bep");
+        var source = new Project { Uri = new Uri(path) };
+        JsonObject json = CoreSerializer.SerializeToJsonObject(
+            source,
+            new CoreSerializerOptions { BaseUri = source.Uri });
+        json["appVersion"] = "3.1.4";
+        json["minAppVersion"] = Project.DefaultMinAppVersion;
+        json.JsonSave(path);
+        Project restored = CoreSerializer.RestoreFromUri<Project>(new Uri(path));
+
+        restored.Items.Add(new MigratedProjectItem("4.2.0"));
+        restored.Items.Add(new MigratedProjectItem("5.1.0"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(restored.AppVersion, Is.EqualTo(BeutlApplication.Version));
+            Assert.That(restored.MinAppVersion, Is.EqualTo("5.1.0"));
+        });
+    }
+
+    [Test]
+    public void Project_serialization_aggregates_plugin_element_migrations()
+    {
+        var project = new Project();
+        var scene = new Scene();
+        project.Items.Add(scene);
+        scene.AddChild(new MigratedElement("6.0.0"));
+
+        JsonObject json = CoreSerializer.SerializeToJsonObject(project);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project.MinAppVersion, Is.EqualTo("6.0.0"));
+            Assert.That((string?)json["minAppVersion"], Is.EqualTo("6.0.0"));
+        });
+    }
+
+    [TestCase(true, false)]
+    [TestCase(false, true)]
+    public void Project_with_legacy_sidecar_discriminator_advances_app_version(
+        bool removeSceneDiscriminator,
+        bool removeElementDiscriminator)
+    {
+        (string projectPath, string scenePath, string elementPath) = CreateProjectWithSidecars();
+        SetPersistedAppVersion(projectPath, "1.0.0");
+        if (removeSceneDiscriminator)
+        {
+            JsonObject sceneJson = JsonNode.Parse(File.ReadAllText(scenePath))!.AsObject();
+            sceneJson.Remove("$type");
+            sceneJson.JsonSave(scenePath);
+        }
+
+        if (removeElementDiscriminator)
+        {
+            JsonObject elementJson = JsonNode.Parse(File.ReadAllText(elementPath))!.AsObject();
+            elementJson.Remove("$type");
+            elementJson.JsonSave(elementPath);
+        }
+
+        Project restored = CoreSerializer.RestoreFromUri<Project>(new Uri(projectPath));
+
+        Assert.That(restored.AppVersion, Is.EqualTo(BeutlApplication.Version));
+    }
+
+    [Test]
+    public void Project_with_current_sidecars_preserves_loaded_app_version()
+    {
+        (string projectPath, _, _) = CreateProjectWithSidecars();
+        SetPersistedAppVersion(projectPath, "3.1.4");
+
+        Project restored = CoreSerializer.RestoreFromUri<Project>(new Uri(projectPath));
+        CoreSerializer.StoreToUri(restored, new Uri(projectPath));
+        JsonObject resaved = JsonNode.Parse(File.ReadAllText(projectPath))!.AsObject();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(restored.AppVersion, Is.EqualTo("3.1.4"));
+            Assert.That((string?)resaved["appVersion"], Is.EqualTo("3.1.4"));
+        });
+    }
+
+    [TestCase(typeof(ProjectItem))]
+    [TestCase(typeof(Element))]
+    public void Present_unresolvable_sidecar_discriminator_is_not_treated_as_legacy(Type type)
+    {
+        const string unknownDiscriminator = "[Missing.Extension]Missing.Extension:UnknownItem";
+        string path = Path.Combine(_tempDirectory, "unknown-sidecar.json");
+        var json = new JsonObject
+        {
+            ["$type"] = unknownDiscriminator,
+        };
+        json.JsonSave(path);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            CoreSerializer.RestoreFromUri(new Uri(path), type));
+
+        JsonObject preserved = JsonNode.Parse(File.ReadAllText(path))!.AsObject();
+        Assert.That((string?)preserved["$type"], Is.EqualTo(unknownDiscriminator));
+    }
+
+    [Test]
+    public void Project_with_empty_legacy_operation_advances_app_version()
+    {
+        (string projectPath, _, string elementPath) = CreateProjectWithSidecars();
+        SetPersistedAppVersion(projectPath, "1.0.0");
+        JsonObject elementJson = JsonNode.Parse(File.ReadAllText(elementPath))!.AsObject();
+        elementJson.Remove(nameof(Element.Objects));
+        elementJson["Operation"] = new JsonObject
+        {
+            ["Children"] = new JsonArray(),
+        };
+        elementJson.JsonSave(elementPath);
+
+        Project restored = CoreSerializer.RestoreFromUri<Project>(new Uri(projectPath));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(restored.AppVersion, Is.EqualTo(BeutlApplication.Version));
+            Assert.That(((Scene)restored.Items.Single()).Children.Single().Objects, Is.Empty);
+        });
+    }
+
+    private (string ProjectPath, string ScenePath, string ElementPath) CreateProjectWithSidecars()
+    {
+        string projectPath = Path.Combine(_tempDirectory, "project.bep");
+        string scenePath = Path.Combine(_tempDirectory, "scene", "scene.scene");
+        string elementPath = Path.Combine(_tempDirectory, "scene", "element.belm");
+        var source = new Project { Uri = new Uri(projectPath) };
+        var scene = new Scene { Uri = new Uri(scenePath) };
+        scene.AddChild(new Element { Uri = new Uri(elementPath) });
+        source.Items.Add(scene);
+        CoreSerializer.StoreToUri(
+            source,
+            source.Uri,
+            CoreSerializationMode.Write | CoreSerializationMode.SaveReferencedObjects);
+        return (projectPath, scenePath, elementPath);
+    }
+
+    private static void SetPersistedAppVersion(string projectPath, string version)
+    {
+        JsonObject projectJson = JsonNode.Parse(File.ReadAllText(projectPath))!.AsObject();
+        projectJson["appVersion"] = version;
+        projectJson.JsonSave(projectPath);
+    }
+
+    private sealed class MigratedProjectItem : ProjectItem
+    {
+        public MigratedProjectItem(string requiredVersion)
+        {
+            ReportPersistedContentMigration(requiredVersion);
+        }
+    }
+
+    private sealed class MigratedElement : Element
+    {
+        public MigratedElement(string requiredVersion)
+        {
+            ReportPersistedContentMigration(requiredVersion);
+        }
     }
 }

--- a/tests/Beutl.UnitTests/ProjectSystem/NoMigrationRegressionTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/NoMigrationRegressionTests.cs
@@ -332,6 +332,64 @@ public class NoMigrationRegressionTests
                 new MigrationNodeContainer()));
     }
 
+    [TestCase(false)]
+    [TestCase(true)]
+    public void Json_population_records_missing_discriminators(bool populateElement)
+    {
+        var scene = new Scene();
+        var element = new Element();
+        scene.Children.Add(element);
+        var project = new Project();
+        project.RestoreVersionMetadata("1.0.0", "1.0.0");
+        project.Items.Add(scene);
+        CoreObject target = populateElement ? element : scene;
+        JsonObject json = CoreSerializer.SerializeToJsonObject(target);
+        json.Remove("$type");
+
+        CoreSerializer.PopulateFromJsonObject(target, json);
+        CoreSerializer.SerializeToJsonObject(project);
+
+        Assert.That(project.MinAppVersion, Is.EqualTo(Project.DefaultMinAppVersion));
+    }
+
+    [Test]
+    public void Detached_sidecar_migration_reaches_its_deserializing_owner()
+    {
+        string path = Path.Combine(_tempDirectory, "detached.belm");
+        JsonObject json = CoreSerializer.SerializeToJsonObject(new Element());
+        json.Remove("$type");
+        json.JsonSave(path);
+        var owner = new DetachedSidecarOwner { SidecarPath = path };
+        JsonObject ownerJson = CoreSerializer.SerializeToJsonObject(owner);
+        var restored = (DetachedSidecarOwner)CoreSerializer.DeserializeFromJsonObject(
+            ownerJson, typeof(DetachedSidecarOwner));
+        var project = new Project();
+        project.RestoreVersionMetadata("1.0.0", "1.0.0");
+        project.Items.Add(restored);
+
+        Assert.That(restored.Child!.HierarchicalParent, Is.Null);
+        Assert.That(project.MinAppVersion, Is.EqualTo(Project.DefaultMinAppVersion));
+    }
+
+    private sealed class DetachedSidecarOwner : ProjectItem
+    {
+        public string SidecarPath { get; set; } = null!;
+        public Element? Child { get; private set; }
+
+        public override void Serialize(ICoreSerializationContext context)
+        {
+            base.Serialize(context);
+            context.SetValue(nameof(SidecarPath), SidecarPath);
+        }
+
+        public override void Deserialize(ICoreSerializationContext context)
+        {
+            base.Deserialize(context);
+            SidecarPath = context.GetValue<string>(nameof(SidecarPath))!;
+            Child = CoreSerializer.RestoreFromUri<Element>(new Uri(SidecarPath));
+        }
+    }
+
     [Test]
     public void PopulateFromUri_reports_a_legacy_discriminator_migration()
     {

--- a/tests/Beutl.UnitTests/ProjectSystem/NoMigrationRegressionTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/NoMigrationRegressionTests.cs
@@ -188,6 +188,48 @@ public class NoMigrationRegressionTests
         });
     }
 
+    [Test]
+    public void Deserialization_aggregates_non_hierarchical_serialized_child_migrations()
+    {
+        var source = new MigratingContainer
+        {
+            Child = new MigratingLeaf(),
+        };
+        JsonObject json = CoreSerializer.SerializeToJsonObject(source);
+
+        var restored = (MigratingContainer)CoreSerializer.DeserializeFromJsonObject(
+            json,
+            typeof(ProjectItem));
+        var project = new Project();
+        project.Items.Add(restored);
+
+        Assert.That(project.MinAppVersion, Is.EqualTo("7.0.0"));
+    }
+
+    [Test]
+    public void PopulateFromUri_reports_a_legacy_discriminator_migration()
+    {
+        string scenePath = Path.Combine(_tempDirectory, "legacy.scene");
+        var source = new Scene { Uri = new Uri(scenePath) };
+        JsonObject json = CoreSerializer.SerializeToJsonObject(source);
+        json.Remove("$type");
+        json.JsonSave(scenePath);
+        JsonObject projectJson = CoreSerializer.SerializeToJsonObject(new Project());
+        projectJson["appVersion"] = "1.0.0";
+        projectJson["minAppVersion"] = "1.0.0";
+        var project = (Project)CoreSerializer.DeserializeFromJsonObject(
+            projectJson,
+            typeof(Project));
+        ProjectItem scene = new Scene { Uri = new Uri(scenePath) };
+        project.Items.Add(scene);
+
+        CoreSerializer.PopulateFromUri(scene, new Uri(scenePath));
+        CoreSerializer.SerializeToJsonObject(project);
+
+        Assert.That(project.AppVersion, Is.EqualTo(BeutlApplication.Version));
+        Assert.That(project.MinAppVersion, Is.EqualTo(Project.DefaultMinAppVersion));
+    }
+
     [TestCase(true, false)]
     [TestCase(false, true)]
     public void Project_with_legacy_sidecar_discriminator_advances_app_version(
@@ -309,6 +351,32 @@ public class NoMigrationRegressionTests
         public MigratedElement(string requiredVersion)
         {
             ReportPersistedContentMigration(requiredVersion);
+        }
+    }
+
+    private sealed class MigratingContainer : ProjectItem
+    {
+        public MigratingLeaf? Child { get; set; }
+
+        public override void Serialize(ICoreSerializationContext context)
+        {
+            base.Serialize(context);
+            context.SetValue(nameof(Child), Child);
+        }
+
+        public override void Deserialize(ICoreSerializationContext context)
+        {
+            base.Deserialize(context);
+            Child = context.GetValue<MigratingLeaf>(nameof(Child));
+        }
+    }
+
+    private sealed class MigratingLeaf : CoreObject
+    {
+        public override void Deserialize(ICoreSerializationContext context)
+        {
+            base.Deserialize(context);
+            ReportPersistedContentMigration("7.0.0");
         }
     }
 }

--- a/tests/Beutl.UnitTests/ProjectSystem/NoMigrationRegressionTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/NoMigrationRegressionTests.cs
@@ -152,8 +152,8 @@ public class NoMigrationRegressionTests
         json.JsonSave(path);
         Project restored = CoreSerializer.RestoreFromUri<Project>(new Uri(path));
 
-        restored.Items.Add(new MigratedProjectItem("4.2.0"));
-        restored.Items.Add(new MigratedProjectItem("5.1.0"));
+        restored.Items.Add(CreateMigrated(new MigratedProjectItem("4.2.0")));
+        restored.Items.Add(CreateMigrated(new MigratedProjectItem("5.1.0")));
 
         Assert.Multiple(() =>
         {
@@ -174,10 +174,10 @@ public class NoMigrationRegressionTests
             Uri = new Uri(Path.Combine(_tempDirectory, "scene.scene")),
         };
         project.Items.Add(scene);
-        scene.AddChild(new MigratedElement("6.0.0")
+        scene.AddChild(CreateMigrated(new MigratedElement("6.0.0")
         {
             Uri = new Uri(Path.Combine(_tempDirectory, "element.belm")),
-        });
+        }));
 
         JsonObject json = CoreSerializer.SerializeToJsonObject(project);
 
@@ -188,22 +188,69 @@ public class NoMigrationRegressionTests
         });
     }
 
-    [Test]
-    public void Deserialization_aggregates_non_hierarchical_serialized_child_migrations()
+    [TestCase(false)]
+    [TestCase(true)]
+    public void Deserialization_aggregates_non_hierarchical_serialized_child_migrations(
+        bool deserializeFromNode)
     {
         var source = new MigratingContainer
         {
-            Child = new MigratingLeaf(),
+            First = new MigratingLeaf("7.0.0"),
+            Second = new MigratingLeaf("8.0.0"),
         };
         JsonObject json = CoreSerializer.SerializeToJsonObject(source);
 
-        var restored = (MigratingContainer)CoreSerializer.DeserializeFromJsonObject(
-            json,
-            typeof(ProjectItem));
+        var restored = (MigratingContainer)(deserializeFromNode
+            ? CoreSerializer.DeserializeFromJsonNode(json, typeof(ProjectItem))!
+            : CoreSerializer.DeserializeFromJsonObject(json, typeof(ProjectItem)));
         var project = new Project();
         project.Items.Add(restored);
 
-        Assert.That(project.MinAppVersion, Is.EqualTo("7.0.0"));
+        Assert.That(project.MinAppVersion, Is.EqualTo("8.0.0"));
+    }
+
+    [Test]
+    public void Invalid_migration_version_is_rejected()
+    {
+        var context = new JsonSerializationContext(
+            typeof(MigratingLeaf),
+            options: new CoreSerializerOptions { Mode = CoreSerializationMode.Read });
+        context.EnablePersistedContentMigrationReporting();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            context.ReportPersistedContentMigration("not-a-version"));
+    }
+
+    [Test]
+    public void PopulateFromJsonObject_aggregates_serialized_child_migrations()
+    {
+        var source = new MigratingContainer
+        {
+            First = new MigratingLeaf("7.0.0"),
+            Second = new MigratingLeaf("8.0.0"),
+        };
+        JsonObject json = CoreSerializer.SerializeToJsonObject(source);
+        var restored = new MigratingContainer();
+
+        CoreSerializer.PopulateFromJsonObject(restored, json);
+        var project = new Project();
+        project.Items.Add(restored);
+
+        Assert.That(project.MinAppVersion, Is.EqualTo("8.0.0"));
+    }
+
+    [Test]
+    public void Failed_deserialization_does_not_attach_a_reported_migration()
+    {
+        var item = new ThrowingMigrationItem();
+        JsonObject json = CoreSerializer.SerializeToJsonObject(item);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            CoreSerializer.PopulateFromJsonObject(item, json));
+        var project = new Project();
+        project.Items.Add(item);
+
+        Assert.That(project.MinAppVersion, Is.EqualTo(Project.DefaultMinAppVersion));
     }
 
     [Test]
@@ -340,43 +387,119 @@ public class NoMigrationRegressionTests
 
     private sealed class MigratedProjectItem : ProjectItem
     {
+        public MigratedProjectItem()
+        {
+        }
+
         public MigratedProjectItem(string requiredVersion)
         {
-            ReportPersistedContentMigration(requiredVersion);
+            RequiredVersion = requiredVersion;
+        }
+
+        public string RequiredVersion { get; set; } = null!;
+
+        public override void Serialize(ICoreSerializationContext context)
+        {
+            base.Serialize(context);
+            context.SetValue(nameof(RequiredVersion), RequiredVersion);
+        }
+
+        public override void Deserialize(ICoreSerializationContext context)
+        {
+            base.Deserialize(context);
+            RequiredVersion = context.GetValue<string>(nameof(RequiredVersion))!;
+            context.ReportPersistedContentMigration(RequiredVersion);
         }
     }
 
     private sealed class MigratedElement : Element
     {
+        public MigratedElement()
+        {
+        }
+
         public MigratedElement(string requiredVersion)
         {
-            ReportPersistedContentMigration(requiredVersion);
+            RequiredVersion = requiredVersion;
+        }
+
+        public string RequiredVersion { get; set; } = null!;
+
+        public override void Serialize(ICoreSerializationContext context)
+        {
+            base.Serialize(context);
+            context.SetValue(nameof(RequiredVersion), RequiredVersion);
+        }
+
+        public override void Deserialize(ICoreSerializationContext context)
+        {
+            base.Deserialize(context);
+            RequiredVersion = context.GetValue<string>(nameof(RequiredVersion))!;
+            context.ReportPersistedContentMigration(RequiredVersion);
         }
     }
 
     private sealed class MigratingContainer : ProjectItem
     {
-        public MigratingLeaf? Child { get; set; }
+        public MigratingLeaf? First { get; set; }
+
+        public MigratingLeaf? Second { get; set; }
 
         public override void Serialize(ICoreSerializationContext context)
         {
             base.Serialize(context);
-            context.SetValue(nameof(Child), Child);
+            context.SetValue(nameof(First), First);
+            context.SetValue(nameof(Second), Second);
         }
 
         public override void Deserialize(ICoreSerializationContext context)
         {
             base.Deserialize(context);
-            Child = context.GetValue<MigratingLeaf>(nameof(Child));
+            First = context.GetValue<MigratingLeaf>(nameof(First));
+            Second = context.GetValue<MigratingLeaf>(nameof(Second));
         }
     }
 
-    private sealed class MigratingLeaf : CoreObject
+    private sealed class MigratingLeaf : ICoreSerializable
+    {
+        public MigratingLeaf()
+        {
+        }
+
+        public MigratingLeaf(string requiredVersion)
+        {
+            RequiredVersion = requiredVersion;
+        }
+
+        public string RequiredVersion { get; set; } = null!;
+
+        public void Serialize(ICoreSerializationContext context)
+        {
+            context.SetValue(nameof(RequiredVersion), RequiredVersion);
+        }
+
+        public void Deserialize(ICoreSerializationContext context)
+        {
+            RequiredVersion = context.GetValue<string>(nameof(RequiredVersion))!;
+            context.ReportPersistedContentMigration(RequiredVersion);
+        }
+    }
+
+    private sealed class ThrowingMigrationItem : ProjectItem
     {
         public override void Deserialize(ICoreSerializationContext context)
         {
             base.Deserialize(context);
-            ReportPersistedContentMigration("7.0.0");
+            context.ReportPersistedContentMigration("9.0.0");
+            throw new InvalidOperationException("migration failed");
         }
+    }
+
+    private static T CreateMigrated<T>(T source)
+        where T : ICoreSerializable
+    {
+        return (T)CoreSerializer.DeserializeFromJsonObject(
+            CoreSerializer.SerializeToJsonObject(source),
+            typeof(T));
     }
 }

--- a/tests/Beutl.UnitTests/ProjectSystem/NoMigrationRegressionTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/NoMigrationRegressionTests.cs
@@ -246,6 +246,24 @@ public class NoMigrationRegressionTests
     }
 
     [Test]
+    public void Concurrent_context_reports_keep_the_highest_migration_version()
+    {
+        var owner = new MigratingContainer();
+        var firstContext = new JsonSerializationContext(typeof(MigratingContainer));
+        var secondContext = new JsonSerializationContext(typeof(MigratingContainer));
+        firstContext.AfterDeserialized(owner);
+        secondContext.AfterDeserialized(owner);
+
+        Parallel.Invoke(
+            () => firstContext.ReportPersistedContentMigration("9.0.0"),
+            () => secondContext.ReportPersistedContentMigration("7.0.0"));
+        var project = new Project();
+        project.Items.Add(owner);
+
+        Assert.That(project.MinAppVersion, Is.EqualTo("9.0.0"));
+    }
+
+    [Test]
     public void PopulateFromJsonObject_aggregates_serialized_child_migrations()
     {
         var source = new MigratingContainer

--- a/tests/Beutl.UnitTests/ProjectSystem/NoMigrationRegressionTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/NoMigrationRegressionTests.cs
@@ -216,10 +216,33 @@ public class NoMigrationRegressionTests
         var context = new JsonSerializationContext(
             typeof(MigratingLeaf),
             options: new CoreSerializerOptions { Mode = CoreSerializationMode.Read });
-        context.EnablePersistedContentMigrationReporting();
 
         Assert.Throws<InvalidOperationException>(() =>
             context.ReportPersistedContentMigration("not-a-version"));
+    }
+
+    [Test]
+    public void Resolve_callback_migration_is_propagated_after_deserialization()
+    {
+        var owner = new MigratingContainer();
+        var target = new Scene();
+        var rootContext = new JsonSerializationContext(
+            typeof(MigratingContainer),
+            options: new CoreSerializerOptions { Mode = CoreSerializationMode.Read });
+        var targetContext = new JsonSerializationContext(
+            typeof(Scene),
+            rootContext,
+            options: new CoreSerializerOptions { Mode = CoreSerializationMode.Read });
+        targetContext.AfterDeserialized(target);
+        rootContext.Resolve(
+            target.Id,
+            _ => rootContext.ReportPersistedContentMigration("9.0.0"));
+
+        rootContext.AfterDeserialized(owner);
+        var project = new Project();
+        project.Items.Add(owner);
+
+        Assert.That(project.MinAppVersion, Is.EqualTo("9.0.0"));
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/ProjectSystem/NoMigrationRegressionTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/NoMigrationRegressionTests.cs
@@ -165,10 +165,19 @@ public class NoMigrationRegressionTests
     [Test]
     public void Project_serialization_aggregates_plugin_element_migrations()
     {
-        var project = new Project();
-        var scene = new Scene();
+        var project = new Project
+        {
+            Uri = new Uri(Path.Combine(_tempDirectory, "project.bep")),
+        };
+        var scene = new Scene
+        {
+            Uri = new Uri(Path.Combine(_tempDirectory, "scene.scene")),
+        };
         project.Items.Add(scene);
-        scene.AddChild(new MigratedElement("6.0.0"));
+        scene.AddChild(new MigratedElement("6.0.0")
+        {
+            Uri = new Uri(Path.Combine(_tempDirectory, "element.belm")),
+        });
 
         JsonObject json = CoreSerializer.SerializeToJsonObject(project);
 


### PR DESCRIPTION
## Description

- Preserve loaded `appVersion` and `minAppVersion` values during ordinary project saves.
- Propagate actual persisted-content migrations through the serialization-context tree, including direct `ICoreSerializable` children.
- Recognize missing legacy sidecar discriminators and empty legacy `Operation.Children` arrays as migrations.
- Preserve present but unavailable extension discriminators instead of reclassifying them as legacy content.
- This PR is based directly on `main`. It has no dependency on PR #2164 or any other feature branch.

## Affected areas

- [ ] Beutl.Engine (rendering / scene / track)
- [x] Beutl.ProjectSystem (project / document persistence)
- [ ] UI (Beutl.Editor, Beutl.Editor.Components, Beutl.Controls)
- [ ] Beutl.Extensibility (plugin abstractions)
- [ ] Beutl.NodeGraph (node editor)
- [ ] Beutl.FFmpegIpc / Beutl.FFmpegWorker (media IPC boundary)
- [ ] Beutl.Api (server API client)
- [ ] Build / CI / docs only

## Breaking changes

`Beutl.Core` adds `ICoreSerializationContext.ReportPersistedContentMigration(string)`. `ICoreSerializable` implementations that rewrite legacy persisted data must call it from `Deserialize`, and custom `ICoreSerializationContext` implementations must implement the new member. Project serialization now preserves loaded version metadata during ordinary saves and advances it only after an actual reported migration.

## Test plan

- Added coverage for `DeserializeFromJsonObject`, `DeserializeFromJsonNode`, and `PopulateFromJsonObject` with direct `ICoreSerializable` children.
- Added invalid-version, failed-deserialization isolation, non-friend public-contract, legacy sidecar, and unchanged-save coverage.
- Local build and tests intentionally skipped; CI is the verification source for this review workflow.
- `git diff --check` passed.

## Fixed issues / References

- Extracted as an independent, direct-main change from the broader work originally reviewed in #2164.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Projects now track the minimum application version required by persisted content, including nested items.
  - Serialization preserves and updates migration metadata during content upgrades.
  - Legacy project data is upgraded to the current application version when applicable.
  - Operation-based content migrations are detected and recorded during loading.
  - Saving migrated scenes now persists updated project version metadata.

- **Bug Fixes**
  - Migration requirements are no longer weakened when combined.
  - Invalid version constraints now produce a clear error.
  - Failed saves restore project contents and version metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->