### PR TITLE
refactor(extensibility)!: make context command execution awaitable

### DIFF
--- a/src/Beutl.Api/Services/ContextCommandManager.cs
+++ b/src/Beutl.Api/Services/ContextCommandManager.cs
@@ -6,6 +6,7 @@ using Beutl.Collections;
 using Beutl.Extensibility;
 using Beutl.Language;
 using Beutl.Logging;
+using Beutl.Services;
 using Microsoft.Extensions.Logging;
 
 namespace Beutl.Api.Services;

--- a/src/Beutl.Api/Services/ContextCommandManager.cs
+++ b/src/Beutl.Api/Services/ContextCommandManager.cs
@@ -18,21 +18,41 @@ public record ContextCommandParsedKeyGesture(KeyGesture? KeyGesture, OSPlatform 
 
 public record ContextCommandHandler(MethodInfo MethodInfo, ParameterInfo[] Parameters)
 {
-    public void Invoke(object context, KeyEventArgs args, ILogger logger)
+    public Task InvokeAsync(object context, KeyEventArgs args, ILogger logger)
     {
+        object? result;
         switch (Parameters.Length)
         {
             case 0:
                 args.Handled = true;
-                MethodInfo.Invoke(context, []);
+                result = MethodInfo.Invoke(context, []);
                 break;
             case 1 when Parameters[0].ParameterType == typeof(KeyEventArgs):
-                MethodInfo.Invoke(context, [args]);
+                result = MethodInfo.Invoke(context, [args]);
                 break;
             default:
                 logger.LogWarning("Invalid parameter count: {ParameterCount}", Parameters.Length);
-                break;
+                return Task.CompletedTask;
         }
+
+        if (result is Task task)
+        {
+            return task;
+        }
+
+        if (result is ValueTask valueTask)
+        {
+            return valueTask.AsTask();
+        }
+
+        if (MethodInfo.ReturnType != typeof(void))
+        {
+            logger.LogWarning(
+                "Invalid context command return type: {ReturnType}",
+                MethodInfo.ReturnType);
+        }
+
+        return Task.CompletedTask;
     }
 }
 
@@ -238,7 +258,7 @@ public class ContextCommandManager(
         {
             element.Focusable = true;
             var logger = _logger;
-            element.KeyDown += (sender, args) =>
+            element.KeyDown += async (sender, args) =>
             {
                 if (sender is not InputElement { DataContext: { } context })
                     return;
@@ -271,7 +291,7 @@ public class ContextCommandManager(
                             continue;
                         }
 
-                        compiledHandler.Execute(execution);
+                        await compiledHandler.ExecuteAsync(execution);
                         return;
                     }
                 }
@@ -294,7 +314,7 @@ public class ContextCommandManager(
 
                     if (handlerRegistry.GetHandler(entry) is { } handler)
                     {
-                        handler.Invoke(context, args, logger);
+                        await handler.InvokeAsync(context, args, logger);
                         return;
                     }
                 }

--- a/src/Beutl.Api/Services/ContextCommandManager.cs
+++ b/src/Beutl.Api/Services/ContextCommandManager.cs
@@ -30,7 +30,6 @@ public record ContextCommandHandler(MethodInfo MethodInfo, ParameterInfo[] Param
                 result = MethodInfo.Invoke(context, []);
                 break;
             case 1 when Parameters[0].ParameterType == typeof(KeyEventArgs):
-                args.Handled = true;
                 result = MethodInfo.Invoke(context, [args]);
                 break;
             default:
@@ -278,6 +277,9 @@ public class ContextCommandManager(
         try
         {
             await execute();
+        }
+        catch (OperationCanceledException)
+        {
         }
         catch (Exception ex)
         {

--- a/src/Beutl.Api/Services/ContextCommandManager.cs
+++ b/src/Beutl.Api/Services/ContextCommandManager.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Nodes;
 using Avalonia.Input;
 using Beutl.Collections;
 using Beutl.Extensibility;
+using Beutl.Language;
 using Beutl.Logging;
 using Microsoft.Extensions.Logging;
 
@@ -28,6 +29,7 @@ public record ContextCommandHandler(MethodInfo MethodInfo, ParameterInfo[] Param
                 result = MethodInfo.Invoke(context, []);
                 break;
             case 1 when Parameters[0].ParameterType == typeof(KeyEventArgs):
+                args.Handled = true;
                 result = MethodInfo.Invoke(context, [args]);
                 break;
             default:
@@ -263,62 +265,82 @@ public class ContextCommandManager(
                 if (sender is not InputElement { DataContext: { } context })
                     return;
 
-                OSPlatform pid = OperatingSystem.IsWindows() ? OSPlatform.Windows :
-                    OperatingSystem.IsMacOS() ? OSPlatform.OSX :
-                    OperatingSystem.IsLinux() ? OSPlatform.Linux :
-                    throw new PlatformNotSupportedException();
-                if (context is IContextCommandHandler compiledHandler)
-                {
-                    foreach (ContextCommandEntry entry in entries)
-                    {
-                        // Platformが一致するものがない場合はスキップ
-                        // Gestureが一致するものがない場合はスキップ
-                        if (entry.KeyGestures.Where(gesture => gesture.Platform == pid)
-                            .All(gesture => gesture.KeyGesture?.Matches(args) != true))
-                        {
-                            continue;
-                        }
-
-                        var execution = new ContextCommandExecution(entry.Definition.Name)
-                        {
-                            KeyEventArgs = args
-                        };
-
-                        // ハンドラが CanExecute で false を返した場合は実行をスキップして
-                        // 同じジェスチャの後続バインディング（フォールバック）に処理を委ねる。
-                        if (!compiledHandler.CanExecute(execution))
-                        {
-                            continue;
-                        }
-
-                        await compiledHandler.ExecuteAsync(execution);
-                        return;
-                    }
-                }
-
-                Type contextType = context.GetType();
-                if (!handlerRegistry.IsRegistered(contextType))
-                {
-                    handlerRegistry.Register(contextType, extension.GetType());
-                }
-
-                foreach (ContextCommandEntry entry in entries)
-                {
-                    // Platformが一致するものがない場合はスキップ
-                    // Gestureが一致するものがない場合はスキップ
-                    if (entry.KeyGestures.Where(gesture => gesture.Platform == pid)
-                        .All(gesture => gesture.KeyGesture?.Matches(args) != true))
-                    {
-                        continue;
-                    }
-
-                    if (handlerRegistry.GetHandler(entry) is { } handler)
-                    {
-                        await handler.InvokeAsync(context, args, logger);
-                        return;
-                    }
-                }
+                await ExecuteSafelyAsync(
+                    () => DispatchAsync(context, args, entries, extension.GetType(), logger),
+                    logger);
             };
+        }
+    }
+
+    internal static async Task ExecuteSafelyAsync(Func<Task> execute, ILogger logger)
+    {
+        try
+        {
+            await execute();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "A context command failed at the input event boundary.");
+            NotificationService.ShowError(
+                MessageStrings.UnexpectedError,
+                MessageStrings.OperationFailed);
+        }
+    }
+
+    private async Task DispatchAsync(
+        object context,
+        KeyEventArgs args,
+        ContextCommandEntry[] entries,
+        Type extensionType,
+        ILogger logger)
+    {
+        OSPlatform pid = OperatingSystem.IsWindows() ? OSPlatform.Windows :
+            OperatingSystem.IsMacOS() ? OSPlatform.OSX :
+            OperatingSystem.IsLinux() ? OSPlatform.Linux :
+            throw new PlatformNotSupportedException();
+        if (context is IContextCommandHandler compiledHandler)
+        {
+            foreach (ContextCommandEntry entry in entries)
+            {
+                if (entry.KeyGestures.Where(gesture => gesture.Platform == pid)
+                    .All(gesture => gesture.KeyGesture?.Matches(args) != true))
+                {
+                    continue;
+                }
+
+                var execution = new ContextCommandExecution(entry.Definition.Name)
+                {
+                    KeyEventArgs = args
+                };
+                if (!compiledHandler.CanExecute(execution))
+                {
+                    continue;
+                }
+
+                await compiledHandler.ExecuteAsync(execution);
+                return;
+            }
+        }
+
+        Type contextType = context.GetType();
+        if (!handlerRegistry.IsRegistered(contextType))
+        {
+            handlerRegistry.Register(contextType, extensionType);
+        }
+
+        foreach (ContextCommandEntry entry in entries)
+        {
+            if (entry.KeyGestures.Where(gesture => gesture.Platform == pid)
+                .All(gesture => gesture.KeyGesture?.Matches(args) != true))
+            {
+                continue;
+            }
+
+            if (handlerRegistry.GetHandler(entry) is { } handler)
+            {
+                await handler.InvokeAsync(context, args, logger);
+                return;
+            }
         }
     }
 }

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/ElementViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/ElementViewModel.cs
@@ -834,7 +834,7 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
         return Model.HasOriginalDuration();
     }
 
-    public void Execute(ContextCommandExecution execution)
+    public Task ExecuteAsync(ContextCommandExecution execution)
     {
         if (execution.KeyEventArgs != null)
             execution.KeyEventArgs.Handled = true;
@@ -854,6 +854,8 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
                     execution.KeyEventArgs.Handled = false;
                 break;
         }
+
+        return Task.CompletedTask;
     }
 
     public record struct PrepareAnimationContext(

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/ElementViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/ElementViewModel.cs
@@ -121,8 +121,9 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
         Cut.Subscribe(OnCut)
             .AddTo(_disposables);
 
-        Copy.Subscribe(async () => await OnCopy())
-            .AddTo(_disposables);
+        Copy = new AsyncReactiveCommand()
+            .WithSubscribe(OnCopy)
+            .DisposeWith(_disposables);
 
         Exclude.Subscribe(OnExclude)
             .AddTo(_disposables);
@@ -429,7 +430,7 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
 
     public AsyncReactiveCommand Cut { get; } = new();
 
-    public ReactiveCommand Copy { get; } = new();
+    public AsyncReactiveCommand Copy { get; }
 
     public ReactiveCommand Exclude { get; } = new();
 

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1020,7 +1020,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         };
     }
 
-    public void Execute(ContextCommandExecution execution)
+    public Task ExecuteAsync(ContextCommandExecution execution)
     {
         _logger.LogDebug("Executing context command {CommandName}.", execution.CommandName);
 
@@ -1032,6 +1032,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             FlushPendingNudgeCommit();
         }
 
+        Task operation = Task.CompletedTask;
         switch (execution.CommandName)
         {
             case "Paste":
@@ -1055,7 +1056,10 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 SelectedElements.FirstOrDefault()?.Copy.Execute();
                 break;
             case "Cut":
-                SelectedElements.FirstOrDefault()?.Cut.Execute();
+                if (SelectedElements.FirstOrDefault() is { } cutTarget)
+                {
+                    operation = cutTarget.Cut.ExecuteAsync();
+                }
                 break;
             case "Delete":
                 SelectedElements.FirstOrDefault()?.Delete.Execute();
@@ -1256,6 +1260,8 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
                 break;
         }
+
+        return operation;
     }
 
     // Timeline shortcuts that use printable keys must not fire while a text input has focus.

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -87,8 +87,9 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
         AddElement.Subscribe(desc => editorContext.GetRequiredService<IElementAdder>().AddElement(desc)).AddTo(_disposables);
 
-        Paste.Subscribe(PasteCore)
-            .AddTo(_disposables);
+        Paste = new AsyncReactiveCommand()
+            .WithSubscribe(PasteCore)
+            .DisposeWith(_disposables);
 
         Duplicate.Subscribe(DuplicateSelectedElements)
             .AddTo(_disposables);
@@ -336,7 +337,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
     public CoreList<LayerHeaderViewModel> LayerHeaders { get; } = [];
 
-    public ReactiveCommand Paste { get; } = new();
+    public AsyncReactiveCommand Paste { get; }
 
     public ReactiveCommand Duplicate { get; } = new();
 
@@ -551,7 +552,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         }
     }
 
-    private async void PasteCore()
+    private async Task PasteCore()
     {
         try
         {
@@ -1036,7 +1037,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         switch (execution.CommandName)
         {
             case "Paste":
-                Paste.Execute();
+                operation = Paste.ExecuteAsync();
                 if (execution.KeyEventArgs != null)
                 {
                     execution.KeyEventArgs.Handled = true;
@@ -1053,7 +1054,11 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
                 break;
             case "Copy":
-                SelectedElements.FirstOrDefault()?.Copy.Execute();
+                if (SelectedElements.FirstOrDefault() is { } copyTarget)
+                {
+                    operation = copyTarget.Copy.ExecuteAsync();
+                }
+
                 break;
             case "Cut":
                 if (SelectedElements.FirstOrDefault() is { } cutTarget)

--- a/src/Beutl.Editor.Components/VersionControlTab/Views/VersionControlTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/VersionControlTab/Views/VersionControlTabView.axaml.cs
@@ -100,18 +100,16 @@ internal sealed partial class VersionControlTabView : UserControl
         return true;
     }
 
-    private Task ExecuteEnableVersionControlAsync()
+    private async Task ExecuteEnableVersionControlAsync()
     {
         if (TopLevel.GetTopLevel(this)?.DataContext is IContextCommandHandler handler)
         {
             var execution = new ContextCommandExecution("EnableVersionControl");
             if (handler.CanExecute(execution))
             {
-                handler.Execute(execution);
+                await handler.ExecuteAsync(execution);
             }
         }
-
-        return Task.CompletedTask;
     }
 
     private Task<bool> LaunchUriAsync(Uri uri)

--- a/src/Beutl.Extensibility/ContextCommandAttribute.cs
+++ b/src/Beutl.Extensibility/ContextCommandAttribute.cs
@@ -6,7 +6,12 @@ namespace Beutl.Extensibility;
 
 public interface IContextCommandHandler
 {
-    void Execute(ContextCommandExecution execution);
+    /// <summary>
+    /// Executes a context command and completes when the command's operation has finished.
+    /// </summary>
+    /// <param name="execution">The context command invocation.</param>
+    /// <returns>A task representing the complete command operation.</returns>
+    Task ExecuteAsync(ContextCommandExecution execution);
 
     bool CanExecute(ContextCommandExecution execution) => true;
 }

--- a/src/Beutl/Services/CommandPaletteService.cs
+++ b/src/Beutl/Services/CommandPaletteService.cs
@@ -94,15 +94,14 @@ public sealed class CommandPaletteService
                     CategoryName: category,
                     KeyGesture: gesture,
                     CanExecute: () => handler.CanExecute(new ContextCommandExecution(capturedEntry.Definition.Name)),
-                    Execute: () =>
+                    ExecuteAsync: () =>
                     {
                         // スロットル窓や状態変化で表示と実行可否がずれる可能性があるため、
                         // 実行直前にもう一度 CanExecute を確認してから Execute する。
                         var execution = new ContextCommandExecution(capturedEntry.Definition.Name);
-                        if (handler.CanExecute(execution))
-                        {
-                            handler.Execute(execution);
-                        }
+                        return handler.CanExecute(execution)
+                            ? handler.ExecuteAsync(execution)
+                            : Task.CompletedTask;
                     })
                 {
                     StateChanged = stateChanged
@@ -154,11 +153,7 @@ public sealed class CommandPaletteService
                 CategoryName: category,
                 KeyGesture: null,
                 CanExecute: () => command.CanExecute(null),
-                Execute: () =>
-                {
-                    if (command.CanExecute(null))
-                        command.Execute(null);
-                }));
+                ExecuteAsync: () => MenuBarViewModel.ExecuteCommandAsync(command)));
         }
     }
 }

--- a/src/Beutl/Services/PaletteCommand.cs
+++ b/src/Beutl/Services/PaletteCommand.cs
@@ -9,7 +9,7 @@ public sealed record PaletteCommand(
     string CategoryName,
     KeyGesture? KeyGesture,
     Func<bool> CanExecute,
-    Action Execute)
+    Func<Task> ExecuteAsync)
 {
     // ハンドラーが状態変化を通知できる場合の observable。
     // パレット側でこれを購読し、通知時に CanExecute を再評価する。

--- a/src/Beutl/ViewModels/CommandPaletteItemViewModel.cs
+++ b/src/Beutl/ViewModels/CommandPaletteItemViewModel.cs
@@ -28,11 +28,13 @@ public sealed class CommandPaletteItemViewModel
 
     internal int Relevance { get; }
 
-    public void Execute()
+    public Task ExecuteAsync()
     {
         if (IsEnabled)
         {
-            Command.Execute();
+            return Command.ExecuteAsync();
         }
+
+        return Task.CompletedTask;
     }
 }

--- a/src/Beutl/ViewModels/CommandPaletteViewModel.cs
+++ b/src/Beutl/ViewModels/CommandPaletteViewModel.cs
@@ -127,14 +127,16 @@ public sealed class CommandPaletteViewModel : BaseViewModel
         previous.Dispose();
     }
 
-    public void ExecuteSelected()
+    public Task ExecuteSelectedAsync()
     {
         CommandPaletteItemViewModel? item = SelectedCommand.Value;
         if (item is { IsEnabled: true })
         {
             Close();
-            item.Execute();
+            return item.ExecuteAsync();
         }
+
+        return Task.CompletedTask;
     }
 
     public void MoveSelection(int delta)

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -96,15 +96,16 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
         };
     }
 
-    public void Execute(ContextCommandExecution execution)
+    public Task ExecuteAsync(ContextCommandExecution execution)
     {
         if (execution.KeyEventArgs != null)
             execution.KeyEventArgs.Handled = true;
         bool isFromTextBox = execution.KeyEventArgs?.Source is TextBox;
+        Task operation = Task.CompletedTask;
         switch (execution.CommandName)
         {
             case "PlayPause" when !isFromTextBox:
-                Player.PlayPause.Execute();
+                operation = Player.PlayPause.ExecuteAsync();
                 break;
             case "Next":
                 Player.Next.Execute();
@@ -165,6 +166,8 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
                     execution.KeyEventArgs.Handled = false;
                 break;
         }
+
+        return operation;
     }
 
     private void ToggleMarkerAtCurrentTime()

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -295,7 +295,7 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
         }
     }
 
-    public void Execute(ContextCommandExecution execution)
+    public Task ExecuteAsync(ContextCommandExecution execution)
     {
         if (execution.KeyEventArgs != null)
             execution.KeyEventArgs.Handled = true;
@@ -303,18 +303,18 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
         if (execution.CommandName == "ShowCommandPalette")
         {
             CommandPalette.Toggle();
-            return;
+            return Task.CompletedTask;
         }
 
         if (MenuBar.FindContextCommand(execution.CommandName) is { } command)
         {
-            if (command.CanExecute(null))
-                command.Execute(null);
-            return;
+            return MenuBarViewModel.ExecuteCommandAsync(command);
         }
 
         if (execution.KeyEventArgs != null)
             execution.KeyEventArgs.Handled = false;
+
+        return Task.CompletedTask;
     }
 
     public bool CanExecute(ContextCommandExecution execution)

--- a/src/Beutl/ViewModels/MenuBarViewModel.Files.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.Files.cs
@@ -85,13 +85,13 @@ public partial class MenuBarViewModel
     //    Recent files
     //    Recent projects
     //    Exit
-    public ReactiveCommandSlim CreateNewProject { get; } = new();
+    public AsyncReactiveCommand CreateNewProject { get; } = new();
 
     public ReactiveCommandSlim CreateNew { get; } = new();
 
-    public ReactiveCommandSlim OpenProject { get; } = new();
+    public AsyncReactiveCommand OpenProject { get; } = new();
 
-    public ReactiveCommandSlim OpenFile { get; } = new();
+    public AsyncReactiveCommand OpenFile { get; } = new();
 
     public ReactiveCommandSlim CloseFile { get; private set; }
 

--- a/src/Beutl/ViewModels/MenuBarViewModel.Palette.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.Palette.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows.Input;
+using Reactive.Bindings;
 
 namespace Beutl.ViewModels;
 
@@ -21,7 +22,7 @@ public partial class MenuBarViewModel
     }
 
     // MainViewExtension の ContextCommand 名から MenuBar 上の ICommand への単一マッピング。
-    // MainViewModel.Execute / CanExecute と CommandPalette が共通で参照するためここに集約している。
+    // MainViewModel.ExecuteAsync / CanExecute と CommandPalette が共通で参照するためここに集約している。
     public ICommand? FindContextCommand(string commandName) => commandName switch
     {
         "CreateNewProject" => CreateNewProject,
@@ -38,4 +39,20 @@ public partial class MenuBarViewModel
         "Exit" => Exit,
         _ => null
     };
+
+    internal static Task ExecuteCommandAsync(ICommand command)
+    {
+        if (!command.CanExecute(null))
+        {
+            return Task.CompletedTask;
+        }
+
+        if (command is AsyncReactiveCommand asyncCommand)
+        {
+            return asyncCommand.ExecuteAsync(null!);
+        }
+
+        command.Execute(null);
+        return Task.CompletedTask;
+    }
 }

--- a/src/Beutl/ViewModels/MenuBarViewModel.Scene.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.Scene.cs
@@ -33,15 +33,8 @@ public partial class MenuBarViewModel
             .WithSubscribe(OnCutElement);
         CopyLayer = new AsyncReactiveCommand(isSceneOpened)
             .WithSubscribe(OnCopyElement);
-        PasteLayer = new ReactiveCommandSlim(isSceneOpened)
-            .WithSubscribe(() =>
-            {
-                if (TryGetSelectedEditViewModel(out EditViewModel? viewModel)
-                    && viewModel.FindToolTab<TimelineTabViewModel>() is TimelineTabViewModel timeline)
-                {
-                    timeline.Paste.Execute();
-                }
-            });
+        PasteLayer = new AsyncReactiveCommand(isSceneOpened)
+            .WithSubscribe(OnPasteElement);
 
         ShowSceneSettings = new ReactiveCommandSlim(isSceneOpened)
             .WithSubscribe(OnShowSceneSettings);
@@ -70,7 +63,7 @@ public partial class MenuBarViewModel
 
     public AsyncReactiveCommand CopyLayer { get; private set; }
 
-    public ReactiveCommandSlim PasteLayer { get; private set; }
+    public AsyncReactiveCommand PasteLayer { get; private set; }
 
     public ReactiveCommandSlim ShowSceneSettings { get; private set; }
 
@@ -130,6 +123,14 @@ public partial class MenuBarViewModel
 
             await clipboard.SetDataAsync(data);
         }
+    }
+
+    private Task OnPasteElement()
+    {
+        return TryGetSelectedEditViewModel(out EditViewModel? viewModel)
+               && viewModel.FindToolTab<TimelineTabViewModel>() is { } timeline
+            ? timeline.Paste.ExecuteAsync()
+            : Task.CompletedTask;
     }
 
     private void OnShowSceneSettings()

--- a/src/Beutl/ViewModels/MenuBarViewModel.Scene.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.Scene.cs
@@ -58,11 +58,11 @@ public partial class MenuBarViewModel
     //       Cut
     //       Copy
     //       Paste
-    public ReactiveCommandSlim NewScene { get; } = new();
+    public AsyncReactiveCommand NewScene { get; } = new();
 
     public ReactiveCommandSlim<EditorTabItem?> RemoveFromProject { get; private set; }
 
-    public ReactiveCommandSlim DeleteLayer { get; private set; }
+    public AsyncReactiveCommand DeleteLayer { get; private set; }
 
     public ReactiveCommandSlim ExcludeLayer { get; private set; }
 

--- a/src/Beutl/ViewModels/TitleBreadcrumbBarViewModel.cs
+++ b/src/Beutl/ViewModels/TitleBreadcrumbBarViewModel.cs
@@ -31,9 +31,9 @@ public class TitleBreadcrumbBarViewModel
 
     public IReactiveProperty<EditorTabItem?> SelectedTabItem => _editorService.SelectedTabItem;
 
-    public ReactiveCommandSlim OpenFile => _viewModel.MenuBar.OpenFile;
+    public AsyncReactiveCommand OpenFile => _viewModel.MenuBar.OpenFile;
 
-    public ReactiveCommandSlim NewScene => _viewModel.MenuBar.NewScene;
+    public AsyncReactiveCommand NewScene => _viewModel.MenuBar.NewScene;
 
     public ReactiveCommandSlim<EditorTabItem> CloseOrRemoveFile => _viewModel.MenuBar.CloseFileCore;
 }

--- a/src/Beutl/Views/CommandPaletteView.axaml.cs
+++ b/src/Beutl/Views/CommandPaletteView.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia.Interactivity;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Beutl.Logging;
+using Beutl.Services;
 using Beutl.ViewModels;
 using Microsoft.Extensions.Logging;
 using Reactive.Bindings.Extensions;
@@ -213,7 +214,7 @@ public partial class CommandPaletteView : UserControl
                 break;
             case Key.Enter:
                 e.Handled = true;
-                await viewModel.ExecuteSelectedAsync();
+                await ExecuteSelectedSafelyAsync(viewModel);
                 break;
         }
     }
@@ -232,7 +233,20 @@ public partial class CommandPaletteView : UserControl
         {
             viewModel.SelectedCommand.Value = item;
             e.Handled = true;
+            await ExecuteSelectedSafelyAsync(viewModel);
+        }
+    }
+
+    private async Task ExecuteSelectedSafelyAsync(CommandPaletteViewModel viewModel)
+    {
+        try
+        {
             await viewModel.ExecuteSelectedAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "A command palette action failed.");
+            await ex.Handle();
         }
     }
 

--- a/src/Beutl/Views/CommandPaletteView.axaml.cs
+++ b/src/Beutl/Views/CommandPaletteView.axaml.cs
@@ -197,7 +197,7 @@ public partial class CommandPaletteView : UserControl
         }
     }
 
-    private void OnRootKeyDown(object? sender, KeyEventArgs e)
+    private async void OnRootKeyDown(object? sender, KeyEventArgs e)
     {
         // IME 変換中の Enter/Escape は IME による確定・取消に使われるため横取りしない。
         if (e.Handled || e.Key == Key.ImeProcessed || DataContext is not CommandPaletteViewModel viewModel)
@@ -212,13 +212,13 @@ public partial class CommandPaletteView : UserControl
                 e.Handled = true;
                 break;
             case Key.Enter:
-                viewModel.ExecuteSelected();
                 e.Handled = true;
+                await viewModel.ExecuteSelectedAsync();
                 break;
         }
     }
 
-    private void OnResultsDoubleTapped(object? sender, TappedEventArgs e)
+    private async void OnResultsDoubleTapped(object? sender, TappedEventArgs e)
     {
         if (DataContext is not CommandPaletteViewModel viewModel)
         {
@@ -231,8 +231,8 @@ public partial class CommandPaletteView : UserControl
             && source.FindAncestorOfType<ListBoxItem>(includeSelf: true) is { DataContext: CommandPaletteItemViewModel item })
         {
             viewModel.SelectedCommand.Value = item;
-            viewModel.ExecuteSelected();
             e.Handled = true;
+            await viewModel.ExecuteSelectedAsync();
         }
     }
 

--- a/src/Beutl/Views/EditorHostFallback.axaml.cs
+++ b/src/Beutl/Views/EditorHostFallback.axaml.cs
@@ -69,9 +69,10 @@ public partial class EditorHostFallback : UserControl
         }
     }
 
-    private void CreateNewProject_Click(object? sender, RoutedEventArgs e)
+    private async void CreateNewProject_Click(object? sender, RoutedEventArgs e)
     {
-        ExecuteMainViewModelCommand(vm => vm.MenuBar.CreateNewProject.Execute());
+        await ExecuteMainViewModelCommandAsync(
+            vm => vm.MenuBar.CreateNewProject.ExecuteAsync(null!));
     }
 
     private void CreateNewScene_Click(object? sender, RoutedEventArgs e)
@@ -79,14 +80,14 @@ public partial class EditorHostFallback : UserControl
         ExecuteMainViewModelCommand(vm => vm.MenuBar.CreateNew.Execute());
     }
 
-    private void OpenProject_Click(object? sender, RoutedEventArgs e)
+    private async void OpenProject_Click(object? sender, RoutedEventArgs e)
     {
-        ExecuteMainViewModelCommand(vm => vm.MenuBar.OpenProject.Execute());
+        await ExecuteMainViewModelCommandAsync(vm => vm.MenuBar.OpenProject.ExecuteAsync(null!));
     }
 
-    private void OpenFile_Click(object? sender, RoutedEventArgs e)
+    private async void OpenFile_Click(object? sender, RoutedEventArgs e)
     {
-        ExecuteMainViewModelCommand(vm => vm.MenuBar.OpenFile.Execute());
+        await ExecuteMainViewModelCommandAsync(vm => vm.MenuBar.OpenFile.ExecuteAsync(null!));
     }
 
     private void ExecuteMainViewModelCommand(Action<MainViewModel> action)
@@ -94,6 +95,14 @@ public partial class EditorHostFallback : UserControl
         if (this.FindAncestorOfType<MainView>() is { DataContext: MainViewModel viewModel })
         {
             action(viewModel);
+        }
+    }
+
+    private async Task ExecuteMainViewModelCommandAsync(Func<MainViewModel, Task> action)
+    {
+        if (this.FindAncestorOfType<MainView>() is { DataContext: MainViewModel viewModel })
+        {
+            await action(viewModel);
         }
     }
 

--- a/src/Beutl/Views/EditorHostFallback.axaml.cs
+++ b/src/Beutl/Views/EditorHostFallback.axaml.cs
@@ -102,7 +102,14 @@ public partial class EditorHostFallback : UserControl
     {
         if (this.FindAncestorOfType<MainView>() is { DataContext: MainViewModel viewModel })
         {
-            await action(viewModel);
+            try
+            {
+                await action(viewModel);
+            }
+            catch (Exception ex)
+            {
+                await ex.Handle();
+            }
         }
     }
 

--- a/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
+++ b/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
@@ -301,7 +301,7 @@ public partial class MainView
         }
     }
 
-    private async void OnDeleteElement()
+    private async Task OnDeleteElement()
     {
         if (TryGetSelectedEditViewModel(out EditViewModel? viewModel)
             && viewModel.Scene is Scene scene
@@ -362,7 +362,7 @@ public partial class MainView
         }
     }
 
-    private async void OnOpenFile()
+    private async Task OnOpenFile()
     {
         if (VisualRoot is not Window window || DataContext is not MainViewModel viewModel)
         {
@@ -389,7 +389,7 @@ public partial class MainView
         }
     }
 
-    private async void OnOpenProject()
+    private async Task OnOpenProject()
     {
         if (VisualRoot is Window window)
         {

--- a/src/Beutl/Views/TitleBreadcrumbBar.axaml.cs
+++ b/src/Beutl/Views/TitleBreadcrumbBar.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
+using Beutl.Services;
 using Beutl.ViewModels;
 
 namespace Beutl.Views;
@@ -18,15 +19,16 @@ public partial class TitleBreadcrumbBar : UserControl
     {
         // Commandプロパティを使わない理由
         // - flyout.Hideを実行するとbuttonのDataContextとCommandがnullになり実行されなくなってしまうため
+        Func<Task>? execute = null;
         if (sender is Button button && DataContext is TitleBreadcrumbBarViewModel viewModel)
         {
             switch (button.Tag)
             {
                 case "OpenFile":
-                    await viewModel.OpenFile.ExecuteAsync(null!);
+                    execute = () => viewModel.OpenFile.ExecuteAsync(null!);
                     break;
                 case "NewScene":
-                    await viewModel.NewScene.ExecuteAsync(null!);
+                    execute = () => viewModel.NewScene.ExecuteAsync(null!);
                     break;
             }
         }
@@ -34,6 +36,18 @@ public partial class TitleBreadcrumbBar : UserControl
         if (FileButton.Flyout is Flyout flyout)
         {
             flyout.Hide();
+        }
+
+        if (execute is not null)
+        {
+            try
+            {
+                await execute();
+            }
+            catch (Exception ex)
+            {
+                await ex.Handle();
+            }
         }
     }
 

--- a/src/Beutl/Views/TitleBreadcrumbBar.axaml.cs
+++ b/src/Beutl/Views/TitleBreadcrumbBar.axaml.cs
@@ -14,7 +14,7 @@ public partial class TitleBreadcrumbBar : UserControl
         InitializeComponent();
     }
 
-    private void OnButtonClick(object? sender, RoutedEventArgs e)
+    private async void OnButtonClick(object? sender, RoutedEventArgs e)
     {
         // Commandプロパティを使わない理由
         // - flyout.Hideを実行するとbuttonのDataContextとCommandがnullになり実行されなくなってしまうため
@@ -23,10 +23,10 @@ public partial class TitleBreadcrumbBar : UserControl
             switch (button.Tag)
             {
                 case "OpenFile":
-                    viewModel.OpenFile.Execute(null);
+                    await viewModel.OpenFile.ExecuteAsync(null!);
                     break;
                 case "NewScene":
-                    viewModel.NewScene.Execute(null);
+                    await viewModel.NewScene.ExecuteAsync(null!);
                     break;
             }
         }

--- a/tests/Beutl.HeadlessUITests/CommandPaletteViewLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/CommandPaletteViewLayoutTests.cs
@@ -54,7 +54,7 @@ public class CommandPaletteViewLayoutTests
                 CategoryName: CategoryText,
                 KeyGesture: new KeyGesture(Key.P, KeyModifiers.Control),
                 CanExecute: () => true,
-                Execute: () => { });
+                ExecuteAsync: () => Task.CompletedTask);
             var item = new CommandPaletteItemViewModel(command, isEnabled: true, relevance: 0);
 
             Control? built = template!.Build(item);

--- a/tests/Beutl.HeadlessUITests/ContextCommandDispatchTests.cs
+++ b/tests/Beutl.HeadlessUITests/ContextCommandDispatchTests.cs
@@ -159,6 +159,57 @@ public class ContextCommandDispatchTests
     }
 
     [AvaloniaTest]
+    [TestCase("Copy")]
+    [TestCase("Paste")]
+    public async Task Timeline_handler_returns_clipboard_command_operations(string commandName)
+    {
+        await TestReset.ResetShellAsync();
+        try
+        {
+            string location = Path.Combine(
+                BeutlHomeIsolation.CurrentHome!,
+                $"context-command-timeline-{commandName.ToLowerInvariant()}");
+            Directory.CreateDirectory(location);
+            Project project = (await TestShell.Project.CreateProject(
+                640,
+                480,
+                30,
+                44100,
+                "timeline-handler",
+                location))!;
+            Scene scene = project.Items.OfType<Scene>().Single();
+            TestShell.Editor.ActivateTabItem(scene);
+            HeadlessTestHelpers.Settle();
+            var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+            var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+            adder.AddElement(new ElementDescription(
+                Start: TimeSpan.Zero,
+                Length: TimeSpan.FromSeconds(1),
+                Layer: 0,
+                EngineObjectFactory: () => new RectShape()));
+            HeadlessTestHelpers.Settle();
+            TimelineTabViewModel timeline = editor.FindToolTab<TimelineTabViewModel>()!;
+            ElementViewModel target = timeline.Elements.Single();
+            timeline.SelectElement(target);
+            AsyncReactiveCommand command = commandName == "Copy" ? target.Copy : timeline.Paste;
+            var gate = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            using IDisposable subscription = command.Subscribe(() => gate.Task);
+
+            Task operation = timeline.ExecuteAsync(new ContextCommandExecution(commandName));
+
+            Assert.That(operation.IsCompleted, Is.False);
+            gate.SetResult();
+            await operation.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(operation.IsCompletedSuccessfully, Is.True);
+        }
+        finally
+        {
+            await TestReset.ResetShellAsync();
+        }
+    }
+
+    [AvaloniaTest]
     public async Task Command_palette_returns_the_handler_operation()
     {
         await TestReset.ResetShellAsync();

--- a/tests/Beutl.HeadlessUITests/ContextCommandDispatchTests.cs
+++ b/tests/Beutl.HeadlessUITests/ContextCommandDispatchTests.cs
@@ -1,0 +1,223 @@
+﻿using Avalonia.Headless.NUnit;
+using Beutl.Api.Services;
+using Beutl.Editor.Components.TimelineTab.ViewModels;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Extensibility;
+using Beutl.Graphics.Shapes;
+using Beutl.ProjectSystem;
+using Beutl.Services;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Reactive.Bindings;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class ContextCommandDispatchTests
+{
+    [AvaloniaTest]
+    public async Task Asynchronous_menu_command_returns_its_complete_operation()
+    {
+        await TestReset.ResetShellAsync();
+        string location = Path.Combine(
+            BeutlHomeIsolation.CurrentHome!,
+            "context-command-dispatch");
+        Directory.CreateDirectory(location);
+        await TestShell.Project.CreateProject(640, 480, 30, 44100, "dispatch", location);
+        HeadlessTestHelpers.Settle();
+
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using IDisposable subscription = TestShell.MainViewModel.MenuBar.SaveAll
+            .Subscribe(() => gate.Task);
+        var execution = new ContextCommandExecution("SaveAll");
+
+        Task operation = TestShell.MainViewModel.ExecuteAsync(execution);
+
+        Assert.That(operation.IsCompleted, Is.False);
+
+        gate.SetResult();
+        await operation;
+
+        Assert.That(operation.IsCompletedSuccessfully, Is.True);
+        await TestReset.ResetShellAsync();
+    }
+
+    [AvaloniaTest]
+    public async Task Disabled_menu_command_returns_a_completed_operation()
+    {
+        await TestReset.ResetShellAsync();
+        HeadlessTestHelpers.Settle();
+
+        var execution = new ContextCommandExecution("SaveAll");
+
+        // No project is open, so the command is disabled and nothing may be dispatched.
+        Task operation = TestShell.MainViewModel.ExecuteAsync(execution);
+
+        Assert.That(operation.IsCompletedSuccessfully, Is.True);
+    }
+
+    [AvaloniaTest]
+    public async Task Menu_command_adapter_returns_any_async_reactive_command_operation()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var command = new AsyncReactiveCommand();
+        using IDisposable subscription = command.Subscribe(() => gate.Task);
+
+        Task operation = MenuBarViewModel.ExecuteCommandAsync(command);
+
+        Assert.That(operation.IsCompleted, Is.False);
+        gate.SetResult();
+        await operation;
+        Assert.That(operation.IsCompletedSuccessfully, Is.True);
+    }
+
+    [AvaloniaTest]
+    public async Task Edit_handler_returns_the_play_pause_operation()
+    {
+        await TestReset.ResetShellAsync();
+        try
+        {
+            string location = Path.Combine(
+                BeutlHomeIsolation.CurrentHome!,
+                "context-command-edit-handler");
+            Directory.CreateDirectory(location);
+            Project project = (await TestShell.Project.CreateProject(
+                640,
+                480,
+                30,
+                44100,
+                "edit-handler",
+                location))!;
+            Scene scene = project.Items.OfType<Scene>().Single();
+            TestShell.Editor.ActivateTabItem(scene);
+            HeadlessTestHelpers.Settle();
+            var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+            var gate = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            using IDisposable subscription = editor.Player.PlayPause.Subscribe(() => gate.Task);
+
+            Task operation = editor.ExecuteAsync(new ContextCommandExecution("PlayPause"));
+
+            Assert.That(operation.IsCompleted, Is.False);
+            gate.SetResult();
+            await operation.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(operation.IsCompletedSuccessfully, Is.True);
+        }
+        finally
+        {
+            await TestReset.ResetShellAsync();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Timeline_handler_returns_the_selected_element_cut_operation()
+    {
+        await TestReset.ResetShellAsync();
+        try
+        {
+            string location = Path.Combine(
+                BeutlHomeIsolation.CurrentHome!,
+                "context-command-timeline-handler");
+            Directory.CreateDirectory(location);
+            Project project = (await TestShell.Project.CreateProject(
+                640,
+                480,
+                30,
+                44100,
+                "timeline-handler",
+                location))!;
+            Scene scene = project.Items.OfType<Scene>().Single();
+            TestShell.Editor.ActivateTabItem(scene);
+            HeadlessTestHelpers.Settle();
+            var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+            var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+            adder.AddElement(new ElementDescription(
+                Start: TimeSpan.Zero,
+                Length: TimeSpan.FromSeconds(1),
+                Layer: 0,
+                EngineObjectFactory: () => new RectShape()));
+            HeadlessTestHelpers.Settle();
+            TimelineTabViewModel timeline = editor.FindToolTab<TimelineTabViewModel>()!;
+            ElementViewModel target = timeline.Elements.Single();
+            timeline.SelectElement(target);
+            var gate = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            using IDisposable subscription = target.Cut.Subscribe(() => gate.Task);
+
+            Task operation = timeline.ExecuteAsync(new ContextCommandExecution("Cut"));
+
+            Assert.That(operation.IsCompleted, Is.False);
+            gate.SetResult();
+            await operation.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(operation.IsCompletedSuccessfully, Is.True);
+        }
+        finally
+        {
+            await TestReset.ResetShellAsync();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Command_palette_returns_the_handler_operation()
+    {
+        await TestReset.ResetShellAsync();
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = new AwaitableHandler(gate.Task);
+        var extension = new AwaitableViewExtension();
+        var manager = new ContextCommandManager(
+            new ContextCommandSettingsStore(),
+            new ContextCommandHandlerRegistry());
+        manager.Register(extension);
+        var extensionProvider = new ExtensionProvider();
+        var editorService = new EditorService(extensionProvider);
+        var service = new CommandPaletteService(
+            manager,
+            new FixedHandlerProvider(handler),
+            menuBarAccessor: () => null,
+            editorService,
+            extensionProvider);
+        using var viewModel = new CommandPaletteViewModel(service, editorService);
+        viewModel.Open();
+        viewModel.SelectedCommand.Value = viewModel.FilteredCommands.Single();
+
+        Task operation = viewModel.ExecuteSelectedAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(operation.IsCompleted, Is.False);
+            Assert.That(viewModel.IsOpen.Value, Is.False);
+            Assert.That(handler.LastExecution?.CommandName, Is.EqualTo("AwaitableCommand"));
+        });
+
+        gate.SetResult();
+        await operation;
+
+        Assert.That(operation.IsCompletedSuccessfully, Is.True);
+    }
+
+    private sealed class AwaitableViewExtension : ViewExtension
+    {
+        public override IEnumerable<ContextCommandDefinition> ContextCommands =>
+        [
+            new ContextCommandDefinition("AwaitableCommand", "Awaitable Command"),
+        ];
+    }
+
+    private sealed class FixedHandlerProvider(IContextCommandHandler handler)
+        : ICommandPaletteHandlerProvider
+    {
+        public IContextCommandHandler? Resolve(Type extensionType) => handler;
+    }
+
+    private sealed class AwaitableHandler(Task operation) : IContextCommandHandler
+    {
+        public ContextCommandExecution? LastExecution { get; private set; }
+
+        public Task ExecuteAsync(ContextCommandExecution execution)
+        {
+            LastExecution = execution;
+            return operation;
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/VersionControlTabViewTests.cs
+++ b/tests/Beutl.HeadlessUITests/VersionControlTabViewTests.cs
@@ -1136,9 +1136,10 @@ public class VersionControlTabViewTests
     {
         public ContextCommandExecution? LastExecution { get; private set; }
 
-        public void Execute(ContextCommandExecution execution)
+        public Task ExecuteAsync(ContextCommandExecution execution)
         {
             LastExecution = execution;
+            return Task.CompletedTask;
         }
     }
 

--- a/tests/Beutl.PublicApiContractTests/Beutl.PublicApiContractTests.csproj
+++ b/tests/Beutl.PublicApiContractTests/Beutl.PublicApiContractTests.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Beutl.Engine\Beutl.Engine.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Editor\Beutl.Editor.csproj" />
+    <ProjectReference Include="..\..\src\Beutl.Extensibility\Beutl.Extensibility.csproj" />
     <!-- Match the analyzer reference used by out-of-tree plugins. -->
     <ProjectReference Include="..\..\src\Beutl.Engine.SourceGenerators\Beutl.Engine.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/tests/Beutl.PublicApiContractTests/ContextCommandHandlerContractTests.cs
+++ b/tests/Beutl.PublicApiContractTests/ContextCommandHandlerContractTests.cs
@@ -1,0 +1,53 @@
+﻿using Beutl.Extensibility;
+
+namespace Beutl.PublicApiContractTests;
+
+[TestFixture]
+public sealed class ContextCommandHandlerContractTests : PublicApiContractTestBase
+{
+    [Test]
+    public async Task Plugin_handler_can_expose_its_complete_operation()
+    {
+        var completion = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = new PluginContextCommandHandler(completion.Task);
+        var execution = new ContextCommandExecution("PluginCommand");
+
+        Task operation = handler.ExecuteAsync(execution);
+
+        Assert.That(operation.IsCompleted, Is.False);
+        completion.SetResult();
+        await operation;
+        Assert.That(handler.Execution, Is.SameAs(execution));
+    }
+
+    [Test]
+    public void Extensibility_does_not_grant_friend_access_to_contract_assembly()
+    {
+        AssertDoesNotHaveFriendAccess(typeof(IContextCommandHandler).Assembly);
+    }
+
+    [Test]
+    public void Contract_has_one_awaitable_execution_path_without_a_completion_side_channel()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(typeof(IContextCommandHandler).GetMethod("Execute"), Is.Null);
+            Assert.That(
+                typeof(IContextCommandHandler).GetMethod(nameof(IContextCommandHandler.ExecuteAsync))?.ReturnType,
+                Is.EqualTo(typeof(Task)));
+            Assert.That(typeof(ContextCommandExecution).GetProperty("Completion"), Is.Null);
+        });
+    }
+
+    private sealed class PluginContextCommandHandler(Task operation) : IContextCommandHandler
+    {
+        public ContextCommandExecution? Execution { get; private set; }
+
+        public Task ExecuteAsync(ContextCommandExecution execution)
+        {
+            Execution = execution;
+            return operation;
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Api/ContextCommandManagerTests.cs
+++ b/tests/Beutl.UnitTests/Api/ContextCommandManagerTests.cs
@@ -17,6 +17,8 @@ public class ContextCommandManagerTests
         public Task TaskCommand() => operation;
 
         public ValueTask ValueTaskCommand() => new(operation);
+
+        public Task TaskCommandWithArgs(KeyEventArgs args) => operation;
     }
 
     // A command binding two platform-less gestures (like the timeline's Exit* commands binding
@@ -69,6 +71,31 @@ public class ContextCommandManagerTests
         gate.SetResult();
         await operation;
         Assert.That(operation.IsCompletedSuccessfully, Is.True);
+    }
+
+    [Test]
+    public async Task Attribute_handler_with_key_args_marks_the_event_handled_before_invocation()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var context = new AwaitableAttributeContext(gate.Task);
+        MethodInfo method = typeof(AwaitableAttributeContext).GetMethod(
+            nameof(AwaitableAttributeContext.TaskCommandWithArgs))!;
+        var handler = new ContextCommandHandler(method, method.GetParameters());
+        var args = new KeyEventArgs();
+
+        Task operation = handler.InvokeAsync(context, args, Mock.Of<ILogger>());
+
+        Assert.That(args.Handled, Is.True);
+        gate.SetResult();
+        await operation;
+    }
+
+    [Test]
+    public void Input_event_boundary_consumes_faulted_command_tasks()
+    {
+        Assert.DoesNotThrowAsync(() => ContextCommandManager.ExecuteSafelyAsync(
+            () => Task.FromException(new InvalidOperationException("command failed")),
+            Mock.Of<ILogger>()));
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Api/ContextCommandManagerTests.cs
+++ b/tests/Beutl.UnitTests/Api/ContextCommandManagerTests.cs
@@ -1,14 +1,24 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text.Json.Nodes;
 using Avalonia.Input;
 using Beutl.Api.Services;
 using Beutl.Extensibility;
+using Microsoft.Extensions.Logging;
+using Moq;
 
 namespace Beutl.UnitTests.Api;
 
 [TestFixture]
 public class ContextCommandManagerTests
 {
+    private sealed class AwaitableAttributeContext(Task operation)
+    {
+        public Task TaskCommand() => operation;
+
+        public ValueTask ValueTaskCommand() => new(operation);
+    }
+
     // A command binding two platform-less gestures (like the timeline's Exit* commands binding
     // V and Escape) — the regression shape for multi-gesture remapping.
     private sealed class TestViewExtension : ViewExtension
@@ -39,6 +49,26 @@ public class ContextCommandManagerTests
             .Where(g => g.Platform == platform)
             .Select(g => g.KeyGesture)
             .ToArray();
+    }
+
+    [TestCase(nameof(AwaitableAttributeContext.TaskCommand))]
+    [TestCase(nameof(AwaitableAttributeContext.ValueTaskCommand))]
+    public async Task Attribute_handler_returns_the_complete_async_operation(string methodName)
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var context = new AwaitableAttributeContext(gate.Task);
+        MethodInfo method = typeof(AwaitableAttributeContext).GetMethod(methodName)!;
+        var handler = new ContextCommandHandler(method, method.GetParameters());
+
+        Task operation = handler.InvokeAsync(
+            context,
+            new KeyEventArgs(),
+            Mock.Of<ILogger>());
+
+        Assert.That(operation.IsCompleted, Is.False);
+        gate.SetResult();
+        await operation;
+        Assert.That(operation.IsCompletedSuccessfully, Is.True);
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Api/ContextCommandManagerTests.cs
+++ b/tests/Beutl.UnitTests/Api/ContextCommandManagerTests.cs
@@ -74,7 +74,7 @@ public class ContextCommandManagerTests
     }
 
     [Test]
-    public async Task Attribute_handler_with_key_args_marks_the_event_handled_before_invocation()
+    public async Task Attribute_handler_with_key_args_preserves_handler_controlled_propagation()
     {
         var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var context = new AwaitableAttributeContext(gate.Task);
@@ -85,7 +85,7 @@ public class ContextCommandManagerTests
 
         Task operation = handler.InvokeAsync(context, args, Mock.Of<ILogger>());
 
-        Assert.That(args.Handled, Is.True);
+        Assert.That(args.Handled, Is.False);
         gate.SetResult();
         await operation;
     }
@@ -95,6 +95,14 @@ public class ContextCommandManagerTests
     {
         Assert.DoesNotThrowAsync(() => ContextCommandManager.ExecuteSafelyAsync(
             () => Task.FromException(new InvalidOperationException("command failed")),
+            Mock.Of<ILogger>()));
+    }
+
+    [Test]
+    public void Input_event_boundary_consumes_canceled_command_tasks()
+    {
+        Assert.DoesNotThrowAsync(() => ContextCommandManager.ExecuteSafelyAsync(
+            () => Task.FromCanceled(new CancellationToken(canceled: true)),
             Mock.Of<ILogger>()));
     }
 

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
@@ -2451,11 +2451,11 @@ public sealed class RenderPipelineMigrationCensusTests
             if (aliasQualified is not null
                 && aliasQualified.Alias.Identifier.ValueText != "global")
             {
-                string aliasName = aliasQualified.Alias.Identifier.ValueText;
-                string prefix = aliasName + ".";
+                string externAliasName = aliasQualified.Alias.Identifier.ValueText;
+                string prefix = externAliasName + ".";
                 return writtenType.StartsWith(prefix, StringComparison.Ordinal)
                        && writtenType[prefix.Length..] == qualifiedTypeName
-                       && ExternAliasTargetsEngine(aliasName, document);
+                       && ExternAliasTargetsEngine(externAliasName, document);
             }
 
             if (IsGloballyQualified(type))

--- a/tests/Beutl.UnitTests/Extensibility/ContextCommandExecutionTests.cs
+++ b/tests/Beutl.UnitTests/Extensibility/ContextCommandExecutionTests.cs
@@ -1,0 +1,39 @@
+﻿using Beutl.Extensibility;
+
+namespace Beutl.UnitTests.Extensibility;
+
+[TestFixture]
+public class ContextCommandExecutionTests
+{
+    [Test]
+    public async Task Handler_contract_exposes_the_complete_operation()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = new AwaitableHandler(gate.Task);
+        var execution = new ContextCommandExecution("TestCommand");
+
+        Task operation = handler.ExecuteAsync(execution);
+
+        Assert.That(operation.IsCompleted, Is.False);
+
+        gate.SetResult();
+        await operation;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(operation.IsCompletedSuccessfully, Is.True);
+            Assert.That(handler.LastExecution, Is.SameAs(execution));
+        });
+    }
+
+    private sealed class AwaitableHandler(Task operation) : IContextCommandHandler
+    {
+        public ContextCommandExecution? LastExecution { get; private set; }
+
+        public Task ExecuteAsync(ContextCommandExecution execution)
+        {
+            LastExecution = execution;
+            return operation;
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Replace `IContextCommandHandler.Execute` with `ExecuteAsync`, making command completion part of the handler contract instead of an optional side channel.
- Preserve complete asynchronous operations through keyboard dispatch, attribute-based handlers, the command palette, and the four built-in context-command handlers.
- Model menu actions that open dialogs or perform asynchronous work as `AsyncReactiveCommand`, and await them at direct UI event boundaries.
- Update the tool-tab extension implementation guide and add non-friend public API, unit, and headless regression coverage.
- This PR is based directly on `main` and has no dependency on any other split PR.

## Affected areas

- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [x] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [x] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes

`IContextCommandHandler.Execute(ContextCommandExecution)` is replaced by `Task ExecuteAsync(ContextCommandExecution)`. Synchronous handlers return `Task.CompletedTask`; asynchronous handlers return the task for their complete operation. Callers must await or otherwise observe that task.

`ContextCommandHandler.Invoke` is replaced by `InvokeAsync`, which observes `Task` and `ValueTask` attribute handlers. `CreateNewProject`, `OpenProject`, `OpenFile`, `NewScene`, and `DeleteLayer` now expose `AsyncReactiveCommand`. Plugin implementations and callers must migrate to these awaitable APIs.

## Test plan

- `dotnet build Beutl.slnx -c Debug --nologo --no-restore`
- `dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --no-build --filter "FullyQualifiedName~ContextCommand|FullyQualifiedName~TimelineTabViewModelTests"` (31 passed)
- `dotnet test tests/Beutl.HeadlessUITests/Beutl.HeadlessUITests.csproj -f net10.0 --no-build --filter "FullyQualifiedName~ContextCommandDispatchTests|FullyQualifiedName~CommandPaletteViewLayoutTests"` (9 passed)
- `dotnet test tests/Beutl.PublicApiContractTests/Beutl.PublicApiContractTests.csproj -f net10.0 --no-build` (212 passed)
- `dotnet format Beutl.slnx --verify-no-changes --no-restore --verbosity minimal`
- `bash .claude/scripts/check-gpl-mit-boundary-diff.sh --files <changed-files>`
- Independent `beutl-design-reviewer` and `beutl-reviewer` audits: Go

## Fixed issues / References


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Command palette, context commands, and menu actions now support asynchronous execution.
  - Command execution can remain in progress until the underlying operation finishes, including playback, cutting, saving, opening, and project actions.
  - Keyboard and double-click command palette actions now await completion.

- **Bug Fixes**
  - Improved reliability when triggering asynchronous commands.
  - Errors from file and project actions can now be observed and handled more consistently.
  - Added coverage to verify command completion behavior across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->