### PR TITLE
fix(agent-host): treat disabled editors as unavailable sessions

### DIFF
--- a/src/Beutl/AgentHost/EditViewModelLiveBinding.cs
+++ b/src/Beutl/AgentHost/EditViewModelLiveBinding.cs
@@ -12,7 +12,31 @@ public sealed class EditViewModelLiveBinding(EditViewModel editViewModel) : ILiv
 
     public HistoryManager? ActiveHistory => editViewModel.HistoryManager;
 
-    public bool IsAlive => editViewModel.Scene is not null;
+    // Host-controlled transitions disable the editor before closing or replacing its scene. An
+    // accepted mutation in that window would only reach stale in-memory state, so the session is
+    // unavailable for exactly as long as the editor is disabled.
+    public bool IsAlive
+    {
+        get
+        {
+            if (editViewModel.Scene is null)
+            {
+                return false;
+            }
+
+            try
+            {
+                return editViewModel.IsEnabled.Value
+                       && !editViewModel.IsDisposingOrDisposed;
+            }
+            catch (ObjectDisposedException)
+            {
+                // Disposal tears down reactive properties before clearing Scene. Treat that short
+                // interval as unavailable instead of leaking the implementation exception.
+                return false;
+            }
+        }
+    }
 
     public void Invoke(Action action)
     {

--- a/src/Beutl/AgentHost/EditorProjectSessionGateway.cs
+++ b/src/Beutl/AgentHost/EditorProjectSessionGateway.cs
@@ -73,6 +73,11 @@ public sealed class EditorProjectSessionGateway(
     {
         return await Dispatcher.UIThread.InvokeAsync(() =>
         {
+            if (activeSession is LiveEditingSession liveSession && !liveSession.ProbeIsAlive())
+            {
+                throw new SessionUnavailableException();
+            }
+
             if (projectService.CurrentProject.Value is not { } project)
             {
                 throw new SessionUnavailableException();

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -65,6 +65,8 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
     private bool _proxyInvalidationScheduled;
     private volatile bool _disposed;
 
+    internal bool IsDisposingOrDisposed => _disposed;
+
     public EditViewModel(Scene scene, Beutl.Api.Services.ExtensionProvider extensionProvider, EditorService editorService)
     {
         ArgumentNullException.ThrowIfNull(scene);

--- a/tests/Beutl.HeadlessUITests/AgentHostEndpointTests.cs
+++ b/tests/Beutl.HeadlessUITests/AgentHostEndpointTests.cs
@@ -218,6 +218,48 @@ public sealed class AgentHostEndpointTests
     }
 
     [AvaloniaTest]
+    public async Task Live_binding_reports_unavailable_when_its_scene_is_cleared()
+    {
+        await TestReset.ResetShellAsync();
+        try
+        {
+            string location = Path.Combine(
+                Beutl.Testing.Headless.BeutlHomeIsolation.CurrentHome!,
+                "agent-live-cleared-scene");
+            Directory.CreateDirectory(location);
+            Project project = (await TestShell.Project.CreateProject(
+                640,
+                480,
+                30,
+                44100,
+                "live",
+                location))!;
+            Scene scene = project.Items.OfType<Scene>().Single();
+            TestShell.Editor.ActivateTabItem(scene);
+            Beutl.Testing.Headless.HeadlessTestHelpers.Settle();
+            var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+            var binding = new EditViewModelLiveBinding(editor);
+            FieldInfo sceneField = typeof(EditViewModel).GetField(
+                "<Scene>k__BackingField",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+            sceneField.SetValue(editor, null);
+            try
+            {
+                Assert.That(binding.IsAlive, Is.False);
+            }
+            finally
+            {
+                sceneField.SetValue(editor, scene);
+            }
+        }
+        finally
+        {
+            await TestReset.ResetShellAsync();
+        }
+    }
+
+    [AvaloniaTest]
     public async Task Endpoint_binds_default_loopback_port_uses_fixed_token_and_stops_cleanly()
     {
         await TestReset.ResetShellAsync();

--- a/tests/Beutl.HeadlessUITests/AgentHostEndpointTests.cs
+++ b/tests/Beutl.HeadlessUITests/AgentHostEndpointTests.cs
@@ -6,6 +6,7 @@ using Avalonia.Headless.NUnit;
 using Beutl.AgentHost;
 using Beutl.AgentToolkit.Common;
 using Beutl.AgentToolkit.Sessions;
+using Beutl.AgentToolkit.Workspace;
 using Beutl.Api.Services;
 using Beutl.Configuration;
 using Beutl.ProjectSystem;
@@ -76,6 +77,100 @@ public sealed class AgentHostEndpointTests
         {
             await TestReset.ResetShellAsync();
         }
+    }
+
+    [AvaloniaTest]
+    public async Task Add_scene_rejects_a_disabled_live_editor_without_mutating_the_project()
+    {
+        await TestReset.ResetShellAsync();
+        try
+        {
+            string location = Path.Combine(
+                Beutl.Testing.Headless.BeutlHomeIsolation.CurrentHome!,
+                "agent-add-scene-disabled-editor");
+            Directory.CreateDirectory(location);
+            Project project = (await TestShell.Project.CreateProject(
+                640,
+                480,
+                30,
+                44100,
+                "live",
+                location))!;
+            Scene scene = project.Items.OfType<Scene>().Single();
+            TestShell.Editor.ActivateTabItem(scene);
+            Beutl.Testing.Headless.HeadlessTestHelpers.Settle();
+            var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+            var liveSessions = new LiveSessionSource();
+            LiveEditingSession session = liveSessions.Attach(new EditViewModelLiveBinding(editor));
+            var sessions = new AgentSessionManager();
+            sessions.UseSource(liveSessions);
+            var gateway = new EditorProjectSessionGateway(
+                TestShell.Project,
+                TestShell.Editor,
+                liveSessions,
+                sessions,
+                new WorkspaceGuard(Beutl.Testing.Headless.BeutlHomeIsolation.CurrentHome!));
+            Dictionary<string, string> filesBefore = SnapshotFiles(location);
+
+            editor.IsEnabled.Value = false;
+            try
+            {
+                SessionUnavailableException? rejection = null;
+                try
+                {
+                    await gateway.AddSceneAsync(session, new SceneCreateOptions(
+                        320,
+                        180,
+                        TimeSpan.Zero,
+                        TimeSpan.FromSeconds(2),
+                        "blocked-scene"));
+                    Assert.Fail("Expected a SessionUnavailableException.");
+                }
+                catch (SessionUnavailableException ex)
+                {
+                    rejection = ex;
+                }
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(rejection, Is.Not.Null);
+                    Assert.That(project.Items.OfType<Scene>().Count(), Is.EqualTo(1));
+                    Assert.That(SnapshotFiles(location), Is.EqualTo(filesBefore));
+                });
+            }
+            finally
+            {
+                editor.IsEnabled.Value = true;
+            }
+
+            ProjectSceneResult added = await gateway.AddSceneAsync(session, new SceneCreateOptions(
+                320,
+                180,
+                TimeSpan.Zero,
+                TimeSpan.FromSeconds(2),
+                "added-scene"));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(project.Items.OfType<Scene>().Count(), Is.EqualTo(2));
+                Assert.That(project.Items, Does.Contain(added.Scene));
+                Assert.That(File.Exists(added.Scene.Uri!.LocalPath), Is.True);
+            });
+        }
+        finally
+        {
+            await TestReset.ResetShellAsync();
+        }
+    }
+
+    private static Dictionary<string, string> SnapshotFiles(string root)
+    {
+        return Directory.GetFiles(root, "*", SearchOption.AllDirectories)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToDictionary(
+                path => Path.GetRelativePath(root, path),
+                path => Convert.ToBase64String(File.ReadAllBytes(path)),
+                StringComparer.Ordinal);
     }
 
     [AvaloniaTest]

--- a/tests/Beutl.HeadlessUITests/AgentHostEndpointTests.cs
+++ b/tests/Beutl.HeadlessUITests/AgentHostEndpointTests.cs
@@ -1,13 +1,16 @@
 ﻿using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Sockets;
+using System.Reflection;
 using Avalonia.Headless.NUnit;
 using Beutl.AgentHost;
 using Beutl.AgentToolkit.Common;
 using Beutl.AgentToolkit.Sessions;
 using Beutl.Api.Services;
 using Beutl.Configuration;
+using Beutl.ProjectSystem;
 using Beutl.Services;
+using Beutl.ViewModels;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 
@@ -15,6 +18,110 @@ namespace Beutl.HeadlessUITests;
 
 public sealed class AgentHostEndpointTests
 {
+    [AvaloniaTest]
+    public async Task Live_session_rejects_mutations_while_the_editor_is_disabled()
+    {
+        await TestReset.ResetShellAsync();
+        try
+        {
+            string location = Path.Combine(
+                Beutl.Testing.Headless.BeutlHomeIsolation.CurrentHome!,
+                "agent-live-disabled-editor");
+            Directory.CreateDirectory(location);
+            Project project = (await TestShell.Project.CreateProject(
+                640,
+                480,
+                30,
+                44100,
+                "live",
+                location))!;
+            Scene scene = project.Items.OfType<Scene>().Single();
+            TestShell.Editor.ActivateTabItem(scene);
+            Beutl.Testing.Headless.HeadlessTestHelpers.Settle();
+            var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+            var binding = new EditViewModelLiveBinding(editor);
+            var source = new LiveSessionSource();
+            LiveEditingSession session = source.Attach(binding);
+            int invocations = 0;
+
+            Assert.That(session.ProbeIsAlive(), Is.True);
+
+            editor.IsEnabled.Value = false;
+            try
+            {
+                Assert.Multiple(() =>
+                {
+                    Assert.That(binding.IsAlive, Is.False);
+                    Assert.That(source.CurrentSession, Is.Null);
+                    Assert.Throws<SessionUnavailableException>(
+                        () => session.Invoke(() => invocations++));
+                    Assert.That(invocations, Is.Zero);
+                });
+            }
+            finally
+            {
+                editor.IsEnabled.Value = true;
+            }
+
+            session.Invoke(() => invocations++);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(binding.IsAlive, Is.True);
+                Assert.That(source.CurrentSession, Is.SameAs(session));
+                Assert.That(invocations, Is.EqualTo(1));
+            });
+        }
+        finally
+        {
+            await TestReset.ResetShellAsync();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Live_session_reports_unavailable_as_soon_as_editor_disposal_starts()
+    {
+        await TestReset.ResetShellAsync();
+        try
+        {
+            string location = Path.Combine(
+                Beutl.Testing.Headless.BeutlHomeIsolation.CurrentHome!,
+                "agent-live-disposed-editor-state");
+            Directory.CreateDirectory(location);
+            Project project = (await TestShell.Project.CreateProject(
+                640,
+                480,
+                30,
+                44100,
+                "live",
+                location))!;
+            Scene scene = project.Items.OfType<Scene>().Single();
+            TestShell.Editor.ActivateTabItem(scene);
+            Beutl.Testing.Headless.HeadlessTestHelpers.Settle();
+            var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+            var binding = new EditViewModelLiveBinding(editor);
+            var source = new LiveSessionSource();
+            LiveEditingSession session = source.Attach(binding);
+
+            FieldInfo disposed = typeof(EditViewModel).GetField(
+                "_disposed",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            disposed.SetValue(editor, true);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(editor.Scene, Is.Not.Null);
+                Assert.That(binding.IsAlive, Is.False);
+                Assert.That(source.CurrentSession, Is.Null);
+                Assert.Throws<SessionUnavailableException>(() => session.Invoke(static () => { }));
+            });
+        }
+        finally
+        {
+            await TestReset.ResetShellAsync();
+        }
+    }
+
     [AvaloniaTest]
     public async Task Endpoint_binds_default_loopback_port_uses_fixed_token_and_stops_cleanly()
     {


### PR DESCRIPTION
## Description

- Make `EditViewModelLiveBinding` include the editor's enabled/disposal state in live-session availability.
- Hide a disabled editor from live-session discovery and reject agent mutations before they can reach stale in-memory scene state.
- Re-check an existing live session inside `AddSceneAsync` before any project/file mutation.
- Restore the same live session and gateway operations automatically when the editor is enabled again.
- Preserve the current-project open fast path, including attachment when no editor tab is selected.
- This PR is based directly on `main` and has no dependency on #2164 or any other split PR.

## Affected areas

- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes

None.

## Test plan

- `dotnet build tests/Beutl.HeadlessUITests/Beutl.HeadlessUITests.csproj -f net10.0 --no-restore` — passed, 0 errors.
- `AgentHostEndpointTests` + `EditorProjectSessionGatewayTests` — 22 passed.
- `git diff --check` — passed.

## Fixed issues / References

- Independent AgentHost admission prerequisite for #2164; this PR still targets `main` directly and is not stacked on it.
- New Open/Create request admission remains part of the separate shutdown/drain prerequisite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Live editing sessions are now unavailable when the editor is disabled, closing, disposed, or its scene is cleared.
  - Mutations attempted while a session is unavailable are rejected before project data or files are changed.
  - Live editing can resume after the editor is enabled again.

- **Tests**
  - Added coverage for unavailable sessions during editor shutdown and cleared-scene states.
  - Added coverage confirming rejected scene additions leave project data and files unchanged.
  - Added coverage confirming scene additions succeed after re-enabling the editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->