### PR TITLE
feat(proxy): add lease-based job admission

### DIFF
--- a/docs/specs/002-proxy-media/contracts/IProxyJobQueue.md
+++ b/docs/specs/002-proxy-media/contracts/IProxyJobQueue.md
@@ -46,7 +46,7 @@ public sealed class ProxyJobChangedEventArgs : EventArgs
     public required ProxyJobChangeKind Kind { get; init; }
 }
 
-public enum ProxyJobChangeKind { Enqueued, Started, Progressed, Succeeded, Failed, Canceled, Skipped }
+public enum ProxyJobChangeKind { Enqueued, Started, Progressed, Succeeded, Failed, Canceled, Skipped, WaitingForAdmission }
 
 public interface IProxyGenerator
 {
@@ -64,6 +64,12 @@ public interface IProxyGenerationAdmission
     /// the queue until generation and terminal cleanup finish.
     /// </summary>
     IDisposable? TryAcquireLease(ProxyJob job);
+
+    /// <summary>
+    /// Signals that host resources may be available. The queue re-runs TryAcquireLease for every
+    /// deferred job and retains bounded retry as a missed-signal fallback.
+    /// </summary>
+    event EventHandler? AvailabilityChanged;
 }
 ```
 
@@ -75,7 +81,7 @@ public interface IProxyGenerationAdmission
 4. **Cancellation semantics**: `Cancel` propagates the queue-level token to the in-flight generator. On cancel, the generator MUST delete any `*.tmp` files it created before completing the job. The job's terminal state is `Canceled`, not `Failed`; cancel never records `ProxyState.Failed` or a failure reason.
 5. **Skipped semantics**: ineligible sources (audio-only, procedural/generative, still images) complete as `ProxyJobStatus.Skipped` and raise `ProxyJobChangeKind.Skipped` with a human-readable `StatusMessage`. Skipped jobs do not call `IProxyStore.Register`, do not create a proxy entry, and leave any existing proxy entry unchanged.
 6. **Generator unavailable → bounded retry or terminal skip**: if the registered `IProxyGenerator` throws `ProxyGeneratorUnavailableException` (the FFmpeg implementation uses this for "FFmpeg not installed"), the behavior depends on whether the generator exposes an availability signal (`IProxyGeneratorAvailability`). With a signal, the job stays `Queued` and the drain loop re-probes after a bounded exponential backoff, resuming immediately when the generator reports availability — the job (and its install prompt) stays alive. Without a signal the queue can never learn the generator recovered, so the job completes as a terminal `Skipped` with the generator's message. The concrete FFmpeg generator, not `Beutl.Engine`, surfaces `FFmpegInstallNotifier`.
-7. **Optional host admission**: constructors that receive `IProxyGenerationAdmission` call its non-blocking `TryAcquireLease` immediately before generator execution. A `null` result keeps the job `Queued`, emits no `Started` event, and defers only that item with exponential backoff capped by the queue's configured maximum; another admissible job at the same priority remains dispatchable. The generator is never entered for a rejected attempt. An accepted lease is held across the complete `GenerateAsync` call and released exactly once before any terminal event, including success, skip, failure, cancellation, and queue disposal. Once cancellation is requested it wins over concurrent admission and generator exceptions, so no failed store entry is recorded. A lease-release failure takes precedence and remains `Failed`, because terminal cleanup could not be proved. Hosts can compose multiple resource policies behind one admission implementation; this primitive does not assume any specific workspace transition or version-control integration.
+7. **Optional host admission**: constructors that receive `IProxyGenerationAdmission` call its non-blocking `TryAcquireLease` immediately before generator execution. A `null` result keeps the job `Queued`, emits one `WaitingForAdmission` event on entry to the wait episode, and defers only that item with exponential backoff capped by the queue's configured maximum; another admissible job at the same priority remains dispatchable. `AvailabilityChanged` wakes every deferred item immediately, while the timer remains a missed-signal fallback. The generator is never entered for a rejected attempt. An accepted lease is held across the complete `GenerateAsync` call and released exactly once before any terminal event, including success, skip, failure, cancellation, and queue disposal. Once cancellation is requested it wins over concurrent admission and generator exceptions, so no failed store entry is recorded. A lease-release or failure-rollback error takes precedence and remains `Failed`, because terminal cleanup could not be proved. Hosts can compose multiple resource policies behind one admission implementation; this primitive does not assume any specific workspace transition or version-control integration.
 8. **Bounded queue**: `EnqueueAsync` awaits once the backing channel is full (capacity 256). UI can pass a short cancellation token to surface "queue full" or "try again" without blocking the UI thread. If the enqueue write itself fails (caller cancellation, queue disposal), the job transitions to a terminal `Canceled` state and raises `JobChanged` before the exception propagates — a deduplicated caller holding the same `ProxyJob` never sees it stuck at `Queued` forever.
 9. **Subscriber isolation**: `JobChanged` handlers are invoked individually; a throwing subscriber is logged and neither faults the queue's drain loop nor starves the remaining subscribers of the notification.
 10. **`AsyncDispose` semantics**: disposing waits for the active job to reach a terminal state (after cancelling it) — never abandons in-flight encoder processes. Every job ever surfaced (returned from `EnqueueAsync` or observed via `JobChanged`) is terminal by the time `DisposeAsync` completes.

--- a/docs/specs/002-proxy-media/contracts/IProxyJobQueue.md
+++ b/docs/specs/002-proxy-media/contracts/IProxyJobQueue.md
@@ -56,6 +56,15 @@ public interface IProxyGenerator
     /// </summary>
     ValueTask GenerateAsync(ProxyJob job);
 }
+
+public interface IProxyGenerationAdmission
+{
+    /// <summary>
+    /// Non-blocking host admission. Null means temporarily busy; a non-null lease transfers to
+    /// the queue until generation and terminal cleanup finish.
+    /// </summary>
+    IDisposable? TryAcquireLease(ProxyJob job);
+}
 ```
 
 ## Behavior contract
@@ -66,9 +75,10 @@ public interface IProxyGenerator
 4. **Cancellation semantics**: `Cancel` propagates the queue-level token to the in-flight generator. On cancel, the generator MUST delete any `*.tmp` files it created before completing the job. The job's terminal state is `Canceled`, not `Failed`; cancel never records `ProxyState.Failed` or a failure reason.
 5. **Skipped semantics**: ineligible sources (audio-only, procedural/generative, still images) complete as `ProxyJobStatus.Skipped` and raise `ProxyJobChangeKind.Skipped` with a human-readable `StatusMessage`. Skipped jobs do not call `IProxyStore.Register`, do not create a proxy entry, and leave any existing proxy entry unchanged.
 6. **Generator unavailable → bounded retry or terminal skip**: if the registered `IProxyGenerator` throws `ProxyGeneratorUnavailableException` (the FFmpeg implementation uses this for "FFmpeg not installed"), the behavior depends on whether the generator exposes an availability signal (`IProxyGeneratorAvailability`). With a signal, the job stays `Queued` and the drain loop re-probes after a bounded exponential backoff, resuming immediately when the generator reports availability — the job (and its install prompt) stays alive. Without a signal the queue can never learn the generator recovered, so the job completes as a terminal `Skipped` with the generator's message. The concrete FFmpeg generator, not `Beutl.Engine`, surfaces `FFmpegInstallNotifier`.
-7. **Bounded queue**: `EnqueueAsync` awaits once the backing channel is full (capacity 256). UI can pass a short cancellation token to surface "queue full" or "try again" without blocking the UI thread. If the enqueue write itself fails (caller cancellation, queue disposal), the job transitions to a terminal `Canceled` state and raises `JobChanged` before the exception propagates — a deduplicated caller holding the same `ProxyJob` never sees it stuck at `Queued` forever.
-8. **Subscriber isolation**: `JobChanged` handlers are invoked individually; a throwing subscriber is logged and neither faults the queue's drain loop nor starves the remaining subscribers of the notification.
-9. **`AsyncDispose` semantics**: disposing waits for the active job to reach a terminal state (after cancelling it) — never abandons in-flight encoder processes. Every job ever surfaced (returned from `EnqueueAsync` or observed via `JobChanged`) is terminal by the time `DisposeAsync` completes.
+7. **Optional host admission**: constructors that receive `IProxyGenerationAdmission` call its non-blocking `TryAcquireLease` immediately before generator execution. A `null` result keeps the job `Queued`, emits no `Started` event, and defers only that item with exponential backoff capped by the queue's configured maximum; another admissible job at the same priority remains dispatchable. The generator is never entered for a rejected attempt. An accepted lease is held across the complete `GenerateAsync` call and released exactly once before any terminal event, including success, skip, failure, cancellation, and queue disposal. Once cancellation is requested it wins over concurrent admission and generator exceptions, so no failed store entry is recorded. A lease-release failure takes precedence and remains `Failed`, because terminal cleanup could not be proved. Hosts can compose multiple resource policies behind one admission implementation; this primitive does not assume any specific workspace transition or version-control integration.
+8. **Bounded queue**: `EnqueueAsync` awaits once the backing channel is full (capacity 256). UI can pass a short cancellation token to surface "queue full" or "try again" without blocking the UI thread. If the enqueue write itself fails (caller cancellation, queue disposal), the job transitions to a terminal `Canceled` state and raises `JobChanged` before the exception propagates — a deduplicated caller holding the same `ProxyJob` never sees it stuck at `Queued` forever.
+9. **Subscriber isolation**: `JobChanged` handlers are invoked individually; a throwing subscriber is logged and neither faults the queue's drain loop nor starves the remaining subscribers of the notification.
+10. **`AsyncDispose` semantics**: disposing waits for the active job to reach a terminal state (after cancelling it) — never abandons in-flight encoder processes. Every job ever surfaced (returned from `EnqueueAsync` or observed via `JobChanged`) is terminal by the time `DisposeAsync` completes.
 
 ## Test obligations (NUnit)
 
@@ -80,3 +90,4 @@ public interface IProxyGenerator
 - `MaxConcurrency == 1` is observable: at most one job is in `Running` state at any point in a stress test (1000 enqueues).
 - Dispose with one in-flight job: completes after the job transitions terminal; no zombie worker processes.
 - Generator-missing path (with availability signal): the job that observes the missing dependency stays `Queued`; subsequent enqueues during the missing window remain queued; after the generator reports availability, the queue resumes draining. Without an availability signal the job completes as `Skipped`.
+- Admission rejection: the generator is not entered and `Started` is not raised; retries follow the configured bounded per-item backoff without starving an admissible peer. Accepted leases are released once on every terminal path and before terminal publication. Cancellation while parked acquires no lease; cancellation/disposal beats concurrent admission or generator errors; disposal racing an active generator waits for its lease release. A release failure remains `Failed` and is never hidden as cancellation.

--- a/docs/specs/002-proxy-media/data-model.md
+++ b/docs/specs/002-proxy-media/data-model.md
@@ -244,6 +244,7 @@ Owns:
 - The single-consumer `Channel<ProxyJob>` plus its drain loop.
 - Job lifecycle, cancellation propagation, completion event surface for UI.
 - Async enqueue back-pressure (`ValueTask<ProxyJob> EnqueueAsync(...)`) so a full bounded queue can wait without blocking the UI thread.
+- Optional `IProxyGenerationAdmission` enforcement immediately before generator execution. Rejected attempts stay queued under capped backoff; accepted leases cover generation through terminal cleanup without prescribing a particular host conflict source.
 
 ### `IProxyGenerator` (Engine abstraction) and `FFmpegProxyGenerator` (concrete extension implementation)
 

--- a/src/Beutl.Engine/Media/Proxy/IProxyJobQueue.cs
+++ b/src/Beutl.Engine/Media/Proxy/IProxyJobQueue.cs
@@ -29,6 +29,28 @@ public interface IProxyGenerator
     ValueTask GenerateAsync(ProxyJob job);
 }
 
+/// <summary>
+/// Lets a host admit proxy generation only while the resources it shares with other operations
+/// are available.
+/// </summary>
+/// <remarks>
+/// Admission is a synchronous, non-blocking try operation. Returning <see langword="null"/> keeps
+/// the job queued and prevents the generator from running; the queue retries after a bounded
+/// per-job backoff without blocking admissible peers. A returned lease transfers to the queue and
+/// is held until generation and its terminal cleanup finish. Cancellation takes precedence over a
+/// concurrent admission or generation error; a lease-release failure remains a failure because
+/// cleanup could not be completed.
+/// </remarks>
+public interface IProxyGenerationAdmission
+{
+    /// <summary>Attempts to acquire the host resources required by <paramref name="job"/>.</summary>
+    /// <returns>
+    /// A lease that the queue disposes exactly once, or <see langword="null"/> when the host is
+    /// temporarily busy.
+    /// </returns>
+    IDisposable? TryAcquireLease(ProxyJob job);
+}
+
 public interface IProxyGeneratorAvailability
 {
     bool IsAvailable { get; }

--- a/src/Beutl.Engine/Media/Proxy/IProxyJobQueue.cs
+++ b/src/Beutl.Engine/Media/Proxy/IProxyJobQueue.cs
@@ -49,6 +49,16 @@ public interface IProxyGenerationAdmission
     /// temporarily busy.
     /// </returns>
     IDisposable? TryAcquireLease(ProxyJob job);
+
+    /// <summary>
+    /// Raised when host resources may have become available after a rejected acquisition.
+    /// </summary>
+    /// <remarks>
+    /// The queue still calls <see cref="TryAcquireLease"/> to make the admission decision. This
+    /// signal only wakes deferred jobs early; bounded retry remains as a fallback for missed or
+    /// unsupported host transitions.
+    /// </remarks>
+    event EventHandler? AvailabilityChanged;
 }
 
 public interface IProxyGeneratorAvailability
@@ -68,6 +78,7 @@ public sealed class ProxyJobChangedEventArgs : EventArgs
 public enum ProxyJobChangeKind
 {
     Enqueued,
+    WaitingForAdmission,
     Started,
     Progressed,
     Succeeded,

--- a/src/Beutl.Engine/Media/Proxy/IProxyJobQueue.cs
+++ b/src/Beutl.Engine/Media/Proxy/IProxyJobQueue.cs
@@ -78,11 +78,11 @@ public sealed class ProxyJobChangedEventArgs : EventArgs
 public enum ProxyJobChangeKind
 {
     Enqueued,
-    WaitingForAdmission,
     Started,
     Progressed,
     Succeeded,
     Failed,
     Canceled,
     Skipped,
+    WaitingForAdmission,
 }

--- a/src/Beutl.Engine/Media/Proxy/ProxyJobQueue.cs
+++ b/src/Beutl.Engine/Media/Proxy/ProxyJobQueue.cs
@@ -504,14 +504,17 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                     {
                         item.ResetAdmissionRejections();
                         item.Job.StatusMessage = null;
-                        await GenerateWithAdmissionLeaseAsync(generator, item, admissionLease)
+                        bool generated = await GenerateWithAdmissionLeaseAsync(
+                                generator,
+                                item,
+                                admissionLease)
                             .ConfigureAwait(false);
-                        if (item.TryCompleteSuccess())
+                        if (generated && item.TryCompleteSuccess())
                         {
                             Interlocked.Exchange(ref _consecutiveUnavailable, 0);
                             OnJobChanged(item.Job, ProxyJobChangeKind.Succeeded);
                         }
-                        else
+                        else if (generated)
                         {
                             CompleteCanceled(item);
                         }
@@ -594,7 +597,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         }
     }
 
-    private async Task GenerateWithAdmissionLeaseAsync(
+    private async Task<bool> GenerateWithAdmissionLeaseAsync(
         IProxyGenerator generator,
         WorkItem item,
         IDisposable? admissionLease)
@@ -613,15 +616,45 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             generationFailure = ExceptionDispatchInfo.Capture(ex);
         }
 
-        Exception? releaseFailure = null;
-        try
+        if (generationFailure is not null
+            && generationFailure.SourceException is not (OperationCanceledException
+                or ProxyGenerationSkippedException
+                or ProxyGeneratorUnavailableException))
         {
-            admissionLease?.Dispose();
+            if (!item.TryClaimNonCancellationTerminal(cancellationWins: true))
+            {
+                Exception? cancellationReleaseFailure = ReleaseAdmissionLease(admissionLease);
+                if (cancellationReleaseFailure is not null)
+                {
+                    throw new AdmissionLeaseReleaseException(cancellationReleaseFailure);
+                }
+
+                CompleteCanceled(item);
+                return false;
+            }
+
+            Exception failure = generationFailure.SourceException;
+            item.Job.Error = failure;
+            // Store bookkeeping is part of terminal cleanup and remains inside admission.
+            RegisterFailure(item.Job, failure.Message);
+
+            Exception? releaseFailure = ReleaseAdmissionLease(admissionLease);
+            if (releaseFailure is not null)
+            {
+                item.Job.Error = new AggregateException(
+                    "Proxy generation and admission-lease release both failed.",
+                    failure,
+                    releaseFailure);
+            }
+
+            // Publish only after admission is released; observers can now safely start conflicting
+            // work and still see the already-recorded Failed store entry.
+            item.Job.Status = ProxyJobStatus.Failed;
+            OnJobChanged(item.Job, ProxyJobChangeKind.Failed);
+            return false;
         }
-        catch (Exception ex)
-        {
-            releaseFailure = ex;
-        }
+
+        Exception? releaseFailure = ReleaseAdmissionLease(admissionLease);
 
         if (generationFailure is not null && releaseFailure is not null)
         {
@@ -638,6 +671,20 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         }
 
         generationFailure?.Throw();
+        return true;
+    }
+
+    private static Exception? ReleaseAdmissionLease(IDisposable? admissionLease)
+    {
+        try
+        {
+            admissionLease?.Dispose();
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return ex;
+        }
     }
 
     private bool RequeueForRetry(WorkItem item)

--- a/src/Beutl.Engine/Media/Proxy/ProxyJobQueue.cs
+++ b/src/Beutl.Engine/Media/Proxy/ProxyJobQueue.cs
@@ -9,6 +9,8 @@ namespace Beutl.Media.Proxy;
 
 public sealed class ProxyJobQueue : IProxyJobQueue
 {
+    private readonly record struct FailureRegistration(ProxyEntry? Previous, bool Changed);
+
     private static readonly ILogger s_logger = Log.CreateLogger("ProxyJobQueue");
     private readonly Func<IProxyGenerator?> _generatorProvider;
     private IProxyGenerator? _generator;
@@ -128,6 +130,10 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         _minUnavailableBackoff = minUnavailableBackoff;
         _maxUnavailableBackoff = maxUnavailableBackoff;
         _admission = admission;
+        if (_admission is not null)
+        {
+            _admission.AvailabilityChanged += OnAdmissionAvailabilityChanged;
+        }
         _delayAsync = delayAsync ?? (static (delay, token) => Task.Delay(delay, token));
         // Unbounded: each queued item needs exactly one wake permit, and the drain (single reader,
         // MaxConcurrency 1) consumes one per dispatch. Items already live in _items — deduplicated by
@@ -371,6 +377,11 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             return;
 
         _disposed = true;
+        if (_admission is not null)
+        {
+            _admission.AvailabilityChanged -= OnAdmissionAvailabilityChanged;
+        }
+
         CancelAll();
         _channel.Writer.TryComplete();
         _disposeCts.Cancel();
@@ -621,30 +632,29 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                 or ProxyGenerationSkippedException
                 or ProxyGeneratorUnavailableException))
         {
-            if (!item.TryClaimNonCancellationTerminal(cancellationWins: true))
-            {
-                Exception? cancellationReleaseFailure = ReleaseAdmissionLease(admissionLease);
-                if (cancellationReleaseFailure is not null)
-                {
-                    throw new AdmissionLeaseReleaseException(cancellationReleaseFailure);
-                }
-
-                CompleteCanceled(item);
-                return false;
-            }
-
             Exception failure = generationFailure.SourceException;
             item.Job.Error = failure;
             // Store bookkeeping is part of terminal cleanup and remains inside admission.
-            RegisterFailure(item.Job, failure.Message);
+            FailureRegistration failureRegistration = RegisterFailure(
+                item.Job,
+                failure.Message);
 
             Exception? releaseFailure = ReleaseAdmissionLease(admissionLease);
             if (releaseFailure is not null)
             {
+                item.TryClaimNonCancellationTerminal(cancellationWins: false);
                 item.Job.Error = new AggregateException(
                     "Proxy generation and admission-lease release both failed.",
                     failure,
                     releaseFailure);
+            }
+            else if (!item.TryClaimNonCancellationTerminal(cancellationWins: true))
+            {
+                RollBackFailure(item.Job, failureRegistration);
+                item.Job.Error = null;
+                item.Job.Status = ProxyJobStatus.Canceled;
+                OnJobChanged(item.Job, ProxyJobChangeKind.Canceled);
+                return false;
             }
 
             // Publish only after admission is released; observers can now safely start conflicting
@@ -701,10 +711,15 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         if (!item.ResetForAdmissionRetry())
             return false;
 
-        OnJobChanged(item.Job, ProxyJobChangeKind.Enqueued);
         TimeSpan backoff = item.NextAdmissionBackoff(
             _minUnavailableBackoff,
-            _maxUnavailableBackoff);
+            _maxUnavailableBackoff,
+            out bool firstRejection);
+        if (firstRejection)
+        {
+            OnJobChanged(item.Job, ProxyJobChangeKind.WaitingForAdmission);
+        }
+
         Task retry = ResumeAdmissionAfterBackoffAsync(item, backoff);
         lock (_lock)
         {
@@ -715,14 +730,62 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         return true;
     }
 
+    private void OnAdmissionAvailabilityChanged(object? sender, EventArgs e)
+    {
+        List<(WorkItem Item, long Generation)> deferred = [];
+        lock (_lock)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            foreach (WorkItem item in _items)
+            {
+                if (item.TryGetAdmissionWait(out long generation, out _))
+                {
+                    deferred.Add((item, generation));
+                }
+            }
+        }
+
+        foreach ((WorkItem item, long generation) in deferred)
+        {
+            item.SignalAdmissionAvailability(generation);
+        }
+    }
+
     private async Task ResumeAdmissionAfterBackoffAsync(WorkItem item, TimeSpan backoff)
     {
+        if (!item.TryGetAdmissionWait(out long generation, out Task availability))
+        {
+            return;
+        }
+
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(
             _disposeCts.Token,
             item.Token);
         try
         {
-            await _delayAsync(backoff, linked.Token).ConfigureAwait(false);
+            Task delay = _delayAsync(backoff, linked.Token);
+            Task completed = await Task.WhenAny(delay, availability)
+                .WaitAsync(linked.Token)
+                .ConfigureAwait(false);
+            if (ReferenceEquals(completed, availability))
+            {
+                linked.Cancel();
+                try
+                {
+                    await delay.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (linked.IsCancellationRequested)
+                {
+                }
+            }
+            else
+            {
+                await delay.ConfigureAwait(false);
+            }
         }
         catch (OperationCanceledException) when (linked.IsCancellationRequested)
         {
@@ -734,7 +797,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             s_logger.LogError(ex, "Proxy admission retry delay failed; retrying immediately.");
         }
 
-        if (item.TryResumeAdmission())
+        if (item.TryResumeAdmission(generation))
         {
             _channel.Writer.TryWrite(item);
         }
@@ -858,15 +921,16 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         item.Cancel();
     }
 
-    private void RegisterFailure(ProxyJob job, string? failureReason)
+    private FailureRegistration RegisterFailure(ProxyJob job, string? failureReason)
     {
         if (_store == null)
-            return;
+            return default;
 
         try
         {
-            if (_store.TryGet(job.Source, job.Preset) is { State: ProxyState.Ready or ProxyState.Stale })
-                return;
+            ProxyEntry? previous = _store.TryGet(job.Source, job.Preset);
+            if (previous is { State: ProxyState.Ready or ProxyState.Stale })
+                return default;
 
             var now = DateTime.UtcNow;
             _store.Register(new ProxyEntry(
@@ -880,6 +944,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                 now,
                 now,
                 failureReason));
+            return new FailureRegistration(previous, Changed: true);
         }
         catch (Exception ex)
         {
@@ -887,6 +952,38 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             s_logger.LogError(
                 ex,
                 "Failed to record Failed proxy entry for {Source} ({Preset}).",
+                job.Source.AbsolutePath,
+                job.Preset);
+            return default;
+        }
+    }
+
+    private void RollBackFailure(ProxyJob job, FailureRegistration registration)
+    {
+        if (_store is null || !registration.Changed)
+        {
+            return;
+        }
+
+        try
+        {
+            if (registration.Previous is { } previous)
+            {
+                _store.Register(previous);
+            }
+            else
+            {
+                _store.Delete(job.Source, job.Preset);
+            }
+        }
+        catch (Exception ex)
+        {
+            job.BookkeepingError = job.BookkeepingError is null
+                ? ex
+                : new AggregateException(job.BookkeepingError, ex);
+            s_logger.LogError(
+                ex,
+                "Failed to roll back the proxy failure entry after cancellation for {Source} ({Preset}).",
                 job.Source.AbsolutePath,
                 job.Preset);
         }
@@ -983,6 +1080,8 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         private readonly Lock _lock = new();
         private bool _started;
         private bool _admissionDeferred;
+        private TaskCompletionSource? _admissionAvailability;
+        private long _admissionGeneration;
         private bool _terminalTransitionClaimed;
         private bool _disposed;
         private int _consecutiveAdmissionRejections;
@@ -1044,16 +1143,23 @@ public sealed class ProxyJobQueue : IProxyJobQueue
 
                 _started = false;
                 _admissionDeferred = true;
+                _admissionGeneration++;
+                _admissionAvailability = new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
                 Job.Status = ProxyJobStatus.Queued;
                 return true;
             }
         }
 
-        public TimeSpan NextAdmissionBackoff(TimeSpan minimum, TimeSpan maximum)
+        public TimeSpan NextAdmissionBackoff(
+            TimeSpan minimum,
+            TimeSpan maximum,
+            out bool firstRejection)
         {
             lock (_lock)
             {
                 int attempt = ++_consecutiveAdmissionRejections;
+                firstRejection = attempt == 1;
                 double factor = Math.Pow(2, Math.Min(attempt - 1, 16));
                 double milliseconds = Math.Min(
                     maximum.TotalMilliseconds,
@@ -1070,7 +1176,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             }
         }
 
-        public bool TryResumeAdmission()
+        public bool TryResumeAdmission(long generation)
         {
             lock (_lock)
             {
@@ -1078,14 +1184,49 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                     || _terminalTransitionClaimed
                     || Cancellation.IsCancellationRequested
                     || IsTerminal(Job.Status)
-                    || !_admissionDeferred)
+                    || !_admissionDeferred
+                    || _admissionGeneration != generation)
                 {
                     return false;
                 }
 
                 _admissionDeferred = false;
+                _admissionAvailability = null;
                 return true;
             }
+        }
+
+        public bool TryGetAdmissionWait(out long generation, out Task availability)
+        {
+            lock (_lock)
+            {
+                if (!_admissionDeferred || _admissionAvailability is null)
+                {
+                    generation = 0;
+                    availability = Task.CompletedTask;
+                    return false;
+                }
+
+                generation = _admissionGeneration;
+                availability = _admissionAvailability.Task;
+                return true;
+            }
+        }
+
+        public void SignalAdmissionAvailability(long generation)
+        {
+            TaskCompletionSource? availability;
+            lock (_lock)
+            {
+                if (!_admissionDeferred || _admissionGeneration != generation)
+                {
+                    return;
+                }
+
+                availability = _admissionAvailability;
+            }
+
+            availability?.TrySetResult();
         }
 
         public bool IsAdmissionDeferred
@@ -1153,7 +1294,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         {
             lock (_lock)
             {
-                if (_disposed || _terminalTransitionClaimed || IsTerminal(Job.Status))
+                if (_disposed || IsTerminal(Job.Status))
                     return;
 
                 Cancellation.Cancel();

--- a/src/Beutl.Engine/Media/Proxy/ProxyJobQueue.cs
+++ b/src/Beutl.Engine/Media/Proxy/ProxyJobQueue.cs
@@ -631,9 +631,10 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                                           && item.TryCloseCancellationWindow();
 
         if (generationFailure is not null
-            && generationFailure.SourceException is not (OperationCanceledException
-                or ProxyGenerationSkippedException
-                or ProxyGeneratorUnavailableException))
+            && generationFailure.SourceException is not (ProxyGenerationSkippedException
+                or ProxyGeneratorUnavailableException)
+            && (generationFailure.SourceException is not OperationCanceledException
+                || !item.Token.IsCancellationRequested))
         {
             Exception failure = generationFailure.SourceException;
             item.Job.Error = failure;
@@ -789,6 +790,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
     private void OnAdmissionAvailabilityChanged(object? sender, EventArgs e)
     {
         List<(WorkItem Item, long Generation)> deferred = [];
+        WorkItem[] items;
         lock (_lock)
         {
             if (_disposed)
@@ -796,12 +798,14 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                 return;
             }
 
-            foreach (WorkItem item in _items)
+            items = [.. _items];
+        }
+
+        foreach (WorkItem item in items)
+        {
+            if (item.TryGetAdmissionWait(out long generation, out _))
             {
-                if (item.TryGetAdmissionWait(out long generation, out _))
-                {
-                    deferred.Add((item, generation));
-                }
+                deferred.Add((item, generation));
             }
         }
 
@@ -1138,10 +1142,11 @@ public sealed class ProxyJobQueue : IProxyJobQueue
     {
         private readonly Lock _lock = new();
         private bool _started;
-        private bool _admissionDeferred;
+        private volatile bool _admissionDeferred;
         private TaskCompletionSource? _admissionAvailability;
         private long _admissionGeneration;
         private bool _terminalTransitionClaimed;
+        private bool _cancellationRequested;
         private bool _cancellationWindowClosed;
         private bool _disposed;
         private int _consecutiveAdmissionRejections;
@@ -1166,6 +1171,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                 if (_disposed
                     || _admissionDeferred
                     || _terminalTransitionClaimed
+                    || _cancellationRequested
                     || Cancellation.IsCancellationRequested)
                     return false;
 
@@ -1180,6 +1186,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             {
                 if (_disposed
                     || _terminalTransitionClaimed
+                    || _cancellationRequested
                     || Cancellation.IsCancellationRequested
                     || IsTerminal(Job.Status))
                     return false;
@@ -1197,6 +1204,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             {
                 if (_disposed
                     || _terminalTransitionClaimed
+                    || _cancellationRequested
                     || Cancellation.IsCancellationRequested
                     || IsTerminal(Job.Status))
                     return false;
@@ -1242,6 +1250,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             {
                 if (_disposed
                     || _terminalTransitionClaimed
+                    || _cancellationRequested
                     || Cancellation.IsCancellationRequested
                     || IsTerminal(Job.Status)
                     || !_admissionDeferred
@@ -1289,16 +1298,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             availability?.TrySetResult();
         }
 
-        public bool IsAdmissionDeferred
-        {
-            get
-            {
-                lock (_lock)
-                {
-                    return _admissionDeferred;
-                }
-            }
-        }
+        public bool IsAdmissionDeferred => _admissionDeferred;
 
         public bool TryCompleteSuccess()
         {
@@ -1325,7 +1325,9 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                 if (_disposed
                     || _terminalTransitionClaimed
                     || IsTerminal(Job.Status)
-                    || (cancellationWins && Cancellation.IsCancellationRequested))
+                    || (cancellationWins
+                        && (_cancellationRequested
+                            || Cancellation.IsCancellationRequested)))
                 {
                     return false;
                 }
@@ -1342,6 +1344,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                 if (_disposed
                     || _terminalTransitionClaimed
                     || _cancellationWindowClosed
+                    || _cancellationRequested
                     || Cancellation.IsCancellationRequested
                     || IsTerminal(Job.Status))
                 {
@@ -1360,7 +1363,8 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                 if (_disposed
                     || _terminalTransitionClaimed
                     || _cancellationWindowClosed
-                    || !Cancellation.IsCancellationRequested
+                    || !_cancellationRequested
+                    && !Cancellation.IsCancellationRequested
                     || IsTerminal(Job.Status))
                 {
                     return false;
@@ -1378,12 +1382,16 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                 if (_disposed
                     || _started
                     || _terminalTransitionClaimed
+                    || _cancellationWindowClosed
                     || IsTerminal(Job.Status))
                     return false;
 
-                Cancellation.Cancel();
-                return true;
+                _cancellationRequested = true;
             }
+
+            CancelSource();
+
+            return true;
         }
 
         public void Cancel()
@@ -1396,7 +1404,20 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                     || IsTerminal(Job.Status))
                     return;
 
+                _cancellationRequested = true;
+            }
+
+            CancelSource();
+        }
+
+        private void CancelSource()
+        {
+            try
+            {
                 Cancellation.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
             }
         }
 

--- a/src/Beutl.Engine/Media/Proxy/ProxyJobQueue.cs
+++ b/src/Beutl.Engine/Media/Proxy/ProxyJobQueue.cs
@@ -639,7 +639,32 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                 item.Job,
                 failure.Message);
 
-            Exception? terminalReleaseFailure = ReleaseAdmissionLease(admissionLease);
+            Exception? rollbackFailure = null;
+            var rollbackSync = new object();
+            Exception? terminalReleaseFailure;
+            using (item.Token.Register(() =>
+                   {
+                       Exception? currentRollbackFailure = RollBackFailure(
+                           item.Job,
+                           failureRegistration);
+                       if (currentRollbackFailure is not null)
+                       {
+                           lock (rollbackSync)
+                           {
+                               rollbackFailure = currentRollbackFailure;
+                           }
+                       }
+                   }))
+            {
+                terminalReleaseFailure = ReleaseAdmissionLease(admissionLease);
+            }
+
+            Exception? synchronizedRollbackFailure;
+            lock (rollbackSync)
+            {
+                synchronizedRollbackFailure = rollbackFailure;
+            }
+
             if (terminalReleaseFailure is not null)
             {
                 item.TryClaimNonCancellationTerminal(cancellationWins: false);
@@ -647,14 +672,26 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                     "Proxy generation and admission-lease release both failed.",
                     failure,
                     terminalReleaseFailure);
+                if (item.Token.IsCancellationRequested && failureRegistration.Changed)
+                {
+                    RegisterFailure(item.Job, item.Job.Error.Message);
+                }
             }
             else if (!item.TryClaimNonCancellationTerminal(cancellationWins: true))
             {
-                RollBackFailure(item.Job, failureRegistration);
-                item.Job.Error = null;
-                item.Job.Status = ProxyJobStatus.Canceled;
-                OnJobChanged(item.Job, ProxyJobChangeKind.Canceled);
-                return false;
+                if (synchronizedRollbackFailure is null)
+                {
+                    item.Job.Error = null;
+                    item.Job.Status = ProxyJobStatus.Canceled;
+                    OnJobChanged(item.Job, ProxyJobChangeKind.Canceled);
+                    return false;
+                }
+
+                item.TryClaimNonCancellationTerminal(cancellationWins: false);
+                item.Job.Error = new AggregateException(
+                    "Proxy generation failed and cancellation rollback did not complete.",
+                    failure,
+                    synchronizedRollbackFailure);
             }
 
             // Publish only after admission is released; observers can now safely start conflicting
@@ -958,11 +995,11 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         }
     }
 
-    private void RollBackFailure(ProxyJob job, FailureRegistration registration)
+    private Exception? RollBackFailure(ProxyJob job, FailureRegistration registration)
     {
         if (_store is null || !registration.Changed)
         {
-            return;
+            return null;
         }
 
         try
@@ -975,6 +1012,8 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             {
                 _store.Delete(job.Source, job.Preset);
             }
+
+            return null;
         }
         catch (Exception ex)
         {
@@ -986,6 +1025,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                 "Failed to roll back the proxy failure entry after cancellation for {Source} ({Preset}).",
                 job.Source.AbsolutePath,
                 job.Preset);
+            return ex;
         }
     }
 

--- a/src/Beutl.Engine/Media/Proxy/ProxyJobQueue.cs
+++ b/src/Beutl.Engine/Media/Proxy/ProxyJobQueue.cs
@@ -542,6 +542,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                 // admission policy or generator concurrently reports another error. Lease-release
                 // failures are handled above because failed cleanup cannot be reported as safe
                 // cancellation.
+                await item.WaitForCancellationCallbacksAsync().ConfigureAwait(false);
                 CompleteCanceled(item);
             }
             catch (ProxyGenerationSkippedException ex)
@@ -784,7 +785,11 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             out bool firstRejection);
         if (firstRejection)
         {
-            OnJobChanged(item.Job, ProxyJobChangeKind.WaitingForAdmission);
+            if (!item.TryPublishAdmissionWaiting(() =>
+                    OnJobChanged(item.Job, ProxyJobChangeKind.WaitingForAdmission)))
+            {
+                return false;
+            }
         }
 
         Task retry = ResumeAdmissionAfterBackoffAsync(item, backoff);
@@ -1336,6 +1341,24 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         }
 
         public bool IsAdmissionDeferred => _admissionDeferred;
+
+        public bool TryPublishAdmissionWaiting(Action publish)
+        {
+            lock (_lock)
+            {
+                if (_disposed
+                    || !_admissionDeferred
+                    || _cancellationRequested
+                    || Cancellation.IsCancellationRequested
+                    || IsTerminal(Job.Status))
+                {
+                    return false;
+                }
+
+                publish();
+                return true;
+            }
+        }
 
         public bool TryCompleteSuccess()
         {

--- a/src/Beutl.Engine/Media/Proxy/ProxyJobQueue.cs
+++ b/src/Beutl.Engine/Media/Proxy/ProxyJobQueue.cs
@@ -734,6 +734,11 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             throw new AdmissionLeaseReleaseException(releaseFailure);
         }
 
+        if (generationFailure is not null && item.Token.IsCancellationRequested)
+        {
+            await item.WaitForCancellationCallbacksAsync().ConfigureAwait(false);
+        }
+
         generationFailure?.Throw();
         if (!successfulGenerationSealed)
         {

--- a/src/Beutl.Engine/Media/Proxy/ProxyJobQueue.cs
+++ b/src/Beutl.Engine/Media/Proxy/ProxyJobQueue.cs
@@ -669,6 +669,10 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                 terminalReleaseFailure = ReleaseAdmissionLease(admissionLease);
                 failureCanPublish = terminalReleaseFailure is not null
                                     || item.TryCloseCancellationWindow();
+                if (!failureCanPublish)
+                {
+                    await item.WaitForCancellationCallbacksAsync().ConfigureAwait(false);
+                }
             }
 
             Exception? synchronizedRollbackFailure;
@@ -733,6 +737,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         generationFailure?.Throw();
         if (!successfulGenerationSealed)
         {
+            await item.WaitForCancellationCallbacksAsync().ConfigureAwait(false);
             item.Token.ThrowIfCancellationRequested();
             throw new InvalidOperationException(
                 "Proxy generation completed after its terminal transition was closed.");
@@ -986,12 +991,22 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         if (_store == null)
             return default;
 
+        ProxyEntry? previous;
         try
         {
-            ProxyEntry? previous = _store.TryGet(job.Source, job.Preset);
-            if (previous is { State: ProxyState.Ready or ProxyState.Stale })
-                return default;
+            previous = _store.TryGet(job.Source, job.Preset);
+        }
+        catch (Exception ex)
+        {
+            RecordBookkeepingFailure(job, ex);
+            return default;
+        }
 
+        if (previous is { State: ProxyState.Ready or ProxyState.Stale })
+            return default;
+
+        try
+        {
             var now = DateTime.UtcNow;
             _store.Register(new ProxyEntry(
                 job.Source,
@@ -1008,14 +1023,23 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         }
         catch (Exception ex)
         {
-            job.BookkeepingError = ex;
-            s_logger.LogError(
-                ex,
-                "Failed to record Failed proxy entry for {Source} ({Preset}).",
-                job.Source.AbsolutePath,
-                job.Preset);
-            return default;
+            RecordBookkeepingFailure(job, ex);
+            // Register may update memory before persistence throws. Treat the result as ambiguous
+            // so a cancellation path restores the captured entry or deletes the attempted one.
+            return new FailureRegistration(previous, Changed: true);
         }
+    }
+
+    private static void RecordBookkeepingFailure(ProxyJob job, Exception failure)
+    {
+        job.BookkeepingError = job.BookkeepingError is null
+            ? failure
+            : new AggregateException(job.BookkeepingError, failure);
+        s_logger.LogError(
+            failure,
+            "Failed to record Failed proxy entry for {Source} ({Preset}).",
+            job.Source.AbsolutePath,
+            job.Preset);
     }
 
     private Exception? RollBackFailure(ProxyJob job, FailureRegistration registration)
@@ -1034,6 +1058,13 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             else
             {
                 _store.Delete(job.Source, job.Preset);
+            }
+
+            ProxyEntry? restored = _store.TryGet(job.Source, job.Preset);
+            if (!Equals(restored, registration.Previous))
+            {
+                throw new InvalidOperationException(
+                    "Proxy failure bookkeeping could not be restored after cancellation.");
             }
 
             return null;
@@ -1144,6 +1175,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         private bool _started;
         private volatile bool _admissionDeferred;
         private TaskCompletionSource? _admissionAvailability;
+        private TaskCompletionSource? _cancellationCallbacksCompleted;
         private long _admissionGeneration;
         private bool _terminalTransitionClaimed;
         private bool _cancellationRequested;
@@ -1377,40 +1409,56 @@ public sealed class ProxyJobQueue : IProxyJobQueue
 
         public bool TryCancelQueued()
         {
+            TaskCompletionSource cancellationCompleted;
             lock (_lock)
             {
                 if (_disposed
                     || _started
                     || _terminalTransitionClaimed
+                    || _cancellationRequested
                     || _cancellationWindowClosed
                     || IsTerminal(Job.Status))
                     return false;
 
                 _cancellationRequested = true;
+                cancellationCompleted = _cancellationCallbacksCompleted = new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
             }
 
-            CancelSource();
+            CancelSource(cancellationCompleted);
 
             return true;
         }
 
         public void Cancel()
         {
+            TaskCompletionSource cancellationCompleted;
             lock (_lock)
             {
                 if (_disposed
                     || _terminalTransitionClaimed
+                    || _cancellationRequested
                     || _cancellationWindowClosed
                     || IsTerminal(Job.Status))
                     return;
 
                 _cancellationRequested = true;
+                cancellationCompleted = _cancellationCallbacksCompleted = new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
             }
 
-            CancelSource();
+            CancelSource(cancellationCompleted);
         }
 
-        private void CancelSource()
+        public Task WaitForCancellationCallbacksAsync()
+        {
+            lock (_lock)
+            {
+                return _cancellationCallbacksCompleted?.Task ?? Task.CompletedTask;
+            }
+        }
+
+        private void CancelSource(TaskCompletionSource cancellationCompleted)
         {
             try
             {
@@ -1418,6 +1466,10 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             }
             catch (ObjectDisposedException)
             {
+            }
+            finally
+            {
+                cancellationCompleted.TrySetResult();
             }
         }
 

--- a/src/Beutl.Engine/Media/Proxy/ProxyJobQueue.cs
+++ b/src/Beutl.Engine/Media/Proxy/ProxyJobQueue.cs
@@ -627,6 +627,9 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             generationFailure = ExceptionDispatchInfo.Capture(ex);
         }
 
+        bool successfulGenerationSealed = generationFailure is null
+                                          && item.TryCloseCancellationWindow();
+
         if (generationFailure is not null
             && generationFailure.SourceException is not (OperationCanceledException
                 or ProxyGenerationSkippedException
@@ -642,8 +645,14 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             Exception? rollbackFailure = null;
             var rollbackSync = new object();
             Exception? terminalReleaseFailure;
+            bool failureCanPublish;
             using (item.Token.Register(() =>
                    {
+                       if (!item.TryClaimCancellationDuringCleanup())
+                       {
+                           return;
+                       }
+
                        Exception? currentRollbackFailure = RollBackFailure(
                            item.Job,
                            failureRegistration);
@@ -657,6 +666,8 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                    }))
             {
                 terminalReleaseFailure = ReleaseAdmissionLease(admissionLease);
+                failureCanPublish = terminalReleaseFailure is not null
+                                    || item.TryCloseCancellationWindow();
             }
 
             Exception? synchronizedRollbackFailure;
@@ -677,7 +688,8 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                     RegisterFailure(item.Job, item.Job.Error.Message);
                 }
             }
-            else if (!item.TryClaimNonCancellationTerminal(cancellationWins: true))
+            else if (!failureCanPublish
+                     || !item.TryClaimNonCancellationTerminal(cancellationWins: false))
             {
                 if (synchronizedRollbackFailure is null)
                 {
@@ -718,6 +730,13 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         }
 
         generationFailure?.Throw();
+        if (!successfulGenerationSealed)
+        {
+            item.Token.ThrowIfCancellationRequested();
+            throw new InvalidOperationException(
+                "Proxy generation completed after its terminal transition was closed.");
+        }
+
         return true;
     }
 
@@ -1123,6 +1142,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         private TaskCompletionSource? _admissionAvailability;
         private long _admissionGeneration;
         private bool _terminalTransitionClaimed;
+        private bool _cancellationWindowClosed;
         private bool _disposed;
         private int _consecutiveAdmissionRejections;
 
@@ -1286,7 +1306,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             {
                 if (_disposed
                     || _terminalTransitionClaimed
-                    || Cancellation.IsCancellationRequested
+                    || !_cancellationWindowClosed
                     || IsTerminal(Job.Status))
                 {
                     return false;
@@ -1315,6 +1335,42 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             }
         }
 
+        public bool TryCloseCancellationWindow()
+        {
+            lock (_lock)
+            {
+                if (_disposed
+                    || _terminalTransitionClaimed
+                    || _cancellationWindowClosed
+                    || Cancellation.IsCancellationRequested
+                    || IsTerminal(Job.Status))
+                {
+                    return false;
+                }
+
+                _cancellationWindowClosed = true;
+                return true;
+            }
+        }
+
+        public bool TryClaimCancellationDuringCleanup()
+        {
+            lock (_lock)
+            {
+                if (_disposed
+                    || _terminalTransitionClaimed
+                    || _cancellationWindowClosed
+                    || !Cancellation.IsCancellationRequested
+                    || IsTerminal(Job.Status))
+                {
+                    return false;
+                }
+
+                _cancellationWindowClosed = true;
+                return true;
+            }
+        }
+
         public bool TryCancelQueued()
         {
             lock (_lock)
@@ -1334,7 +1390,10 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         {
             lock (_lock)
             {
-                if (_disposed || IsTerminal(Job.Status))
+                if (_disposed
+                    || _terminalTransitionClaimed
+                    || _cancellationWindowClosed
+                    || IsTerminal(Job.Status))
                     return;
 
                 Cancellation.Cancel();

--- a/src/Beutl.Engine/Media/Proxy/ProxyJobQueue.cs
+++ b/src/Beutl.Engine/Media/Proxy/ProxyJobQueue.cs
@@ -639,14 +639,14 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                 item.Job,
                 failure.Message);
 
-            Exception? releaseFailure = ReleaseAdmissionLease(admissionLease);
-            if (releaseFailure is not null)
+            Exception? terminalReleaseFailure = ReleaseAdmissionLease(admissionLease);
+            if (terminalReleaseFailure is not null)
             {
                 item.TryClaimNonCancellationTerminal(cancellationWins: false);
                 item.Job.Error = new AggregateException(
                     "Proxy generation and admission-lease release both failed.",
                     failure,
-                    releaseFailure);
+                    terminalReleaseFailure);
             }
             else if (!item.TryClaimNonCancellationTerminal(cancellationWins: true))
             {

--- a/src/Beutl.Engine/Media/Proxy/ProxyJobQueue.cs
+++ b/src/Beutl.Engine/Media/Proxy/ProxyJobQueue.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Channels;
+﻿using System.Runtime.ExceptionServices;
+using System.Threading.Channels;
 
 using Beutl.Logging;
 
@@ -18,10 +19,13 @@ public sealed class ProxyJobQueue : IProxyJobQueue
     private readonly CancellationTokenSource _disposeCts = new();
     private readonly Dictionary<(ProxyFingerprint Source, ProxyPreset Preset), WorkItem> _itemsByKey = [];
     private readonly List<WorkItem> _items = [];
+    private readonly HashSet<Task> _admissionRetryTasks = [];
     private readonly Lock _lock = new();
     private readonly Task _drainTask;
     private readonly TimeSpan _minUnavailableBackoff;
     private readonly TimeSpan _maxUnavailableBackoff;
+    private readonly IProxyGenerationAdmission? _admission;
+    private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
     private TaskCompletionSource? _resumeAfterGeneratorUnavailable;
     private int _consecutiveUnavailable;
     private bool _disposed;
@@ -36,12 +40,37 @@ public sealed class ProxyJobQueue : IProxyJobQueue
     {
     }
 
+    /// <summary>
+    /// Constructs a queue whose generator runs only while <paramref name="admission"/> grants a
+    /// lease.
+    /// </summary>
+    public ProxyJobQueue(
+        IProxyGenerator generator,
+        IProxyStore? store,
+        IProxyGenerationAdmission admission)
+        : this(
+            EagerProvider(generator),
+            store,
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromSeconds(30),
+            admission ?? throw new ArgumentNullException(nameof(admission)))
+    {
+    }
+
     internal ProxyJobQueue(
         IProxyGenerator generator,
         IProxyStore? store,
         TimeSpan minUnavailableBackoff,
-        TimeSpan maxUnavailableBackoff)
-        : this(EagerProvider(generator), store, minUnavailableBackoff, maxUnavailableBackoff)
+        TimeSpan maxUnavailableBackoff,
+        IProxyGenerationAdmission? admission = null,
+        Func<TimeSpan, CancellationToken, Task>? delayAsync = null)
+        : this(
+            EagerProvider(generator),
+            store,
+            minUnavailableBackoff,
+            maxUnavailableBackoff,
+            admission,
+            delayAsync)
     {
     }
 
@@ -58,13 +87,39 @@ public sealed class ProxyJobQueue : IProxyJobQueue
     {
     }
 
+    /// <summary>
+    /// Constructs a lazy-generator queue whose generator runs only while
+    /// <paramref name="admission"/> grants a lease.
+    /// </summary>
+    public ProxyJobQueue(
+        Func<IProxyGenerator?> generatorProvider,
+        IProxyStore? store,
+        IProxyGenerationAdmission admission)
+        : this(
+            generatorProvider,
+            store,
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromSeconds(30),
+            admission ?? throw new ArgumentNullException(nameof(admission)))
+    {
+    }
+
     internal ProxyJobQueue(
         Func<IProxyGenerator?> generatorProvider,
         IProxyStore? store,
         TimeSpan minUnavailableBackoff,
-        TimeSpan maxUnavailableBackoff)
+        TimeSpan maxUnavailableBackoff,
+        IProxyGenerationAdmission? admission = null,
+        Func<TimeSpan, CancellationToken, Task>? delayAsync = null)
     {
         ArgumentNullException.ThrowIfNull(generatorProvider);
+        if (admission is null && delayAsync is not null)
+        {
+            throw new ArgumentException(
+                "A custom admission delay requires an admission policy.",
+                nameof(delayAsync));
+        }
+
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(minUnavailableBackoff, TimeSpan.Zero);
         ArgumentOutOfRangeException.ThrowIfLessThan(maxUnavailableBackoff, minUnavailableBackoff);
 
@@ -72,6 +127,8 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         _store = store;
         _minUnavailableBackoff = minUnavailableBackoff;
         _maxUnavailableBackoff = maxUnavailableBackoff;
+        _admission = admission;
+        _delayAsync = delayAsync ?? (static (delay, token) => Task.Delay(delay, token));
         // Unbounded: each queued item needs exactly one wake permit, and the drain (single reader,
         // MaxConcurrency 1) consumes one per dispatch. Items already live in _items — deduplicated by
         // (source, preset) — so the channel is a pure wake signal, not the memory bound. A bounded
@@ -326,6 +383,14 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         {
         }
 
+        Task[] admissionRetries;
+        lock (_lock)
+        {
+            admissionRetries = [.. _admissionRetryTasks];
+        }
+
+        await Task.WhenAll(admissionRetries).ConfigureAwait(false);
+
         // Unsubscribe only after the drain loop has ended. DrainAsync is the sole place that resolves a
         // generator and subscribes (under _lock), so reading _generatorAvailability before awaiting it
         // could miss a subscription taken between the read and the drain finishing, leaking a live
@@ -386,11 +451,10 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         }
     }
 
-    // Drives one channel permit to a terminal state, then loops while a dispatchable item
-    // remains. Each iteration either completes the item or requeues it and waits up to
-    // _maxUnavailableBackoff for generator availability, so the loop is bounded by
-    // ceil(_maxUnavailableBackoff / _minUnavailableBackoff) consecutive unavailable retries
-    // before a successful dispatch or an empty _items set ends the call.
+    // Drives one channel permit to a terminal state, then loops while a dispatchable item remains.
+    // Generator unavailability parks the serial drain under its bounded wait. Admission rejection
+    // instead defers only that item and schedules a future permit, allowing an admissible peer to
+    // run immediately.
     private async Task ProcessOneAsync()
     {
         while (true)
@@ -407,10 +471,8 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                 return;
             }
 
-            item.Job.Status = ProxyJobStatus.Running;
-            OnJobChanged(item.Job, ProxyJobChangeKind.Started);
-
             bool requeued = false;
+            bool admissionRejected = false;
             try
             {
                 // ResolveGenerator runs inside the guarded region: the provider is plugin-supplied
@@ -418,6 +480,8 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                 IProxyGenerator? generator = ResolveGenerator();
                 if (generator is null)
                 {
+                    item.Job.Status = ProxyJobStatus.Running;
+                    OnJobChanged(item.Job, ProxyJobChangeKind.Started);
                     // No generator has registered yet. Keep the job queued and re-probe after the same
                     // bounded backoff used for unavailable generators; extension loading may register one.
                     item.Job.StatusMessage = "Waiting for proxy generator registration.";
@@ -427,24 +491,48 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                 }
                 else
                 {
-                    item.Job.StatusMessage = null;
-                    await generator.GenerateAsync(item.Job).ConfigureAwait(false);
-                    item.Job.Status = ProxyJobStatus.Succeeded;
-                    Interlocked.Exchange(ref _consecutiveUnavailable, 0);
-                    OnJobChanged(item.Job, ProxyJobChangeKind.Succeeded);
+                    IDisposable? admissionLease = _admission?.TryAcquireLease(item.Job);
+                    if (_admission is not null && admissionLease is null)
+                    {
+                        item.Job.StatusMessage = "Waiting for proxy generation admission.";
+                        admissionRejected = true;
+                        requeued = RequeueForAdmissionRetry(item);
+                        if (!requeued)
+                            CompleteCanceled(item);
+                    }
+                    else
+                    {
+                        item.ResetAdmissionRejections();
+                        item.Job.StatusMessage = null;
+                        await GenerateWithAdmissionLeaseAsync(generator, item, admissionLease)
+                            .ConfigureAwait(false);
+                        if (item.TryCompleteSuccess())
+                        {
+                            Interlocked.Exchange(ref _consecutiveUnavailable, 0);
+                            OnJobChanged(item.Job, ProxyJobChangeKind.Succeeded);
+                        }
+                        else
+                        {
+                            CompleteCanceled(item);
+                        }
+                    }
                 }
+            }
+            catch (AdmissionLeaseReleaseException ex)
+            {
+                FailJob(item, ex.Failure, cancellationWins: false);
+            }
+            catch (Exception) when (item.Token.IsCancellationRequested)
+            {
+                // Cancellation owns terminal classification once requested, even when an
+                // admission policy or generator concurrently reports another error. Lease-release
+                // failures are handled above because failed cleanup cannot be reported as safe
+                // cancellation.
+                CompleteCanceled(item);
             }
             catch (ProxyGenerationSkippedException ex)
             {
-                item.Job.Status = ProxyJobStatus.Skipped;
-                item.Job.StatusMessage = ex.Message;
-                OnJobChanged(item.Job, ProxyJobChangeKind.Skipped);
-            }
-            catch (OperationCanceledException) when (item.Token.IsCancellationRequested)
-            {
-                // Guarded so an OCE thrown by a generator whose own token was NOT canceled is
-                // reported as Failed below instead of masquerading as a user cancellation.
-                CompleteCanceled(item);
+                CompleteSkippedOrCanceled(item, ex.Message);
             }
             catch (ProxyGeneratorUnavailableException ex)
             {
@@ -463,9 +551,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                     // With no availability signal the queue can never learn the generator recovered,
                     // so requeuing would occupy the serial queue forever (e.g. a build without FFmpeg).
                     // Treat it as a terminal skip instead.
-                    item.Job.Status = ProxyJobStatus.Skipped;
-                    item.Job.StatusMessage = ex.Message;
-                    OnJobChanged(item.Job, ProxyJobChangeKind.Skipped);
+                    CompleteSkippedOrCanceled(item, ex.Message);
                 }
                 else
                 {
@@ -483,12 +569,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             }
             catch (Exception ex)
             {
-                // Record the Failed store entry before the terminal transition so an observer
-                // that sees Status == Failed can already read the entry from the store.
-                item.Job.Error = ex;
-                RegisterFailure(item.Job, ex.Message);
-                item.Job.Status = ProxyJobStatus.Failed;
-                OnJobChanged(item.Job, ProxyJobChangeKind.Failed);
+                FailJob(item, ex, cancellationWins: true);
             }
 
             if (!requeued)
@@ -498,10 +579,65 @@ public sealed class ProxyJobQueue : IProxyJobQueue
                 return;
             }
 
+            if (admissionRejected)
+            {
+                // This item is deferred until its own bounded retry task republishes a permit.
+                // Continue immediately so another dispatchable job can run instead of sitting
+                // behind a job-aware policy that keeps rejecting this one.
+                continue;
+            }
+
             await WaitForGeneratorResumeOrDisposeAsync(item.Token).ConfigureAwait(false);
+
             if (_disposeCts.IsCancellationRequested)
                 return;
         }
+    }
+
+    private async Task GenerateWithAdmissionLeaseAsync(
+        IProxyGenerator generator,
+        WorkItem item,
+        IDisposable? admissionLease)
+    {
+        ExceptionDispatchInfo? generationFailure = null;
+        try
+        {
+            item.Token.ThrowIfCancellationRequested();
+            item.Job.Status = ProxyJobStatus.Running;
+            OnJobChanged(item.Job, ProxyJobChangeKind.Started);
+            await generator.GenerateAsync(item.Job).ConfigureAwait(false);
+            item.Token.ThrowIfCancellationRequested();
+        }
+        catch (Exception ex)
+        {
+            generationFailure = ExceptionDispatchInfo.Capture(ex);
+        }
+
+        Exception? releaseFailure = null;
+        try
+        {
+            admissionLease?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            releaseFailure = ex;
+        }
+
+        if (generationFailure is not null && releaseFailure is not null)
+        {
+            throw new AdmissionLeaseReleaseException(
+                new AggregateException(
+                    "Proxy generation and admission-lease release both failed.",
+                    generationFailure.SourceException,
+                    releaseFailure));
+        }
+
+        if (releaseFailure is not null)
+        {
+            throw new AdmissionLeaseReleaseException(releaseFailure);
+        }
+
+        generationFailure?.Throw();
     }
 
     private bool RequeueForRetry(WorkItem item)
@@ -511,6 +647,59 @@ public sealed class ProxyJobQueue : IProxyJobQueue
 
         OnJobChanged(item.Job, ProxyJobChangeKind.Enqueued);
         return true;
+    }
+
+    private bool RequeueForAdmissionRetry(WorkItem item)
+    {
+        if (!item.ResetForAdmissionRetry())
+            return false;
+
+        OnJobChanged(item.Job, ProxyJobChangeKind.Enqueued);
+        TimeSpan backoff = item.NextAdmissionBackoff(
+            _minUnavailableBackoff,
+            _maxUnavailableBackoff);
+        Task retry = ResumeAdmissionAfterBackoffAsync(item, backoff);
+        lock (_lock)
+        {
+            _admissionRetryTasks.Add(retry);
+        }
+
+        _ = RemoveAdmissionRetryWhenCompleteAsync(retry);
+        return true;
+    }
+
+    private async Task ResumeAdmissionAfterBackoffAsync(WorkItem item, TimeSpan backoff)
+    {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(
+            _disposeCts.Token,
+            item.Token);
+        try
+        {
+            await _delayAsync(backoff, linked.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (linked.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            // The production delay is Task.Delay; this guard keeps a host/test scheduler failure
+            // from silently stranding the job forever.
+            s_logger.LogError(ex, "Proxy admission retry delay failed; retrying immediately.");
+        }
+
+        if (item.TryResumeAdmission())
+        {
+            _channel.Writer.TryWrite(item);
+        }
+    }
+
+    private async Task RemoveAdmissionRetryWhenCompleteAsync(Task retry)
+    {
+        await retry.ConfigureAwait(false);
+        lock (_lock)
+        {
+            _admissionRetryTasks.Remove(retry);
+        }
     }
 
     private async Task WaitForGeneratorResumeOrDisposeAsync(CancellationToken jobCancellation)
@@ -562,6 +751,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             {
                 if (!candidate.Published
                     || candidate.Job.Status != ProxyJobStatus.Queued
+                    || candidate.IsAdmissionDeferred
                     || candidate.Cancellation.IsCancellationRequested)
                 {
                     continue;
@@ -655,6 +845,35 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         }
     }
 
+    private void CompleteSkippedOrCanceled(WorkItem item, string message)
+    {
+        if (!item.TryClaimNonCancellationTerminal(cancellationWins: true))
+        {
+            CompleteCanceled(item);
+            return;
+        }
+
+        item.Job.Status = ProxyJobStatus.Skipped;
+        item.Job.StatusMessage = message;
+        OnJobChanged(item.Job, ProxyJobChangeKind.Skipped);
+    }
+
+    private void FailJob(WorkItem item, Exception failure, bool cancellationWins)
+    {
+        if (!item.TryClaimNonCancellationTerminal(cancellationWins))
+        {
+            CompleteCanceled(item);
+            return;
+        }
+
+        // Record the Failed store entry before the terminal transition so an observer that sees
+        // Status == Failed can already read the entry from the store.
+        item.Job.Error = failure;
+        RegisterFailure(item.Job, failure.Message);
+        item.Job.Status = ProxyJobStatus.Failed;
+        OnJobChanged(item.Job, ProxyJobChangeKind.Failed);
+    }
+
     private void Remove(WorkItem item)
     {
         lock (_lock)
@@ -706,11 +925,20 @@ public sealed class ProxyJobQueue : IProxyJobQueue
             or ProxyJobStatus.Canceled
             or ProxyJobStatus.Skipped;
 
+    private sealed class AdmissionLeaseReleaseException(Exception failure)
+        : Exception("The proxy-generation admission lease could not be released.", failure)
+    {
+        public Exception Failure { get; } = failure;
+    }
+
     private sealed class WorkItem(ProxyJob job, CancellationTokenSource cancellation) : IDisposable
     {
         private readonly Lock _lock = new();
         private bool _started;
+        private bool _admissionDeferred;
+        private bool _terminalTransitionClaimed;
         private bool _disposed;
+        private int _consecutiveAdmissionRejections;
 
         public ProxyJob Job { get; } = job;
 
@@ -729,7 +957,10 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         {
             lock (_lock)
             {
-                if (_disposed || Cancellation.IsCancellationRequested)
+                if (_disposed
+                    || _admissionDeferred
+                    || _terminalTransitionClaimed
+                    || Cancellation.IsCancellationRequested)
                     return false;
 
                 _started = true;
@@ -741,11 +972,117 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         {
             lock (_lock)
             {
-                if (_disposed || Cancellation.IsCancellationRequested || IsTerminal(Job.Status))
+                if (_disposed
+                    || _terminalTransitionClaimed
+                    || Cancellation.IsCancellationRequested
+                    || IsTerminal(Job.Status))
                     return false;
 
                 _started = false;
+                _admissionDeferred = false;
                 Job.Status = ProxyJobStatus.Queued;
+                return true;
+            }
+        }
+
+        public bool ResetForAdmissionRetry()
+        {
+            lock (_lock)
+            {
+                if (_disposed
+                    || _terminalTransitionClaimed
+                    || Cancellation.IsCancellationRequested
+                    || IsTerminal(Job.Status))
+                    return false;
+
+                _started = false;
+                _admissionDeferred = true;
+                Job.Status = ProxyJobStatus.Queued;
+                return true;
+            }
+        }
+
+        public TimeSpan NextAdmissionBackoff(TimeSpan minimum, TimeSpan maximum)
+        {
+            lock (_lock)
+            {
+                int attempt = ++_consecutiveAdmissionRejections;
+                double factor = Math.Pow(2, Math.Min(attempt - 1, 16));
+                double milliseconds = Math.Min(
+                    maximum.TotalMilliseconds,
+                    minimum.TotalMilliseconds * factor);
+                return TimeSpan.FromMilliseconds(milliseconds);
+            }
+        }
+
+        public void ResetAdmissionRejections()
+        {
+            lock (_lock)
+            {
+                _consecutiveAdmissionRejections = 0;
+            }
+        }
+
+        public bool TryResumeAdmission()
+        {
+            lock (_lock)
+            {
+                if (_disposed
+                    || _terminalTransitionClaimed
+                    || Cancellation.IsCancellationRequested
+                    || IsTerminal(Job.Status)
+                    || !_admissionDeferred)
+                {
+                    return false;
+                }
+
+                _admissionDeferred = false;
+                return true;
+            }
+        }
+
+        public bool IsAdmissionDeferred
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _admissionDeferred;
+                }
+            }
+        }
+
+        public bool TryCompleteSuccess()
+        {
+            lock (_lock)
+            {
+                if (_disposed
+                    || _terminalTransitionClaimed
+                    || Cancellation.IsCancellationRequested
+                    || IsTerminal(Job.Status))
+                {
+                    return false;
+                }
+
+                Job.Status = ProxyJobStatus.Succeeded;
+                _terminalTransitionClaimed = true;
+                return true;
+            }
+        }
+
+        public bool TryClaimNonCancellationTerminal(bool cancellationWins)
+        {
+            lock (_lock)
+            {
+                if (_disposed
+                    || _terminalTransitionClaimed
+                    || IsTerminal(Job.Status)
+                    || (cancellationWins && Cancellation.IsCancellationRequested))
+                {
+                    return false;
+                }
+
+                _terminalTransitionClaimed = true;
                 return true;
             }
         }
@@ -754,7 +1091,10 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         {
             lock (_lock)
             {
-                if (_disposed || _started || IsTerminal(Job.Status))
+                if (_disposed
+                    || _started
+                    || _terminalTransitionClaimed
+                    || IsTerminal(Job.Status))
                     return false;
 
                 Cancellation.Cancel();
@@ -766,7 +1106,7 @@ public sealed class ProxyJobQueue : IProxyJobQueue
         {
             lock (_lock)
             {
-                if (_disposed || IsTerminal(Job.Status))
+                if (_disposed || _terminalTransitionClaimed || IsTerminal(Job.Status))
                     return;
 
                 Cancellation.Cancel();

--- a/tests/Beutl.PublicApiContractTests/ProxyGenerationAdmissionContractTests.cs
+++ b/tests/Beutl.PublicApiContractTests/ProxyGenerationAdmissionContractTests.cs
@@ -6,6 +6,22 @@ namespace Beutl.PublicApiContractTests;
 public sealed class ProxyGenerationAdmissionContractTests : PublicApiContractTestBase
 {
     [Test]
+    public void Waiting_change_kind_preserves_existing_public_ordinals()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That((int)ProxyJobChangeKind.Enqueued, Is.EqualTo(0));
+            Assert.That((int)ProxyJobChangeKind.Started, Is.EqualTo(1));
+            Assert.That((int)ProxyJobChangeKind.Progressed, Is.EqualTo(2));
+            Assert.That((int)ProxyJobChangeKind.Succeeded, Is.EqualTo(3));
+            Assert.That((int)ProxyJobChangeKind.Failed, Is.EqualTo(4));
+            Assert.That((int)ProxyJobChangeKind.Canceled, Is.EqualTo(5));
+            Assert.That((int)ProxyJobChangeKind.Skipped, Is.EqualTo(6));
+            Assert.That((int)ProxyJobChangeKind.WaitingForAdmission, Is.EqualTo(7));
+        });
+    }
+
+    [Test]
     public async Task ExternalHost_CanImplementAndUseProxyGenerationAdmission()
     {
         AssertDoesNotHaveFriendAccess(typeof(ProxyJobQueue).Assembly);

--- a/tests/Beutl.PublicApiContractTests/ProxyGenerationAdmissionContractTests.cs
+++ b/tests/Beutl.PublicApiContractTests/ProxyGenerationAdmissionContractTests.cs
@@ -1,0 +1,74 @@
+﻿using Beutl.Media.Proxy;
+
+namespace Beutl.PublicApiContractTests;
+
+[TestFixture]
+public sealed class ProxyGenerationAdmissionContractTests : PublicApiContractTestBase
+{
+    [Test]
+    public async Task ExternalHost_CanImplementAndUseProxyGenerationAdmission()
+    {
+        AssertDoesNotHaveFriendAccess(typeof(ProxyJobQueue).Assembly);
+
+        var generator = new TestGenerator();
+        var admission = new TestAdmission();
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var queue = new ProxyJobQueue(generator, store: null, admission);
+        queue.JobChanged += (_, args) =>
+        {
+            if (args.Kind == ProxyJobChangeKind.Succeeded)
+            {
+                completed.TrySetResult();
+            }
+        };
+
+        await queue.EnqueueAsync(
+            new ProxyFingerprint(
+                Path.Combine(Path.GetTempPath(), "contract-input.mov"),
+                1,
+                DateTime.UnixEpoch),
+            ProxyPreset.Quarter);
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(generator.GenerateCalls, Is.EqualTo(1));
+            Assert.That(admission.AcquireCalls, Is.EqualTo(1));
+            Assert.That(admission.Lease.DisposeCalls, Is.EqualTo(1));
+        });
+    }
+
+    private sealed class TestAdmission : IProxyGenerationAdmission
+    {
+        public int AcquireCalls { get; private set; }
+
+        public TestLease Lease { get; } = new();
+
+        public IDisposable TryAcquireLease(ProxyJob job)
+        {
+            AcquireCalls++;
+            return Lease;
+        }
+    }
+
+    private sealed class TestGenerator : IProxyGenerator
+    {
+        public int GenerateCalls { get; private set; }
+
+        public ValueTask GenerateAsync(ProxyJob job)
+        {
+            GenerateCalls++;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class TestLease : IDisposable
+    {
+        public int DisposeCalls { get; private set; }
+
+        public void Dispose()
+        {
+            DisposeCalls++;
+        }
+    }
+}

--- a/tests/Beutl.PublicApiContractTests/ProxyGenerationAdmissionContractTests.cs
+++ b/tests/Beutl.PublicApiContractTests/ProxyGenerationAdmissionContractTests.cs
@@ -40,6 +40,8 @@ public sealed class ProxyGenerationAdmissionContractTests : PublicApiContractTes
 
     private sealed class TestAdmission : IProxyGenerationAdmission
     {
+        public event EventHandler? AvailabilityChanged;
+
         public int AcquireCalls { get; private set; }
 
         public TestLease Lease { get; } = new();
@@ -49,6 +51,8 @@ public sealed class ProxyGenerationAdmissionContractTests : PublicApiContractTes
             AcquireCalls++;
             return Lease;
         }
+
+        public void SignalAvailability() => AvailabilityChanged?.Invoke(this, EventArgs.Empty);
     }
 
     private sealed class TestGenerator : IProxyGenerator

--- a/tests/Beutl.UnitTests/Media/Proxy/ProxyJobQueueTests.cs
+++ b/tests/Beutl.UnitTests/Media/Proxy/ProxyJobQueueTests.cs
@@ -150,6 +150,44 @@ public class ProxyJobQueueTests
         });
     }
 
+    [Test]
+    public async Task Failed_store_bookkeeping_stays_admitted_until_terminal_publication()
+    {
+        string root = CreateRoot();
+        var store = new ProxyStore(root);
+        var admission = new SequencedAdmission(rejections: 0);
+        int leaseDisposeCountAtRegistration = -1;
+        int leaseDisposeCountAtFailure = -1;
+        store.Changed += (_, args) =>
+        {
+            if (args.Kind == ProxyStoreChangeKind.Registered && admission.Leases.Count == 1)
+            {
+                leaseDisposeCountAtRegistration = admission.Leases[0].DisposeCount;
+            }
+        };
+        await using var queue = new ProxyJobQueue(new FailingGenerator(), store, admission);
+        queue.JobChanged += (_, args) =>
+        {
+            if (args.Kind == ProxyJobChangeKind.Failed)
+            {
+                leaseDisposeCountAtFailure = admission.Leases.Single().DisposeCount;
+            }
+        };
+
+        ProxyJob job = await queue.EnqueueAsync(
+            CreateFingerprint("admitted-failure.mov"),
+            ProxyPreset.Quarter);
+        await WaitForTerminalAsync(job);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Failed));
+            Assert.That(leaseDisposeCountAtRegistration, Is.Zero);
+            Assert.That(leaseDisposeCountAtFailure, Is.EqualTo(1));
+            Assert.That(admission.Leases.Single().DisposeCount, Is.EqualTo(1));
+        });
+    }
+
     [TestCase(AdmissionGeneratorOutcome.Success, ProxyJobStatus.Succeeded)]
     [TestCase(AdmissionGeneratorOutcome.Skipped, ProxyJobStatus.Skipped)]
     [TestCase(AdmissionGeneratorOutcome.Failed, ProxyJobStatus.Failed)]

--- a/tests/Beutl.UnitTests/Media/Proxy/ProxyJobQueueTests.cs
+++ b/tests/Beutl.UnitTests/Media/Proxy/ProxyJobQueueTests.cs
@@ -357,8 +357,10 @@ public class ProxyJobQueueTests
     }
 
     [Test]
-    public async Task Cancel_racing_admission_release_wins_before_success_publication()
+    public async Task Completed_generation_wins_cancellation_during_admission_release()
     {
+        string root = CreateRoot();
+        var store = new ProxyStore(root);
         var releaseStarted = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseLease = new TaskCompletionSource(
@@ -369,7 +371,10 @@ public class ProxyJobQueueTests
                 disposeStarted: releaseStarted,
                 disposeRelease: releaseLease.Task));
         int succeededEvents = 0;
-        await using var queue = new ProxyJobQueue(new RecordingGenerator(), store: null, admission);
+        await using var queue = new ProxyJobQueue(
+            new ReadyPublishingGenerator(store, root),
+            store,
+            admission);
         queue.JobChanged += (_, args) =>
         {
             if (args.Kind == ProxyJobChangeKind.Succeeded)
@@ -389,9 +394,12 @@ public class ProxyJobQueueTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Canceled));
+            Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Succeeded));
+            Assert.That(
+                store.TryGet(job.Source, job.Preset)?.State,
+                Is.EqualTo(ProxyState.Ready));
             Assert.That(admission.Leases.Single().DisposeCount, Is.EqualTo(1));
-            Assert.That(Volatile.Read(ref succeededEvents), Is.Zero);
+            Assert.That(Volatile.Read(ref succeededEvents), Is.EqualTo(1));
         });
     }
 
@@ -1854,6 +1862,17 @@ public class ProxyJobQueueTests
         public ValueTask GenerateAsync(ProxyJob job)
         {
             throw new InvalidOperationException("encode failed");
+        }
+    }
+
+    private sealed class ReadyPublishingGenerator(
+        IProxyStore store,
+        string storeRoot) : IProxyGenerator
+    {
+        public ValueTask GenerateAsync(ProxyJob job)
+        {
+            store.Register(CreateReadyEntry(storeRoot, job.Source));
+            return ValueTask.CompletedTask;
         }
     }
 

--- a/tests/Beutl.UnitTests/Media/Proxy/ProxyJobQueueTests.cs
+++ b/tests/Beutl.UnitTests/Media/Proxy/ProxyJobQueueTests.cs
@@ -413,6 +413,41 @@ public class ProxyJobQueueTests
     }
 
     [Test]
+    public async Task Canceled_job_stays_active_until_token_callbacks_finish()
+    {
+        var callbackStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseCallback = new ManualResetEventSlim();
+        var generator = new CancellationCallbackGenerator(() =>
+        {
+            callbackStarted.TrySetResult();
+            releaseCallback.Wait();
+        });
+        await using var queue = new ProxyJobQueue(generator);
+        ProxyJob job = await queue.EnqueueAsync(
+            CreateFingerprint("blocking-cancellation-callback.mov"),
+            ProxyPreset.Quarter);
+        await generator.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Task cancellation = Task.Run(() => queue.Cancel(job.JobId));
+        try
+        {
+            await callbackStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(
+                job.Status,
+                Is.Not.EqualTo(ProxyJobStatus.Canceled));
+        }
+        finally
+        {
+            releaseCallback.Set();
+        }
+
+        await cancellation.WaitAsync(TimeSpan.FromSeconds(5));
+        await WaitForTerminalAsync(job);
+        Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Canceled));
+    }
+
+    [Test]
     public async Task Completed_generation_wins_cancellation_during_admission_release()
     {
         string root = CreateRoot();

--- a/tests/Beutl.UnitTests/Media/Proxy/ProxyJobQueueTests.cs
+++ b/tests/Beutl.UnitTests/Media/Proxy/ProxyJobQueueTests.cs
@@ -249,6 +249,14 @@ public class ProxyJobQueueTests
             leaseFactory: () => new CountingLease(
                 disposeStarted: releaseStarted,
                 disposeRelease: releaseLease.Task));
+        bool leaseReleasedAtRollback = true;
+        store.Changed += (_, args) =>
+        {
+            if (args.Kind == ProxyStoreChangeKind.Deleted)
+            {
+                leaseReleasedAtRollback = admission.Leases.Single().ReleaseCompleted;
+            }
+        };
         await using var queue = new ProxyJobQueue(new FailingGenerator(), store, admission);
         ProxyFingerprint source = CreateFingerprint("failure-cleanup-cancel.mov");
 
@@ -264,6 +272,37 @@ public class ProxyJobQueueTests
             Assert.That(job.Error, Is.Null);
             Assert.That(store.TryGet(source, ProxyPreset.Quarter), Is.Null);
             Assert.That(admission.Leases.Single().DisposeCount, Is.EqualTo(1));
+            Assert.That(leaseReleasedAtRollback, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task Failure_rollback_error_prevents_clean_cancellation_publication()
+    {
+        var store = new ThrowingDeleteStore();
+        var releaseStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLease = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var admission = new SequencedAdmission(
+            rejections: 0,
+            leaseFactory: () => new CountingLease(
+                disposeStarted: releaseStarted,
+                disposeRelease: releaseLease.Task));
+        await using var queue = new ProxyJobQueue(new FailingGenerator(), store, admission);
+        ProxyFingerprint source = CreateFingerprint("failure-rollback-error.mov");
+
+        ProxyJob job = await queue.EnqueueAsync(source, ProxyPreset.Quarter);
+        await releaseStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        queue.Cancel(job.JobId);
+        releaseLease.TrySetResult();
+        await WaitForTerminalAsync(job);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Failed));
+            Assert.That(job.Error, Is.TypeOf<AggregateException>());
+            Assert.That(store.TryGet(source, ProxyPreset.Quarter)?.State, Is.EqualTo(ProxyState.Failed));
         });
     }
 
@@ -1694,11 +1733,14 @@ public class ProxyJobQueueTests
 
         public int DisposeCount => Volatile.Read(ref _disposeCount);
 
+        public bool ReleaseCompleted { get; private set; }
+
         public void Dispose()
         {
             Interlocked.Increment(ref _disposeCount);
             disposeStarted?.TrySetResult();
             disposeRelease?.GetAwaiter().GetResult();
+            ReleaseCompleted = true;
             if (disposeFailure is not null)
             {
                 ExceptionDispatchInfo.Capture(disposeFailure).Throw();
@@ -1985,6 +2027,37 @@ public class ProxyJobQueueTests
 #pragma warning disable CS0067 // Not exercised by these tests.
         public event EventHandler<ProxyStoreChangedEventArgs>? Changed;
 #pragma warning restore CS0067
+    }
+
+    private sealed class ThrowingDeleteStore : IProxyStore
+    {
+        private ProxyEntry? _entry;
+
+        public string StoreRootPath => Path.GetTempPath();
+
+        public ProxyEntry? TryGet(ProxyFingerprint source, ProxyPreset preset) => _entry;
+
+        public IReadOnlyList<ProxyEntry> Enumerate() => _entry is null ? [] : [_entry];
+
+        public void Register(ProxyEntry entry) => _entry = entry;
+
+        public bool TryTransition(ProxyFingerprint source, ProxyPreset preset, ProxyState newState, string? failureReason = null) => false;
+
+        public bool Delete(ProxyFingerprint source, ProxyPreset preset) => throw new IOException("delete failed");
+
+        public void Touch(ProxyFingerprint source, ProxyPreset preset, DateTime nowUtc)
+        {
+        }
+
+        public long GetTotalBytes() => 0;
+
+        public long GetTotalBytes(IReadOnlySet<string> sourceAbsolutePaths) => 0;
+
+        public Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task ReconcileAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public event EventHandler<ProxyStoreChangedEventArgs>? Changed;
     }
 
     private sealed class ControlledBlockingGenerator : IProxyGenerator

--- a/tests/Beutl.UnitTests/Media/Proxy/ProxyJobQueueTests.cs
+++ b/tests/Beutl.UnitTests/Media/Proxy/ProxyJobQueueTests.cs
@@ -306,6 +306,36 @@ public class ProxyJobQueueTests
         });
     }
 
+    [Test]
+    public async Task Cancellation_rolls_back_an_ambiguous_failure_registration()
+    {
+        var store = new MutatingThenThrowStore();
+        var releaseStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLease = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var admission = new SequencedAdmission(
+            rejections: 0,
+            leaseFactory: () => new CountingLease(
+                disposeStarted: releaseStarted,
+                disposeRelease: releaseLease.Task));
+        await using var queue = new ProxyJobQueue(new FailingGenerator(), store, admission);
+        ProxyFingerprint source = CreateFingerprint("ambiguous-failure-registration.mov");
+
+        ProxyJob job = await queue.EnqueueAsync(source, ProxyPreset.Quarter);
+        await releaseStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        queue.Cancel(job.JobId);
+        releaseLease.TrySetResult();
+        await WaitForTerminalAsync(job);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Canceled));
+            Assert.That(job.BookkeepingError, Is.InstanceOf<InvalidOperationException>());
+            Assert.That(store.TryGet(source, ProxyPreset.Quarter), Is.Null);
+        });
+    }
+
     [TestCase(AdmissionGeneratorOutcome.Success, ProxyJobStatus.Succeeded)]
     [TestCase(AdmissionGeneratorOutcome.Skipped, ProxyJobStatus.Skipped)]
     [TestCase(AdmissionGeneratorOutcome.Failed, ProxyJobStatus.Failed)]
@@ -2135,6 +2165,57 @@ public class ProxyJobQueueTests
         public Task ReconcileAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
         public event EventHandler<ProxyStoreChangedEventArgs>? Changed;
+    }
+
+    private sealed class MutatingThenThrowStore : IProxyStore
+    {
+        private ProxyEntry? _entry;
+        private bool _throwOnRegister = true;
+
+        public string StoreRootPath => Path.GetTempPath();
+
+        public ProxyEntry? TryGet(ProxyFingerprint source, ProxyPreset preset) => _entry;
+
+        public IReadOnlyList<ProxyEntry> Enumerate() => _entry is null ? [] : [_entry];
+
+        public void Register(ProxyEntry entry)
+        {
+            _entry = entry;
+            if (_throwOnRegister)
+            {
+                _throwOnRegister = false;
+                throw new InvalidOperationException("persistence failed after mutation");
+            }
+        }
+
+        public bool TryTransition(
+            ProxyFingerprint source,
+            ProxyPreset preset,
+            ProxyState newState,
+            string? failureReason = null) => false;
+
+        public bool Delete(ProxyFingerprint source, ProxyPreset preset)
+        {
+            bool removed = _entry is not null;
+            _entry = null;
+            return removed;
+        }
+
+        public void Touch(ProxyFingerprint source, ProxyPreset preset, DateTime nowUtc)
+        {
+        }
+
+        public long GetTotalBytes() => 0;
+
+        public long GetTotalBytes(IReadOnlySet<string> sourceAbsolutePaths) => 0;
+
+        public Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task ReconcileAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+#pragma warning disable CS0067 // Not exercised by these tests.
+        public event EventHandler<ProxyStoreChangedEventArgs>? Changed;
+#pragma warning restore CS0067
     }
 
     private sealed class ControlledBlockingGenerator : IProxyGenerator

--- a/tests/Beutl.UnitTests/Media/Proxy/ProxyJobQueueTests.cs
+++ b/tests/Beutl.UnitTests/Media/Proxy/ProxyJobQueueTests.cs
@@ -39,6 +39,8 @@ public class ProxyJobQueueTests
         var releaseFirstDelay = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var delays = new List<TimeSpan>();
         int startedEvents = 0;
+        int enqueuedEvents = 0;
+        int waitingEvents = 0;
         await using var queue = new ProxyJobQueue(
             generator,
             store: null,
@@ -65,6 +67,14 @@ public class ProxyJobQueueTests
             if (args.Kind == ProxyJobChangeKind.Started)
             {
                 Interlocked.Increment(ref startedEvents);
+            }
+            else if (args.Kind == ProxyJobChangeKind.Enqueued)
+            {
+                Interlocked.Increment(ref enqueuedEvents);
+            }
+            else if (args.Kind == ProxyJobChangeKind.WaitingForAdmission)
+            {
+                Interlocked.Increment(ref waitingEvents);
             }
         };
 
@@ -107,6 +117,43 @@ public class ProxyJobQueueTests
             Assert.That(admission.Leases[0].DisposeCount, Is.EqualTo(1));
             Assert.That(generator.Sources, Has.Count.EqualTo(1));
             Assert.That(Volatile.Read(ref startedEvents), Is.EqualTo(1));
+            Assert.That(Volatile.Read(ref enqueuedEvents), Is.EqualTo(1));
+            Assert.That(Volatile.Read(ref waitingEvents), Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task Admission_availability_signal_wakes_a_deferred_job_before_its_backoff()
+    {
+        var generator = new RecordingGenerator();
+        var admission = new SequencedAdmission(rejections: 1);
+        var delayStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var queue = new ProxyJobQueue(
+            generator,
+            store: null,
+            minUnavailableBackoff: TimeSpan.FromSeconds(30),
+            maxUnavailableBackoff: TimeSpan.FromSeconds(30),
+            admission,
+            async (_, cancellationToken) =>
+            {
+                delayStarted.TrySetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            });
+
+        ProxyJob job = await queue.EnqueueAsync(
+            CreateFingerprint("admission-signal.mov"),
+            ProxyPreset.Quarter);
+        await delayStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        admission.SignalAvailability();
+        await WaitForTerminalAsync(job);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Succeeded));
+            Assert.That(admission.Attempts, Is.EqualTo(2));
+            Assert.That(generator.Sources, Has.Count.EqualTo(1));
         });
     }
 
@@ -184,6 +231,38 @@ public class ProxyJobQueueTests
             Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Failed));
             Assert.That(leaseDisposeCountAtRegistration, Is.Zero);
             Assert.That(leaseDisposeCountAtFailure, Is.EqualTo(1));
+            Assert.That(admission.Leases.Single().DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task Cancellation_during_failure_cleanup_rolls_back_the_failed_store_entry()
+    {
+        string root = CreateRoot();
+        var store = new ProxyStore(root);
+        var releaseStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLease = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var admission = new SequencedAdmission(
+            rejections: 0,
+            leaseFactory: () => new CountingLease(
+                disposeStarted: releaseStarted,
+                disposeRelease: releaseLease.Task));
+        await using var queue = new ProxyJobQueue(new FailingGenerator(), store, admission);
+        ProxyFingerprint source = CreateFingerprint("failure-cleanup-cancel.mov");
+
+        ProxyJob job = await queue.EnqueueAsync(source, ProxyPreset.Quarter);
+        await releaseStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        queue.Cancel(job.JobId);
+        releaseLease.TrySetResult();
+        await WaitForTerminalAsync(job);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Canceled));
+            Assert.That(job.Error, Is.Null);
+            Assert.That(store.TryGet(source, ProxyPreset.Quarter), Is.Null);
             Assert.That(admission.Leases.Single().DisposeCount, Is.EqualTo(1));
         });
     }
@@ -1512,6 +1591,8 @@ public class ProxyJobQueueTests
         int rejections,
         Func<CountingLease>? leaseFactory = null) : IProxyGenerationAdmission
     {
+        public event EventHandler? AvailabilityChanged;
+
         private readonly Lock _lock = new();
         private readonly List<CountingLease> _leases = [];
         private int _attempts;
@@ -1545,10 +1626,14 @@ public class ProxyJobQueueTests
 
             return lease;
         }
+
+        public void SignalAvailability() => AvailabilityChanged?.Invoke(this, EventArgs.Empty);
     }
 
     private sealed class BlockingThrowingAdmission(Exception failure) : IProxyGenerationAdmission
     {
+        public event EventHandler? AvailabilityChanged;
+
         private readonly TaskCompletionSource _release = new(
             TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -1567,11 +1652,15 @@ public class ProxyJobQueueTests
         {
             _release.TrySetResult();
         }
+
+        public void SignalAvailability() => AvailabilityChanged?.Invoke(this, EventArgs.Empty);
     }
 
     private sealed class JobAwareAdmission(ProxyFingerprint deniedSource)
         : IProxyGenerationAdmission
     {
+        public event EventHandler? AvailabilityChanged;
+
         private int _deniedAttempts;
         private int _admittedAttempts;
 
@@ -1592,6 +1681,8 @@ public class ProxyJobQueueTests
             Interlocked.Increment(ref _admittedAttempts);
             return Lease;
         }
+
+        public void SignalAvailability() => AvailabilityChanged?.Invoke(this, EventArgs.Empty);
     }
 
     private sealed class CountingLease(

--- a/tests/Beutl.UnitTests/Media/Proxy/ProxyJobQueueTests.cs
+++ b/tests/Beutl.UnitTests/Media/Proxy/ProxyJobQueueTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Channels;
+﻿using System.Runtime.ExceptionServices;
+using System.Threading.Channels;
 
 using Beutl.Media;
 using Beutl.Media.Proxy;
@@ -26,6 +27,485 @@ public class ProxyJobQueueTests
             Assert.That(generator.Sources, Is.EqualTo(new[] { first, second }));
             Assert.That(firstJob.Status, Is.EqualTo(ProxyJobStatus.Succeeded));
             Assert.That(secondJob.Status, Is.EqualTo(ProxyJobStatus.Succeeded));
+        });
+    }
+
+    [Test]
+    public async Task Admission_rejection_requeues_without_starting_and_caps_backoff()
+    {
+        var generator = new RecordingGenerator();
+        var admission = new SequencedAdmission(rejections: 4);
+        var firstDelay = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstDelay = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var delays = new List<TimeSpan>();
+        int startedEvents = 0;
+        await using var queue = new ProxyJobQueue(
+            generator,
+            store: null,
+            minUnavailableBackoff: TimeSpan.FromMilliseconds(10),
+            maxUnavailableBackoff: TimeSpan.FromMilliseconds(25),
+            admission,
+            async (delay, cancellationToken) =>
+            {
+                int count;
+                lock (delays)
+                {
+                    delays.Add(delay);
+                    count = delays.Count;
+                }
+
+                if (count == 1)
+                {
+                    firstDelay.TrySetResult();
+                    await releaseFirstDelay.Task.WaitAsync(cancellationToken);
+                }
+            });
+        queue.JobChanged += (_, args) =>
+        {
+            if (args.Kind == ProxyJobChangeKind.Started)
+            {
+                Interlocked.Increment(ref startedEvents);
+            }
+        };
+
+        ProxyJob job = await queue.EnqueueAsync(
+            CreateFingerprint("admission-backoff.mov"),
+            ProxyPreset.Quarter);
+        await firstDelay.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Queued));
+            Assert.That(job.StatusMessage, Is.EqualTo("Waiting for proxy generation admission."));
+            Assert.That(generator.Sources, Is.Empty);
+            Assert.That(Volatile.Read(ref startedEvents), Is.Zero);
+        });
+
+        releaseFirstDelay.TrySetResult();
+        await WaitForTerminalAsync(job);
+
+        TimeSpan[] observedDelays;
+        lock (delays)
+        {
+            observedDelays = [.. delays];
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Succeeded));
+            Assert.That(
+                observedDelays,
+                Is.EqualTo(new[]
+                {
+                    TimeSpan.FromMilliseconds(10),
+                    TimeSpan.FromMilliseconds(20),
+                    TimeSpan.FromMilliseconds(25),
+                    TimeSpan.FromMilliseconds(25),
+                }));
+            Assert.That(admission.Attempts, Is.EqualTo(5));
+            Assert.That(admission.Leases, Has.Count.EqualTo(1));
+            Assert.That(admission.Leases[0].DisposeCount, Is.EqualTo(1));
+            Assert.That(generator.Sources, Has.Count.EqualTo(1));
+            Assert.That(Volatile.Read(ref startedEvents), Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task Accepted_admission_lease_is_held_until_generation_and_terminal_publication()
+    {
+        var generator = new SignalingGenerator(ignoreCancellation: false);
+        var admission = new SequencedAdmission(rejections: 0);
+        int leaseDisposeCountAtSuccess = -1;
+        var succeeded = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var queue = new ProxyJobQueue(generator, store: null, admission);
+        queue.JobChanged += (_, args) =>
+        {
+            if (args.Kind == ProxyJobChangeKind.Succeeded)
+            {
+                leaseDisposeCountAtSuccess = admission.Leases.Single().DisposeCount;
+                succeeded.TrySetResult();
+            }
+        };
+
+        ProxyJob job = await queue.EnqueueAsync(
+            CreateFingerprint("admission-lifetime.mov"),
+            ProxyPreset.Quarter);
+        await generator.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Running));
+            Assert.That(admission.Leases, Has.Count.EqualTo(1));
+            Assert.That(admission.Leases[0].DisposeCount, Is.Zero);
+        });
+
+        generator.Release();
+        await succeeded.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Succeeded));
+            Assert.That(admission.Leases[0].DisposeCount, Is.EqualTo(1));
+            Assert.That(leaseDisposeCountAtSuccess, Is.EqualTo(1));
+        });
+    }
+
+    [TestCase(AdmissionGeneratorOutcome.Success, ProxyJobStatus.Succeeded)]
+    [TestCase(AdmissionGeneratorOutcome.Skipped, ProxyJobStatus.Skipped)]
+    [TestCase(AdmissionGeneratorOutcome.Failed, ProxyJobStatus.Failed)]
+    [TestCase(AdmissionGeneratorOutcome.Unavailable, ProxyJobStatus.Skipped)]
+    public async Task Admission_lease_is_released_once_on_each_generator_terminal_path(
+        AdmissionGeneratorOutcome outcome,
+        ProxyJobStatus expectedStatus)
+    {
+        var admission = new SequencedAdmission(rejections: 0);
+        await using var queue = new ProxyJobQueue(
+            new OutcomeGenerator(outcome),
+            store: null,
+            admission);
+
+        ProxyJob job = await queue.EnqueueAsync(
+            CreateFingerprint($"admission-{outcome}.mov"),
+            ProxyPreset.Quarter);
+        await WaitForTerminalAsync(job);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Status, Is.EqualTo(expectedStatus));
+            Assert.That(admission.Attempts, Is.EqualTo(1));
+            Assert.That(admission.Leases, Has.Count.EqualTo(1));
+            Assert.That(admission.Leases[0].DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task Cancel_releases_the_active_admission_lease_once()
+    {
+        var generator = new SignalingGenerator(ignoreCancellation: false);
+        var admission = new SequencedAdmission(rejections: 0);
+        await using var queue = new ProxyJobQueue(generator, store: null, admission);
+
+        ProxyJob job = await queue.EnqueueAsync(
+            CreateFingerprint("admission-cancel.mov"),
+            ProxyPreset.Quarter);
+        await generator.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        queue.Cancel(job.JobId);
+        await WaitForTerminalAsync(job);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Canceled));
+            Assert.That(admission.Leases.Single().DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task Cancel_racing_admission_release_wins_before_success_publication()
+    {
+        var releaseStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLease = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var admission = new SequencedAdmission(
+            rejections: 0,
+            leaseFactory: () => new CountingLease(
+                disposeStarted: releaseStarted,
+                disposeRelease: releaseLease.Task));
+        int succeededEvents = 0;
+        await using var queue = new ProxyJobQueue(new RecordingGenerator(), store: null, admission);
+        queue.JobChanged += (_, args) =>
+        {
+            if (args.Kind == ProxyJobChangeKind.Succeeded)
+            {
+                Interlocked.Increment(ref succeededEvents);
+            }
+        };
+
+        ProxyJob job = await queue.EnqueueAsync(
+            CreateFingerprint("admission-release-cancel-race.mov"),
+            ProxyPreset.Quarter);
+        await releaseStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        queue.Cancel(job.JobId);
+        releaseLease.TrySetResult();
+        await WaitForTerminalAsync(job);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Canceled));
+            Assert.That(admission.Leases.Single().DisposeCount, Is.EqualTo(1));
+            Assert.That(Volatile.Read(ref succeededEvents), Is.Zero);
+        });
+    }
+
+    [Test]
+    public async Task Admission_release_failure_remains_failed_when_cancellation_races_cleanup()
+    {
+        string root = CreateRoot();
+        var store = new ProxyStore(root);
+        var releaseStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLease = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var expected = new InvalidOperationException("admission release failed");
+        var admission = new SequencedAdmission(
+            rejections: 0,
+            leaseFactory: () => new CountingLease(
+                expected,
+                releaseStarted,
+                releaseLease.Task));
+        await using var queue = new ProxyJobQueue(new RecordingGenerator(), store, admission);
+        ProxyFingerprint source = CreateFingerprint("admission-release-failure-cancel-race.mov");
+
+        ProxyJob job = await queue.EnqueueAsync(source, ProxyPreset.Quarter);
+        await releaseStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        queue.Cancel(job.JobId);
+        releaseLease.TrySetResult();
+        await WaitForTerminalAsync(job);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Failed));
+            Assert.That(job.Error, Is.SameAs(expected));
+            Assert.That(store.TryGet(source, ProxyPreset.Quarter)?.State,
+                Is.EqualTo(ProxyState.Failed));
+            Assert.That(admission.Leases.Single().DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task Cancel_while_admission_is_denied_never_runs_or_acquires_a_lease()
+    {
+        var generator = new RecordingGenerator();
+        var admission = new SequencedAdmission(rejections: int.MaxValue);
+        var delayStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var delayCanceled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var queue = new ProxyJobQueue(
+            generator,
+            store: null,
+            minUnavailableBackoff: TimeSpan.FromSeconds(30),
+            maxUnavailableBackoff: TimeSpan.FromSeconds(30),
+            admission,
+            async (_, cancellationToken) =>
+            {
+                delayStarted.TrySetResult();
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    delayCanceled.TrySetResult();
+                    throw;
+                }
+            });
+
+        ProxyJob job = await queue.EnqueueAsync(
+            CreateFingerprint("admission-denied-cancel.mov"),
+            ProxyPreset.Quarter);
+        await delayStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        queue.Cancel(job.JobId);
+        await delayCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await WaitForTerminalAsync(job);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Canceled));
+            Assert.That(admission.Attempts, Is.EqualTo(1));
+            Assert.That(admission.Leases, Is.Empty);
+            Assert.That(generator.Sources, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Cancel_wins_when_a_blocked_admission_callback_later_throws()
+    {
+        string root = CreateRoot();
+        var store = new ProxyStore(root);
+        var generator = new RecordingGenerator();
+        var expected = new InvalidOperationException("admission callback failed");
+        var admission = new BlockingThrowingAdmission(expected);
+        await using var queue = new ProxyJobQueue(generator, store, admission);
+        ProxyFingerprint source = CreateFingerprint("admission-callback-cancel.mov");
+
+        ProxyJob job = await queue.EnqueueAsync(source, ProxyPreset.Quarter);
+        await admission.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        queue.Cancel(job.JobId);
+        admission.Release();
+        await WaitForTerminalAsync(job);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Canceled));
+            Assert.That(job.Error, Is.Null);
+            Assert.That(store.TryGet(source, ProxyPreset.Quarter), Is.Null);
+            Assert.That(generator.Sources, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Dispose_wins_when_a_blocked_admission_callback_later_throws()
+    {
+        string root = CreateRoot();
+        var store = new ProxyStore(root);
+        var generator = new RecordingGenerator();
+        var admission = new BlockingThrowingAdmission(
+            new InvalidOperationException("admission callback failed"));
+        var queue = new ProxyJobQueue(generator, store, admission);
+        ProxyFingerprint source = CreateFingerprint("admission-callback-dispose.mov");
+        ProxyJob job = await queue.EnqueueAsync(source, ProxyPreset.Quarter);
+        await admission.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Task disposal = queue.DisposeAsync().AsTask();
+        Assert.That(disposal.IsCompleted, Is.False);
+        admission.Release();
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Canceled));
+            Assert.That(job.Error, Is.Null);
+            Assert.That(store.TryGet(source, ProxyPreset.Quarter), Is.Null);
+            Assert.That(generator.Sources, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Job_aware_admission_denial_does_not_starve_an_admissible_peer()
+    {
+        var generator = new RecordingGenerator();
+        ProxyFingerprint deniedSource = CreateFingerprint("admission-denied-a.mov");
+        ProxyFingerprint admittedSource = CreateFingerprint("admission-admitted-b.mov");
+        var admission = new JobAwareAdmission(deniedSource);
+        var delayStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseDelay = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var queue = new ProxyJobQueue(
+            generator,
+            store: null,
+            minUnavailableBackoff: TimeSpan.FromSeconds(30),
+            maxUnavailableBackoff: TimeSpan.FromSeconds(30),
+            admission,
+            async (_, cancellationToken) =>
+            {
+                delayStarted.TrySetResult();
+                await releaseDelay.Task.WaitAsync(cancellationToken);
+            });
+
+        ProxyJob denied = await queue.EnqueueAsync(deniedSource, ProxyPreset.Quarter);
+        await delayStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        ProxyJob admitted = await queue.EnqueueAsync(admittedSource, ProxyPreset.Quarter);
+        await WaitForTerminalAsync(admitted);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(denied.Status, Is.EqualTo(ProxyJobStatus.Queued));
+            Assert.That(admitted.Status, Is.EqualTo(ProxyJobStatus.Succeeded));
+            Assert.That(generator.Sources, Is.EqualTo(new[] { admittedSource }));
+            Assert.That(admission.DeniedAttempts, Is.EqualTo(1));
+            Assert.That(admission.AdmittedAttempts, Is.EqualTo(1));
+            Assert.That(admission.Lease.DisposeCount, Is.EqualTo(1));
+        });
+
+        queue.Cancel(denied.JobId);
+        releaseDelay.TrySetResult();
+        await WaitForTerminalAsync(denied);
+        Assert.That(denied.Status, Is.EqualTo(ProxyJobStatus.Canceled));
+    }
+
+    [Test]
+    public async Task Dispose_waits_for_generation_before_releasing_admission_once()
+    {
+        var generator = new SignalingGenerator(ignoreCancellation: true);
+        var admission = new SequencedAdmission(rejections: 0);
+        var queue = new ProxyJobQueue(generator, store: null, admission);
+        ProxyJob job = await queue.EnqueueAsync(
+            CreateFingerprint("admission-dispose.mov"),
+            ProxyPreset.Quarter);
+        await generator.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Task disposal = queue.DisposeAsync().AsTask();
+        await generator.CancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        queue.Cancel(job.JobId);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(disposal.IsCompleted, Is.False);
+            Assert.That(admission.Leases.Single().DisposeCount, Is.Zero);
+        });
+
+        generator.Release();
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+        await queue.DisposeAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Canceled));
+            Assert.That(admission.Leases.Single().DisposeCount, Is.EqualTo(1));
+            Assert.That(queue.Pending(), Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Admission_release_failure_fails_the_job_without_success_publication()
+    {
+        var expected = new InvalidOperationException("admission release failed");
+        var admission = new SequencedAdmission(
+            rejections: 0,
+            leaseFactory: () => new CountingLease(expected));
+        int succeededEvents = 0;
+        await using var queue = new ProxyJobQueue(new RecordingGenerator(), store: null, admission);
+        queue.JobChanged += (_, args) =>
+        {
+            if (args.Kind == ProxyJobChangeKind.Succeeded)
+            {
+                Interlocked.Increment(ref succeededEvents);
+            }
+        };
+
+        ProxyJob job = await queue.EnqueueAsync(
+            CreateFingerprint("admission-release-failure.mov"),
+            ProxyPreset.Quarter);
+        await WaitForTerminalAsync(job);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Failed));
+            Assert.That(job.Error, Is.SameAs(expected));
+            Assert.That(admission.Leases.Single().DisposeCount, Is.EqualTo(1));
+            Assert.That(Volatile.Read(ref succeededEvents), Is.Zero);
+        });
+    }
+
+    [Test]
+    public async Task Generator_retry_releases_each_attempts_admission_before_requeueing()
+    {
+        var generator = new ToggleAvailabilityGenerator();
+        var admission = new SequencedAdmission(rejections: 0);
+        await using var queue = new ProxyJobQueue(
+            generator,
+            store: null,
+            minUnavailableBackoff: TimeSpan.FromMilliseconds(10),
+            maxUnavailableBackoff: TimeSpan.FromMilliseconds(20),
+            admission);
+
+        ProxyJob job = await queue.EnqueueAsync(
+            CreateFingerprint("admission-generator-retry.mov"),
+            ProxyPreset.Quarter);
+        await generator.UnavailableHit.WaitAsync(TimeSpan.FromSeconds(5));
+        await WaitUntilAsync(() => admission.Leases.Count == 1
+                                   && admission.Leases[0].DisposeCount == 1);
+
+        generator.SetAvailable();
+        await WaitForTerminalAsync(job);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Succeeded));
+            Assert.That(admission.Attempts, Is.EqualTo(2));
+            Assert.That(admission.Leases, Has.Count.EqualTo(2));
+            Assert.That(admission.Leases.Select(static lease => lease.DisposeCount),
+                Is.All.EqualTo(1));
         });
     }
 
@@ -921,6 +1401,15 @@ public class ProxyJobQueueTests
         }
     }
 
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (!condition())
+        {
+            await Task.Delay(10, cts.Token);
+        }
+    }
+
     private static ProxyFingerprint CreateFingerprint(string fileName)
     {
         string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, fileName);
@@ -953,6 +1442,171 @@ public class ProxyJobQueueTests
             now,
             now,
             null);
+    }
+
+    public enum AdmissionGeneratorOutcome
+    {
+        Success,
+        Skipped,
+        Failed,
+        Unavailable,
+    }
+
+    private sealed class OutcomeGenerator(AdmissionGeneratorOutcome outcome) : IProxyGenerator
+    {
+        public ValueTask GenerateAsync(ProxyJob job)
+        {
+            return outcome switch
+            {
+                AdmissionGeneratorOutcome.Success => ValueTask.CompletedTask,
+                AdmissionGeneratorOutcome.Skipped => ValueTask.FromException(
+                    new ProxyGenerationSkippedException("skipped")),
+                AdmissionGeneratorOutcome.Failed => ValueTask.FromException(
+                    new InvalidOperationException("failed")),
+                AdmissionGeneratorOutcome.Unavailable => ValueTask.FromException(
+                    new ProxyGeneratorUnavailableException("unavailable")),
+                _ => throw new ArgumentOutOfRangeException(nameof(outcome)),
+            };
+        }
+    }
+
+    private sealed class SequencedAdmission(
+        int rejections,
+        Func<CountingLease>? leaseFactory = null) : IProxyGenerationAdmission
+    {
+        private readonly Lock _lock = new();
+        private readonly List<CountingLease> _leases = [];
+        private int _attempts;
+
+        public int Attempts => Volatile.Read(ref _attempts);
+
+        public IReadOnlyList<CountingLease> Leases
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return [.. _leases];
+                }
+            }
+        }
+
+        public IDisposable? TryAcquireLease(ProxyJob job)
+        {
+            int attempt = Interlocked.Increment(ref _attempts);
+            if (attempt <= rejections)
+            {
+                return null;
+            }
+
+            CountingLease lease = leaseFactory?.Invoke() ?? new CountingLease();
+            lock (_lock)
+            {
+                _leases.Add(lease);
+            }
+
+            return lease;
+        }
+    }
+
+    private sealed class BlockingThrowingAdmission(Exception failure) : IProxyGenerationAdmission
+    {
+        private readonly TaskCompletionSource _release = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Entered { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public IDisposable? TryAcquireLease(ProxyJob job)
+        {
+            Entered.TrySetResult();
+            _release.Task.GetAwaiter().GetResult();
+            ExceptionDispatchInfo.Capture(failure).Throw();
+            return null;
+        }
+
+        public void Release()
+        {
+            _release.TrySetResult();
+        }
+    }
+
+    private sealed class JobAwareAdmission(ProxyFingerprint deniedSource)
+        : IProxyGenerationAdmission
+    {
+        private int _deniedAttempts;
+        private int _admittedAttempts;
+
+        public int DeniedAttempts => Volatile.Read(ref _deniedAttempts);
+
+        public int AdmittedAttempts => Volatile.Read(ref _admittedAttempts);
+
+        public CountingLease Lease { get; } = new();
+
+        public IDisposable? TryAcquireLease(ProxyJob job)
+        {
+            if (job.Source == deniedSource)
+            {
+                Interlocked.Increment(ref _deniedAttempts);
+                return null;
+            }
+
+            Interlocked.Increment(ref _admittedAttempts);
+            return Lease;
+        }
+    }
+
+    private sealed class CountingLease(
+        Exception? disposeFailure = null,
+        TaskCompletionSource? disposeStarted = null,
+        Task? disposeRelease = null) : IDisposable
+    {
+        private int _disposeCount;
+
+        public int DisposeCount => Volatile.Read(ref _disposeCount);
+
+        public void Dispose()
+        {
+            Interlocked.Increment(ref _disposeCount);
+            disposeStarted?.TrySetResult();
+            disposeRelease?.GetAwaiter().GetResult();
+            if (disposeFailure is not null)
+            {
+                ExceptionDispatchInfo.Capture(disposeFailure).Throw();
+            }
+        }
+    }
+
+    private sealed class SignalingGenerator(bool ignoreCancellation) : IProxyGenerator
+    {
+        private readonly TaskCompletionSource _release = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Started { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource CancellationObserved { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async ValueTask GenerateAsync(ProxyJob job)
+        {
+            using CancellationTokenRegistration registration = job.CancellationToken.Register(
+                () => CancellationObserved.TrySetResult());
+            Started.TrySetResult();
+            if (ignoreCancellation)
+            {
+                await _release.Task;
+            }
+            else
+            {
+                await _release.Task.WaitAsync(job.CancellationToken);
+            }
+        }
+
+        public void Release()
+        {
+            _release.TrySetResult();
+        }
     }
 
     private sealed class RecordingGenerator : IProxyGenerator

--- a/tests/Beutl.UnitTests/Media/Proxy/ProxyJobQueueTests.cs
+++ b/tests/Beutl.UnitTests/Media/Proxy/ProxyJobQueueTests.cs
@@ -600,6 +600,45 @@ public class ProxyJobQueueTests
     }
 
     [Test]
+    public async Task Admission_failure_waits_for_token_cancellation_callbacks()
+    {
+        var admission = new BlockingThrowingAdmission(
+            new InvalidOperationException("admission callback failed"));
+        await using var queue = new ProxyJobQueue(
+            new RecordingGenerator(),
+            store: null,
+            admission);
+        ProxyJob job = await queue.EnqueueAsync(
+            CreateFingerprint("admission-callback-cleanup.mov"),
+            ProxyPreset.Quarter);
+        await admission.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var callbackStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseCallback = new ManualResetEventSlim();
+        using CancellationTokenRegistration registration = job.CancellationToken.Register(() =>
+        {
+            callbackStarted.TrySetResult();
+            releaseCallback.Wait();
+        });
+
+        Task cancellation = Task.Run(() => queue.Cancel(job.JobId));
+        try
+        {
+            await callbackStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            admission.Release();
+            Assert.That(job.Status, Is.Not.EqualTo(ProxyJobStatus.Canceled));
+        }
+        finally
+        {
+            releaseCallback.Set();
+        }
+
+        await cancellation.WaitAsync(TimeSpan.FromSeconds(5));
+        await WaitForTerminalAsync(job);
+        Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Canceled));
+    }
+
+    [Test]
     public async Task Dispose_wins_when_a_blocked_admission_callback_later_throws()
     {
         string root = CreateRoot();

--- a/tests/Beutl.UnitTests/Media/Proxy/ProxyJobQueueTests.cs
+++ b/tests/Beutl.UnitTests/Media/Proxy/ProxyJobQueueTests.cs
@@ -357,6 +357,32 @@ public class ProxyJobQueueTests
     }
 
     [Test]
+    public async Task Cancellation_callback_can_query_the_queue_without_lock_inversion()
+    {
+        ProxyJobQueue? queue = null;
+        var callbackCompleted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var generator = new CancellationCallbackGenerator(() =>
+        {
+            _ = queue!.Pending();
+            callbackCompleted.TrySetResult();
+        });
+        await using var activeQueue = new ProxyJobQueue(generator);
+        queue = activeQueue;
+        ProxyJob job = await activeQueue.EnqueueAsync(
+            CreateFingerprint("cancellation-callback-query.mov"),
+            ProxyPreset.Quarter);
+        await generator.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Task.Run(() => activeQueue.Cancel(job.JobId))
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        await callbackCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await WaitForTerminalAsync(job);
+
+        Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Canceled));
+    }
+
+    [Test]
     public async Task Completed_generation_wins_cancellation_during_admission_release()
     {
         string root = CreateRoot();
@@ -1482,7 +1508,21 @@ public class ProxyJobQueueTests
     [Test]
     public async Task GeneratorThrowsOceWithoutCancellation_ReportsFailedNotCanceled()
     {
-        await using var queue = new ProxyJobQueue(new OceThrowingGenerator());
+        string root = CreateRoot();
+        var store = new ProxyStore(root);
+        var admission = new SequencedAdmission(rejections: 0);
+        int leaseDisposeCountAtRegistration = -1;
+        store.Changed += (_, args) =>
+        {
+            if (args.Kind == ProxyStoreChangeKind.Registered)
+            {
+                leaseDisposeCountAtRegistration = admission.Leases.Single().DisposeCount;
+            }
+        };
+        await using var queue = new ProxyJobQueue(
+            new OceThrowingGenerator(),
+            store,
+            admission);
         ProxyFingerprint source = CreateFingerprint("spurious-oce.mov");
 
         ProxyJob job = await queue.EnqueueAsync(source, ProxyPreset.Quarter);
@@ -1492,6 +1532,10 @@ public class ProxyJobQueueTests
         {
             Assert.That(job.Status, Is.EqualTo(ProxyJobStatus.Failed));
             Assert.That(job.Error, Is.InstanceOf<OperationCanceledException>());
+            Assert.That(leaseDisposeCountAtRegistration, Is.Zero);
+            Assert.That(store.TryGet(source, ProxyPreset.Quarter)?.State,
+                Is.EqualTo(ProxyState.Failed));
+            Assert.That(admission.Leases.Single().DisposeCount, Is.EqualTo(1));
         });
     }
 
@@ -1785,6 +1829,20 @@ public class ProxyJobQueueTests
         public void Release()
         {
             _release.TrySetResult();
+        }
+    }
+
+    private sealed class CancellationCallbackGenerator(Action callback) : IProxyGenerator
+    {
+        public TaskCompletionSource Started { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async ValueTask GenerateAsync(ProxyJob job)
+        {
+            using CancellationTokenRegistration registration =
+                job.CancellationToken.Register(callback);
+            Started.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, job.CancellationToken);
         }
     }
 


### PR DESCRIPTION
## Description

- Add the public, job-aware `IProxyGenerationAdmission` try-contract to `Beutl.Engine`. Existing queue constructors remain unrestricted; hosts opt in through new additive `ProxyJobQueue` overloads.
- Keep rejected jobs queued without entering the generator or publishing `Started`. Each rejected item receives its own capped exponential retry, so an admissible peer at the same priority can continue instead of starving behind it.
- Transfer every accepted lease to the queue for the complete `GenerateAsync` lifetime and release it exactly once before terminal publication on success, skip, failure, cancellation, retry, and disposal paths.
- Make cancellation win over concurrent admission or generator errors without recording a failed proxy entry. Lease-release failures remain `Failed` because cleanup could not be proved.
- This is a standalone change based directly on `main`. It does not depend on #2164, #2319, or any other pull request.
- This PR does not claim that proxy generation is gated during version-control restores. Out of scope are restore wiring, `EditorService` and output admission APIs, `ProxyMediaServices` or `MainViewModel` host bindings, package flows, AgentHost, and shutdown behavior.

## Affected areas

- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes

None. The admission interface and constructor overloads are additive, and existing constructors preserve unrestricted generation.

## Test plan

- `dotnet build Beutl.slnx -c Debug --no-restore` — passed with 0 warnings and 0 errors.
- `Beutl.UnitTests.Media.Proxy.ProxyJobQueueTests` — 48 passed, covering bounded backoff, fairness, every terminal path, cancellation/error precedence, release failure, retry, disposal, and races.
- `Beutl.PublicApiContractTests` — 210 passed, including external implementation and consumption of `IProxyGenerationAdmission`.
- Changed-file `dotnet format --verify-no-changes`, `git diff --check`, and the GPL/MIT diff scan — passed.
- Public API design review — passed with no remaining medium-or-higher findings.
- No UI layout changed, so screenshots are not applicable.

## Fixed issues / References


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional admission control for proxy generation based on host resource availability.
  - Jobs that cannot be admitted remain queued with bounded retry backoff while other jobs continue processing.
  - Deferred jobs can resume sooner when resources become available.
  - Generation leases remain active through completion and cleanup, with release failures reported as errors.
  - Added a `WaitingForAdmission` status event for deferred jobs.

- **Bug Fixes**
  - Improved cancellation and failure handling to prevent inconsistent terminal job states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->