### PR TITLE
fix(file-browser): ignore watcher events after disposal

### DIFF
--- a/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
@@ -597,6 +597,8 @@ internal sealed class DirectoryWatcherService : IDisposable
         }
     }
 
+    internal void OnFileSystemEvent(string path) => NotifyPathChanged(path);
+
     internal void NotifyPathChanged(string path) => NotifyPathChanged(path, sourceWatcher: null);
 
     private void NotifyPathChanged(string path, object? sourceWatcher)

--- a/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
@@ -219,13 +219,16 @@ internal sealed class DirectoryWatcherService : IDisposable
 
         Dispatcher.UIThread.Post(() =>
         {
-            if (!IsCurrentWatcher(sender))
-                return;
-
-            if (TryRearmAfterError())
+            lock (_stateSync)
             {
-                // Resync changes missed while the watcher was down.
-                Changed?.Invoke();
+                if (!IsCurrentWatcher(sender))
+                    return;
+
+                if (TryRearmAfterError())
+                {
+                    // Resync changes missed while the watcher was down.
+                    Changed?.Invoke();
+                }
             }
         });
     }
@@ -597,8 +600,6 @@ internal sealed class DirectoryWatcherService : IDisposable
         }
     }
 
-    internal void OnFileSystemEvent(string path) => NotifyPathChanged(path);
-
     internal void NotifyPathChanged(string path) => NotifyPathChanged(path, sourceWatcher: null);
 
     private void NotifyPathChanged(string path, object? sourceWatcher)
@@ -682,7 +683,6 @@ internal sealed class DirectoryWatcherService : IDisposable
 
     private void TryDeliver(CancellationTokenSource debounce, long deliveryGeneration)
     {
-        Action? changed;
         lock (_stateSync)
         {
             if (_disposed
@@ -695,11 +695,9 @@ internal sealed class DirectoryWatcherService : IDisposable
             _debounceCts = null;
             _errorRearmCount = 0;
             _failingCanonicalPath = null;
-            changed = Changed;
+            debounce.Dispose();
+            Changed?.Invoke();
         }
-
-        debounce.Dispose();
-        changed?.Invoke();
     }
 
     // A delivered event resets the rearm budget.
@@ -707,6 +705,9 @@ internal sealed class DirectoryWatcherService : IDisposable
     {
         lock (_stateSync)
         {
+            if (_disposed)
+                return;
+
             _errorRearmCount = 0;
             _failingCanonicalPath = null;
         }

--- a/tests/Beutl.UnitTests/Editor/DirectoryWatcherServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/DirectoryWatcherServiceTests.cs
@@ -149,6 +149,20 @@ public class DirectoryWatcherServiceTests
     }
 
     [Test]
+    public void An_event_that_arrives_after_disposal_is_dropped()
+    {
+        var service = new DirectoryWatcherService();
+        service.Watch(_scratch);
+        string changed = Path.Combine(_scratch, "late.txt");
+
+        service.Dispose();
+
+        // The OS keeps delivering on the watcher's own thread after Dispose, and the
+        // exception that used to escape there took the whole process with it.
+        Assert.DoesNotThrow(() => service.OnFileSystemEvent(changed));
+    }
+
+    [Test]
     public void Watching_a_missing_path_leaves_nothing_armed()
     {
         using var service = new DirectoryWatcherService();

--- a/tests/Beutl.UnitTests/Editor/DirectoryWatcherServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/DirectoryWatcherServiceTests.cs
@@ -155,11 +155,46 @@ public class DirectoryWatcherServiceTests
         service.Watch(_scratch);
         string changed = Path.Combine(_scratch, "late.txt");
 
+        service.NotifyPathChanged(changed);
         service.Dispose();
 
         // The OS keeps delivering on the watcher's own thread after Dispose, and the
         // exception that used to escape there took the whole process with it.
-        Assert.DoesNotThrow(() => service.OnFileSystemEvent(changed));
+        Assert.DoesNotThrow(() => service.NotifyPathChanged(changed));
+    }
+
+    [Test]
+    public void Watching_after_disposal_cannot_rearm_the_watcher()
+    {
+        var service = new DirectoryWatcherService();
+        service.Watch(_scratch);
+        service.Dispose();
+        service.Watch(_scratch);
+        Assert.That(service.IsWatching, Is.False);
+        Assert.That(service.TryRearmAfterError(), Is.False);
+    }
+
+    [Test]
+    public async Task Events_watch_and_disposal_can_contend_without_rearming_or_throwing()
+    {
+        for (int iteration = 0; iteration < 100; iteration++)
+        {
+            var service = new DirectoryWatcherService();
+            service.Watch(_scratch);
+            service.NotifyPathChanged(Path.Combine(_scratch, "before.txt"));
+            using var start = new ManualResetEventSlim();
+            Task callbacks = Task.Run(() =>
+            {
+                start.Wait();
+                for (int i = 0; i < 10; i++)
+                    service.NotifyPathChanged(Path.Combine(_scratch, "event.txt"));
+            });
+            Task watch = Task.Run(() => { start.Wait(); service.Watch(_scratch); });
+            Task dispose = Task.Run(() => { start.Wait(); service.Dispose(); });
+            start.Set();
+            await Task.WhenAll(callbacks, watch, dispose).WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(service.IsWatching, Is.False);
+        }
     }
 
     [Test]


### PR DESCRIPTION
## Description

- Serialize debounce cancellation ownership across file-system callbacks and disposal.
- Ignore events delivered after the watcher has been disposed.
- Extract this independent fix from #2305 so the paid AI pull request stays focused.

## Affected areas

- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes

None.

## Test plan

- `dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --filter "FullyQualifiedName~DirectoryWatcherServiceTests"` — 9 passed.
- Quick pre-PR format, GPL/MIT boundary, targeted build, and diff checks passed.

## Fixed issues / References

- Extracted from #2305.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file and directory monitoring stability during shutdown.
  - Prevented late file-system events from causing errors after monitoring has been disposed.
  - Improved handling of rapid file-system events to avoid cancellation conflicts.

- **Tests**
  - Added coverage for events received after disposal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->