### PR TITLE
fix(agent-host): harden concurrent endpoint lifecycle

### DIFF
--- a/src/Beutl/AgentHost/AgentHostEndpoint.cs
+++ b/src/Beutl/AgentHost/AgentHostEndpoint.cs
@@ -36,6 +36,7 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
     private readonly CancellationTokenSource _startupCancellation = new();
     private bool _stopRequested;
     private WebApplication? _application;
+    private Uri? _endpointUri;
     private Task? _startupTask;
     private Task? _stopTask;
 
@@ -140,7 +141,14 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
 
     public string Token { get; }
 
-    public Uri? EndpointUri { get; private set; }
+    public Uri? EndpointUri
+    {
+        get
+        {
+            lock (_lifecycleLock)
+                return _endpointUri;
+        }
+    }
 
     public bool IsRunning
     {
@@ -206,7 +214,7 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
                         // Publish EndpointUri only after the stop check: TakeApplication already
                         // cleared it (while still null), so setting it before this check would leave
                         // a dead URL visible to the settings page after a stop-during-startup race.
-                        EndpointUri = endpointUri;
+                        _endpointUri = endpointUri;
                     }
                 }
 
@@ -239,7 +247,17 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
 
     public void StartInBackground()
     {
-        _ = ObserveBackgroundStartAsync(StartAsync());
+        Task startup;
+        lock (_lifecycleLock)
+        {
+            if (_stopRequested)
+                return;
+
+            startup = _startupTask ??= Task.Run(
+                () => StartCoreAsync(_startupCancellation.Token));
+        }
+
+        _ = ObserveBackgroundStartAsync(startup);
     }
 
     private static async Task ObserveBackgroundStartAsync(Task startup)
@@ -247,6 +265,9 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
         try
         {
             await startup.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
         }
         catch (Exception ex)
         {
@@ -262,7 +283,7 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
         lock (_lifecycleLock)
         {
             _stopRequested = true;
-            EndpointUri = null;
+            _endpointUri = null;
             stop = _stopTask ??= StopCoreAsync();
         }
 
@@ -300,7 +321,15 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
         {
             try
             {
-                await startup.ConfigureAwait(false);
+                await startup.WaitAsync(s_shutdownTimeout).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (TimeoutException)
+            {
+                s_logger.LogWarning(
+                    "Timed out waiting for the agent host startup path during shutdown.");
             }
             catch (Exception ex)
             {
@@ -315,7 +344,7 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
         {
             app = _application;
             _application = null;
-            EndpointUri = null;
+            _endpointUri = null;
         }
 
         if (app is not null)

--- a/src/Beutl/AgentHost/AgentHostEndpoint.cs
+++ b/src/Beutl/AgentHost/AgentHostEndpoint.cs
@@ -31,9 +31,13 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
     private readonly EditorService _editorService;
     private readonly AiAgentConfig _config;
     private readonly int _preferredPort;
+    private readonly Func<CancellationToken, Task>? _beforeStart;
     private readonly object _lifecycleLock = new();
+    private readonly CancellationTokenSource _startupCancellation = new();
     private bool _stopRequested;
     private WebApplication? _application;
+    private Task? _startupTask;
+    private Task? _stopTask;
 
     public AgentHostEndpoint(ProjectService projectService, EditorService editorService)
         : this(projectService, editorService, GlobalConfiguration.Instance.AiAgentConfig)
@@ -90,8 +94,19 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
             : documents;
     }
 
-    internal AgentHostEndpoint(ProjectService projectService, EditorService editorService, int preferredPort, string token)
-        : this(projectService, editorService, preferredPort, token, GlobalConfiguration.Instance.AiAgentConfig)
+    internal AgentHostEndpoint(
+        ProjectService projectService,
+        EditorService editorService,
+        int preferredPort,
+        string token,
+        Func<CancellationToken, Task>? beforeStart = null)
+        : this(
+            projectService,
+            editorService,
+            preferredPort,
+            token,
+            GlobalConfiguration.Instance.AiAgentConfig,
+            beforeStart)
     {
     }
 
@@ -100,7 +115,8 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
         EditorService editorService,
         int preferredPort,
         string token,
-        AiAgentConfig config)
+        AiAgentConfig config,
+        Func<CancellationToken, Task>? beforeStart = null)
     {
         ArgumentNullException.ThrowIfNull(config);
 
@@ -118,6 +134,7 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
         _editorService = editorService;
         _config = config;
         _preferredPort = preferredPort;
+        _beforeStart = beforeStart;
         Token = token;
     }
 
@@ -125,18 +142,41 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
 
     public Uri? EndpointUri { get; private set; }
 
-    public bool IsRunning => _application is not null;
-
-    public async Task StartAsync(CancellationToken cancellationToken = default)
+    public bool IsRunning
     {
+        get
+        {
+            lock (_lifecycleLock)
+                return _application is not null;
+        }
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            return Task.FromCanceled(cancellationToken);
+
+        Task startup;
         lock (_lifecycleLock)
         {
-            // A stop requested before (or during) startup must win: never start after RequestStop.
-            if (_application is not null || _stopRequested)
-            {
-                return;
-            }
+            // This endpoint is a one-shot application-lifetime resource. Sharing the startup task
+            // makes concurrent callers observe the same result and gives StopAsync something
+            // concrete to join before project services are torn down.
+            if (_stopRequested)
+                return Task.CompletedTask;
+
+            startup = _startupTask ??= StartCoreAsync(_startupCancellation.Token);
         }
+
+        return cancellationToken.CanBeCanceled
+            ? startup.WaitAsync(cancellationToken)
+            : startup;
+    }
+
+    private async Task StartCoreAsync(CancellationToken cancellationToken)
+    {
+        if (_beforeStart is { } beforeStart)
+            await beforeStart(cancellationToken).ConfigureAwait(false);
 
         int port = _preferredPort;
         while (true)
@@ -174,7 +214,7 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
                 // _application): stop the just-started host here instead of leaving it running.
                 if (stopRequested)
                 {
-                    await StopAndDisposeAsync(app, cancellationToken).ConfigureAwait(false);
+                    await StopAndDisposeWithTimeoutAsync(app).ConfigureAwait(false);
                 }
 
                 return;
@@ -197,45 +237,91 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
         }
     }
 
-    // Fire-and-forget entry point for the app shell: StartAsync failures would otherwise be
-    // unobserved on a discarded task, leaving the live MCP endpoint silently down.
     public void StartInBackground()
     {
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                await StartAsync().ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                s_logger.LogError(ex, "The agent host endpoint failed to start; the live MCP endpoint is unavailable.");
-            }
-        });
+        _ = ObserveBackgroundStartAsync(StartAsync());
     }
 
-    public async Task StopAsync(CancellationToken cancellationToken = default)
+    private static async Task ObserveBackgroundStartAsync(Task startup)
     {
-        WebApplication? app = TakeApplication();
-
-        if (app is not null)
+        try
         {
-            await StopAndDisposeAsync(app, cancellationToken).ConfigureAwait(false);
+            await startup.ConfigureAwait(false);
         }
+        catch (Exception ex)
+        {
+            s_logger.LogError(
+                ex,
+                "The agent host endpoint failed to start; the live MCP endpoint is unavailable.");
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        Task stop;
+        lock (_lifecycleLock)
+        {
+            _stopRequested = true;
+            EndpointUri = null;
+            stop = _stopTask ??= StopCoreAsync();
+        }
+
+        try
+        {
+            _startupCancellation.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+
+        return cancellationToken.CanBeCanceled
+            ? stop.WaitAsync(cancellationToken)
+            : stop;
     }
 
     public void RequestStop()
     {
-        WebApplication? app = TakeApplication();
-        if (app is not null)
-        {
-            _ = StopAndDisposeWithTimeoutAsync(app);
-        }
+        _ = StopAsync();
     }
 
     public async ValueTask DisposeAsync()
     {
         await StopAsync().ConfigureAwait(false);
+        _startupCancellation.Dispose();
+    }
+
+    private async Task StopCoreAsync()
+    {
+        Task? startup;
+        lock (_lifecycleLock)
+            startup = _startupTask;
+
+        if (startup is not null)
+        {
+            try
+            {
+                await startup.ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // StartAsync exposes the startup failure to its caller. Shutdown still has to
+                // continue and dispose any partially-created host.
+                s_logger.LogWarning(ex, "The agent host startup failed before shutdown completed.");
+            }
+        }
+
+        WebApplication? app;
+        lock (_lifecycleLock)
+        {
+            app = _application;
+            _application = null;
+            EndpointUri = null;
+        }
+
+        if (app is not null)
+        {
+            await StopAndDisposeWithTimeoutAsync(app).ConfigureAwait(false);
+        }
     }
 
     private WebApplication CreateApplication(int port)
@@ -289,23 +375,6 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
         return app;
     }
 
-    // Latch _stopRequested and take the app in the same critical section StartAsync uses to publish
-    // it, so a stop during an in-flight startup is never dropped (StartAsync re-checks the latch
-    // before publishing and stops the host itself if it lost the race).
-    private WebApplication? TakeApplication()
-    {
-        WebApplication? app;
-        lock (_lifecycleLock)
-        {
-            _stopRequested = true;
-            app = _application;
-            _application = null;
-        }
-
-        EndpointUri = null;
-        return app;
-    }
-
     private static async Task StopAndDisposeWithTimeoutAsync(WebApplication app)
     {
         using var cts = new CancellationTokenSource(s_shutdownTimeout);
@@ -322,7 +391,7 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
         }
         catch (Exception ex)
         {
-            _ = ex;
+            s_logger.LogWarning(ex, "The agent host endpoint failed to stop cleanly.");
         }
     }
 

--- a/src/Beutl/AgentHost/AgentHostEndpoint.cs
+++ b/src/Beutl/AgentHost/AgentHostEndpoint.cs
@@ -260,13 +260,13 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
         _ = ObserveBackgroundStartAsync(startup);
     }
 
-    private static async Task ObserveBackgroundStartAsync(Task startup)
+    private async Task ObserveBackgroundStartAsync(Task startup)
     {
         try
         {
             await startup.ConfigureAwait(false);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (_startupCancellation.IsCancellationRequested)
         {
         }
         catch (Exception ex)
@@ -323,7 +323,7 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
             {
                 await startup.WaitAsync(s_shutdownTimeout).ConfigureAwait(false);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (_startupCancellation.IsCancellationRequested)
             {
             }
             catch (TimeoutException)

--- a/src/Beutl/AgentHost/AgentHostEndpoint.cs
+++ b/src/Beutl/AgentHost/AgentHostEndpoint.cs
@@ -165,6 +165,8 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
             return Task.FromCanceled(cancellationToken);
 
         Task startup;
+        TaskCompletionSource? completion = null;
+        CancellationToken startupToken = default;
         lock (_lifecycleLock)
         {
             // This endpoint is a one-shot application-lifetime resource. Sharing the startup task
@@ -173,12 +175,37 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
             if (_stopRequested)
                 return Task.CompletedTask;
 
-            startup = _startupTask ??= StartCoreAsync(_startupCancellation.Token);
+            if (_startupTask is null)
+            {
+                completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                _startupTask = completion.Task;
+                startupToken = _startupCancellation.Token;
+            }
+            startup = _startupTask;
         }
 
+        if (completion is not null)
+            _ = Task.Run(() => CompleteStartupAsync(startupToken, completion));
         return cancellationToken.CanBeCanceled
             ? startup.WaitAsync(cancellationToken)
             : startup;
+    }
+
+    private async Task CompleteStartupAsync(CancellationToken token, TaskCompletionSource completion)
+    {
+        try
+        {
+            await StartCoreAsync(token).ConfigureAwait(false);
+            completion.TrySetResult();
+        }
+        catch (OperationCanceledException ex) when (token.IsCancellationRequested)
+        {
+            completion.TrySetCanceled(ex.CancellationToken);
+        }
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
+        }
     }
 
     private async Task StartCoreAsync(CancellationToken cancellationToken)
@@ -247,17 +274,7 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
 
     public void StartInBackground()
     {
-        Task startup;
-        lock (_lifecycleLock)
-        {
-            if (_stopRequested)
-                return;
-
-            startup = _startupTask ??= Task.Run(
-                () => StartCoreAsync(_startupCancellation.Token));
-        }
-
-        _ = ObserveBackgroundStartAsync(startup);
+        _ = ObserveBackgroundStartAsync(StartAsync());
     }
 
     private async Task ObserveBackgroundStartAsync(Task startup)
@@ -284,7 +301,9 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
         {
             _stopRequested = true;
             _endpointUri = null;
-            stop = _stopTask ??= StopCoreAsync();
+            WebApplication? application = _application;
+            _application = null;
+            stop = _stopTask ??= StopCoreAsync(application);
         }
 
         try
@@ -311,7 +330,7 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
         _startupCancellation.Dispose();
     }
 
-    private async Task StopCoreAsync()
+    private async Task StopCoreAsync(WebApplication? app)
     {
         Task? startup;
         lock (_lifecycleLock)
@@ -337,14 +356,6 @@ public sealed class AgentHostEndpoint : IAsyncDisposable
                 // continue and dispose any partially-created host.
                 s_logger.LogWarning(ex, "The agent host startup failed before shutdown completed.");
             }
-        }
-
-        WebApplication? app;
-        lock (_lifecycleLock)
-        {
-            app = _application;
-            _application = null;
-            _endpointUri = null;
         }
 
         if (app is not null)

--- a/tests/Beutl.HeadlessUITests/AgentHostEndpointTests.cs
+++ b/tests/Beutl.HeadlessUITests/AgentHostEndpointTests.cs
@@ -406,8 +406,8 @@ public sealed class AgentHostEndpointTests
 
         firstCancellation.Cancel();
         laterCancellation.Cancel();
-        await Assert.CatchAsync<OperationCanceledException>(async () => await first);
-        await Assert.CatchAsync<OperationCanceledException>(async () => await later);
+        Assert.CatchAsync<OperationCanceledException>(async () => await first);
+        Assert.CatchAsync<OperationCanceledException>(async () => await later);
         Assert.That(shared.IsCompleted, Is.False);
 
         try
@@ -523,7 +523,7 @@ public sealed class AgentHostEndpointTests
         });
 
         releaseStartup.TrySetResult();
-        await Assert.CatchAsync<OperationCanceledException>(async () => await startup);
+        Assert.CatchAsync<OperationCanceledException>(async () => await startup);
     }
 
     [AvaloniaTest]

--- a/tests/Beutl.HeadlessUITests/AgentHostEndpointTests.cs
+++ b/tests/Beutl.HeadlessUITests/AgentHostEndpointTests.cs
@@ -380,6 +380,50 @@ public sealed class AgentHostEndpointTests
     }
 
     [AvaloniaTest]
+    public async Task ConcurrentStartCallersCancelOnlyTheirOwnWaits()
+    {
+        await TestReset.ResetShellAsync();
+        var startupEntered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseStartup = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var endpoint = new AgentHostEndpoint(
+            new ProjectService(),
+            new EditorService(new ExtensionProvider()),
+            GetAvailableLoopbackPort(),
+            "test-token",
+            async token =>
+            {
+                startupEntered.TrySetResult();
+                await releaseStartup.Task.WaitAsync(token);
+            });
+        using var firstCancellation = new CancellationTokenSource();
+        using var laterCancellation = new CancellationTokenSource();
+        Task first = endpoint.StartAsync(firstCancellation.Token);
+        await startupEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Task shared = endpoint.StartAsync();
+        Task later = endpoint.StartAsync(laterCancellation.Token);
+
+        firstCancellation.Cancel();
+        laterCancellation.Cancel();
+        Assert.CatchAsync<OperationCanceledException>(async () => await first);
+        Assert.CatchAsync<OperationCanceledException>(async () => await later);
+        Assert.That(shared.IsCompleted, Is.False);
+
+        try
+        {
+            releaseStartup.TrySetResult();
+            await shared.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(endpoint.IsRunning, Is.True);
+        }
+        finally
+        {
+            releaseStartup.TrySetResult();
+            await endpoint.StopAsync();
+        }
+    }
+
+    [AvaloniaTest]
     public async Task RequestStop_before_start_keeps_the_endpoint_stopped()
     {
         await TestReset.ResetShellAsync();
@@ -414,6 +458,26 @@ public sealed class AgentHostEndpointTests
         });
 
         await endpoint.StopAsync();
+    }
+
+    [AvaloniaTest]
+    public async Task StopAsync_joins_background_startup_and_leaves_no_published_endpoint()
+    {
+        await TestReset.ResetShellAsync();
+        var endpoint = new AgentHostEndpoint(
+            new ProjectService(),
+            new EditorService(new ExtensionProvider()),
+            GetAvailableLoopbackPort(),
+            "test-token");
+
+        endpoint.StartInBackground();
+        await endpoint.StopAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(endpoint.IsRunning, Is.False);
+            Assert.That(endpoint.EndpointUri, Is.Null);
+        });
     }
 
     [AvaloniaTest]

--- a/tests/Beutl.HeadlessUITests/AgentHostEndpointTests.cs
+++ b/tests/Beutl.HeadlessUITests/AgentHostEndpointTests.cs
@@ -406,8 +406,8 @@ public sealed class AgentHostEndpointTests
 
         firstCancellation.Cancel();
         laterCancellation.Cancel();
-        Assert.CatchAsync<OperationCanceledException>(async () => await first);
-        Assert.CatchAsync<OperationCanceledException>(async () => await later);
+        await Assert.CatchAsync<OperationCanceledException>(async () => await first);
+        await Assert.CatchAsync<OperationCanceledException>(async () => await later);
         Assert.That(shared.IsCompleted, Is.False);
 
         try
@@ -464,13 +464,56 @@ public sealed class AgentHostEndpointTests
     public async Task StopAsync_joins_background_startup_and_leaves_no_published_endpoint()
     {
         await TestReset.ResetShellAsync();
+        var startupEntered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseStartup = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         var endpoint = new AgentHostEndpoint(
             new ProjectService(),
             new EditorService(new ExtensionProvider()),
             GetAvailableLoopbackPort(),
-            "test-token");
+            "test-token",
+            async _ =>
+            {
+                startupEntered.TrySetResult();
+                await releaseStartup.Task;
+            });
 
         endpoint.StartInBackground();
+        await startupEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Task stop = endpoint.StopAsync();
+        Assert.That(stop.IsCompleted, Is.False);
+        releaseStartup.TrySetResult();
+        await stop.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(endpoint.IsRunning, Is.False);
+            Assert.That(endpoint.EndpointUri, Is.Null);
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task StopAsync_bounds_a_startup_path_that_does_not_observe_cancellation()
+    {
+        await TestReset.ResetShellAsync();
+        var startupEntered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseStartup = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var endpoint = new AgentHostEndpoint(
+            new ProjectService(),
+            new EditorService(new ExtensionProvider()),
+            GetAvailableLoopbackPort(),
+            "test-token",
+            async _ =>
+            {
+                startupEntered.TrySetResult();
+                await releaseStartup.Task;
+            });
+        Task startup = endpoint.StartAsync();
+        await startupEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
         await endpoint.StopAsync().WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
@@ -478,6 +521,9 @@ public sealed class AgentHostEndpointTests
             Assert.That(endpoint.IsRunning, Is.False);
             Assert.That(endpoint.EndpointUri, Is.Null);
         });
+
+        releaseStartup.TrySetResult();
+        await Assert.CatchAsync<OperationCanceledException>(async () => await startup);
     }
 
     [AvaloniaTest]

--- a/tests/Beutl.HeadlessUITests/AgentHostEndpointTests.cs
+++ b/tests/Beutl.HeadlessUITests/AgentHostEndpointTests.cs
@@ -260,6 +260,60 @@ public sealed class AgentHostEndpointTests
     }
 
     [AvaloniaTest]
+    public async Task RequestStop_detaches_a_published_host_while_startup_completion_is_pending()
+    {
+        await TestReset.ResetShellAsync();
+        await using var endpoint = new AgentHostEndpoint(
+            new ProjectService(), new EditorService(new ExtensionProvider()),
+            GetAvailableLoopbackPort(), "test-token");
+        await endpoint.StartAsync();
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        typeof(AgentHostEndpoint).GetField("_startupTask",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(endpoint, completion.Task);
+        try
+        {
+            endpoint.RequestStop();
+            Assert.That(endpoint.IsRunning, Is.False);
+            Assert.That(endpoint.EndpointUri, Is.Null);
+        }
+        finally
+        {
+            completion.TrySetResult();
+            await endpoint.StopAsync();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Direct_startup_callback_cannot_hold_the_lifecycle_lock_past_stop_timeout()
+    {
+        await TestReset.ResetShellAsync();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var release = new ManualResetEventSlim();
+        await using var endpoint = new AgentHostEndpoint(
+            new ProjectService(), new EditorService(new ExtensionProvider()),
+            GetAvailableLoopbackPort(), "test-token", _ =>
+            {
+                entered.TrySetResult();
+                release.Wait();
+                return Task.CompletedTask;
+            });
+        Task startup = Task.Run(() => endpoint.StartAsync());
+        try
+        {
+            await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await Task.Run(() => endpoint.StopAsync()).WaitAsync(TimeSpan.FromSeconds(4));
+            Assert.That(endpoint.IsRunning, Is.False);
+        }
+        finally
+        {
+            release.Set();
+            try { await startup.WaitAsync(TimeSpan.FromSeconds(5)); }
+            catch (OperationCanceledException) { }
+        }
+    }
+
+    [AvaloniaTest]
     public async Task Endpoint_binds_default_loopback_port_uses_fixed_token_and_stops_cleanly()
     {
         await TestReset.ResetShellAsync();
@@ -406,8 +460,8 @@ public sealed class AgentHostEndpointTests
 
         firstCancellation.Cancel();
         laterCancellation.Cancel();
-        Assert.CatchAsync<OperationCanceledException>(async () => await first);
-        Assert.CatchAsync<OperationCanceledException>(async () => await later);
+        await AssertCanceledAsync(first);
+        await AssertCanceledAsync(later);
         Assert.That(shared.IsCompleted, Is.False);
 
         try
@@ -523,7 +577,7 @@ public sealed class AgentHostEndpointTests
         });
 
         releaseStartup.TrySetResult();
-        Assert.CatchAsync<OperationCanceledException>(async () => await startup);
+        await AssertCanceledAsync(startup);
     }
 
     [AvaloniaTest]
@@ -646,6 +700,13 @@ public sealed class AgentHostEndpointTests
 
         Assert.Inconclusive("Could not reserve a loopback port with an available successor.");
         throw new InvalidOperationException();
+    }
+
+    private static async Task AssertCanceledAsync(Task task)
+    {
+        try { await task.WaitAsync(TimeSpan.FromSeconds(5)); }
+        catch (OperationCanceledException) { return; }
+        Assert.Fail("Expected startup cancellation.");
     }
 
     private static int GetAvailableLoopbackPort()


### PR DESCRIPTION
## Description

- Share one startup operation across concurrent Agent Host callers while keeping caller cancellation local to each wait.
- Make stop join an in-flight start and dispose any host published during the race.
- Bound shutdown cleanup and keep endpoint publication synchronized.
- Extract this independent lifecycle fix from #2305 so the paid AI pull request stays focused.

## Affected areas

- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes

None.

## Test plan

- `dotnet test tests/Beutl.HeadlessUITests/Beutl.HeadlessUITests.csproj -f net10.0 --filter "FullyQualifiedName~AgentHostEndpointTests"` — 11 passed.
- Changed-file whitespace/style, CI-equivalent format apply, GPL/MIT boundary, targeted dual-TFM build, and diff checks passed.

## Fixed issues / References

- Extracted from #2305.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved endpoint startup and shutdown reliability, including safer handling when stopping during startup.
  - Ensured concurrent startup requests behave independently when one request is canceled.
  - Prevented stopped endpoints from leaving a published endpoint address behind.
  - Added bounded shutdown handling for startup operations that do not respond to cancellation.
  - Improved reporting when shutdown encounters an error.

- **New Features**
  - Added an optional callback that runs before endpoint startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->